### PR TITLE
Add Qdrant as a long memory backend.

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -63,6 +63,13 @@ OPENAI_API_KEY=your-openai-api-key
 # PINECONE_API_KEY=your-pinecone-api-key
 # PINECONE_ENV=your-pinecone-region
 
+### QDRANT
+# QDRANT_HOST - Qdrant host (Default: localhost)
+# QDRANT_PORT - Qdrant port (Default: 6333)
+# MEMORY_INDEX - Name of index created in Qdrant database (Default: auto-gpt)
+QDRANT_HOST=localhost
+QDRANT_PORT=6333
+
 ### REDIS
 ## REDIS_HOST - Redis host (Default: localhost, use "redis" for docker-compose)
 ## REDIS_PORT - Redis port (Default: 6379)

--- a/autogpt/config/config.py
+++ b/autogpt/config/config.py
@@ -113,7 +113,8 @@ class Config(metaclass=Singleton):
             "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36"
             " (KHTML, like Gecko) Chrome/83.0.4103.97 Safari/537.36",
         )
-
+        self.qdrant_host = os.getenv("QDRANT_HOST", "localhost")
+        self.qdrant_port = os.getenv("QDRANT_PORT", "6333")
         self.redis_host = os.getenv("REDIS_HOST", "localhost")
         self.redis_port = os.getenv("REDIS_PORT", "6379")
         self.redis_password = os.getenv("REDIS_PASSWORD", "")

--- a/autogpt/config/config.py
+++ b/autogpt/config/config.py
@@ -113,6 +113,7 @@ class Config(metaclass=Singleton):
             "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36"
             " (KHTML, like Gecko) Chrome/83.0.4103.97 Safari/537.36",
         )
+
         self.qdrant_host = os.getenv("QDRANT_HOST", "localhost")
         self.qdrant_port = os.getenv("QDRANT_PORT", "6333")
         self.redis_host = os.getenv("REDIS_HOST", "localhost")

--- a/autogpt/memory/__init__.py
+++ b/autogpt/memory/__init__.py
@@ -37,6 +37,14 @@ except ImportError:
     # print("pymilvus not installed. Skipping import.")
     MilvusMemory = None
 
+try:
+    from autogpt.memory.qdrant import QdrantMemory
+
+    supported_memory.append("qdrant")
+except ImportError:
+    print("Qdrant not installed. Skipping import.")
+    QdrantMemory = None
+
 
 def get_memory(cfg, init=False):
     memory = None
@@ -48,6 +56,16 @@ def get_memory(cfg, init=False):
             )
         else:
             memory = PineconeMemory(cfg)
+            if init:
+                memory.clear()
+    elif cfg.memory_backend == "qdrant":
+        if not QdrantMemory:
+            print(
+                "Error: Qdrant is not installed. Please install qdrant"
+                " to use Qdrant as a memory backend."
+            )
+        else:
+            memory = QdrantMemory(cfg)
             if init:
                 memory.clear()
     elif cfg.memory_backend == "redis":
