### PR TITLE
Strip spaces from the end of truncated ai_name in log_cycle.py

### DIFF
--- a/autogpt/log_cycle/log_cycle.py
+++ b/autogpt/log_cycle/log_cycle.py
@@ -43,7 +43,7 @@ class LogCycleHandler:
         return outer_folder_path
 
     def get_agent_short_name(self, ai_name):
-        return ai_name[:15] if ai_name else DEFAULT_PREFIX
+        return ai_name[:15].rstrip() if ai_name else DEFAULT_PREFIX
 
     def create_inner_directory(self, outer_folder_path: str, cycle_count: int) -> str:
         nested_folder_name = str(cycle_count).zfill(3)


### PR DESCRIPTION
### Background
Pointed out by user Saven in Discord VC: Auto-GPT will crash on Windows if the AI's name has a space as its 16th character:
* `create_outer_directory` -> `get_agent_short_name` truncates the AI name to 16 characters and uses it to create a folder
* space is stripped from the end of folder name -> created folder has no space at the end
* `create_inner_directory` fails because it expects the outer directory to have the space in the path

### Changes
* Strip any whitespace from the end of the truncated AI name

### Documentation
x

### Test Plan
x

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [ ] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes. <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->
- [x] I have run the following commands against my code to ensure it passes our linters:
    ```shell
    black .
    isort .
    mypy
    autoflake --remove-all-unused-imports --recursive --ignore-init-module-imports --ignore-pass-after-docstring autogpt tests --in-place
    ```
