### PR TITLE
Fix errors in Mandatory Tasks of Benchmarks

### DIFF
--- a/tests/challenges/basic_abilities/test_write_file.py
+++ b/tests/challenges/basic_abilities/test_write_file.py
@@ -1,5 +1,6 @@
 import pytest
 
+from autogpt.config import Config
 from autogpt.workspace import Workspace
 from tests.challenges.challenge_decorator.challenge_decorator import challenge
 from tests.challenges.utils import get_workspace_path, run_challenge
@@ -17,6 +18,7 @@ USER_INPUTS = [
 
 @challenge()
 def test_write_file(
+    config: Config,
     patched_api_requestor: None,
     monkeypatch: pytest.MonkeyPatch,
     level_to_run: int,

--- a/tests/challenges/memory/test_memory_challenge_a.py
+++ b/tests/challenges/memory/test_memory_challenge_a.py
@@ -1,6 +1,7 @@
 import pytest
 from pytest_mock import MockerFixture
 
+from autogpt.config import Config
 from autogpt.workspace import Workspace
 from tests.challenges.challenge_decorator.challenge_decorator import challenge
 from tests.challenges.utils import get_workspace_path, run_challenge
@@ -12,6 +13,7 @@ USER_INPUT = "Use the command read_file to read the instructions_1.txt file\nFol
 
 @challenge()
 def test_memory_challenge_a(
+    config: Config,
     patched_api_requestor: MockerFixture,
     monkeypatch: pytest.MonkeyPatch,
     level_to_run: int,


### PR DESCRIPTION
<!-- ⚠️ At the moment any non-essential commands are not being merged.
If you want to add non-essential commands to Auto-GPT, please create a plugin instead.
We are expecting to ship plugin support within the week (PR #757).
Resources:
* https://github.com/Significant-Gravitas/Auto-GPT-Plugin-Template
-->

<!-- 📢 Announcement
We've recently noticed an increase in pull requests focusing on combining multiple changes. While the intentions behind these PRs are appreciated, it's essential to maintain a clean and manageable git history. To ensure the quality of our repository, we kindly ask you to adhere to the following guidelines when submitting PRs:

Focus on a single, specific change.
Do not include any unrelated or "extra" modifications.
Provide clear documentation and explanations of the changes made.
Ensure diffs are limited to the intended lines — no applying preferred formatting styles or line endings (unless that's what the PR is about).
For guidance on committing only the specific lines you have changed, refer to this helpful video: https://youtu.be/8-hSNHHbiZg

Check out our [wiki page on Contributing](https://github.com/Significant-Gravitas/Nexus/wiki/Contributing)

By following these guidelines, your PRs are more likely to be merged quickly after testing, as long as they align with the project's overall direction. -->

### Background
This PR is intended to fix the errors at the following URL.
https://github.com/Significant-Gravitas/Auto-GPT/actions/runs/5461866933

### Changes
As can be seen in the URL below, an error occurs during the `__init__` process of the `api_requestor` in the openai library, within `original_init` in `tests/vcr/__init__.py`.
https://github.com/Significant-Gravitas/Auto-GPT/actions/runs/5461866933/jobs/9940430084#step:7:202

This seems to be because `config` defined as a pytest.fixture in the `tests/conftest.py` is not being called during the execution of the pytest, causing `os.environ["OPENAI_API_KEY"]` to become `None`. So, modifying files, as shown below, will resolve this issue.

```python
@challenge()
def test_write_file(
+   config: Config,  # or agent: Agent
    patched_api_requestor: None,
    monkeypatch: pytest.MonkeyPatch,
    level_to_run: int,
    challenge_name: str,
    workspace: Workspace,
    patched_make_workspace: pytest.fixture,
) -> None:
```

### Test Plan
I performed the following pytests.
```bash
$ PROXY="http://localhost:8080" pytest -n auto --record-mode=all tests/challenges/basic_abilities/test_write_file.py
$ PROXY="http://localhost:8080" pytest -n auto --record-mode=all tests/challenges/memory/test_memory_challenge_a.py
```

Due to this commit, the error changed from 

```
FAILED tests/challenges/basic_abilities/test_write_file.py::test_write_file - openai.error.AuthenticationError: No API key provided. You can set your API key in code using 'openai.api_key = <API-KEY>', or you can set the environment variable OPENAI_API_KEY=<API-KEY>). If your API key is stored in a file, you can point the openai module at it with 'openai.api_key_path = <PATH>'. You can generate API keys in the OpenAI web interface. See https://onboard.openai.com for details, or email support@openai.com if you have any questions.
``` 

to 

```
FAILED tests/challenges/basic_abilities/test_write_file.py::test_write_file - openai.error.APIConnectionError: Error communicating with OpenAI: HTTPConnectionPool(host='localhost', port=8080): Max retries exceeded with url: /v1/chat/completions (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7fa3acc83850>: Failed to establish a new connection: [Errno 111] Connection refused'))
```

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes. <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->
- [x] I have run the following commands against my code to ensure it passes our linters:
    ```shell
    black .
    isort .
    mypy
    autoflake --remove-all-unused-imports --recursive --ignore-init-module-imports --ignore-pass-after-docstring autogpt tests --in-place
    ```

<!-- If you haven't added tests, please explain why. If you have, check the appropriate box. If you've ensured your PR is atomic and well-documented, check the corresponding boxes. -->

<!-- By submitting this, I agree that my pull request should be closed if I do not fill this out or follow the guidelines. -->
