### PR TITLE
fix(python-run): prompt users to install Docker when execute_python_file encounters a Docker error

### DIFF
--- a/autogpt/commands/execute_code.py
+++ b/autogpt/commands/execute_code.py
@@ -83,11 +83,13 @@ def execute_python_file(file: str):
         # print(f"Logs: {logs}")
 
         return logs
-    
+
     except docker.errors.DockerException as e:
-        print("Could not run the script in a container. If you haven't already, please install Docker https://docs.docker.com/get-docker/")
+        print(
+            "Could not run the script in a container. If you haven't already, please install Docker https://docs.docker.com/get-docker/"
+        )
         return f"Error: {str(e)}"
-    
+
     except Exception as e:
         return f"Error: {str(e)}"
 

--- a/autogpt/commands/execute_code.py
+++ b/autogpt/commands/execute_code.py
@@ -83,7 +83,11 @@ def execute_python_file(file: str):
         # print(f"Logs: {logs}")
 
         return logs
-
+    
+    except docker.errors.DockerException as e:
+        print("Docker ran into an error. If you haven't already, please install Docker https://docs.docker.com")
+        return f"Error: {str(e)}"
+    
     except Exception as e:
         return f"Error: {str(e)}"
 

--- a/autogpt/commands/execute_code.py
+++ b/autogpt/commands/execute_code.py
@@ -85,7 +85,7 @@ def execute_python_file(file: str):
         return logs
     
     except docker.errors.DockerException as e:
-        print("Docker ran into an error. If you haven't already, please install Docker https://docs.docker.com")
+        print("Could not run the script in a container. If you haven't already, please install Docker https://docs.docker.com/get-docker/")
         return f"Error: {str(e)}"
     
     except Exception as e:


### PR DESCRIPTION
### Background
The first time Auto-GPT tried to run Python code, I didn't have Docker installed. I had to dig through the source code and ask ChatGPT before I got it working, but the issue was a very simple fix (I just had to install Docker). I added an extra `except` clause to the function which will intercept Docker errors and suggest to the users that they may need to install Docker if they haven't already.

### Changes
The only change was to add an additional `except` clause in the `execute_python_file` function. The except clause prompts the user they may want to install Docker, then returns the error message.

### Documentation
This is a pretty simple addition, and the code is pretty reasonable, so I'd argue it's sufficient documentation in and of itself. (If not I'm happy to add comments)

### Test Plan
I ran the function from an interactive Python session without Docker installed on my system (but with the `docker` module installed in Python). It printed the correct help message and returned the correct string. I then tested the code and raised `KeyboardInterrupt` before the script tried to load the Docker environment. It skipped my code and returned the error message in the usual way.

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thoroughly tested my changes with multiple different prompts.
    - I didn't test the full Auto-GPT system with prompts, but I don't think it's necessary or worth the API costs for this change. Please let me know if this is not the case.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes 
