### PR TITLE
fix(pr-label): concurrency group cannot be empty

### DIFF
--- a/.github/workflows/pr-label.yml
+++ b/.github/workflows/pr-label.yml
@@ -8,8 +8,8 @@ on:
   pull_request_target:
     types: [opened, synchronize]
 concurrency:
-  group: ${{ github.event_name == 'pull_request_target' && format('pr-label-{0}', github.event.pull_request.number) || '' }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request_target' || '' }}
+  group: ${{ format('pr-label-{0}', github.event.pull_request.number || github.sha) }}
+  cancel-in-progress: true
 
 jobs:
   conflicts:


### PR DESCRIPTION
### Background
First we had too many concurrent runs, then the workflow broke.. This should be it.

### Changes
Set concurrency group even if not triggered by a PR.

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [ ] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->

<!-- If you haven't added tests, please explain why. If you have, check the appropriate box. If you've ensured your PR is atomic and well-documented, check the corresponding boxes. -->

<!-- By submitting this, I agree that my pull request should be closed if I do not fill this out or follow the guidelines. -->
