### PR TITLE
gave google_official a different name ('google' doesn't work if api s…

### DIFF
--- a/autogpt/commands/google_search.py
+++ b/autogpt/commands/google_search.py
@@ -38,7 +38,7 @@ def google_search(query: str, num_results: int = 8) -> str:
 
 
 @command(
-    "google",
+    "google_api",
     "Google Search",
     '"query": "<query>"',
     bool(CFG.google_api_key),
@@ -109,9 +109,7 @@ def safe_google_results(results: str | list) -> str:
         str: The results of the search.
     """
     if isinstance(results, list):
-        safe_message = json.dumps(
-            [result.encode("utf-8", "ignore") for result in results]
-        )
+        safe_message = json.dumps(results)
     else:
         safe_message = results.encode("utf-8", "ignore").decode("utf-8")
     return safe_message


### PR DESCRIPTION
Issue: google_search and google_official_search both associated with the command google but the former fails if the google api key is specified.
Action: renamed google_official_search command from google to google_api

Issue: json.dump takes strings and not bytestreams (binary) - it throws an exception.
Action: removed the corresponding encoding and successfully tested the change.