### PR TITLE
setting google API key to blank

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -99,7 +99,7 @@ HUGGINGFACE_API_TOKEN=your-huggingface-api-token
 ### GOOGLE
 # GOOGLE_API_KEY - Google API key (Example: my-google-api-key)
 # CUSTOM_SEARCH_ENGINE_ID - Custom search engine ID (Example: my-custom-search-engine-id)
-GOOGLE_API_KEY=your-google-api-key
+GOOGLE_API_KEY=
 CUSTOM_SEARCH_ENGINE_ID=your-custom-search-engine-id
 
 ################################################################################


### PR DESCRIPTION
### Background

since google API key is set by default, AutoGPT will try to call invalid API. removing API key string so that this code is triggered:
https://github.com/Torantulino/Auto-GPT/blob/master/scripts/commands.py#L63


### Changes
setting google API key to blank in env template. 

### Test Plan
no

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [ ] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->

