### PR TITLE
Add warning for LLM to avoid context overflow

### DIFF
--- a/autogpt/agent/agent.py
+++ b/autogpt/agent/agent.py
@@ -5,6 +5,7 @@ from autogpt.config import Config
 from autogpt.json_utils.json_fix_llm import fix_json_using_multiple_techniques
 from autogpt.json_utils.utilities import LLM_DEFAULT_RESPONSE_FORMAT, validate_json
 from autogpt.llm import chat_with_ai, create_chat_completion, create_chat_message
+from autogpt.llm.token_counter import count_string_tokens
 from autogpt.logs import logger, print_assistant_thoughts
 from autogpt.speech import say_text
 from autogpt.spinner import Spinner
@@ -232,6 +233,12 @@ class Agent:
                     self.config.prompt_generator,
                 )
                 result = f"Command {command_name} returned: " f"{command_result}"
+
+                result_tlength = count_string_tokens(command_result, cfg.fast_llm_model)
+                memory_tlength = count_string_tokens(self.summary_memory, cfg.fast_llm_model)
+                if result_tlength + memory_tlength + 80 > cfg.fast_token_limit:
+                    result = f"Failure: command {command_name} returned too much output. \
+                        Do not execute this command again with the same arguments."
 
                 for plugin in cfg.plugins:
                     if not plugin.can_handle_post_command():

--- a/autogpt/agent/agent.py
+++ b/autogpt/agent/agent.py
@@ -234,11 +234,13 @@ class Agent:
                 )
                 result = f"Command {command_name} returned: " f"{command_result}"
 
-                result_tlength = count_string_tokens(command_result, cfg.fast_llm_model)
-                memory_tlength = count_string_tokens(
-                    self.summary_memory, cfg.fast_llm_model
+                result_tlength = count_string_tokens(
+                    str(command_result), cfg.fast_llm_model
                 )
-                if result_tlength + memory_tlength + 80 > cfg.fast_token_limit:
+                memory_tlength = count_string_tokens(
+                    str(self.summary_memory), cfg.fast_llm_model
+                )
+                if result_tlength + memory_tlength + 600 > cfg.fast_token_limit:
                     result = f"Failure: command {command_name} returned too much output. \
                         Do not execute this command again with the same arguments."
 

--- a/autogpt/agent/agent.py
+++ b/autogpt/agent/agent.py
@@ -235,7 +235,9 @@ class Agent:
                 result = f"Command {command_name} returned: " f"{command_result}"
 
                 result_tlength = count_string_tokens(command_result, cfg.fast_llm_model)
-                memory_tlength = count_string_tokens(self.summary_memory, cfg.fast_llm_model)
+                memory_tlength = count_string_tokens(
+                    self.summary_memory, cfg.fast_llm_model
+                )
                 if result_tlength + memory_tlength + 80 > cfg.fast_token_limit:
                     result = f"Failure: command {command_name} returned too much output. \
                         Do not execute this command again with the same arguments."


### PR DESCRIPTION
### Background
Large command outputs can currently cause a crash in the subsequent cycle, by overflowing the prompt of `update_running_summary`. Until we have a robust way to handle large amounts of data, this should at least prevent crashes on such instances.

### Changes
* Added a check to the agent interaction loop that catches command outputs
    * pass a warning to the LLM when this happens

### Test Plan
- [x] Test by pushing the LLM to use `get_hyperlinks` on a Brittanica page

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [ ] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes