### PR TITLE
Update .env.template

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -63,7 +63,7 @@ PINECONE_API_KEY=your-pinecone-api-key
 PINECONE_ENV=your-pinecone-region
 
 ### REDIS
-# REDIS_HOST - Redis host (Default: localhost)
+# REDIS_HOST - Redis host (Default: localhost, use "redis" for docker-compose)
 # REDIS_PORT - Redis port (Default: 6379)
 # REDIS_PASSWORD - Redis password (Default: "")
 # WIPE_REDIS_ON_START - Wipes data / index on start (Default: False)


### PR DESCRIPTION
"redis" as hostname for redis to correctly use the docker compose internal networking feature
