### PR TITLE
Wikipedia Search Command

### DIFF
--- a/autogpt/commands/wikipedia_search.py
+++ b/autogpt/commands/wikipedia_search.py
@@ -1,0 +1,62 @@
+"""Wikipedia search command for Autogpt."""
+from __future__ import annotations
+
+import json
+import re
+from urllib.parse import quote
+
+import requests
+
+from autogpt.commands.command import command
+from autogpt.config import Config
+from autogpt.logs import logger
+
+HTML_TAG_CLEANER = re.compile("<.*?>|&([a-z0-9]+|#[0-9]{1,6}|#x[0-9a-f]{1,6});")
+
+
+@command(
+    "wikipedia_search",
+    "Wikipedia Search",
+    '"query": "<query>"',
+)
+def wikipedia_search(query: str, num_results: int = 5) -> str | list[str]:
+    """Return the results of a Wikipedia search
+
+    Args:
+        query (str): The search query.
+        num_results (int): The number of results to return.
+
+    Returns:
+        str: The results of the search. The resulting string is a `json.dumps`
+             of a list of len `num_results` containing dictionaries with the
+             following structure: `{'title': <title>, 'summary': <summary>,
+             'url': <url to relevant page>}`
+    """
+    search_url = (
+        "https://en.wikipedia.org/w/api.php?action=query&"
+        "format=json&list=search&utf8=1&formatversion=2&"
+        f"srsearch={quote(query)}"
+    )
+    with requests.Session() as session:
+        session.headers.update({"User-Agent": Config().user_agent})
+        session.headers.update({"Accept": "application/json"})
+        results = session.get(search_url)
+        try:
+            results = results.json()
+            r = []
+            for item in results["query"]["search"]:
+                summary = re.sub(HTML_TAG_CLEANER, "", item["snippet"])
+                r.append(
+                    {
+                        "title": item["title"],
+                        "summary": summary,
+                        "url": f"http://en.wikipedia.org/?curid={item['pageid']}",
+                    }
+                )
+                if len(r) == num_results:
+                    break
+        except Exception as e:
+            logger.debug(f"'wikipedia_search' on query: {query} raised exception: {e}")
+            return f"Error: {e}"
+
+    return [json.dumps(item, ensure_ascii=False, indent=4) for item in r]


### PR DESCRIPTION
Background
Wikipedia Search could provide the capability of searching for encyclopedia-like information and, in this sense, I think is a very relevant and general command to have. I will be more than happy to update it later to the plugin template once will be merged to stable.

Changes
Added Wikipedia Search command.

Documentation
The new command wikipedia_search will search in Wikipedia for relevant information. The resulting string is a json.dumps of a list of len num_results containing dictionaries with the following structure: {'title': <title>, 'summary': <summary>, 'url': <url to relevant page>}.

Test Plan
As far as this is a very simple functionality I not added tests as per some other similar functionality.

PR Quality Checklist
✔️ My pull request is atomic and focuses on a single change.
✔️ I have thoroughly tested my changes with multiple different prompts.
✔️ I have considered potential risks and mitigations for my changes.
✔️ I have documented my changes clearly and comprehensively.
✔️ I have not snuck in any "extra" small tweaks changes