### PR TITLE
Fix: Align docker with default run user and readme

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,17 +11,17 @@ ENV PIP_NO_CACHE_DIR=yes \
     PYTHONDONTWRITEBYTECODE=1
 
 # Create a non-root user and set permissions
-RUN useradd --create-home appuser
-WORKDIR /home/appuser
-RUN chown appuser:appuser /home/appuser
-USER appuser
+RUN useradd --create-home user
+WORKDIR /home/user
+RUN chown user:user /home/appuser
+USER user
 
 # Copy the requirements.txt file and install the requirements
-COPY --chown=appuser:appuser requirements-docker.txt .
+COPY --chown=user:user requirements-docker.txt .
 RUN pip install --no-cache-dir --user -r requirements-docker.txt
 
 # Copy the application files
-COPY --chown=appuser:appuser autogpt/ ./autogpt
+COPY --chown=user:user autogpt/ ./autogpt
 
 # Set the entrypoint
 ENTRYPOINT ["python", "-m", "autogpt"]

--- a/README.md
+++ b/README.md
@@ -177,12 +177,12 @@ You can also build this into a docker image and run it:
 
 ```
 docker build -t autogpt .
-docker run -it --env-file=./.env -v $PWD/auto_gpt_workspace:/app/auto_gpt_workspace autogpt
+docker run -it --env-file=./.env -v $PWD/auto_gpt_workspace:/home/user/auto_gpt_workspace autogpt
 ```
 
 You can pass extra arguments, for instance, running with `--gpt3only` and `--continuous` mode:
 ```
-docker run -it --env-file=./.env -v $PWD/auto_gpt_workspace:/app/auto_gpt_workspace autogpt --gpt3only --continuous
+docker run -it --env-file=./.env -v $PWD/auto_gpt_workspace:/home/user/auto_gpt_workspace autogpt --gpt3only --continuous
 ```
 ### Command Line Arguments
 Here are some common arguments you can use when running Auto-GPT:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,9 @@ services:
     env_file:
       - .env
     volumes:
-      - "./autogpt:/app"
-      - ".env:/app/.env"
+      - "./autogpt:/home/user/autogpt"
+      - ".env:/home/user/autogpt/.env"
+      - "./auto_gpt_workspace:/home/user/auto_gpt_workspace"
     profiles: ["exclude-from-up"]
 
   redis:


### PR DESCRIPTION
### Background
currently
when using docker run failing due to path issues
example:
git clone will clone to /home/user instead  /home/appuser


### Changes
change dockerfile appuser to user
update working path based off docker file

### Documentation
change dockerfile appuser to user
update docker-compose and readme to align with previous dockerfile changes

### Test Plan
run via docker run using git prompt

### PR Quality Checklist
- [ ] My pull request is atomic and focuses on a single change.
- [ ] I have thoroughly tested my changes with multiple different prompts.
- [ ] I have considered potential risks and mitigations for my changes.
- [ ] I have documented my changes clearly and comprehensively.
- [ ] I have not snuck in any "extra" small tweaks changes <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->

