### PR TITLE
Ensure Fore.RED is followed by Fore.RESET

### DIFF
--- a/autogpt/config/config.py
+++ b/autogpt/config/config.py
@@ -277,6 +277,7 @@ def check_openai_api_key() -> None:
         print(
             Fore.RED
             + "Please set your OpenAI API key in .env or as an environment variable."
+            + Fore.RESET
         )
         print("You can get your key from https://platform.openai.com/account/api-keys")
         exit(1)


### PR DESCRIPTION

### Background

This fixes a simple bug in which one particular log statement emits the RED terminal color code sequence to start writing red text, but does not emit the matching RESET code to switch back to the default color, thus turning all text on the screen red.

The affected log statement is likely to be encountered by new users on first usage, but is unlikely to be seen by experienced users.

### Changes

This PR properly resets the terminal, ensuring that the red text is red and the normal text remains unaffected, in this one log statement where `Fore.RESET` was previously missing.

### Documentation

N/A

### Test Plan

To reproduce: `./run.sh` on a completely clean system with no `.env` file. Notice that all text is red.

### PR Quality Checklist
- [*] My pull request is atomic and focuses on a single change.
- [*] I have thoroughly tested my changes with multiple different prompts.
- [*] I have considered potential risks and mitigations for my changes.
- [*] I have documented my changes clearly and comprehensively.
- [*] I have not snuck in any "extra" small tweaks changes <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->
