### PR TITLE
Huggingface retry generate_image with delay

### DIFF
--- a/autogpt/commands/image_gen.py
+++ b/autogpt/commands/image_gen.py
@@ -1,6 +1,8 @@
 """ Image Generation Module for AutoGPT."""
 import io
 import uuid
+import time
+import json
 from base64 import b64decode
 
 import openai
@@ -61,21 +63,38 @@ def generate_image_with_hf(prompt: str, filename: str) -> str:
         "X-Use-Cache": "false",
     }
 
-    response = requests.post(
-        API_URL,
-        headers=headers,
-        json={
-            "inputs": prompt,
-        },
-    )
 
-    image = Image.open(io.BytesIO(response.content))
-    print(f"Image Generated for prompt:{prompt}")
+    retry_count = 0
+    while retry_count < 10:
+        response = requests.post(
+            API_URL,
+            headers=headers,
+            json={
+                "inputs": prompt
+            },
+        )
 
-    image.save(path_in_workspace(filename))
+        if response.ok:
+            try:
+                image = Image.open(io.BytesIO(response.content))
+                image.save(path_in_workspace(filename))
+                return f"Saved to disk:{filename}"
+            except Exception as e:
+                print(e)
+        else:
+            try:
+                error = json.loads(response.text)
+                if "estimated_time" in error:
+                    delay = error["estimated_time"]
+                    print(response.text)
+                    print("Retrying in", delay)
+                    time.sleep(delay)
+            except Exception as e:
+                print(e)
 
-    return f"Saved to disk:{filename}"
+        retry_count += 1
 
+    return f"Error creating image."
 
 def generate_image_with_dalle(prompt: str, filename: str) -> str:
     """Generate an image with DALL-E.


### PR DESCRIPTION
### Background

The command `generate_image` with huggingface may return an error response due to the service queuing the request. This results in the image failing to generate. A delay may be invoked and the request retried, in order to return a successful image.

```
cannot identify image file <_io.BytesIO object at 0x7f6eac20ef40>
b'{"error":"Model CompVis/stable-diffusion-v1-4 is currently loading","estimated_time":20.0}'
```

### Changes

- Check for error in response from huggingface and retry with delay up to 10 times.
- Delay in seconds is obtained from huggingface response.

### Documentation

- No additional documentation required for users.

### Test Plan

- Tested locally by running with generate_image command.

### PR Quality Checklist
- [X] My pull request is atomic and focuses on a single change.
- [X] I have thoroughly tested my changes with multiple different prompts.
- [X] I have considered potential risks and mitigations for my changes.
- [X] I have documented my changes clearly and comprehensively.
- [X] I have not snuck in any "extra" small tweaks changes
