### PR TITLE
Fix(tests): restore config values after changing them in tests

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -38,47 +38,89 @@ class TestConfig(TestCase):
         """
         Test if the set_continuous_mode() method updates the continuous_mode attribute.
         """
+        # Store continuous mode to reset it after the test
+        continuous_mode = self.config.continuous_mode
+
         self.config.set_continuous_mode(True)
         self.assertTrue(self.config.continuous_mode)
+
+        # Reset continuous mode
+        self.config.set_continuous_mode(continuous_mode)
 
     def test_set_speak_mode(self):
         """
         Test if the set_speak_mode() method updates the speak_mode attribute.
         """
+        # Store speak mode to reset it after the test
+        speak_mode = self.config.speak_mode
+
         self.config.set_speak_mode(True)
         self.assertTrue(self.config.speak_mode)
+
+        # Reset speak mode
+        self.config.set_speak_mode(speak_mode)
 
     def test_set_fast_llm_model(self):
         """
         Test if the set_fast_llm_model() method updates the fast_llm_model attribute.
         """
+        # Store model name to reset it after the test
+        fast_llm_model = self.config.fast_llm_model
+
         self.config.set_fast_llm_model("gpt-3.5-turbo-test")
         self.assertEqual(self.config.fast_llm_model, "gpt-3.5-turbo-test")
+
+        # Reset model name
+        self.config.set_fast_llm_model(fast_llm_model)
 
     def test_set_smart_llm_model(self):
         """
         Test if the set_smart_llm_model() method updates the smart_llm_model attribute.
         """
+        # Store model name to reset it after the test
+        smart_llm_model = self.config.smart_llm_model
+
         self.config.set_smart_llm_model("gpt-4-test")
         self.assertEqual(self.config.smart_llm_model, "gpt-4-test")
+
+        # Reset model name
+        self.config.set_smart_llm_model(smart_llm_model)
 
     def test_set_fast_token_limit(self):
         """
         Test if the set_fast_token_limit() method updates the fast_token_limit attribute.
         """
+        # Store token limit to reset it after the test
+        fast_token_limit = self.config.fast_token_limit
+
         self.config.set_fast_token_limit(5000)
         self.assertEqual(self.config.fast_token_limit, 5000)
+
+        # Reset token limit
+        self.config.set_fast_token_limit(fast_token_limit)
 
     def test_set_smart_token_limit(self):
         """
         Test if the set_smart_token_limit() method updates the smart_token_limit attribute.
         """
+        # Store token limit to reset it after the test
+        smart_token_limit = self.config.smart_token_limit
+
         self.config.set_smart_token_limit(9000)
         self.assertEqual(self.config.smart_token_limit, 9000)
+
+        # Reset token limit
+        self.config.set_smart_token_limit(smart_token_limit)
 
     def test_set_debug_mode(self):
         """
         Test if the set_debug_mode() method updates the debug_mode attribute.
         """
+        # Store debug mode to reset it after the test
+        debug_mode = self.config.debug_mode
+
         self.config.set_debug_mode(True)
         self.assertTrue(self.config.debug_mode)
+
+        # Reset debug mode
+        self.config.set_debug_mode(debug_mode)


### PR DESCRIPTION
### Background
<!-- Provide a concise overview of the rationale behind this change. Include relevant context, prior discussions, or links to related issues. Ensure that the change aligns with the project's overall direction. -->
Config values are currently being changed during testing, which effects later tests in the queue.

Example error this can cause:
`openai.error.InvalidRequestError: The model gpt-3.5-turbo-test does not exist`

### Changes
<!-- Describe the specific, focused change made in this pull request. Detail the modifications clearly and avoid any unrelated or "extra" changes. -->
This PR ensures all values changed during testing are reset after the test.

### Documentation
<!-- Explain how your changes are documented, such as in-code comments or external documentation. Ensure that the documentation is clear, concise, and easy to understand. -->
All code commented.

### Test Plan
<!-- Describe how you tested this functionality. Include steps to reproduce, relevant test cases, and any other pertinent information. -->
Tests are still passing on this file.

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->

<!-- If you haven't added tests, please explain why. If you have, check the appropriate box. If you've ensured your PR is atomic and well-documented, check the corresponding boxes. -->

<!-- By submitting this, I agree that my pull request should be closed if I do not fill this out or follow the guidelines. -->
