### PR TITLE
Fix: Update run_continuous.sh to correctly pass all command-line arguments

### DIFF
--- a/run_continuous.sh
+++ b/run_continuous.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-./run.sh --continuous "$@"
+./run.sh --continuous $@

--- a/run_continuous.sh
+++ b/run_continuous.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-argument="--continuous"
-./run.sh "$argument"
+
+./run.sh --continuous "$@"


### PR DESCRIPTION
### Background
This pull request aims to improve the usability of the `run_continuous.sh` script by ensuring that all command-line arguments are passed through to the `run.sh` script and the `autogpt` module. The original implementation did not properly pass additional command-line arguments, which could lead to confusion and limited flexibility for users.

### Changes
- Modified `run_continuous.sh` to include the `--continuous` flag directly in the command:
  - Removed the unused `argument` variable.
  - Added the `--continuous` flag to the `./run.sh` command.
  - Ensured all command-line arguments are passed through to `run.sh` and the `autogpt` module.

### Documentation
The changes made are documented [here](https://github.com/Significant-Gravitas/Auto-GPT/pull/1941#discussion_r1167977442)

### Test Plan
1. Tested the `run_continuous.sh` script on a Linux system with various command-line arguments.
2. Verified that the `--continuous` flag was added to the command-line arguments when running the script.
3. Confirmed that all additional command-line arguments were passed through to the `run.sh` script and the `autogpt` module.

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes