### PR TITLE
Fix commands with same name overwriting

### DIFF
--- a/autogpt/commands/command.py
+++ b/autogpt/commands/command.py
@@ -143,7 +143,7 @@ def command(
     """The command decorator is used to create Command objects from ordinary functions."""
 
     if not enabled:
-        if disabled_reason is not None and cfg.debug_mode:
+        if disabled_reason is not None:
             logger.debug(f"Command '{name}' is disabled: {disabled_reason}")
         return lambda func: func
 

--- a/autogpt/commands/command.py
+++ b/autogpt/commands/command.py
@@ -3,8 +3,13 @@ import importlib
 import inspect
 from typing import Any, Callable, Optional
 
+from autogpt.config import Config
+from autogpt.logs import logger
+
 # Unique identifier for auto-gpt commands
 AUTO_GPT_COMMAND_IDENTIFIER = "auto_gpt_command"
+
+cfg = Config()
 
 
 class Command:
@@ -59,6 +64,8 @@ class CommandRegistry:
         return importlib.reload(module)
 
     def register(self, cmd: Command) -> None:
+        if cmd.name in self.commands:
+            logger.warn(f"Command '{cmd.name}' already registered and will be overwritten!")
         self.commands[cmd.name] = cmd
 
     def unregister(self, command_name: str):
@@ -132,6 +139,11 @@ def command(
     disabled_reason: Optional[str] = None,
 ) -> Callable[..., Any]:
     """The command decorator is used to create Command objects from ordinary functions."""
+
+    if not enabled:
+        if disabled_reason is not None and cfg.debug_mode:
+            logger.debug(f"Command '{name}' is disabled: {disabled_reason}")
+        return lambda func: func
 
     def decorator(func: Callable[..., Any]) -> Command:
         cmd = Command(

--- a/autogpt/commands/command.py
+++ b/autogpt/commands/command.py
@@ -65,7 +65,9 @@ class CommandRegistry:
 
     def register(self, cmd: Command) -> None:
         if cmd.name in self.commands:
-            logger.warn(f"Command '{cmd.name}' already registered and will be overwritten!")
+            logger.warn(
+                f"Command '{cmd.name}' already registered and will be overwritten!"
+            )
         self.commands[cmd.name] = cmd
 
     def unregister(self, command_name: str):

--- a/autogpt/commands/command.py
+++ b/autogpt/commands/command.py
@@ -3,13 +3,10 @@ import importlib
 import inspect
 from typing import Any, Callable, Optional
 
-from autogpt.config import Config
 from autogpt.logs import logger
 
 # Unique identifier for auto-gpt commands
 AUTO_GPT_COMMAND_IDENTIFIER = "auto_gpt_command"
-
-cfg = Config()
 
 
 class Command:


### PR DESCRIPTION
### Background
Having a command with the same name overwrites the first one even if the second one is disabled.

### Changes
Do not register a command if the command is disabled. Add warning if something is gonna overwrite a command.

### Related to
https://github.com/Significant-Gravitas/Auto-GPT/issues/3904

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [ ] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->
