### PR TITLE
chat_with_ai changes

### DIFF
--- a/scripts/chat.py
+++ b/scripts/chat.py
@@ -53,72 +53,71 @@ def chat_with_ai(
         full_message_history,
         permanent_memory,
         token_limit):
-    """Interact with the OpenAI API, sending the prompt, user input, message history, and permanent memory."""
+    """
+    Interact with the OpenAI API, sending the prompt, user input, message history, and permanent memory.
+
+    Args:
+    prompt (str): The prompt explaining the rules to the AI.
+    user_input (str): The input from the user.
+    full_message_history (list): The list of all messages sent between the user and the AI.
+    permanent_memory (Obj): The memory object containing the permanent memory.
+    token_limit (int): The maximum number of tokens allowed in the API call.
+
+    Returns:
+    str: The AI's response.
+    """
     while True:
+        model = cfg.fast_llm_model # TODO: Change model from hardcode to argument
+        # Reserve 1000 tokens for the response
+
+        logger.debug(f"Token limit: {token_limit}")
+        send_token_limit = token_limit - 1000
+
+        relevant_memory = '' if len(full_message_history) ==0 else  permanent_memory.get_relevant(str(full_message_history[-9:]), 10)
+
+        logger.debug(f'Memory Stats: {permanent_memory.get_stats()}')
+
+        # How much space is left in the token limit for memories?
+        empty_context = generate_context(prompt, user_input, [], [])
+        empty_context_tokens = token_counter.count_message_tokens(empty_context, model)
+        memories_token_limit = 2500 - empty_context_tokens
+        msg_history_token_limit = send_token_limit - empty_context_tokens - memories_token_limit
+
+        # Reduce the memories to fit in the token limit
+        reduced_memories = reduce_dataset(relevant_memory,
+                                          limit=memories_token_limit,
+                                          f=token_counter.count_string_tokens,
+                                          model=model
+                                          )
+
+        # Reduce the message history to fit in the token limit
+        reduced_message_history = reduce_dataset(full_message_history[::-1],
+                                                 limit=msg_history_token_limit,
+                                                 f=token_counter.count_message_tokens,
+                                                 model=model
+                                                 )[::-1]
+
+        # Generate the context
+        current_context = generate_context(prompt, user_input, reduced_memories, reduced_message_history)
+        context_tokens = token_counter.count_message_tokens(current_context, model)
+
+        tokens_remaining = token_limit - context_tokens
+
+
+        # Debug print the current context
+        logger.debug(f"Token limit: {token_limit}")
+        logger.debug(f"Send Token Count: {context_tokens}")
+        logger.debug(f"Tokens remaining for response: {tokens_remaining}")
+        logger.debug("------------ CONTEXT SENT TO AI ---------------")
+        for message in current_context:
+            # Skip printing the prompt
+            if message["role"] == "system" and message["content"] == prompt:
+                continue
+            logger.debug(f"{message['role'].capitalize()}: {message['content']}")
+            logger.debug("")
+        logger.debug("----------- END OF CONTEXT ----------------")
+
         try:
