### PR TITLE
Fix memory_ovr to explain that is using indexes in the parameter list instead of keys

### DIFF
--- a/scripts/commands.py
+++ b/scripts/commands.py
@@ -183,7 +183,7 @@ def commit_memory(string):
 
 
 def delete_memory(key):
-    if key >= 0 and key < len(mem.permanent_memory):
+    if key >= -len(mem.permanent_memory) and key < len(mem.permanent_memory):
         _text = "Deleting memory with key " + str(key)
         del mem.permanent_memory[key]
         print(_text)

--- a/scripts/data/prompt.txt
+++ b/scripts/data/prompt.txt
@@ -8,8 +8,8 @@ COMMANDS:
 
 1. Google Search: "google", args: "input": "<search>"
 2. Memory Add: "memory_add", args: "string": "<string>"
-3. Memory Delete: "memory_del", args: "key": "<key>"
-4. Memory Overwrite: "memory_ovr", args: "key": "<key>", "string": "<string>"
+3. Memory Delete: "memory_del", args: "key": "<index_of_memory_to_delete>"
+4. Memory Overwrite: "memory_ovr", args: "key": "<index_of_memory_to_overwrite>", "string": "<string>"
 5. Browse Website: "browse_website", args: "url": "<url>", "question": "<what_you_want_to_find_on_website>"
 6. Start GPT Agent: "start_agent",  args: "name": <name>, "task": "<short_task_desc>", "prompt": "<prompt>"
 7. Message GPT Agent: "message_agent", args: "key": "<key>", "message": "<message>"


### PR DESCRIPTION
AutoGPT was getting confused, and causing errors because it thought the keys for memory_ovr were strings instead of an integer. This better explains that the keys are actually indexes, which helps prevent this error.