### PR TITLE
cleaned up docker/docker-compose stuff a bit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,10 @@ RUN sed -i '/Items below this point will not be included in the Docker Image/,$d
 	pip install --no-cache-dir --user -r requirements.txt
 
 # Copy the application files
-COPY --chown=appuser:appuser autogpt/ ./autogpt
+COPY --chown=appuser:appuser autogpt/ /home/appuser/autogpt
+
+# Copy the plugins folder
+COPY --chown=appuser:appuser plugins /home/appuser/plugins
 
 # Set the entrypoint
 ENTRYPOINT ["python", "-m", "autogpt"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,9 +9,10 @@ services:
     build: ./
     env_file:
       - .env
-    volumes:
-      - "./autogpt:/home/appuser"
-      - ".env:/home/appuser/.env"
+    volumes:                                            # uncommented iff you need any volume
+      - ".workspace:/home/appuser/auto_gpt_workspace/" # uncomment if you want to peek workspace
+#      - "plugins:/home/appuser/plugins/"               # uncomment if you don't want to rebuild the container everytime you touch the plugin folder
+#      - "autogpt:/home/appuser/autogpt/"               # uncomment if you don't want to rebuild the container every time you change a file
     profiles: ["exclude-from-up"]
 
   redis:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,8 @@ services:
     build: ./
     env_file:
       - .env
-    volumes:                                            # uncommented iff you need any volume
-      - ".workspace:/home/appuser/auto_gpt_workspace/" # uncomment if you want to peek workspace
+#    volumes:                                            # uncommented iff you need any volume
+#      - ".workspace:/home/appuser/auto_gpt_workspace/" # uncomment if you want to peek workspace
 #      - "plugins:/home/appuser/plugins/"               # uncomment if you don't want to rebuild the container everytime you touch the plugin folder
 #      - "autogpt:/home/appuser/autogpt/"               # uncomment if you don't want to rebuild the container every time you change a file
     profiles: ["exclude-from-up"]


### PR DESCRIPTION
I've run into a few smaller issues when running autogpt in docker through docker-compose, mostly related to weirdness with paths and the Dockerfile copying things while the docker-compose file mounted volumes oddly.

### Changes
#### Dockerfile
* using full path for autogpt module, so the directory is copied to the place where its needed
* adding plugins folder to be copied, so that plugins can be installed as well

#### docker-compose.yml
Overhauled volumes
* mounting .env shouldn't be necessary, as env_file should already take care of making the environment variables available at run time (dropped)
* mounting autogpt into /home/appuser made autogpt the home, while the dockerfile made it a subdirectory of home (it should be the later), a commented out example how to mount it as such was added
* mounting plugins can save time when working on plugins, a commented out example was provided
* mounting the workspace can be extremly usefull, an example has been provided here as well, although i suspect people are using other folders / pathes
  
### Documentation
changes are documented in changes above, and have code comments if context requires

### Test Plan
Run  autogpt through docker or docker-compose

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes

I have not added any new tests, as i've not created any real code