### PR TITLE
fix #1363

### DIFF
--- a/autogpt/commands/execute_code.py
+++ b/autogpt/commands/execute_code.py
@@ -6,7 +6,7 @@ import subprocess
 import docker
 from docker.errors import ImageNotFound
 
-WORKING_DIRECTORY = Path(__file__).parent.parent / "auto_gpt_workspace"
+WORKING_DIRECTORY = Path(__file__).parent.parent.parent / "auto_gpt_workspace"
 
 
 def execute_python_file(file: str):

--- a/autogpt/commands/image_gen.py
+++ b/autogpt/commands/image_gen.py
@@ -12,7 +12,7 @@ from autogpt.config import Config
 
 CFG = Config()
 
-WORKING_DIRECTORY = Path(__file__).parent.parent / "auto_gpt_workspace"
+WORKING_DIRECTORY = Path(__file__).parent.parent.parent / "auto_gpt_workspace"
 
 
 def generate_image(prompt: str) -> str:


### PR DESCRIPTION
### Background
Investigate the missing python executable error reported in #1363,#1896, etc.

### Changes.
Correct file path specification.

### Test Plan
We have verified that it runs correctly after the modification. Here is the prompt I used

- Create a python script that outputs "Hello world"
- Save and run the script file.
- Save the script file and run it.

