### PR TITLE
Fix for 'requires string as left operand, not PosixPath'

### DIFF
--- a/autogpt/commands/execute_code.py
+++ b/autogpt/commands/execute_code.py
@@ -100,7 +100,7 @@ def execute_shell(command_line: str) -> str:
     """
     current_dir = os.getcwd()
 
-    if WORKING_DIRECTORY not in current_dir:  # Change dir into workspace if necessary
+    if str(WORKING_DIRECTORY) not in current_dir:  # Change dir into workspace if necessary
         work_dir = os.path.join(os.getcwd(), WORKING_DIRECTORY)
         os.chdir(work_dir)
 


### PR DESCRIPTION
### Background
System: Command execute_shell returned: Error: 'in <string>' requires string as left operand, not PosixPath

### Changes
recast variable as a string

### Documentation


### Test Plan


### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->

<!-- If you haven't added tests, please explain why. If you have, check the appropriate box. If you've ensured your PR is atomic and well-documented, check the corresponding boxes. -->

<!-- By submitting this, I agree that my pull request should be closed if I do not fill this out or follow the guide lines. -->
