### PR TITLE
Update .env.template

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -25,9 +25,9 @@ OPENAI_API_KEY=your-openai-api-key
 ## PROMPT_SETTINGS_FILE - Specifies which Prompt Settings file to use (defaults to prompt_settings.yaml)
 # PROMPT_SETTINGS_FILE=prompt_settings.yaml
 
-## OPENAI_API_BASE_URL - Custom url for the OpenAI API, useful for connecting to custom backends. No effect if USE_AZURE is true, leave blank to keep the default url
+## OPENAI_API_BASE - Custom url for the OpenAI API, useful for connecting to custom backends. No effect if USE_AZURE is true, leave blank to keep the default url
 # the following is an example:
-# OPENAI_API_BASE_URL=http://localhost:443/v1
+# OPENAI_API_BASE=http://localhost:443/v1
 
 ## OPENAI_FUNCTIONS - Enables OpenAI functions: https://platform.openai.com/docs/guides/gpt/function-calling
 ## WARNING: this feature is only supported by OpenAI's newest models. Until these models become the default on 27 June, add a '-0613' suffix to the model of your choosing.

--- a/autogpt/config/config.py
+++ b/autogpt/config/config.py
@@ -243,8 +243,8 @@ class Config(Configurable):
             config_dict["openai_api_base"] = azure_config["openai_api_base"]
             config_dict["openai_api_version"] = azure_config["openai_api_version"]
 
-        if os.getenv("OPENAI_API_BASE_URL"):
-            config_dict["openai_api_base"] = os.getenv("OPENAI_API_BASE_URL")
+        if os.getenv("OPENAI_API_BASE"):
+            config_dict["openai_api_base"] = os.getenv("OPENAI_API_BASE")
 
         openai_organization = os.getenv("OPENAI_ORGANIZATION")
         if openai_organization is not None:


### PR DESCRIPTION
Fixing the .env.template with a typo.
Per https://github.com/openai/openai-python/blob/041bf5a8ec54da19aad0169671793c2078bd6173/openai/__init__.py#L49 the actual api_base environment override does not contain "_URL" at the end. This is probably an old typo.

<!-- ⚠️ At the moment any non-essential commands are not being merged.
If you want to add non-essential commands to Auto-GPT, please create a plugin instead.
We are expecting to ship plugin support within the week (PR #757).
Resources:
* https://github.com/Significant-Gravitas/Auto-GPT-Plugin-Template
-->

<!-- 📢 Announcement
We've recently noticed an increase in pull requests focusing on combining multiple changes. While the intentions behind these PRs are appreciated, it's essential to maintain a clean and manageable git history. To ensure the quality of our repository, we kindly ask you to adhere to the following guidelines when submitting PRs:

Focus on a single, specific change.
Do not include any unrelated or "extra" modifications.
Provide clear documentation and explanations of the changes made.
Ensure diffs are limited to the intended lines — no applying preferred formatting styles or line endings (unless that's what the PR is about).
For guidance on committing only the specific lines you have changed, refer to this helpful video: https://youtu.be/8-hSNHHbiZg

Check out our [wiki page on Contributing](https://github.com/Significant-Gravitas/Nexus/wiki/Contributing)

By following these guidelines, your PRs are more likely to be merged quickly after testing, as long as they align with the project's overall direction. -->

### Background
<!-- Provide a concise overview of the rationale behind this change. Include relevant context, prior discussions, or links to related issues. Ensure that the change aligns with the project's overall direction. -->
The `.env.template` example has a typo in it and will not work correctly when trying to override the base URL of the OpenAI API.

### Changes
<!-- Describe the specific, focused change made in this pull request. Detail the modifications clearly and avoid any unrelated or "extra" changes. -->

I made one change to `.env.template` to replace an environment variable name.

### Documentation
<!-- Explain how your changes are documented, such as in-code comments or external documentation. Ensure that the documentation is clear, concise, and easy to understand. -->

Included within `.env.template`

### Test Plan
<!-- Describe how you tested this functionality. Include steps to reproduce, relevant test cases, and any other pertinent information. -->

I tested this using https://github.com/keldenl/gpt-llama.cpp and after my change to my own local `.env` everything worked correctly.

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes. <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->
- [x] I have run the following commands against my code to ensure it passes our linters:
    ```shell
    black .
    isort .
    mypy
    autoflake --remove-all-unused-imports --recursive --ignore-init-module-imports --ignore-pass-after-docstring autogpt tests --in-place
    ```

<!-- If you haven't added tests, please explain why. If you have, check the appropriate box. If you've ensured your PR is atomic and well-documented, check the corresponding boxes. -->

I have not added any tests as this is not strictly code, but a sample environment variable override. The issue is not even in this library as the actual environment var check is in OpenAI's library. But it seemed like the right thing to do so others don't learn the same lesson.

<!-- By submitting this, I agree that my pull request should be closed if I do not fill this out or follow the guidelines. -->

I agree!