### PR TITLE
Add config options to documentation site

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,7 @@ nav:
   - Usage: usage.md
   - Plugins: plugins.md
   - Configuration:
+    - Options: configuration/options.md
     - Search: configuration/search.md
     - Memory: configuration/memory.md
     - Voice: configuration/voice.md


### PR DESCRIPTION
### Background
We get many support requests about things that are configurable, but aren't in the docs. The options.md file that describes the .env options exists but isn't linked from mkdocs.yaml, so it doesn't show up in the online docs at agpt.co/docs

### Changes
Added options.md to mkdocs.yaml

### Documentation
This is a documentation change

### Test Plan
I ran mkdocs locally and confirmed the change.

### PR Quality Checklist
- [X] My pull request is atomic and focuses on a single change.
- [X] I have thoroughly tested my changes with multiple different prompts.
- [X] I have considered potential risks and mitigations for my changes.
- [X] I have documented my changes clearly and comprehensively.
- [X] I have not snuck in any "extra" small tweaks changes. <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->
- [X] I have run the following commands against my code to ensure it passes our linters:
    ```shell
    black .
    isort .
    mypy
    autoflake --remove-all-unused-imports --recursive --ignore-init-module-imports --ignore-pass-after-docstring autogpt tests --in-place
    ```