### PR TITLE
fix: Nonetype error from command_name.startswith()

### DIFF
--- a/autogpt/app/main.py
+++ b/autogpt/app/main.py
@@ -343,23 +343,24 @@ def update_user(
     print_assistant_thoughts(ai_config.ai_name, assistant_reply_dict, config)
 
     if command_name is not None:
-        if config.speak_mode:
-            say_text(f"I want to execute {command_name}", config)
+        if command_name.lower().startswith("error"):
+            logger.typewriter_log(
+                "ERROR: ",
+                Fore.RED,
+                f"The Agent failed to select an action. " f"Error message: {command_name}",
+            )
+        else:
+            if config.speak_mode:
+                say_text(f"I want to execute {command_name}", config)
 
-        # First log new-line so user can differentiate sections better in console
-        logger.typewriter_log("\n")
-        logger.typewriter_log(
-            "NEXT ACTION: ",
-            Fore.CYAN,
-            f"COMMAND = {Fore.CYAN}{remove_ansi_escape(command_name)}{Style.RESET_ALL}  "
-            f"ARGUMENTS = {Fore.CYAN}{command_args}{Style.RESET_ALL}",
-        )
-    elif command_name.lower().startswith("error"):
-        logger.typewriter_log(
-            "ERROR: ",
-            Fore.RED,
-            f"The Agent failed to select an action. " f"Error message: {command_name}",
-        )
+            # First log new-line so user can differentiate sections better in console
+            logger.typewriter_log("\n")
+            logger.typewriter_log(
+                "NEXT ACTION: ",
+                Fore.CYAN,
+                f"COMMAND = {Fore.CYAN}{remove_ansi_escape(command_name)}{Style.RESET_ALL}  "
+                f"ARGUMENTS = {Fore.CYAN}{command_args}{Style.RESET_ALL}",
+            )
     else:
         logger.typewriter_log(
             "NO ACTION SELECTED: ",

--- a/autogpt/app/main.py
+++ b/autogpt/app/main.py
@@ -347,7 +347,8 @@ def update_user(
             logger.typewriter_log(
                 "ERROR: ",
                 Fore.RED,
-                f"The Agent failed to select an action. " f"Error message: {command_name}",
+                f"The Agent failed to select an action. "
+                f"Error message: {command_name}",
             )
         else:
             if config.speak_mode:

--- a/tests/integration/test_update_user.py
+++ b/tests/integration/test_update_user.py
@@ -1,0 +1,27 @@
+from colorama import Fore
+import pytest
+from unittest.mock import MagicMock, patch
+
+from autogpt.app.main import update_user
+
+def test_update_user_command_name_is_none():
+    # Mock necessary objects
+    config = MagicMock()
+    ai_config = MagicMock()
+    assistant_reply_dict = MagicMock()
+
+    # Mock print_assistant_thoughts and logger.typewriter_log
+    with patch("autogpt.app.main.print_assistant_thoughts") as mock_print_assistant_thoughts, \
+         patch("autogpt.app.main.logger.typewriter_log") as mock_logger_typewriter_log:
+        # Test the update_user function with None command_name
+        update_user(config, ai_config, None, None, assistant_reply_dict)
+
+    # Check that print_assistant_thoughts was called once
+    mock_print_assistant_thoughts.assert_called_once_with(ai_config.ai_name, assistant_reply_dict, config)
+
+    # Check that logger.typewriter_log was called once with expected arguments
+    mock_logger_typewriter_log.assert_called_once_with(
+        "NO ACTION SELECTED: ",
+        Fore.RED,
+        f"The Agent failed to select an action.",
+    )

--- a/tests/integration/test_update_user.py
+++ b/tests/integration/test_update_user.py
@@ -1,23 +1,29 @@
-from colorama import Fore
-import pytest
 from unittest.mock import MagicMock, patch
+
+from colorama import Fore
 
 from autogpt.app.main import update_user
 
-def test_update_user_command_name_is_none():
+
+def test_update_user_command_name_is_none() -> None:
     # Mock necessary objects
     config = MagicMock()
     ai_config = MagicMock()
     assistant_reply_dict = MagicMock()
 
     # Mock print_assistant_thoughts and logger.typewriter_log
-    with patch("autogpt.app.main.print_assistant_thoughts") as mock_print_assistant_thoughts, \
-         patch("autogpt.app.main.logger.typewriter_log") as mock_logger_typewriter_log:
+    with patch(
+        "autogpt.app.main.print_assistant_thoughts"
+    ) as mock_print_assistant_thoughts, patch(
+        "autogpt.app.main.logger.typewriter_log"
+    ) as mock_logger_typewriter_log:
         # Test the update_user function with None command_name
         update_user(config, ai_config, None, None, assistant_reply_dict)
 
     # Check that print_assistant_thoughts was called once
-    mock_print_assistant_thoughts.assert_called_once_with(ai_config.ai_name, assistant_reply_dict, config)
+    mock_print_assistant_thoughts.assert_called_once_with(
+        ai_config.ai_name, assistant_reply_dict, config
+    )
 
     # Check that logger.typewriter_log was called once with expected arguments
     mock_logger_typewriter_log.assert_called_once_with(


### PR DESCRIPTION
### Background
`update_user()` in `app/main.py` only checks for command errors if the `command_name` is `None`, which causes a `NoneType` error.

### Changes
Refactor the logic to check for `command_name` errors within the "command_name is not None" block.

### Documentation
<!-- Explain how your changes are documented, such as in-code comments or external documentation. Ensure that the documentation is clear, concise, and easy to understand. -->

### Test Plan
Added a test to confirm

### PR Quality Checklist
- [X] My pull request is atomic and focuses on a single change.
- [X] I have thoroughly tested my changes with multiple different prompts.
- [X] I have considered potential risks and mitigations for my changes.
- [X] I have documented my changes clearly and comprehensively.
- [X] I have not snuck in any "extra" small tweaks changes. <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->
- [X] I have run the following commands against my code to ensure it passes our linters:
    ```shell
    black .
    isort .
    mypy
    autoflake --remove-all-unused-imports --recursive --ignore-init-module-imports --ignore-pass-after-docstring autogpt tests --in-place
    ```