### PR TITLE
Gracefully handle non-image response content from HuggingFace

### DIFF
--- a/autogpt/commands/image_gen.py
+++ b/autogpt/commands/image_gen.py
@@ -62,7 +62,10 @@ def generate_image_with_hf(prompt: str, filename: str) -> str:
         },
     )
 
-    image = Image.open(io.BytesIO(response.content))
+    try:
+        image = Image.open(io.BytesIO(response.content))
+    except IOError as e:
+        raise ValueError("Cannot identify image file")
     print(f"Image Generated for prompt:{prompt}")
 
     image.save(os.path.join(WORKING_DIRECTORY, filename))


### PR DESCRIPTION
Fixes #513


### Background
<!-- Provide a concise overview of the rationale behind this change. Include relevant context, prior discussions, or links to related issues. Ensure that the change aligns with the project's overall direction. -->

See issue #513 

### Changes
<!-- Describe the specific, focused change made in this pull request. Detail the modifications clearly and avoid any unrelated or "extra" changes. -->

Wrapped the `Image.open()` in try/except catch.

### Documentation
<!-- Explain how your changes are documented, such as in-code comments or external documentation. Ensure that the documentation is clear, concise, and easy to understand. -->

Raises an error if it cannot open a content that isn't an image.

### Test Plan
<!-- Describe how you tested this functionality. Include steps to reproduce, relevant test cases, and any other pertinent information. -->

None. 

### PR Quality Checklist
- [X] My pull request is atomic and focuses on a single change.
- [ ] I have thoroughly tested my changes with multiple different prompts.
- [X] I have considered potential risks and mitigations for my changes.
- [X] I have documented my changes clearly and comprehensively.
- [X] I have not snuck in any "extra" small tweaks changes <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->

<!-- If you haven't added tests, please explain why. If you have, check the appropriate box. If you've ensured your PR is atomic and well-documented, check the corresponding boxes. -->
Just a tiny try/except catch block to ensure that the `response.content` is indeed an image or not.
<!-- By submitting this, I agree that my pull request should be closed if I do not fill this out or follow the guide lines. -->
