### PR TITLE
Feature/ability to disallow certain shell commands

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -220,3 +220,10 @@ ALLOWLISTED_PLUGINS=
 ################################################################################
 # CHAT_MESSAGES_ENABLED - Enable chat messages (Default: False)
 # CHAT_MESSAGES_ENABLED=False
+
+################################################################################
+### DISALLOWED SHELL COMMANDS
+### - instead shell_executed returns ("Error: Disallowed command detected...")
+################################################################################
+## DISALLOWED_COMMANDS=command1,command2,...
+# DISALLOWED_COMMANDS=nano,vi,gedit

--- a/autogpt/commands/execute_code.py
+++ b/autogpt/commands/execute_code.py
@@ -117,7 +117,7 @@ def execute_shell(command_line: str) -> str:
     """
     
     # Get disallowed commands from the environment variable, check if any are in the command line input.
-    disallowed_commands = os.getenv('DISALLOWED_COMMANDS').split(',')
+    disallowed_commands = [cmd.strip() for cmd in os.getenv('DISALLOWED_COMMANDS').split(',')]
     if any(command in command_line for command in disallowed_commands):
         return ("Error: Disallowed command detected. Use another command to fulfill task")
 

--- a/autogpt/commands/execute_code.py
+++ b/autogpt/commands/execute_code.py
@@ -97,6 +97,11 @@ def execute_python_file(filename: str) -> str:
         return f"Error: {str(e)}"
 
 
+def load_disallowed_commands() -> list:
+    """Load disallowed commands from environment variable"""
+    return [cmd.strip() for cmd in os.getenv('DISALLOWED_COMMANDS', '').split(',')]
+
+
 @command(
     "execute_shell",
     "Execute Shell Command, non-interactive commands only",
@@ -107,7 +112,8 @@ def execute_python_file(filename: str) -> str:
     "in your config. Do not attempt to bypass the restriction.",
 )
 def execute_shell(command_line: str) -> str:
-    """Execute a shell command and return the output
+    """
+    Execute a shell command and return the output.
 
     Args:
         command_line (str): The command line to execute
@@ -115,9 +121,9 @@ def execute_shell(command_line: str) -> str:
     Returns:
         str: The output of the command
     """
-    
-    # Get disallowed commands from the environment variable, check if any are in the command line input.
-    disallowed_commands = [cmd.strip() for cmd in os.getenv('DISALLOWED_COMMANDS').split(',')]
+
+    disallowed_commands = load_disallowed_commands()
+
     if any(command in command_line for command in disallowed_commands):
         return ("Error: Disallowed command detected. Use another command to fulfill task")
 
@@ -134,9 +140,9 @@ def execute_shell(command_line: str) -> str:
     output = f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
 
     # Change back to whatever the prior working dir was
-
     os.chdir(current_dir)
     return output
+
 
 
 @command(

--- a/autogpt/commands/execute_code.py
+++ b/autogpt/commands/execute_code.py
@@ -115,7 +115,8 @@ def execute_shell(command_line: str) -> str:
     Returns:
         str: The output of the command
     """
-
+    
+    # Get disallowed commands from the environment variable, check if any are in the command line input.
     disallowed_commands = os.getenv('DISALLOWED_COMMANDS').split(',')
     if any(command in command_line for command in disallowed_commands):
         return ("Error: Disallowed command detected. Use another command to fulfill task")

--- a/autogpt/commands/execute_code.py
+++ b/autogpt/commands/execute_code.py
@@ -116,6 +116,10 @@ def execute_shell(command_line: str) -> str:
         str: The output of the command
     """
 
+    disallowed_commands = os.getenv('DISALLOWED_COMMANDS').split(',')
+    if any(command in command_line for command in disallowed_commands):
+        return ("Error: Disallowed command detected. Use another command to fulfill task")
+
     current_dir = Path.cwd()
     # Change dir into workspace if necessary
     if not current_dir.is_relative_to(CFG.workspace_path):


### PR DESCRIPTION
A simple "if any" to be able to set disallowed shell commands in the .env

<!-- ⚠️ At the moment any non-essential commands are not being merged.
If you want to add non-essential commands to Auto-GPT, please create a plugin instead.
We are expecting to ship plugin support within the week (PR #757).
Resources:
* https://github.com/Significant-Gravitas/Auto-GPT-Plugin-Template
-->

<!-- 📢 Announcement
We've recently noticed an increase in pull requests focusing on combining multiple changes. While the intentions behind these PRs are appreciated, it's essential to maintain a clean and manageable git history. To ensure the quality of our repository, we kindly ask you to adhere to the following guidelines when submitting PRs:

Focus on a single, specific change.
Do not include any unrelated or "extra" modifications.
Provide clear documentation and explanations of the changes made.
Ensure diffs are limited to the intended lines — no applying preferred formatting styles or line endings (unless that's what the PR is about).
For guidance on committing only the specific lines you have changed, refer to this helpful video: https://youtu.be/8-hSNHHbiZg

By following these guidelines, your PRs are more likely to be merged quickly after testing, as long as they align with the project's overall direction. -->

### Background
Many times I encountered an agent getting stuck when starting a GUI application like vi or nano via the execute_shell command. Resulting in auto-GPT waiting endlessly until I either killed the command through another terminal session or I had to completely abandon the session with CTRL+C.

The GUI applications nano and vi or gedit are unnecessary as auto-GPT has the write_to_file and append_to_file commands to take care of that.

### Changes
To be able to set the disallowed commands, I added the parameter "DISALLOWED_COMMANDS" to the .env.template.

### Documentation
In the .env file you can set the DISALLOWED_COMMANDS, comma separated like DISALLOWED_COMMANDS=nano,vi,gedit

The variable DISALLOWED_COMMANDS can contain commands with spaces. The code that checks for disallowed commands isn't designed to handle complex commands with arguments, it's just looking for specific command names in the input string. If we need to handle complex commands, we may need a more sophisticated approach.

### Test Plan
Tested with various goals which might triggered commands that we want to disallow, like nano, vi, gedit.

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes
