### PR TITLE
Add missing `size` param to generate_image_with_dalle

### DIFF
--- a/autogpt/commands/image_gen.py
+++ b/autogpt/commands/image_gen.py
@@ -77,7 +77,7 @@ def generate_image_with_hf(prompt: str, filename: str) -> str:
     return f"Saved to disk:{filename}"
 
 
-def generate_image_with_dalle(prompt: str, filename: str) -> str:
+def generate_image_with_dalle(prompt: str, filename: str, size:int) -> str:
     """Generate an image with DALL-E.
 
     Args:

--- a/autogpt/commands/image_gen.py
+++ b/autogpt/commands/image_gen.py
@@ -77,7 +77,7 @@ def generate_image_with_hf(prompt: str, filename: str) -> str:
     return f"Saved to disk:{filename}"
 
 
-def generate_image_with_dalle(prompt: str, filename: str, size:int) -> str:
+def generate_image_with_dalle(prompt: str, filename: str, size: int) -> str:
     """Generate an image with DALL-E.
 
     Args:

--- a/autogpt/commands/image_gen.py
+++ b/autogpt/commands/image_gen.py
@@ -83,6 +83,7 @@ def generate_image_with_dalle(prompt: str, filename: str, size: int) -> str:
     Args:
         prompt (str): The prompt to use
         filename (str): The filename to save the image to
+        size (int): The size of the image
 
     Returns:
         str: The filename of the image


### PR DESCRIPTION
### Background
Size parameter was not used in required function parameter.

### Changes
Adds size variable to functions parameters.