### PR TITLE
Use explicit API keys when querying OpenAI

### DIFF
--- a/autogpt/api_manager.py
+++ b/autogpt/api_manager.py
@@ -7,7 +7,6 @@ from autogpt.logs import logger
 from autogpt.modelsinfo import COSTS
 
 cfg = Config()
-openai.api_key = cfg.openai_api_key
 print_total_cost = cfg.debug_mode
 
 
@@ -50,6 +49,7 @@ class ApiManager:
                 messages=messages,
                 temperature=temperature,
                 max_tokens=max_tokens,
+                api_key=cfg.openai_api_key,
             )
         else:
             response = openai.ChatCompletion.create(
@@ -57,6 +57,7 @@ class ApiManager:
                 messages=messages,
                 temperature=temperature,
                 max_tokens=max_tokens,
+                api_key=cfg.openai_api_key,
             )
         if self.debug:
             logger.debug(f"Response: {response}")

--- a/autogpt/commands/image_gen.py
+++ b/autogpt/commands/image_gen.py
@@ -87,7 +87,6 @@ def generate_image_with_dalle(prompt: str, filename: str, size: int) -> str:
     Returns:
         str: The filename of the image
     """
-    openai.api_key = CFG.openai_api_key
 
     # Check for supported image sizes
     if size not in [256, 512, 1024]:
@@ -102,6 +101,7 @@ def generate_image_with_dalle(prompt: str, filename: str, size: int) -> str:
         n=1,
         size=f"{size}x{size}",
         response_format="b64_json",
+        api_key=CFG.openai_api_key,
     )
 
     print(f"Image Generated for prompt:{prompt}")

--- a/autogpt/config/config.py
+++ b/autogpt/config/config.py
@@ -128,8 +128,6 @@ class Config(metaclass=Singleton):
         # Note that indexes must be created on db 0 in redis, this is not configurable.
 
         self.memory_backend = os.getenv("MEMORY_BACKEND", "local")
-        # Initialize the OpenAI API client
-        openai.api_key = self.openai_api_key
 
         self.plugins_dir = os.getenv("PLUGINS_DIR", "plugins")
         self.plugins: List[AutoGPTPluginTemplate] = []

--- a/autogpt/llm_utils.py
+++ b/autogpt/llm_utils.py
@@ -14,7 +14,6 @@ from autogpt.logs import logger
 from autogpt.types.openai import Message
 
 CFG = Config()
-openai.api_key = CFG.openai_api_key
 
 
 def retry_openai_api(
@@ -248,5 +247,8 @@ def create_embedding(
     Returns:
         openai.Embedding: The embedding object.
     """
-
-    return openai.Embedding.create(input=[text], **kwargs)
+    return openai.Embedding.create(
+        input=[text],
+        api_key=CFG.openai_api_key,
+        **kwargs,
+    )


### PR DESCRIPTION
### Background
We are currently relying on import time side-effects to make sure we're sending along the user's OpenAI api key.  This is incredibly fragile and has the pattern

```
import openai
openai.api_key = config.openai_api_key
```
proliferating about the codebase.

### Changes
- Explicitly use the api key from the config when calling openai services.
- Cleanup import time side effects

### Documentation
N/A

### Test Plan
CI is working, which covers most of what these import time side effects were meant to allow.  Manual application runs successful as well.

### PR Quality Checklist
- [X] My pull request is atomic and focuses on a single change.
- [X] I have thoroughly tested my changes with multiple different prompts.
- [X] I have considered potential risks and mitigations for my changes.
- [X] I have documented my changes clearly and comprehensively.
- [X] I have not snuck in any "extra" small tweaks changes <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->

<!-- If you haven't added tests, please explain why. If you have, check the appropriate box. If you've ensured your PR is atomic and well-documented, check the corresponding boxes. -->

<!-- By submitting this, I agree that my pull request should be closed if I do not fill this out or follow the guidelines. -->
