### PR TITLE
Use readline if available

### DIFF
--- a/autogpt/utils.py
+++ b/autogpt/utils.py
@@ -5,6 +5,12 @@ import yaml
 from colorama import Fore
 from git import Repo
 
+# Use readline if available (for clean_input)
+try:
+    import readline
+except:
+    pass
+
 
 def clean_input(prompt: str = ""):
     try:


### PR DESCRIPTION
### Background
On POSIX systems, the use of `input()` at `clean_input` falls a bit short, since it does not allow for the use of arrow keys to correct mistakes, nor Emacs-like shortcuts that are generally used in the shell (Ctrl-A, Ctrl-E...).

### Changes
On line 8 of `utils.py`, the module `readline` is imported if available. This is the case for all POSIX systems I know, but not for Windows. Importing `readline` sort of monkeypatches the `input()` global function to make it more user-friendly.

In the future, `pyreadline` could be considered as an alternative for Windows, but this PR disregards it.

### Documentation
Even though I've added two lines, it seems appropriate to let the future readers know why that try-catch statement is there, so I've added a small comment.

### Test Plan
1. Run the current version of Auto-GPT and check that arrow keys do not work while inputting text; for instance, at the `Name your AI:` prompt.
2. Implement the patch I've submitted, and run again on a POSIX system. Now, arrow keys and Emacs-like keybindings will work fine.

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->