@@ -93,6 +111,7 @@ __all__ = [
     "LocalCache",
     "RedisMemory",
     "PineconeMemory",
+    "QdrantMemory",
     "NoMemory",
     "MilvusMemory",
     "WeaviateMemory",

--- a/autogpt/memory/qdrant.py
+++ b/autogpt/memory/qdrant.py
@@ -1,0 +1,96 @@
+import uuid
+from qdrant_client import QdrantClient
+from qdrant_client.http import models as rest
+from qdrant_client.http.models import PointStruct
+from qdrant_client.http.exceptions import UnexpectedResponse
+from autogpt.memory.base import MemoryProviderSingleton, get_ada_embedding
+
+
+class QdrantMemory(MemoryProviderSingleton):
+    def __init__(self, cfg):
+        self.qdrant_host = cfg.qdrant_host
+        self.qdrant_port = cfg.qdrant_port
+        self.dimension = 1536
+        self.metric = rest.Distance["COSINE"]
+        self.index_name = cfg.memory_index
+        self.client = QdrantClient(host=self.qdrant_host, port=self.qdrant_port)
+        self.vec_num = uuid.uuid4().hex
+
+        # Check connection
+        if not self.ping():
+            raise ConnectionError(
+                f"Unable to connect to Qdrant server at {self.qdrant_host}:{self.qdrant_port}"
+            )
+
+        # Create index if not exists
+        try:
+            self.client.get_collection(self.index_name)
+        except UnexpectedResponse:
+            self.client.recreate_collection(
+                self.index_name,
+                vectors_config=rest.VectorParams(
+                    size=self.dimension,
+                    distance=self.metric
+                )
+            )
+
+    def ping(self):
+        try:
+            self.client.get_collections()
+            return True
+        except Exception as e:
+            print(f"Error while connecting to Qdrant server: {e}")
+            return False
+
+    def add(self, data):
+        vector = get_ada_embedding(data)
+        point = PointStruct(
+            id=self.vec_num,
+            vector=vector,
+            payload={"raw_text": data},
+        )
+        resp = self.client.upsert(
+            collection_name=self.index_name,
+            points=[point],
+            wait=True
+        )
+        _text = f"Inserting data into memory at index: {self.vec_num}:\n data: {data}"
+        self.vec_num = uuid.uuid4().hex
+        return _text
+
+    def get(self, data):
+        return self.get_relevant(data, 1)
+
+    def clear(self):
+        self.client.delete_collection(self.index_name);
+        self.client.recreate_collection(
+            self.index_name,
+            vectors_config=rest.VectorParams(
+                size=self.dimension,
+                distance=self.metric
+            )
+        )
+        self.vec_num = 0
+        return "Obliviated"
+
+    def get_relevant(self, data, num_relevant=5):
+        query_embedding = get_ada_embedding(data)
+        results = self.client.search(
+            collection_name=self.index_name,
+            query_vector=query_embedding,
+            top=num_relevant,
+            payload=True,
+        )
+        sorted_results = sorted(results, key=lambda x: -x.score)[:num_relevant]
+
+        return [item.payload["raw_text"] for item in sorted_results]
+
+    def get_stats(self):
+        collection_info = self.client.get_collection(collection_name=self.index_name)
+        return {
+            "optimizer_status": collection_info.optimizer_status,
+            "vectors_count": collection_info.vectors_count,
+            "indexed_vectors_count": collection_info.indexed_vectors_count,
+            "points_count": collection_info.points_count,
+            "segments_count": collection_info.segments_count,
+        }

--- a/autogpt/memory/qdrant.py
+++ b/autogpt/memory/qdrant.py
@@ -1,8 +1,10 @@
 import uuid
+
 from qdrant_client import QdrantClient
 from qdrant_client.http import models as rest
-from qdrant_client.http.models import PointStruct
 from qdrant_client.http.exceptions import UnexpectedResponse
+from qdrant_client.http.models import PointStruct
+
 from autogpt.memory.base import MemoryProviderSingleton, get_ada_embedding
 
 
@@ -29,9 +31,8 @@ class QdrantMemory(MemoryProviderSingleton):
             self.client.recreate_collection(
                 self.index_name,
                 vectors_config=rest.VectorParams(
-                    size=self.dimension,
-                    distance=self.metric
-                )
+                    size=self.dimension, distance=self.metric
+                ),
             )
 
     def ping(self):
@@ -50,9 +51,7 @@ class QdrantMemory(MemoryProviderSingleton):
             payload={"raw_text": data},
         )
         resp = self.client.upsert(
-            collection_name=self.index_name,
-            points=[point],
-            wait=True
+            collection_name=self.index_name, points=[point], wait=True
         )
         _text = f"Inserting data into memory at index: {self.vec_num}:\n data: {data}"
         self.vec_num = uuid.uuid4().hex
