### PR TITLE
Adding a timestamped workspace

### DIFF
--- a/autogpt/core/workspace/timestamped.py
+++ b/autogpt/core/workspace/timestamped.py
@@ -1,29 +1,34 @@
-from datetime import datetime
 import logging
-from pathlib import Path
 import shutil
+from datetime import datetime
+from pathlib import Path
+
 from autogpt.core.workspace.simple import SimpleWorkspace
 
 
 class TimestampedWorkspace(SimpleWorkspace):
     """A workspace which creates a timestamped directory on each run."""
-    run_prefix="run-", 
+
+    run_prefix = ("run-",)
 
     @staticmethod
     def setup_workspace(settings: "AgentSettings", logger: logging.Logger) -> Path:
         workspace_root = SimpleWorkspace.setup_workspace(settings, logger)
-        
-        run_root = workspace_root / TimestampedWorkspace.run_folder_prefix + str(datetime.now())
+
+        run_root = workspace_root / TimestampedWorkspace.run_folder_prefix + str(
+            datetime.now()
+        )
         run_root.mkdir(parents=True, exist_ok=True)
-        
+
         settings.workspace.configuration.root = str(run_root)
         settings.workspace.configuration.parent = str(workspace_root)
-        
-        shutil.copy(workspace_root / "agent_settings.json", run_root / "agent_settings.json")
-        
-        run_log_path = run_root / "logs" 
+
+        shutil.copy(
+            workspace_root / "agent_settings.json", run_root / "agent_settings.json"
+        )
+
+        run_log_path = run_root / "logs"
         run_log_path.mkdir(parents=True, exist_ok=True)
         (run_log_path / "debug.log").touch()
         (run_log_path / "cycle.log").touch()
         return run_root
-    

--- a/autogpt/core/workspace/timestamped.py
+++ b/autogpt/core/workspace/timestamped.py
@@ -1,0 +1,29 @@
+from datetime import datetime
+import logging
+from pathlib import Path
+import shutil
+from autogpt.core.workspace.simple import SimpleWorkspace
+
+
+class TimestampedWorkspace(SimpleWorkspace):
+    """A workspace which creates a timestamped directory on each run."""
+    run_prefix="run-", 
+
+    @staticmethod
+    def setup_workspace(settings: "AgentSettings", logger: logging.Logger) -> Path:
+        workspace_root = SimpleWorkspace.setup_workspace(settings, logger)
+        
+        run_root = workspace_root / TimestampedWorkspace.run_folder_prefix + str(datetime.now())
+        run_root.mkdir(parents=True, exist_ok=True)
+        
+        settings.workspace.configuration.root = str(run_root)
+        settings.workspace.configuration.parent = str(workspace_root)
+        
+        shutil.copy(workspace_root / "agent_settings.json", run_root / "agent_settings.json")
+        
+        run_log_path = run_root / "logs" 
+        run_log_path.mkdir(parents=True, exist_ok=True)
+        (run_log_path / "debug.log").touch()
+        (run_log_path / "cycle.log").touch()
+        return run_root
+    


### PR DESCRIPTION
This PR adds a TimestampedWorkspace feature that allows users to track each agent run separately. This will save them from having to duplicate or clear the workspace between runs, especially if the agent encounters an error or if they need to make adjustments to the prompts.

Do you think this feature would be useful? If so, I can start working on tests and submit the update for review.

I have a couple of questions as well:
- Should we make the feature configurable? My suggestion is to default to creating a run-XXX directory unless the user disables it by passing a `--resume` flag.
- Would it be useful if we allow users to send a run-id and resume that run? '--resume run-XXX'
- Would you also like us to separate agent memory on each run? Let me know your thoughts.