### PR TITLE
Fix delete memory error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ scripts/node_modules/
 scripts/__pycache__/keys.cpython-310.pyc
 package-lock.json
 *.pyc
-scripts/auto_gpt_workspace/*
+auto_gpt_workspace/*
 *.mpeg
 .env
 last_run_ai_settings.yaml

--- a/scripts/commands.py
+++ b/scripts/commands.py
@@ -140,7 +140,7 @@ def commit_memory(string):
 
 
 def delete_memory(key):
-    if key >= 0 and key < len(mem.permanent_memory):
+    if int(key) >= 0 and key < len(mem.permanent_memory):
         _text = "Deleting memory with key " + str(key)
         del mem.permanent_memory[key]
         print(_text)

--- a/scripts/commands.py
+++ b/scripts/commands.py
@@ -140,7 +140,7 @@ def commit_memory(string):
 
 
 def delete_memory(key):
-    if int(key) >= 0 and key < len(mem.permanent_memory):
+    if key in mem.permanent_memory:
         _text = "Deleting memory with key " + str(key)
         del mem.permanent_memory[key]
         print(_text)
@@ -151,7 +151,7 @@ def delete_memory(key):
 
 
 def overwrite_memory(key, string):
-    if int(key) >= 0 and key < len(mem.permanent_memory):
+    if key in mem.permanent_memory:
         _text = "Overwriting memory with key " + \
             str(key) + " and string " + string
         mem.permanent_memory[key] = string


### PR DESCRIPTION
delete_memory made consistent with overwrite_memory, preventing the error:

```
Command memory_del returned: Error: '>=' not supported between instances of 'str' and 'int'
```