@@ -62,13 +61,10 @@ class QdrantMemory(MemoryProviderSingleton):
         return self.get_relevant(data, 1)
 
     def clear(self):
-        self.client.delete_collection(self.index_name);
+        self.client.delete_collection(self.index_name)
         self.client.recreate_collection(
             self.index_name,
-            vectors_config=rest.VectorParams(
-                size=self.dimension,
-                distance=self.metric
-            )
+            vectors_config=rest.VectorParams(size=self.dimension, distance=self.metric),
         )
         self.vec_num = 0
         return "Obliviated"

--- a/docs/configuration/memory.md
+++ b/docs/configuration/memory.md
@@ -120,6 +120,24 @@ WEAVIATE_EMBEDDED_PATH="/home/me/.local/share/weaviate" # this is optional and i
 USE_WEAVIATE_EMBEDDED=False # set to True to run Embedded Weaviate
 MEMORY_INDEX="Autogpt" # name of the index to create for the application
 ```
+
+### Qdrant Setup
+Install docker desktop.
+
+Run:
+
+```
+docker run -p "6333:6333" -p "6334:6334" qdrant/qdrant:v1.0.3
+```
+
+In your `.env` file set the following:
+
+```
+MEMORY_BACKEND=qdrant
+QDRANT_HOST=localhost
+QDRANT_PORT=6333
+```
+
  
 ## View Memory Usage
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,8 @@ docker
 duckduckgo-search
 google-api-python-client #(https://developers.google.com/custom-search/v1/overview)
 pinecone-client==2.2.1
+pymilvus==2.2.4
+qdrant-client==1.1.1
 redis
 orjson
 Pillow

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,8 +13,6 @@ docker
 duckduckgo-search
 google-api-python-client #(https://developers.google.com/custom-search/v1/overview)
 pinecone-client==2.2.1
-pymilvus==2.2.4
-qdrant-client==1.1.1
 redis
 orjson
 Pillow

--- a/tests/integration/qdrant_memory_tests.py
+++ b/tests/integration/qdrant_memory_tests.py
@@ -1,0 +1,47 @@
+import random
+import string
+import unittest
+
+from autogpt.config import Config
+from autogpt.memory.qdrant import QdrantMemory
+
+
+class TestQdrantMemory(unittest.TestCase):
+    def random_string(self, length):
+        return "".join(random.choice(string.ascii_letters) for _ in range(length))
+
+    def setUp(self):
+        cfg = cfg = Config()
+        self.memory = QdrantMemory(cfg)
+        self.memory.clear()
+
+        # Add example texts to the cache
+        self.example_texts = [
+            "The quick brown fox jumps over the lazy dog",
+            "I love machine learning and natural language processing",
+            "The cake is a lie, but the pie is always true",
+            "ChatGPT is an advanced AI model for conversation",
+        ]
+
+        for text in self.example_texts:
+            self.memory.add(text)
+
+        # Add some random strings to test noise
+        for _ in range(5):
+            self.memory.add(self.random_string(10))
+
+    def test_get_relevant(self):
+        query = "I'm interested in artificial intelligence and NLP"
+        k = 3
+        relevant_texts = self.memory.get_relevant(query, k)
+
+        print(f"Top {k} relevant texts for the query '{query}':")
+        for i, text in enumerate(relevant_texts, start=1):
+            print(f"{i}. {text}")
+
+        self.assertEqual(len(relevant_texts), k)
+        self.assertIn(self.example_texts[1], relevant_texts)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/qdrant_memory_test.py
+++ b/tests/qdrant_memory_test.py
@@ -1,0 +1,74 @@
+# sourcery skip: snake-case-functions
+"""Tests for the QdrantMemory class."""
+import unittest
+
+try:
+    from autogpt.memory.qdrant import QdrantMemory
+
+    def mock_config() -> dict:
+        """Mock the Config class"""
+        return type(
+            "MockConfig",
+            (object,),
+            {
+                "debug_mode": False,
+                "continuous_mode": False,
+                "speak_mode": False,
+                "memory_index": "autogpt",
+                "qdrant_host": "localhost",
+                "qdrant_port": "6333",
+            },
+        )
+
+    class TestQdrantMemory(unittest.TestCase):
+        """Tests for the MilvusMemory class."""
+
+        def setUp(self) -> None:
+            """Set up the test environment"""
+            self.cfg = mock_config()
+            self.memory = QdrantMemory(self.cfg)
+
+        def test_add(self) -> None:
+            """Test adding a text to the cache"""
+            text = "Sample text"
+            self.memory.clear()
+            self.memory.add(text)
+            result = self.memory.get(text)
+            self.assertEqual([text], result)
+
+        def test_clear(self) -> None:
+            """Test clearing the cache"""
+            self.memory.clear()
+
+        def test_get(self) -> None:
+            """Test getting a text from the cache"""
+            text = "Sample text"
+            self.memory.clear()
+            self.memory.add(text)
+            result = self.memory.get(text)
+            self.assertEqual(result, [text])
+
+        def test_get_relevant(self) -> None:
+            """Test getting relevant texts from the cache"""
+            text1 = "Sample text 1"
+            text2 = "Sample text 2"
+            self.memory.clear()
+            self.memory.add(text1)
+            self.memory.add(text2)
+            result = self.memory.get_relevant(text1, 1)
+            self.assertEqual(result, [text1])
+
+        def test_get_stats(self) -> None:
+            """Test getting the cache stats"""
+            text = "Sample text"
+            self.memory.clear()
+            self.memory.add(text)
+            stats = self.memory.get_stats()
+            self.assertEqual(5, len(stats))
+
+except:
+    print("Qdrant not installed, skipping tests")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Hi there!
For this pull request, I have read your announcement carefully.

###  Background
As I notice there are many vector databases provided in [chatgpt-retrieve-plugin.](https://github.com/openai/chatgpt-retrieval-plugin/tree/main/datastore/providers)
I think all the vector databases can be used by you as a long-term memory. So this is the first commit to add the most easier used one 'Qdrant'. And I am willing to implement them all!

### Changes
This commit only  "Add Qdrant as a long memory backend."
what I do is:
- Implement QdrantMemory based on MemoryProviderSingleton
- add 'qdrant' option in "memory/__init__.py"
- add 'qdrant-client' in requirements.txt
- add unit test and integration test in 'qdrant_memory_test.py' and 'qdrant_memory_tests.py' 

### Documentation
The implement is very clear in-code comments. I just implement all your API and test all them to work.
- def add(self, data)
- def get(self, data)
- def clear(self)
- def get_relevant(self, data, num_relevant=5)
- def get_stats(self)

### Test Plan
- Unit test in 'qdrant_memory_test.py' 
- IntegrationTest in 'qdrant_memory_tests.py' 
- Test step: Lauch a Qdrant docker instance `docker run -p "6333:6333" -p "6334:6334" qdrant/qdrant:v1.0.3`  and then just run all the related cases.
- I've also tested with the following instructions:
```
Enter up to 5 goals for your AI:  For example: Increase net worth, Grow Twitter Account, Develop and manage multiple businesses autonomously'
Enter nothing to load defaults, enter nothing when finished.
Goal 1: Visit a website which provides today's news.
Goal 2: Summarize the articles and write the results to text files
Goal 3: Terminate
Goal 4: 
Using memory of type: QdrantMemory
SUMMARIZE TODAY'S LEADING NEWS THOUGHTS:  I need to determine which news website to visit and then summarize 
...
```

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes 
<!-- By submitting this, I agree that my pull request should be closed if I do not fill this out or follow the guide lines. -->
