### PR TITLE
Fix typo in warning message when non allowlisted plugins found

### DIFF
--- a/autogpt/plugins.py
+++ b/autogpt/plugins.py
@@ -261,7 +261,7 @@ def denylist_allowlist_check(plugin_name: str, cfg: Config) -> bool:
     if plugin_name in cfg.plugins_allowlist:
         return True
     ack = input(
-        f"WARNNG Plugin {plugin_name} found. But not in the"
+        f"WARNING: Plugin {plugin_name} found. But not in the"
         " allowlist... Load? (y/n): "
     )
     return ack.lower() == "y"


### PR DESCRIPTION
<!-- ⚠️ At the moment any non-essential commands are not being merged.
If you want to add non-essential commands to Auto-GPT, please create a plugin instead.
We are expecting to ship plugin support within the week (PR #757).
Resources:
* https://github.com/Significant-Gravitas/Auto-GPT-Plugin-Template
-->

<!-- 📢 Announcement
We've recently noticed an increase in pull requests focusing on combining multiple changes. While the intentions behind these PRs are appreciated, it's essential to maintain a clean and manageable git history. To ensure the quality of our repository, we kindly ask you to adhere to the following guidelines when submitting PRs:

Focus on a single, specific change.
Do not include any unrelated or "extra" modifications.
Provide clear documentation and explanations of the changes made.
Ensure diffs are limited to the intended lines — no applying preferred formatting styles or line endings (unless that's what the PR is about).
For guidance on committing only the specific lines you have changed, refer to this helpful video: https://youtu.be/8-hSNHHbiZg

By following these guidelines, your PRs are more likely to be merged quickly after testing, as long as they align with the project's overall direction. -->

### Background
There is a typo in the warning message when Auto-GPT tries to load a plugin which is not allowlisted.

### Changes
Replace WARNNG to WARNING to be consistent with the other messages. 

### Documentation
N/A

### Test Plan
I've checked if the application shows WARNING: instead of WARNNG when a not whitelisted plugin found.

### PR Quality Checklist
- [X] My pull request is atomic and focuses on a single change.
- [X] I have thoroughly tested my changes with multiple different prompts.
- [X] I have considered potential risks and mitigations for my changes.
- [X] I have documented my changes clearly and comprehensively.
- [X] I have not snuck in any "extra" small tweaks changes <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->

<!-- If you haven't added tests, please explain why. If you have, check the appropriate box. If you've ensured your PR is atomic and well-documented, check the corresponding boxes. -->

<!-- By submitting this, I agree that my pull request should be closed if I do not fill this out or follow the guidelines. -->
