### PR TITLE
Hotfix - call model_post_init explicitly until pydantic 2.0

### DIFF
--- a/autogpt/config/config.py
+++ b/autogpt/config/config.py
@@ -83,6 +83,13 @@ class Config(SystemSettings):
     plugins: list[str]
     authorise_key: str
 
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        # Hotfix: Call model_post_init explictly as it doesn't seem to be called for pydantic<2.0.0
+        # https://github.com/pydantic/pydantic/issues/1729#issuecomment-1300576214
+        self.model_post_init(**kwargs)
+
     # Executed immediately after init by Pydantic
     def model_post_init(self, **kwargs) -> None:
         if not self.plugins_config.plugins:

--- a/autogpt/main.py
+++ b/autogpt/main.py
@@ -54,6 +54,10 @@ def run_auto_gpt(
     logger.speak_mode = speak
 
     config = ConfigBuilder.build_config_from_env()
+    
+    # Hotfix: Call model_post_init explictly as it doesn't seem to be called for pydantic<2.0.0
+    # https://github.com/pydantic/pydantic/issues/1729#issuecomment-1300576214
+    config.model_post_init()
 
     # TODO: fill in llm values here
     check_openai_api_key(config)

--- a/autogpt/main.py
+++ b/autogpt/main.py
@@ -54,7 +54,7 @@ def run_auto_gpt(
     logger.speak_mode = speak
 
     config = ConfigBuilder.build_config_from_env()
-    
+
     # Hotfix: Call model_post_init explictly as it doesn't seem to be called for pydantic<2.0.0
     # https://github.com/pydantic/pydantic/issues/1729#issuecomment-1300576214
     config.model_post_init()

--- a/autogpt/main.py
+++ b/autogpt/main.py
@@ -55,10 +55,6 @@ def run_auto_gpt(
 
     config = ConfigBuilder.build_config_from_env()
 
-    # Hotfix: Call model_post_init explictly as it doesn't seem to be called for pydantic<2.0.0
-    # https://github.com/pydantic/pydantic/issues/1729#issuecomment-1300576214
-    config.model_post_init()
-
     # TODO: fill in llm values here
     check_openai_api_key(config)
 


### PR DESCRIPTION
As per https://github.com/pydantic/pydantic/issues/1729#issuecomment-1300576214, the implementation of `model_post_init()` is postponed until Pydantic v2. As a result, the initialization of PluginConfig is being skipped.

This fix calls `plugin.model_post_init()` explicitly.

The recency of the Pydantic v2 release means that some of the other extensions we use do not support it yet. Specifically, extensions such as spacy and openapi-python-client are currently limited to Pydantic versions that are less than 2.0. There may be other extensions that have the same limitation as well.