### PR TITLE
Prompt improvement: Scrubbed self-critique to save tokens.

### DIFF
--- a/autogpt/agent/agent.py
+++ b/autogpt/agent/agent.py
@@ -178,7 +178,7 @@ class Agent:
                         break
                     elif console_input.lower().strip() == "s":
                         logger.typewriter_log(
-                            "-=-=-=-=-=-=-= THOUGHTS, REASONING, PLAN AND CRITICISM WILL NOW BE VERIFIED BY AGENT -=-=-=-=-=-=-=",
+                            "-=-=-=-=-=-=-= THOUGHTS, REASONING AND PLAN WILL NOW BE VERIFIED BY AGENT -=-=-=-=-=-=-=",
                             Fore.GREEN,
                             "",
                         )
@@ -311,12 +311,12 @@ class Agent:
     def get_self_feedback(self, thoughts: dict, llm_model: str) -> str:
         """Generates a feedback response based on the provided thoughts dictionary.
         This method takes in a dictionary of thoughts containing keys such as 'reasoning',
-        'plan', 'thoughts', and 'criticism'. It combines these elements into a single
+        'plan', and 'thoughts'. It combines these elements into a single
         feedback message and uses the create_chat_completion() function to generate a
         response based on the input message.
         Args:
             thoughts (dict): A dictionary containing thought elements like reasoning,
-            plan, thoughts, and criticism.
+            plan, and thoughts.
         Returns:
             str: A feedback response generated using the provided thoughts dictionary.
         """

--- a/autogpt/json_utils/json_fix_llm.py
+++ b/autogpt/json_utils/json_fix_llm.py
@@ -28,7 +28,6 @@ JSON_SCHEMA = """
         "text": "thought",
         "reasoning": "reasoning",
         "plan": "- short bulleted\n- list that conveys\n- long-term plan",
-        "criticism": "constructive self-criticism",
         "speak": "thoughts summary to say to user"
     }
 }

--- a/autogpt/json_utils/llm_response_format_1.json
+++ b/autogpt/json_utils/llm_response_format_1.json
@@ -8,10 +8,9 @@
                 "text": {"type": "string"},
                 "reasoning": {"type": "string"},
                 "plan": {"type": "string"},
-                "criticism": {"type": "string"},
                 "speak": {"type": "string"}
             },
-            "required": ["text", "reasoning", "plan", "criticism", "speak"],
+            "required": ["text", "reasoning", "plan", "speak"],
             "additionalProperties": false
         },
         "command": {

--- a/autogpt/logs.py
+++ b/autogpt/logs.py
@@ -259,14 +259,12 @@ def print_assistant_thoughts(
     assistant_thoughts_reasoning = None
     assistant_thoughts_plan = None
     assistant_thoughts_speak = None
-    assistant_thoughts_criticism = None
 
     assistant_thoughts = assistant_reply_json_valid.get("thoughts", {})
     assistant_thoughts_text = assistant_thoughts.get("text")
     if assistant_thoughts:
         assistant_thoughts_reasoning = assistant_thoughts.get("reasoning")
         assistant_thoughts_plan = assistant_thoughts.get("plan")
-        assistant_thoughts_criticism = assistant_thoughts.get("criticism")
         assistant_thoughts_speak = assistant_thoughts.get("speak")
     logger.typewriter_log(
         f"{ai_name.upper()} THOUGHTS:", Fore.YELLOW, f"{assistant_thoughts_text}"
@@ -285,7 +283,6 @@ def print_assistant_thoughts(
         for line in lines:
             line = line.lstrip("- ")
             logger.typewriter_log("- ", Fore.GREEN, line.strip())
-    logger.typewriter_log("CRITICISM:", Fore.YELLOW, f"{assistant_thoughts_criticism}")
     # Speak the assistant's thoughts
     if speak_mode and assistant_thoughts_speak:
         say_text(assistant_thoughts_speak)

--- a/autogpt/prompts/generator.py
+++ b/autogpt/prompts/generator.py
@@ -27,7 +27,6 @@ class PromptGenerator:
                 "text": "thought",
                 "reasoning": "reasoning",
                 "plan": "- short bulleted\n- list that conveys\n- long-term plan",
-                "criticism": "constructive self-criticism",
                 "speak": "thoughts summary to say to user",
             },
             "command": {"name": "command name", "args": {"arg name": "value"}},

--- a/autogpt/prompts/prompt.py
+++ b/autogpt/prompts/prompt.py
@@ -57,9 +57,6 @@ def build_default_prompt_generator() -> PromptGenerator:
         " the best of your abilities."
     )
     prompt_generator.add_performance_evaluation(
-        "Constructively self-criticize your big-picture behavior constantly."
-    )
-    prompt_generator.add_performance_evaluation(
         "Reflect on past decisions and strategies to refine your approach."
     )
     prompt_generator.add_performance_evaluation(

--- a/tests/integration/test_memory_management.py
+++ b/tests/integration/test_memory_management.py
@@ -17,7 +17,6 @@ def message_history_fixture():
             "text": "thoughts",
             "reasoning": "reasoning",
             "plan": "plan",
-            "criticism": "criticism",
             "speak": "speak",
         },
         "command": {"name": "google", "args": {"query": "google_query"}},
@@ -35,7 +34,6 @@ def expected_permanent_memory() -> str:
         "text": "thoughts",
         "reasoning": "reasoning",
         "plan": "plan",
-        "criticism": "criticism",
         "speak": "speak"
     },
     "command": {

--- a/tests/unit/_test_json_parser.py
+++ b/tests/unit/_test_json_parser.py
@@ -50,7 +50,6 @@ class TestParseJson(unittest.TestCase):
         "text": "I suggest we start browsing the repository to find any issues that we can fix.",
         "reasoning": "Browsing the repository will give us an idea of the current state of the codebase and identify any issues that we can address to improve the repo.",
         "plan": "- Look through the repository to find any issues.\n- Investigate any issues to determine what needs to be fixed\n- Identify possible solutions to fix the issues\n- Open Pull Requests with fixes",
-        "criticism": "I should be careful while browsing so as not to accidentally introduce any new bugs or issues.",
         "speak": "I will start browsing the repository to find any issues we can fix."
     }
 }"""
