### PR TITLE
Added testing timout in gh actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
       # python-coverage-comment-action branch, and for editing existing
       # comments (to avoid publishing multiple comments in the same PR)
       contents: write
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
### Background
Currently the testing steps in github actions do not have any overall timeouts. The total combined time of all the tests can become large. It could also significantly increase our openai cost. The idea of this PR is to try and add a reasonable overall timout to the testing step in our github workflow. Motivation for this PR is the third point in issue #2900 

### Changes
After looking at some f the recent ci.yml jobs in the project, I realised most of the testing jobs take around 1-3 mins of time. So, I've added a overall timeout of 10 minutes in testing job, whihch should be resonable enough for all our tests to finish and yet good enough to interrupt any malformed/misconfigured test runs. Thus making the openai costs somewhat predictable.

### Documentation
The change is self explanatory.

### Test Plan
Tried running an infinite loop in a test and verified that the timeout works as expected.

### PR Quality Checklist
- [ x] My pull request is atomic and focuses on a single change.
- [ x] I have thoroughly tested my changes with multiple different prompts.
- [ x] I have considered potential risks and mitigations for my changes.
- [ x] I have documented my changes clearly and comprehensively.
- [ x] I have not snuck in any "extra" small tweaks changes 
