### PR TITLE
Added Function Calling and Related Updates with Minimal Changes

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -45,6 +45,9 @@ OPENAI_API_KEY=your-openai-api-key
 ### LLM PROVIDER
 ################################################################################
 
+## ENABLE_FUNCTION_CALLING - Enable Function Calling or not (Default: False)
+# ENABLE_FUNCTION_CALLING=False
+
 ## TEMPERATURE - Sets temperature in OpenAI (Default: 0)
 # TEMPERATURE=0
 

--- a/autogpt/config/config.py
+++ b/autogpt/config/config.py
@@ -69,6 +69,7 @@ class Config:
         self.openai_api_key = os.getenv("OPENAI_API_KEY")
         self.openai_organization = os.getenv("OPENAI_ORGANIZATION")
         self.temperature = float(os.getenv("TEMPERATURE", "0"))
+        self.enable_function_calling = os.getenv("ENABLE_FUNCTION_CALLING") == "True"
         self.use_azure = os.getenv("USE_AZURE") == "True"
         self.execute_local_commands = (
             os.getenv("EXECUTE_LOCAL_COMMANDS", "False") == "True"

--- a/autogpt/llm/base.py
+++ b/autogpt/llm/base.py
@@ -16,6 +16,12 @@ class MessageDict(TypedDict):
     content: str
 
 
+class FunctionDict(TypedDict):
+    name: str
+    description: str
+    parameters: dict
+
+
 @dataclass
 class Message:
     """OpenAI Message object containing a role and the message content"""
@@ -26,6 +32,22 @@ class Message:
 
     def raw(self) -> MessageDict:
         return {"role": self.role, "content": self.content}
+
+
+@dataclass
+class Function:
+    """OpenAI Function object containing a name, a description and parameters"""
+
+    name: str
+    description: str
+    parameters: dict
+
+    def raw(self) -> FunctionDict:
+        return {
+            "name": self.name,
+            "description": self.description,
+            "parameters": self.parameters,
+        }
 
 
 @dataclass

--- a/autogpt/prompts/generator.py
+++ b/autogpt/prompts/generator.py
@@ -1,6 +1,7 @@
 """ A module for generating custom prompt strings."""
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
 
+from autogpt.config import Config
 from autogpt.json_utils.utilities import llm_response_schema
 
 if TYPE_CHECKING:
@@ -135,13 +136,21 @@ class PromptGenerator:
         Returns:
             str: The generated prompt string.
         """
-        return (
+        base_string = (
             f"Constraints:\n{self._generate_numbered_list(self.constraints)}\n\n"
             "Commands:\n"
             f"{self._generate_numbered_list(self.commands, item_type='command')}\n\n"
             f"Resources:\n{self._generate_numbered_list(self.resources)}\n\n"
             "Performance Evaluation:\n"
             f"{self._generate_numbered_list(self.performance_evaluation)}\n\n"
-            "Respond with only valid JSON conforming to the following schema: \n"
-            f"{llm_response_schema()}\n"
         )
+        config = Config()
+        if config.enable_function_calling:
+            return base_string + (
+                "Respond with only valid JSON conforming to the schema: \n"
+            )
+        else:
+            return base_string + (
+                "Respond with only valid JSON conforming to the following schema: \n"
+                f"{llm_response_schema()}\n"
+            )


### PR DESCRIPTION
<!-- ⚠️ At the moment any non-essential commands are not being merged.
If you want to add non-essential commands to Auto-GPT, please create a plugin instead.
We are expecting to ship plugin support within the week (PR #757).
Resources:
* https://github.com/Significant-Gravitas/Auto-GPT-Plugin-Template
-->

<!-- 📢 Announcement
We've recently noticed an increase in pull requests focusing on combining multiple changes. While the intentions behind these PRs are appreciated, it's essential to maintain a clean and manageable git history. To ensure the quality of our repository, we kindly ask you to adhere to the following guidelines when submitting PRs:

Focus on a single, specific change.
Do not include any unrelated or "extra" modifications.
Provide clear documentation and explanations of the changes made.
Ensure diffs are limited to the intended lines — no applying preferred formatting styles or line endings (unless that's what the PR is about).
For guidance on committing only the specific lines you have changed, refer to this helpful video: https://youtu.be/8-hSNHHbiZg

Check out our [wiki page on Contributing](https://github.com/Significant-Gravitas/Nexus/wiki/Contributing)

By following these guidelines, your PRs are more likely to be merged quickly after testing, as long as they align with the project's overall direction. -->

### Background
The OpenAI API was updated on June 13th to implement function calls. To test this feature's performance in Auto-GPT, I've incorporated a toggle for function calls, `ENABLE_FUNCTION_CALLING`.

- When `ENABLE_FUNCTION_CALLING` is set to False, Auto-GPT operates as usual.
- When `ENABLE_FUNCTION_CALLING` is set to True and `FAST_LLM_MODEL` corresponds to a model updated as of June 13th with a function calling ability (such as 'gpt-3.5-turbo-0613' or 'gpt-4-0613'), function calls are executed.

### Changes
1. Added Enable Function Calling Feature  
I have introduced a new environmental variable ENABLE_FUNCTION_CALLING in .env.template which can be set to enable function calling. It is False by default.

2. Modified create_chat_completion method  
In the create_chat_completion method in autogpt/llm/utils/__init__.py, a new parameter functions has been added. The method now also checks if function calling is enabled and if so, adds the raw functions to chat_completion_kwargs.

3. Updated Prompt Generator  
The prompt generator in autogpt/prompts/generator.py has been updated to generate different prompts based on whether function calling is enabled.

### Test Plan
- I confirmed that pytest passed all tests, except for the following error, when `ENABLE_FUNCTION_CALLING=True`, `FAST_LLM_MODEL=gpt-4-0613`:

```
FAILED tests/unit/test_config.py::test_initial_values - AssertionError: assert 'gpt-4-0613' == 'gpt-3.5-turbo'
```

Please note that 'pytest' almost always fail with 'gpt-3.5-turbo', as the 'args' of the command are not included in the OpenAI API responses.

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [ ] I have thoroughly tested my changes with multiple different prompts.
- [ ] I have considered potential risks and mitigations for my changes.
- [ ] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes. <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->
- [x] I have run the following commands against my code to ensure it passes our linters:
    ```shell
    black .
    isort .
    mypy
    autoflake --remove-all-unused-imports --recursive --ignore-init-module-imports --ignore-pass-after-docstring autogpt tests --in-place
    ```

<!-- If you haven't added tests, please explain why. If you have, check the appropriate box. If you've ensured your PR is atomic and well-documented, check the corresponding boxes. -->

<!-- By submitting this, I agree that my pull request should be closed if I do not fill this out or follow the guidelines. -->
