### PR TITLE
Adding Space After Colon in Console Input Prompt

### DIFF
--- a/autogpts/autogpt/autogpt/app/main.py
+++ b/autogpts/autogpt/autogpt/app/main.py
@@ -416,7 +416,7 @@ def get_user_feedback(
             console_input = clean_input(config, "Waiting for your response...")
         else:
             console_input = clean_input(
-                config, Fore.MAGENTA + "Input:" + Style.RESET_ALL
+                config, Fore.MAGENTA + "Input: " + Style.RESET_ALL
             )
 
         # Parse user input


### PR DESCRIPTION
### Background

This PR was created to introduce a small change in the console input formatting line to improve readability. It adds a space following the colon in console input prompt, enhancing its visual appearance and ease of input.

### Changes 🏗️

- Added a space after "Input:" in the console input line.

### PR Quality Scorecard ✨

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [x] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [ ] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [x] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of Auto-GPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts` 

Given the atomic nature of this PR, it does not address a GitHub issue, add/change a feature, or alter the behavior of Auto-GPT hence, no score in these areas. The change was small and strictly focusing on improvement in console prompt readability.