### PR TITLE
Drop AbstractSingleton as a parent class of the vector memory

### DIFF
--- a/autogpt/memory/vector/providers/base.py
+++ b/autogpt/memory/vector/providers/base.py
@@ -6,13 +6,12 @@ import numpy as np
 
 from autogpt.config.config import Config
 from autogpt.logs import logger
-from autogpt.singleton import AbstractSingleton
 
 from .. import MemoryItem, MemoryItemRelevance
 from ..utils import Embedding, get_embedding
 
 
-class VectorMemoryProvider(MutableSet[MemoryItem], AbstractSingleton):
+class VectorMemoryProvider(MutableSet[MemoryItem]):
     @abc.abstractmethod
     def __init__(self, config: Config):
         pass

--- a/autogpt/speech/base.py
+++ b/autogpt/speech/base.py
@@ -9,8 +9,6 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from autogpt.config import Config
 
-from autogpt.singleton import AbstractSingleton
-
 
 class VoiceBase(AbstractSingleton):
     """

--- a/autogpt/speech/base.py
+++ b/autogpt/speech/base.py
@@ -9,6 +9,8 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from autogpt.config import Config
 
+from autogpt.singleton import AbstractSingleton
+
 
 class VoiceBase(AbstractSingleton):
     """

--- a/tests/integration/memory/test_json_file_memory.py
+++ b/tests/integration/memory/test_json_file_memory.py
@@ -8,12 +8,6 @@ from autogpt.memory.vector import JSONFileMemory, MemoryItem
 from autogpt.workspace import Workspace
 
 
-@pytest.fixture(autouse=True)
-def cleanup_sut_singleton():
-    if JSONFileMemory in JSONFileMemory._instances:
-        del JSONFileMemory._instances[JSONFileMemory]
-
-
 def test_json_memory_init_without_backing_file(config: Config, workspace: Workspace):
     index_file = workspace.root / f"{config.memory_index}.json"
 


### PR DESCRIPTION
### Background
Singletons are bad and we don't need them

### Changes
- Remove the abstract singleton parent class from the vector memory

### Documentation
N/A

### Test Plan
CI

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes. <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->
- [x] I have run the following commands against my code to ensure it passes our linters:
    ```shell
    black .
    isort .
    mypy
    autoflake --remove-all-unused-imports --recursive --ignore-init-module-imports --ignore-pass-after-docstring autogpt tests --in-place
    ```

<!-- If you haven't added tests, please explain why. If you have, check the appropriate box. If you've ensured your PR is atomic and well-documented, check the corresponding boxes. -->

<!-- By submitting this, I agree that my pull request should be closed if I do not fill this out or follow the guidelines. -->
