### PR TITLE
internal resource request bug

### DIFF
--- a/autogpt/commands/web_requests.py
+++ b/autogpt/commands/web_requests.py
@@ -58,9 +58,28 @@ def check_local_file_access(url: str) -> bool:
     """
     local_prefixes = [
         "file:///",
+        "file://localhost/",
         "file://localhost",
         "http://localhost",
+        "http://localhost/",
         "https://localhost",
+        "https://localhost/",
+        "http://2130706433",
+        "http://2130706433/",
+        "https://2130706433",
+        "https://2130706433/",
+        "http://127.0.0.1/",
+        "http://127.0.0.1",
+        "https://127.0.0.1/",
+        "https://127.0.0.1",
+        "https://0.0.0.0/",
+        "https://0.0.0.0",
+        "http://0.0.0.0/",
+        "http://0.0.0.0",
+        "http://0000",
+        "http://0000/",
+        "https://0000",
+        "https://0000/"
     ]
     return any(url.startswith(prefix) for prefix in local_prefixes)
 


### PR DESCRIPTION
### Background
The `web_requests.py` module attempts to identify if a document is internal or not. There are a few ways to bypass these. A common attack for access internal resources is SSRF. More information can be found here: https://github.com/swisskyrepo/PayloadsAllTheThings/blob/master/Server%20Side%20Request%20Forgery/README.md

### Changes
I added a few extra items to the list for checking to see if the program is access internal resources. The `startswith()` function only checks the first part of the string, which could disallow legitimate domains too like `http://localhost.something.com`. The biggest change was to add '127.0.0.1' as a localhost.

### Documentation
I didn't add any comments, as I can imagine this might just add clutter to the overall program itself, with everyone commenting little changes like this.

### Test Plan
I wrote a list of internal links and attempted to access them and found that they were not caught.

### PR Quality Checklist
- [X] My pull request is atomic and focuses on a single change.
- [X] I have thoroughly tested my changes with multiple different prompts.
- [X] I have considered potential risks and mitigations for my changes.
- [X] I have documented my changes clearly and comprehensively.
- [X] I have not snuck in any "extra" small tweaks changes 
