### PR TITLE
Add openai base and organization to credentials when calling api

### DIFF
--- a/autogpt/config/config.py
+++ b/autogpt/config/config.py
@@ -144,7 +144,18 @@ class Config(SystemSettings, arbitrary_types_allowed=True):
         ), f"Plugins must subclass AutoGPTPluginTemplate; {p} is a template instance"
         return p
 
-    def get_azure_kwargs(self, model: str) -> dict[str, str]:
+    def get_openai_credentials(self, model: str) -> dict[str, str]:
+        credentials = {
+            "api_key": self.openai_api_key,
+            "api_base": self.openai_api_base,
+            "organization": self.openai_organization,
+        }
+        if self.use_azure:
+            azure_credentials = self.get_azure_credentials(model)
+            credentials.update(azure_credentials)
+        return credentials
+
+    def get_azure_credentials(self, model: str) -> dict[str, str]:
         """Get the kwargs for the Azure API."""
 
         # Fix --gpt3only and --gpt4only in combination with Azure

--- a/autogpt/llm/utils/__init__.py
+++ b/autogpt/llm/utils/__init__.py
@@ -78,10 +78,8 @@ def create_text_completion(
     if temperature is None:
         temperature = config.temperature
 
-    if config.use_azure:
-        kwargs = config.get_azure_kwargs(model)
-    else:
-        kwargs = {"model": model}
+    kwargs = {"model": model}
+    kwargs.update(config.get_openai_credentials(model))
 
     response = iopenai.create_text_completion(
         prompt=prompt,
@@ -150,9 +148,7 @@ def create_chat_completion(
             if message is not None:
                 return message
 
-    chat_completion_kwargs["api_key"] = config.openai_api_key
-    if config.use_azure:
-        chat_completion_kwargs.update(config.get_azure_kwargs(model))
+    chat_completion_kwargs.update(config.get_openai_credentials(model))
 
     if functions:
         chat_completion_kwargs["functions"] = [
@@ -196,11 +192,7 @@ def check_model(
     config: Config,
 ) -> str:
     """Check if model is available for use. If not, return gpt-3.5-turbo."""
-    openai_credentials = {
-        "api_key": config.openai_api_key,
-    }
-    if config.use_azure:
-        openai_credentials.update(config.get_azure_kwargs(model_name))
+    openai_credentials = config.get_openai_credentials(model_name)
 
     api_manager = ApiManager()
     models = api_manager.get_models(**openai_credentials)

--- a/autogpt/memory/vector/utils.py
+++ b/autogpt/memory/vector/utils.py
@@ -41,10 +41,8 @@ def get_embedding(
         input = [text.replace("\n", " ") for text in input]
 
     model = config.embedding_model
-    if config.use_azure:
-        kwargs = config.get_azure_kwargs(model)
-    else:
-        kwargs = {"model": model}
+    kwargs = {"model": model}
+    kwargs.update(config.get_openai_credentials(model))
 
     logger.debug(
         f"Getting embedding{f's for {len(input)} inputs' if multiple else ''}"

--- a/autogpt/memory/vector/utils.py
+++ b/autogpt/memory/vector/utils.py
@@ -55,7 +55,6 @@ def get_embedding(
     embeddings = iopenai.create_embedding(
         input,
         **kwargs,
-        api_key=config.openai_api_key,
     ).data
 
     if not multiple:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -174,18 +174,32 @@ azure_model_map:
 
     fast_llm = config.fast_llm
     smart_llm = config.smart_llm
-    assert config.get_azure_kwargs(config.fast_llm)["deployment_id"] == "FAST-LLM_ID"
-    assert config.get_azure_kwargs(config.smart_llm)["deployment_id"] == "SMART-LLM_ID"
+    assert (
+        config.get_azure_credentials(config.fast_llm)["deployment_id"] == "FAST-LLM_ID"
+    )
+    assert (
+        config.get_azure_credentials(config.smart_llm)["deployment_id"]
+        == "SMART-LLM_ID"
+    )
 
     # Emulate --gpt4only
     config.fast_llm = smart_llm
-    assert config.get_azure_kwargs(config.fast_llm)["deployment_id"] == "SMART-LLM_ID"
-    assert config.get_azure_kwargs(config.smart_llm)["deployment_id"] == "SMART-LLM_ID"
+    assert (
+        config.get_azure_credentials(config.fast_llm)["deployment_id"] == "SMART-LLM_ID"
+    )
+    assert (
+        config.get_azure_credentials(config.smart_llm)["deployment_id"]
+        == "SMART-LLM_ID"
+    )
 
     # Emulate --gpt3only
     config.fast_llm = config.smart_llm = fast_llm
-    assert config.get_azure_kwargs(config.fast_llm)["deployment_id"] == "FAST-LLM_ID"
-    assert config.get_azure_kwargs(config.smart_llm)["deployment_id"] == "FAST-LLM_ID"
+    assert (
+        config.get_azure_credentials(config.fast_llm)["deployment_id"] == "FAST-LLM_ID"
+    )
+    assert (
+        config.get_azure_credentials(config.smart_llm)["deployment_id"] == "FAST-LLM_ID"
+    )
 
     del os.environ["USE_AZURE"]
     del os.environ["AZURE_CONFIG_FILE"]


### PR DESCRIPTION
### Background
The OpenAI Organization and API base as implemented by #2594 were dropped in #4803. This brings them back.

### Changes
- Add a general `get_openai_credentials` function on the config.
- Have it load the org and api base generally and overwrite the api base when using azure.
- 
### Documentation

### Test Plan
CI + manual testing

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes. <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->
- [x] I have run the following commands against my code to ensure it passes our linters:
    ```shell
    black .
    isort .
    mypy
    autoflake --remove-all-unused-imports --recursive --ignore-init-module-imports --ignore-pass-after-docstring autogpt tests --in-place
    ```

<!-- If you haven't added tests, please explain why. If you have, check the appropriate box. If you've ensured your PR is atomic and well-documented, check the corresponding boxes. -->

<!-- By submitting this, I agree that my pull request should be closed if I do not fill this out or follow the guidelines. -->
