### PR TITLE
fix docker build by making docker builds ignore sourcer

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,11 +27,13 @@ flake8
 numpy
 pre-commit
 black
-sourcery
 isort
 gitpython==3.1.31
 
 # Items below this point will not be included in the Docker Image
+
+# Readability
+sourcery
 
 # Testing dependencies
 pytest


### PR DESCRIPTION
### Background
docker build -t autogpt . would fail as it would fail to install sourcery on the container

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/6670312/232873939-caf51b9b-1d81-4819-b1bc-93641724c306.png">

This is me running Docker from an m1 mac

### Changes
I have moved sourcery to after `# Items below this point will not be included in the Docker Image` in the requirements.txt so that Docker ignores it

Update - Sourcery seems to be a plugin useful while actually writing code in an IDE; running AutoGPT inside Docker doesn'tr need sourcery

### Documentation

The requirement while still exists is under the `# Items below this point will not be included in the Docker Image` banner and under `# Readability` under it

### Test Plan

``` bash
docker build -t autogpt .
docker run -it --env-file=./.env -v $PWD/auto_gpt_workspace:/app/auto_gpt_workspace autogpt
```

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->

<!-- If you haven't added tests, please explain why. If you have, check the appropriate box. If you've ensured your PR is atomic and well-documented, check the corresponding boxes. -->

<!-- By submitting this, I agree that my pull request should be closed if I do not fill this out or follow the guidelines. -->
