### PR TITLE
Adding mypy

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -2,7 +2,7 @@
 follow_imports = skip
 check_untyped_defs = True
 disallow_untyped_defs = True
-files = tests/challenges/**/*.py tests/integration/**/*.py
+files = tests/challenges/**/*.py,tests/integration/**/*.py
 
 [mypy-requests.*]
 ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,7 +2,7 @@
 follow_imports = skip
 check_untyped_defs = True
 disallow_untyped_defs = True
-files = tests/challenges/**/*.py,tests/integration/**/*.py
+files = tests/challenges/**/*.py,tests/integration/memory
 
 [mypy-requests.*]
 ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,7 +2,7 @@
 follow_imports = skip
 check_untyped_defs = True
 disallow_untyped_defs = True
-files = tests/challenges/**/*.py,tests/integration/memory
+files = tests/challenges/**/*.py, tests/integration/memory/conftest.py, tests/integration/memory/test_json_file_memory.py
 
 [mypy-requests.*]
 ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,7 +2,7 @@
 follow_imports = skip
 check_untyped_defs = True
 disallow_untyped_defs = True
-files = tests/challenges/**/*.py
+files = tests/challenges/**/*.py tests/integration/**/*.py
 
 [mypy-requests.*]
 ignore_missing_imports = True

--- a/tests/integration/memory/conftest.py
+++ b/tests/integration/memory/conftest.py
@@ -5,7 +5,7 @@ from autogpt.memory.vector.utils import Embedding
 
 
 @pytest.fixture
