### PR TITLE
Enhance runBenchmark with TestSuite Tracking

### DIFF
--- a/frontend/lib/viewmodels/skill_tree_viewmodel.dart
+++ b/frontend/lib/viewmodels/skill_tree_viewmodel.dart
@@ -5,8 +5,10 @@ import 'package:auto_gpt_flutter_client/models/skill_tree/skill_tree_edge.dart';
 import 'package:auto_gpt_flutter_client/models/skill_tree/skill_tree_node.dart';
 import 'package:auto_gpt_flutter_client/models/step.dart';
 import 'package:auto_gpt_flutter_client/models/task.dart';
+import 'package:auto_gpt_flutter_client/models/test_suite.dart';
 import 'package:auto_gpt_flutter_client/services/benchmark_service.dart';
 import 'package:auto_gpt_flutter_client/viewmodels/chat_viewmodel.dart';
+import 'package:auto_gpt_flutter_client/viewmodels/task_viewmodel.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
@@ -139,10 +141,14 @@ class SkillTreeViewModel extends ChangeNotifier {
   }
 
   // TODO: Move to task queue view model
-  // TODO: We should be creating TestSuite objects
-  Future<void> runBenchmark(ChatViewModel chatViewModel) async {
+  Future<void> runBenchmark(
+      ChatViewModel chatViewModel, TaskViewModel taskViewModel) async {
     // Clear the benchmarkStatusList
     benchmarkStatusList.clear();
+
+    // Create a new TestSuite object with the current timestamp
+    final testSuite =
+        TestSuite(timestamp: DateTime.now().toIso8601String(), tests: []);
 
     // Set the benchmark running flag to true
     isBenchmarkRunning = true;
@@ -209,7 +215,11 @@ class SkillTreeViewModel extends ChangeNotifier {
               "Benchmark for node ${node.id} failed. Stopping all benchmarks.");
           break;
         }
+        testSuite.tests.add(task);
       }
+
+      // Add the TestSuite to the TaskViewModel
+      taskViewModel.addTestSuite(testSuite);
     } catch (e) {
       print("Error while running benchmark: $e");
     }

--- a/frontend/lib/views/task_queue/task_queue_view.dart
+++ b/frontend/lib/views/task_queue/task_queue_view.dart
@@ -1,4 +1,5 @@
 import 'package:auto_gpt_flutter_client/viewmodels/chat_viewmodel.dart';
+import 'package:auto_gpt_flutter_client/viewmodels/task_viewmodel.dart';
 import 'package:flutter/material.dart';
 import 'package:auto_gpt_flutter_client/viewmodels/skill_tree_viewmodel.dart';
 import 'package:provider/provider.dart';
@@ -56,12 +57,14 @@ class TaskQueueView extends StatelessWidget {
                 onPressed: viewModel.isBenchmarkRunning
                     ? null
                     : () {
-                        // TODO: Handle this better
+                        // TODO: We should not be passing this dependency in like this
                         final chatViewModel =
                             Provider.of<ChatViewModel>(context, listen: false);
+                        final taskViewModel =
+                            Provider.of<TaskViewModel>(context, listen: false);
                         chatViewModel.clearCurrentTaskAndChats();
                         // Call runBenchmark method from SkillTreeViewModel
-                        viewModel.runBenchmark(chatViewModel);
+                        viewModel.runBenchmark(chatViewModel, taskViewModel);
                       },
                 child: Row(
                   mainAxisAlignment:


### PR DESCRIPTION
### Background
The `runBenchmark` method in `SkillTreeViewModel` runs benchmarks for various skill tree nodes. To better track and manage these benchmarks, it's beneficial to group them into test suites, especially when multiple benchmarks are run in succession.

### Changes
- At the start of the `runBenchmark` method, a new `TestSuite` object is created with the current timestamp.
- Each new `Task` object created during the benchmarking process is added to the `TestSuite`.
- Once the benchmarking process completes, the `TestSuite` object is added to the `TaskViewModel` using its `addTestSuite` method.

This enhancement provides a structured way to group benchmarks and facilitates better tracking and reporting of benchmark runs.

### PR Quality Scorecard ✨

<!--
Check out our contribution guide:
https://github.com/Significant-Gravitas/Nexus/wiki/Contributing

1. Avoid duplicate work, issues, PRs etc.
2. Also consider contributing something other than code; see the [contribution guide]
   for options.
3. Clearly explain your changes.
4. Avoid making unnecessary changes, especially if they're purely based on personal
   preferences. Doing so is the maintainers' job. ;-)
-->

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [ ] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [ ] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [ ] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of Auto-GPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`
