### PR TITLE
Enforce mypy type annotation rules on tests/**

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -2,7 +2,7 @@
 follow_imports = skip
 check_untyped_defs = True
 disallow_untyped_defs = True
-files = tests/challenges/**/*.py, tests/integration/memory/*.py,tests/integration/agent_factory.py,tests/integration/test_execute_code.py, tests/integration/test_provider_openai.py
+files = tests/challenges/**/*.py, tests/integration/memory/*.py,tests/integration/agent_factory.py,tests/integration/test_execute_code.py, tests/integration/test_provider_openai.py, tests/integration/test_setup.py
 
 [mypy-requests.*]
 ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,7 +2,7 @@
 follow_imports = skip
 check_untyped_defs = True
 disallow_untyped_defs = True
-files = tests/challenges/**/*.py tests/integration/**/*.py
+files = tests/challenges/**/*.py,tests/integration/**/*.py
 
 [mypy-requests.*]
 ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,7 +2,7 @@
 follow_imports = skip
 check_untyped_defs = True
 disallow_untyped_defs = True
-files = tests/challenges/**/*.py, tests/integration/memory/*.py
+files = tests/challenges/**/*.py, tests/integration/memory/*.py,tests/integration/agent_factory.py
 
 [mypy-requests.*]
 ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,7 +2,7 @@
 follow_imports = skip
 check_untyped_defs = True
 disallow_untyped_defs = True
-files = tests/challenges/**/*.py,tests/integration/**/*.py
+files = tests/challenges/**/*.py,tests/integration/memory
 
 [mypy-requests.*]
 ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,7 +2,7 @@
 follow_imports = skip
 check_untyped_defs = True
 disallow_untyped_defs = True
-files = tests/challenges/**/*.py, tests/integration/memory/conftest.py, tests/integration/memory/test_json_file_memory.py
+files = tests/challenges/**/*.py, tests/integration/memory/*.py
 
 [mypy-requests.*]
 ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,7 +2,7 @@
 follow_imports = skip
 check_untyped_defs = True
 disallow_untyped_defs = True
-files = tests/challenges/**/*.py,tests/integration/memory
+files = tests/challenges/**/*.py, tests/integration/memory/conftest.py, tests/integration/memory/test_json_file_memory.py
 
 [mypy-requests.*]
 ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,7 +2,7 @@
 follow_imports = skip
 check_untyped_defs = True
 disallow_untyped_defs = True
-files = tests/challenges/**/*.py, tests/integration/memory/*.py,tests/integration/agent_factory.py,tests/integration/test_execute_code.py
+files = tests/challenges/**/*.py, tests/integration/memory/*.py,tests/integration/agent_factory.py,tests/integration/test_execute_code.py, tests/integration/test_provider_openai.py
 
 [mypy-requests.*]
 ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,7 +2,7 @@
 follow_imports = skip
 check_untyped_defs = True
 disallow_untyped_defs = True
-files = tests/challenges/**/*.py, tests/integration/memory/*.py,tests/integration/agent_factory.py,tests/integration/test_execute_code.py, tests/integration/test_provider_openai.py, tests/integration/test_setup.py
+files = tests/challenges/**/*.py, tests/integration/memory/*.py,tests/integration/agent_factory.py,tests/integration/test_execute_code.py, tests/integration/test_provider_openai.py, tests/integration/test_setup.py,tests/integration/test_web_selenium.py
 
 [mypy-requests.*]
 ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,7 +2,8 @@
 follow_imports = skip
 check_untyped_defs = True
 disallow_untyped_defs = True
-files = tests/challenges/**/*.py, tests/integration/memory/*.py,tests/integration/agent_factory.py,tests/integration/test_execute_code.py, tests/integration/test_provider_openai.py, tests/integration/test_setup.py,tests/integration/test_web_selenium.py
+exclude=tests/integration/test_image_gen.py  ;Because i was not able to figure out type annotation for now
+files = tests/challenges/**/*.py,tests/integration/memory/*.py ,tests/integration/agent_factory.py,tests/integration/test_execute_code.py,tests/integration/test_provider_openai.py,tests/integration/test_setup.py,tests/integration/test_web_selenium.py
 
 [mypy-requests.*]
 ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,7 +2,7 @@
 follow_imports = skip
 check_untyped_defs = True
 disallow_untyped_defs = True
-files = tests/challenges/**/*.py
+files = tests/challenges/**/*.py tests/integration/**/*.py
 
 [mypy-requests.*]
 ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,7 +2,7 @@
 follow_imports = skip
 check_untyped_defs = True
 disallow_untyped_defs = True
