### PR TITLE
get_memory function clears the memory where init is true

### DIFF
--- a/scripts/memory/__init__.py
+++ b/scripts/memory/__init__.py
@@ -36,6 +36,8 @@ def get_memory(cfg, init=False):
                   " use Redis as a memory backend.")
         else:
             memory = RedisMemory(cfg)
+            if init:
+                memory.clear()
     elif cfg.memory_backend == "no_memory":
         memory = NoMemory(cfg)
 


### PR DESCRIPTION
get_memory function should clear the memory when init is true. This was missed in case of "redis", so I added the memory.clear() in case of "redis" + init=True.

Warning: I have not tested it, it just made sense. Request to test if someone can. I do not have the required APIs to test it through.

### Background
memory should be cleared if init is True. This was missed for Redis.

### Changes
Following the example of Pinecone, I added the same logic in the Redis branch of if else logic.

### Documentation
The change is small enough and follows the expected logic of the function. Documenting this change is unnecessary.
 
As only atomic changes are allowed, I will make a separate pull request for the function documentation of get_memory

### Test Plan
> :warning: **UNTESTED CODE CHANGE**
I have not tested the code in anyway. I am just expecting it to work.

Atm, I do not have API keys to test.
Kindly reject the pull request if it doesn't pass the tests.


### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [ ] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes 
