### PR TITLE
Typo in prompt start - missing space resulted in joined words in the prompt

### DIFF
--- a/autogpt/config/ai_config.py
+++ b/autogpt/config/ai_config.py
@@ -100,7 +100,7 @@ class AIConfig:
 
         prompt_start = (
             "Your decisions must always be made independently without"
-            "seeking user assistance. Play to your strengths as an LLM and pursue"
+            " seeking user assistance. Play to your strengths as an LLM and pursue"
             " simple strategies with no legal complications."
             ""
         )

--- a/autogpt/logs.py
+++ b/autogpt/logs.py
@@ -272,6 +272,10 @@ def print_assistant_thoughts(ai_name, assistant_reply):
         # Speak the assistant's thoughts
         if CFG.speak_mode and assistant_thoughts_speak:
             say_text(assistant_thoughts_speak)
+        else:
+            logger.typewriter_log(
+                "SPEAK:", Fore.YELLOW, f"{assistant_thoughts_speak}"
+            )
 
         return assistant_reply_json
     except json.decoder.JSONDecodeError:


### PR DESCRIPTION
I noticed the prompt had two joined words, so I fixed it by adding a space

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [ ] I have thoroughly tested my changes with multiple different prompts.
- [ ] I have considered potential risks and mitigations for my changes.
- [ ] I have documented my changes clearly and comprehensively.
- [ ] I have not snuck in any "extra" small tweaks changes <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->
