### PR TITLE
Unregister commands incompatible with current config.

### DIFF
--- a/autogpt/main.py
+++ b/autogpt/main.py
@@ -138,6 +138,13 @@ def run_auto_gpt(
     for command_category in enabled_command_categories:
         command_registry.import_commands(command_category)
 
+    # Unregister commands that will not run due to config settings
+    for command in command_registry.commands:
+        if callable(command.enabled) and not command.enabled(config):
+            command.enabled = False
+            command_registry.unregister_command(command.name)
+            logger.info(f"Unregistering disabled command '{command.name}': {command.disabled_reason or 'Disabled by config settings.'}")
+            
     ai_name = ""
     ai_config = construct_main_ai_config(config)
     ai_config.command_registry = command_registry

--- a/autogpt/main.py
+++ b/autogpt/main.py
@@ -140,14 +140,18 @@ def run_auto_gpt(
         command_registry.import_commands(command_category)
 
     # Unregister commands that are incompatible with the current config
-    for command in command_registry.commands:
+    incompatible_commands = []
+    for command in command_registry.commands.values():
         if callable(command.enabled) and not command.enabled(config):
             command.enabled = False
-            command_registry.unregister_command(command.name)
-            logger.info(
-                f"Unregistering disabled command: {command.name}, "
-                f"reason - {command.disabled_reason or 'Incompatible with current config.'}"
-            )
+            incompatible_commands.append(command)
+    
+    for command in incompatible_commands:
+        command_registry.unregister(command.name)
+        logger.debug(
+            f"Unregistering incompatible command: {command.name}, "
+            f"reason - {command.disabled_reason or 'Disabled by current config.'}"
+        )
 
     ai_name = ""
     ai_config = construct_main_ai_config(config)

--- a/autogpt/main.py
+++ b/autogpt/main.py
@@ -145,9 +145,8 @@ def run_auto_gpt(
             command.enabled = False
             command_registry.unregister_command(command.name)
             logger.info(
-                f"Unregistering disabled command: "
-                f"'{command.name}' - "
-                f"{command.disabled_reason or 'Incompatible with current config.'}"
+                f"Unregistering disabled command: {command.name}, "
+                f"reason - {command.disabled_reason or 'Incompatible with current config.'}"
             )
 
     ai_name = ""

--- a/autogpt/main.py
+++ b/autogpt/main.py
@@ -139,13 +139,17 @@ def run_auto_gpt(
     for command_category in enabled_command_categories:
         command_registry.import_commands(command_category)
 
-    # Unregister commands that will not run due to config settings
+    # Unregister commands that are incompatible with the current config
     for command in command_registry.commands:
         if callable(command.enabled) and not command.enabled(config):
             command.enabled = False
             command_registry.unregister_command(command.name)
-            logger.info(f"Unregistering disabled command '{command.name}': {command.disabled_reason or 'Disabled by config settings.'}")
-            
+            logger.info(
+                f"Unregistering disabled command: "
+                f"'{command.name}' - "
+                f"{command.disabled_reason or 'Incompatible with current config.'}"
+            )
+
     ai_name = ""
     ai_config = construct_main_ai_config(config)
     ai_config.command_registry = command_registry

--- a/autogpt/main.py
+++ b/autogpt/main.py
@@ -145,7 +145,7 @@ def run_auto_gpt(
         if callable(command.enabled) and not command.enabled(config):
             command.enabled = False
             incompatible_commands.append(command)
-    
+
     for command in incompatible_commands:
         command_registry.unregister(command.name)
         logger.debug(


### PR DESCRIPTION
This commit changes the `run_auto_gpt` function in `main.py`
to unregister commands which are ultimately incompatible
with the config and would be disabled when the config was injected.

This way, the LLM and only ever sees commands that can run.
