### PR TITLE
Update test_image_gen.py file

### DIFF
--- a/autogpt/commands/image_gen.py
+++ b/autogpt/commands/image_gen.py
@@ -77,7 +77,7 @@ def generate_image_with_hf(prompt: str, filename: str) -> str:
     return f"Saved to disk:{filename}"
 
 
-def generate_image_with_dalle(prompt: str, filename: str) -> str:
+def generate_image_with_dalle(prompt: str, filename: str, size: int) -> str:
     """Generate an image with DALL-E.
 
     Args:

--- a/tests/test_image_gen.py
+++ b/tests/test_image_gen.py
@@ -13,7 +13,7 @@ def lst(txt):
     return txt.split(":")[1].strip()
 
 
-@unittest.skipIf(os.getenv("CI"), "Skipping image generation tests")
+@unittest.skipIf(not os.getenv("CI", False), "Skipping image generation tests")
 class TestImageGen(unittest.TestCase):
     def setUp(self):
         self.config = Config()

--- a/tests/test_image_gen.py
+++ b/tests/test_image_gen.py
@@ -13,7 +13,16 @@ def lst(txt):
     return txt.split(":")[1].strip()
 
 
-@unittest.skipIf(not os.getenv("CI"), "Skipping image generation tests")
+# Chreck if we are running in CI
+def is_ci():
+    """Check if we are running in CI"""
+    if os.getenv("CI") is not None:
+        if os.getenv("CI").lower() == "true":
+            return True
+    return False
+
+
+@unittest.skipIf(not is_ci(), "Skipping image generation tests")
 class TestImageGen(unittest.TestCase):
     def setUp(self):
         self.config = Config()

--- a/tests/test_image_gen.py
+++ b/tests/test_image_gen.py
@@ -19,10 +19,11 @@ def is_ci():
     if os.getenv("CI") is not None:
         if os.getenv("CI").lower() == "true":
             return True
+        os.environ["CI"] = "False"
     return False
 
 
-@unittest.skipIf(not is_ci(), "Skipping image generation tests")
+@unittest.skipIf(not os.getenv("CI"), "Skipping image generation tests")
 class TestImageGen(unittest.TestCase):
     def setUp(self):
         self.config = Config()
@@ -108,4 +109,5 @@ class TestImageGen(unittest.TestCase):
 
 
 if __name__ == "__main__":
+    is_ci()
     unittest.main()

--- a/tests/test_image_gen.py
+++ b/tests/test_image_gen.py
@@ -19,7 +19,7 @@ def is_ci():
     if os.getenv("CI") is not None:
         if os.getenv("CI").lower() == "true":
             return True
-        os.environ["CI"] = "False"
+        os.environ["CI"] = ""
     return False
 
 

--- a/tests/test_image_gen.py
+++ b/tests/test_image_gen.py
@@ -13,7 +13,7 @@ def lst(txt):
     return txt.split(":")[1].strip()
 
 
-@unittest.skipIf(not os.getenv("CI", False), "Skipping image generation tests")
+@unittest.skipIf(not os.getenv("CI"), "Skipping image generation tests")
 class TestImageGen(unittest.TestCase):
     def setUp(self):
         self.config = Config()

--- a/tests/test_image_gen.py
+++ b/tests/test_image_gen.py
@@ -19,7 +19,7 @@ def is_ci():
     if os.getenv("CI") is not None:
         if os.getenv("CI").lower() == "true":
             return True
-        os.environ["CI"] = ""
+        os.environ["CI"] = False
     return False
 
 


### PR DESCRIPTION
### Background
The environment variable "CI" is commonly used in continuous integration and deployment (CI/CD) systems to indicate that a build is running in a CI environment. By setting this variable by default in the project, we can avoid errors that might occur due to differences between the local development environment and the CI environment. Therefore, a pull request has been submitted to set the environment variable "CI" by default in the project.

### Changes
Adds a default value for the "CI" environment, environment variable "CI" will be set to False.
