### PR TITLE
Azure Speech Service integration in the new standard speech plugin format with env temp changes, config and readme.md update 

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -132,3 +132,18 @@ USE_BRIAN_TTS=False
 ELEVENLABS_API_KEY=your-elevenlabs-api-key
 ELEVENLABS_VOICE_1_ID=your-voice-id-1
 ELEVENLABS_VOICE_2_ID=your-voice-id-2
+
+# USE_AZURE_CS_TTS - Use Azure Cognative Services TTS, Default False
+USE_AZURE_CS_TTS=False
+# AZURE_CS_TTS_APIKEY - Azure Cog Services API key (Example: my-azure-cs-tts-apikey)
+# AZURE_CS_TTS_REGION - Azure Cog Services Region (Example: east-us)
+# AZURE_CS_TTS_VOICE_1_ID - Azure Cog Services voice 1 ID (Example: en-US-DavisNeural)
+# AZURE_CS_TTS_VOICE_1_STYLE -  Azure Cog Services voice 1 style (Example: terrified)
+# AZURE_CS_TTS_VOICE_2_ID -  Azure Cog Services voice 2 ID (Example: en-US-SaraNeural)
+# AZURE_CS_TTS_VOICE_2_STYLE -  Azure Cog Services voice 2 style (Example: Whispering)
+AZURE_CS_TTS_APIKEY=your-azure-cog-services-speech-apikey
+AZURE_CS_TTS_REGION=your-azure-cog-services-speech-region
+AZURE_CS_TTS_VOICE_1_ID=your-voice-id-1
+AZURE_CS_TTS_VOICE_1_STYLE=your-voice-1-style
+AZURE_CS_TTS_VOICE_2_ID=your-voice-id-2
+AZURE_CS_TTS_VOICE_2_STYLE=your-voice-2-style

