### PR TITLE
Only add audio to text command to the prompt if model is set

### DIFF
--- a/autogpt/prompt.py
+++ b/autogpt/prompt.py
@@ -82,9 +82,18 @@ def get_prompt() -> str:
         ),
         ("Execute Python File", "execute_python_file", {"file": "<file>"}),
         ("Generate Image", "generate_image", {"prompt": "<prompt>"}),
-        ("Convert Audio to text", "read_audio_from_file", {"file": "<file>"}),
         ("Send Tweet", "send_tweet", {"text": "<text>"}),
     ]
+
+    # Only add the audio to text command if the model is specified
+    if cfg.huggingface_audio_to_text_model:
+        commands.append(
+            (
+                "Convert Audio to text",
+                "read_audio_from_file",
+                {"file": "<file>"}
+            ),
+        )
 
     # Only add shell command to the prompt if the AI is allowed to execute it
     if cfg.execute_local_commands:


### PR DESCRIPTION
### Background
I think we should only append commands to the prompt which AutoGPT can execute since all configuration parameter is set. 

### Changes
For example in this change the `Audio to text` command will be only appended to the prompt when the huggingface model is specified. 

### Documentation
Commented in the code

### Test Plan

Should work, but I was unable to test.

### PR Quality Checklist
- [X] My pull request is atomic and focuses on a single change.
- [ ] I have thoroughly tested my changes with multiple different prompts.
- [X] I have considered potential risks and mitigations for my changes.
- [X] I have documented my changes clearly and comprehensively.
- [X] I have not snuck in any "extra" small tweaks changes <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->

<!-- If you haven't added tests, please explain why. If you have, check the appropriate box. If you've ensured your PR is atomic and well-documented, check the corresponding boxes. -->

<!-- By submitting this, I agree that my pull request should be closed if I do not fill this out or follow the guide lines. -->
