### PR TITLE
fix(workspace): resolve symlinks in workspace path before checking

### DIFF
--- a/autogpt/workspace.py
+++ b/autogpt/workspace.py
@@ -37,6 +37,7 @@ def safe_path_join(base: Path, *paths: str | Path) -> Path:
     Returns:
         Path: The joined path
     """
+    base = base.resolve()
     joined_path = base.joinpath(*paths).resolve()
 
     if CFG.restrict_to_workspace and not joined_path.is_relative_to(base):


### PR DESCRIPTION
One-line fix to solve cases where the workspace is in a symlinked directory subtree