--- a/README.md
+++ b/README.md
@@ -115,9 +115,10 @@ cd Auto-GPT
 pip install -r requirements.txt
 ```
 
-5. Rename `.env.template` to `.env` and fill in your `OPENAI_API_KEY`. If you plan to use Speech Mode, fill in your `ELEVEN_LABS_API_KEY` as well.
+5. Rename `.env.template` to `.env` and fill in your `OPENAI_API_KEY`. If you plan to use Speech Mode, fill in your `ELEVEN_LABS_API_KEY` or set `USE_AZURE_CS_TTS` to `true` to use Azure Speech Services.
   - See [OpenAI API Keys Configuration](#openai-api-keys-configuration) to obtain your OpenAI API key.
   - Obtain your ElevenLabs API key from: https://elevenlabs.io. You can view your xi-api-key using the "Profile" tab on the website.
+  - If you are using Azure Speech Services, obtain and set your API key, region and voice parameters, see [Azure Speech Services Configuration](#azure-speech-services-configuration) for details.
   - If you want to use GPT on an Azure instance, set `USE_AZURE` to `True` and then follow these steps:
     - Rename `azure.yaml.template` to `azure.yaml` and provide the relevant `azure_api_base`, `azure_api_version` and all the deployment IDs for the relevant models in the `azure_model_map` section:
       - `fast_llm_model_deployment_id` - your gpt-3.5-turbo or gpt-4 deployment ID
@@ -195,6 +196,34 @@ Use this to use TTS _(Text-to-Speech)_ for Auto-GPT
 ```bash
 python -m autogpt --speak
 ```
+
+### Azure Speech Services Configuration
+
+If you need an Azure Speech Services account, you can get one to try for free here : [Azure Speech Services](https://azure.microsoft.com/en-us/products/cognitive-services/speech-services/)
+
+  Once you have an account go to the [Azure portal](https://portal.azure.com) for your API key and region values.
+
+  To get your API and region: Go to the "Keys and Endpoint" section of your Speech Service (you don't need the endpoint url)
+
+Voices and Styles available to Auto-GPT:
+
+  You can find a list of valid values for Auto-GPT here : [Voice and Style values](https://learn.microsoft.com/en-us/azure/cognitive-services/speech-service/language-support?tabs=tts#voice-styles-and-roles)
+
+Configure Auto-GPT to use Azure Speech Services
+
+  Add/edit these entries for your env:
+
+```
+USE_AZURE_CS_TTS=True
+AZURE_CS_TTS_APIKEY=<your key here>
+AZURE_CS_TTS_REGION=<your region here>
+AZURE_CS_TTS_VOICE_1_ID=en-US-DavisNeural
+AZURE_CS_TTS_VOICE_1_STYLE=terrified
+AZURE_CS_TTS_VOICE_2_ID=en-US-SaraNeural
+AZURE_CS_TTS_VOICE_2_STYLE=Whispering
+```
+
+NOTE: If you have USE_AZURE_CS_TTS set to true it will be used over ElevenLabs and other speech providers.
 
 ## OpenAI API Keys Configuration
 

--- a/autogpt/config/config.py
+++ b/autogpt/config/config.py
@@ -51,6 +51,15 @@ class Config(metaclass=Singleton):
         self.elevenlabs_voice_1_id = os.getenv("ELEVENLABS_VOICE_1_ID")
         self.elevenlabs_voice_2_id = os.getenv("ELEVENLABS_VOICE_2_ID")
 
+        self.use_azure_cs_tts = False
+        self.use_azure_cs_tts = os.getenv("USE_AZURE_CS_TTS")
+        self.azure_cs_tts_apikey = os.getenv("AZURE_CS_TTS_APIKEY")
+        self.azure_cs_tts_region = os.getenv("AZURE_CS_TTS_REGION")
+        self.azure_cs_tts_voice_1_id = os.getenv("AZURE_CS_TTS_VOICE_1_ID")
+        self.azure_cs_tts_voice_1_style = os.getenv("AZURE_CS_TTS_VOICE_1_STYLE")
+        self.azure_cs_tts_voice_2_id = os.getenv("AZURE_CS_TTS_VOICE_2_ID")
+        self.azure_cs_tts_voice_2_style = os.getenv("AZURE_CS_TTS_VOICE_2_STYLE")
+
         self.use_mac_os_tts = False
         self.use_mac_os_tts = os.getenv("USE_MAC_OS_TTS")
 
@@ -193,6 +202,30 @@ class Config(metaclass=Singleton):
     def set_elevenlabs_voice_2_id(self, value: str) -> None:
         """Set the ElevenLabs Voice 2 ID value."""
         self.elevenlabs_voice_2_id = value
+
+    def set_azure_cs_tts_apikey(self, value: str) -> None:
+        """Set the Azure Cog Services API key value."""
+        self.azure_cs_tts_apikey = value
+
+    def set_azure_cs_tts_region(self, value: str) -> None:
+        """Set the Azure Cog Services region value."""
+        self.azure_cs_tts_region = value
+
+    def set_azure_cs_tts_voice_1_id(self, value: str) -> None:
+        """Set the Azure Cog Services Voice 1 ID value."""
+        self.azure_cs_tts_voice_1_id = value
+
+    def set_azure_cs_tts_voice_1_style(self, value: str) -> None:
+        """Set the Azure Cog Services Voice 1 Style value."""
+        self.azure_cs_tts_voice_1_style = value
+
+    def set_azure_cs_tts_voice_2_id(self, value: str) -> None:
+        """Set the Azure Cog Services Voice 2 ID value."""
+        self.azure_cs_tts_voice_2_id = value
+
+    def set_azure_cs_tts_voice_2_style(self, value: str) -> None:
+        """Set the Azure Cog Services Voice 2 Style value."""
+        self.azure_cs_tts_voice_2_style = value
 
     def set_google_api_key(self, value: str) -> None:
         """Set the Google API key value."""

--- a/autogpt/speech/azure_cog_services_speech.py
+++ b/autogpt/speech/azure_cog_services_speech.py
@@ -22,7 +22,6 @@ class AzureCogServicesSpeech(VoiceBase):
         """
         cfg = Config()
         self._region = cfg.azure_cs_tts_region
-        self._url = cfg.azure_cs_tts_endpoint 
         default_voices = [ "en-US-JennyMultilingualNeural", "en-US-DavisNeural" ]
         default_style = [ "Default", "Default" ]
         self._headers = {
@@ -73,7 +72,7 @@ class AzureCogServicesSpeech(VoiceBase):
 
         if result.reason == speechsdk.ResultReason.SynthesizingAudioCompleted:
             audio_data = result.audio_data
-            with open("speech.mp3", "wb") as f:
+            with open("speech.mpeg", "wb") as f:
                 f.write(audio_data)
             playsound("speech.mpeg", True)
             os.remove("speech.mpeg")

--- a/autogpt/speech/azure_cog_services_speech.py
+++ b/autogpt/speech/azure_cog_services_speech.py
@@ -1,0 +1,83 @@
+"""Azure Cog Services speech module"""
+import os
+import requests
+
+from playsound import playsound
+import azure.cognitiveservices.speech as speechsdk
+
+from autogpt.config import Config
+from autogpt.speech.base import VoiceBase
+
+VOICE_PLACEHOLDERS = { "your-voice-id-1","your-voice-id-2" }
+VOICE_STYLE_PLACEHOLDERS = { "your-voice-1-style", "your-voice-2-style" }
+
+class AzureCogServicesSpeech(VoiceBase):
+    """Azure Cog Services speech class"""
+
+    def _setup(self) -> None:
+        """Setup the voices, API key, etc.
+
+        Returns:
+            None: None
+        """
+        cfg = Config()
+        self._region = cfg.azure_cs_tts_region
+        self._url = cfg.azure_cs_tts_endpoint 
+        default_voices = [ "en-US-JennyMultilingualNeural", "en-US-DavisNeural" ]
+        default_style = [ "Default", "Default" ]
+        self._headers = {
+            "Ocp-Apim-Subscription-Key": cfg.azure_cs_tts_apikey,
+            "Content-Type": "application/ssml+xml",
+            "X-Microsoft-OutputFormat": "audio-24khz-48kbitrate-mono-mp3",
+        }
+        self._voices = default_voices.copy()
+        self._voicesStyle = default_style.copy()
+        self._use_custom_voice(cfg.azure_cs_tts_voice_1_id, cfg.azure_cs_tts_voice_1_style, 0)
+        self._use_custom_voice(cfg.azure_cs_tts_voice_2_id, cfg.azure_cs_tts_voice_2_style, 1)
+
+    def _use_custom_voice(self, voice, style, voice_index) -> None:
+        """Use a custom voice if provided and not a placeholder
+
+        Args:
+            voice (str): The voice ID
+            voice_index (int): The voice index
+
+        Returns:
+            None: None
+        """
+        # Placeholder values that should be treated as empty
+        if voice and voice not in VOICE_PLACEHOLDERS:
+            self._voices[voice_index] = voice
+
+        if style and style not in VOICE_STYLE_PLACEHOLDERS:
+            self._voicesStyle[voice_index] = style
+
+    def _speech(self, text: str, voice_index: int = 0) -> bool:
+        """Speak text using Azure Cog Services
+
+        Args:
+            text (str): The text to speak
+            voice_index (int, optional): The voice to use. Defaults to 0.
+
+        Returns:
+            bool: True if the request was successful, False otherwise
+        """
+        speech_config = speechsdk.SpeechConfig(subscription=self._headers["Ocp-Apim-Subscription-Key"], region=self._region)
+        speech_config.set_speech_synthesis_output_format(speechsdk.SpeechSynthesisOutputFormat["Audio24Khz48KBitRateMonoMp3"])
+
+        speech_config.speech_synthesis_voice_name = self._voices[voice_index]
+        ssml_text = "<speak version='1.0' xmlns='http://www.w3.org/2001/10/synthesis' xml:lang='en-US'><voice name='" + self._voices[voice_index] + "' style='" + self._voicesStyle[voice_index] + "'>" + text + "</voice></speak>"
+
+        synthesizer = speechsdk.SpeechSynthesizer(speech_config=speech_config)
+        result = synthesizer.speak_ssml_async(ssml_text).get()
+
+        if result.reason == speechsdk.ResultReason.SynthesizingAudioCompleted:
+            audio_data = result.audio_data
+            with open("speech.mp3", "wb") as f:
+                f.write(audio_data)
+            playsound("speech.mpeg", True)
+            os.remove("speech.mpeg")
+            return True
+        else:
+            print("Speech synthesis failed: {}".format(result.reason))
+            return False

--- a/autogpt/speech/say.py
+++ b/autogpt/speech/say.py
@@ -7,12 +7,15 @@ from autogpt.speech.brian import BrianSpeech
 from autogpt.speech.macos_tts import MacOSTTS
 from autogpt.speech.gtts import GTTSVoice
 from autogpt.speech.eleven_labs import ElevenLabsSpeech
+from autogpt.speech.azure_cog_services_speech import AzureCogServicesSpeech
 
 
 CFG = Config()
 DEFAULT_VOICE_ENGINE = GTTSVoice()
 VOICE_ENGINE = None
-if CFG.elevenlabs_api_key:
+if CFG.azure_cs_tts_apikey and CFG.use_azure_cs_tts:
+    VOICE_ENGINE = AzureCogServicesSpeech()
+elif CFG.elevenlabs_api_key:
     VOICE_ENGINE = ElevenLabsSpeech()
 elif CFG.use_mac_os_tts == "True":
     VOICE_ENGINE = MacOSTTS()

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ docker
 duckduckgo-search
 google-api-python-client #(https://developers.google.com/custom-search/v1/overview)
 pinecone-client==2.2.1
+azure-cognitiveservices-speech==1.27.0
 redis
 orjson
 Pillow


### PR DESCRIPTION
### Background
I have integrated Azure Speech Services as an alternative speech provider, including support for dozens of voices and dozens of different voice styles, such as terrified, cheerful etc.

This is a great as an alternative to elevenlab if you run out of free tokens, as you can also sign up and get free credits and it seems to be super cheap after that. It also has some really fun voices.

### Changes

Added - speech/azure_cog_services_speech.py - this is the speech provider, it uses the official python speech sdk for azure, uses the pattern you established in one of the recent updates.

Modified - speech/say.py - updated to check the config and if azure speech is enabled and there is an api key present then it will use it as the first choice, other wise it follows the previous logic.

Modified - config/config.py - added the config variables and getters for the speech provider.

Modified - .env.example - to include the required env vars for the config

Modified - requirements.txt - to add azure-cognitiveservices-speech==1.27.0

Modified - README.md - to include instructions to use it as an alternative speech provider, including setup, config and information of voices and styles supported.

### Documentation
README.md

### Test Plan
I did not produce any unit tests, I tested it on a clean branch from a fresh installation.

### PR Quality Checklist
- [Check] My pull request is atomic and focuses on a single change.
- [Check] I have thoroughly tested my changes with multiple different prompts.
- [Check] I have considered potential risks and mitigations for my changes.
- [Check] I have documented my changes clearly and comprehensively.
- [Check] I have not snuck in any "extra" small tweaks changes
