### PR TITLE
runner.cli parsers set as a library

### DIFF
--- a/autogpt/core/runner/cli_app/main.py
+++ b/autogpt/core/runner/cli_app/main.py
@@ -2,8 +2,12 @@ import click
 
 from autogpt.core.agent import AgentSettings, SimpleAgent
 from autogpt.core.runner.client_lib.logging import get_client_logger
-from autogpt.core.runner.client_lib.parser import parse_agent_name_and_goals , parse_ability_result , parse_agent_plan , parse_next_ability
-
+from autogpt.core.runner.client_lib.parser import (
+    parse_ability_result,
+    parse_agent_name_and_goals,
+    parse_agent_plan,
+    parse_next_ability,
+)
 
 
 async def run_auto_gpt(user_configuration: dict):
@@ -63,4 +67,3 @@ async def run_auto_gpt(user_configuration: dict):
         )
         ability_result = await agent.execute_next_ability(user_input)
         print(parse_ability_result(ability_result))
-

--- a/autogpt/core/runner/cli_app/main.py
+++ b/autogpt/core/runner/cli_app/main.py
@@ -2,6 +2,8 @@ import click
 
 from autogpt.core.agent import AgentSettings, SimpleAgent
 from autogpt.core.runner.client_lib.logging import get_client_logger
+from autogpt.core.runner.client_lib.parser import parse_agent_name_and_goals , parse_ability_result , parse_agent_plan , parse_next_ability
+
 
 
 async def run_auto_gpt(user_configuration: dict):
@@ -62,49 +64,3 @@ async def run_auto_gpt(user_configuration: dict):
         ability_result = await agent.execute_next_ability(user_input)
         print(parse_ability_result(ability_result))
 
-
-def parse_agent_name_and_goals(name_and_goals: dict) -> str:
-    parsed_response = f"Agent Name: {name_and_goals['agent_name']}\n"
-    parsed_response += f"Agent Role: {name_and_goals['agent_role']}\n"
-    parsed_response += "Agent Goals:\n"
-    for i, goal in enumerate(name_and_goals["agent_goals"]):
-        parsed_response += f"{i+1}. {goal}\n"
-    return parsed_response
-
-
-def parse_agent_plan(plan: dict) -> str:
-    parsed_response = f"Agent Plan:\n"
-    for i, task in enumerate(plan["task_list"]):
-        parsed_response += f"{i+1}. {task['objective']}\n"
-        parsed_response += f"Task type: {task['type']}  "
-        parsed_response += f"Priority: {task['priority']}\n"
-        parsed_response += f"Ready Criteria:\n"
-        for j, criteria in enumerate(task["ready_criteria"]):
-            parsed_response += f"    {j+1}. {criteria}\n"
-        parsed_response += f"Acceptance Criteria:\n"
-        for j, criteria in enumerate(task["acceptance_criteria"]):
-            parsed_response += f"    {j+1}. {criteria}\n"
-        parsed_response += "\n"
-
-    return parsed_response
-
-
-def parse_next_ability(current_task, next_ability: dict) -> str:
-    parsed_response = f"Current Task: {current_task.objective}\n"
-    ability_args = ", ".join(
-        f"{k}={v}" for k, v in next_ability["ability_arguments"].items()
-    )
-    parsed_response += f"Next Ability: {next_ability['next_ability']}({ability_args})\n"
-    parsed_response += f"Motivation: {next_ability['motivation']}\n"
-    parsed_response += f"Self-criticism: {next_ability['self_criticism']}\n"
-    parsed_response += f"Reasoning: {next_ability['reasoning']}\n"
-    return parsed_response
-
-
-def parse_ability_result(ability_result) -> str:
-    parsed_response = f"Ability: {ability_result['ability_name']}\n"
-    parsed_response += f"Ability Arguments: {ability_result['ability_args']}\n"
-    parsed_response = f"Ability Result: {ability_result['success']}\n"
-    parsed_response += f"Message: {ability_result['message']}\n"
-    parsed_response += f"Data: {ability_result['new_knowledge']}\n"
-    return parsed_response

