### PR TITLE
Add knowledge cutoff date to prompt

### DIFF
--- a/scripts/data/prompt.txt
+++ b/scripts/data/prompt.txt
@@ -1,3 +1,5 @@
+Knowledge Cutoff Date: Please remember that your knowledge and information are accurate and up-to-date as of September 2021. Please use this information to better coordinate your searches and thoughts.
+
 CONSTRAINTS:
 
 1. ~4000 word limit for short term memory. Your short term memory is short, so immediately save important information to files.


### PR DESCRIPTION
### Background
This change was made to the `ai_config.py` file #185. However, based on a suggestion, the knowledge cutoff was directly added to the `prompt.txt` file. This aims to provide metadata to the AI, enhancing its search coordination and thought processes.

### Changes
A single line was added on top of `prompt.txt` file. The line added is `Knowledge Cutoff Date: Please remember that your knowledge and information are accurate and up-to-date as of September 2021. Please use this information to better coordinate your searches and thoughts.`

### Documentation
Unfortunately, no documentation is made.

### Test Plan
No test was conducted.

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [ ] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not included any "extra" small tweaks or changes.