### PR TITLE
Pin BeautifulSoup version to fix `browse_website`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-beautifulsoup4
+beautifulsoup4>=4.12.2
 colorama==0.4.6
 openai==0.27.2
 playsound==1.2.2


### PR DESCRIPTION
### Background

As reported in the issue #2514, `browse_website` command fails (in particular, its parsing part) with an error `module 'collections' has no attribute 'Callable'`.

The issue appears on Python 3.10 (3.10.11) as well as 3.11 (3.11.3), and on the following Auto-GPT versions: `master`, `0.2.1`, `0.2.2`, and `0.2.2-test`.

### Changes

The fix is simply to upgrade BeautifulSoup4 lib to the latest version (my previous version was 4.6.0):

```
pip install beautifulsoup4==4.12.2
```

which is then to be reflected in `requirements.txt` as `beautifulsoup4>=4.12.2`.
Note that this is easier and more elegant fix as the originally proposed in #2596

### Documentation

No in-code documentation needed.

### Test Plan

Tested on:
- Python: `3.10`, and `3.11`
- Auto-GPT: `master`, `0.2.1`, `0.2.2`, and `0.2.2-test`.

After upgrading BeautifulSoup4 lib, the issue disappeared in all the cases.

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes