### PR TITLE
Exclude DS_Store again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,3 +152,6 @@ dmypy.json
 .pyre/
 llama-*
 vicuna-*
+
+# For Macs Dev Environs: ignoring .Desktop Services_Store
+*.DS_Store


### PR DESCRIPTION
This was already approved in #1062, but was overwritten in a subsequent commit: [added-more-tools](https://github.com/Significant-Gravitas/Auto-GPT/commit/6ca6a8aa608c5253ba4b3a577cf95e3517974207)

Full PR Description:

> Added ignoring .DS_Store for mac environments.
> 
> Can save precious time for some devs using Mac systems.
> 
> ### Background
> In some cases, developers may not have configured global `.gitignore` settings for their Mac environments. This can result in the `.DS_Store` file, a hidden file created by macOS Finder, being accidentally included in their git repositories. Since this file contains metadata about the folder, it may cause unnecessary conflicts during git operations such as push, commit, and merge. This commit will ease the friction of rejected push, commit rollback, again putting changes from stashes and then again pushing.
> 
> ### Changes
> `.DS_Store` file added to `.gitignore` list
> 
> ### Documentation
> The `.DS_Store` addition is clearly documented in the commit message, explaining the change and intention.
> 
> ### Test Plan
> Tested locally. Works as intended. More testing un-necessary

