### PR TITLE
Remove obsolete full_message_history kwarg from tests

### DIFF
--- a/tests/integration/agent_factory.py
+++ b/tests/integration/agent_factory.py
@@ -158,7 +158,6 @@ def get_company_revenue_agent(
     agent = Agent(
         ai_name="Get-CompanyRevenue",
         memory=memory_json_file,
-        full_message_history=[],
         command_registry=command_registry,
         config=ai_config,
         next_action_count=0,
@@ -191,7 +190,6 @@ def kubernetes_agent(memory_json_file, workspace: Workspace):
     agent = Agent(
         ai_name="Kubernetes-Demo",
         memory=memory_json_file,
-        full_message_history=[],
         command_registry=command_registry,
         config=ai_config,
         next_action_count=0,


### PR DESCRIPTION
### Background
![image](https://github.com/Significant-Gravitas/Auto-GPT/assets/64261260/7e71b7c6-79e9-4d77-98ca-37c25ce76cb5)

### Changes
Remove full_message_history kwarg from get_company_revenue_agent and kubernetes_agent

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [ ] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes. <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->
- [x] I have run `black .` and `isort .` against my code to ensure it passes our linter.
