### PR TITLE
make the redis stack server name more intention revealing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,5 +14,5 @@ services:
       - ".env:/app/.env"
     profiles: ["exclude-from-up"]
 
-  redis:
+  redis-stack-server:
     image: "redis/redis-stack-server:latest"


### PR DESCRIPTION
### Background
The redis container name in docker compose could be more specific about its role

### Changes
Make the redis container's name more self descriptive

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes 