### PR TITLE
new ui for ai_settings to support multiple configurations

### DIFF
--- a/autogpt/config/ai_config.py
+++ b/autogpt/config/ai_config.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import os
 import platform
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
 import distro
 import yaml
@@ -17,7 +17,6 @@ if TYPE_CHECKING:
     from autogpt.prompts.generator import PromptGenerator
 
 # Soon this will go in a folder where it remembers more stuff about the run(s)
-SAVE_FILE = str(Path(os.getcwd()) / "ai_settings.yaml")
 
 
 class AIConfig:
@@ -30,6 +29,8 @@ class AIConfig:
         ai_goals (list): The list of objectives the AI is supposed to complete.
         api_budget (float): The maximum dollar value for API calls (0.0 means infinite)
     """
+
+    SAVE_FILE = str(Path(os.getcwd()) / "ai_settings.yaml")
 
     def __init__(
         self,
@@ -59,58 +60,136 @@ class AIConfig:
         self.command_registry: CommandRegistry | None = None
 
     @staticmethod
-    def load(config_file: str = SAVE_FILE) -> "AIConfig":
+    def load(ai_name: str, config_file: str = SAVE_FILE) -> Optional["AIConfig"]:
         """
-        Returns class object with parameters (ai_name, ai_role, ai_goals, api_budget) loaded from
-          yaml file if yaml file exists,
-        else returns class with no parameters.
+        Load a specific AI configuration from the config file.
 
-        Parameters:
-           config_file (int): The path to the config yaml file.
-             DEFAULT: "../ai_settings.yaml"
+        Args:
+            ai_name (str): The name of the AI configuration to load.
+            config_file (str): The path to the configuration file.
 
         Returns:
-            cls (object): An instance of given cls object
+            AIConfig: The loaded AI configuration, or None if no such configuration exists.
         """
 
+        all_configs = AIConfig.load_all(config_file)  # type: ignore
+
+        if ai_name in all_configs:
+            return all_configs[ai_name]
+        else:
+            return None
+
+    @staticmethod
+    def load_all(config_file: str = SAVE_FILE) -> Dict[str, "AIConfig"]:
         try:
             with open(config_file, encoding="utf-8") as file:
-                config_params = yaml.load(file, Loader=yaml.FullLoader) or {}
+                all_configs: Dict[str, Any] = yaml.safe_load(file) or {}
         except FileNotFoundError:
-            config_params = {}
+            all_configs = {}
 
-        ai_name = config_params.get("ai_name", "")
-        ai_role = config_params.get("ai_role", "")
-        ai_goals = [
-            str(goal).strip("{}").replace("'", "").replace('"', "")
-            if isinstance(goal, dict)
-            else str(goal)
-            for goal in config_params.get("ai_goals", [])
-        ]
-        api_budget = config_params.get("api_budget", 0.0)
-        # type: Type[AIConfig]
-        return AIConfig(ai_name, ai_role, ai_goals, api_budget)
+        configs = all_configs.get("configs", {}) or {}
 
-    def save(self, config_file: str = SAVE_FILE) -> None:
+        ai_configs = {}
+        for ai_name, config_params in configs.items():
+            ai_role = config_params.get("ai_role", "")
+            ai_goals = [
+                str(goal).strip("{}").replace("'", "").replace('"', "")
+                if isinstance(goal, dict)
+                else str(goal)
+                for goal in config_params.get("ai_goals", [])
+            ]
+            api_budget = config_params.get("api_budget", 0.0)
+            ai_configs[ai_name] = AIConfig(ai_name, ai_role, ai_goals, api_budget)
+
+        return ai_configs
+
+    def save(
+        self,
+        config_file: str = SAVE_FILE,
+        append: bool = False,
+        old_ai_name: Optional[str] = None,
+    ) -> None:
         """
-        Saves the class parameters to the specified file yaml file path as a yaml file.
+        Saves the class parameters to the specified file YAML file path as a YAML file.
 
         Parameters:
-            config_file(str): The path to the config yaml file.
-              DEFAULT: "../ai_settings.yaml"
+            config_file(str): The path to the config YAML file.
+                DEFAULT: "../ai_settings.yaml"
+            append(bool): Whether to append the new configuration to the existing file.
+                If False, the file will be overwritten. If True, the new configuration will be appended.
+                DEFAULT: False
+            old_ai_name(str, optional): The old AI name. If provided, the function will remove the existing
+                configuration for old_ai_name before adding the new configuration.
+
+        Returns:
+            None
+        """
+        # Prevent saving if the ai_name is an empty string
+        if not self.ai_name:
+            print("The AI name cannot be empty. The configuration was not saved.")
+            return
+
+        new_config = {
+            self.ai_name: {
+                "ai_goals": self.ai_goals,
+                "ai_role": self.ai_role,
+                "api_budget": self.api_budget,
+            }
+        }
+
+        if not append or not os.path.exists(config_file):
+            all_configs: Dict[str, Dict[str, Any]] = {"configs": {}}
+        else:
+            with open(config_file, "r", encoding="utf-8") as file:
+                all_configs = yaml.safe_load(file)
+
+        # Remove old configuration if old_ai_name is provided
+        if old_ai_name and old_ai_name in all_configs["configs"]:
+            del all_configs["configs"][old_ai_name]
+
+        # Append the new config
+        all_configs["configs"].update(new_config)
+
+        with open(config_file, "w", encoding="utf-8") as file:
+            file.write(yaml.dump(all_configs, allow_unicode=True))
+
+    def delete(self, config_file: str = SAVE_FILE, ai_name: str = "") -> None:
+        """
+        Deletes a configuration from the specified YAML file.
+
+        Parameters:
+            config_file(str): The path to the config YAML file.
+                DEFAULT: "../ai_settings.yaml"
+            ai_name(str): The name of the AI whose configuration is to be deleted.
 
         Returns:
             None
         """
 
-        config = {
-            "ai_name": self.ai_name,
-            "ai_role": self.ai_role,
-            "ai_goals": self.ai_goals,
-            "api_budget": self.api_budget,
-        }
+        # If no AI name is provided, exit the function
+        if ai_name == "":
+            print(
+                "No AI name provided. Please provide an AI name to delete its configuration."
+            )
+            return
+
+        # Load the existing configurations
+        if not os.path.exists(config_file):
+            print("No configurations to delete.")
+            return
+        else:
+            with open(config_file, "r", encoding="utf-8") as file:
+                all_configs = yaml.safe_load(file)
+
+        # Check if the AI configuration exists
+        if ai_name in all_configs["configs"]:
+            del all_configs["configs"][ai_name]
+        else:
+            print(f"No configuration found for AI '{ai_name}'.")
+
+        # Save the configurations back to the file
         with open(config_file, "w", encoding="utf-8") as file:
-            yaml.dump(config, file, allow_unicode=True)
+            file.write(yaml.dump(all_configs, allow_unicode=True))
 
     def construct_full_prompt(
         self, prompt_generator: Optional[PromptGenerator] = None

--- a/tests/integration/test_setup.py
+++ b/tests/integration/test_setup.py
@@ -4,10 +4,7 @@ import pytest
 
 from autogpt.config.ai_config import AIConfig
 from autogpt.prompts.prompt import construct_main_ai_config
-from autogpt.setup import (
-    generate_aiconfig_automatic,
-    prompt_user,
-)
+from autogpt.setup import generate_aiconfig_automatic, prompt_user
 from tests.utils import requires_api_key
 
 

--- a/tests/integration/test_setup.py
+++ b/tests/integration/test_setup.py
@@ -1,15 +1,11 @@
 from unittest.mock import patch
 
 import pytest
-import yaml
-from colorama import Fore
 
 from autogpt.config.ai_config import AIConfig
-from autogpt.logs import logger
 from autogpt.prompts.prompt import construct_main_ai_config
 from autogpt.setup import (
     generate_aiconfig_automatic,
-    generate_aiconfig_manual,
     prompt_user,
 )
 from tests.utils import requires_api_key

--- a/tests/integration/test_setup.py
+++ b/tests/integration/test_setup.py
@@ -1,9 +1,17 @@
 from unittest.mock import patch
 
 import pytest
+import yaml
+from colorama import Fore
 
 from autogpt.config.ai_config import AIConfig
-from autogpt.setup import generate_aiconfig_automatic, prompt_user
+from autogpt.logs import logger
+from autogpt.prompts.prompt import construct_main_ai_config
+from autogpt.setup import (
+    generate_aiconfig_automatic,
+    generate_aiconfig_manual,
+    prompt_user,
+)
 from tests.utils import requires_api_key
 
 
@@ -72,3 +80,235 @@ def test_prompt_user_manual_mode(patched_api_requestor):
     assert ai_config.ai_name == "Chef-GPT"
     assert ai_config.ai_role == "an AI designed to browse bake a cake."
     assert ai_config.ai_goals == ["Purchase ingredients", "Bake a cake"]
+
+
+@pytest.mark.vcr
+@requires_api_key("OPENAI_API_KEY")
+def test_generate_aiconfig_delete_and_select(tmp_path):
+    """Test delete configuration and select."""
+
+    # Temporary path / file
+    temp_config_file = tmp_path / "ai_settings.yaml"
+
+    # Temporary config
+    config_content = """configs:
+    simple-GPT:
+        ai_goals:
+        -  save a text file test1.txt with the text "hello world"
+        -  use list_files to confirm the file test1.txt does exist
+        -  delete file test1.txt
+        -  list_files the text file to confirm it does not exist
+        -  shutdown
+        ai_role: do a simple file task
+        api_budget: 0.0
+    normal-GPT:
+        ai_goals:
+        -  save a text file test2.txt with the text "hello space"
+        -  use read_file to confirm the file test2.txt contains the words "hello space"
+        -  rename file test2.txt to test-2.txt
+        -  delete file test-2.txt
+        -  shutdown
+        ai_role: do a normal file task
+        api_budget: 0.0
+    """
+
+    # Write to the temporary file
+    with open(temp_config_file, "w") as temp_file:
+        temp_file.write(config_content)
+
+    # Sequence of user inputs:
+    user_inputs = ["5", "", "1", "", "1", ""]
+
+    # Patch function to use the user_inputs list
+    with patch("builtins.input", side_effect=user_inputs):
+        ai_config = construct_main_ai_config(str(temp_config_file))
+
+    # Asserts
+    assert ai_config.ai_name == "normal-GPT"
+    assert ai_config.ai_role == "do a normal file task"
+    assert ai_config.ai_goals == [
+        'save a text file test2.txt with the text "hello space"',
+        'use read_file to confirm the file test2.txt contains the words "hello space"',
+        "rename file test2.txt to test-2.txt",
+        "delete file test-2.txt",
+        "shutdown",
+    ]
+
+
+@pytest.mark.vcr
+@requires_api_key("OPENAI_API_KEY")
+def test_generate_aiconfig_change_and_select(tmp_path):
+    """Test change configuration and select."""
+
+    # Temporary path / file
+    temp_config_file = tmp_path / "ai_settings.yaml"
+
+    # Temporary config
+    config_content = """configs:
+    simple-GPT:
+        ai_goals:
+        -  save a text file test1.txt with the text "hello world"
+        -  shutdown
+        ai_role: do a simple file task
+        api_budget: 0.0
+    normal-GPT:
+        ai_goals:
+        -  save a text file test2.txt with the text "hello space".
+        -  use read_file to confirm the file test2.txt contains the words "hello space".
+        -  rename file test2.txt to test-4.txt.
+        -  delete file test-2.txt.
+        -  shutdown.
+        ai_role: do a normal file task
+        api_budget: 0.0
+    """
+
+    # Write to the temporary file
+    with open(temp_config_file, "w") as temp_file:
+        temp_file.write(config_content)
+
+    # Sequence of user inputs:
+    user_inputs = [
+        "4",
+        "1",
+        "2",
+        "change-GPT",
+        "do a changed file task",
+        "",
+        "",
+        "",
+        "1",
+        "",
+    ]
+
+    # Patch function to use the user_inputs list
+    with patch("builtins.input", side_effect=user_inputs):
+        ai_config = construct_main_ai_config(str(temp_config_file))
+
+    # Asserts
+    assert ai_config.ai_name == "change-GPT"
+    assert ai_config.ai_role == "do a changed file task"
+    assert ai_config.ai_goals == [
+        'save a text file test1.txt with the text "hello world"',
+        "shutdown",
+    ]
+
+
+@pytest.mark.vcr
+@requires_api_key("OPENAI_API_KEY")
+def test_generate_aiconfig_create_and_select(tmp_path):
+    """Test change configuration and select."""
+
+    # Temporary path / file
+    temp_config_file = tmp_path / "ai_settings.yaml"
+
+    # Temporary config
+    config_content = """configs:
+    simple-GPT:
+        ai_goals:
+        -  save a text file test1.txt with the text "hello world"
+        -  shutdown
+        ai_role: do a simple file task
+        api_budget: 0.0
+    normal-GPT:
+        ai_goals:
+        -  save a text file test2.txt with the text "hello space".
+        -  use read_file to confirm the file test2.txt contains the words "hello space".
+        -  rename file test2.txt to test-4.txt.
+        -  delete file test-2.txt.
+        -  shutdown.
+        ai_role: do a normal file task
+        api_budget: 0.0
+    """
+
+    # Write to the temporary file
+    with open(temp_config_file, "w") as temp_file:
+        temp_file.write(config_content)
+
+    # Sequence of user inputs:
+    user_inputs = [
+        "3",
+        "2",
+        "new-GPT",
+        "an agent that looks for the newest python code",
+        "go online and search for new python code",
+        "grab it, save it in a file and shutdown",
+        "",
+        "3",
+        "",
+    ]
+
+    # Patch function to use the user_inputs list
+    with patch("builtins.input", side_effect=user_inputs):
+        ai_config = construct_main_ai_config(str(temp_config_file))
+
+    # Asserts
+    assert ai_config.ai_name == "new-GPT"
+    assert ai_config.ai_role == "an agent that looks for the newest python code"
+    assert ai_config.ai_goals == [
+        "go online and search for new python code",
+        "grab it, save it in a file and shutdown",
+    ]
+
+
+@pytest.mark.vcr
+@requires_api_key("OPENAI_API_KEY")
+def test_generate_aiconfig_create_first(tmp_path):
+    """Test create first configuration."""
+
+    # Temporary path / file
+    temp_config_file = tmp_path / "ai_settings.yaml"
+
+    # Temporary config
+    config_content = """configs:
+    """
+
+    # Write to the temporary file
+    with open(temp_config_file, "w") as temp_file:
+        temp_file.write(config_content)
+
+    # Sequence of user inputs:
+    user_inputs = ["scan the internet for new python code"]
+
+    # Patch function to use the user_inputs list
+    with patch("builtins.input", side_effect=user_inputs):
+        ai_config = construct_main_ai_config(str(temp_config_file))
+
+    # Asserts
+    assert ai_config.ai_name is not None and ai_config.ai_name != ""
+    assert ai_config.ai_role is not None and ai_config.ai_role != ""
+    assert ai_config.ai_goals != []
+
+
+@pytest.mark.vcr
+@requires_api_key("OPENAI_API_KEY")
+def test_generate_aiconfig_delete_and_create_new(tmp_path):
+    """Test delete and create new configuration."""
+
+    # Temporary path / file
+    temp_config_file = tmp_path / "ai_settings.yaml"
+
+    # Temporary config
+    config_content = """configs:
+    simple-GPT:
+        ai_goals:
+        -  save a text file test1.txt with the text "hello world"
+        -  shutdown
+        ai_role: do a simple file task
+        api_budget: 0.0
+    """
+
+    # Write to the temporary file
+    with open(temp_config_file, "w") as temp_file:
+        temp_file.write(config_content)
+
+    # Sequence of user inputs:
+    user_inputs = ["4", "1", "scan the internet for new python code"]
+
+    # Patch function to use the user_inputs list
+    with patch("builtins.input", side_effect=user_inputs):
+        ai_config = construct_main_ai_config(str(temp_config_file))
+
+    # Asserts
+    assert ai_config.ai_name is not None and ai_config.ai_name != ""
+    assert ai_config.ai_role is not None and ai_config.ai_role != ""
+    assert ai_config.ai_goals != []

--- a/tests/test_ai_config.py
+++ b/tests/test_ai_config.py
@@ -1,3 +1,5 @@
+import yaml
+
 from autogpt.config.ai_config import AIConfig
 
 """
@@ -9,20 +11,21 @@ settings from a YAML file.
 def test_goals_are_always_lists_of_strings(tmp_path):
     """Test if the goals attribute is always a list of strings."""
 
-    yaml_content = """
-ai_goals:
-- Goal 1: Make a sandwich
-- Goal 2, Eat the sandwich
-- Goal 3 - Go to sleep
-- "Goal 4: Wake up"
-ai_name: McFamished
-ai_role: A hungry AI
-api_budget: 0.0
-"""
+    yaml_content = """configs:
+      McFamished:
+        ai_goals:
+        - 'Goal 1: Make a sandwich'
+        - 'Goal 2, Eat the sandwich'
+        - 'Goal 3 - Go to sleep'
+        - 'Goal 4: Wake up'
+        ai_role: A hungry AI
+        api_budget: 0.0
+    """
+
     config_file = tmp_path / "ai_settings.yaml"
     config_file.write_text(yaml_content)
 
-    ai_config = AIConfig.load(config_file)
+    ai_config = AIConfig.load("McFamished", config_file)
 
     assert len(ai_config.ai_goals) == 4
     assert ai_config.ai_goals[0] == "Goal 1: Make a sandwich"
@@ -33,16 +36,22 @@ api_budget: 0.0
     config_file.write_text("")
     ai_config.save(config_file)
 
