### PR TITLE
Enable support for loading multiple plugins per zip file

### DIFF
--- a/tests/unit/test_plugins.py
+++ b/tests/unit/test_plugins.py
@@ -3,7 +3,7 @@ import pytest
 from autogpt.config import Config
 from autogpt.plugins import (
     denylist_allowlist_check,
-    inspect_zip_for_module,
+    inspect_zip_for_modules,
     scan_plugins,
 )
 
@@ -13,9 +13,9 @@ PLUGIN_TEST_INIT_PY = "Auto-GPT-Plugin-Test-master/src/auto_gpt_vicuna/__init__.
 PLUGIN_TEST_OPENAI = "https://weathergpt.vercel.app/"
 
 
-def test_inspect_zip_for_module():
-    result = inspect_zip_for_module(str(f"{PLUGINS_TEST_DIR}/{PLUGIN_TEST_ZIP_FILE}"))
-    assert result == PLUGIN_TEST_INIT_PY
+def test_inspect_zip_for_modules():
+    result = inspect_zip_for_modules(str(f"{PLUGINS_TEST_DIR}/{PLUGIN_TEST_ZIP_FILE}"))
+    assert result == [PLUGIN_TEST_INIT_PY]
 
 
 @pytest.fixture


### PR DESCRIPTION
### Background
The current implementation of Auto-GPT supports loading only one plugin per zip file. However, the architecture of [Auto-GPT-Plugins](https://github.com/Significant-Gravitas/Auto-GPT-Plugins) is designed to accommodate multiple plugins within a single Auto-GPT-Plugins.zip file. In order to enable this design, it is essential to update the codebase to enable the loading of multiple plugins from a single zip file.

### Changes
This pull request introduces a modification to the `inspect_zip_for_module` function in `autogpt/plugins.py`. Instead of exiting early upon discovering a single plugin, the function now compiles a list of all modules found within the zip file. This adjustment enables the loading of multiple plugins from one zip file.

### Documentation
The modifications have been clearly documented through in-code comments and updated docstrings for the revised function.

### Test Plan
To validate the functionality, I created a sample zip file containing multiple plugins and verified that Auto-GPT successfully loaded all of them. Additionally, I conducted tests with various combinations of valid and invalid plugins to ensure proper handling of edge cases.

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes.