### PR TITLE
Better code resilience - Add fallback to empty dictionary for config_params if it is None

### DIFF
--- a/autogpt/config/ai_config.py
+++ b/autogpt/config/ai_config.py
@@ -70,6 +70,8 @@ class AIConfig:
         except FileNotFoundError:
             config_params = {}
 
+        if config_params == None:
+            config_params = {}
         ai_name = config_params.get("ai_name", "")
         ai_role = config_params.get("ai_role", "")
         ai_goals = config_params.get("ai_goals", [])


### PR DESCRIPTION
### Background
When the app is loaded and there's a config file available but empty, there's nothing to hinder that objects isn't instantiated and in this case `config_params` will turn out `None`.
Since values are expected an error is thrown an unhandled.
But the flow could actually handle that there aren't values in the dictionary, as it's the case when settings-file isn't present.

### Changes
Check for None and if true, instantiate to empty.

### Documentation
I think it would be self-explonary. If I'm wrong on that one, I would very much appreciate some advice.

### Test Plan
I would have written a unit-test to prove the error - if I had any idea on how to :) Sorry, but the is the first time ever, that I have opened a PR against some python-code.

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes 

<!-- If you haven't added tests, please explain why. If you have, check the appropriate box. If you've ensured your PR is atomic and well-documented, check the corresponding boxes. -->
I just wish I had the skills, and the time to be introduced to another programming language, it would have saved the weekend with a nice unit-test or two.

