### PR TITLE
Clean up image generation tests

### DIFF
--- a/tests/test_image_gen.py
+++ b/tests/test_image_gen.py
@@ -1,10 +1,78 @@
+import functools
 import hashlib
 from pathlib import Path
 
+import pytest
 from PIL import Image
 
 from autogpt.commands.image_gen import generate_image, generate_image_with_sd_webui
 from tests.utils import requires_api_key
+
+
+@pytest.fixture(params=[256, 512, 1024])
+def image_size(request):
+    """Parametrize image size."""
+    return request.param
+
+
+@requires_api_key("OPENAI_API_KEY")
+def test_dalle(config, workspace, image_size):
+    """Test DALL-E image generation."""
+    generate_and_validate(
+        config,
+        workspace,
+        image_provider="dalle",
+        image_size=image_size,
+    )
+
+
+@requires_api_key("HUGGINGFACE_API_TOKEN")
+@pytest.mark.parametrize(
+    "image_model",
+    ["CompVis/stable-diffusion-v1-4", "stabilityai/stable-diffusion-2-1"],
+)
+def test_huggingface(config, workspace, image_size, image_model):
+    """Test HuggingFace image generation."""
+    generate_and_validate(
+        config,
+        workspace,
+        image_provider="huggingface",
+        image_size=image_size,
+        hugging_face_image_model=image_model,
+    )
+
+
+@pytest.mark.xfail(reason="SD WebUI call does not work.")
+def test_sd_webui(config, workspace, image_size):
+    """Test SD WebUI image generation."""
+    generate_and_validate(
+        config,
+        workspace,
+        image_provider="sd_webui",
+        image_size=image_size,
+    )
+
+
+@pytest.mark.xfail(reason="SD WebUI call does not work.")
+def test_sd_webui_negative_prompt(config, workspace, image_size):
+    gen_image = functools.partial(
+        generate_image_with_sd_webui,
+        prompt="astronaut riding a horse",
+        size=image_size,
+        extra={"seed": 123},
+    )
+
+    # Generate an image with a negative prompt
+    image_path = lst(gen_image(negative_prompt="horse", filename="negative.jpg"))
+    with Image.open(image_path) as img:
+        neg_image_hash = hashlib.md5(img.tobytes()).hexdigest()
+
+    # Generate an image without a negative prompt
+    image_path = lst(gen_image(filename="positive.jpg"))
+    with Image.open(image_path) as img:
+        image_hash = hashlib.md5(img.tobytes()).hexdigest()
+
+    assert image_hash != neg_image_hash
 
 
 def lst(txt):
@@ -12,84 +80,20 @@ def lst(txt):
     return Path(txt.split(":")[1].strip())
 
 
-@requires_api_key("OPENAI_API_KEY")
-def test_dalle(request, config, workspace):
-    """Test DALL-E image generation."""
-    config.image_provider = "dalle"
+def generate_and_validate(
+    config,
+    workspace,
+    image_size,
+    image_provider,
+    hugging_face_image_model=None,
+    **kwargs,
+):
+    """Generate an image and validate the output."""
+    config.image_provider = image_provider
+    config.huggingface_image_model = hugging_face_image_model
+    prompt = "astronaut riding a horse"
 
-    # Test using size 256
-    image_path = lst(generate_image("astronaut riding a horse", 256))
+    image_path = lst(generate_image(prompt, image_size, **kwargs))
     assert image_path.exists()
     with Image.open(image_path) as img:
-        assert img.size == (256, 256)
-    image_path.unlink()
-
-    # Test using size 512
-    image_path = lst(generate_image("astronaut riding a horse", 512))
-    with Image.open(image_path) as img:
-        assert img.size == (512, 512)
-    image_path.unlink()
-
-
-@requires_api_key("HUGGINGFACE_API_TOKEN")
-def test_huggingface(request, config, workspace):
-    """Test HuggingFace image generation."""
-    config.image_provider = "huggingface"
-
-    # Test using SD 1.4 model and size 512
-    config.huggingface_image_model = "CompVis/stable-diffusion-v1-4"
-    image_path = lst(generate_image("astronaut riding a horse", 512))
-    assert image_path.exists()
-    with Image.open(image_path) as img:
-        assert img.size == (512, 512)
-    image_path.unlink()
-
-    # Test using SD 2.1 768 model and size 768
-    config.huggingface_image_model = "stabilityai/stable-diffusion-2-1"
-    image_path = lst(generate_image("astronaut riding a horse", 768))
-    with Image.open(image_path) as img:
-        assert img.size == (768, 768)
-    image_path.unlink()
-
-
-def test_sd_webui(config, workspace):
-    """Test SD WebUI image generation."""
-    config.image_provider = "sd_webui"
-    return
-
-    # Test using size 128
-    image_path = lst(generate_image_with_sd_webui("astronaut riding a horse", 128))
-    assert image_path.exists()
-    with Image.open(image_path) as img:
-        assert img.size == (128, 128)
-    image_path.unlink()
-
-    # Test using size 64 and negative prompt
-    result = lst(
-        generate_image_with_sd_webui(
-            "astronaut riding a horse",
-            negative_prompt="horse",
-            size=64,
-            extra={"seed": 123},
-        )
-    )
-    image_path = path_in_workspace(result)
-    with Image.open(image_path) as img:
-        assert img.size == (64, 64)
-
-    neg_image_hash = hashlib.md5(img.tobytes()).hexdigest()
-    image_path.unlink()
-
-    # Same test as above but without the negative prompt
-    result = lst(
-        generate_image_with_sd_webui(
-            "astronaut riding a horse", image_size=64, size=1, extra={"seed": 123}
-        )
-    )
-    image_path = path_in_workspace(result)
-    with Image.open(image_path) as img:
-        assert img.size == (64, 64)
-        image_hash = hashlib.md5(img.tobytes()).hexdigest()
-    image_path.unlink()
-
-    assert image_hash != neg_image_hash
+        assert img.size == (image_size, image_size)


### PR DESCRIPTION
### Background
Working from @merwanehamadi 's changes to make these tests work correctly and remove some code duplication.

### Changes
- Parameterize image size so all models are tested over several sizes.
- Extract a function to generate an image with a provider and validate the image size.
- Remove the `request` args from the funcs as they are not used and a holdover from a closed PR.
- Mark the SD WebUI as xfail because they fail for me.

### Documentation
N/A

### Test Plan
All testing here.

### PR Quality Checklist
- [X] My pull request is atomic and focuses on a single change.
- [X] I have thoroughly tested my changes with multiple different prompts.
- [X] I have considered potential risks and mitigations for my changes.
- [X] I have documented my changes clearly and comprehensively.
- [X] I have not snuck in any "extra" small tweaks changes <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->

<!-- If you haven't added tests, please explain why. If you have, check the appropriate box. If you've ensured your PR is atomic and well-documented, check the corresponding boxes. -->

<!-- By submitting this, I agree that my pull request should be closed if I do not fill this out or follow the guidelines. -->
