### PR TITLE
Rename write_to_file to create_new_file to prevent misunderstanding 

### DIFF
--- a/autogpt/app.py
+++ b/autogpt/app.py
@@ -16,7 +16,7 @@ from autogpt.commands.file_operations import (
     delete_file,
     read_file,
     search_files,
-    write_to_file,
+    create_new_file,
 )
 from autogpt.json_fixes.parsing import fix_and_parse_json
 from autogpt.memory import get_memory
@@ -93,8 +93,8 @@ def map_command_synonyms(command_name: str):
     string matches a list of common/known hallucinations
     """
     synonyms = [
-        ("write_file", "write_to_file"),
-        ("create_file", "write_to_file"),
+        ("write_file", "create_new_file"),
+        ("write_to_file", "append_to_file"),
         ("search", "google"),
     ]
     for seen_command, actual_command_name in synonyms:
@@ -156,8 +156,8 @@ def execute_command(command_name: str, arguments):
             )
         elif command_name == "read_file":
             return read_file(arguments["file"])
-        elif command_name == "write_to_file":
-            return write_to_file(arguments["file"], arguments["text"])
+        elif command_name == "create_new_file":
+            return create_new_file(arguments["file"], arguments["text"])
         elif command_name == "append_to_file":
             return append_to_file(arguments["file"], arguments["text"])
         elif command_name == "delete_file":

--- a/autogpt/commands/file_operations.py
+++ b/autogpt/commands/file_operations.py
@@ -122,7 +122,7 @@ def ingest_file(
         print(f"Error while ingesting file '{filename}': {str(e)}")
 
 
-def write_to_file(filename: str, text: str) -> str:
+def create_new_file(filename: str, text: str) -> str:
     """Write text to a file
 
     Args:
@@ -133,7 +133,7 @@ def write_to_file(filename: str, text: str) -> str:
         str: A message indicating success or failure
     """
     if check_duplicate_operation("write", filename):
-        return "Error: File has already been updated."
+        return "ERROR. FILE ALREADY EXISTS."
     try:
         filepath = path_in_workspace(filename)
         directory = os.path.dirname(filepath)

--- a/autogpt/prompt.py
+++ b/autogpt/prompt.py
@@ -64,7 +64,7 @@ def get_prompt() -> str:
             "clone_repository",
             {"repository_url": "<url>", "clone_path": "<directory>"},
         ),
-        ("Write to file", "write_to_file", {"file": "<file>", "text": "<text>"}),
+        ("Create a new file", "create_new_file", {"file": "<file>", "text": "<text>"}),
         ("Read file", "read_file", {"file": "<file>"}),
         ("Append to file", "append_to_file", {"file": "<file>", "text": "<text>"}),
         ("Delete file", "delete_file", {"file": "<file>"}),

--- a/tests/smoke_test.py
+++ b/tests/smoke_test.py
@@ -9,9 +9,9 @@ from autogpt.commands.file_operations import delete_file, read_file
 
 
 @pytest.mark.integration_test
-def test_write_file() -> None:
+def test_create_file() -> None:
     """
-    Test case to check if the write_file command can successfully write 'Hello World' to a file
+    Test case to check if the create_new_file command can successfully write 'Hello World' to a file
     named 'hello_world.txt'.
 
     Read the current ai_settings.yaml file and store its content.
@@ -28,9 +28,9 @@ def test_write_file() -> None:
             # Clean up any existing 'hello_world.txt' file before testing.
             delete_file("hello_world.txt")
         # Prepare input data for the test.
-        input_data = """write_file-GPT
-an AI designed to use the write_file command to write 'Hello World' into a file named "hello_world.txt" and then use the task_complete command to complete the task.
-Use the write_file command to write 'Hello World' into a file named "hello_world.txt".
+        input_data = """create_new_file-GPT
+an AI designed to use the create_new_file command to write 'Hello World' into a file named "hello_world.txt" and then use the task_complete command to complete the task.
+Use the create_new_file command to write 'Hello World' into a file named "hello_world.txt".
 Use the task_complete command to complete the task.
 Do not use any other commands.
 


### PR DESCRIPTION
### Background
GPT really struggles with attempting to write to files which already exist. Most of the time it attempts to write the same file over and over, ignoring the error.

### Changes
This change renames the command from 'write_file' to 'create_new_file' so as to discourage the model from assuming that it will work as an append. Sometimes this is still not sufficient, so the error message is changed to be in all caps and look more like a system error message. This seems to work to get it to react to the file's existence.

### Documentation
This just  renames an existing method and changes some error text. All similarly named methods and aliases are updated.

### Test Plan
I have tested it on multiple research focused prompts and this is a significant improvement.

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes 