### PR TITLE
Added support for using chatgpt reverse engineered api

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -19,9 +19,11 @@ AI_SETTINGS_FILE=ai_settings.yaml
 
 ### OPENAI
 # OPENAI_API_KEY - OpenAI API Key (Example: my-openai-api-key)
+# OPENAI_CHATGPT_ACCESS_TOKEN - OpenAI ChatGPT Access Token (Example: my-openai-chatgpt-access-token)
 # TEMPERATURE - Sets temperature in OpenAI (Default: 0)
 # USE_AZURE - Use Azure OpenAI or not (Default: False)
 OPENAI_API_KEY=your-openai-api-key
+OPENAI_CHATGPT_ACCESS_TOKEN=your-openai-chatgpt-access-token
 TEMPERATURE=0
 USE_AZURE=False
 

--- a/autogpt/agent/agent_manager.py
+++ b/autogpt/agent/agent_manager.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 
 from typing import Union
 
-from autogpt.config.config import Singleton
+from autogpt.config.config import Singleton, Config
 from autogpt.llm_utils import create_chat_completion
 
+cfg = Config()
 
 class AgentManager(metaclass=Singleton):
     """Agent manager for managing GPT agents"""
@@ -36,6 +37,7 @@ class AgentManager(metaclass=Singleton):
         agent_reply = create_chat_completion(
             model=model,
             messages=messages,
+            use_chatgpt=cfg.use_chatgpt,
         )
 
         # Update full message history
@@ -69,6 +71,7 @@ class AgentManager(metaclass=Singleton):
         agent_reply = create_chat_completion(
             model=model,
             messages=messages,
+            use_chatgpt=cfg.use_chatgpt,
         )
 
         # Update full message history

--- a/autogpt/agent/agent_manager.py
+++ b/autogpt/agent/agent_manager.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 
 from typing import Union
 
-from autogpt.config.config import Singleton, Config
+from autogpt.config.config import Config, Singleton
 from autogpt.llm_utils import create_chat_completion
 
 cfg = Config()
+
 
 class AgentManager(metaclass=Singleton):
     """Agent manager for managing GPT agents"""

