### PR TITLE
Improve the error logging for OAI Issues

### DIFF
--- a/autogpt/llm_utils.py
+++ b/autogpt/llm_utils.py
@@ -5,9 +5,10 @@ import time
 
 import openai
 from openai.error import APIError, RateLimitError
-from colorama import Fore
+from colorama import Fore, Style
 
 from autogpt.config import Config
+from autogpt.logs import logger
 
 CFG = Config()
 
@@ -70,6 +71,7 @@ def create_chat_completion(
     """
     response = None
     num_retries = 10
+    warned_user = False
     if CFG.debug_mode:
         print(
             Fore.GREEN
@@ -101,6 +103,11 @@ def create_chat_completion(
                     Fore.RED + "Error: ",
                     f"Reached rate limit, passing..." + Fore.RESET,
                 )
+            if not warned_user:
+                logger.double_check(
+                    f"Please double check that you have setup a {Fore.CYAN + Style.BRIGHT}PAID{Style.RESET_ALL} OpenAI API Account. " +
+                    f"You can read more here: {Fore.CYAN}https://github.com/Significant-Gravitas/Auto-GPT#openai-api-keys-configuration{Fore.RESET}")
+                warned_user = True
         except APIError as e:
             if e.http_status == 502:
                 pass
@@ -115,7 +122,17 @@ def create_chat_completion(
             )
         time.sleep(backoff)
     if response is None:
-        raise RuntimeError(f"Failed to get response after {num_retries} retries")
+        logger.typewriter_log(
+            "FAILED TO GET RESPONSE FROM OPENAI", 
+            Fore.RED,
+            "Auto-GPT has failed to get a response from OpenAI's services. " +
+            f"Try running Auto-GPT again, and if the problem the persists try running it with `{Fore.CYAN}--debug{Fore.RESET}`."
+        )
+        logger.double_check()
+        if CFG.debug_mode:
+            raise RuntimeError(f"Failed to get response after {num_retries} retries")
+        else:
+            quit(1)
 
     return response.choices[0].message["content"]
 

--- a/autogpt/llm_utils.py
+++ b/autogpt/llm_utils.py
@@ -123,7 +123,7 @@ def create_chat_completion(
         time.sleep(backoff)
     if response is None:
         logger.typewriter_log(
-            "FAILED TO GET RESPONSE FROM OPENAI", 
+            "FAILED TO GET RESPONSE FROM OPENAI",
             Fore.RED,
             "Auto-GPT has failed to get a response from OpenAI's services. " +
             f"Try running Auto-GPT again, and if the problem the persists try running it with `{Fore.CYAN}--debug{Fore.RESET}`."


### PR DESCRIPTION
<!-- 📢 Announcement
We've recently noticed an increase in pull requests focusing on combining multiple changes. While the intentions behind these PRs are appreciated, it's essential to maintain a clean and manageable git history. To ensure the quality of our repository, we kindly ask you to adhere to the following guidelines when submitting PRs:

Focus on a single, specific change.
Do not include any unrelated or "extra" modifications.
Provide clear documentation and explanations of the changes made.
Ensure diffs are limited to the intended lines — no applying preferred formatting styles or line endings (unless that's what the PR is about).
For guidance on committing only the specific lines you have changed, refer to this helpful video: https://youtu.be/8-hSNHHbiZg

By following these guidelines, your PRs are more likely to be merged quickly after testing, as long as they align with the project's overall direction. -->

### Background
This is a QoL update for a user facing issue that seems to be pretty common: users not setting up paid accounts and inevitably getting hit with a nasty exception vaguely telling them: "Failed to get response after x retries". This doesn't help anyone.

This PR just improves the logging for this common issue by outputting better logs and directing the user to possible causes for hitting the rate limit.

### Changes
Added better logging in `llm_utils.py` in the `create_chat_completion` function.

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->

<!-- If you haven't added tests, please explain why. If you have, check the appropriate box. If you've ensured your PR is atomic and well-documented, check the corresponding boxes. -->

<!-- By submitting this, I agree that my pull request should be closed if I do not fill this out or follow the guide lines. -->