-def memory_item(mock_embedding: Embedding)-> MemoryItem:
+def memory_item(mock_embedding: Embedding) -> MemoryItem:
     return MemoryItem(
         raw_content="test content",
         summary="test content summary",

--- a/tests/integration/memory/conftest.py
+++ b/tests/integration/memory/conftest.py
@@ -5,7 +5,7 @@ from autogpt.memory.vector.utils import Embedding
 
 
 @pytest.fixture
-def memory_item(mock_embedding: Embedding):
+def memory_item(mock_embedding: Embedding)-> MemoryItem:
     return MemoryItem(
         raw_content="test content",
         summary="test content summary",

--- a/tests/integration/memory/test_json_file_memory.py
+++ b/tests/integration/memory/test_json_file_memory.py
@@ -1,22 +1,25 @@
 # sourcery skip: snake-case-functions
 """Tests for JSONFileMemory class"""
+from typing import Callable
+
 import orjson
 import pytest
+from pytest_mock import MockerFixture
 
 from autogpt.config import Config
 from autogpt.memory.vector import JSONFileMemory, MemoryItem
 from autogpt.workspace import Workspace
-from typing import Callable
-from pytest_mock import MockerFixture
 
 
 @pytest.fixture(autouse=True)
-def cleanup_sut_singleton()-> None:
+def cleanup_sut_singleton() -> None:
     if JSONFileMemory in JSONFileMemory._instances:
         del JSONFileMemory._instances[JSONFileMemory]
 
 
-def test_json_memory_init_without_backing_file(config: Config, workspace: Workspace) ->None:
+def test_json_memory_init_without_backing_file(
+    config: Config, workspace: Workspace
+) -> None:
     index_file = workspace.root / f"{config.memory_index}.json"
 
     assert not index_file.exists()
@@ -25,7 +28,9 @@ def test_json_memory_init_without_backing_file(config: Config, workspace: Worksp
     assert index_file.read_text() == "[]"
 
 
-def test_json_memory_init_with_backing_empty_file(config: Config, workspace: Workspace) -> None:
+def test_json_memory_init_with_backing_empty_file(
+    config: Config, workspace: Workspace
+) -> None:
     index_file = workspace.root / f"{config.memory_index}.json"
     index_file.touch()
 
@@ -37,7 +42,7 @@ def test_json_memory_init_with_backing_empty_file(config: Config, workspace: Wor
 
 def test_json_memory_init_with_backing_invalid_file(
     config: Config, workspace: Workspace
-)-> None:
+) -> None:
     index_file = workspace.root / f"{config.memory_index}.json"
     index_file.touch()
 
@@ -52,7 +57,7 @@ def test_json_memory_init_with_backing_invalid_file(
     assert index_file.read_text() == "[]"
 
 
-def test_json_memory_add(config: Config, memory_item: MemoryItem) ->None:
+def test_json_memory_add(config: Config, memory_item: MemoryItem) -> None:
     index = JSONFileMemory(config)
     index.add(memory_item)
     assert index.memories[0] == memory_item
@@ -69,7 +74,11 @@ def test_json_memory_clear(config: Config, memory_item: MemoryItem) -> None:
     assert index.memories == []
 
 
-def test_json_memory_get(config: Config, memory_item: MemoryItem, mock_get_embedding:Callable[[MockerFixture, int], None]) -> None:
+def test_json_memory_get(
+    config: Config,
+    memory_item: MemoryItem,
+    mock_get_embedding: Callable[[MockerFixture, int], None],
+) -> None:
     index = JSONFileMemory(config)
     assert (
         index.get("test", config) == None
@@ -81,7 +90,7 @@ def test_json_memory_get(config: Config, memory_item: MemoryItem, mock_get_embed
     assert retrieved.memory_item == memory_item
 
 
-def test_json_memory_load_index(config: Config, memory_item: MemoryItem) ->None:
+def test_json_memory_load_index(config: Config, memory_item: MemoryItem) -> None:
     index = JSONFileMemory(config)
     index.add(memory_item)
 

--- a/tests/integration/memory/test_json_file_memory.py
+++ b/tests/integration/memory/test_json_file_memory.py
@@ -9,12 +9,12 @@ from autogpt.workspace import Workspace
 
 
 @pytest.fixture(autouse=True)
-def cleanup_sut_singleton():
+def cleanup_sut_singleton()-> None:
     if JSONFileMemory in JSONFileMemory._instances:
         del JSONFileMemory._instances[JSONFileMemory]
 
 
-def test_json_memory_init_without_backing_file(config: Config, workspace: Workspace):
+def test_json_memory_init_without_backing_file(config: Config, workspace: Workspace) ->None:
     index_file = workspace.root / f"{config.memory_index}.json"
 
     assert not index_file.exists()
@@ -23,7 +23,7 @@ def test_json_memory_init_without_backing_file(config: Config, workspace: Worksp
     assert index_file.read_text() == "[]"
 
 
-def test_json_memory_init_with_backing_empty_file(config: Config, workspace: Workspace):
+def test_json_memory_init_with_backing_empty_file(config: Config, workspace: Workspace) -> None:
     index_file = workspace.root / f"{config.memory_index}.json"
     index_file.touch()
 
@@ -35,7 +35,7 @@ def test_json_memory_init_with_backing_empty_file(config: Config, workspace: Wor
 
 def test_json_memory_init_with_backing_invalid_file(
     config: Config, workspace: Workspace
-):
+)-> None:
     index_file = workspace.root / f"{config.memory_index}.json"
     index_file.touch()
 
@@ -50,13 +50,13 @@ def test_json_memory_init_with_backing_invalid_file(
     assert index_file.read_text() == "[]"
 
 
-def test_json_memory_add(config: Config, memory_item: MemoryItem):
+def test_json_memory_add(config: Config, memory_item: MemoryItem) ->None:
     index = JSONFileMemory(config)
     index.add(memory_item)
     assert index.memories[0] == memory_item
 
 
-def test_json_memory_clear(config: Config, memory_item: MemoryItem):
+def test_json_memory_clear(config: Config, memory_item: MemoryItem) -> None:
     index = JSONFileMemory(config)
     assert index.memories == []
 
@@ -67,7 +67,7 @@ def test_json_memory_clear(config: Config, memory_item: MemoryItem):
     assert index.memories == []
 
 
-def test_json_memory_get(config: Config, memory_item: MemoryItem, mock_get_embedding):
+def test_json_memory_get(config: Config, memory_item: MemoryItem, mock_get_embedding) -> None:
     index = JSONFileMemory(config)
     assert (
         index.get("test", config) == None
@@ -79,7 +79,7 @@ def test_json_memory_get(config: Config, memory_item: MemoryItem, mock_get_embed
     assert retrieved.memory_item == memory_item
 
 
-def test_json_memory_load_index(config: Config, memory_item: MemoryItem):
+def test_json_memory_load_index(config: Config, memory_item: MemoryItem) ->None:
     index = JSONFileMemory(config)
     index.add(memory_item)
 

--- a/tests/integration/memory/test_json_file_memory.py
+++ b/tests/integration/memory/test_json_file_memory.py
@@ -6,6 +6,8 @@ import pytest
 from autogpt.config import Config
 from autogpt.memory.vector import JSONFileMemory, MemoryItem
 from autogpt.workspace import Workspace
+from typing import Callable
+from pytest_mock import MockerFixture
 
 
 @pytest.fixture(autouse=True)
@@ -67,7 +69,7 @@ def test_json_memory_clear(config: Config, memory_item: MemoryItem) -> None:
     assert index.memories == []
 
 
-def test_json_memory_get(config: Config, memory_item: MemoryItem, mock_get_embedding) -> None:
+def test_json_memory_get(config: Config, memory_item: MemoryItem, mock_get_embedding:Callable[[MockerFixture, int], None]) -> None:
     index = JSONFileMemory(config)
     assert (
         index.get("test", config) == None


### PR DESCRIPTION


### Background
Issue Link : https://github.com/Significant-Gravitas/Auto-GPT/issues/4788
### Changes
Made changes to two source file and mypy.ini to add typeannotaion.
Source files:
tests/integration/memory/conftest.py
tests/integration/memory/test_json_file_memory.py


### Test Plan
I executed `mypy` command and it didn't give any error

### PR Quality Checklist
- [ :heavy_check_mark: ] My pull request is atomic and focuses on a single change.
- [ :heavy_check_mark: ] I have considered potential risks and mitigations for my changes..
- [ :heavy_check_mark: ] I have not snuck in any "extra" small tweaks changes. <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->
- [ :heavy_check_mark: ] I have run the following commands against my code to ensure it passes our linters:
    ```
   black .
    isort .
    mypy
      autoflake --remove-all-unused-imports --recursive --ignore-init-module-imports --ignore-pass-after-docstring autogpt tests --in-place
    ```

<!-- By submitting this, I agree that my pull request should be closed if I do not fill this out or follow the guidelines. -->
