### PR TITLE
Fix milvus test Error: 'NameError: name 'MockConfig' is not defined'

### DIFF
--- a/tests/milvus_memory_test.py
+++ b/tests/milvus_memory_test.py
@@ -26,7 +26,7 @@ try:
 
         def setUp(self) -> None:
             """Set up the test environment"""
-            self.cfg = MockConfig()
+            self.cfg = mock_config()
             self.memory = MilvusMemory(self.cfg)
 
         def test_add(self) -> None:


### PR DESCRIPTION
### Background
After minimall add pytest (#1859) merged. The test case is not worked. Try to fix it.

```
=================================== FAILURES ===================================
__________________________ TestMilvusMemory.test_add ___________________________

self = <tests.milvus_memory_test.TestMilvusMemory testMethod=test_add>

    def setUp(self) -> None:
        """Set up the test environment"""
>       self.cfg = MockConfig()
E       NameError: name 'MockConfig' is not defined
```

### Changes
call correct `mock_config()`, not `MockConfig()`

### Test Plan
```
============================= test session starts ==============================
collecting ... collected 5 items

milvus_memory_test.py::TestMilvusMemory::test_add 
milvus_memory_test.py::TestMilvusMemory::test_clear 
milvus_memory_test.py::TestMilvusMemory::test_get 
milvus_memory_test.py::TestMilvusMemory::test_get_relevant 
milvus_memory_test.py::TestMilvusMemory::test_get_stats 

============================== 5 passed in 20.20s ==============================
```

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->