-files = tests/challenges/**/*.py, tests/integration/memory/*.py,tests/integration/agent_factory.py
+files = tests/challenges/**/*.py, tests/integration/memory/*.py,tests/integration/agent_factory.py,tests/integration/test_execute_code.py
 
 [mypy-requests.*]
 ignore_missing_imports = True

--- a/tests/integration/agent_factory.py
+++ b/tests/integration/agent_factory.py
@@ -13,7 +13,6 @@ from autogpt.workspace import Workspace
         mypy
         tests/integration/memory/utils.py:5: error: Skipping analyzing ".autogpt.memory.vector.providers.base": module is installed, but missing library stubs or py.typed marker  [import]
         tests/integration/memory/utils.py:5: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
-    
     This import file is necessary for giving the type hint for memory_json_file function
 """
 from autogpt.memory.vector.providers.base import (

--- a/tests/integration/agent_factory.py
+++ b/tests/integration/agent_factory.py
@@ -16,7 +16,7 @@ from autogpt.workspace import Workspace
     
     This import file is necessary for giving the type hint for memory_json_file function
 """
-from ....autogpt.memory.vector.providers.base import (
+from autogpt.memory.vector.providers.base import (
     VectorMemoryProvider as VectorMemory,  # type: ignore
 )
 

--- a/tests/integration/agent_factory.py
+++ b/tests/integration/agent_factory.py
@@ -5,10 +5,20 @@ from autogpt.config import AIConfig, Config
 from autogpt.memory.vector import get_memory
 from autogpt.models.command_registry import CommandRegistry
 from autogpt.workspace import Workspace
+from typing import Generator
+"""
+    Added #type: ignore because without it, mypy command gave following error:
+        mypy
+        tests/integration/memory/utils.py:5: error: Skipping analyzing ".autogpt.memory.vector.providers.base": module is installed, but missing library stubs or py.typed marker  [import]
+        tests/integration/memory/utils.py:5: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
+    
+    This import file is necessary for giving the type hint for memory_json_file function
+"""
+from ....autogpt.memory.vector.providers.base import VectorMemoryProvider as VectorMemory # type: ignore 
 
 
 @pytest.fixture
-def memory_json_file(config: Config):
+def memory_json_file(config: Config) -> Generator[VectorMemory, None, None]:
     was_memory_backend = config.memory_backend
 
     config.memory_backend = "json_file"
@@ -20,7 +30,7 @@ def memory_json_file(config: Config):
 
 
 @pytest.fixture
-def dummy_agent(config: Config, memory_json_file, workspace: Workspace):
+def dummy_agent(config: Config, memory_json_file:Generator[VectorMemory, None, None], workspace: Workspace)->Agent:
     command_registry = CommandRegistry()
 
     ai_config = AIConfig(

--- a/tests/integration/agent_factory.py
+++ b/tests/integration/agent_factory.py
@@ -1,3 +1,5 @@
+from typing import Generator
+
 import pytest
 
 from autogpt.agent import Agent
@@ -5,7 +7,7 @@ from autogpt.config import AIConfig, Config
 from autogpt.memory.vector import get_memory
 from autogpt.models.command_registry import CommandRegistry
 from autogpt.workspace import Workspace
-from typing import Generator
+
 """
     Added #type: ignore because without it, mypy command gave following error:
         mypy
@@ -14,7 +16,9 @@ from typing import Generator
     
     This import file is necessary for giving the type hint for memory_json_file function
 """
-from ....autogpt.memory.vector.providers.base import VectorMemoryProvider as VectorMemory # type: ignore 
+from ....autogpt.memory.vector.providers.base import (
+    VectorMemoryProvider as VectorMemory,  # type: ignore
+)
 
 
 @pytest.fixture
@@ -30,7 +34,11 @@ def memory_json_file(config: Config) -> Generator[VectorMemory, None, None]:
 
 
 @pytest.fixture
-def dummy_agent(config: Config, memory_json_file:Generator[VectorMemory, None, None], workspace: Workspace)->Agent:
+def dummy_agent(
+    config: Config,
+    memory_json_file: Generator[VectorMemory, None, None],
+    workspace: Workspace,
+) -> Agent:
     command_registry = CommandRegistry()
 
     ai_config = AIConfig(

--- a/tests/integration/memory/conftest.py
+++ b/tests/integration/memory/conftest.py
@@ -5,7 +5,7 @@ from autogpt.memory.vector.utils import Embedding
 
 
 @pytest.fixture
-def memory_item(mock_embedding: Embedding)-> MemoryItem:
+def memory_item(mock_embedding: Embedding) -> MemoryItem:
     return MemoryItem(
         raw_content="test content",
         summary="test content summary",

--- a/tests/integration/memory/conftest.py
+++ b/tests/integration/memory/conftest.py
@@ -5,6 +5,7 @@ from autogpt.memory.vector.utils import Embedding
 
 
 @pytest.fixture
+## Added MemoryItem type notation to funciton return type
 def memory_item(mock_embedding: Embedding) -> MemoryItem:
     return MemoryItem(
         raw_content="test content",

--- a/tests/integration/memory/conftest.py
+++ b/tests/integration/memory/conftest.py
@@ -5,7 +5,7 @@ from autogpt.memory.vector.utils import Embedding
 
 
 @pytest.fixture
-def memory_item(mock_embedding: Embedding):
+def memory_item(mock_embedding: Embedding)-> MemoryItem:
     return MemoryItem(
         raw_content="test content",
         summary="test content summary",

--- a/tests/integration/memory/test_json_file_memory.py
+++ b/tests/integration/memory/test_json_file_memory.py
@@ -1,22 +1,25 @@
 # sourcery skip: snake-case-functions
 """Tests for JSONFileMemory class"""
+from typing import Callable
+
 import orjson
 import pytest
+from pytest_mock import MockerFixture
 
 from autogpt.config import Config
 from autogpt.memory.vector import JSONFileMemory, MemoryItem
 from autogpt.workspace import Workspace
-from typing import Callable
-from pytest_mock import MockerFixture
 
 
 @pytest.fixture(autouse=True)
-def cleanup_sut_singleton()-> None:
+def cleanup_sut_singleton() -> None:
     if JSONFileMemory in JSONFileMemory._instances:
         del JSONFileMemory._instances[JSONFileMemory]
 
 
-def test_json_memory_init_without_backing_file(config: Config, workspace: Workspace) ->None:
+def test_json_memory_init_without_backing_file(
+    config: Config, workspace: Workspace
+) -> None:
     index_file = workspace.root / f"{config.memory_index}.json"
 
     assert not index_file.exists()
@@ -25,7 +28,9 @@ def test_json_memory_init_without_backing_file(config: Config, workspace: Worksp
     assert index_file.read_text() == "[]"
 
 
-def test_json_memory_init_with_backing_empty_file(config: Config, workspace: Workspace) -> None:
+def test_json_memory_init_with_backing_empty_file(
+    config: Config, workspace: Workspace
+) -> None:
     index_file = workspace.root / f"{config.memory_index}.json"
     index_file.touch()
 
@@ -37,7 +42,7 @@ def test_json_memory_init_with_backing_empty_file(config: Config, workspace: Wor
 
 def test_json_memory_init_with_backing_invalid_file(
     config: Config, workspace: Workspace
-)-> None:
+) -> None:
     index_file = workspace.root / f"{config.memory_index}.json"
     index_file.touch()
 
@@ -52,7 +57,7 @@ def test_json_memory_init_with_backing_invalid_file(
     assert index_file.read_text() == "[]"
 
 
-def test_json_memory_add(config: Config, memory_item: MemoryItem) ->None:
+def test_json_memory_add(config: Config, memory_item: MemoryItem) -> None:
     index = JSONFileMemory(config)
     index.add(memory_item)
     assert index.memories[0] == memory_item
@@ -69,7 +74,11 @@ def test_json_memory_clear(config: Config, memory_item: MemoryItem) -> None:
     assert index.memories == []
 
 
-def test_json_memory_get(config: Config, memory_item: MemoryItem, mock_get_embedding:Callable[[MockerFixture, int], None]) -> None:
+def test_json_memory_get(
+    config: Config,
+    memory_item: MemoryItem,
+    mock_get_embedding: Callable[[MockerFixture, int], None],
+) -> None:
     index = JSONFileMemory(config)
     assert (
         index.get("test", config) == None
@@ -81,7 +90,7 @@ def test_json_memory_get(config: Config, memory_item: MemoryItem, mock_get_embed
     assert retrieved.memory_item == memory_item
 
 
-def test_json_memory_load_index(config: Config, memory_item: MemoryItem) ->None:
+def test_json_memory_load_index(config: Config, memory_item: MemoryItem) -> None:
     index = JSONFileMemory(config)
     index.add(memory_item)
 

--- a/tests/integration/memory/test_json_file_memory.py
+++ b/tests/integration/memory/test_json_file_memory.py
@@ -9,12 +9,12 @@ from autogpt.workspace import Workspace
 
 
 @pytest.fixture(autouse=True)
-def cleanup_sut_singleton():
+def cleanup_sut_singleton()-> None:
     if JSONFileMemory in JSONFileMemory._instances:
         del JSONFileMemory._instances[JSONFileMemory]
 
 
-def test_json_memory_init_without_backing_file(config: Config, workspace: Workspace):
+def test_json_memory_init_without_backing_file(config: Config, workspace: Workspace) ->None:
     index_file = workspace.root / f"{config.memory_index}.json"
 
     assert not index_file.exists()
@@ -23,7 +23,7 @@ def test_json_memory_init_without_backing_file(config: Config, workspace: Worksp
     assert index_file.read_text() == "[]"
 
 
-def test_json_memory_init_with_backing_empty_file(config: Config, workspace: Workspace):
+def test_json_memory_init_with_backing_empty_file(config: Config, workspace: Workspace) -> None:
     index_file = workspace.root / f"{config.memory_index}.json"
     index_file.touch()
 
@@ -35,7 +35,7 @@ def test_json_memory_init_with_backing_empty_file(config: Config, workspace: Wor
 
 def test_json_memory_init_with_backing_invalid_file(
     config: Config, workspace: Workspace
-):
+)-> None:
     index_file = workspace.root / f"{config.memory_index}.json"
     index_file.touch()
 
@@ -50,13 +50,13 @@ def test_json_memory_init_with_backing_invalid_file(
     assert index_file.read_text() == "[]"
 
 
-def test_json_memory_add(config: Config, memory_item: MemoryItem):
+def test_json_memory_add(config: Config, memory_item: MemoryItem) ->None:
     index = JSONFileMemory(config)
     index.add(memory_item)
     assert index.memories[0] == memory_item
 
 
-def test_json_memory_clear(config: Config, memory_item: MemoryItem):
+def test_json_memory_clear(config: Config, memory_item: MemoryItem) -> None:
     index = JSONFileMemory(config)
     assert index.memories == []
 
@@ -67,7 +67,7 @@ def test_json_memory_clear(config: Config, memory_item: MemoryItem):
     assert index.memories == []
 
 
-def test_json_memory_get(config: Config, memory_item: MemoryItem, mock_get_embedding):
+def test_json_memory_get(config: Config, memory_item: MemoryItem, mock_get_embedding) -> None:
     index = JSONFileMemory(config)
     assert (
         index.get("test", config) == None
@@ -79,7 +79,7 @@ def test_json_memory_get(config: Config, memory_item: MemoryItem, mock_get_embed
     assert retrieved.memory_item == memory_item
 
 
-def test_json_memory_load_index(config: Config, memory_item: MemoryItem):
+def test_json_memory_load_index(config: Config, memory_item: MemoryItem) ->None:
     index = JSONFileMemory(config)
     index.add(memory_item)
 

--- a/tests/integration/memory/test_json_file_memory.py
+++ b/tests/integration/memory/test_json_file_memory.py
@@ -6,6 +6,8 @@ import pytest
 from autogpt.config import Config
 from autogpt.memory.vector import JSONFileMemory, MemoryItem
 from autogpt.workspace import Workspace
+from typing import Callable
+from pytest_mock import MockerFixture
 
 
 @pytest.fixture(autouse=True)
@@ -67,7 +69,7 @@ def test_json_memory_clear(config: Config, memory_item: MemoryItem) -> None:
     assert index.memories == []
 
 
-def test_json_memory_get(config: Config, memory_item: MemoryItem, mock_get_embedding) -> None:
+def test_json_memory_get(config: Config, memory_item: MemoryItem, mock_get_embedding:Callable[[MockerFixture, int], None]) -> None:
     index = JSONFileMemory(config)
     assert (
         index.get("test", config) == None

--- a/tests/integration/memory/test_json_file_memory.py
+++ b/tests/integration/memory/test_json_file_memory.py
@@ -12,11 +12,13 @@ from autogpt.workspace import Workspace
 
 
 @pytest.fixture(autouse=True)
+# Added None return type notation
 def cleanup_sut_singleton() -> None:
     if JSONFileMemory in JSONFileMemory._instances:
         del JSONFileMemory._instances[JSONFileMemory]
 
 
+# Added None return type notation
 def test_json_memory_init_without_backing_file(
     config: Config, workspace: Workspace
 ) -> None:
@@ -28,6 +30,7 @@ def test_json_memory_init_without_backing_file(
     assert index_file.read_text() == "[]"
 
 
+#  Added None return type notation
 def test_json_memory_init_with_backing_empty_file(
     config: Config, workspace: Workspace
 ) -> None:
@@ -40,6 +43,7 @@ def test_json_memory_init_with_backing_empty_file(
     assert index_file.read_text() == "[]"
 
 
+# Added None return typenotation
 def test_json_memory_init_with_backing_invalid_file(
     config: Config, workspace: Workspace
 ) -> None:
@@ -57,12 +61,14 @@ def test_json_memory_init_with_backing_invalid_file(
     assert index_file.read_text() == "[]"
 
 
+# Added None return type notation
 def test_json_memory_add(config: Config, memory_item: MemoryItem) -> None:
     index = JSONFileMemory(config)
     index.add(memory_item)
     assert index.memories[0] == memory_item
 
 
+# Added None return type notation
 def test_json_memory_clear(config: Config, memory_item: MemoryItem) -> None:
     index = JSONFileMemory(config)
     assert index.memories == []
@@ -74,6 +80,8 @@ def test_json_memory_clear(config: Config, memory_item: MemoryItem) -> None:
     assert index.memories == []
 
 
+## Added None return type Notation
+## Added Type notation to mock_get_embedding argument
 def test_json_memory_get(
     config: Config,
     memory_item: MemoryItem,
@@ -90,6 +98,7 @@ def test_json_memory_get(
     assert retrieved.memory_item == memory_item
 
 
+## Added return type notation
 def test_json_memory_load_index(config: Config, memory_item: MemoryItem) -> None:
     index = JSONFileMemory(config)
     index.add(memory_item)

--- a/tests/integration/memory/utils.py
+++ b/tests/integration/memory/utils.py
@@ -9,7 +9,6 @@ from pytest_mock import MockerFixture
         mypy
         tests/integration/memory/utils.py:5: error: Skipping analyzing ".autogpt.memory.vector.providers.base": module is installed, but missing library stubs or py.typed marker  [import]
         tests/integration/memory/utils.py:5: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
-    
     This import file is necessary for giving the type hint for memory_none function
 """
 import autogpt.memory.vector.memory_item as vector_memory_item
@@ -19,7 +18,7 @@ from autogpt.llm.providers.openai import OPEN_AI_EMBEDDING_MODELS
 from autogpt.memory.vector import get_memory
 from autogpt.memory.vector.utils import Embedding
 
-from ......autogpt.memory.vector.providers.base import (
+from autogpt.memory.vector.providers.base import (
     VectorMemoryProvider as VectorMemory,  # type: ignore
 )
 

--- a/tests/integration/memory/utils.py
+++ b/tests/integration/memory/utils.py
@@ -1,7 +1,9 @@
+from typing import Generator
+
 import numpy
 import pytest
 from pytest_mock import MockerFixture
-from typing import Generator
+
 """
     Added #type: ignore because without it, mypy command gave following error:
         mypy
@@ -10,8 +12,6 @@ from typing import Generator
     
     This import file is necessary for giving the type hint for memory_none function
 """
-from ......autogpt.memory.vector.providers.base import VectorMemoryProvider as VectorMemory # type: ignore 
-
 import autogpt.memory.vector.memory_item as vector_memory_item
 import autogpt.memory.vector.providers.base as memory_provider_base
 from autogpt.config.config import Config
@@ -19,9 +19,15 @@ from autogpt.llm.providers.openai import OPEN_AI_EMBEDDING_MODELS
 from autogpt.memory.vector import get_memory
 from autogpt.memory.vector.utils import Embedding
 
+from ......autogpt.memory.vector.providers.base import (
+    VectorMemoryProvider as VectorMemory,  # type: ignore
+)
+
 
 @pytest.fixture
-def embedding_dimension(config: Config)-> int:      ## Because embedding_dimensions has int type
+def embedding_dimension(
+    config: Config,
+) -> int:  ## Because embedding_dimensions has int type
     return OPEN_AI_EMBEDDING_MODELS[config.embedding_model].embedding_dimensions
 
 
@@ -45,7 +51,9 @@ def mock_get_embedding(mocker: MockerFixture, embedding_dimension: int) -> None:
 
 
 @pytest.fixture
-def memory_none(agent_test_config: Config, mock_get_embedding : None) -> Generator[VectorMemory, None, None]:
+def memory_none(
+    agent_test_config: Config, mock_get_embedding: None
+) -> Generator[VectorMemory, None, None]:
     was_memory_backend = agent_test_config.memory_backend
 
     agent_test_config.memory_backend = "no_memory"

--- a/tests/integration/memory/utils.py
+++ b/tests/integration/memory/utils.py
@@ -1,14 +1,17 @@
-from typing import Generator
+from typing import Any, Callable, Generator
 
 import numpy
 import pytest
 from pytest_mock import MockerFixture
+
+from autogpt.workspace import Workspace
 
 """
     Added #type: ignore because without it, mypy command gave following error:
         mypy
         tests/integration/memory/utils.py:5: error: Skipping analyzing ".autogpt.memory.vector.providers.base": module is installed, but missing library stubs or py.typed marker  [import]
         tests/integration/memory/utils.py:5: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
+    
     This import file is necessary for giving the type hint for memory_none function
 """
 import autogpt.memory.vector.memory_item as vector_memory_item
@@ -19,18 +22,17 @@ from autogpt.memory.vector import get_memory
 from autogpt.memory.vector.providers.base import (
     VectorMemoryProvider as VectorMemory,  # type: ignore
 )
-from autogpt.memory.vector.utils import Embedding
 
 
 @pytest.fixture
 def embedding_dimension(
-    config: Config,
+    config: Callable[[str, MockerFixture, Workspace], Config],
 ) -> int:  ## Because embedding_dimensions has int type
     return OPEN_AI_EMBEDDING_MODELS[config.embedding_model].embedding_dimensions
 
 
 @pytest.fixture
-def mock_embedding(embedding_dimension: int) -> Embedding:
+def mock_embedding(embedding_dimension: int) -> Any:
     return numpy.full((1, embedding_dimension), 0.0255, numpy.float32)[0]
 
 
@@ -51,7 +53,7 @@ def mock_get_embedding(mocker: MockerFixture, embedding_dimension: int) -> None:
 @pytest.fixture
 def memory_none(
     agent_test_config: Config, mock_get_embedding: None
-) -> Generator[VectorMemory, None, None]:
+) -> Generator[VectorMemory, Any, None]:
     was_memory_backend = agent_test_config.memory_backend
 
     agent_test_config.memory_backend = "no_memory"

--- a/tests/integration/memory/utils.py
+++ b/tests/integration/memory/utils.py
@@ -4,6 +4,11 @@ import numpy
 import pytest
 from pytest_mock import MockerFixture
 
+import autogpt.memory.vector.memory_item as vector_memory_item
+import autogpt.memory.vector.providers.base as memory_provider_base
+from autogpt.config.config import Config
+from autogpt.llm.providers.openai import OPEN_AI_EMBEDDING_MODELS
+from autogpt.memory.vector import get_memory
 from autogpt.workspace import Workspace
 
 """
@@ -12,11 +17,6 @@ from autogpt.workspace import Workspace
         tests/integration/memory/utils.py:5: error: Skipping analyzing ".autogpt.memory.vector.providers.base": module is installed, but missing library stubs or py.typed marker  [import]
         tests/integration/memory/utils.py:5: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
 """
-import autogpt.memory.vector.memory_item as vector_memory_item
-import autogpt.memory.vector.providers.base as memory_provider_base
-from autogpt.config.config import Config
-from autogpt.llm.providers.openai import OPEN_AI_EMBEDDING_MODELS
-from autogpt.memory.vector import get_memory
 from autogpt.memory.vector.providers.base import (
     VectorMemoryProvider as VectorMemory,  # type: ignore
 )
@@ -24,7 +24,7 @@ from autogpt.memory.vector.providers.base import (
 
 @pytest.fixture
 def embedding_dimension(
-    config: Callable[[str, MockerFixture, Workspace], Config],
+    config: Config,
 ) -> int:  ## Because embedding_dimensions has int type
     return OPEN_AI_EMBEDDING_MODELS[config.embedding_model].embedding_dimensions
 

--- a/tests/integration/memory/utils.py
+++ b/tests/integration/memory/utils.py
@@ -16,11 +16,10 @@ import autogpt.memory.vector.providers.base as memory_provider_base
 from autogpt.config.config import Config
 from autogpt.llm.providers.openai import OPEN_AI_EMBEDDING_MODELS
 from autogpt.memory.vector import get_memory
-from autogpt.memory.vector.utils import Embedding
-
 from autogpt.memory.vector.providers.base import (
     VectorMemoryProvider as VectorMemory,  # type: ignore
 )
+from autogpt.memory.vector.utils import Embedding
 
 
 @pytest.fixture

--- a/tests/integration/memory/utils.py
+++ b/tests/integration/memory/utils.py
@@ -10,7 +10,7 @@ from typing import Generator
     
     This import file is necessary for giving the type hint for memory_none function
 """
-from ....autogpt.memory.vector.providers.base import VectorMemoryProvider as VectorMemory # type: ignore 
+from ......autogpt.memory.vector.providers.base import VectorMemoryProvider as VectorMemory # type: ignore 
 
 import autogpt.memory.vector.memory_item as vector_memory_item
 import autogpt.memory.vector.providers.base as memory_provider_base

--- a/tests/integration/memory/utils.py
+++ b/tests/integration/memory/utils.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Generator
+from typing import Any, Generator
 
 import numpy
 import pytest
@@ -9,7 +9,6 @@ import autogpt.memory.vector.providers.base as memory_provider_base
 from autogpt.config.config import Config
 from autogpt.llm.providers.openai import OPEN_AI_EMBEDDING_MODELS
 from autogpt.memory.vector import get_memory
-from autogpt.workspace import Workspace
 
 """
     Added #type: ignore because without it, mypy command gave following error:

--- a/tests/integration/memory/utils.py
+++ b/tests/integration/memory/utils.py
@@ -1,6 +1,16 @@
 import numpy
 import pytest
 from pytest_mock import MockerFixture
+from typing import Generator
+"""
+    Added #type: ignore because without it, mypy command gave following error:
+        mypy
+        tests/integration/memory/utils.py:5: error: Skipping analyzing ".autogpt.memory.vector.providers.base": module is installed, but missing library stubs or py.typed marker  [import]
+        tests/integration/memory/utils.py:5: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
+    
+    This import file is necessary for giving the type hint for memory_none function
+"""
+from ....autogpt.memory.vector.providers.base import VectorMemoryProvider as VectorMemory # type: ignore 
 
 import autogpt.memory.vector.memory_item as vector_memory_item
 import autogpt.memory.vector.providers.base as memory_provider_base
@@ -11,7 +21,7 @@ from autogpt.memory.vector.utils import Embedding
 
 
 @pytest.fixture
-def embedding_dimension(config: Config):
+def embedding_dimension(config: Config)-> int:      ## Because embedding_dimensions has int type
     return OPEN_AI_EMBEDDING_MODELS[config.embedding_model].embedding_dimensions
 
 
@@ -21,7 +31,7 @@ def mock_embedding(embedding_dimension: int) -> Embedding:
 
 
 @pytest.fixture
-def mock_get_embedding(mocker: MockerFixture, embedding_dimension: int):
+def mock_get_embedding(mocker: MockerFixture, embedding_dimension: int) -> None:
     mocker.patch.object(
         vector_memory_item,
         "get_embedding",
@@ -35,7 +45,7 @@ def mock_get_embedding(mocker: MockerFixture, embedding_dimension: int):
 
 
 @pytest.fixture
-def memory_none(agent_test_config: Config, mock_get_embedding):
+def memory_none(agent_test_config: Config, mock_get_embedding : None) -> Generator[VectorMemory, None, None]:
     was_memory_backend = agent_test_config.memory_backend
 
     agent_test_config.set_memory_backend("no_memory")

--- a/tests/integration/memory/utils.py
+++ b/tests/integration/memory/utils.py
@@ -11,8 +11,6 @@ from autogpt.workspace import Workspace
         mypy
         tests/integration/memory/utils.py:5: error: Skipping analyzing ".autogpt.memory.vector.providers.base": module is installed, but missing library stubs or py.typed marker  [import]
         tests/integration/memory/utils.py:5: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
-    
-    This import file is necessary for giving the type hint for memory_none function
 """
 import autogpt.memory.vector.memory_item as vector_memory_item
 import autogpt.memory.vector.providers.base as memory_provider_base

--- a/tests/integration/test_execute_code.py
+++ b/tests/integration/test_execute_code.py
@@ -2,9 +2,9 @@ import os
 import random
 import string
 import tempfile
+from typing import Generator
 
 import pytest
-from typing import Generator
 
 import autogpt.commands.execute_code as sut  # system under testing
 from autogpt.agent.agent import Agent
@@ -12,12 +12,12 @@ from autogpt.config import Config
 
 
 @pytest.fixture
-def random_code(random_string:str) -> str:
+def random_code(random_string: str) -> str:
     return f"print('Hello {random_string}!')"
 
 
 @pytest.fixture
-def python_test_file(config: Config, random_code: str) -> Generator[str,None,None]:
+def python_test_file(config: Config, random_code: str) -> Generator[str, None, None]:
     temp_file = tempfile.NamedTemporaryFile(dir=config.workspace_path, suffix=".py")
     temp_file.write(str.encode(random_code))
     temp_file.flush()
@@ -27,16 +27,20 @@ def python_test_file(config: Config, random_code: str) -> Generator[str,None,Non
 
 
 @pytest.fixture
-def random_string()->str:
+def random_string() -> str:
     return "".join(random.choice(string.ascii_lowercase) for _ in range(10))
 
 
-def test_execute_python_file(python_test_file: str, random_string: str, agent: Agent) -> None:
+def test_execute_python_file(
+    python_test_file: str, random_string: str, agent: Agent
+) -> None:
     result: str = sut.execute_python_file(python_test_file, agent=agent)
     assert result.replace("\r", "") == f"Hello {random_string}!\n"
 
 
-def test_execute_python_code(random_code: str, random_string: str, agent: Agent)-> None:
+def test_execute_python_code(
+    random_code: str, random_string: str, agent: Agent
+) -> None:
     ai_name = agent.ai_name
 
     result: str = sut.execute_python_code(random_code, "test_code", agent=agent)
@@ -52,7 +56,7 @@ def test_execute_python_code(random_code: str, random_string: str, agent: Agent)
 
 def test_execute_python_code_disallows_name_arg_path_traversal(
     random_code: str, agent: Agent
-)->None:
+) -> None:
     result: str = sut.execute_python_code(
         random_code, name="../../test_code", agent=agent
     )
@@ -64,7 +68,7 @@ def test_execute_python_code_disallows_name_arg_path_traversal(
     assert not dst_with_traversal.is_file(), "Path traversal by filename not prevented"
 
 
-def test_execute_python_code_overwrites_file(random_code: str, agent: Agent)-> None:
+def test_execute_python_code_overwrites_file(random_code: str, agent: Agent) -> None:
     ai_name = agent.ai_name
     destination = os.path.join(
         agent.config.workspace_path, ai_name, "executed_code", "test_code.py"
@@ -103,7 +107,9 @@ def test_execute_shell(random_string: str, agent: Agent) -> None:
     assert f"Hello {random_string}!" in result
 
 
-def test_execute_shell_local_commands_not_allowed(random_string: str, agent: Agent) -> None:
+def test_execute_shell_local_commands_not_allowed(
+    random_string: str, agent: Agent
+) -> None:
     result = sut.execute_shell(f"echo 'Hello {random_string}!'", agent)
     assert f"Hello {random_string}!" in result
 

--- a/tests/integration/test_provider_openai.py
+++ b/tests/integration/test_provider_openai.py
@@ -1,22 +1,22 @@
 from unittest.mock import MagicMock, patch
-
+from pytest import LogCaptureFixture
 import pytest
-
+from typing import List
 from autogpt.llm.api_manager import ApiManager
 from autogpt.llm.providers import openai
-
+from typing import Generator
 api_manager = ApiManager()
 
 
 @pytest.fixture(autouse=True)
-def reset_api_manager():
+def reset_api_manager() -> Generator[None,None,None]:
     api_manager.reset()
     yield
 
 
 class TestProviderOpenAI:
     @staticmethod
-    def test_create_chat_completion_debug_mode(caplog):
+    def test_create_chat_completion_debug_mode(caplog :LogCaptureFixture) -> None:
         """Test if debug mode logs response."""
         messages = [
             {"role": "system", "content": "You are a helpful assistant."},
@@ -35,9 +35,9 @@ class TestProviderOpenAI:
             assert "Response" in caplog.text
 
     @staticmethod
-    def test_create_chat_completion_empty_messages():
+    def test_create_chat_completion_empty_messages() -> None:
         """Test if empty messages result in zero tokens and cost."""
-        messages = []
+        messages: List[str]= []
         model = "gpt-3.5-turbo"
 
         with patch("openai.ChatCompletion.create") as mock_create:

--- a/tests/integration/test_provider_openai.py
+++ b/tests/integration/test_provider_openai.py
@@ -1,22 +1,24 @@
+from typing import Generator, List
 from unittest.mock import MagicMock, patch
-from pytest import LogCaptureFixture
+
 import pytest
-from typing import List
+from pytest import LogCaptureFixture
+
 from autogpt.llm.api_manager import ApiManager
 from autogpt.llm.providers import openai
-from typing import Generator
+
 api_manager = ApiManager()
 
 
 @pytest.fixture(autouse=True)
-def reset_api_manager() -> Generator[None,None,None]:
+def reset_api_manager() -> Generator[None, None, None]:
     api_manager.reset()
     yield
 
 
 class TestProviderOpenAI:
     @staticmethod
-    def test_create_chat_completion_debug_mode(caplog :LogCaptureFixture) -> None:
+    def test_create_chat_completion_debug_mode(caplog: LogCaptureFixture) -> None:
         """Test if debug mode logs response."""
         messages = [
             {"role": "system", "content": "You are a helpful assistant."},
@@ -37,7 +39,7 @@ class TestProviderOpenAI:
     @staticmethod
     def test_create_chat_completion_empty_messages() -> None:
         """Test if empty messages result in zero tokens and cost."""
-        messages: List[str]= []
+        messages: List[str] = []
         model = "gpt-3.5-turbo"
 
         with patch("openai.ChatCompletion.create") as mock_create:

--- a/tests/integration/test_setup.py
+++ b/tests/integration/test_setup.py
@@ -1,14 +1,16 @@
 from unittest.mock import patch
-
+from autogpt.config.config import Config
 import pytest
-
+from typing import Callable
+from autogpt.workspace import Workspace
 from autogpt.config.ai_config import AIConfig
 from autogpt.setup import generate_aiconfig_automatic, prompt_user
+from pytest_mock import MockerFixture
 
 
 @pytest.mark.vcr
 @pytest.mark.requires_openai_api_key
-def test_generate_aiconfig_automatic_default(patched_api_requestor, config):
+def test_generate_aiconfig_automatic_default(patched_api_requestor: Callable[[MockerFixture],None], config:Callable[[str,MockerFixture,Workspace],Config])-> None:
     user_inputs = [""]
     with patch("autogpt.utils.session.prompt", side_effect=user_inputs):
         ai_config = prompt_user(config)
@@ -21,7 +23,7 @@ def test_generate_aiconfig_automatic_default(patched_api_requestor, config):
 
 @pytest.mark.vcr
 @pytest.mark.requires_openai_api_key
-def test_generate_aiconfig_automatic_typical(patched_api_requestor, config):
+def test_generate_aiconfig_automatic_typical(patched_api_requestor:Callable[[MockerFixture],None], config:Callable[[str,MockerFixture,Workspace],Config]) -> None:
     user_prompt = "Help me create a rock opera about cybernetic giraffes"
     ai_config = generate_aiconfig_automatic(user_prompt, config)
 
@@ -33,7 +35,7 @@ def test_generate_aiconfig_automatic_typical(patched_api_requestor, config):
 
 @pytest.mark.vcr
 @pytest.mark.requires_openai_api_key
-def test_generate_aiconfig_automatic_fallback(patched_api_requestor, config):
+def test_generate_aiconfig_automatic_fallback(patched_api_requestor:Callable[[MockerFixture],None], config:Callable[[str,MockerFixture,Workspace],Config]) -> None:
     user_inputs = [
         "T&GF£OIBECC()!*",
         "Chef-GPT",
@@ -54,7 +56,7 @@ def test_generate_aiconfig_automatic_fallback(patched_api_requestor, config):
 
 @pytest.mark.vcr
 @pytest.mark.requires_openai_api_key
-def test_prompt_user_manual_mode(patched_api_requestor, config):
+def test_prompt_user_manual_mode(ppatched_api_requestor:Callable[[MockerFixture],None], config:Callable[[str,MockerFixture,Workspace],Config]) -> None:
     user_inputs = [
         "--manual",
         "Chef-GPT",

--- a/tests/integration/test_setup.py
+++ b/tests/integration/test_setup.py
@@ -1,16 +1,21 @@
-from unittest.mock import patch
-from autogpt.config.config import Config
-import pytest
 from typing import Callable
-from autogpt.workspace import Workspace
-from autogpt.config.ai_config import AIConfig
-from autogpt.setup import generate_aiconfig_automatic, prompt_user
+from unittest.mock import patch
+
+import pytest
 from pytest_mock import MockerFixture
+
+from autogpt.config.ai_config import AIConfig
+from autogpt.config.config import Config
+from autogpt.setup import generate_aiconfig_automatic, prompt_user
+from autogpt.workspace import Workspace
 
 
 @pytest.mark.vcr
 @pytest.mark.requires_openai_api_key
-def test_generate_aiconfig_automatic_default(patched_api_requestor: Callable[[MockerFixture],None], config:Callable[[str,MockerFixture,Workspace],Config])-> None:
+def test_generate_aiconfig_automatic_default(
+    patched_api_requestor: Callable[[MockerFixture], None],
+    config: Callable[[str, MockerFixture, Workspace], Config],
+) -> None:
     user_inputs = [""]
     with patch("autogpt.utils.session.prompt", side_effect=user_inputs):
         ai_config = prompt_user(config)
@@ -23,7 +28,10 @@ def test_generate_aiconfig_automatic_default(patched_api_requestor: Callable[[Mo
 
 @pytest.mark.vcr
 @pytest.mark.requires_openai_api_key
-def test_generate_aiconfig_automatic_typical(patched_api_requestor:Callable[[MockerFixture],None], config:Callable[[str,MockerFixture,Workspace],Config]) -> None:
+def test_generate_aiconfig_automatic_typical(
+    patched_api_requestor: Callable[[MockerFixture], None],
+    config: Callable[[str, MockerFixture, Workspace], Config],
+) -> None:
     user_prompt = "Help me create a rock opera about cybernetic giraffes"
     ai_config = generate_aiconfig_automatic(user_prompt, config)
 
@@ -35,7 +43,10 @@ def test_generate_aiconfig_automatic_typical(patched_api_requestor:Callable[[Moc
 
 @pytest.mark.vcr
 @pytest.mark.requires_openai_api_key
-def test_generate_aiconfig_automatic_fallback(patched_api_requestor:Callable[[MockerFixture],None], config:Callable[[str,MockerFixture,Workspace],Config]) -> None:
+def test_generate_aiconfig_automatic_fallback(
+    patched_api_requestor: Callable[[MockerFixture], None],
+    config: Callable[[str, MockerFixture, Workspace], Config],
+) -> None:
     user_inputs = [
         "T&GF£OIBECC()!*",
         "Chef-GPT",
@@ -56,7 +67,10 @@ def test_generate_aiconfig_automatic_fallback(patched_api_requestor:Callable[[Mo
 
 @pytest.mark.vcr
 @pytest.mark.requires_openai_api_key
-def test_prompt_user_manual_mode(ppatched_api_requestor:Callable[[MockerFixture],None], config:Callable[[str,MockerFixture,Workspace],Config]) -> None:
+def test_prompt_user_manual_mode(
+    ppatched_api_requestor: Callable[[MockerFixture], None],
+    config: Callable[[str, MockerFixture, Workspace], Config],
+) -> None:
     user_inputs = [
         "--manual",
         "Chef-GPT",

--- a/tests/integration/test_web_selenium.py
+++ b/tests/integration/test_web_selenium.py
@@ -7,7 +7,7 @@ from autogpt.commands.web_selenium import browse_website
 
 @pytest.mark.vcr
 @pytest.mark.requires_openai_api_key
-def test_browse_website(agent: Agent, patched_api_requestor: MockerFixture)  -> None:
+def test_browse_website(agent: Agent, patched_api_requestor: MockerFixture) -> None:
     url = "https://barrel-roll.com"
     question = "How to execute a barrel roll"
 

--- a/tests/integration/test_web_selenium.py
+++ b/tests/integration/test_web_selenium.py
@@ -7,7 +7,7 @@ from autogpt.commands.web_selenium import browse_website
 
 @pytest.mark.vcr
 @pytest.mark.requires_openai_api_key
-def test_browse_website(agent: Agent, patched_api_requestor: MockerFixture):
+def test_browse_website(agent: Agent, patched_api_requestor: MockerFixture)  -> None:
     url = "https://barrel-roll.com"
     question = "How to execute a barrel roll"
 


### PR DESCRIPTION


### Background
Issue Link : https://github.com/Significant-Gravitas/Auto-GPT/issues/4788

### Changes
- Changed mypy.ini
- added static type hints to following source files:
    tests/integration/memory/conftest.py
    tests/integration/memory/test_json_file_memory.py
### Documentation
I have documented the affected source files, informing about which type hints i have added

### Test Plan
I executed following commands: 
mypy
black .
isort .
autoflake --remove-all-unused-imports --recursive --ignore-init-module-imports --ignore-pass-after-docstring autogpt tests --in-place

### PR Quality Checklist
- [:heavy_check_mark: ] My pull request is atomic and focuses on a single change.
- [ :heavy_check_mark: ] I have thoroughly tested my changes with multiple different prompts.
- [ :heavy_check_mark: ] I have considered potential risks and mitigations for my changes.
- [ :heavy_check_mark: ] I have documented my changes clearly and comprehensively.
- [ :heavy_check_mark: ] I have not snuck in any "extra" small tweaks changes. <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->
- [:heavy_check_mark:  ] I have run the following commands against my code to ensure it passes our linters:
    ```shell
    black .
    isort .
    mypy
    autoflake --remove-all-unused-imports --recursive --ignore-init-module-imports --ignore-pass-after-docstring autogpt tests --in-place
    ```
