### PR TITLE
fix logic for executing a python file with a subprocess

### DIFF
--- a/autogpt/commands/execute_code.py
+++ b/autogpt/commands/execute_code.py
@@ -28,7 +28,7 @@ def execute_python_file(file: str) -> str:
     if not os.path.isfile(file_path):
         return f"Error: File '{file}' does not exist."
 
-    if we_are_running_in_a_docker_container():
+    if not we_are_running_in_a_docker_container():
         result = subprocess.run(
             f"python {file_path}", capture_output=True, encoding="utf8", shell=True
         )


### PR DESCRIPTION
### Background
https://github.com/Significant-Gravitas/Auto-GPT/issues/2006 https://github.com/Significant-Gravitas/Auto-GPT/issues/1966 https://github.com/Significant-Gravitas/Auto-GPT/issues/2257

### Changes
We should use the subprocess to execute python files when we are not in a Docker container. We were just missing a "not".

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->
