### PR TITLE
fix(pr-label): set job permissions explicitly

### DIFF
--- a/.github/workflows/pr-label.yml
+++ b/.github/workflows/pr-label.yml
@@ -11,6 +11,9 @@ on:
 jobs:
   conflicts:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Update PRs with conflict labels
         uses: eps1lon/actions-label-merge-conflict@releases/2.x


### PR DESCRIPTION
### Background
PR label workflow broken :(

### Changes
Set permissions for the GITHUB_TOKEN explicitly.

### Test Plan
We'll see, no harm if it doesn't work.

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [ ] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->

<!-- If you haven't added tests, please explain why. If you have, check the appropriate box. If you've ensured your PR is atomic and well-documented, check the corresponding boxes. -->

<!-- By submitting this, I agree that my pull request should be closed if I do not fill this out or follow the guide lines. -->
