### PR TITLE
Fix PLAIN_OUTPUT for normal execution

### DIFF
--- a/autogpt/logs.py
+++ b/autogpt/logs.py
@@ -7,7 +7,7 @@ import random
 import re
 import time
 from logging import LogRecord
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Optional
 
 from colorama import Fore, Style
 
@@ -85,16 +85,26 @@ class Logger(metaclass=Singleton):
         self.json_logger.addHandler(error_handler)
         self.json_logger.setLevel(logging.DEBUG)
 
-        self.speak_mode = False
-        self.config = None
+        self._config: Optional[Config] = None
         self.chat_plugins = []
+
+    @property
+    def config(self) -> Config | None:
+        return self._config
+
+    @config.setter
+    def config(self, config: Config):
+        self._config = config
+        if config.plain_output:
+            self.typing_logger.removeHandler(self.typing_console_handler)
+            self.typing_logger.addHandler(self.console_handler)
 
     def typewriter_log(
         self, title="", title_color="", content="", speak_text=False, level=logging.INFO
     ):
         from autogpt.speech import say_text
 
-        if speak_text and self.speak_mode:
+        if speak_text and self.config and self.config.speak_mode:
             say_text(f"{title}. {content}", self.config)
 
         for plugin in self.chat_plugins:

--- a/autogpt/main.py
+++ b/autogpt/main.py
@@ -55,7 +55,6 @@ def run_auto_gpt(
 ):
     # Configure logging before we do anything else.
     logger.set_level(logging.DEBUG if debug else logging.INFO)
-    logger.speak_mode = speak
 
     config = ConfigBuilder.build_config_from_env()
     # HACK: This is a hack to allow the config into the logger without having to pass it around everywhere

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,6 @@ from autogpt.agent.agent import Agent
 from autogpt.config import AIConfig, Config, ConfigBuilder
 from autogpt.config.ai_config import AIConfig
 from autogpt.llm.api_manager import ApiManager
-from autogpt.logs import TypingConsoleHandler
 from autogpt.memory.vector import get_memory
 from autogpt.models.command_registry import CommandRegistry
 from autogpt.prompts.prompt import DEFAULT_TRIGGERING_PROMPT
@@ -79,18 +78,6 @@ def api_manager() -> ApiManager:
     if ApiManager in ApiManager._instances:
         del ApiManager._instances[ApiManager]
     return ApiManager()
-
-
-@pytest.fixture(autouse=True)
-def patch_emit(monkeypatch):
-    # convert plain_output to a boolean
-
-    if bool(os.environ.get("PLAIN_OUTPUT")):
-
-        def quick_emit(self, record: str):
-            print(self.format(record))
-
-        monkeypatch.setattr(TypingConsoleHandler, "emit", quick_emit)
 
 
 @pytest.fixture


### PR DESCRIPTION
### Background
`PLAIN_OUTPUT` only works when combined with a monkeypatch applied by a pytest fixture.

### Changes
* Remove the `patch_emit` fixture
* Patch the output handler in `Logger` when `config.plain_output` is `True`

### Documentation
x

### Test Plan
* Tested manually
* CI

### PR Quality Checklist
- [ ] My pull request is atomic and focuses on a single change.
- [x] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [ ] I have not snuck in any "extra" small tweaks changes. <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->
- [x] I have run the following commands against my code to ensure it passes our linters:
    ```shell
    black .
    isort .
    mypy
    autoflake --remove-all-unused-imports --recursive --ignore-init-module-imports --ignore-pass-after-docstring autogpt tests --in-place
    ```

<!-- If you haven't added tests, please explain why. If you have, check the appropriate box. If you've ensured your PR is atomic and well-documented, check the corresponding boxes. -->

<!-- By submitting this, I agree that my pull request should be closed if I do not fill this out or follow the guidelines. -->
