### PR TITLE
Fix split file to handle edge case where overlap size > last chunk size

### DIFF
--- a/autogpt/commands/file_operations.py
+++ b/autogpt/commands/file_operations.py
@@ -49,7 +49,7 @@ def split_file(
     """
     Split text into chunks of a specified maximum length with a specified overlap
     between chunks.
-    
+
     :param content: The input text to be split into chunks
     :param max_length: The maximum length of each chunk,
         default is 4000 (about 1k token)

--- a/autogpt/commands/file_operations.py
+++ b/autogpt/commands/file_operations.py
@@ -49,6 +49,7 @@ def split_file(
     """
     Split text into chunks of a specified maximum length with a specified overlap
     between chunks.
+    
     :param content: The input text to be split into chunks
     :param max_length: The maximum length of each chunk,
         default is 4000 (about 1k token)

--- a/autogpt/commands/file_operations.py
+++ b/autogpt/commands/file_operations.py
@@ -42,6 +42,7 @@ def log_operation(operation: str, filename: str) -> None:
 
     append_to_file(LOG_FILE, log_entry, shouldLog = False)
 
+
 def split_file(
     content: str, max_length: int = 4000, overlap: int = 0
 ) -> Generator[str, None, None]:

--- a/autogpt/commands/file_operations.py
+++ b/autogpt/commands/file_operations.py
@@ -42,14 +42,12 @@ def log_operation(operation: str, filename: str) -> None:
 
     append_to_file(LOG_FILE, log_entry, shouldLog = False)
 
-
 def split_file(
     content: str, max_length: int = 4000, overlap: int = 0
 ) -> Generator[str, None, None]:
     """
     Split text into chunks of a specified maximum length with a specified overlap
     between chunks.
-
     :param content: The input text to be split into chunks
     :param max_length: The maximum length of each chunk,
         default is 4000 (about 1k token)
@@ -63,9 +61,14 @@ def split_file(
     while start < content_length:
         end = start + max_length
         if end + overlap < content_length:
-            chunk = content[start : end + overlap]
+            chunk = content[start : end + overlap - 1]
         else:
             chunk = content[start:content_length]
+
+            # Account for the case where the last chunk is shorter than the overlap, so it has already been consumed
+            if len(chunk) <= overlap:
+                break
+
         yield chunk
         start += max_length - overlap
 


### PR DESCRIPTION
### Background
Currently split_file will double count the last overlap# chars in a document due to the way we are consuming the chunks

### Changes
Add logic to handle this case in the split_file function

### Documentation
Commented

### Test Plan
Tested with new file_operation unit tests, which will be included in a following PR, and tested with a file operation prompt

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->

<!-- If you haven't added tests, please explain why. If you have, check the appropriate box. If you've ensured your PR is atomic and well-documented, check the corresponding boxes. -->

<!-- By submitting this, I agree that my pull request should be closed if I do not fill this out or follow the guide lines. -->
