### PR TITLE
Fix the version of duckduckgo-search to avoid empty result issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ requests
 tiktoken==0.3.3
 gTTS==2.3.1
 docker
-duckduckgo-search>=2.9.5
+duckduckgo-search>=3.0.2
 google-api-python-client #(https://developers.google.com/custom-search/v1/overview)
 pinecone-client==2.2.1
 redis


### PR DESCRIPTION
### Background
Default google search command is returning nothing

### Changes
Putting this quick fix for the issue due to the underlying duckduckgo package. Fixing it to 3.0.2 is a workaround for time being. The workaround was proposed in #4350. Resolves #4350

### Test Plan
<!-- Describe how you tested this functionality. Include steps to reproduce, relevant test cases, and any other pertinent information. -->

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [ ] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes. <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->
- [] I have run `black .` and `isort .` against my code to ensure it passes our linter.

<!-- If you haven't added tests, please explain why. If you have, check the appropriate box. If you've ensured your PR is atomic and well-documented, check the corresponding boxes. -->

<!-- By submitting this, I agree that my pull request should be closed if I do not fill this out or follow the guidelines. -->
