### PR TITLE
Support multiple pythons

### DIFF
--- a/run.bat
+++ b/run.bat
@@ -1,15 +1,8 @@
 @echo off
-
-setlocal
-
-set PY_CMD=python3
-where %PY_CMD% >nul 2>nul || set PY_CMD=python
-
-%PY_CMD% scripts/check_requirements.py requirements.txt
+python scripts/check_requirements.py requirements.txt
 if errorlevel 1 (
     echo Installing missing packages...
     pip install -r requirements.txt
 )
-
-%PY_CMD% -m autogpt %*
+python -m autogpt %*
 pause

--- a/run.bat
+++ b/run.bat
@@ -1,8 +1,15 @@
 @echo off
-python scripts/check_requirements.py requirements.txt
+
+setlocal
+
+set PY_CMD=python3
+where %PY_CMD% >nul 2>nul || set PY_CMD=python
+
+%PY_CMD% scripts/check_requirements.py requirements.txt
 if errorlevel 1 (
     echo Installing missing packages...
     pip install -r requirements.txt
 )
-python -m autogpt %*
+
+%PY_CMD% -m autogpt %*
 pause

--- a/run.sh
+++ b/run.sh
@@ -1,9 +1,26 @@
 #!/bin/bash
-python scripts/check_requirements.py requirements.txt
+
+# Check if python or python3 is installed
+if command -v python >/dev/null 2>&1; then
+    PY=python
+    PIP=pip
+elif command -v python3 >/dev/null 2>&1; then
+    PY=python3
+    PIP=pip3
+else
+    echo "Python is not installed. Please install Python 2.7 or 3.x."
+    exit 1
+fi
+
+# Check if the required packages are installed
+$PY scripts/check_requirements.py requirements.txt
 if [ $? -eq 1 ]
 then
     echo Installing missing packages...
-    pip install -r requirements.txt
+    $PIP install -r requirements.txt
 fi
-python -m autogpt $@
+
+# Run the autogpt script with the command line arguments
+$PY -m autogpt $@
+
 read -p "Press any key to continue..."


### PR DESCRIPTION
### Background
Some systems have different versions of Python installed and they will have an error running Auto GPT with the existing run script.

### Changes
The code first checks if Python or Python3 is installed then set the variables $PY and $PIP accordingly and then use these variables to run the rest of the script. If neither Python nor Python3 is installed, the script will exit with an error message

### Documentation
An updated version of the run script that checks for both Python and Python3 and proceeds to run the rest of the script with the appropriate version:

### Test Plan
Ran the run script without any errors.

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes 