@@ -63,7 +62,6 @@ class TestParseJson(unittest.TestCase):
                 "text": "I suggest we start browsing the repository to find any issues that we can fix.",
                 "reasoning": "Browsing the repository will give us an idea of the current state of the codebase and identify any issues that we can address to improve the repo.",
                 "plan": "- Look through the repository to find any issues.\n- Investigate any issues to determine what needs to be fixed\n- Identify possible solutions to fix the issues\n- Open Pull Requests with fixes",
-                "criticism": "I should be careful while browsing so as not to accidentally introduce any new bugs or issues.",
                 "speak": "I will start browsing the repository to find any issues we can fix.",
             },
         }
@@ -88,7 +86,6 @@ class TestParseJson(unittest.TestCase):
         "text": "Browsing the repository to identify potential bugs",
         "reasoning": "Before fixing bugs, I need to identify what needs fixing. I will use the 'browse_website' command to analyze the repository.",
         "plan": "- Analyze the repository for potential bugs and areas of improvement",
-        "criticism": "I need to ensure I am thorough and pay attention to detail while browsing the repository.",
         "speak": "I am browsing the repository to identify potential bugs."
     }
 }"""
@@ -101,7 +98,6 @@ class TestParseJson(unittest.TestCase):
                 "text": "Browsing the repository to identify potential bugs",
                 "reasoning": "Before fixing bugs, I need to identify what needs fixing. I will use the 'browse_website' command to analyze the repository.",
                 "plan": "- Analyze the repository for potential bugs and areas of improvement",
-                "criticism": "I need to ensure I am thorough and pay attention to detail while browsing the repository.",
                 "speak": "I am browsing the repository to identify potential bugs.",
             },
         }

--- a/tests/unit/test_json_parser.py
+++ b/tests/unit/test_json_parser.py
@@ -46,7 +46,6 @@ class TestParseJson(TestCase):
         "text": "I suggest we start browsing the repository to find any issues that we can fix.",
         "reasoning": "Browsing the repository will give us an idea of the current state of the codebase and identify any issues that we can address to improve the repo.",
         "plan": "- Look through the repository to find any issues.\n- Investigate any issues to determine what needs to be fixed\n- Identify possible solutions to fix the issues\n- Open Pull Requests with fixes",
-        "criticism": "I should be careful while browsing so as not to accidentally introduce any new bugs or issues.",
         "speak": "I will start browsing the repository to find any issues we can fix."
     }
 }"""
@@ -59,7 +58,6 @@ class TestParseJson(TestCase):
                 "text": "I suggest we start browsing the repository to find any issues that we can fix.",
                 "reasoning": "Browsing the repository will give us an idea of the current state of the codebase and identify any issues that we can address to improve the repo.",
                 "plan": "- Look through the repository to find any issues.\n- Investigate any issues to determine what needs to be fixed\n- Identify possible solutions to fix the issues\n- Open Pull Requests with fixes",
-                "criticism": "I should be careful while browsing so as not to accidentally introduce any new bugs or issues.",
                 "speak": "I will start browsing the repository to find any issues we can fix.",
             },
         }


### PR DESCRIPTION
### Background

The LLM context window is today's dial-up modem. LLM short-term memory is a precious resource that the community is working hard to optimize.

While prevailing research suggests that reflection can improve LLM accuracy, similar research suggests that asking the LLM to self-critique within the same request is ineffective. Instead, multiple requests should be made to self-criticize correctly, which involves feeding the output (and, optionally, the critique) back into the model. We are not doing this today.

Better zero-shot prompts are:
- Let's think step by step
- Let's work this output in a step-by-step way to be sure we have the right answer

REF: 
1. https://arxiv.org/abs/2305.02897.pdf (Automatically discovered COT - (Konstantin et al., 2003) 
2. https://arxiv.org/abs/2205.11916 (LLMs are zero-shot reasoners - "Let's think step by step." (Kojima et al., 2022))
3. https://arxiv.org/abs/2211.01910 (LLMs are human-level prompt engineers - "Let's work through this..." (Zhou et al., 2023))


### Changes
This PR scrubs self-critique from the current prompts as a precursor to adding some of the proposed zero-shot improvements.

### Documentation
No changes.

### Test Plan
The entire existing test suite has been run to confirm no regressions have been introduced. No tests have been added because current tests cover the changed parts.

### PR Quality Checklist
- [X] My pull request is atomic and focuses on a single change.
- [X] I have thoroughly tested my changes with multiple prompts.
- [X] I have considered potential risks and mitigations for my changes.
- [X] I have documented my changes clearly and comprehensively.
- [X] I have not snuck in any "extra" minor tweaks or changes 