### PR TITLE
Migrate google search to use DDGS.text function

### DIFF
--- a/autogpt/commands/google_search.py
+++ b/autogpt/commands/google_search.py
@@ -2,8 +2,9 @@
 from __future__ import annotations
 
 import json
+from itertools import islice
 
-from duckduckgo_search import ddg
+from duckduckgo_search import DDGS
 
 from autogpt.commands.command import command
 from autogpt.config import Config
@@ -26,12 +27,12 @@ def google_search(query: str, num_results: int = 8) -> str:
     if not query:
         return json.dumps(search_results)
 
-    results = ddg(query, max_results=num_results)
+    results = DDGS().text(query)
     if not results:
         return json.dumps(search_results)
 
-    for j in results:
-        search_results.append(j)
+    for item in islice(results, num_results):
+        search_results.append(item)
 
     results = json.dumps(search_results, ensure_ascii=False, indent=4)
     return safe_google_results(results)

--- a/tests/integration/test_google_search.py
+++ b/tests/integration/test_google_search.py
@@ -42,7 +42,7 @@ def test_google_search(query, num_results, expected_output, return_value, mocker
     mock_ddg = mocker.Mock()
     mock_ddg.return_value = return_value
 
-    mocker.patch("autogpt.commands.google_search.ddg", mock_ddg)
+    mocker.patch("autogpt.commands.google_search.DDGS.text", mock_ddg)
     actual_output = google_search(query, num_results=num_results)
     expected_output = safe_google_results(expected_output)
     assert actual_output == expected_output


### PR DESCRIPTION
### Background
The new [duckduckgo_search](https://github.com/deedy5/duckduckgo_search) version deprecated the ddg function and max_result parameters. Users are seeing the following warning messages when auto-gpt executes google command.

*\AppData\Local\Programs\Python\Python310\lib\site-packages\duckduckgo_search\compat.py:20: UserWarning: ddg is deprecated. Use DDGS().text() generator warnings.warn("ddg is deprecated. Use DDGS().text() generator")
UserWarning: parameter max_results is deprecated, use DDGS().text() warnings.warn("parameter max_results is deprecated, use DDGS().text()")

This fixes #4376 

### Changes
Migrate the search func to use the new function and use islice to limit the iterators up to max_results. Itertools.islice handles the iterators in an efficient way. Itertools is a module in python.

### Documentation
<!-- Explain how your changes are documented, such as in-code comments or external documentation. Ensure that the documentation is clear, concise, and easy to understand. -->

### Test Plan
Updated the google search's integration test

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes. <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->
- [x] I have run `black .` and `isort .` against my code to ensure it passes our linter.

<!-- If you haven't added tests, please explain why. If you have, check the appropriate box. If you've ensured your PR is atomic and well-documented, check the corresponding boxes. -->

<!-- By submitting this, I agree that my pull request should be closed if I do not fill this out or follow the guidelines. -->
