### PR TITLE
Fix docs: sample docker-compose.yml broken indents

### DIFF
--- a/docs/content/setup.md
+++ b/docs/content/setup.md
@@ -46,24 +46,24 @@ Get your OpenAI API key from: [https://platform.openai.com/account/api-keys](htt
     ```yaml
     version: "3.9"
     services:
-        auto-gpt:
+      auto-gpt:
         image: significantgravitas/auto-gpt
         env_file:
-            - .env
+          - .env
         profiles: ["exclude-from-up"]
         volumes:
-            - ./auto_gpt_workspace:/app/auto_gpt_workspace
-            - ./data:/app/data
-            ## allow auto-gpt to write logs to disk
-            - ./logs:/app/logs
-            ## uncomment following lines if you want to make use of these files
-            ## you must have them existing in the same folder as this docker-compose.yml
-            #- type: bind
-            #  source: ./azure.yaml
-            #  target: /app/azure.yaml
-            #- type: bind
-            #  source: ./ai_settings.yaml
-            #  target: /app/ai_settings.yaml
+          - ./auto_gpt_workspace:/app/auto_gpt_workspace
+          - ./data:/app/data
+          ## allow auto-gpt to write logs to disk
+          - ./logs:/app/logs
+          ## uncomment following lines if you want to make use of these files
+          ## you must have them existing in the same folder as this docker-compose.yml
+          #- type: bind
+          #  source: ./azure.yaml
+          #  target: /app/azure.yaml
+          #- type: bind
+          #  source: ./ai_settings.yaml
+          #  target: /app/ai_settings.yaml
     ```
 
 4. Create the necessary [configuration](#configuration) files. If needed, you can find


### PR DESCRIPTION
auto-gpt keys were mis-nested under auto-gpt section of the docker-compose.yml after modern material improvements in 7cd407b7b4a9f4395761e772335e859e40e8c3d3 part of PR #5035.