### PR TITLE
Make `load_azure_config` throw if `azure.yaml` does not exist

### DIFF
--- a/autogpt/config/config.py
+++ b/autogpt/config/config.py
@@ -174,11 +174,8 @@ class Config(metaclass=Singleton):
         Returns:
             None
         """
-        try:
-            with open(config_file) as file:
-                config_params = yaml.load(file, Loader=yaml.FullLoader)
-        except FileNotFoundError:
-            config_params = {}
+        with open(config_file) as file:
+            config_params = yaml.load(file, Loader=yaml.FullLoader)
         self.openai_api_type = config_params.get("azure_api_type") or "azure"
         self.openai_api_base = config_params.get("azure_api_base") or ""
         self.openai_api_version = (


### PR DESCRIPTION
### Background
When `azure.yaml` can't be loaded, it now just continues silently even if `USE_AZURE` is set. Instead of breaking later on when the API calls start to fail, it should fail immediately and throw a `FileNotFoundError`.

### Changes
* Remove `try` / `except` block in `load_azure_config`

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [ ] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes
