### PR TITLE
Pass TestSearch benchmark consistently (Add browse_website SUMMARIZATION_TRIGGER_LENGTH)

### DIFF
--- a/autogpt/commands/web_selenium.py
+++ b/autogpt/commands/web_selenium.py
@@ -16,7 +16,7 @@ from selenium.webdriver.chrome.options import Options as ChromeOptions
 from selenium.webdriver.chrome.service import Service as ChromeDriverService
 from selenium.webdriver.chrome.webdriver import WebDriver as ChromeDriver
 from selenium.webdriver.common.by import By
-from selenium.webdriver.common.options import ArgOptions
+from selenium.webdriver.common.options import ArgOptions as BrowserOptions
 from selenium.webdriver.edge.options import Options as EdgeOptions
 from selenium.webdriver.edge.service import Service as EdgeDriverService
 from selenium.webdriver.edge.webdriver import WebDriver as EdgeDriver
@@ -38,8 +38,6 @@ from autogpt.logs import logger
 from autogpt.memory.vector import MemoryItem, get_memory
 from autogpt.processing.html import extract_hyperlinks, format_hyperlinks
 from autogpt.url_utils.validators import validate_url
-
-BrowserOptions = ChromeOptions | EdgeOptions | FirefoxOptions | SafariOptions
 
 FILE_DIR = Path(__file__).parent.parent
 SUMMARIZATION_TRIGGER_LENGTH = 250  # Approximately 50 tokens for GPT-4
@@ -105,14 +103,14 @@ def scrape_text_with_selenium(url: str, agent: Agent) -> tuple[WebDriver, str]:
     """
     logging.getLogger("selenium").setLevel(logging.CRITICAL)
 
-    options_available: dict[str, ArgOptions] = {
+    options_available: dict[str, BrowserOptions] = {
         "chrome": ChromeOptions,
         "edge": EdgeOptions,
         "firefox": FirefoxOptions,
         "safari": SafariOptions,
     }
 
-    options: ArgOptions = options_available[agent.config.selenium_web_browser]()
+    options: BrowserOptions = options_available[agent.config.selenium_web_browser]()
     options.add_argument(
         "user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.5615.49 Safari/537.36"
     )


### PR DESCRIPTION
### Background
TestSearch was failing half the time because of browse_website summarization.

Also, for shorter text, this PR saves us an extra LLM call, which is faster and cheaper, without degrading performance - the main LLM can pull answers from the text, just like the summarizing LLM would have.

#### Benchmarks:
1. With this fix, if --nc is used (no timeout), Auto-GPT passes all agbenchmarks (version from pypi) except r2.1, r2.2, r3 (answers are correct but precision is tricky) and d4 (it starts the web server but cannot terminate the process)

### Changes
- Added `SUMMARIZATION_TRIGGER_LENGTH = 250,` which is approximately 50 tokens (for GPT-4)
- Altered `browse_website` to only trigger summarization if the text is longer than SUMMARIZATION_TRIGGER_LENGTH.
- Fixed minor typing issues found by mypy

### Documentation
N/A

### Test Plan
- Ran existing tests
- Tested locally
- Passed benchmarks

### PR Quality Checklist
- [X] My pull request is atomic and focuses on a single change.
- [X] I have thoroughly tested my changes with multiple different prompts.
- [X] I have considered potential risks and mitigations for my changes.
- [X] I have documented my changes clearly and comprehensively.
- [X] I have not snuck in any "extra" small tweaks changes.
- [X] I have run the following commands against my code to ensure it passes our linters:
    ```shell
    black .
    isort .
    mypy
    autoflake --remove-all-unused-imports --recursive --ignore-init-module-imports --ignore-pass-after-docstring autogpt tests --in-place
    ```