### PR TITLE
this is a way to help people who use docker to persist output to host

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     volumes:
       - "./autogpt:/app"
       - ".env:/app/.env"
+      - "./auto_gpt_workspace:/home/appuser/auto_gpt_workspace"
     profiles: ["exclude-from-up"]
 
   redis:


### PR DESCRIPTION
### Background
Based on personal experience and interaction with multiple users on the discord, the inability to easily persist autogpt output beyond the lifespan of the docker container is problematic.  By setting the default docker compose to mount a volume on the host, at least the output files should persist.  This will allow follow on runs to potentially ingest these.

### Changes
This adds the auto_gpt_workspace to the volumes in the docker-compose.yml

### Documentation
This change should be self-explanatory

### Test Plan
Tested this locally

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.

I did not add tests because this is a configuration change that should be straightforward.
