### PR TITLE
Add a regression test for the embedding

### DIFF
--- a/tests/integration/test_llm_utils.py
+++ b/tests/integration/test_llm_utils.py
@@ -1,0 +1,25 @@
+import string
+
+import pytest
+from numpy.random import RandomState
+
+from autogpt.llm_utils import get_ada_embedding
+from tests.utils import requires_api_key
+
+
+@pytest.fixture(scope="session")
+def random_large_string():
+    """Big string used to overwhelm token limits."""
+    seed = 42
+    n_characters = 30_000
+    random = RandomState(seed)
+    return "".join(random.choice(list(string.ascii_lowercase), size=n_characters))
+
+
+@pytest.mark.xfail(reason="We have no mechanism for embedding large strings.")
+@requires_api_key("OPENAI_API_KEY")
+def test_get_ada_embedding_large_context(random_large_string):
+    # This test should be able to mock the openai call after we have a fix.  We don't need
+    # to hit the API to test the logic of the function (so not using vcr). This is a quick
+    # regression test to document the issue.
+    get_ada_embedding(random_large_string)


### PR DESCRIPTION
### Background
There are many open issues related to the maximum tokens allowed to be passed to the embedding.  This is a quick regression test to formally document the issue.

There are many related PRs and issues: 
- #3222 
- #2801 
- #2871
- #2906 
- #3244 

### Changes
Add regression test for attempting to embed a string that's too long.

### Documentation
Comments in the test explaining what it's for.

### Test Plan
This

### PR Quality Checklist
- [X] My pull request is atomic and focuses on a single change.
- [X] I have thoroughly tested my changes with multiple different prompts.
- [X] I have considered potential risks and mitigations for my changes.
- [X] I have documented my changes clearly and comprehensively.
- [X] I have not snuck in any "extra" small tweaks changes <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->

<!-- If you haven't added tests, please explain why. If you have, check the appropriate box. If you've ensured your PR is atomic and well-documented, check the corresponding boxes. -->

<!-- By submitting this, I agree that my pull request should be closed if I do not fill this out or follow the guidelines. -->
