### PR TITLE
Allow azure.yaml from parent directory

### DIFF
--- a/autogpt/config/config.py
+++ b/autogpt/config/config.py
@@ -132,7 +132,11 @@ class Config(metaclass=Singleton):
             return ""
 
     AZURE_CONFIG_FILE = os.path.join(os.path.dirname(__file__), "..", "azure.yaml")
-    AZURE_CONFIG_FILE = AZURE_CONFIG_FILE if os.path.isfile(AZURE_CONFIG_FILE) else os.path.join(os.path.dirname(__file__), "../..", "azure.yaml")
+    AZURE_CONFIG_FILE = (
+        AZURE_CONFIG_FILE
+        if os.path.isfile(AZURE_CONFIG_FILE)
+        else os.path.join(os.path.dirname(__file__), "../..", "azure.yaml")
+    )
 
     def load_azure_config(self, config_file: str = AZURE_CONFIG_FILE) -> None:
         """

--- a/autogpt/config/config.py
+++ b/autogpt/config/config.py
@@ -132,6 +132,7 @@ class Config(metaclass=Singleton):
             return ""
 
     AZURE_CONFIG_FILE = os.path.join(os.path.dirname(__file__), "..", "azure.yaml")
+    AZURE_CONFIG_FILE = AZURE_CONFIG_FILE if os.path.isfile(AZURE_CONFIG_FILE) else os.path.join(os.path.dirname(__file__), "../..", "azure.yaml")
 
     def load_azure_config(self, config_file: str = AZURE_CONFIG_FILE) -> None:
         """


### PR DESCRIPTION
### Background

Allow `azure.yaml` to exist in the folder `/Auto-GPT`.

### Changes

Added ability to use `azure.yaml` from the parent folder `/Auto-GPT` or `/Auto-GPT/autogpt`.

### Documentation

If using Azure OpenAI, save the configuration file `azure.yaml` in the parent directory `/Auto-GPT/azure.yaml`.

### Test Plan

Tested by running locally with `/Auto-GPT/azure.yaml` and `/Auto-GPT/autogpt/azure.yaml`.

### PR Quality Checklist
- [X] My pull request is atomic and focuses on a single change.
- [X] I have thoroughly tested my changes with multiple different prompts.
- [X] I have considered potential risks and mitigations for my changes.
- [X] I have documented my changes clearly and comprehensively.
- [X] I have not snuck in any "extra" small tweaks changes

Re: https://github.com/Significant-Gravitas/Auto-GPT/issues/2186
Re: https://github.com/Significant-Gravitas/Auto-GPT/pull/2214