--- a/autogpt/core/runner/client_lib/parser.py
+++ b/autogpt/core/runner/client_lib/parser.py
@@ -1,0 +1,48 @@
+
+def parse_agent_name_and_goals(name_and_goals: dict) -> str:
+    parsed_response = f"Agent Name: {name_and_goals['agent_name']}\n"
+    parsed_response += f"Agent Role: {name_and_goals['agent_role']}\n"
+    parsed_response += "Agent Goals:\n"
+    for i, goal in enumerate(name_and_goals["agent_goals"]):
+        parsed_response += f"{i+1}. {goal}\n"
+    return parsed_response
+ 
+
+
+def parse_agent_plan(plan: dict) -> str:
+    parsed_response = f"Agent Plan:\n"
+    for i, task in enumerate(plan["task_list"]):
+        parsed_response += f"{i+1}. {task['objective']}\n"
+        parsed_response += f"Task type: {task['type']}  "
+        parsed_response += f"Priority: {task['priority']}\n"
+        parsed_response += f"Ready Criteria:\n"
+        for j, criteria in enumerate(task["ready_criteria"]):
+            parsed_response += f"    {j+1}. {criteria}\n"
+        parsed_response += f"Acceptance Criteria:\n"
+        for j, criteria in enumerate(task["acceptance_criteria"]):
+            parsed_response += f"    {j+1}. {criteria}\n"
+        parsed_response += "\n"
+
+    return parsed_response
+
+
+def parse_next_ability(current_task, next_ability: dict) -> str:
+    parsed_response = f"Current Task: {current_task.objective}\n"
+    ability_args = ", ".join(
+        f"{k}={v}" for k, v in next_ability["ability_arguments"].items()
+    ) 
+    parsed_response += f"Next Ability: {next_ability['next_ability']}({ability_args})\n"
+    parsed_response += f"Motivation: {next_ability['motivation']}\n"
+    parsed_response += f"Self-criticism: {next_ability['self_criticism']}\n"
+    parsed_response += f"Reasoning: {next_ability['reasoning']}\n"
+    return parsed_response
+
+
+def parse_ability_result(ability_result) -> str:
+    parsed_response = f"Ability: {ability_result['ability_name']}\n"
+    parsed_response += f"Ability Arguments: {ability_result['ability_args']}\n"
+    parsed_response = f"Ability Result: {ability_result['success']}\n"
+    parsed_response += f"Message: {ability_result['message']}\n"
+    parsed_response += f"Data: {ability_result['new_knowledge']}\n"
+    return parsed_response
+

--- a/autogpt/core/runner/client_lib/parser.py
+++ b/autogpt/core/runner/client_lib/parser.py
@@ -1,4 +1,3 @@
-
 def parse_agent_name_and_goals(name_and_goals: dict) -> str:
     parsed_response = f"Agent Name: {name_and_goals['agent_name']}\n"
     parsed_response += f"Agent Role: {name_and_goals['agent_role']}\n"
@@ -6,7 +5,6 @@ def parse_agent_name_and_goals(name_and_goals: dict) -> str:
     for i, goal in enumerate(name_and_goals["agent_goals"]):
         parsed_response += f"{i+1}. {goal}\n"
     return parsed_response
- 
 
 
 def parse_agent_plan(plan: dict) -> str:
@@ -30,7 +28,7 @@ def parse_next_ability(current_task, next_ability: dict) -> str:
     parsed_response = f"Current Task: {current_task.objective}\n"
     ability_args = ", ".join(
         f"{k}={v}" for k, v in next_ability["ability_arguments"].items()
-    ) 
+    )
     parsed_response += f"Next Ability: {next_ability['next_ability']}({ability_args})\n"
     parsed_response += f"Motivation: {next_ability['motivation']}\n"
     parsed_response += f"Self-criticism: {next_ability['self_criticism']}\n"
@@ -45,4 +43,3 @@ def parse_ability_result(ability_result) -> str:
     parsed_response += f"Message: {ability_result['message']}\n"
     parsed_response += f"Data: {ability_result['new_knowledge']}\n"
     return parsed_response
-


### PR DESCRIPTION
### Background

As there are plan to build a web-app , and add modularity to the code, it would be beneficial to set the parser as a library.

### Changes

Move the parser in a separate file

### Documentation



### Test Plan

Run.

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [ ] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes. <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->
- [x] I have run the following commands against my code to ensure it passes our linters:
    ```shell
    black .
    isort .
    mypy
    autoflake --remove-all-unused-imports --recursive --ignore-init-module-imports --ignore-pass-after-docstring autogpt tests --in-place
    ```

<!-- If you haven't added tests, please explain why. If you have, check the appropriate box. If you've ensured your PR is atomic and well-documented, check the corresponding boxes. -->

<!-- By submitting this, I agree that my pull request should be closed if I do not fill this out or follow the guidelines. -->
