### PR TITLE
Truncate text before create_embedding_with_ada()

### DIFF
--- a/autogpt/llm_utils.py
+++ b/autogpt/llm_utils.py
@@ -175,9 +175,7 @@ def create_embedding_with_ada(text) -> list:
     for attempt in range(num_retries):
         backoff = 2 ** (attempt + 2)
         try:
-            return api_manager.embedding_create(
-                text_list=[text], model=model
-            )
+            return api_manager.embedding_create(text_list=[text], model=model)
         except RateLimitError:
             pass
         except (APIError, Timeout) as e:


### PR DESCRIPTION
### Background
If the text exceeds the token limit (such as trying to remember an entire file), the whole Auto-GPT crashes.

Should fix https://github.com/Significant-Gravitas/Auto-GPT/issues/1639 (but the token limits in https://github.com/Significant-Gravitas/Auto-GPT/issues/1211 and https://github.com/Significant-Gravitas/Auto-GPT/issues/796 seem unrelated).

### Changes
This truncates the text to fit within the token limit of the ada model, which is used to create the embedding in `create_embedding_with_ada()`.

### Documentation
The code is self-explanatory and has a comment explaining why it's there.

### Test Plan
Auto-GPT would previously try to read a README.md file and crash:

```
NEXT ACTION:  COMMAND = read_file ARGUMENTS = {'file': 'README.md', 'chunk_size': 1000}
Enter 'y' to authorise command, 'y -N' to run N continuous commands, 'n' to exit program, or enter feedback for ...
Input:y
-=-=-=-=-=-=-= COMMAND AUTHORISED BY USER -=-=-=-=-=-=-=
Traceback (most recent call last):
…
\Auto-GPT\autogpt\llm_utils.py", line 137, in create_embedding_with_ada
    return openai.Embedding.create(
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Anaconda3\envs\autogpt\Lib\site-packages\openai\api_resources\embedding.py", line 33, in create
    response = super().create(*args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Anaconda3\envs\autogpt\Lib\site-packages\openai\api_resources\abstract\engine_api_resource.py", line 153, in create
    response, _, api_key = requestor.request(
                           ^^^^^^^^^^^^^^^^^^
  File "C:\Anaconda3\envs\autogpt\Lib\site-packages\openai\api_requestor.py", line 226, in request
    resp, got_stream = self._interpret_response(result, stream)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Anaconda3\envs\autogpt\Lib\site-packages\openai\api_requestor.py", line 619, in _interpret_response
    self._interpret_response_line(
  File "C:\Anaconda3\envs\autogpt\Lib\site-packages\openai\api_requestor.py", line 682, in _interpret_response_line
    raise self.handle_error_response(
openai.error.InvalidRequestError: This model's maximum context length is 8191 tokens, however you requested 10957 tokens (10957 in your prompt; 0 for the completion). Please reduce your prompt; or completion length.				
```

Now it can read the file and add (part of) it to memory.  I'm not sure it even makes sense to commit an entire file (8191 tokens) to a single embedding (1536-vector), but at least it doesn't crash and lose all work now.

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->

<!-- If you haven't added tests, please explain why. If you have, check the appropriate box. If you've ensured your PR is atomic and well-documented, check the corresponding boxes. -->

<!-- By submitting this, I agree that my pull request should be closed if I do not fill this out or follow the guide lines. -->
