### PR TITLE
Move to Python 3.10 & improve CI workflow

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,10 +1,10 @@
-# [Choice] Python version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.10, 3.9, 3.8, 3.7, 3.6, 3-bullseye, 3.10-bullseye, 3.9-bullseye, 3.8-bullseye, 3.7-bullseye, 3.6-bullseye, 3-buster, 3.10-buster, 3.9-buster, 3.8-buster, 3.7-buster, 3.6-buster
+# [Choice] Python version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.10, 3-bullseye, 3.10-bullseye, 3-buster, 3.10-buster
 ARG VARIANT=3-bullseye
-FROM --platform=linux/amd64 python:3.8
+FROM --platform=linux/amd64 python:3.10
 
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     # Remove imagemagick due to https://security-tracker.debian.org/tracker/CVE-2019-10131
-    && apt-get purge -y imagemagick imagemagick-6-common 
+    && apt-get purge -y imagemagick imagemagick-6-common
 
 # Temporary: Upgrade python packages due to https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-40897
 # They are installed by the base image (python) which does not have the patch.

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -9,11 +9,11 @@ jobs:
     environment: benchmark
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: ['3.10']
 
     steps:
     - name: Check out repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,26 +2,21 @@ name: Python CI
 
 on:
   push:
-    branches:
-      - master
+    branches: [master]
   pull_request:
-    branches:
-      - '**'
-  pull_request_target:
-    branches:
-      - '**'
+    branches: [master]
+
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
-
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: ['3.10']
 
     steps:
     - name: Check out repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
@@ -34,16 +29,35 @@ jobs:
         pip install -r requirements.txt
 
     - name: Lint with flake8
-      continue-on-error: false
       run: flake8
 
     - name: Check black formatting
-      continue-on-error: false
       run: black . --check
+      if: success() || failure()
 
     - name: Check isort formatting
-      continue-on-error: false
       run: isort . --check
+      if: success() || failure()
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.10']
+
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v3
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
 
     - name: Run unittest tests with coverage
       run: |
@@ -53,3 +67,4 @@ jobs:
       run: |
         coverage report
         coverage xml
+      if: success() || failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [master]
 
+concurrency:
+  group: ${{ format('ci-{0}', format('pr-{0}', github.event.pull_request.number) || github.sha) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   lint:

--- a/.sourcery.yaml
+++ b/.sourcery.yaml
@@ -30,7 +30,7 @@ rule_settings:
   - refactoring
   - suggestion
   - comment
-  python_version: '3.9' # A string specifying the lowest Python version your project supports. Sourcery will not suggest refactorings requiring a higher Python version.
+  python_version: '3.10' # A string specifying the lowest Python version your project supports. Sourcery will not suggest refactorings requiring a higher Python version.
 
 # rules:  # A list of custom rules Sourcery will include in its analysis.
 # - id: no-print-statements

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Python base image from the Docker Hub
-FROM python:3.11-slim
+FROM python:3.10-slim
 
 # Install git
 RUN apt-get -y update


### PR DESCRIPTION
### Background
CI workflow was updated but now runs twice. Also runs with Python 3.8 which is inconsistent with README (#2342). Python version in other places is also inconsistent.

`pull_request_target` is both risky and unnecessary: CI will already run on `push` in the fork.

### Changes
* Split `build` workflow into `lint` and `test` workflows
* Run all checks even if some fail
* Fix double PR runs
* Adopted #2343
* Adopted #2107

### ~~Documentation~~
<!-- Explain how your changes are documented, such as in-code comments or external documentation. Ensure that the documentation is clear, concise, and easy to understand. -->

### ~~Test Plan~~
<!-- Describe how you tested this functionality. Include steps to reproduce, relevant test cases, and any other pertinent information. -->

### PR Quality Checklist
- [ ] My pull request is atomic and focuses on a single change.
- [x] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->

<!-- If you haven't added tests, please explain why. If you have, check the appropriate box. If you've ensured your PR is atomic and well-documented, check the corresponding boxes. -->

<!-- By submitting this, I agree that my pull request should be closed if I do not fill this out or follow the guidelines. -->
