### PR TITLE
Load .env in package init

### DIFF
--- a/autogpt/__init__.py
+++ b/autogpt/__init__.py
@@ -1,0 +1,6 @@
+from dotenv import load_dotenv
+
+# Load the users .env file into environment variables
+load_dotenv(verbose=True, override=True)
+
+del load_dotenv

--- a/autogpt/commands/twitter.py
+++ b/autogpt/commands/twitter.py
@@ -2,11 +2,8 @@
 import os
 
 import tweepy
-from dotenv import load_dotenv
 
 from autogpt.commands.command import command
-
-load_dotenv()
 
 
 @command(

--- a/autogpt/config/config.py
+++ b/autogpt/config/config.py
@@ -6,11 +6,8 @@ import openai
 import yaml
 from auto_gpt_plugin_template import AutoGPTPluginTemplate
 from colorama import Fore
-from dotenv import load_dotenv
 
 from autogpt.singleton import Singleton
-
-load_dotenv(verbose=True, override=True)
 
 
 class Config(metaclass=Singleton):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,11 @@
 from pathlib import Path
 
 import pytest
-from dotenv import load_dotenv
 
 from autogpt.api_manager import ApiManager
 from autogpt.api_manager import api_manager as api_manager_
 from autogpt.config import Config
 from autogpt.workspace import Workspace
-
-load_dotenv()
 
 
 @pytest.fixture()


### PR DESCRIPTION
### Background
The .env file is currently loaded in a bunch of places, but canonically is loaded for the creation of the `Config` object.  Other entries have shown up because testing requires it or because some modules can get loaded out of context.  This PR ensures the .env is loaded at the very start of package import so it can happen once and work in all contexts.

### Changes
- load .env at package import.

### Documentation
N/A

### Test Plan
CI & manual application runs function normally.

### PR Quality Checklist
- [X] My pull request is atomic and focuses on a single change.
- [X] I have thoroughly tested my changes with multiple different prompts.
- [X] I have considered potential risks and mitigations for my changes.
- [X] I have documented my changes clearly and comprehensively.
- [X] I have not snuck in any "extra" small tweaks changes <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->

<!-- If you haven't added tests, please explain why. If you have, check the appropriate box. If you've ensured your PR is atomic and well-documented, check the corresponding boxes. -->

<!-- By submitting this, I agree that my pull request should be closed if I do not fill this out or follow the guidelines. -->
