### PR TITLE
Retry ServiceUnavailableError

### DIFF
--- a/autogpt/llm/providers/openai.py
+++ b/autogpt/llm/providers/openai.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 import openai
 import openai.api_resources.abstract.engine_api_resource as engine_api_resource
 from colorama import Fore, Style
-from openai.error import APIError, RateLimitError, Timeout, ServiceUnavailableError
+from openai.error import APIError, RateLimitError, ServiceUnavailableError, Timeout
 from openai.openai_object import OpenAIObject
 
 if TYPE_CHECKING:
@@ -164,7 +164,10 @@ def retry_api(
         warn_user bool: Whether to warn the user. Defaults to True.
     """
     retry_limit_msg = f"{Fore.RED}Error: " f"Reached rate limit, passing...{Fore.RESET}"
-    retry_service_unavailable_msg = f"{Fore.RED}Error: " f"The OpenAI API engine is currently overloaded, passing...{Fore.RESET}"
+    retry_service_unavailable_msg = (
+        f"{Fore.RED}Error: "
+        f"The OpenAI API engine is currently overloaded, passing...{Fore.RESET}"
+    )
     api_key_error_msg = (
         f"Please double check that you have setup a "
         f"{Fore.CYAN + Style.BRIGHT}PAID{Style.RESET_ALL} OpenAI API Account. You can "
@@ -202,9 +205,7 @@ def retry_api(
                         user_warned = True
 
                 except (APIError, Timeout) as e:
-                    if (e.http_status not in [429, 502]) or (
-                        attempt == num_attempts
-                    ):
+                    if (e.http_status not in [429, 502]) or (attempt == num_attempts):
                         raise
 
                 backoff = backoff_base ** (attempt + 2)

--- a/tests/unit/test_retry_provider_openai.py
+++ b/tests/unit/test_retry_provider_openai.py
@@ -1,10 +1,10 @@
 import pytest
-from openai.error import APIError, RateLimitError
+from openai.error import APIError, RateLimitError, ServiceUnavailableError
 
 from autogpt.llm.providers import openai
 
 
-@pytest.fixture(params=[RateLimitError, APIError])
+@pytest.fixture(params=[RateLimitError, ServiceUnavailableError, APIError])
 def error(request):
     if request.param == APIError:
         return request.param("Error", http_status=502)
@@ -52,7 +52,7 @@ def test_retry_open_api_no_error(capsys):
     ids=["passing", "passing_edge", "failing", "failing_edge", "failing_no_retries"],
 )
 def test_retry_open_api_passing(capsys, error, error_count, retry_count, failure):
-    """Tests the retry with simulated errors [RateLimitError, APIError], but should ulimately pass"""
+    """Tests the retry with simulated errors [RateLimitError, ServiceUnavailableError, APIError], but should ulimately pass"""
     call_count = min(error_count, retry_count) + 1
 
     raises = error_factory(error, error_count, retry_count)
@@ -70,6 +70,9 @@ def test_retry_open_api_passing(capsys, error, error_count, retry_count, failure
     if error_count and retry_count:
         if type(error) == RateLimitError:
             assert "Reached rate limit, passing..." in output.out
+            assert "Please double check" in output.out
+        if type(error) == ServiceUnavailableError:
+            assert "The OpenAI API engine is currently overloaded, passing..." in output.out
             assert "Please double check" in output.out
         if type(error) == APIError:
             assert "API Bad gateway" in output.out
@@ -91,6 +94,22 @@ def test_retry_open_api_rate_limit_no_warn(capsys):
     output = capsys.readouterr()
 
     assert "Reached rate limit, passing..." in output.out
+    assert "Please double check" not in output.out
+
+def test_retry_open_api_service_unavairable_no_warn(capsys):
+    """Tests the retry logic with a service unavairable error"""
+    error_count = 2
+    retry_count = 10
+
+    raises = error_factory(ServiceUnavailableError, error_count, retry_count, warn_user=False)
+    result = raises()
+    call_count = min(error_count, retry_count) + 1
+    assert result == call_count
+    assert raises.count == call_count
+
+    output = capsys.readouterr()
+
+    assert "The OpenAI API engine is currently overloaded, passing..." in output.out
     assert "Please double check" not in output.out
 
 

--- a/tests/unit/test_retry_provider_openai.py
+++ b/tests/unit/test_retry_provider_openai.py
@@ -72,7 +72,10 @@ def test_retry_open_api_passing(capsys, error, error_count, retry_count, failure
             assert "Reached rate limit, passing..." in output.out
             assert "Please double check" in output.out
         if type(error) == ServiceUnavailableError:
-            assert "The OpenAI API engine is currently overloaded, passing..." in output.out
+            assert (
+                "The OpenAI API engine is currently overloaded, passing..."
+                in output.out
+            )
             assert "Please double check" in output.out
         if type(error) == APIError:
             assert "API Bad gateway" in output.out
@@ -96,12 +99,15 @@ def test_retry_open_api_rate_limit_no_warn(capsys):
     assert "Reached rate limit, passing..." in output.out
     assert "Please double check" not in output.out
 
+
 def test_retry_open_api_service_unavairable_no_warn(capsys):
     """Tests the retry logic with a service unavairable error"""
     error_count = 2
     retry_count = 10
 
-    raises = error_factory(ServiceUnavailableError, error_count, retry_count, warn_user=False)
+    raises = error_factory(
+        ServiceUnavailableError, error_count, retry_count, warn_user=False
+    )
     result = raises()
     call_count = min(error_count, retry_count) + 1
     assert result == call_count


### PR DESCRIPTION
<!-- ⚠️ At the moment any non-essential commands are not being merged.
If you want to add non-essential commands to Auto-GPT, please create a plugin instead.
We are expecting to ship plugin support within the week (PR #757).
Resources:
* https://github.com/Significant-Gravitas/Auto-GPT-Plugin-Template
-->

<!-- 📢 Announcement
We've recently noticed an increase in pull requests focusing on combining multiple changes. While the intentions behind these PRs are appreciated, it's essential to maintain a clean and manageable git history. To ensure the quality of our repository, we kindly ask you to adhere to the following guidelines when submitting PRs:

Focus on a single, specific change.
Do not include any unrelated or "extra" modifications.
Provide clear documentation and explanations of the changes made.
Ensure diffs are limited to the intended lines — no applying preferred formatting styles or line endings (unless that's what the PR is about).
For guidance on committing only the specific lines you have changed, refer to this helpful video: https://youtu.be/8-hSNHHbiZg

Check out our [wiki page on Contributing](https://github.com/Significant-Gravitas/Nexus/wiki/Contributing)

By following these guidelines, your PRs are more likely to be merged quickly after testing, as long as they align with the project's overall direction. -->

### Background
This is the PR for retrying when a `ServiceUnavailableError` occurs. 
This is an improved version of #4744 .

### Changes
The code has been modified to perform a retry operation when a `ServiceUnavailableError` (503 error) occurs.

[The original code](https://github.com/Significant-Gravitas/Auto-GPT/blob/de97097db15c7a10eadaece9ad01bc5d760f5c13/autogpt/llm/providers/openai.py#L194) handles specific exceptions such as `APIError` and `Timeout` that occur when calling the OpenAI API. When one of the two exceptions occurs, Auto-GPT checks if the HTTP status code of that exception is 429, 502, 503, or if the default number of retry attempts (num_attempts) has been reached. If so, it rethrows (raises) the exception.

However, when specific exceptions such as `APIError` and `Timeout` occur, the HTTP status code can not become 503. [The HTTP status code becomes 503 only when a ServiceUnavailableError occurs.](https://github.com/openai/openai-python/blob/main/openai/api_requestor.py#L744) Therefore, I added the process to handle the occurrence of `ServiceUnavailableError`.

### Documentation
<!-- Explain how your changes are documented, such as in-code comments or external documentation. Ensure that the documentation is clear, concise, and easy to understand. -->

### Test Plan
<!-- Describe how you tested this functionality. Include steps to reproduce, relevant test cases, and any other pertinent information. -->

### PR Quality Checklist
- [ ] My pull request is atomic and focuses on a single change.
- [ ] I have thoroughly tested my changes with multiple different prompts.
- [ ] I have considered potential risks and mitigations for my changes.
- [ ] I have documented my changes clearly and comprehensively.
- [ ] I have not snuck in any "extra" small tweaks changes. <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->
- [ ] I have run the following commands against my code to ensure it passes our linters:
    ```shell
    black .
    isort .
    mypy
    autoflake --remove-all-unused-imports --recursive --ignore-init-module-imports --ignore-pass-after-docstring autogpt tests --in-place
    ```

<!-- If you haven't added tests, please explain why. If you have, check the appropriate box. If you've ensured your PR is atomic and well-documented, check the corresponding boxes. -->

<!-- By submitting this, I agree that my pull request should be closed if I do not fill this out or follow the guidelines. -->