-    yaml_content2 = """ai_goals:
-- 'Goal 1: Make a sandwich'
-- Goal 2, Eat the sandwich
-- Goal 3 - Go to sleep
-- 'Goal 4: Wake up'
-ai_name: McFamished
-ai_role: A hungry AI
-api_budget: 0.0
-"""
-    assert config_file.read_text() == yaml_content2
+    saved_yaml = yaml.safe_load(config_file.read_text())
+
+    expected_yaml = yaml.safe_load(
+        """configs:
+      McFamished:
+        ai_goals:
+        - 'Goal 1: Make a sandwich'
+        - 'Goal 2, Eat the sandwich'
+        - 'Goal 3 - Go to sleep'
+        - 'Goal 4: Wake up'
+        ai_role: A hungry AI
+        api_budget: 0.0
+    """
+    )
+
+    assert saved_yaml == expected_yaml
 
 
 def test_ai_config_file_not_exists(workspace):
@@ -50,13 +59,8 @@ def test_ai_config_file_not_exists(workspace):
 
     config_file = workspace.get_path("ai_settings.yaml")
 
-    ai_config = AIConfig.load(str(config_file))
-    assert ai_config.ai_name == ""
-    assert ai_config.ai_role == ""
-    assert ai_config.ai_goals == []
-    assert ai_config.api_budget == 0.0
-    assert ai_config.prompt_generator is None
-    assert ai_config.command_registry is None
+    ai_config = AIConfig.load("Test", str(config_file))
+    assert ai_config is None
 
 
 def test_ai_config_file_is_empty(workspace):
