### PR TITLE
Incorporating current summary length in token count calculation for the update_running_summary function

### DIFF
--- a/autogpt/memory/message_history.py
+++ b/autogpt/memory/message_history.py
@@ -174,6 +174,7 @@ class MessageHistory:
         # TODO make this default dynamic
         prompt_template_length = 100
         max_tokens = OPEN_AI_CHAT_MODELS.get(cfg.fast_llm_model).max_tokens
+        summary_tlength = count_string_tokens(str(self.summary), cfg.fast_llm_model)
         batch = []
         batch_tlength = 0
 
@@ -181,9 +182,15 @@ class MessageHistory:
         for event in new_events:
             event_tlength = count_string_tokens(str(event), cfg.fast_llm_model)
 
-            if batch_tlength + event_tlength > max_tokens - prompt_template_length:
+            if (
+                batch_tlength + event_tlength
+                > max_tokens - prompt_template_length - summary_tlength
+            ):
                 # The batch is full. Summarize it and start a new one.
                 self.summarize_batch(batch, cfg)
+                summary_tlength = count_string_tokens(
+                    str(self.summary), cfg.fast_llm_model
+                )
                 batch = [event]
                 batch_tlength = event_tlength
             else:


### PR DESCRIPTION
### Background
This PR addresses an oversight in my previous PR #4652, which introduced a new batch processing approach within the update_running_summary function. The goal of this approach is to prevent the total token count from exceeding the model's maximum limit when new events are being processed. While this method accounted for the token length of new events and the summarization prompt, it failed to consider the length of the current summary.

### Changes
In the modified version, a summary_tlength variable has been introduced in the update_running_summary function. This variable holds the token length of the current summary, ensuring the total token count of three components: 1) the current summary, 2) the new events, and 3) the summarization prompt, does not surpass the maximum token limit imposed by the model.

### Test Plan
Reran the tests and passed.

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [ ] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes. <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->
- [x] I have run the following commands against my code to ensure it passes our linters:
    ```shell
    black .
    isort .
    mypy
    autoflake --remove-all-unused-imports --recursive --ignore-init-module-imports --ignore-pass-after-docstring autogpt tests --in-place
    ```