### PR TITLE
needed gcc and python3-dev for the later pip install -r requirements.…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y \
 
 # Install utilities
 RUN apt-get update && apt-get install -y \
-    curl jq wget git \
+    curl jq wget git gcc python3-dev \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Set environment variables


### PR DESCRIPTION
needed gcc and python3-dev for the later pip install -r requirements