### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,21 @@ services:
       - "./autogpt:/app"
       - ".env:/app/.env"
     profiles: ["exclude-from-up"]
+    networks:
+      - default
 
   redis:
     image: "redis/redis-stack-server:latest"
+    volumes:
+      - "./redis:/data"
+    env_file:
+      - .env
+    profiles: ["exclude-from-up"]
+    expose:
+      - 6379
+    networks:
+      - default
+
+networks:
+  default:
+      name: "autogpt_default"


### PR DESCRIPTION
Create docker network.

### Background
AutoGPT container doesn't find Redis hostname using docker-compose.

### Changes
Creates Docker network and attaches autoGPT and Redis containers.
