### PR TITLE
auto-install plugin deps

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
     environment:
       MEMORY_BACKEND: ${MEMORY_BACKEND:-redis}
       REDIS_HOST: ${REDIS_HOST:-redis}
+    command: ["python", "-m", "autogpt", "--install-plugin-deps"]
     volumes:
       - ./:/app
     profiles: ["exclude-from-up"]


### PR DESCRIPTION
## CREDIT
I give all credit for the idea to [k-boikov](https://github.com/k-boikov) from https://github.com/Significant-Gravitas/Auto-GPT/pull/4151

### Background
Plugin dependencies are not installed automatically without using the `--install-plugin-deps` flag; however, this isn't very user-friendly from the docker side of things.

### Changes
Overwriting the entrypoint via docker-compose to auto-install plugin dependencies if needed

### Documentation
`--install-plugin-deps` is already documented; this is just a uuser-friendlyaddition of that flag to the docker-compose file

### Test Plan
`docker-compose run auto-gpt`

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes 