### PR TITLE
fix for #4813

### DIFF
--- a/autogpt/processing/text.py
+++ b/autogpt/processing/text.py
@@ -136,7 +136,7 @@ def summarize_text(
 
     logger.info(f"Summarized {len(chunks)} chunks")
 
-    summary, _ = summarize_text("\n\n".join(summaries), config)
+    summary, _ = summarize_text("\n\n".join(summaries), config, instruction)
     return summary.strip(), [
         (summaries[i], chunks[i][0]) for i in range(0, len(chunks))
     ]

--- a/autogpt/processing/text.py
+++ b/autogpt/processing/text.py
@@ -131,13 +131,12 @@ def summarize_text(
         logger.info(
             f"Summarizing chunk {i + 1} / {len(chunks)} of length {chunk_length} tokens"
         )
-        summary, _ = summarize_text(chunk, instruction)
+        summary, _ = summarize_text(chunk, config, instruction)
         summaries.append(summary)
 
     logger.info(f"Summarized {len(chunks)} chunks")
 
-    summary, _ = summarize_text("\n\n".join(summaries))
-
+    summary, _ = summarize_text("\n\n".join(summaries), config)
     return summary.strip(), [
         (summaries[i], chunks[i][0]) for i in range(0, len(chunks))
     ]


### PR DESCRIPTION
`summarize_text` is currently broken, because it calls itself with the wrong args (missing `config`).