### PR TITLE
Fix CI for internal PRs with CI changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,16 +2,24 @@ name: Python CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, ci-test* ]
+    paths-ignore:
+      - 'tests/Auto-GPT-test-cassettes'
+      - 'tests/integration/challenges/current_score.json'
+  pull_request:
+    branches: [ stable, master ]
   pull_request_target:
-    branches: [ master, stable ]
+    branches: [ master, ci-test* ]
 
 concurrency:
-  group: ${{ format('ci-{0}', github.head_ref && format('pr-{0}', github.event.pull_request.number) || github.sha) }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request_target' }}
+  group: ${{ format('ci-{0}', github.head_ref && format('{0}-{1}', github.event_name, github.event.pull_request.number) || github.sha) }}
+  cancel-in-progress: ${{ startsWith(github.event_name, 'pull_request') }}
 
 jobs:
   lint:
+    # eliminate duplicate runs on master
+    if: github.event_name == 'push' || github.ref_name != 'master' || (github.event.pull_request.head.repo.fork == (github.event_name == 'pull_request_target'))
+
     runs-on: ubuntu-latest
     env:
       min-python-version: "3.10"
@@ -45,7 +53,19 @@ jobs:
         run: isort . --check
         if: success() || failure()
 
+      - name: Check mypy formatting
+        run: mypy
+        if: success() || failure()
+
+      - name: Check for unused imports and pass statements
+        run: |
+          cmd="autoflake --remove-all-unused-imports --recursive --ignore-init-module-imports autogpt tests"
+          $cmd --check || (echo "You have unused imports or pass statements, please run '${cmd} --in-place'" && exit 1)
+
   test:
+    # eliminate duplicate runs on master
+    if: github.event_name == 'push' || github.ref_name != 'master' || (github.event.pull_request.head.repo.fork == (github.event_name == 'pull_request_target'))
+
     permissions:
       # Gives the action the necessary permissions for publishing new
       # comments in pull requests.
@@ -55,6 +75,7 @@ jobs:
       # comments (to avoid publishing multiple comments in the same PR)
       contents: write
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       matrix:
         python-version: ["3.10"]
@@ -66,6 +87,33 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
+          submodules: true
+
+      - name: Check out cassettes
+        if: ${{ startsWith(github.event_name, 'pull_request') }}
+        run: |
+          cassette_branch="${{ github.event.pull_request.user.login }}-${{ github.event.pull_request.head.ref }}"
+          git config --global user.name "Auto-GPT-Bot"
+          git config --global user.email "github-bot@agpt.co"
+          cd tests/Auto-GPT-test-cassettes
+
+          if git ls-remote --exit-code --heads origin $cassette_branch ; then
+            git fetch origin $cassette_branch
+            git fetch origin ${{ github.event.pull_request.base.ref }}
+
+            git checkout $cassette_branch
+
+            if git merge --no-commit --no-ff ${{ github.event.pull_request.base.ref }}; then
+              echo "Using cassettes from mirror branch, synced to upstream branch '${{ github.event.pull_request.base.ref }}'"
+            else
+              echo "Could not merge upstream changes to cassettes. Using cassettes from ${{ github.event.pull_request.base.ref }}."
+              git merge --abort
+              git checkout ${{ github.event.pull_request.base.ref }}
+            fi
+          else
+            echo "Branch '$cassette_branch' does not exist in cassette submodule."\
+              "Using cassettes from ${{ github.event.pull_request.base.ref }}."
+          fi
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
@@ -77,25 +125,108 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
-      - name: Run unittest tests with coverage
+      - name: Run pytest tests with coverage
         run: |
           pytest -n auto --cov=autogpt --cov-report term-missing --cov-branch --cov-report xml --cov-report term
+          python tests/integration/challenges/utils/build_current_score.py
         env:
           CI: true
-          PROXY: ${{ vars.PROXY }}
+          PROXY: ${{ secrets.PROXY }}
           AGENT_MODE: ${{ vars.AGENT_MODE }}
           AGENT_TYPE: ${{ vars.AGENT_TYPE }}
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
 
-      - name: Stage new files and commit
+      - id: setup_git_auth
+        name: Set up git token authentication
         run: |
-          git add tests
-          git diff --cached --quiet && echo "No changes to commit" && exit 0
-          git config user.email "github-actions@github.com"
-          git config user.name "GitHub Actions"
-          git commit -m "Add new cassettes"
-          git checkout -b cassette-diff-${{ github.event.pull_request.number }}
-          git remote add target https://${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.event.pull_request.base.repo.full_name }}
-          git push -f target cassette-diff-${{ github.event.pull_request.number }}
+          config_key="http.${{ github.server_url }}/.extraheader"
+          git config "$config_key" \
+            "Authorization: Basic x-access-token:${{ secrets.PAT_REVIEW }}"
+
+          echo "config_key=$config_key" >> $GITHUB_OUTPUT
+
+      - name: Push updated challenge scores
+        if: github.event_name == 'push'
+        run: |
+          score_file="tests/integration/challenges/current_score.json"
+
+          if ! git diff --quiet $score_file; then
+            git add $score_file
+            git commit -m "Update challenge scores"
+            git push origin HEAD:${{ github.ref }}
+          else
+            echo "The challenge scores didn't change."
+          fi
+
+      - id: push_cassettes
+        name: Push updated cassettes
+        run: |
+          if [[ "${{ startsWith(github.event_name, 'pull_request') }}" = "true" ]]; then
+            is_pull_request=true
+            cassette_branch="${{ github.event.pull_request.user.login }}-${{ github.event.pull_request.head.ref }}"
+            base_branch="${{ github.event.pull_request.base.ref }}"
+          else
+            current_branch=$(echo ${{ github.ref }} | sed -e "s/refs\/heads\///g")
+            cassette_branch=$current_branch
+          fi
+
+          cd tests/Auto-GPT-test-cassettes
+          git fetch origin $cassette_branch
+
+          # Commit & push changes to cassettes if any
+          if ! git diff-index --quiet $cassette_branch; then
+            git add .
+            git commit -m "Auto-update cassettes"
+            git pull --rebase origin $cassette_branch
+
+            git push origin HEAD:$cassette_branch
+
+            cd ../..
+            if [ $is_pull_request ]; then
+              git fetch origin $base_branch
+              cassette_diff=$(git diff $cassette_branch origin/$base_branch)
+            else
+              git add tests/Auto-GPT-test-cassettes
+              git commit -m "Update cassette submodule"
+              git push origin HEAD:$current_branch
+            fi
+          else
+            echo "No cassette changes to commit"
+          fi
+
+          if [ -n "$cassette_diff" ]; then
+            echo "updated=true" >> $GITHUB_OUTPUT
+          else
+            echo "updated=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Post Set up git token auth
+        run: |
+          git config --unset "${{ steps.setup_git_auth.outputs.config_key }}"
+
+      - name: Apply or remove behaviour change label and comment on PR
+        if: ${{ startsWith(github.event_name, 'pull_request') }}
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          TOKEN=${{ secrets.PAT_REVIEW }}
+          REPO=${{ github.repository }}
+
+          if [[ "${{ steps.push_cassettes.outputs.updated }}" == "true" ]]; then
+            echo "Adding label and comment..."
+            curl -X POST \
+            -H "Authorization: Bearer $TOKEN" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/$REPO/issues/$PR_NUMBER/labels \
+            -d '{"labels":["behaviour change"]}'
+
+            echo $TOKEN | gh auth login --with-token
+            gh api repos/$REPO/issues/$PR_NUMBER/comments -X POST -F body="You changed AutoGPT's behaviour. The cassettes have been updated and will be merged to the submodule when this Pull Request gets merged."
+          else
+            echo "Removing label..."
+            curl -X DELETE \
+            -H "Authorization: Bearer $TOKEN" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/$REPO/issues/$PR_NUMBER/labels/behaviour%20change
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ on:
     branches: [ master, ci-test* ]
 
 concurrency:
-  group: ${{ format('ci-{0}', github.head_ref && format('{0}-{1}', github.event_name, github.event.pull_request.number) || github.sha) }}
-  cancel-in-progress: ${{ startsWith(github.event_name, 'pull_request') }}
+  group: ${{ format('ci-{0}', github.head_ref && format('pr-{0}', github.event.pull_request.number) || github.sha) }}
+  cancel-in-progress: ${{ startsWith(github.event_name, 'pull_request') && github.event.pull_request.head.repo.fork == (github.event_name == 'pull_request_target') }}
 
 jobs:
   lint:


### PR DESCRIPTION
### Background
CI currently breaks quite easily because we use `pull_request_target`: https://github.com/Significant-Gravitas/Auto-GPT/actions/runs/5154842393/jobs/9287034366#logs

### Changes
* Use `pull_request` instead of `pull_request_target` for internal pull requests
* Clean up CI workflow
* Fix git authentication set-up

### Test Plan
See checks below: since this is an internal PR, the CI runs on `pull_request`. For PRs from forks, it should still run on `pull_request_target`.

### PR Quality Checklist
- [ ] My pull request is atomic and focuses on a single change.
- [ ] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [ ] I have not snuck in any "extra" small tweaks changes. <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->
