### PR TITLE
Fix elevenLabs config error

### DIFF
--- a/autogpt/speech/eleven_labs.py
+++ b/autogpt/speech/eleven_labs.py
@@ -43,10 +43,7 @@ class ElevenLabsSpeech(VoiceBase):
         self._voices = default_voices.copy()
         if config.elevenlabs_voice_id in voice_options:
             config.elevenlabs_voice_id = voice_options[config.elevenlabs_voice_id]
-        if config.elevenlabs_voice_2_id in voice_options:
-            config.elevenlabs_voice_2_id = voice_options[config.elevenlabs_voice_2_id]
         self._use_custom_voice(config.elevenlabs_voice_id, 0)
-        self._use_custom_voice(config.elevenlabs_voice_2_id, 1)
 
     def _use_custom_voice(self, voice, voice_index) -> None:
         """Use a custom voice if provided and not a placeholder


### PR DESCRIPTION
<!-- ⚠️ At the moment any non-essential commands are not being merged.
If you want to add non-essential commands to Auto-GPT, please create a plugin instead.
We are expecting to ship plugin support within the week (PR #757).
Resources:
* https://github.com/Significant-Gravitas/Auto-GPT-Plugin-Template
-->

<!-- 📢 Announcement
We've recently noticed an increase in pull requests focusing on combining multiple changes. While the intentions behind these PRs are appreciated, it's essential to maintain a clean and manageable git history. To ensure the quality of our repository, we kindly ask you to adhere to the following guidelines when submitting PRs:

Focus on a single, specific change.
Do not include any unrelated or "extra" modifications.
Provide clear documentation and explanations of the changes made.
Ensure diffs are limited to the intended lines — no applying preferred formatting styles or line endings (unless that's what the PR is about).
For guidance on committing only the specific lines you have changed, refer to this helpful video: https://youtu.be/8-hSNHHbiZg

Check out our [wiki page on Contributing](https://github.com/Significant-Gravitas/Nexus/wiki/Contributing)

By following these guidelines, your PRs are more likely to be merged quickly after testing, as long as they align with the project's overall direction. -->

### Background
<!-- Provide a concise overview of the rationale behind this change. Include relevant context, prior discussions, or links to related issues. Ensure that the change aligns with the project's overall direction. -->

Running speak mode with elevenLabs on not only stable branch but also master fails with a config error like below.
```
  File "/Users/danna/Desktop/Personal/Auto-GPT/autogpt/speech/eleven_labs.py", line 46, in _setup
    if config.elevenlabs_voice_2_id in voice_options:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'Config' object has no attribute 'elevenlabs_voice_2_id'. Did you mean: 'elevenlabs_voice_id'?
```

I just followed the guide on [docs](https://docs.agpt.co/configuration/voice/), and encountered this issue, so I think either the docs or the code should be updated.

### Changes
<!-- Describe the specific, focused change made in this pull request. Detail the modifications clearly and avoid any unrelated or "extra" changes. -->

I saw the commit history in which the `elevenlabs_voice_2_id` was deleted on .env.template, thus instead of adding it again on config.py, I decided to remove `elevenlabs_voice_2_id`-related-codes on eleven_labs.py. (I assumed eleven_labs.py is the legacy one here)
It's now all synchronized and is not running into errors anymore.

### Documentation
<!-- Explain how your changes are documented, such as in-code comments or external documentation. Ensure that the documentation is clear, concise, and easy to understand. -->

### Test Plan
<!-- Describe how you tested this functionality. Include steps to reproduce, relevant test cases, and any other pertinent information. -->

It worked fine on both my local environment and docker.

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes. <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->
- [x] I have run the following commands against my code to ensure it passes our linters:
    ```shell
    black .
    isort .
    mypy
    autoflake --remove-all-unused-imports --recursive --ignore-init-module-imports --ignore-pass-after-docstring autogpt tests --in-place
    ```

<!-- If you haven't added tests, please explain why. If you have, check the appropriate box. If you've ensured your PR is atomic and well-documented, check the corresponding boxes. -->

<!-- By submitting this, I agree that my pull request should be closed if I do not fill this out or follow the guidelines. -->
