### PR TITLE
Disable proxy for internal pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,9 +159,10 @@ jobs:
           python tests/challenges/utils/build_current_score.py
         env:
           CI: true
-          PROXY: ${{ secrets.PROXY }}
-          AGENT_MODE: ${{ secrets.AGENT_MODE }}
-          AGENT_TYPE: ${{ secrets.AGENT_TYPE }}
+          PROXY: ${{ github.event_name == 'pull_request_target' && secrets.PROXY || '' }}
+          AGENT_MODE: ${{ github.event_name == 'pull_request_target' && secrets.AGENT_MODE || '' }}
+          AGENT_TYPE: ${{ github.event_name == 'pull_request_target' && secrets.AGENT_TYPE || '' }}
+          OPENAI_API_KEY: ${{ github.event_name == 'pull_request' && secrets.OPENAI_API_KEY || '' }}
           PLAIN_OUTPUT: True
 
       - name: Upload coverage reports to Codecov


### PR DESCRIPTION
### Background
* CI fails to make API calls via the proxy, gets 400 Bad Request: https://github.com/Significant-Gravitas/Auto-GPT/actions/runs/5533011279/jobs/10096906731
* Taking the proxy out of the equation lets CI pass: https://github.com/Significant-Gravitas/Auto-GPT/actions/runs/5532961197/jobs/10095778254?pr=4799#logs

### Changes
Pass `OPENAI_API_TOKEN` instead of using `PROXY` on internal PRs (so from a branch in the repo to another branch in the repo).

### Documentation
x

### Test Plan
CI

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [ ] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes. <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->