### PR TITLE
Fix file logging infinite loop issue

### DIFF
--- a/autogpt/commands/file_operations.py
+++ b/autogpt/commands/file_operations.py
@@ -45,7 +45,7 @@ def log_operation(operation: str, filename: str) -> None:
         with open(LOG_FILE_PATH, "w", encoding="utf-8") as f:
             f.write("File Operation Logger ")
 
-    append_to_file(LOG_FILE, log_entry)
+    append_to_file(LOG_FILE, log_entry, shouldLog = False)
 
 
 def safe_join(base: str, *paths) -> str:
@@ -171,7 +171,7 @@ def write_to_file(filename: str, text: str) -> str:
         return f"Error: {str(e)}"
 
 
-def append_to_file(filename: str, text: str) -> str:
+def append_to_file(filename: str, text: str, shouldLog: bool = True) -> str:
     """Append text to a file
 
     Args:
@@ -185,7 +185,10 @@ def append_to_file(filename: str, text: str) -> str:
         filepath = safe_join(WORKING_DIRECTORY, filename)
         with open(filepath, "a") as f:
             f.write(text)
-        log_operation("append", filename)
+        
+        if shouldLog:
+            log_operation("append", filename)
+
         return "Text appended successfully."
     except Exception as e:
         return f"Error: {str(e)}"

--- a/autogpt/commands/file_operations.py
+++ b/autogpt/commands/file_operations.py
@@ -185,7 +185,7 @@ def append_to_file(filename: str, text: str, shouldLog: bool = True) -> str:
         filepath = safe_join(WORKING_DIRECTORY, filename)
         with open(filepath, "a") as f:
             f.write(text)
-        
+
         if shouldLog:
             log_operation("append", filename)
 


### PR DESCRIPTION
### Background
There is a new file logging capability that logs every file operation to file_logger.txt. However, the append operation creates another log line, which creates another append operation, etc.

### Changes
Added a bool which controls whether the append operation should log.

### Documentation
Trivial

### Test Plan
Ran unit tests and verified the file operations from autogpt no longer produce this:
![image](https://user-images.githubusercontent.com/22483488/232320370-c856f0d1-8b96-4de9-ba49-7135ed0a1d63.png)


### PR Quality Checklist
- [x ] My pull request is atomic and focuses on a single change.
- [ x] I have thoroughly tested my changes with multiple different prompts.
- [x ] I have considered potential risks and mitigations for my changes.
- [n/a ] I have documented my changes clearly and comprehensively.
- [ x] I have not snuck in any "extra" small tweaks changes <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->

<!-- If you haven't added tests, please explain why. If you have, check the appropriate box. If you've ensured your PR is atomic and well-documented, check the corresponding boxes. -->

<!-- By submitting this, I agree that my pull request should be closed if I do not fill this out or follow the guide lines. -->
