### PR TITLE
Fix user_input prompt - request response should only be in JSON

### DIFF
--- a/scripts/main.py
+++ b/scripts/main.py
@@ -316,7 +316,7 @@ full_message_history = []
 result = None
 next_action_count = 0
 # Make a constant:
-user_input = "Determine which next command to use, and respond using the format specified above:"
+user_input = "Determine which next command to use, respond exclusively in JSON and only JSON:"
 
 # Initialize memory and make sure it is empty.
 # this is particularly important for indexing and referencing pinecone memory


### PR DESCRIPTION
### Background
Improve JSON response

The original prompt is generic.
"Determine which next command to use, and respond using the format specified above:"

Let's be explicit.
"Determine which next command to use, respond exclusively in JSON and only JSON:"

### Changes
update user_input prompt to encourage valid JSON responses

### Documentation
none

### Test Plan
<!-- Describe how you tested this functionality. Include steps to reproduce, relevant test cases, and any other pertinent information. -->

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thouroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes <!-- Submit these as seperate Pull Reqests, they are the easiest to merge! -->