@@ -65,10 +69,146 @@ def test_ai_config_file_is_empty(workspace):
     config_file = workspace.get_path("ai_settings.yaml")
     config_file.write_text("")
 
-    ai_config = AIConfig.load(str(config_file))
-    assert ai_config.ai_name == ""
-    assert ai_config.ai_role == ""
-    assert ai_config.ai_goals == []
+    ai_config = AIConfig.load("Test", str(config_file))
+    assert ai_config is None
+
+
+def test_delete_method(tmp_path):
+    """Test if the delete method properly removes an AI configuration from the file."""
+
+    yaml_content = """configs:
+      AI1:
+        ai_goals:
+        - Goal 1
+        ai_role: Test role
+        api_budget: 0.0
+      AI2:
+        ai_goals:
+        - Goal 2
+        ai_role: Another role
+        api_budget: 0.0
+    """
+
+    config_file = tmp_path / "ai_settings.yaml"
+    config_file.write_text(yaml_content)
+
+    AIConfig().delete(
+        config_file,
+        "AI1",
+    )
+
+    # Print file contents after deletion
+    print(config_file.read_text())
+
+    ai_config = AIConfig.load("AI1", str(config_file))
+    assert ai_config is None
+
+    ai_config2 = AIConfig.load("AI2", str(config_file))
+    assert ai_config2 is not None
+
+    # Clean up the configuration file and related variables
+    config_file.unlink()
+    ai_config = None
+    ai_config2 = None
+
+
+def test_special_character_config(tmp_path):
+    yaml_content = """configs:
+      SpécialAI:
+        ai_goals:
+        - 'Gôal 1: Mäke a sàndwich'
+        ai_role: 'A hùngry AI'
+        api_budget: 0.0
+    """
+
+    config_file = tmp_path / "ai_settings.yaml"
+    config_file.write_text(yaml_content)
+
+    ai_config = AIConfig.load("SpécialAI", config_file)
+
+    assert ai_config.ai_goals == ["Gôal 1: Mäke a sàndwich"]
+    assert ai_config.ai_role == "A hùngry AI"
     assert ai_config.api_budget == 0.0
