### PR TITLE
Fix call to relative_to in workspace

### DIFF
--- a/autogpt/workspace.py
+++ b/autogpt/workspace.py
@@ -35,7 +35,7 @@ def safe_path_join(base: Path, *paths: str | Path) -> Path:
     """
     joined_path = base.joinpath(*paths).resolve()
 
-    if not joined_path.is_relative_to(base):
+    if not joined_path.relative_to(base):
         raise ValueError(f"Attempted to access path '{joined_path}' outside of working directory '{base}'.")
 
     return joined_path


### PR DESCRIPTION
### Background
Fixes #2027 . Is_relative_to is a typo and should be relative_to
https://docs.python.org/3/library/pathlib.html#:~:text=PurePath.is_relative_to(*other)%C2%B6

### Changes
Fixed typo

### Documentation
n/a

### Test Plan
Ran personal unit tests (not committed yet)

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->


