### PR TITLE
Make plugin scan logging more selective

### DIFF
--- a/autogpt/plugins/__init__.py
+++ b/autogpt/plugins/__init__.py
@@ -265,33 +265,35 @@ def scan_plugins(config: Config, debug: bool = False) -> List[AutoGPTPluginTempl
 
                     if (
                         inspect.isclass(a_module)
-                        and issubclass(a_module, AutoGPTPluginTemplate)
-                        and a_module.__name__ != "AutoGPTPluginTemplate"
                     ):
-                        plugin_name = a_module.__name__
-                        plugin_configured = plugins_config.get(plugin_name) is not None
-                        plugin_enabled = plugins_config.is_enabled(plugin_name)
+                        if (
+                            issubclass(a_module, AutoGPTPluginTemplate)
+                            and a_module.__name__ != "AutoGPTPluginTemplate"
+                        ):
+                            plugin_name = a_module.__name__
+                            plugin_configured = plugins_config.get(plugin_name) is not None
+                            plugin_enabled = plugins_config.is_enabled(plugin_name)
 
-                        if plugin_configured and plugin_enabled:
+                            if plugin_configured and plugin_enabled:
+                                logger.debug(
+                                    f"Loading plugin {plugin_name} as it was enabled in config."
+                                )
+                                loaded_plugins.append(a_module())
+                            elif plugin_configured and not plugin_enabled:
+                                logger.debug(
+                                    f"Not loading plugin {plugin_name} as it was disabled in config."
+                                )
+                            elif not plugin_configured:
+                                logger.warn(
+                                    f"Not loading plugin {plugin_name} as it was not found in config. "
+                                    f"Please check your config. Starting with 0.4.1, plugins will not be loaded unless "
+                                    f"they are enabled in plugins_config.yaml. Zipped plugins should use the class "
+                                    f"name ({plugin_name}) as the key."
+                                )
+                        else:
                             logger.debug(
-                                f"Loading plugin {plugin_name} as it was enabled in config."
+                                f"Skipping {key}: {a_module.__name__} because it doesn't subclass AutoGPTPluginTemplate."
                             )
-                            loaded_plugins.append(a_module())
-                        elif plugin_configured and not plugin_enabled:
-                            logger.debug(
-                                f"Not loading plugin {plugin_name} as it was disabled in config."
-                            )
-                        elif not plugin_configured:
-                            logger.warn(
-                                f"Not loading plugin {plugin_name} as it was not found in config. "
-                                f"Please check your config. Starting with 0.4.1, plugins will not be loaded unless "
-                                f"they are enabled in plugins_config.yaml. Zipped plugins should use the class "
-                                f"name ({plugin_name}) as the key."
-                            )
-                    else:
-                        logger.debug(
-                            f"Skipping {key}: {a_module.__name__} because it doesn't subclass AutoGPTPluginTemplate."
-                        )
 
     # OpenAI plugins
     if config.plugins_openai:

--- a/autogpt/plugins/__init__.py
+++ b/autogpt/plugins/__init__.py
@@ -263,15 +263,15 @@ def scan_plugins(config: Config, debug: bool = False) -> List[AutoGPTPluginTempl
                         continue
                     a_module = getattr(zipped_module, key)
 
-                    if (
-                        inspect.isclass(a_module)
-                    ):
+                    if inspect.isclass(a_module):
                         if (
                             issubclass(a_module, AutoGPTPluginTemplate)
                             and a_module.__name__ != "AutoGPTPluginTemplate"
                         ):
                             plugin_name = a_module.__name__
-                            plugin_configured = plugins_config.get(plugin_name) is not None
+                            plugin_configured = (
+                                plugins_config.get(plugin_name) is not None
+                            )
                             plugin_enabled = plugins_config.is_enabled(plugin_name)
 
                             if plugin_configured and plugin_enabled:


### PR DESCRIPTION
### Background
As reported by @NeonN3mesis, `autogpt.plugins.scan_plugins()` can crash when scanning exported items from a module, when an item is an *instance* of a class, instead of a class.

Example:

    AttributeError: 'AnsiFore' object has no attribute '__name__'. Did you mean: '__ne__'?

### Changes
Only log anything if the item in question is a class in the first place.

### Documentation
x

### Test Plan
CI

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [ ] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes. <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->
- [x] I have run the following commands against my code to ensure it passes our linters:
    ```shell
    black .
    isort .
    mypy
    autoflake --remove-all-unused-imports --recursive --ignore-init-module-imports --ignore-pass-after-docstring autogpt tests --in-place
    ```
