### PR TITLE
Fixes multiple typos of the word authorize

### DIFF
--- a/autogpt/agent/agent.py
+++ b/autogpt/agent/agent.py
@@ -106,7 +106,7 @@ class Agent:
                     f"ARGUMENTS = {Fore.CYAN}{arguments}{Style.RESET_ALL}",
                 )
                 print(
-                    "Enter 'y' to authorise command, 'y -N' to run N continuous "
+                    "Enter 'y' to authorize command, 'y -N' to run N continuous "
                     "commands, 'n' to exit program, or enter feedback for "
                     f"{self.ai_name}...",
                     flush=True,
@@ -141,7 +141,7 @@ class Agent:
 
                 if user_input == "GENERATE NEXT COMMAND JSON":
                     logger.typewriter_log(
-                        "-=-=-=-=-=-=-= COMMAND AUTHORISED BY USER -=-=-=-=-=-=-=",
+                        "-=-=-=-=-=-=-= COMMAND AUTHORIZED BY USER -=-=-=-=-=-=-=",
                         Fore.MAGENTA,
                         "",
                     )

--- a/autogpt/args.py
+++ b/autogpt/args.py
@@ -76,7 +76,7 @@ def parse_arguments() -> None:
             Fore.RED,
             "Continuous mode is not recommended. It is potentially dangerous and may"
             " cause your AI to run forever or carry out actions you would not usually"
-            " authorise. Use at your own risk.",
+            " authorize. Use at your own risk.",
         )
         CFG.set_continuous_mode(True)
 


### PR DESCRIPTION
#Background
I noticed multiple places where the word "authorize" was typoed as "authorise" .

The changes were all in printed statements shown to the user.

No variable names or prompts were changed.

#Changes
- Fixes 3 typos in print outputs.

#Documentation

#Test Plan
This change does not affect functionality.

#PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes