### PR TITLE
Improve dev containers so autogpt can browse the web

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 # [Choice] Python version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.10, 3.9, 3.8, 3.7, 3.6, 3-bullseye, 3.10-bullseye, 3.9-bullseye, 3.8-bullseye, 3.7-bullseye, 3.6-bullseye, 3-buster, 3.10-buster, 3.9-buster, 3.8-buster, 3.7-buster, 3.6-buster
 ARG VARIANT=3-bullseye
-FROM python:3.8
+FROM --platform=linux/amd64 python:3.8
 
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     # Remove imagemagick due to https://security-tracker.debian.org/tracker/CVE-2019-10131
@@ -9,6 +9,11 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 # Temporary: Upgrade python packages due to https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-40897
 # They are installed by the base image (python) which does not have the patch.
 RUN python3 -m pip install --upgrade setuptools
+
+# Install Chrome for web browsing
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && curl -sSL https://dl.google.com/linux/direct/google-chrome-stable_current_$(dpkg --print-architecture).deb -o /tmp/chrome.deb \
+    && apt-get -y install /tmp/chrome.deb
 
 # [Optional] If your pip requirements rarely change, uncomment this section to add them to the image.
 # COPY requirements.txt /tmp/pip-tmp/

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,6 +11,7 @@
       "userGid": "1000",
       "upgradePackages": "true"
     },
+    "ghcr.io/devcontainers/features/desktop-lite:1": {},
     "ghcr.io/devcontainers/features/python:1": "none",
     "ghcr.io/devcontainers/features/node:1": "none",
     "ghcr.io/devcontainers/features/git:1": {

--- a/autogpt/commands/web_selenium.py
+++ b/autogpt/commands/web_selenium.py
@@ -74,6 +74,7 @@ def scrape_text_with_selenium(url: str) -> Tuple[WebDriver, str]:
         # See https://developer.apple.com/documentation/webkit/testing_with_webdriver_in_safari
         driver = webdriver.Safari(options=options)
     else:
+        options.add_argument("--no-sandbox")
         driver = webdriver.Chrome(
             executable_path=ChromeDriverManager().install(), options=options
         )


### PR DESCRIPTION
### Background
Currently dev containers do not contain everything necessary to run AutoGPT, and between different environments installing these dependencies can be quite a mess.

This diff aims to give the containers everything necessary to just follow the readme and get going with auto-gpt in dev containers

### Changes
- Update dockerfile to pull from know environment, the expectation is on apple silicon people will use rosetta to run this container, this change allows us to install chrome, sourcery and other standard things without much finangling
- Install Chrome, necessary to browse
- add options.add_argument("--no-sandbox") to Chrome startup so it can run in dev containers, this does have bad security implications https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/design/sandbox.md, and we might be able to get around it in another way (changing user starting chrome from root -> userspace, moving from debian(?))

### Documentation
All specific things added are self documented, I could add a comment above the chrome install line if we wanted to outline, but seems readable as is

### Test Plan
Reload and rebuild dev container

Run autogpt with goals of [Navigate to https://en.wikipedia.org/wiki/John_Wick:_Chapter_4', 'summarize page', 'output to file'] and role of "an AI designed to summarize webpages"

Observe glory

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes

Currently no tests exists for dev containers, I only learnt about these today when pulling down autogpt but might be wortwhile investing in