### PR TITLE
Add an alternate requirements file for better compatibility

### DIFF
--- a/requirements-alternate.txt
+++ b/requirements-alternate.txt
@@ -1,0 +1,14 @@
+beautifulsoup4
+colorama
+openai
+playsound
+python-dotenv
+pyyaml
+readability-lxml
+requests
+tiktoken
+gTTS
+docker
+duckduckgo-search
+google-api-python-client #(https://developers.google.com/custom-search/v1/overview) 
+googlesearch-python


### PR DESCRIPTION
### Background

Devs and aspiring contributors frequently have dependency conflicts when trying to clone the repo and build dependencies for the first time. 

Adding an alternate requirements file:
- Removes package versions, allowing pip to resolve dependency conflicts with less strict versioning
- Explicitly adds packages to be installed, that was being missed by pip and resulting in 'module not found' errors


### Changes

Add a new requirements-alternate.txt

### Test Plan

Other contributors and myself have found success with this requirements file, as opposed to the main one.

### Change Safety

- [x] I have added tests to cover my changes
- [x] I have considered potential risks and mitigations for my changes

<!-- If you haven't added tests, please explain why. If you have, check the appropriate box. -->
