### PR TITLE
Make working directory part of global config with env var

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -185,3 +185,8 @@ TW_CONSUMER_KEY=
 TW_CONSUMER_SECRET=
 TW_ACCESS_TOKEN=
 TW_ACCESS_TOKEN_SECRET=
+
+################################################################################
+### WORKSPACE PATH
+################################################################################
+WORKSPACE_PATH=auto_gpt_workspace

--- a/autogpt/config/config.py
+++ b/autogpt/config/config.py
@@ -117,6 +117,9 @@ class Config(metaclass=Singleton):
         # Note that indexes must be created on db 0 in redis, this is not configurable.
 
         self.memory_backend = os.getenv("MEMORY_BACKEND", "local")
+
+        self.workspace_path = os.getenv("WORKSPACE_PATH", "auto_gpt_workspace")
+
         # Initialize the OpenAI API client
         openai.api_key = self.openai_api_key
 

--- a/autogpt/workspace.py
+++ b/autogpt/workspace.py
@@ -8,7 +8,7 @@ from autogpt.config import Config
 CFG = Config()
 
 # Set a dedicated folder for file I/O
-WORKSPACE_PATH = Path(os.getcwd()) / "auto_gpt_workspace"
+WORKSPACE_PATH = Path(os.getcwd()) / CFG.workspace_path
 
 # Create the directory if it doesn't exist
 if not os.path.exists(WORKSPACE_PATH):

--- a/data_ingestion.py
+++ b/data_ingestion.py
@@ -88,7 +88,7 @@ def main() -> None:
     else:
         print(
             "Please provide either a file path (--file) or a directory name (--dir)"
-            " inside the auto_gpt_workspace directory as input."
+            f" inside the {cfg.workspace_path} directory as input."
         )
 
 


### PR DESCRIPTION
### Background
The working directory was hardcoded in a few separate bits of the codebase

### Changes
Made working directory part of global config and possible to set via env variable

### Documentation
added to `.env.template`

### Test Plan
Smoke tested locally after refactor and works ok

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes 