### PR TITLE
Fix BRIAN_TTS - Prevent TypeError exception in _speech method

### DIFF
--- a/autogpt/speech/brian.py
+++ b/autogpt/speech/brian.py
@@ -13,7 +13,7 @@ class BrianSpeech(VoiceBase):
         """Setup the voices, API key, etc."""
         pass
 
-    def _speech(self, text: str) -> bool:
+    def _speech(self, text: str, _: int = 0) -> bool:
         """Speak text using Brian with the streamelements API
 
         Args:


### PR DESCRIPTION
### Background
Using USE_BRIAN_TTS=True, throws this exception:
```
Exception in thread Thread-1 (speak):
WelcomeTraceback (most recent call last):
  File "/usr/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
     self.run()
  File "/usr/lib/python3.10/threading.py", line 953, in run
    self._target(*self._args, **self._kwargs)
  File "/home/gabriel/Auto-GPT/autogpt/speech/say.py", line 34, in speak
    success = VOICE_ENGINE.say(text, voice_index)
  File "/home/gabriel/Auto-GPT/autogpt/speech/base.py", line 33, in say
    return self._speech(text, voice_index)
TypeError: BrianSpeech._speech() takes 2 positional arguments but 3 were given
```

### Changes
Use the same arguments as used in _speech method from gtts.py as it doesn't need the third parameter "voice_index".

### PR Quality Checklist
- [ ✓] My pull request is atomic and focuses on a single change.
- [ ✓] I have thoroughly tested my changes with multiple different prompts.
- [ ✓] I have considered potential risks and mitigations for my changes.
- [✓ ] I have documented my changes clearly and comprehensively.
- [✓ ] I have not snuck in any "extra" small tweaks changes 
