### PR TITLE
Command Base Class Interface

### DIFF
--- a/autogpt/core/command/base.py
+++ b/autogpt/core/command/base.py
@@ -1,12 +1,12 @@
 import abc
 import importlib
 import inspect
-from typing import Any, Callable, Optional, Tuple, Dict, Boolean
+from typing import Any, Callable, Optional, Tuple, Dict
 from dataclasses import dataclass
 
 @dataclass
 class CommandResult:
-    ok: Boolean
+    ok: bool
     message: str
 
 class Command(abc.ABC):
@@ -24,7 +24,7 @@ class Command(abc.ABC):
 		method: Callable[..., Any],
 		signature: str = "",
 		enabled: bool = True,
-		disabled_reason: Optional[str] = None,
+		disabled_reason: Optional[str] = None
 	):
         self.name = name
         self.description = description
@@ -35,7 +35,7 @@ class Command(abc.ABC):
 
     def __call__(self, *args, **kwargs) -> CommandResult:
         if not self.enabled:
-            return f"Command '{self.name}' is disabled: {self.disabled_reason}"
+            return CommandResult(False, f"Command '{self.name}' is disabled: {self.disabled_reason}")
         
         args, kwargs = self.__pre_call__(*args, **kwargs)
         
@@ -91,7 +91,7 @@ class CommandRegistry(abc.ABC):
             return command_result
             
         except Exception as e:
-           return f"Error: {str(e)}"
+            return CommandResult(False, f"Error: {str(e)}")
         
         
     def import_commands(self, module_name: str) -> None:

--- a/autogpt/core/command/base.py
+++ b/autogpt/core/command/base.py
@@ -1,9 +1,124 @@
 import abc
+import importlib
+import inspect
+from typing import Any, Callable, Optional, Tuple, Dict, Boolean
+from dataclasses import dataclass
 
+@dataclass
+class CommandResult:
+    ok: Boolean
+    message: str
 
 class Command(abc.ABC):
-    pass
+    """A class representing a command. Commands are actions which an agent can take.
+
+	Attributes:
+		name (str): The name of the command.
+		description (str): A brief description of what the command does.
+		signature (str): The signature of the function that theicommand executes. Defaults to None.
+	"""
+    def __init__(
+		self,
+		name: str,
+		description: str,
+		method: Callable[..., Any],
+		signature: str = "",
+		enabled: bool = True,
+		disabled_reason: Optional[str] = None,
+	):
+        self.name = name
+        self.description = description
+        self.method = method
+        self.signature = signature if signature else str(inspect.signature(self.method))
+        self.enabled = enabled
+        self.disabled_reason = disabled_reason
+
+    def __call__(self, *args, **kwargs) -> CommandResult:
+        if not self.enabled:
+            return f"Command '{self.name}' is disabled: {self.disabled_reason}"
+        
+        args, kwargs = self.__pre_call__(*args, **kwargs)
+        
+        command_result = self.method(*args, **kwargs)
+        if isinstance(command_result, str):
+            command_result = CommandResult(True, command_result)
+        
+        command_result = self.__post_hook__(command_result)
+        return command_result
+    
+    def __pre_call__(self, *args, **kwargs) -> Tuple[Any, Dict[str, Any]]:
+        # Return the unmodified *args and **kwargs by default, as a tuple and a dictionary
+        return args, kwargs
+
+    def __post_call__(self, command_result) -> CommandResult:
+        # Return the unmodified command_result by default
+        return command_result
+
+    def __str__(self) -> str:
+        return f"{self.name}: {self.description}, args: {self.signature}"
 
 
 class CommandRegistry(abc.ABC):
-    pass
+    """
+    The CommandRegistry class is a manager for a collection of Command objects.
+    It allows the registration, and retrieval of Command objects,
+    as well as the scanning and loading of command plugins from a specified
+    directory.
+    """
+    AUTO_GPT_COMMAND_IDENTIFIER = "auto_gpt_command"
+    
+    def __init__(self):
+        self.commands = {}
+        
+    def register_command(self, cmd: Command) -> None:
+        self.commands[cmd.name] = cmd
+    
+    def list_commands(self) -> None:
+        pass
+
+    def get_command(self, command_name: str) -> Command:
+        if command_name not in self.commands:
+            raise KeyError(f"Command '{command_name}' not found in registry.")
+        return self.commands[command_name]
+
+    def execute_command(self, command_name: str, **kwargs) -> CommandResult:
+        try:
+            if command_name not in self.commands:
+                raise KeyError(f"Command '{command_name}' not found in registry.")
+            command = self.commands[command_name]
+            
+            command_result = command(**kwargs)
+            return command_result
+            
+        except Exception as e:
+           return f"Error: {str(e)}"
+        
+        
+    def import_commands(self, module_name: str) -> None:
+        """
+        Imports the specified Python module containing command plugins.
+
+        This method imports the associated module and registers any functions or
+        classes that are decorated with the `AUTO_GPT_COMMAND_IDENTIFIER` attribute
+        as `Command` objects. The registered `Command` objects are then added to the
+        `commands` dictionary of the `CommandRegistry` object.
+
+        Args:
+            module_name (str): The name of the module to import for command plugins.
+        """
+
+        module = importlib.import_module(module_name)
+
+        for attr_name in dir(module):
+            attr = getattr(module, attr_name)
+            # Register decorated functions
+            if hasattr(attr, self.AUTO_GPT_COMMAND_IDENTIFIER) and getattr(
+                attr, self.AUTO_GPT_COMMAND_IDENTIFIER
+            ):
+                self.register(attr.command)
+            # Register command classes
+            elif (
+                inspect.isclass(attr) and issubclass(attr, Command) and attr != Command
+            ):
+                cmd_instance = attr()
+                self.register(cmd_instance)


### PR DESCRIPTION
### Overview
- Added command and command registry as discussed in the re-arch meeting.
- Mainly a port of the existing interface 

### Changes
- Added pre and post hooks
- Added command result data class. This will change a little bit on what to do with the result, however no change to any existing commands.

### To discuss
- The original method to execute commands was to have a function with the command register and command name ([code](https://github.com/Significant-Gravitas/Auto-GPT/blob/f2bef76368e792eeccf2309690da0da662690cc0/autogpt/app.py#L92)), in this function the command result is then added to memory by getting the memory module. This is separated out here for the sake of modularity and understandability - it feels like this is something that should happen in the acting section of the agent and be configurable there. Happy to change this though!

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [ ] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes

Notes:
- No tests yet, happy to add them though!