--- a/autogpt/chat.py
+++ b/autogpt/chat.py
@@ -157,6 +157,7 @@ def chat_with_ai(
             # TODO: use a model defined elsewhere, so that model can contain
             # temperature and other settings we care about
             assistant_reply = create_chat_completion(
+                use_chatgpt=cfg.use_chatgpt,
                 model=model,
                 messages=current_context,
                 max_tokens=tokens_remaining,

--- a/autogpt/config/config.py
+++ b/autogpt/config/config.py
@@ -24,6 +24,7 @@ class Config(metaclass=Singleton):
         self.speak_mode = False
         self.skip_reprompt = False
         self.allow_downloads = False
+        self.use_chatgpt = False
 
         self.selenium_web_browser = os.getenv("USE_WEB_BROWSER", "chrome")
         self.ai_settings_file = os.getenv("AI_SETTINGS_FILE", "ai_settings.yaml")
@@ -34,6 +35,7 @@ class Config(metaclass=Singleton):
         self.browse_chunk_max_length = int(os.getenv("BROWSE_CHUNK_MAX_LENGTH", 8192))
 
         self.openai_api_key = os.getenv("OPENAI_API_KEY")
+        self.openai_chatgpt_access_token = os.getenv("OPENAI_CHATGPT_ACCESS_TOKEN")
         self.temperature = float(os.getenv("TEMPERATURE", "1"))
         self.use_azure = os.getenv("USE_AZURE") == "True"
         self.execute_local_commands = (

--- a/autogpt/llm_utils.py
+++ b/autogpt/llm_utils.py
@@ -6,8 +6,8 @@ from ast import List
 
 import openai
 from colorama import Fore, Style
-from revChatGPT.V1 import Chatbot
 from openai.error import APIError, RateLimitError
+from revChatGPT.V1 import Chatbot
 
 from autogpt.config import Config
 from autogpt.logs import logger
@@ -18,7 +18,7 @@ openai.api_key = CFG.openai_api_key
 
 
 def call_ai_function(
-        function: str, args: list, description: str, model: str | None = None
+    function: str, args: list, description: str, model: str | None = None
 ) -> str:
     """Call an AI function
 
@@ -44,7 +44,7 @@ def call_ai_function(
         {
             "role": "system",
             "content": f"You are now the following python function: ```# {description}"
-                       f"\n{function}```\n\nOnly respond with your `return` value.",
+            f"\n{function}```\n\nOnly respond with your `return` value.",
         },
         {"role": "user", "content": args},
     ]
@@ -55,11 +55,11 @@ def call_ai_function(
 # Overly simple abstraction until we create something better
 # simple retry mechanism when getting a rate error or a bad gateway
 def create_chat_completion(
-        messages: list,  # type: ignore
-        use_chatgpt: bool | False = False,
-        model: str | None = None,
-        temperature: float = CFG.temperature,
-        max_tokens: int | None = None,
+    messages: list,  # type: ignore
+    use_chatgpt: bool | False = False,
+    model: str | None = None,
+    temperature: float = CFG.temperature,
+    max_tokens: int | None = None,
 ) -> str:
     """Create a chat completion using the OpenAI API
 
@@ -80,13 +80,15 @@ def create_chat_completion(
         print(
             Fore.GREEN
             + f"Creating chat completion with model {model}, temperature {temperature},"
-              f" max_tokens {max_tokens}" + Fore.RESET
+            f" max_tokens {max_tokens}" + Fore.RESET
         )
     for attempt in range(num_retries):
         backoff = 2 ** (attempt + 2)
         try:
             if use_chatgpt:
-                chatgpt = Chatbot(config={"access_token": CFG.openai_chatgpt_access_token})
+                chatgpt = Chatbot(
+                    config={"access_token": CFG.openai_chatgpt_access_token}
+                )
                 for i in range(len(messages)):
                     message = messages[i]
                     role = message.get("role", "user")
@@ -104,9 +106,9 @@ def create_chat_completion(
                             "content": {"content_type": "text", "parts": [content]},
                         }
 
-                for data in chatgpt.post_messages(messages, model=model):
+                for data in chatgpt.post_messages(messages=messages, model=model):
                     response = data["message"]
-            if CFG.use_azure:
+            elif CFG.use_azure:
                 response = openai.ChatCompletion.create(
                     deployment_id=CFG.get_azure_deployment_id_for_model(model),
                     model=model,
@@ -160,7 +162,7 @@ def create_chat_completion(
         else:
             quit(1)
 
-    return response if chatgpt else response.choices[0].message["content"]
+    return response if use_chatgpt else response.choices[0].message["content"]
 
 
 def create_embedding_with_ada(text) -> list:

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ webdriver-manager
 jsonschema
 tweepy
 click
+revChatGPT
 
 ##Dev
 coverage


### PR DESCRIPTION
Added the ablity for user to chose chatgpt as the llm that powers their auto-gpt instance. It's only an option for create_chat_completion, not create_embedding, so some charges will still occur, however, it will be significantly less than before.
### Background
<!-- Provide a concise overview of the rationale behind this change. Include relevant context, prior discussions, or links to related issues. Ensure that the change aligns with the project's overall direction. -->
Running auto-gpt can be costly so offering another way to make calls to GPT seemed imperative, also allows chatgpt-plus users a way to get their 20 bucks worth and be able to use auto-gpt with gpt4.
### Changes
<!-- Describe the specific, focused change made in this pull request. Detail the modifications clearly and avoid any unrelated or "extra" changes. -->
--> Modified create_chat_completion in llm_utils to take a parameter of 'use_chatgpt'.
--> Modified chat_with_ai, message_agent and create_agent to pass cfg.use_chatgpt
--> Modified Config to have use_chatgpt flag and openai_chatgpt_access_token var
--> Modified env_template to include a place to define openai_chatgpt_access_token
### Documentation
<!-- Explain how your changes are documented, such as in-code comments or external documentation. Ensure that the documentation is clear, concise, and easy to understand. -->
Only create_chat_completion was significantly modified so added doc string for use_chatgpt flag
### Test Plan
<!-- Describe how you tested this functionality. Include steps to reproduce, relevant test cases, and any other pertinent information. -->
Manually tested. Do note that with the current implementation, a new chat will be created every time create_chat_completion is called with use_chatgpt true. Also once use_chatgpt is used once, you can't revert back to regular api in that instance's execution. 

To get your access token: login to chatgpt, than visit https://chat.openai.com/api/auth/session
### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->

<!-- If you haven't added tests, please explain why. If you have, check the appropriate box. If you've ensured your PR is atomic and well-documented, check the corresponding boxes. -->
It's not really testable as there's no logic other than trivially adapting messages to a format chatgpt expects
<!-- By submitting this, I agree that my pull request should be closed if I do not fill this out or follow the guidelines. -->
