### PR TITLE
Fixed a bug in the function that tries to enclose the json properties with double quotes

### DIFF
--- a/autogpt/json_utils/json_fix_general.py
+++ b/autogpt/json_utils/json_fix_general.py
@@ -80,7 +80,7 @@ def add_quotes_to_property_names(json_string: str) -> str:
     def replace_func(match: re.Match) -> str:
         return f'"{match[1]}":{match[2]}'
 
-    #It matches any word followed by : and then an space or ", { or [
+    # It matches any word followed by : and then an space or ", { or [
     property_name_pattern = re.compile(r"(\w+):( ?[\"\{\[])")
     corrected_json_string = property_name_pattern.sub(replace_func, json_string)
 

--- a/autogpt/json_utils/json_fix_general.py
+++ b/autogpt/json_utils/json_fix_general.py
@@ -78,9 +78,10 @@ def add_quotes_to_property_names(json_string: str) -> str:
     """
 
     def replace_func(match: re.Match) -> str:
-        return f'"{match[1]}":'
+        return f'"{match[1]}":{match[2]}'
 
-    property_name_pattern = re.compile(r"(\w+):")
+    #It matches any word followed by : and then an space or ", { or [
+    property_name_pattern = re.compile(r"(\w+):( ?[\"\{\[])")
     corrected_json_string = property_name_pattern.sub(replace_func, json_string)
 
     try:

--- a/tests/unit/_test_json_parser.py
+++ b/tests/unit/_test_json_parser.py
@@ -111,3 +111,9 @@ def test_invalid_json_leading_sentence_with_gpt(self):
     }
 
     assert fix_and_parse_json(json_str, try_to_fix_with_gpt=False) == good_obj
+
+def test_invalid_json_property_name_missing_quotes():
+    # Test that an invalid JSON missing quotes around property names can be fixed
+    json_str = '{"name": "John", "age": 30, link: "something http://google.com"}'
+    good_obj = {"name": "John", "age": 30, "link": "something http://google.com"}
+    assert fix_and_parse_json(json_str, try_to_fix_with_gpt=False) == good_obj


### PR DESCRIPTION

### Background
The existing function to add quotes to the property name has an issue. It contains a simple regex that matches to content already inside quotes. The existing function would change the property value "something http://link.to/" to "something "http":link.to"

I have updated the regex to avoid matching to content enclosed by quotes.
### Changes
<!-- Describe the specific, focused change made in this pull request. Detail the modifications clearly and avoid any unrelated or "extra" changes. -->


### Test Plan
The JSON response from openAI should contain properties missing the double quotes

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x ] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->
