### PR TITLE
Stable

### DIFF
--- a/autogpt/agent/agent.py
+++ b/autogpt/agent/agent.py
@@ -148,6 +148,7 @@ class Agent:
                         continue
                     elif new_command_name is not None:
                         command_name = new_command_name
+                    break
 
                 if self.user_input == "GENERATE NEXT COMMAND JSON":
                     logger.typewriter_log(

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -1,0 +1,56 @@
+import unittest
+
+from autogpt.agent.agent import should_prompt_user, generate_user_feedback_message, \
+    calculate_next_command_from_user_input
+
+
+class TestAgent(unittest.TestCase):
+    def test_should_prompt_user_given_not_in_continuous_mode_and_next_action_count_is_zero_returns_true(self):
+        self.assertTrue(should_prompt_user(False, 0))
+
+    def test_should_prompt_user_given_not_in_continuous_mode_and_next_action_count_is_greater_than_zero_returns_false(
+            self):
+        self.assertFalse(should_prompt_user(False, 2))
+
+    def test_should_prompt_user_given_in_continuous_mode_and_next_action_count_is_zero_returns_false(self):
+        self.assertFalse(should_prompt_user(True, 0))
+
+    def test_should_prompt_user_given_in_continuous_mode_and_next_action_count_is_greater_than_zero_returns_false(self):
+        self.assertFalse(should_prompt_user(True, 100))
+
+    def test_generate_user_feedback_message_should_format_message_with_ai_name(self):
+        expected_message = "Enter 'y' to authorise command, 'y -N' to run N continuous commands," \
+                           "'n' to exit program, or enter feedback for the_ai_name... "
+        self.assertEquals(generate_user_feedback_message("the_ai_name"), expected_message)
+
+    def test_calculate_next_command_from_user_input_given_user_entered_y_result_is_generate_next_command(self):
+        command_name, next_count, user_input = calculate_next_command_from_user_input("y")
+        self.assertIsNone(command_name)
+        self.assertEquals(next_count, 0)
+        self.assertEquals(user_input, "GENERATE NEXT COMMAND JSON")
+
+    def test_calculate_next_command_from_user_input_given_user_entered_y_dash_number_result_generate_next_command(self):
+        command_name, next_count, user_input = calculate_next_command_from_user_input("y -20")
+        self.assertIsNone(command_name)
+        self.assertEquals(next_count, 20)
+        self.assertEquals(user_input, "GENERATE NEXT COMMAND JSON")
+
+    def test_calculate_next_command_from_user_input_given_user_entered_y_dash_and_invalid_number_print_error(self):
+        command_name, next_count, user_input = calculate_next_command_from_user_input("y -X")
+        self.assertEquals(command_name, "input error")
+        self.assertEquals(next_count, 0)
+        self.assertEquals(user_input, "Invalid input format. Please enter 'y -n' where n is the number of continuous "
+                                      "tasks.")
+
+    def test_calculate_next_command_from_user_input_given_user_entered_n_result_is_exit(self):
+        command_name, next_count, user_input = calculate_next_command_from_user_input("n")
+        self.assertIsNone(command_name)
+        self.assertEquals(next_count, 0)
+        self.assertEquals(user_input, "EXIT")
+
+    def test_calculate_next_command_from_user_input_given_user_text_result_is_feedback(self):
+        the_input = "Some item to tell the AI about while it is doing stuff."
+        command_name, next_count, user_input = calculate_next_command_from_user_input(the_input)
+        self.assertEquals(command_name, "human_feedback")
+        self.assertEquals(next_count, 0)
+        self.assertEquals(user_input, the_input)


### PR DESCRIPTION
### Background
While running with the 'y -XXX' prompt, I found myself wanting to know how many steps had been performed, and how many were left out of how many I had authorized. Additionally, I wanted a way to interrupt the process without resorting to crashing the system or killing a process outright.

### Changes
Changes are extracting some methods for the functionality I eventually want to change and create unit tests for same.

### Documentation
Unit tests - also added a comment at 144 about how the parsing error was being handled.

### Test Plan
Created unit tests for the changes to ensure current functionality and lay the foundation for future changes.

### PR Quality Checklist
- [X] My pull request is atomic and focuses on a single change.
- [X] I have thoroughly tested my changes with multiple different prompts.
- [X] I have considered potential risks and mitigations for my changes.
- [X] I have documented my changes clearly and comprehensively.
- [X] I have not snuck in any "extra" small tweaks changes.

Ran the app and tested the following inputs:
- 'n' - exited appropriately
- 'y -X' - showed error message and re-prompted
- 'y -2' - continued twice
- '(some relevant feedback)' - parsed feedback
- 'y asdfasdfads' - gave error message and looped back correctly
