### PR TITLE
Add GitHub Action for AI PR Summarizer

### DIFF
--- a/.github/workflows/gpt-commit-summarizer.yml
+++ b/.github/workflows/gpt-commit-summarizer.yml
@@ -1,0 +1,21 @@
+name: GPT Commits summarizer
+# Summary: This action will write a comment about every commit in a pull request, 
+# as well as generate a summary for every file that was modified and add it to the
+# review page, compile a PR summary from all commit summaries and file diff 
+# summaries, and delete outdated code review comments
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  summarize:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+      - uses: KanHarI/gpt-commit-summarizer@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}


### PR DESCRIPTION
This PR uses a [Pull Request Summarizer](https://github.com/marketplace/actions/pull-request-summarizer) action to automatically summarize PRs with GPT.

I checked out the repo and ran `npx add-gpt-summarizer@latest`, committed the results, and created this PR.

In order for it to function, you need to follow [its directions](https://github.com/marketplace/actions/pull-request-summarizer#setting-up) to create a repository secret for your OpenAI API Key.

> ... To do this, go to your repository's settings and navigate to the "Secrets" section. Click on "Add a new secret" and enter the secret name OPENAI_API_KEY and the value of your API key.