### PR TITLE
fix #2654 spacy language model installation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ jsonschema
 tweepy
 click
 spacy>=3.0.0,<4.0.0
-en_core_web_sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.4.0/en_core_web_sm-3.4.0-py3-none-any.whl
+en-core-web-sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.5.0/en_core_web_sm-3.5.0-py3-none-any.whl
 
 ##Dev
 coverage

--- a/scripts/check_requirements.py
+++ b/scripts/check_requirements.py
@@ -1,3 +1,4 @@
+import re
 import sys
 
 import pkg_resources
@@ -16,7 +17,7 @@ def main():
     for package in required_packages:
         if not package:  # Skip empty lines
             continue
-        package_name = package.strip().split("==")[0]
+        package_name = re.split("[<>=@ ]+", package.strip())[0]
         if package_name.lower() not in installed_packages:
             missing_packages.append(package_name)
 


### PR DESCRIPTION
### Background
* #2654

### Changes
* Fix `requirements.txt` line splitting in `check_requirements.py`
* Install spacy language model as `en-core-web-sm` so it doesn't mismatch in `check_requirments.py`
    * This works with the current config setup, e.g. `BROWSE_SPACY_LANGUAGE_MODEL=en_core_web_sm`

### Test Plan
`docker-compose run --build --rm --entrypoint python auto-gpt -c 'import spacy; spacy.load("en_core_web_sm")'`

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->

<!-- If you haven't added tests, please explain why. If you have, check the appropriate box. If you've ensured your PR is atomic and well-documented, check the corresponding boxes. -->

<!-- By submitting this, I agree that my pull request should be closed if I do not fill this out or follow the guidelines. -->
