### PR TITLE
Increase thresholds for PR autolabeler

### DIFF
--- a/.github/workflows/pr-label.yml
+++ b/.github/workflows/pr-label.yml
@@ -48,11 +48,10 @@ jobs:
           s_label: 'size/s'
           s_max_size: 10
           m_label: 'size/m'
-          m_max_size: 50
+          m_max_size: 100
           l_label: 'size/l'
-          l_max_size: 200
+          l_max_size: 500
           xl_label: 'size/xl'
           message_if_xl: >
-            This PR exceeds the recommended size of 200 lines.
+            This PR exceeds the recommended size of 500 lines.
             Please make sure you are NOT addressing multiple issues with one PR.
-            Note this PR might be rejected due to its size  


### PR DESCRIPTION
### Background
Lots of spam from the autolabeler, warning for PRs larger than 200 lines.

### Changes
* Increased threshold for `m` size bracket from 50 to 100
* Increased threshold for `l` size bracket from 200 to 500
  * Warnings will only be posted on XL PRs = over 500 lines