### PR TITLE
Allow null input in StepRequestBody for Continuous Chat Mode

### DIFF
--- a/forge/autogpt/sdk/schema.py
+++ b/forge/autogpt/sdk/schema.py
@@ -116,7 +116,7 @@ class StepRequestBody(BaseModel):
     name: Optional[str] = Field(
         None, description="The name of the task step.", example="Write to file"
     )
-    input: str = Field(
+    input: Optional[str] = Field(
         None,
         min_length=1,
         description="Input prompt for the step.",


### PR DESCRIPTION
### Background

This pull request updates the StepRequestBody class to allow for a null value in the input field. The change is critical for supporting a "Continuous Chat Mode" where the absence of an input message should be allowed to automatically trigger the next step in the agent conversation.

### Changes 🏗️

Updated the `StepRequestBody` class to set the default value of `input` to `None` instead of `...`, thus allowing null values.

### PR Quality Scorecard ✨

<!--
Check out our contribution guide:
https://github.com/Significant-Gravitas/Nexus/wiki/Contributing

1. Avoid duplicate work, issues, PRs etc.
2. Also consider contributing something other than code; see the [contribution guide]
   for options.
3. Clearly explain your changes.
4. Avoid making unnecessary changes, especially if they're purely based on personal
   preferences. Doing so is the maintainers' job. ;-)
-->

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [x] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [ ] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [ ] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of Auto-GPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`