-            """
-            Interact with the OpenAI API, sending the prompt, user input, message history, and permanent memory.
-
-            Args:
-            prompt (str): The prompt explaining the rules to the AI.
-            user_input (str): The input from the user.
-            full_message_history (list): The list of all messages sent between the user and the AI.
-            permanent_memory (Obj): The memory object containing the permanent memory.
-            token_limit (int): The maximum number of tokens allowed in the API call.
-
-            Returns:
-            str: The AI's response.
-            """
-            model = cfg.fast_llm_model # TODO: Change model from hardcode to argument
-            # Reserve 1000 tokens for the response
-
-            logger.debug(f"Token limit: {token_limit}")
-            send_token_limit = token_limit - 1000
-
-            relevant_memory = '' if len(full_message_history) ==0 else  permanent_memory.get_relevant(str(full_message_history[-9:]), 10)
-
-            logger.debug(f'Memory Stats: {permanent_memory.get_stats()}')
-
-            # How much space is left in the token limit for memories?
-            empty_context = generate_context(prompt, user_input, [], [])
-            empty_context_tokens = token_counter.count_message_tokens(empty_context, model)
-            memories_token_limit = 2500 - empty_context_tokens
-            msg_history_token_limit = send_token_limit - empty_context_tokens - memories_token_limit
-
-            # Reduce the memories to fit in the token limit
-            reduced_memories = reduce_dataset(relevant_memory,
-                                              limit=memories_token_limit,
-                                              f=token_counter.count_string_tokens,
-                                              model=model
-                                              )
-
-            # Reduce the message history to fit in the token limit
-            reduced_message_history = reduce_dataset(full_message_history[::-1],
-                                                     limit=msg_history_token_limit,
-                                                     f=token_counter.count_message_tokens,
-                                                     model=model
-                                                     )[::-1]
-
-            # Generate the context
-            current_context = generate_context(prompt, user_input, reduced_memories, reduced_message_history)
-            context_tokens = token_counter.count_message_tokens(current_context, model)
-
-            tokens_remaining = token_limit - context_tokens
-
-
-            # Debug print the current context
-            logger.debug(f"Token limit: {token_limit}")
-            logger.debug(f"Send Token Count: {current_tokens_used}")
-            logger.debug(f"Tokens remaining for response: {tokens_remaining}")
-            logger.debug("------------ CONTEXT SENT TO AI ---------------")
-            for message in current_context:
-                # Skip printing the prompt
-                if message["role"] == "system" and message["content"] == prompt:
-                    continue
-                logger.debug(f"{message['role'].capitalize()}: {message['content']}")
-                logger.debug("")
-            logger.debug("----------- END OF CONTEXT ----------------")
-
             # TODO: use a model defined elsewhere, so that model can contain temperature and other settings we care about
             assistant_reply = create_chat_completion(
                 model=model,
@@ -127,8 +126,12 @@ def chat_with_ai(
             )
 
             # Update full message history
-            full_message_history.append( create_chat_message( "user", user_input))
-            full_message_history.append( create_chat_message( "assistant", assistant_reply))
+            full_message_history.append(
+                create_chat_message(
+                    "user", user_input))
+            full_message_history.append(
+                create_chat_message(
+                    "assistant", assistant_reply))
 
             return assistant_reply
         except openai.error.RateLimitError:

--- a/scripts/token_counter.py
+++ b/scripts/token_counter.py
@@ -14,6 +14,8 @@ def count_message_tokens(messages : List[Dict[str, str]], model : str = "gpt-3.5
     int: The number of tokens used by the list of messages.
     """
     try:
+        if not isinstance(messages, list):
+            messages = [messages]
         encoding = tiktoken.encoding_for_model(model)
     except KeyError:
         logger.warn("Warning: model not found. Using cl100k_base encoding.")
@@ -39,21 +41,21 @@ def count_message_tokens(messages : List[Dict[str, str]], model : str = "gpt-3.5
             num_tokens += len(encoding.encode(value))
             if key == "name":
                 num_tokens += tokens_per_name
+
     num_tokens += 3  # every reply is primed with <|start|>assistant<|message|>
     return num_tokens
 
-
-def count_string_tokens(string: str, model_name: str) -> int:
+def count_string_tokens(string: str, model: str) -> int:
     """
     Returns the number of tokens in a text string.
 
     Args:
     string (str): The text string.
-    model_name (str): The name of the encoding to use. (e.g., "gpt-3.5-turbo")
+    model (str): The name of the encoding to use. (e.g., "gpt-3.5-turbo")
 
     Returns:
     int: The number of tokens in the text string.
     """
-    encoding = tiktoken.encoding_for_model(model_name)
+    encoding = tiktoken.encoding_for_model(model)
     num_tokens = len(encoding.encode(string))
     return num_tokens


### PR DESCRIPTION
### Background
The chat_with_ai function was full of variables, create context returned a tuple of 4 variables(!!!) and the loop was just kind of hard to read. Additionally the try-except statement includes too much code

### Changes
- added reduce_dataset() to trim down memories and msg_history in a cleaner way
- moved much of the chat_with_ai code outside of the try-except as it doesnt reach out to openai, and cannot raise a rate limiting error. the try block now encompases ONLY the reachout.
- reworked generate_context to only return the context, not a bunch of other meta vars

### Documentation
inline comments. 

### Test Plan
ran before and after with same yaml files. ensured the loop didnt break and that prompts were acting on the new information from the last run

### PR Quality Checklist
- [X] My pull request is atomic and focuses on a single change.
- [X] I have thoroughly tested my changes with multiple different prompts.
- [X] I have considered potential risks and mitigations for my changes.
- [X] I have documented my changes clearly and comprehensively.
- [X] I have not snuck in any "extra" small tweaks changes <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->

<!-- If you haven't added tests, please explain why. If you have, check the appropriate box. If you've ensured your PR is atomic and well-documented, check the corresponding boxes. -->

<!-- By submitting this, I agree that my pull request should be closed if I do not fill this out or follow the guide lines. -->
