### PR TITLE
Small fix to the windows usage command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,12 +133,11 @@ _To execute the following commands, open a CMD, Bash, or Powershell window by na
 ## 🔧 Usage
 
 1. Run `autogpt` Python module in your terminal.
-  On linux or mac:
     ```bash
-    # On Linux of Mac:
-   ./run.sh start
-   # On Windows:
-   ./run.bat start
+    # On Linux Or Mac Use This Command:
+    ./run.sh start
+    # Or If Your On Windows Use This Command:
+    run.bat start
    ```
    Running with `--help` after `start` lists all the possible command line arguments you can pass.
 


### PR DESCRIPTION
### Changes
Just fixes the usage command for windows in the README.md as windows doesn't start a .bat file using "./"

### PR Quality Checklist
- [ x] My pull request is atomic and focuses on a single change.
- [ x] I have thoroughly tested my changes with multiple different prompts.
- [ x] I have considered potential risks and mitigations for my changes.
- [ x] I have documented my changes clearly and comprehensively.
- [ x] I have not snuck in any "extra" small tweaks changes 
