### PR TITLE
 Command-Error-Loop---'dict'-object-#1459  & checking for website url before trying to load url

### DIFF
--- a/autogpt/web.py
+++ b/autogpt/web.py
@@ -15,6 +15,9 @@ cfg = Config()
 
 
 def browse_website(url, question):
+    if(url == "<website_url>"):
+        return f"You did not provide a website URL for the param <website_url>, please re-run with a URL",
+    
     driver, text = scrape_text_with_selenium(url)
     add_header(driver)
     summary_text = summary.summarize_text(driver, text, question)


### PR DESCRIPTION
### Background
 Command-Error-Loop---'dict'-object- #1459 

### Changes
Implemented proposed changes and they are working. Added an extra check with a different style. 

Added 

            try:
                json.loads(assistant_reply_json)
                
            except json.JSONDecodeError as e:
                assistant_reply_json = json.dumps(fix_and_parse_json(assistant_reply_json))
                
`
                
and 
```
 if(url == "<website_url>"):
        return f"You did not provide a website URL for the param <website_url>, please re-run with a URL",
```
        
To prevent loading of pages with empty URLs that have been happening a lot. 

### Documentation




### PR Quality Checklist
- [ ] My pull request is atomic and focuses on a single change.
- [X ] I have thoroughly tested my changes with multiple different prompts.
- [X] I have considered potential risks and mitigations for my changes.
- [X] I have documented my changes clearly and comprehensively.
- [X] I have not snuck in any "extra" small tweaks changes <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->

