### PR TITLE
Consolidate and fix workspace resolution

### DIFF
--- a/autogpt/commands/audio_text.py
+++ b/autogpt/commands/audio_text.py
@@ -2,15 +2,13 @@ import requests
 import json
 
 from autogpt.config import Config
-from autogpt.commands.file_operations import safe_join
+from autogpt.workspace import path_in_workspace
 
 cfg = Config()
 
-working_directory = "auto_gpt_workspace"
-
 
 def read_audio_from_file(audio_path):
-    audio_path = safe_join(working_directory, audio_path)
+    audio_path = path_in_workspace(audio_path)
     with open(audio_path, "rb") as audio_file:
         audio = audio_file.read()
     return read_audio(audio)

--- a/autogpt/commands/execute_code.py
+++ b/autogpt/commands/execute_code.py
@@ -1,12 +1,11 @@
 """Execute code in a Docker container"""
 import os
-from pathlib import Path
 import subprocess
 
 import docker
 from docker.errors import ImageNotFound
 
-WORKING_DIRECTORY = Path(__file__).parent.parent / "auto_gpt_workspace"
+from autogpt.workspace import path_in_workspace, WORKSPACE_PATH
 
 
 def execute_python_file(file: str):
@@ -19,12 +18,12 @@ def execute_python_file(file: str):
         str: The output of the file
     """
 
-    print(f"Executing file '{file}' in workspace '{WORKING_DIRECTORY}'")
+    print(f"Executing file '{file}' in workspace '{WORKSPACE_PATH}'")
 
     if not file.endswith(".py"):
         return "Error: Invalid file type. Only .py files are allowed."
 
-    file_path = os.path.join(WORKING_DIRECTORY, file)
+    file_path = path_in_workspace(file)
 
     if not os.path.isfile(file_path):
         return f"Error: File '{file}' does not exist."
@@ -65,7 +64,7 @@ def execute_python_file(file: str):
             image_name,
             f"python {file}",
             volumes={
-                os.path.abspath(WORKING_DIRECTORY): {
+                os.path.abspath(WORKSPACE_PATH): {
                     "bind": "/workspace",
                     "mode": "ro",
                 }
@@ -100,9 +99,8 @@ def execute_shell(command_line: str) -> str:
     """
     current_dir = os.getcwd()
     # Change dir into workspace if necessary
-    if str(WORKING_DIRECTORY) not in current_dir:
-        work_dir = os.path.join(os.getcwd(), WORKING_DIRECTORY)
-        os.chdir(work_dir)
+    if str(WORKSPACE_PATH) not in current_dir:
+        os.chdir(WORKSPACE_PATH)
 
     print(f"Executing command '{command_line}' in working directory '{os.getcwd()}'")
 

--- a/autogpt/commands/image_gen.py
+++ b/autogpt/commands/image_gen.py
@@ -7,12 +7,10 @@ from base64 import b64decode
 import openai
 import requests
 from PIL import Image
-from pathlib import Path
 from autogpt.config import Config
+from autogpt.workspace import path_in_workspace
 
 CFG = Config()
-
-WORKING_DIRECTORY = Path(__file__).parent.parent / "auto_gpt_workspace"
 
 
 def generate_image(prompt: str) -> str:
@@ -65,7 +63,7 @@ def generate_image_with_hf(prompt: str, filename: str) -> str:
     image = Image.open(io.BytesIO(response.content))
     print(f"Image Generated for prompt:{prompt}")
 
-    image.save(os.path.join(WORKING_DIRECTORY, filename))
+    image.save(path_in_workspace(filename))
 
     return f"Saved to disk:{filename}"
 
@@ -93,7 +91,7 @@ def generate_image_with_dalle(prompt: str, filename: str) -> str:
 
     image_data = b64decode(response["data"][0]["b64_json"])
 
-    with open(f"{WORKING_DIRECTORY}/{filename}", mode="wb") as png:
+    with open(path_in_workspace(filename), mode="wb") as png:
         png.write(image_data)
 
     return f"Saved to disk:{filename}"

--- a/autogpt/workspace.py
+++ b/autogpt/workspace.py
@@ -1,0 +1,39 @@
+import os
+from pathlib import Path
+
+# Set a dedicated folder for file I/O
+WORKSPACE_PATH = Path(os.getcwd()) / "auto_gpt_workspace"
+
+# Create the directory if it doesn't exist
+if not os.path.exists(WORKSPACE_PATH):
+    os.makedirs(WORKSPACE_PATH)
+
+
+def path_in_workspace(relative_path: str | Path) -> Path:
+    """Get full path for item in workspace
+
+    Parameters:
+        relative_path (str | Path): Path to translate into the workspace
+
+    Returns:
+        Path: Absolute path for the given path in the workspace
+    """
+    return safe_path_join(WORKSPACE_PATH, relative_path)
+
+
+def safe_path_join(base: Path, *paths: str | Path) -> Path:
+    """Join one or more path components, asserting the resulting path is within the workspace.
+
+    Args:
+        base (Path): The base path
+        *paths (str): The paths to join to the base path
+
+    Returns:
+        Path: The joined path
+    """
+    joined_path = base.joinpath(*paths).resolve()
+
+    if not joined_path.is_relative_to(base):
+        raise ValueError(f"Attempted to access path '{joined_path}' outside of working directory '{base}'.")
+
+    return joined_path


### PR DESCRIPTION
### Background
Currently, four commands use three different ways to resolve the workspace path and all implement it themselves. Also, workspace path resolution is broken for `execute_shell`.

PR #1903 also fixes the immediate failure of `execute_code.py` and `image_gen.py`, but does not address the unordered approach in other files.

### Changes
* Consolidated workspace resolution functionality in `autogpt/workspace.py`

### Documentation
No changes for users, so no docs needed.

### Test Plan
Tested by letting Auto-GPT read a file in the workspace, both directly and using `cat`.

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->

<!-- If you haven't added tests, please explain why. If you have, check the appropriate box. If you've ensured your PR is atomic and well-documented, check the corresponding boxes. -->

<!-- By submitting this, I agree that my pull request should be closed if I do not fill this out or follow the guide lines. -->
