### PR TITLE
Improve plugin backward compatibility

### DIFF
--- a/autogpt/plugins/__init__.py
+++ b/autogpt/plugins/__init__.py
@@ -254,11 +254,6 @@ def scan_plugins(cfg: Config, debug: bool = False) -> List[AutoGPTPluginTemplate
                 logger.debug(f"Plugin: {plugin} Module: {module}")
                 zipped_package = zipimporter(str(plugin))
                 zipped_module = zipped_package.load_module(str(module.parent))
-                plugin_module_name = zipped_module.__name__.split(os.path.sep)[-1]
-
-                if not plugins_config.is_enabled(plugin_module_name):
-                    logger.warn(f"Plugin {plugin_module_name} found but not configured")
-                    continue
 
                 for key in dir(zipped_module):
                     if key.startswith("__"):
@@ -269,7 +264,17 @@ def scan_plugins(cfg: Config, debug: bool = False) -> List[AutoGPTPluginTemplate
                         "_abc_impl" in a_keys
                         and a_module.__name__ != "AutoGPTPluginTemplate"
                     ):
-                        loaded_plugins.append(a_module())
+                        plugin_name = a_module.__name__
+                        plugin_configured = plugins_config.get(plugin_name) is not None
+                        plugin_enabled = plugins_config.is_enabled(plugin_name)
+                        
+                        if plugin_configured and plugin_enabled:
+                            logger.debug(f"Loading plugin {plugin_name} as it was enabled in config.")
+                            loaded_plugins.append(a_module())
+                        elif plugin_configured and not plugin_enabled:
+                            logger.debug(f"Not loading plugin {plugin_name} as it was disabled in config.")
+                        elif not plugin_configured:
+                             logger.warn(f"Not loading plugin {plugin_name} as it was not found in config. Please check your config. Starting with 0.4.1, plugins will not be loaded unless they are enabled in plugins_config.yaml. Zipped plugins should use the class name ({plugin_name}) as the key.")
 
     # OpenAI plugins
     if cfg.plugins_openai:

--- a/autogpt/plugins/__init__.py
+++ b/autogpt/plugins/__init__.py
@@ -267,14 +267,20 @@ def scan_plugins(cfg: Config, debug: bool = False) -> List[AutoGPTPluginTemplate
                         plugin_name = a_module.__name__
                         plugin_configured = plugins_config.get(plugin_name) is not None
                         plugin_enabled = plugins_config.is_enabled(plugin_name)
-                        
+
                         if plugin_configured and plugin_enabled:
-                            logger.debug(f"Loading plugin {plugin_name} as it was enabled in config.")
+                            logger.debug(
+                                f"Loading plugin {plugin_name} as it was enabled in config."
+                            )
                             loaded_plugins.append(a_module())
                         elif plugin_configured and not plugin_enabled:
-                            logger.debug(f"Not loading plugin {plugin_name} as it was disabled in config.")
+                            logger.debug(
+                                f"Not loading plugin {plugin_name} as it was disabled in config."
+                            )
                         elif not plugin_configured:
-                             logger.warn(f"Not loading plugin {plugin_name} as it was not found in config. Please check your config. Starting with 0.4.1, plugins will not be loaded unless they are enabled in plugins_config.yaml. Zipped plugins should use the class name ({plugin_name}) as the key.")
+                            logger.warn(
+                                f"Not loading plugin {plugin_name} as it was not found in config. Please check your config. Starting with 0.4.1, plugins will not be loaded unless they are enabled in plugins_config.yaml. Zipped plugins should use the class name ({plugin_name}) as the key."
+                            )
 
     # OpenAI plugins
     if cfg.plugins_openai:

--- a/autogpt/plugins/__init__.py
+++ b/autogpt/plugins/__init__.py
@@ -279,7 +279,10 @@ def scan_plugins(cfg: Config, debug: bool = False) -> List[AutoGPTPluginTemplate
                             )
                         elif not plugin_configured:
                             logger.warn(
-                                f"Not loading plugin {plugin_name} as it was not found in config. Please check your config. Starting with 0.4.1, plugins will not be loaded unless they are enabled in plugins_config.yaml. Zipped plugins should use the class name ({plugin_name}) as the key."
+                                f"Not loading plugin {plugin_name} as it was not found in config. "
+                                f"Please check your config. Starting with 0.4.1, plugins will not be loaded unless "
+                                f"they are enabled in plugins_config.yaml. Zipped plugins should use the class "
+                                f"name ({plugin_name}) as the key."
                             )
 
     # OpenAI plugins


### PR DESCRIPTION
### Background
Legacy zipped plugins don't load on 0.4.1, and instead emit a "plugin not configured" warning. The reason appears to be the move from class-based config keys to directory-based config keys.

This PR enables class-based config keys for zipped plugins, which allows legacy plugins to load.

### Changes
Updated the code that checks whether a zipped plugin is configured to do so within the plugin load loop, where the class name is available, and updated the emitted debug and warning logs.

### Documentation
No change to docs as this is the legacy behavior.

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [ ] I have thoroughly tested my changes with multiple different prompts.
- [ ] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes. <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->
- [x] I have run the following commands against my code to ensure it passes our linters:
    ```shell
    black .
    isort .
    mypy
    autoflake --remove-all-unused-imports --recursive --ignore-init-module-imports --ignore-pass-after-docstring autogpt tests --in-place
    ```