### PR TITLE
Add Early Termination to runBenchmark on Benchmark Failure

### DIFF
--- a/frontend/lib/viewmodels/skill_tree_viewmodel.dart
+++ b/frontend/lib/viewmodels/skill_tree_viewmodel.dart
@@ -202,6 +202,13 @@ class SkillTreeViewModel extends ChangeNotifier {
           (element) => element.keys.first.id == node.id,
         );
         nodeStatus[node] = successStatus;
+
+        // If successStatus is false, break out of the loop
+        if (!successStatus) {
+          print(
+              "Benchmark for node ${node.id} failed. Stopping all benchmarks.");
+          break;
+        }
       }
     } catch (e) {
       print("Error while running benchmark: $e");


### PR DESCRIPTION
### Background
The `runBenchmark` method in `SkillTreeViewModel` currently iterates through all the nodes in the skill tree to run benchmarks. However, it lacks a mechanism to halt the entire benchmarking process if a particular node's benchmark fails.

### Changes
- Added a conditional statement in the `runBenchmark` method to check the `successStatus` of each node's benchmark.
- If `successStatus` is false, the benchmarking process will terminate early, and a message will be printed to the console indicating which node caused the termination.

This change enhances the efficiency of the benchmarking process and provides immediate feedback when a benchmark fails.

### PR Quality Scorecard ✨

<!--
Check out our contribution guide:
https://github.com/Significant-Gravitas/Nexus/wiki/Contributing

1. Avoid duplicate work, issues, PRs etc.
2. Also consider contributing something other than code; see the [contribution guide]
   for options.
3. Clearly explain your changes.
4. Avoid making unnecessary changes, especially if they're purely based on personal
   preferences. Doing so is the maintainers' job. ;-)
-->

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [ ] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [ ] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [ ] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of Auto-GPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`
