### PR TITLE
Fix naive json names find/replace

### DIFF
--- a/autogpt/json_fixes/missing_quotes.py
+++ b/autogpt/json_fixes/missing_quotes.py
@@ -17,7 +17,8 @@ def add_quotes_to_property_names(json_string: str) -> str:
     def replace_func(match: re.Match) -> str:
         return f'"{match[1]}":'
 
-    property_name_pattern = re.compile(r"(\w+):")
+    # (?=(?:(?:[^"]*"){2})*[^"]*$) is a positive lookahead that ensures that the word is not enclosed by double quotes.
+    property_name_pattern = re.compile(r"(?=(?:(?:[^\"]*\"){2})*[^\"]*$)(\b\w+\b)")
     corrected_json_string = property_name_pattern.sub(replace_func, json_string)
 
     try:


### PR DESCRIPTION
### Background
The existing function to add quotes to the property name has an issue, It contains a simple regex that matches to content already inside quotes. The existing function would change the property value  "http://link.to" to ""http":link.to"

I have updated the regex to avoid matching to content enclosed by quotes.