### PR TITLE
Add telegraphese constraint

### DIFF
--- a/autogpt/prompt.py
+++ b/autogpt/prompt.py
@@ -41,6 +41,9 @@ def get_prompt() -> str:
     prompt_generator.add_constraint(
         "Use subprocesses for commands that will not terminate within a few minutes"
     )
+    prompt_generator.add_constraint(
+        "You speak in telegraphese only: using very short sentences and omitting unnecessary words and punctuation"
+    )
 
     # Define the command list
     commands = [


### PR DESCRIPTION
### Background
The primary thing holding AutoGPT back is the costs and response times of GPT-4. Its natural style is very verbose, but it is perfectly capable of understanding terse language and extrapolating the meaning behind it. Reduced verbosity could additionally assist AutoGPT with sticking to simple strategies.

### Changes
I added a constraint to speak in "telegraphese" with a short description. [Telegraphese](https://en.wikipedia.org/wiki/Telegram_style) is the name of the style that was used in telegraphs to save money, as telegraphs were charged per-word. If verbose descriptions for the user are truly desired, then GPT-3.5 can be used to expand the terse phrases to complete sentences at trivial additional cost.

### Documentation
It is self-explanatory like the rest of the constraints.

### Test Plan
I do not have access to the GPT-4 API so I tested it using ChatGPT Plus. I used [this prompt](https://pastebin.com/TGbUDBaw) and it consistently got less (20-30% smaller) token-heavy responses. On the other hand, GPT-3.5 completely ignored the constraint, but it's 30x less expensive so it's less of a priority.

### PR Quality Checklist
- [X] My pull request is atomic and focuses on a single change.
- [ ] I have thoroughly tested my changes with multiple different prompts.
- [X] I have considered potential risks and mitigations for my changes.
- [X] I have documented my changes clearly and comprehensively.
- [X] I have not snuck in any "extra" small tweaks changes

I cannot directly test this on AutoGPT as it only seems to work on GPT-4, which I only have access to through ChatGPT Plus.