### PR TITLE
Fix `validate_json` scheme path

### DIFF
--- a/autogpt/json_utils/utilities.py
+++ b/autogpt/json_utils/utilities.py
@@ -10,7 +10,6 @@ from autogpt.logs import logger
 
 CFG = Config()
 LLM_DEFAULT_RESPONSE_FORMAT = "llm_response_format_1"
-LLM_RESPONSE_DIRECTORY = os.path.dirname(__file__)
 
 
 def extract_char_position(error_message: str) -> int:

--- a/autogpt/json_utils/utilities.py
+++ b/autogpt/json_utils/utilities.py
@@ -37,7 +37,7 @@ def validate_json(json_object: object, schema_name: str) -> dict | None:
     :param schema_name: str
     :type json_object: object
     """
-    scheme_file = os.path.join(LLM_RESPONSE_DIRECTORY, f"{schema_name}.json")
+    scheme_file = os.path.join(os.path.dirname(__file__), f"{schema_name}.json")
     with open(scheme_file, "r") as f:
         schema = json.load(f)
     validator = Draft7Validator(schema)

--- a/autogpt/json_utils/utilities.py
+++ b/autogpt/json_utils/utilities.py
@@ -1,5 +1,6 @@
 """Utilities for the json_fixes package."""
 import json
+import os
 import re
 
 from jsonschema import Draft7Validator
@@ -9,6 +10,7 @@ from autogpt.logs import logger
 
 CFG = Config()
 LLM_DEFAULT_RESPONSE_FORMAT = "llm_response_format_1"
+LLM_RESPONSE_DIRECTORY = os.path.dirname(__file__)
 
 
 def extract_char_position(error_message: str) -> int:
@@ -35,7 +37,8 @@ def validate_json(json_object: object, schema_name: str) -> dict | None:
     :param schema_name: str
     :type json_object: object
     """
-    with open(f"autogpt/json_utils/{schema_name}.json", "r") as f:
+    scheme_file = os.path.join(LLM_RESPONSE_DIRECTORY, f"{schema_name}.json")
+    with open(scheme_file, "r") as f:
         schema = json.load(f)
     validator = Draft7Validator(schema)
 


### PR DESCRIPTION
### Background
validate_json is throwing error when used from tests
![image](https://user-images.githubusercontent.com/64261260/235482747-ff07db0e-e1d9-4e37-9acc-bef168afed19.png)


### Changes
Set scheme patch to be relative to the .py file

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [ ] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->