-    assert ai_config.prompt_generator is None
-    assert ai_config.command_registry is None
+
+    # Clean up the configuration file and related variables
+    config_file.unlink()
+    ai_config = None
+
+
+def test_handling_special_characters_configuration(tmp_path):
+    config_file = tmp_path / "ai_settings.yaml"
+    config_file.write_text(
+        "configs:\n  AI1:\n    ai_goals: ['Goal with special characters: !@#$%^&*()']\n"
+    )
+
+    ai_config = AIConfig.load("AI1", config_file)
+
+    assert len(ai_config.ai_goals) == 1
+    assert ai_config.ai_goals[0] == "Goal with special characters: !@#$%^&*()"
+
+    ai_config.save(config_file)
+
+    saved_yaml = yaml.safe_load(config_file.read_text())
+    expected_yaml = {
+        "configs": {
+            "AI1": {
+                "ai_goals": ["Goal with special characters: !@#$%^&*()"],
+            }
+        }
+    }
+    assert (
+        saved_yaml["configs"]["AI1"]["ai_goals"][0]
+        == "Goal with special characters: !@#$%^&*()"
+    )
+
+    # Clean up the configuration file and related variables
+    config_file.unlink()
+    ai_config = None
+
+
+def test_loading_large_configuration(tmp_path):
+    config_file = tmp_path / "ai_settings.yaml"
+
+    # Create a large configuration with 100 AI entries
+    config_content = "configs:\n"
+    for i in range(100):
+        config_content += f"  AI{i+1}:\n    ai_goals: ['Goal {i+1}']\n"
+
+    config_file.write_text(config_content)
+
+    ai_config = AIConfig.load("AI50", config_file)
+
+    assert ai_config.ai_name == "AI50"
+    assert ai_config.ai_goals == ["Goal 50"]
+    assert ai_config.api_budget == 0.0
+
+    # Clean up the configuration file and related variables
+    config_file.unlink()
+    ai_config = None
+    config_content = None
+
+
+def test_saving_large_configuration(tmp_path):
+    config_file = tmp_path / "ai_settings.yaml"
+    ai_config = AIConfig("AI1", ai_goals=["Goal 1"])
+
+    # Create a large configuration with 100 AI entries
+    config_content = "configs:\n"
+    for i in range(100):
+        config_content += f"  AI{i+1}:\n    ai_goals: ['Goal {i+1}']\n"
+
+    config_file.write_text(config_content)
+
+    ai_config.save(config_file)
+
+    saved_yaml = yaml.safe_load(config_file.read_text())
+    expected_yaml = {
+        "configs": {"AI1": {"ai_goals": ["Goal 1"], "ai_role": "", "api_budget": 0.0}}
+    }
+
+    assert saved_yaml == expected_yaml
+
+    # Clean up the configuration file and related variables
+    config_file.unlink()
+    ai_config = None
+    config_content = None


### PR DESCRIPTION
Changed the ai_settings.yaml workflow and added dictionary yaml support to allow selecting from multiple ai configurations, storing them, changing them or deleting them.

- support storing multiple ai configurations
- support choose existing ai configuration(s)
- support create new ai configuration(s)
- support delete ai existing configuration(s)
- support change ai configuration(s) -> e.g. ai_name, ai_role, ai_goals[] and api_budget

added multiple new pytests to support testing the changes
- test_ai_config.py
- integration\test_setup.py

*** This is a new approach which makes #3711 obsolete, can be closed.

### Test Plan
Added pytests to support future testing.
Although I tested the new functionality thoroughly, it's quite a big change so please make sure it's reviewed well.

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes.
- [x] I have run the following commands against my code to ensure it passes our linters:
    ```shell
    black .
    isort .
    mypy
    autoflake --remove-all-unused-imports --recursive --ignore-init-module-imports autogpt tests --in-place
    ```
    