### PR TITLE
Fix side effects on message history

### DIFF
--- a/autogpt/memory_management/summary_memory.py
+++ b/autogpt/memory_management/summary_memory.py
@@ -93,7 +93,7 @@ Summary So Far:
 
 Latest Development:
 """
-{new_events}
+{updated_new_events}
 """
 '''
 

--- a/autogpt/memory_management/summary_memory.py
+++ b/autogpt/memory_management/summary_memory.py
@@ -61,8 +61,11 @@ def update_running_summary(current_memory: str, new_events: List[Dict]) -> str:
         update_running_summary(new_events)
         # Returns: "This reminds you of these events from your past: \nI entered the kitchen and found a scrawled note saying 7."
     """
+    # Create a copy of the new_events list to prevent modifying the original list
+    updated_new_events = new_events.copy()
+
     # Replace "assistant" with "you". This produces much better first person past tense results.
-    for event in new_events:
+    for event in updated_new_events:
         if event["role"].lower() == "assistant":
             event["role"] = "you"
             # Remove "thoughts" dictionary from "content"
@@ -74,8 +77,7 @@ def update_running_summary(current_memory: str, new_events: List[Dict]) -> str:
             event["role"] = "your computer"
         # Delete all user messages
         elif event["role"] == "user":
-            new_events.remove(event)
-
+            updated_new_events.remove(event)
     # This can happen at any point during execturion, not just the beginning
     if len(new_events) == 0:
         new_events = "Nothing new happened."

--- a/autogpt/memory_management/summary_memory.py
+++ b/autogpt/memory_management/summary_memory.py
@@ -1,3 +1,4 @@
+import copy
 import json
 from typing import Dict, List, Tuple
 
@@ -44,7 +45,9 @@ def get_newly_trimmed_messages(
     return new_messages_not_in_context, new_index
 
 
-def update_running_summary(current_memory: str, new_events: List[Dict]) -> str:
+def update_running_summary(
+    current_memory: str, new_events: List[Dict[str, str]]
+) -> str:
     """
     This function takes a list of dictionaries representing new events and combines them with the current summary,
     focusing on key and potentially important information to remember. The updated summary is returned in a message
@@ -62,22 +65,26 @@ def update_running_summary(current_memory: str, new_events: List[Dict]) -> str:
         # Returns: "This reminds you of these events from your past: \nI entered the kitchen and found a scrawled note saying 7."
     """
     # Create a copy of the new_events list to prevent modifying the original list
-    updated_new_events = new_events.copy()
+    new_events = copy.deepcopy(new_events)
 
     # Replace "assistant" with "you". This produces much better first person past tense results.
-    for event in updated_new_events:
+    for event in new_events:
         if event["role"].lower() == "assistant":
             event["role"] = "you"
+
             # Remove "thoughts" dictionary from "content"
             content_dict = json.loads(event["content"])
             if "thoughts" in content_dict:
                 del content_dict["thoughts"]
             event["content"] = json.dumps(content_dict)
+
         elif event["role"].lower() == "system":
             event["role"] = "your computer"
+
         # Delete all user messages
         elif event["role"] == "user":
-            updated_new_events.remove(event)
+            new_events.remove(event)
+
     # This can happen at any point during execturion, not just the beginning
     if len(new_events) == 0:
         new_events = "Nothing new happened."
@@ -93,7 +100,7 @@ Summary So Far:
 
 Latest Development:
 """
-{updated_new_events}
+{new_events}
 """
 '''
 


### PR DESCRIPTION
<!-- ⚠️ At the moment any non-essential commands are not being merged.
If you want to add non-essential commands to Auto-GPT, please create a plugin instead.
We are expecting to ship plugin support within the week (PR #757).
Resources:
* https://github.com/Significant-Gravitas/Auto-GPT-Plugin-Template
-->

<!-- 📢 Announcement
We've recently noticed an increase in pull requests focusing on combining multiple changes. While the intentions behind these PRs are appreciated, it's essential to maintain a clean and manageable git history. To ensure the quality of our repository, we kindly ask you to adhere to the following guidelines when submitting PRs:

Focus on a single, specific change.
Do not include any unrelated or "extra" modifications.
Provide clear documentation and explanations of the changes made.
Ensure diffs are limited to the intended lines — no applying preferred formatting styles or line endings (unless that's what the PR is about).
For guidance on committing only the specific lines you have changed, refer to this helpful video: https://youtu.be/8-hSNHHbiZg

By following these guidelines, your PRs are more likely to be merged quickly after testing, as long as they align with the project's overall direction. -->

### Background
<!-- Provide a concise overview of the rationale behind this change. Include relevant context, prior discussions, or links to related issues. Ensure that the change aligns with the project's overall direction. -->
An issue was caused by the update_running_summary function, which was directly modifying the new_events list passed as an argument. Since the new_events list is a part of the full_message_history, any modifications made to the new_events list would also affect the original full_message_history.


### Changes
<!-- Describe the specific, focused change made in this pull request. Detail the modifications clearly and avoid any unrelated or "extra" changes. --> 

Create a copy of the new_events list: To avoid modifying the original new_events list and full_message_history, a copy of the new_events list was created using new_events.copy(), and the copy was named updated_new_events. Then added `updated_new_events` to the prompt.

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->

<!-- If you haven't added tests, please explain why. If you have, check the appropriate box. If you've ensured your PR is atomic and well-documented, check the corresponding boxes. -->

<!-- By submitting this, I agree that my pull request should be closed if I do not fill this out or follow the guidelines. -->
