### PR TITLE
Fix  update bracket_termination.py with f string

### DIFF
--- a/autogpt/json_fixes/bracket_termination.py
+++ b/autogpt/json_fixes/bracket_termination.py
@@ -37,7 +37,7 @@ def attempt_to_fix_json_by_finding_outermost_brackets(json_string: str):
 
     except (json.JSONDecodeError, ValueError):
         if CFG.debug_mode:
-            logger.error("Error: Invalid JSON: %s\n", json_string)
+            logger.error(f"Error: Invalid JSON: {json_string}\n")
         if CFG.speak_mode:
             say_text("Didn't work. I will have to ignore this response then.")
         logger.error("Error: Invalid JSON, setting it to empty JSON now.\n")


### PR DESCRIPTION
### Background
the logger statement is using '%' which does not convert to a variable

### Changes
replace 
logger.error("Error: Invalid JSON: %s\n", json_string)
with
logger.error(f"Error: Invalid JSON: {json_string}")

### Documentation


### Test Plan


### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->

<!-- If you haven't added tests, please explain why. If you have, check the appropriate box. If you've ensured your PR is atomic and well-documented, check the corresponding boxes. -->

<!-- By submitting this, I agree that my pull request should be closed if I do not fill this out or follow the guide lines. -->
