### PR TITLE
fixes Weaviate index name to classname conversion

### DIFF
--- a/autogpt/memory/weaviate.py
+++ b/autogpt/memory/weaviate.py
@@ -37,8 +37,17 @@ class WeaviateMemory(MemoryProviderSingleton):
         else:
             self.client = Client(url, auth_client_secret=auth_credentials)
 
-        self.index = cfg.memory_index
+        self.index = WeaviateMemory.format_classname(cfg.memory_index)
         self._create_schema()
+
+    @staticmethod
+    def format_classname(index):
+        # weaviate uses capitalised index names
+        # The python client uses the following code to format
+        # index names before the corresponding class is created
+        if len(index) == 1:
+            return index.capitalize()
+        return index[0].capitalize() + index[1:]
 
     def _create_schema(self):
         schema = default_schema(self.index)


### PR DESCRIPTION
### Background
It fixes an issue in the Weaviate integration whereby if a lowercase index name is specified in the MEMORY_INDEX environment variable it will raise a key error when processing Weaviate results

### Changes
Added static function that replicates the converrsion from index name to classname that the Weaviate python client uses.

### Documentation
A note about the conversion is made in code comment form for the `format_classname` static method.

### Test Plan
The current tests have been updated to reflect the conversion from indexname to classname.

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->
