### PR TITLE
Bugfix/broken azure config

### DIFF
--- a/autogpt/config/config.py
+++ b/autogpt/config/config.py
@@ -88,33 +88,14 @@ class Config(SystemSettings):
 
     def get_azure_kwargs(self, model: str) -> dict[str, str]:
         """Get the kwargs for the Azure API."""
-
-        # Fix --gpt3only and --gpt4only in combination with Azure
-        fast_llm = (
-            self.fast_llm
-            if not (
-                self.fast_llm == self.smart_llm
-                and self.fast_llm.startswith(GPT_4_MODEL)
-            )
-            else f"not_{self.fast_llm}"
-        )
-        smart_llm = (
-            self.smart_llm
-            if not (
-                self.smart_llm == self.fast_llm
-                and self.smart_llm.startswith(GPT_3_MODEL)
-            )
-            else f"not_{self.smart_llm}"
-        )
-
         deployment_id = {
-            fast_llm: self.azure_model_to_deployment_id_map.get(
+            self.fast_llm: self.azure_model_to_deployment_id_map.get(
                 "fast_llm_deployment_id",
                 self.azure_model_to_deployment_id_map.get(
                     "fast_llm_model_deployment_id"  # backwards compatibility
                 ),
             ),
-            smart_llm: self.azure_model_to_deployment_id_map.get(
+            self.smart_llm: self.azure_model_to_deployment_id_map.get(
                 "smart_llm_deployment_id",
                 self.azure_model_to_deployment_id_map.get(
                     "smart_llm_model_deployment_id"  # backwards compatibility

--- a/autogpt/config/config.py
+++ b/autogpt/config/config.py
@@ -88,14 +88,33 @@ class Config(SystemSettings):
 
     def get_azure_kwargs(self, model: str) -> dict[str, str]:
         """Get the kwargs for the Azure API."""
+
+        # Fix --gpt3only and --gpt4only in combination with Azure
+        fast_llm = (
+            self.fast_llm
+            if not (
+                self.fast_llm == self.smart_llm
+                and self.fast_llm.startswith(GPT_4_MODEL)
+            )
+            else f"not_{self.fast_llm}"
+        )
+        smart_llm = (
+            self.smart_llm
+            if not (
+                self.smart_llm == self.fast_llm
+                and self.smart_llm.startswith(GPT_3_MODEL)
+            )
+            else f"not_{self.smart_llm}"
+        )
+
         deployment_id = {
-            self.fast_llm: self.azure_model_to_deployment_id_map.get(
+            fast_llm: self.azure_model_to_deployment_id_map.get(
                 "fast_llm_deployment_id",
                 self.azure_model_to_deployment_id_map.get(
                     "fast_llm_model_deployment_id"  # backwards compatibility
                 ),
             ),
-            self.smart_llm: self.azure_model_to_deployment_id_map.get(
+            smart_llm: self.azure_model_to_deployment_id_map.get(
                 "smart_llm_deployment_id",
                 self.azure_model_to_deployment_id_map.get(
                     "smart_llm_model_deployment_id"  # backwards compatibility

--- a/autogpt/configurator.py
+++ b/autogpt/configurator.py
@@ -53,7 +53,6 @@ def create_config(
     config.continuous_mode = False
     config.speak_mode = False
 
-
     if debug:
         logger.typewriter_log("Debug Mode: ", Fore.GREEN, "ENABLED")
         config.debug_mode = True
@@ -89,7 +88,11 @@ def create_config(
         # --gpt3only should always use gpt-3.5-turbo, despite user's FAST_LLM config
         config.fast_llm = GPT_3_MODEL
         config.smart_llm = GPT_3_MODEL
-    elif gpt4only and check_model(GPT_4_MODEL, model_type="smart_llm", config=config) == GPT_4_MODEL:
+    elif (
+        gpt4only
+        and check_model(GPT_4_MODEL, model_type="smart_llm", config=config)
+        == GPT_4_MODEL
+    ):
         logger.typewriter_log("GPT4 Only Mode: ", Fore.GREEN, "ENABLED")
         # --gpt4only should always use gpt-4, despite user's SMART_LLM config
         config.fast_llm = GPT_4_MODEL

--- a/autogpt/configurator.py
+++ b/autogpt/configurator.py
@@ -53,6 +53,7 @@ def create_config(
     config.continuous_mode = False
     config.speak_mode = False
 
+
     if debug:
         logger.typewriter_log("Debug Mode: ", Fore.GREEN, "ENABLED")
         config.debug_mode = True
@@ -82,21 +83,25 @@ def create_config(
         logger.typewriter_log("Speak Mode: ", Fore.GREEN, "ENABLED")
         config.speak_mode = True
 
+    openai_credentials = {
+        'api_key': config.openai_api_key,
+    }
+    if config.use_azure:
+        openai_credentials.update(config.get_azure_kwargs())
     # Set the default LLM models
     if gpt3only:
         logger.typewriter_log("GPT3.5 Only Mode: ", Fore.GREEN, "ENABLED")
         # --gpt3only should always use gpt-3.5-turbo, despite user's FAST_LLM config
         config.fast_llm = GPT_3_MODEL
         config.smart_llm = GPT_3_MODEL
-
-    elif gpt4only and check_model(GPT_4_MODEL, model_type="smart_llm") == GPT_4_MODEL:
+    elif gpt4only and check_model(GPT_4_MODEL, model_type="smart_llm", config=config) == GPT_4_MODEL:
         logger.typewriter_log("GPT4 Only Mode: ", Fore.GREEN, "ENABLED")
         # --gpt4only should always use gpt-4, despite user's SMART_LLM config
         config.fast_llm = GPT_4_MODEL
         config.smart_llm = GPT_4_MODEL
     else:
-        config.fast_llm = check_model(config.fast_llm, "fast_llm")
-        config.smart_llm = check_model(config.smart_llm, "smart_llm")
+        config.fast_llm = check_model(config.fast_llm, "fast_llm", config=config)
+        config.smart_llm = check_model(config.smart_llm, "smart_llm", config=config)
 
     if memory_type:
         supported_memory = get_supported_memory_backends()

--- a/autogpt/configurator.py
+++ b/autogpt/configurator.py
@@ -83,11 +83,6 @@ def create_config(
         logger.typewriter_log("Speak Mode: ", Fore.GREEN, "ENABLED")
         config.speak_mode = True
 
-    openai_credentials = {
-        'api_key': config.openai_api_key,
-    }
-    if config.use_azure:
-        openai_credentials.update(config.get_azure_kwargs())
     # Set the default LLM models
     if gpt3only:
         logger.typewriter_log("GPT3.5 Only Mode: ", Fore.GREEN, "ENABLED")

--- a/autogpt/llm/api_manager.py
+++ b/autogpt/llm/api_manager.py
@@ -95,7 +95,7 @@ class ApiManager(metaclass=Singleton):
         """
         return self.total_budget
 
-    def get_models(self) -> List[Model]:
+    def get_models(self, **openai_credentials) -> List[Model]:
         """
         Get list of available GPT models.
 
@@ -104,7 +104,7 @@ class ApiManager(metaclass=Singleton):
 
         """
         if self.models is None:
-            all_models = openai.Model.list()["data"]
+            all_models = openai.Model.list(**openai_credentials)["data"]
             self.models = [model for model in all_models if "gpt" in model["id"]]
 
         return self.models

--- a/autogpt/llm/utils/__init__.py
+++ b/autogpt/llm/utils/__init__.py
@@ -173,10 +173,20 @@ def create_chat_completion(
     )
 
 
-def check_model(model_name: str, model_type: Literal["smart_llm", "fast_llm"]) -> str:
+def check_model(
+    model_name: str,
+    model_type: Literal["smart_llm", "fast_llm"],
+    config: Config,
+) -> str:
     """Check if model is available for use. If not, return gpt-3.5-turbo."""
+    openai_credentials = {
+        "api_key": config.openai_api_key,
+    }
+    if config.use_azure:
+        openai_credentials.update(config.get_azure_kwargs(model_name))
+
     api_manager = ApiManager()
-    models = api_manager.get_models()
+    models = api_manager.get_models(**openai_credentials)
 
     if any(model_name in m["id"] for m in models):
         return model_name


### PR DESCRIPTION
### Background
We introduced a reliance on setting openai module attributes a couple of months ago to verify model access.  This was causing breakages in Azure usage not fixed by #4875 or #4098.

**Known Issue**: We have default fallbacks when gpt4 is not available (use gpt-3.5-turbo), but azure deployments can modify the names of models and there are no guarantees that a system will have gpt3.5 if it doesn't have gpt4.  I think this is mostly a non-issue as someone using azure wants their model to fail on misconfiguration as this is most likely a user error.

### Changes
- Pass in credentials when we check for model validity.
- Put azure resolution of --gpt3only and --gpt4only on the same path.

### Documentation

### Test Plan
CI

Manual testing of `./run.sh` with no flags, with --gpt3only flag and with --gpt4only flag on an azure instance.

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes. <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->
- [x] I have run the following commands against my code to ensure it passes our linters:
    ```shell
    black .
    isort .
    mypy
    autoflake --remove-all-unused-imports --recursive --ignore-init-module-imports --ignore-pass-after-docstring autogpt tests --in-place
    ```

<!-- If you haven't added tests, please explain why. If you have, check the appropriate box. If you've ensured your PR is atomic and well-documented, check the corresponding boxes. -->

<!-- By submitting this, I agree that my pull request should be closed if I do not fill this out or follow the guidelines. -->
