### PR TITLE
Import missing module in commands.py

### DIFF
--- a/autogpt/commands.py
+++ b/autogpt/commands.py
@@ -1,6 +1,18 @@
 import datetime
 import json
 
+from autogpt import browse
+import json
+from autogpt.memory import get_memory
+import datetime
+import autogpt.agent_manager as agents
+from autogpt import speak
+from autogpt.config import Config
+import autogpt.ai_functions as ai
+from autogpt.file_operations import read_file, write_to_file, append_to_file, delete_file, search_files
+from autogpt.execute_code import execute_python_file, execute_shell
+from autogpt.json_parser import fix_and_parse_json
+from autogpt.image_gen import generate_image
 from duckduckgo_search import ddg
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError


### PR DESCRIPTION
### Background
This pull request addresses an issue where the commands.py file was missing multiple import statements for required modules. This caused an error or prevented the bot from running properly when running the application.

### Changes
I have added the missing import statement to commands.py. The bot now runs without any errors and is able to function as expected.

### Documentation

### Test Plan

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->