### PR TITLE
fix: allow absolute paths if contained in workspace

### DIFF
--- a/autogpt/workspace/workspace.py
+++ b/autogpt/workspace/workspace.py
@@ -120,7 +120,8 @@ class Workspace:
 
         logger.debug(f"Resolved root as '{root}'")
 
-        if relative_path.is_absolute():
+        # Allow exception for absolute paths if they are contained in your workspace directory.
+        if relative_path.is_absolute() and not relative_path.is_relative_to(root):
             raise ValueError(
                 f"Attempted to access absolute path '{relative_path}' in workspace '{root}'."
             )


### PR DESCRIPTION

### Background
<!-- Provide a concise overview of the rationale behind this change. Include relevant context, prior discussions, or links to related issues. Ensure that the change aligns with the project's overall direction. -->
Maybe I'm missing something but I don't see the harm of accessing an absolute path if it's contained in the workspace

### Changes
Instead of blindly erroring on absolute paths, let's make an exception if they are contained in the workspace

### Documentation
Simple one line change with a clear comment is there

### Test Plan
Besides not running into this issue that reported here after my changes:
https://github.com/Significant-Gravitas/Auto-GPT/issues/3705

I've also instructed the AI to write to absolute paths in my workspace, and try to write to an absolute path outside of the workspace, as well as relative paths inside and outside workspaces

-  Write "hello" to file path "/Users/stefanayala"
-  Write "hello" to file path "/Users/stefanayala/baseAutoGPT/autogpt/auto_gpt_workspace"
-  Write "hello" using a relative path to the autogpt workspace
-  Write "hello" to relative path ~/

Here are the results:
<img width="1080" alt="Screen Shot 2023-05-06 at 4 30 21 PM" src="https://user-images.githubusercontent.com/1424113/236650379-d896cf7f-f338-4ddf-894d-b9bcc03fd24b.png">
<img width="1270" alt="Screen Shot 2023-05-06 at 4 29 42 PM" src="https://user-images.githubusercontent.com/1424113/236650388-349be50c-f641-4e9c-813a-425438238aac.png">
<img width="1107" alt="Screen Shot 2023-05-06 at 4 23 48 PM" src="https://user-images.githubusercontent.com/1424113/236650399-f01b51a8-8f31-4f55-9e1e-7430991e0825.png">



### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->

<!-- If you haven't added tests, please explain why. If you have, check the appropriate box. If you've ensured your PR is atomic and well-documented, check the corresponding boxes. -->
I haven't added tests yet because I'm not sure if this is behavior we want, if this is wanted behavior then I'll go ahead and write a test for this

<!-- By submitting this, I agree that my pull request should be closed if I do not fill this out or follow the guidelines. -->
