### PR TITLE
Fixing error with plugin config

### DIFF
--- a/autogpt/config/config.py
+++ b/autogpt/config/config.py
@@ -255,7 +255,7 @@ class ConfigBuilder(Configurable[Config]):
             "redis_password": os.getenv("REDIS_PASSWORD"),
             "wipe_redis_on_start": os.getenv("WIPE_REDIS_ON_START", "True") == "True",
             "plugins_dir": os.getenv("PLUGINS_DIR"),
-            "plugins_config_file": os.getenv("PLUGINS_CONFIG_FILE"),
+            "plugins_config_file": os.getenv("PLUGINS_CONFIG_FILE", PLUGINS_CONFIG_FILE),
             "chat_messages_enabled": os.getenv("CHAT_MESSAGES_ENABLED") == "True",
         }
 


### PR DESCRIPTION
Fixing this error: "Plugin config is invalid, continuing without plugins. Error: stat: path should be a string, byte, os.PathLike or integer, not NoneType"

This error is because the first time the Config is loaded, the plugin config path is None. Setting the default to PLUGINS_CONFIG_FILE removes the error. 

This matches the approach used for AZURE_CONFIG_FILE.
