### PR TITLE
add utf-8 encoding to file handlers for logging

### DIFF
--- a/autogpt/logs.py
+++ b/autogpt/logs.py
@@ -46,7 +46,9 @@ class Logger(metaclass=Singleton):
         self.console_handler.setFormatter(console_formatter)
 
         # Info handler in activity.log
-        self.file_handler = logging.FileHandler(os.path.join(log_dir, log_file))
+        self.file_handler = logging.FileHandler(
+            os.path.join(log_dir, log_file), 'a', 'utf-8'
+        )
         self.file_handler.setLevel(logging.DEBUG)
         info_formatter = AutoGptFormatter(
             "%(asctime)s %(levelname)s %(title)s %(message_no_color)s"
@@ -54,7 +56,9 @@ class Logger(metaclass=Singleton):
         self.file_handler.setFormatter(info_formatter)
 
         # Error handler error.log
-        error_handler = logging.FileHandler(os.path.join(log_dir, error_file))
+        error_handler = logging.FileHandler(
+            os.path.join(log_dir, error_file), 'a', 'utf-8'
+        )
         error_handler.setLevel(logging.ERROR)
         error_formatter = AutoGptFormatter(
             "%(asctime)s %(levelname)s %(module)s:%(funcName)s:%(lineno)d %(title)s"


### PR DESCRIPTION
### Background
Using characters (like “→”) not in cp1252 causes logger to throw error:

`UnicodeEncodeError: 'charmap' codec can't encode character '\u2192' in position 48: character maps to <undefined>`

![image](https://user-images.githubusercontent.com/64261260/232323624-c3af15ea-a00e-44af-a816-0c54f720b017.png)


### Changes
Added 'utf-8' parameter to Logger's FileHandlers.

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->

<!-- If you haven't added tests, please explain why. If you have, check the appropriate box. If you've ensured your PR is atomic and well-documented, check the corresponding boxes. -->

<!-- By submitting this, I agree that my pull request should be closed if I do not fill this out or follow the guide lines. -->
