### PR TITLE
Update ci.yml file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ env.min-python-version }}
+        node-version: '16'
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
### Background
Node 12 will be deprecaded in future GitHub Actions versions.
### Changes
This PR updates Node version used from 12 to 16.

### Documentation

[GitHub Actions documentation](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsusing-for-javascript-actions)