### PR TITLE
install chrome/firefox for headless browing when running in docker co…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,16 @@ FROM python:3.11-slim
 RUN apt-get -y update
 RUN apt-get -y install git
 
+# Install Xvfb and other dependencies for headless browser testing
+RUN apt-get update \
+    && apt-get install -y wget gnupg2 libgtk-3-0 libdbus-glib-1-2 dbus-x11 xvfb ca-certificates
+
+# Install Firefox / Chromium
+RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+    && echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list \
+    && apt-get update \
+    && apt-get install -y chromium firefox-esr
+
 # Set environment variables
 ENV PIP_NO_CACHE_DIR=yes \
     PYTHONUNBUFFERED=1 \


### PR DESCRIPTION
### Background
install chrome/firefox for headless browing when running in docker

### Changes
adds dockerfile command to install chrome and firefox for headless browser testing when running in docker environments

```
# Install Firefox / Chromium
RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
    && echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list \
    && apt-get update \
    && apt-get install -y chromium firefox-esr
```

### Documentation
might need `--privileged` flag and ` -e DISPLAY=0 `  so that container has access to display of host ie `docker run --privileged -e DISPLAY=0 ...`

### Test Plan


### PR Quality Checklist
- [ ] My pull request is atomic and focuses on a single change.

