### PR TITLE
fix: use config instead of hardcoded filename

### DIFF
--- a/autogpt/agent/agent.py
+++ b/autogpt/agent/agent.py
@@ -280,7 +280,7 @@ class Agent:
             str: A feedback response generated using the provided thoughts dictionary.
         """
 
-        with open("ai_settings.yaml", "r") as yaml_file:
+        with open(Config().ai_settings_file, "r") as yaml_file:
             parsed_yaml = yaml.safe_load(yaml_file)
             ai_role = parsed_yaml["ai_role"]
 


### PR DESCRIPTION
### Background
a recent merge (#3013 by ) added self-feedback functionality, however, it is trying to read the role from a file with a hardcoded name, which might not even exist causing a crash, and if it exists might not be the one running

### Changes
this PR changes this from the hardcoded filename to be read from the config object.

### Documentation
Bugfix, no additional documentation

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks or changes

