### PR TITLE
Extract application code from the agent

### DIFF
--- a/autogpt/agents/agent.py
+++ b/autogpt/agents/agent.py
@@ -26,7 +26,7 @@ from autogpt.logs.log_cycle import (
 )
 from autogpt.workspace import Workspace
 
-from .base import BaseAgent
+from .base import BaseAgent, CommandName, CommandArgs, AgentThoughts
 
 
 class Agent(BaseAgent):
@@ -72,7 +72,6 @@ class Agent(BaseAgent):
         )
 
         # Add budget information (if any) to prompt
-        budget_msg: Message | None = None
         api_manager = ApiManager()
         if api_manager.get_total_budget() > 0.0:
             remaining_budget = (
@@ -117,7 +116,7 @@ class Agent(BaseAgent):
         command_name: str | None,
         command_args: dict[str, str] | None,
         user_input: str | None,
-    ):
+    ) -> str:
         # Execute command
         if command_name is not None and command_name.lower().startswith("error"):
             result = f"Could not execute command: {command_name}{command_args}"
@@ -165,7 +164,7 @@ class Agent(BaseAgent):
 
     def parse_and_process_response(
         self, llm_response: ChatModelResponse, *args, **kwargs
-    ) -> tuple[str | None, dict[str, str] | None, dict[str, Any]]:
+    ) -> tuple[CommandName | None, CommandArgs | None, AgentThoughts]:
         if not llm_response.content:
             raise SyntaxError("Assistant response has no text content")
 

--- a/autogpt/agents/agent.py
+++ b/autogpt/agents/agent.py
@@ -1,14 +1,11 @@
 from __future__ import annotations
 
 import json
-import signal
-import sys
 import time
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, ContextManager, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
-from colorama import Fore, Style
 
 if TYPE_CHECKING:
     from autogpt.config import AIConfig, Config
@@ -20,16 +17,13 @@ from autogpt.json_utils.utilities import extract_dict_from_response, validate_di
 from autogpt.llm.api_manager import ApiManager
 from autogpt.llm.base import Message
 from autogpt.llm.utils import count_string_tokens
-from autogpt.logs import logger, print_assistant_thoughts, remove_ansi_escape
+from autogpt.logs import logger
 from autogpt.logs.log_cycle import (
     FULL_MESSAGE_HISTORY_FILE_NAME,
     NEXT_ACTION_FILE_NAME,
     USER_INPUT_FILE_NAME,
     LogCycleHandler,
 )
-from autogpt.speech import say_text
-from autogpt.spinner import Spinner
-from autogpt.utils import clean_input
 from autogpt.workspace import Workspace
 
 from .base import BaseAgent
@@ -68,30 +62,6 @@ class Agent(BaseAgent):
         self.log_cycle_handler = LogCycleHandler()
         """LogCycleHandler for structured debug logging."""
 
-    def start_interaction_loop(self) -> None:
-        # Signal handler for interrupting y -N or continuous mode
-        def signal_handler(*_) -> None:
-            if self.cycle_budget == 0 or self.cycles_remaining == 0:
-                sys.exit()
-            else:
-                print(
-                    Fore.RED
-                    + "Interrupt signal received. Stopping continuous command execution."
-                    + Style.RESET_ALL
-                )
-                self.cycles_remaining = 0
-
-        signal.signal(signal.SIGINT, signal_handler)
-
-        while True:
-            try:
-                next(self)
-            except StopIteration:
-                break
-
-    def context_while_think(self) -> ContextManager:
-        return Spinner("Thinking... ", plain_output=self.config.plain_output)
-
     def construct_base_prompt(self, *args, **kwargs) -> ChatSequence:
         if kwargs.get("append_messages") is None:
             kwargs["append_messages"] = []
@@ -129,8 +99,8 @@ class Agent(BaseAgent):
 
         return super().construct_base_prompt(*args, **kwargs)
 
-    def on_before_think(self, *args, **kwargs):
-        super().on_before_think(*args, **kwargs)
+    def on_before_think(self, *args, **kwargs) -> ChatSequence:
+        prompt = super().on_before_think(*args, **kwargs)
 
         self.log_cycle_handler.log_count_within_cycle = 0
         self.log_cycle_handler.log_cycle(
@@ -140,10 +110,62 @@ class Agent(BaseAgent):
             self.history.raw(),
             FULL_MESSAGE_HISTORY_FILE_NAME,
         )
+        return prompt
+
+    def execute(
+        self,
+        command_name: str | None,
+        command_args: dict[str, str] | None,
+        user_input: str | None,
+    ):
+        # Execute command
+        if command_name is not None and command_name.lower().startswith("error"):
+            result = f"Could not execute command: {command_name}{command_args}"
+        elif command_name == "human_feedback":
+            result = f"Human feedback: {user_input}"
+            self.log_cycle_handler.log_cycle(
+                self.ai_config.ai_name,
+                self.created_at,
+                self.cycle_count,
+                user_input,
+                USER_INPUT_FILE_NAME,
+            )
+
+        else:
+            for plugin in self.config.plugins:
+                if not plugin.can_handle_pre_command():
+                    continue
+                command_name, arguments = plugin.pre_command(command_name, command_args)
+            command_result = execute_command(
+                command_name=command_name,
+                arguments=command_args,
+                agent=self,
+            )
+            result = f"Command {command_name} returned: " f"{command_result}"
+
+            result_tlength = count_string_tokens(str(command_result), self.llm.name)
+            memory_tlength = count_string_tokens(
+                str(self.history.summary_message()), self.llm.name
+            )
+            if result_tlength + memory_tlength > self.send_token_limit:
+                result = f"Failure: command {command_name} returned too much output. \
+                    Do not execute this command again with the same arguments."
+
+            for plugin in self.config.plugins:
+                if not plugin.can_handle_post_command():
+                    continue
+                result = plugin.post_command(command_name, result)
+        # Check if there's a result from the command append it to the message
+        if result is None:
+            self.history.add("system", "Unable to execute command", "action_result")
+        else:
+            self.history.add("system", result, "action_result")
+
+        return result
 
     def parse_and_process_response(
         self, llm_response: ChatModelResponse, *args, **kwargs
-    ) -> None:
+    ) -> tuple[str | None, dict[str, str] | None, dict[str, Any]]:
         if not llm_response.content:
             raise SyntaxError("Assistant response has no text content")
 
@@ -161,23 +183,16 @@ class Agent(BaseAgent):
                 continue
             assistant_reply_dict = plugin.post_planning(assistant_reply_dict)
 
-        command_name: str | None = None
-        arguments: dict[str, str] | None = None
-        user_input = ""
+        response = None, None, assistant_reply_dict
 
         # Print Assistant thoughts
         if assistant_reply_dict != {}:
             # Get command name and arguments
             try:
-                print_assistant_thoughts(
-                    self.ai_config.ai_name, assistant_reply_dict, self.config
-                )
                 command_name, arguments = extract_command(
                     assistant_reply_dict, llm_response, self.config
                 )
-                if self.config.speak_mode:
-                    say_text(f"I want to execute {command_name}", self.config)
-
+                response = command_name, arguments, assistant_reply_dict
             except Exception as e:
                 logger.error("Error: \n", str(e))
 
@@ -188,134 +203,7 @@ class Agent(BaseAgent):
             assistant_reply_dict,
             NEXT_ACTION_FILE_NAME,
         )
-
-        # First log new-line so user can differentiate sections better in console
-        logger.typewriter_log("\n")
-        logger.typewriter_log(
-            "NEXT ACTION: ",
-            Fore.CYAN,
-            f"COMMAND = {Fore.CYAN}{remove_ansi_escape(command_name)}{Style.RESET_ALL}  "
-            f"ARGUMENTS = {Fore.CYAN}{arguments}{Style.RESET_ALL}",
-        )
-
-        if self.cycles_remaining == 0:
-            # ### GET USER AUTHORIZATION TO EXECUTE COMMAND ###
-            # Get key press: Prompt the user to press enter to continue or escape
-            # to exit
-            self.user_input = ""
-            logger.info(
-                f"Enter '{self.config.authorise_key}' to authorise command, "
-                f"'{self.config.authorise_key} -N' to run N continuous commands, "
-                f"'{self.config.exit_key}' to exit program, or enter feedback for "
-                f"{self.ai_config.ai_name}..."
-            )
-            while True:
-                if self.config.chat_messages_enabled:
-                    console_input = clean_input(
-                        self.config, "Waiting for your response..."
-                    )
-                else:
-                    console_input = clean_input(
-                        self.config, Fore.MAGENTA + "Input:" + Style.RESET_ALL
-                    )
-                if console_input.lower().strip() == self.config.authorise_key:
-                    user_input = "GENERATE NEXT COMMAND JSON"
-
-                    # Case 1: Continuous iteration was interrupted -> resume
-                    # Case 2: The agent used up its cycle budget -> reset
-                    self.cycles_remaining = self.cycle_budget
-                    break
-                elif console_input.lower().strip() == "":
-                    logger.warn("Invalid input format.")
-                    continue
-                elif console_input.lower().startswith(f"{self.config.authorise_key} -"):
-                    try:
-                        self.reset_cycle_budget(abs(int(console_input.split(" ")[1])))
-                        user_input = "GENERATE NEXT COMMAND JSON"
-                    except ValueError:
-                        logger.warn(
-                            f"Invalid input format. "
-                            f"Please enter '{self.config.authorise_key} -N'"
-                            " where N is the number of continuous tasks."
-                        )
-                        continue
-                    break
-                elif console_input.lower() == self.config.exit_key:
-                    user_input = "EXIT"
-                    break
-                else:
-                    user_input = console_input
-                    command_name = "human_feedback"
-                    self.log_cycle_handler.log_cycle(
-                        self.ai_config.ai_name,
-                        self.created_at,
-                        self.cycle_count,
-                        user_input,
-                        USER_INPUT_FILE_NAME,
-                    )
-                    break
-
-            if user_input == "GENERATE NEXT COMMAND JSON":
-                logger.typewriter_log(
-                    "-=-=-=-=-=-=-= COMMAND AUTHORISED BY USER -=-=-=-=-=-=-=",
-                    Fore.MAGENTA,
-                    "",
-                )
-            elif user_input == "EXIT":
-                logger.info("Exiting...")
-                raise StopIteration
-        else:
-            # First log new-line so user can differentiate sections better in console
-            logger.typewriter_log("\n")
-
-            if self.cycles_remaining is not None:
-                # Print authorized commands left value
-                logger.typewriter_log(
-                    f"{Fore.CYAN}AUTHORISED COMMANDS LEFT: {Style.RESET_ALL}"
-                    f"{self.cycles_remaining}"
-                )
-
-        # Execute command
-        if command_name is not None and command_name.lower().startswith("error"):
-            result = f"Could not execute command: {arguments}"
-        elif command_name == "human_feedback":
-            result = f"Human feedback: {user_input}"
-
-            if self.cycles_remaining is not None:
-                self.cycles_remaining += 1
-        else:
-            for plugin in self.config.plugins:
-                if not plugin.can_handle_pre_command():
-                    continue
-                command_name, arguments = plugin.pre_command(command_name, arguments)
-            command_result = execute_command(
-                command_name=command_name,
-                arguments=arguments,
-                agent=self,
-            )
-            result = f"Command {command_name} returned: " f"{command_result}"
-
-            result_tlength = count_string_tokens(str(command_result), self.llm.name)
-            memory_tlength = count_string_tokens(
-                str(self.history.summary_message()), self.llm.name
-            )
-            if result_tlength + memory_tlength > self.send_token_limit:
-                result = f"Failure: command {command_name} returned too much output. \
-                    Do not execute this command again with the same arguments."
-
-            for plugin in self.config.plugins:
-                if not plugin.can_handle_post_command():
-                    continue
-                result = plugin.post_command(command_name, result)
-
-        # Check if there's a result from the command append it to the message
-        # history
-        if result is not None:
-            self.history.add("system", result, "action_result")
-            logger.typewriter_log("SYSTEM: ", Fore.YELLOW, result)
-        else:
-            self.history.add("system", "Unable to execute command", "action_result")
-            logger.typewriter_log("SYSTEM: ", Fore.YELLOW, "Unable to execute command")
+        return response
 
 
 def extract_command(

--- a/autogpt/agents/base.py
+++ b/autogpt/agents/base.py
@@ -86,7 +86,6 @@ class BaseAgent(metaclass=ABCMeta):
 
     def think(
         self,
-        prompt: ChatSequence,
         instruction: str,
     ) -> tuple[str | None, dict[str, str] | None, dict[str, Any]]:
         """Runs the agent for one cycle.
@@ -94,6 +93,8 @@ class BaseAgent(metaclass=ABCMeta):
         Params:
             instruction: The instruction to put at the end of the prompt.
         """
+        prompt = self.on_before_think(instruction)
+
         raw_response = create_chat_completion(
             prompt,
             self.config,

--- a/autogpt/agents/base.py
+++ b/autogpt/agents/base.py
@@ -101,7 +101,8 @@ class BaseAgent(metaclass=ABCMeta):
         Returns:
             The command name and arguments, if any, and the agent's thoughts.
         """
-        prompt = self.on_before_think(instruction)
+        prompt: ChatSequence = self.construct_prompt(instruction)
+        prompt = self.on_before_think(prompt, instruction)
 
         raw_response = create_chat_completion(
             prompt,
@@ -197,7 +198,7 @@ class BaseAgent(metaclass=ABCMeta):
 
         return prompt
 
-    def on_before_think(self, instruction: str) -> ChatSequence:
+    def on_before_think(self, prompt: ChatSequence, instruction: str) -> ChatSequence:
         """Called after constructing the prompt but before executing it.
 
         Calls the `on_planning` hook of any enabled and capable plugins, adding their
@@ -209,7 +210,6 @@ class BaseAgent(metaclass=ABCMeta):
         Returns:
             The prompt to execute
         """
-        prompt: ChatSequence = self.construct_prompt(instruction)
         current_tokens_used = prompt.token_length
         plugin_count = len(self.config.plugins)
         for i, plugin in enumerate(self.config.plugins):

--- a/autogpt/agents/base.py
+++ b/autogpt/agents/base.py
@@ -95,12 +95,11 @@ class BaseAgent(metaclass=ABCMeta):
     ) -> tuple[CommandName | None, CommandArgs | None, AgentThoughts]:
         """Runs the agent for one cycle.
 
-        Args:
+        Params:
             instruction: The instruction to put at the end of the prompt.
 
         Returns:
             The command name and arguments, if any, and the agent's thoughts.
-
         """
         prompt = self.on_before_think(instruction)
 
@@ -124,14 +123,13 @@ class BaseAgent(metaclass=ABCMeta):
     ) -> str:
         """Executes the given command, if any, and returns the agent's response.
 
-        Args:
+        Params:
             command_name: The name of the command to execute, if any.
             command_args: The arguments to pass to the command, if any.
             user_input: The user's input, if any.
 
         Returns:
             The results of the command.
-
         """
         ...
 
@@ -210,7 +208,6 @@ class BaseAgent(metaclass=ABCMeta):
 
         Returns:
             The prompt to execute
-
         """
         prompt: ChatSequence = self.construct_prompt(instruction)
         current_tokens_used = prompt.token_length
@@ -250,7 +247,6 @@ class BaseAgent(metaclass=ABCMeta):
 
         Returns:
             The parsed command name and command args, if any, and the agent thoughts.
-
         """
 
         # Save assistant reply to message history
@@ -289,7 +285,6 @@ class BaseAgent(metaclass=ABCMeta):
 
         Returns:
             The parsed command name and command args, if any, and the agent thoughts.
-
         """
         pass
 

--- a/autogpt/main.py
+++ b/autogpt/main.py
@@ -1,20 +1,25 @@
 """The application entry point.  Can be invoked by a CLI or any other front end application."""
 import logging
+import signal
 import sys
 from pathlib import Path
-from typing import Optional
+from types import FrameType
+from typing import Callable, Optional
 
 from colorama import Fore, Style
 
 from autogpt.agents import Agent
 from autogpt.config.config import ConfigBuilder, check_openai_api_key
 from autogpt.configurator import create_config
-from autogpt.logs import logger
+from autogpt.logs import Logger, logger, print_assistant_thoughts, remove_ansi_escape
 from autogpt.memory.vector import get_memory
 from autogpt.models.command_registry import CommandRegistry
 from autogpt.plugins import scan_plugins
 from autogpt.prompts.prompt import DEFAULT_TRIGGERING_PROMPT, construct_main_ai_config
+from autogpt.speech import say_text
+from autogpt.spinner import Spinner
 from autogpt.utils import (
+    clean_input,
     get_current_git_branch,
     get_latest_bulletin,
     get_legal_warning,
@@ -192,4 +197,161 @@ def run_auto_gpt(
         ai_config=ai_config,
         config=config,
     )
-    agent.start_interaction_loop()
+
+    #########################
+    # Application Main Loop #
+    #########################
+
+    # Set up an interrupt signal for the agent.
+    signal.signal(signal.SIGINT, graceful_agent_interrupt(agent, logger))
+
+    if config.debug_mode:
+        logger.typewriter_log(
+            f"{ai_config.ai_name} System Prompt:", Fore.GREEN, agent.system_prompt
+        )
+
+    if config.continuous_mode:
+        if config.continuous_limit:
+            cycle_budget = config.continuous_limit
+        else:
+            cycle_budget = None
+    else:
+        cycle_budget = 1
+
+    cycles_remaining = cycle_budget
+
+    while True:
+        if cycles_remaining is not None and cycles_remaining < 0:
+            break
+
+        logger.debug(f"Cycle budget: {cycle_budget}; remaining: {cycles_remaining}")
+
+        prompt = agent.on_before_think(DEFAULT_TRIGGERING_PROMPT)
+
+        with Spinner("Thinking... ", plain_output=config.plain_output):
+            command_name, command_args, assistant_reply_dict = agent.think(
+                prompt,
+                DEFAULT_TRIGGERING_PROMPT,
+            )
+
+        print_assistant_thoughts(ai_config.ai_name, assistant_reply_dict, config)
+
+        if command_name is not None:
+            if config.speak_mode:
+                say_text(f"I want to execute {command_name}", config)
+
+            # First log new-line so user can differentiate sections better in console
+            logger.typewriter_log("\n")
+            logger.typewriter_log(
+                "NEXT ACTION: ",
+                Fore.CYAN,
+                f"COMMAND = {Fore.CYAN}{remove_ansi_escape(command_name)}{Style.RESET_ALL}  "
+                f"ARGUMENTS = {Fore.CYAN}{command_args}{Style.RESET_ALL}",
+            )
+            if cycles_remaining is not None:
+                cycles_remaining -= 1
+        elif command_name.lower().startswith("error"):
+            logger.typewriter_log(
+                "ERROR: ",
+                Fore.RED,
+                f"The Agent failed to select an action. "
+                f"Error message: {command_name}",
+            )
+        else:
+            logger.typewriter_log(
+                "NO ACTION SELECTED: ",
+                Fore.RED,
+                f"The Agent failed to select an action.",
+            )
+
+        user_input = ""
+        if cycles_remaining == 0:
+            # ### GET USER AUTHORIZATION TO EXECUTE COMMAND ###
+            # Get key press: Prompt the user to press enter to continue or escape
+            # to exit
+            logger.info(
+                f"Enter '{config.authorise_key}' to authorise command, "
+                f"'{config.authorise_key} -N' to run N continuous commands, "
+                f"'{config.exit_key}' to exit program, or enter feedback for "
+                f"{ai_config.ai_name}..."
+            )
+            while not user_input:
+                # Get input from user
+                if config.chat_messages_enabled:
+                    console_input = clean_input(config, "Waiting for your response...")
+                else:
+                    console_input = clean_input(
+                        config, Fore.MAGENTA + "Input:" + Style.RESET_ALL
+                    )
+
+                # Parse user input
+                if console_input.lower().strip() == config.authorise_key:
+                    user_input = "GENERATE NEXT COMMAND JSON"
+                    # Case 1: Continuous iteration was interrupted -> resume
+                    # Case 2: The agent used up its cycle budget -> reset
+                    cycles_remaining = cycle_budget
+                elif console_input.lower().strip() == "":
+                    logger.warn("Invalid input format.")
+                elif console_input.lower().startswith(f"{config.authorise_key} -"):
+                    try:
+                        new_cycle_budget = abs(int(console_input.split(" ")[1]))
+                        cycle_budget = cycles_remaining = new_cycle_budget
+                        user_input = "GENERATE NEXT COMMAND JSON"
+                    except ValueError:
+                        logger.warn(
+                            f"Invalid input format. "
+                            f"Please enter '{config.authorise_key} -N'"
+                            " where N is the number of continuous tasks."
+                        )
+                elif console_input.lower() == config.exit_key:
+                    user_input = "EXIT"
+                else:
+                    user_input = console_input
+                    command_name = "human_feedback"
+                    if cycles_remaining is not None:
+                        cycles_remaining += 1
+
+            if user_input == "GENERATE NEXT COMMAND JSON":
+                logger.typewriter_log(
+                    "-=-=-=-=-=-=-= COMMAND AUTHORISED BY USER -=-=-=-=-=-=-=",
+                    Fore.MAGENTA,
+                    "",
+                )
+            elif user_input == "EXIT":
+                logger.info("Exiting...")
+                exit()
+        else:
+            # First log new-line so user can differentiate sections better in console
+            logger.typewriter_log("\n")
+            if cycles_remaining is not None:
+                # Print authorized commands left value
+                logger.typewriter_log(
+                    "AUTHORISED COMMANDS LEFT: ", Fore.CYAN, f"{cycles_remaining}"
+                )
+
+        result = agent.execute(command_name, command_args, user_input)
+
+        # history
+        if result is not None:
+            logger.typewriter_log("SYSTEM: ", Fore.YELLOW, result)
+        else:
+            logger.typewriter_log("SYSTEM: ", Fore.YELLOW, "Unable to execute command")
+
+
+def graceful_agent_interrupt(
+    agent: Agent,
+    logger_: Logger,
+) -> Callable[[int, Optional[FrameType]], None]:
+    """Create a signal handler to interrupt an agent executing multiple steps."""
+
+    def signal_handler(signum: int, frame: Optional[FrameType]) -> None:
+        if agent.cycle_budget == 0 or agent.cycles_remaining == 0:
+            sys.exit()
+        else:
+            logger_.typewriter_log(
+                "Interrupt signal received. Stopping continuous command execution.",
+                Fore.RED,
+            )
+            agent.cycles_remaining = 0
+
+    return signal_handler

--- a/autogpt/main.py
+++ b/autogpt/main.py
@@ -213,11 +213,11 @@ def graceful_agent_interrupt(
     This is used to allow the agent to finish its current step before exiting.
 
     Args:
-        agent (Agent): The agent to interrupt.
-        logger_ (Logger): The logger to use to print a message.
+        agent: The agent to interrupt.
+        logger_: The logger to use to print a message.
 
     Returns:
-
+        A signal handler that can be used to interrupt the agent.
 
     """
 
@@ -240,7 +240,10 @@ def run_interaction_loop(
     """Run the main interaction loop for the agent.
 
     Args:
-        agent (Agent): The agent to run the interaction loop for.
+        agent: The agent to run the interaction loop for.
+
+    Returns:
+        None
 
     """
     # These contain both application config and agent config, so grab them here.

--- a/autogpt/main.py
+++ b/autogpt/main.py
@@ -218,7 +218,6 @@ def graceful_agent_interrupt(
 
     Returns:
         A signal handler that can be used to interrupt the agent.
-
     """
 
     def signal_handler(signum: int, frame: Optional[FrameType]) -> None:
@@ -244,7 +243,6 @@ def run_interaction_loop(
 
     Returns:
         None
-
     """
     # These contain both application config and agent config, so grab them here.
     config = agent.config

--- a/autogpt/main.py
+++ b/autogpt/main.py
@@ -198,6 +198,8 @@ def run_auto_gpt(
         config=config,
     )
 
+    run_interaction_loop(agent)
+
 
 
 

--- a/benchmarks.py
+++ b/benchmarks.py
@@ -1,6 +1,6 @@
 from autogpt.agents import Agent
 from autogpt.config import AIConfig, Config, ConfigBuilder
-from autogpt.main import COMMAND_CATEGORIES
+from autogpt.main import COMMAND_CATEGORIES, run_interaction_loop
 from autogpt.memory.vector import get_memory
 from autogpt.models.command_registry import CommandRegistry
 from autogpt.prompts.prompt import DEFAULT_TRIGGERING_PROMPT
@@ -9,7 +9,7 @@ from autogpt.workspace import Workspace
 
 def run_task(task) -> None:
     agent = bootstrap_agent(task)
-    agent.start_interaction_loop()
+    run_interaction_loop(agent)
 
 
 def bootstrap_agent(task):


### PR DESCRIPTION
### Background
We have a ton of application code in the Agent (getting/parsing user input, displaying non-logging messages to the UI, running UI context managers, signal handling).  This distracts from the core operations of the Agent. This is a first pass to try to at least crudely separate application concerns from the agent logic.

### Changes
- Lift getting/parsing user input out of the agent
- Lift all calls to logger.typewriter_log (UI updates) out of the agent
- Lift user signal handling out of the agent
- Lift the Spinner UI context manager out of the agent
- Add a `run_interaction_loop` function to `main.py` that does all of the above.

#### Updates to the agent interface
Since the agent now has no method to run forever, it's step is split along boundaries where we either want to start some UI element or we want to interact with the user.

- `on_before_think` now is called directly by the main loop and returns the prompt.
- `think` consists of interacting with the language model and parsing the response, which is now returned to the main loop
- `execute` has been split out as a separate method (from inside `parse_and_process_response` which now just parses and processes the response). 
- `execute` is now invoked by the main loop 



### Documentation
This is primarily code motion, so I've not documented existing things except to add typing.

### Test Plan
CI + manual runs.

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes. <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->
- [x] I have run the following commands against my code to ensure it passes our linters:
    ```shell
    black .
    isort .
    mypy
    autoflake --remove-all-unused-imports --recursive --ignore-init-module-imports --ignore-pass-after-docstring autogpt tests --in-place
    ```

<!-- If you haven't added tests, please explain why. If you have, check the appropriate box. If you've ensured your PR is atomic and well-documented, check the corresponding boxes. -->

<!-- By submitting this, I agree that my pull request should be closed if I do not fill this out or follow the guidelines. -->
