### PR TITLE
Added google text to speech as alternative ( cheaper )

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -171,3 +171,9 @@ TW_CONSUMER_KEY=
 TW_CONSUMER_SECRET=
 TW_ACCESS_TOKEN=
 TW_ACCESS_TOKEN_SECRET=
+
+
+##add path to client_secrets.json file or service_account.json file to enable google text to speech.
+GOOGLE_SERVICE_ACCOUNT_JSON=
+GOOGLE_VOICE_1_ID=
+GOOGLE_VOICE_2_ID=

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,10 @@ logs
 *.log
 *.mp3
 
+#private files
+*service_account.json
+*client_secret.json
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -216,6 +216,17 @@ python -m autogpt --speak
 - Adam : pNInz6obpgDQGcFmaJgB
 - Sam : yoZ06aMxZJJ28mfd3POQ
 
+#####
+### if you want to use google text to speech instead:
+# 1. Visit cloud.google.com libraries and activate google text to speech API
+
+# 2. Generate a client_secrets or service_account.json file from "api's and services" -> "credentials", save the generated file on your computer.
+
+# 3. Specify env variable GOOGLE_SERVICE_ACCOUNT_JSON={path_to_client_secret_or_service_account.json} this should be a path to the credentials file. 
+
+# 4. Run "python -m autogpt --speak" as normal.
+#####
+
 ## 🔍 Google API Keys Configuration
 
 This section is optional, use the official google api if you are having issues with error 429 when running a google search.

--- a/autogpt/config/config.py
+++ b/autogpt/config/config.py
@@ -53,6 +53,10 @@ class Config(metaclass=Singleton):
         self.use_mac_os_tts = False
         self.use_mac_os_tts = os.getenv("USE_MAC_OS_TTS")
 
+        self.google_speak_key_path = os.getenv("GOOGLE_SERVICE_ACCOUNT_JSON")
+        self.google_voice_1_id = os.getenv("GOOGLE_VOICE_1_ID")
+        self.google_voice_2_id = os.getenv("GOOGLE_VOICE_2_ID")
+
         self.use_brian_tts = False
         self.use_brian_tts = os.getenv("USE_BRIAN_TTS")
 

--- a/autogpt/speech/google_speak.py
+++ b/autogpt/speech/google_speak.py
@@ -1,0 +1,103 @@
+from google.cloud import texttospeech
+import io, os
+from autogpt.speech.base import VoiceBase
+from autogpt.config import Config
+from playsound import playsound
+
+PATH = os.path.dirname(os.path.abspath(__file__))
+
+PLACEHOLDERS = {"your-voice-id"}
+
+class GoogleSpeech(VoiceBase):
+    """Google speech class"""
+    # Instantiates a client
+
+    def _setup(self) -> None:
+        """Set up the voices, API key, etc.
+
+        Returns:
+            None: None
+        """
+        cfg = Config()
+        self.client = texttospeech.TextToSpeechClient.from_service_account_json(cfg.google_speak_key_path)
+        default_voices = ["a", "b"]
+        voice_options = {
+            "a": "en-US-Neural2-J",
+            "b": "en-US-Neural2-A",
+            "c": "en-US-Neural2-B",
+            "d": "en-US-Neural2-C",
+            "e": "en-US-Neural2-D",
+            "f": "en-US-Neural2-E",
+            "g": "en-US-Neural2-F",
+            "h": "en-US-Neural2-G",
+            "i": "en-US-Neural2-H"
+        }
+        self._voices = default_voices.copy()
+        self._voice_options = voice_options.copy()
+        if cfg.google_voice_1_id in voice_options:
+            cfg.google_voice_1_id = voice_options[cfg.google_voice_1_id]
+        if cfg.google_voice_2_id in voice_options:
+            cfg.google_voice_2_id = voice_options[cfg.google_voice_2_id]
+        
+        self._use_custom_voice(cfg.google_voice_1_id, 0)
+        self._use_custom_voice(cfg.google_voice_2_id, 1)
+        
+    def _use_custom_voice(self, voice, voice_index) -> None:
+        """Use a custom voice if provided and not a placeholder
+
+        Args:
+            voice (str): The voice ID
+            voice_index (int): The voice index
+
+        Returns:
+            None: None
+        """
+        # Placeholder values that should be treated as empty
+        if voice and voice not in PLACEHOLDERS:
+            self._voices[voice_index] = voice
+
+
+    def _speech(self, text: str, voice_index: int = 0) -> bool:
+        """
+        Speak text using Google's API
+        Args:
+            text (str): The text to speak
+            voice_name (str): The voice name default: "en-US-Neural2-J"
+        Returns:
+            bool: True if successful, False otherwise
+        """
+        synthesis_input = texttospeech.SynthesisInput(text=text)
+
+        # Build the voice request, select the language code ("en-US") and the ssml
+        # voice gender ("neutral")
+
+
+        # voice = texttospeech.VoiceSelectionParams(
+        #     language_code="en-US",
+        #     ssml_gender=texttospeech.SsmlVoiceGender.NEUTRAL
+        # )
+
+        voice_name = self._voice_options[self._voices[voice_index]]
+        voice = texttospeech.VoiceSelectionParams(
+            language_code="en-US", name=voice_name
+        )
+
+        # Select the type of audio file you want returned
+        audio_config = texttospeech.AudioConfig(
+            audio_encoding=texttospeech.AudioEncoding.MP3
+        )
+
+        try:
+            # Perform the text-to-speech request on the text input with the selected
+            # voice parameters and audio file type
+            response = self.client.synthesize_speech(
+                input=synthesis_input, voice=voice, audio_config=audio_config
+            )
+            with open(PATH+"/output.mp3", "wb") as f:
+                f.write(response.audio_content)
+            playsound(PATH+"/output.mp3", True)
+            os.remove(PATH+"/output.mp3")
+            return True
+        except Exception as e:
+            print("Google tts request failed: "+ str(e))
+            return False

