### PR TITLE
Remove unused function `split_file` from file_operations.py

### DIFF
--- a/autogpt/commands/file_operations.py
+++ b/autogpt/commands/file_operations.py
@@ -119,38 +119,6 @@ def log_operation(
     )
 
 
-def split_file(
-    content: str, max_length: int = 4000, overlap: int = 0
-) -> Generator[str, None, None]:
-    """
-    Split text into chunks of a specified maximum length with a specified overlap
-    between chunks.
-
-    :param content: The input text to be split into chunks
-    :param max_length: The maximum length of each chunk,
-        default is 4000 (about 1k token)
-    :param overlap: The number of overlapping characters between chunks,
-        default is no overlap
-    :return: A generator yielding chunks of text
-    """
-    start = 0
-    content_length = len(content)
-
-    while start < content_length:
-        end = start + max_length
-        if end + overlap < content_length:
-            chunk = content[start : end + max(overlap - 1, 0)]
-        else:
-            chunk = content[start:content_length]
-
-            # Account for the case where the last chunk is shorter than the overlap, so it has already been consumed
-            if len(chunk) <= overlap:
-                break
-
-        yield chunk
-        start += max_length - overlap
-
-
 @command("read_file", "Read a file", '"filename": "<filename>"')
 def read_file(filename: str, agent: Agent) -> str:
     """Read a file and return the contents

--- a/tests/unit/test_file_operations.py
+++ b/tests/unit/test_file_operations.py
@@ -188,43 +188,6 @@ def test_log_operation_with_checksum(agent: Agent):
     assert f"log_test: path/to/test #ABCDEF\n" in content
 
 
-@pytest.mark.parametrize(
-    "max_length, overlap, content, expected",
-    [
-        (
-            4,
-            1,
-            "abcdefghij",
-            ["abcd", "defg", "ghij"],
-        ),
-        (
-            4,
-            0,
-            "abcdefghijkl",
-            ["abcd", "efgh", "ijkl"],
-        ),
-        (
-            4,
-            0,
-            "abcdefghijklm",
-            ["abcd", "efgh", "ijkl", "m"],
-        ),
-        (
-            4,
-            0,
-            "abcdefghijk",
-            ["abcd", "efgh", "ijk"],
-        ),
-    ],
-)
-# Test splitting a file into chunks
-def test_split_file(max_length, overlap, content, expected):
-    assert (
-        list(file_ops.split_file(content, max_length=max_length, overlap=overlap))
-        == expected
-    )
-
-
 def test_read_file(
     mock_MemoryItem_from_text,
     test_file_with_content_path: Path,


### PR DESCRIPTION
### Background
`split_file` is not in use since #4208, see https://github.com/Significant-Gravitas/Auto-GPT/pull/3757#issuecomment-1586359778

### Changes
* Remove `split_file` in file_operations.py
* Remove unit test for `split_file`

### Test Plan
x

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [ ] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes. <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->
- [ ] I have run the following commands against my code to ensure it passes our linters:
    ```shell
    black .
    isort .
    mypy
    autoflake --remove-all-unused-imports --recursive --ignore-init-module-imports --ignore-pass-after-docstring autogpt tests --in-place
    ```

<!-- If you haven't added tests, please explain why. If you have, check the appropriate box. If you've ensured your PR is atomic and well-documented, check the corresponding boxes. -->

<!-- By submitting this, I agree that my pull request should be closed if I do not fill this out or follow the guidelines. -->
