### PR TITLE
[bug] `list_files` api signature change in `data_ingestion.py` and lo…

### DIFF
--- a/data_ingestion.py
+++ b/data_ingestion.py
@@ -1,7 +1,7 @@
 import argparse
 import logging
 
-from autogpt.commands.file_operations import ingest_file, search_files
+from autogpt.commands.file_operations import ingest_file, list_files
 from autogpt.config import Config
 from autogpt.memory import get_memory
 
@@ -10,12 +10,11 @@ cfg = Config()
 
 def configure_logging():
     logging.basicConfig(
-        filemode="a",
         format="%(asctime)s,%(msecs)d %(name)s %(levelname)s %(message)s",
         datefmt="%H:%M:%S",
         level=logging.DEBUG,
         handlers=[
-            logging.FileHandler(filename="log-ingestion.txt"),
+            logging.FileHandler(filename="log-ingestion.txt", mode="a"),
             logging.StreamHandler(),
         ],
     )
@@ -31,7 +30,7 @@ def ingest_directory(directory, memory, args):
     """
     global logger
     try:
-        files = search_files(directory)
+        files = list_files(directory)
         for file in files:
             ingest_file(file, memory, args.max_length, args.overlap)
     except Exception as e:
@@ -68,7 +67,6 @@ def main() -> None:
         help="The max_length of each chunk when ingesting files (default: 4000)",
         default=4000,
     )
-
     args = parser.parse_args()
 
     # Initialize memory


### PR DESCRIPTION
`list_files` api signature change in `data_ingestion.py` and fix logging related bugs in `data_ingestion.py`

<!-- ⚠️ At the moment any non-essential commands are not being merged.
If you want to add non-essential commands to Auto-GPT, please create a plugin instead.
We are expecting to ship plugin support within the week (PR #757).
Resources:
* https://github.com/Significant-Gravitas/Auto-GPT-Plugin-Template
-->

<!-- 📢 Announcement
We've recently noticed an increase in pull requests focusing on combining multiple changes. While the intentions behind these PRs are appreciated, it's essential to maintain a clean and manageable git history. To ensure the quality of our repository, we kindly ask you to adhere to the following guidelines when submitting PRs:

Focus on a single, specific change.
Do not include any unrelated or "extra" modifications.
Provide clear documentation and explanations of the changes made.
Ensure diffs are limited to the intended lines — no applying preferred formatting styles or line endings (unless that's what the PR is about).
For guidance on committing only the specific lines you have changed, refer to this helpful video: https://youtu.be/8-hSNHHbiZg

By following these guidelines, your PRs are more likely to be merged quickly after testing, as long as they align with the project's overall direction. -->

### Background
<!-- Provide a concise overview of the rationale behind this change. Include relevant context, prior discussions, or links to related issues. Ensure that the change aligns with the project's overall direction. -->

Integrating #3595 led to an API change that created an `ImportError` in `data_ingestion.py`. Integrating #3056 created a ValueError with the `configure_logging` function because `filemode` is an invalid argument: 
```
Traceback (most recent call last):
  File "/home/ubuntu/exploration/Auto-GPT/data_ingestion.py", line 106, in <module>
    main()
  File "/home/ubuntu/exploration/Auto-GPT/data_ingestion.py", line 42, in main
    logger = configure_logging()
  File "/home/ubuntu/exploration/Auto-GPT/data_ingestion.py", line 12, in configure_logging
    logging.basicConfig(
  File "/home/ubuntu/miniconda3/envs/autogpt-project/lib/python3.10/logging/__init__.py", line 2062, in basicConfig
    raise ValueError('Unrecognised argument(s): %s' % keys)
ValueError: Unrecognised argument(s): filemode
```

The `data_ingestion.py` file is also not usable when using `LocalCache` memory since the `Config` object has no `workspace_path` set to it. I can send a follow up PR that adds this option. Let me know if that is a direction you wish to support. 

### Changes
<!-- Describe the specific, focused change made in this pull request. Detail the modifications clearly and avoid any unrelated or "extra" changes. -->

This PR fixes two bugs in the `data_ingestion.py` that made it un-callable. 

1. Fix import errors created because of the API signature change from #3595 
2. Fix logging-related options changed from #3056 

### Documentation
<!-- Explain how your changes are documented, such as in-code comments or external documentation. Ensure that the documentation is clear, concise, and easy to understand. -->

### Test Plan
<!-- Describe how you tested this functionality. Include steps to reproduce, relevant test cases, and any other pertinent information. -->

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->

<!-- If you haven't added tests, please explain why. If you have, check the appropriate box. If you've ensured your PR is atomic and well-documented, check the corresponding boxes. -->

<!-- By submitting this, I agree that my pull request should be closed if I do not fill this out or follow the guidelines. -->