--- a/autogpt/speech/say.py
+++ b/autogpt/speech/say.py
@@ -7,11 +7,14 @@ from autogpt.speech.brian import BrianSpeech
 from autogpt.speech.eleven_labs import ElevenLabsSpeech
 from autogpt.speech.gtts import GTTSVoice
 from autogpt.speech.macos_tts import MacOSTTS
+from autogpt.speech.google_speak import GoogleSpeech
 
 CFG = Config()
 DEFAULT_VOICE_ENGINE = GTTSVoice()
 VOICE_ENGINE = None
-if CFG.elevenlabs_api_key:
+if CFG.google_speak_key_path:
+    VOICE_ENGINE = GoogleSpeech()
+elif CFG.elevenlabs_api_key:
     VOICE_ENGINE = ElevenLabsSpeech()
 elif CFG.use_mac_os_tts == "True":
     VOICE_ENGINE = MacOSTTS()

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ readability-lxml==0.8.1
 requests
 tiktoken==0.3.3
 gTTS==2.3.1
+google-cloud-texttospeech==2.14.1
 docker
 duckduckgo-search
 google-api-python-client #(https://developers.google.com/custom-search/v1/overview)


### PR DESCRIPTION
<!-- 📢 Announcement
We've recently noticed an increase in pull requests focusing on combining multiple changes. While the intentions behind these PRs are appreciated, it's essential to maintain a clean and manageable git history. To ensure the quality of our repository, we kindly ask you to adhere to the following guidelines when submitting PRs:

Focus on a single, specific change.
Do not include any unrelated or "extra" modifications.
Provide clear documentation and explanations of the changes made.
Ensure diffs are limited to the intended lines — no applying preferred formatting styles or line endings (unless that's what the PR is about).
For guidance on committing only the specific lines you have changed, refer to this helpful video: https://youtu.be/8-hSNHHbiZg

By following these guidelines, your PRs are more likely to be merged quickly after testing, as long as they align with the project's overall direction. -->

### Background
<!-- Provide a concise overview of the rationale behind this change. Include relevant context, prior discussions, or links to related issues. Ensure that the change aligns with the project's overall direction. -->
No discussions, but I was looking for a cheaper alternative to elevenlabs and saw that google's text to speech is much cheaper. Not quite as good as eleven, but way better than standard tts, and the free quota on elevenlabs ran out pretty quickly. Google's TTS is widely used and has good, natural sounding voices for a much cheaper cost.

### Changes
I added a "google_speak.py" file which inherits the base class just like the other voice classes that are already written, which means it'll nicely integrate with the current code base. The only thing the user needs to do is to get credentials from google and specify the path to the credentials-file in the .env.template file). If a path is set, TTS will use google.

### Documentation
I added information to README.md which clearly describes how to use google TTS if the user wants to. I placed the info beneath the eleven labs information:

if you want to use google text to speech instead:
1. Visit cloud.google.com libraries and activate google text to speech API

2. Generate a client_secrets or service_account.json file from "api's and services" -> "credentials", save the generated file on your computer.

3. Specify env variable GOOGLE_SERVICE_ACCOUNT_JSON={path_to_client_secret_or_service_account.json} this should be a path to the credentials file. 

4. Run "python -m autogpt --speak" as normal.


### Test Plan
1. I got the service_account.json file from google, and downloaded it to my computer.
2. I. specified the path to the file using the new .env variable GOOGLE_SERVICE_ACCOUNT_JSON found in .env.template
3. I added the openAI api key to the .env.template file too.
4. I renamed .env.template to .env
5. I created a virtual environment using "virtualenv venv" and activated it with "source venv/bin/activate"
6. I installed all packages (including google's tts that I added to requirements.txt) using "pip install -r requirements.txt"
7. I got an error ( That I also got before doing any changes, which is why I'm not fixing this in this pull request ).
The error was: ModuleNotFoundError: No module named 'AppKit' and it was easily solved for me with pip install pyobjc. I didn't want to include this in the request because it might have to do with my machine specifically and it probably deserves a discussion first.
8. I ran the script "python -m autogpt --speak" and got the soothing voice from google's TTS :)

### PR Quality Checklist
- [ X ] My pull request is atomic and focuses on a single change.
- [ X ] I have thoroughly tested my changes with multiple different prompts.
- [ X ] I have considered potential risks and mitigations for my changes.
- [ X ] I have documented my changes clearly and comprehensively.
- [ X ] I have not snuck in any "extra" small tweaks changes <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->

<!-- If you haven't added tests, please explain why. If you have, check the appropriate box. If you've ensured your PR is atomic and well-documented, check the corresponding boxes. -->
Testing requires human quality reassurance (ears), so I've tested everything manually as described above.

<!-- By submitting this, I agree that my pull request should be closed if I do not fill this out or follow the guidelines. -->
