### PR TITLE
logger was used but not imported in token_counter.py

### DIFF
--- a/scripts/token_counter.py
+++ b/scripts/token_counter.py
@@ -1,4 +1,5 @@
 import tiktoken
+from logger import logger
 from typing import List, Dict
 
 


### PR DESCRIPTION
logger was used but not imported.

Used in  line 19 or line 20 : logger.warn("Warning: model not found. Using cl100k_base encoding.")

### Changes
from logger import logger

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes