### PR TITLE
Fix configuring TTS engine

### DIFF
--- a/autogpt/config/config.py
+++ b/autogpt/config/config.py
@@ -277,16 +277,16 @@ class ConfigBuilder(Configurable[Config]):
         config_dict["elevenlabs_voice_id"] = os.getenv(
             "ELEVENLABS_VOICE_ID", os.getenv("ELEVENLABS_VOICE_1_ID")
         )
-        elevenlabs_api_key = os.getenv("ELEVENLABS_API_KEY")
-        if os.getenv("USE_MAC_OS_TTS"):
-            default_tts_provider = "macos"
-        elif elevenlabs_api_key:
-            default_tts_provider = "elevenlabs"
-        elif os.getenv("USE_BRIAN_TTS"):
-            default_tts_provider = "streamelements"
-        else:
-            default_tts_provider = "gtts"
-        config_dict["text_to_speech_provider"] = default_tts_provider
+        if not config_dict["text_to_speech_provider"]:
+            if os.getenv("USE_MAC_OS_TTS"):
+                default_tts_provider = "macos"
+            elif config_dict["elevenlabs_api_key"]:
+                default_tts_provider = "elevenlabs"
+            elif os.getenv("USE_BRIAN_TTS"):
+                default_tts_provider = "streamelements"
+            else:
+                default_tts_provider = "gtts"
+            config_dict["text_to_speech_provider"] = default_tts_provider
 
         config_dict["plugins_allowlist"] = _safe_split(os.getenv("ALLOWLISTED_PLUGINS"))
         config_dict["plugins_denylist"] = _safe_split(os.getenv("DENYLISTED_PLUGINS"))


### PR DESCRIPTION
### Background
`TEXT_TO_SPEECH_PROVIDER` is bulldozed in `ConfigBuilder.build_config_from_env()`:
* https://github.com/Significant-Gravitas/Auto-GPT/pull/4931#issuecomment-1638962278
* https://github.com/Significant-Gravitas/Auto-GPT/blob/a758acef2cf12b206d7172b47880dd876f8ad4bc/autogpt/config/config.py#L289

### Changes
* Enclose the offending piece of code in an `if not config_dict["text_to_speech_provider"]`
* Get config values from `config_dict` instead of repeatedly calling `os.getenv` for the same variable

### Documentation
x

### Test Plan
CI

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [ ] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [ ] I have not snuck in any "extra" small tweaks changes. <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->
- [x] I have run the following commands against my code to ensure it passes our linters:
    ```shell
    black .
    isort .
    mypy
    autoflake --remove-all-unused-imports --recursive --ignore-init-module-imports --ignore-pass-after-docstring autogpt tests --in-place
    ```

<!-- If you haven't added tests, please explain why. If you have, check the appropriate box. If you've ensured your PR is atomic and well-documented, check the corresponding boxes. -->

<!-- By submitting this, I agree that my pull request should be closed if I do not fill this out or follow the guidelines. -->
