### PR TITLE
Remove two unused app commands

### DIFF
--- a/autogpt/app.py
+++ b/autogpt/app.py
@@ -169,6 +169,12 @@ def get_hyperlinks(url: str) -> Union[str, List[str]]:
     return scrape_links(url)
 
 
+def shutdown() -> NoReturn:
+    """Shut down the program"""
+    print("Shutting down...")
+    quit()
+
+
 @command(
     "start_agent",
     "Start GPT Agent",


### PR DESCRIPTION
<!-- 📢 Announcement
We've recently noticed an increase in pull requests focusing on combining multiple changes. While the intentions behind these PRs are appreciated, it's essential to maintain a clean and manageable git history. To ensure the quality of our repository, we kindly ask you to adhere to the following guidelines when submitting PRs:

Focus on a single, specific change.
Do not include any unrelated or "extra" modifications.
Provide clear documentation and explanations of the changes made.
Ensure diffs are limited to the intended lines — no applying preferred formatting styles or line endings (unless that's what the PR is about).
For guidance on committing only the specific lines you have changed, refer to this helpful video: https://youtu.be/8-hSNHHbiZg

By following these guidelines, your PRs are more likely to be merged quickly after testing, as long as they align with the project's overall direction. -->

### Background
The `get_text_summary` and `get_hyperlinks` are never being used by the Agent.

### Changes
Remove these. two methods to improve code quality and avoid extra code.

### Documentation
Just remove unused methods

### Test Plan
`python3.10 -m unittest discover tests`
`coverage run -m unittest discover tests`

### PR Quality Checklist
- [x ] My pull request is atomic and focuses on a single change.
- [x ] I have thoroughly tested my changes with multiple different prompts.
- [x ] I have considered potential risks and mitigations for my changes.
- [x ] I have documented my changes clearly and comprehensively.
- [x ] I have not snuck in any "extra" small tweaks changes <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->

<!-- If you haven't added tests, please explain why. If you have, check the appropriate box. If you've ensured your PR is atomic and well-documented, check the corresponding boxes. -->

<!-- By submitting this, I agree that my pull request should be closed if I do not fill this out or follow the guide lines. -->
