### PR TITLE
Refactor SkillTreeViewModel and Update TaskQueueView UI for Task Status

### DIFF
--- a/frontend/lib/models/benchmark/benchmark_task_status.dart
+++ b/frontend/lib/models/benchmark/benchmark_task_status.dart
@@ -1,0 +1,6 @@
+enum BenchmarkTaskStatus {
+  notStarted,
+  inProgress,
+  success,
+  failure,
+}

--- a/frontend/lib/viewmodels/skill_tree_viewmodel.dart
+++ b/frontend/lib/viewmodels/skill_tree_viewmodel.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'package:auto_gpt_flutter_client/models/benchmark/benchmark_step_request_body.dart';
 import 'package:auto_gpt_flutter_client/models/benchmark/benchmark_task_request_body.dart';
+import 'package:auto_gpt_flutter_client/models/benchmark/benchmark_task_status.dart';
 import 'package:auto_gpt_flutter_client/models/skill_tree/skill_tree_edge.dart';
 import 'package:auto_gpt_flutter_client/models/skill_tree/skill_tree_node.dart';
 import 'package:auto_gpt_flutter_client/models/step.dart';
@@ -20,7 +21,7 @@ class SkillTreeViewModel extends ChangeNotifier {
   // TODO: Potentially move to task queue view model when we create one
   bool isBenchmarkRunning = false;
   // TODO: Potentially move to task queue view model when we create one
-  List<Map<SkillTreeNode, bool>> benchmarkStatusList = [];
+  Map<SkillTreeNode, BenchmarkTaskStatus> benchmarkStatusMap = {};
 
   List<SkillTreeNode> _skillTreeNodes = [];
   List<SkillTreeEdge> _skillTreeEdges = [];
@@ -144,7 +145,7 @@ class SkillTreeViewModel extends ChangeNotifier {
   Future<void> runBenchmark(
       ChatViewModel chatViewModel, TaskViewModel taskViewModel) async {
     // Clear the benchmarkStatusList
-    benchmarkStatusList.clear();
+    benchmarkStatusMap.clear();
 
     // Create a new TestSuite object with the current timestamp
     final testSuite =
@@ -159,12 +160,14 @@ class SkillTreeViewModel extends ChangeNotifier {
     final reversedSelectedNodeHierarchy =
         List.from(_selectedNodeHierarchy!.reversed);
     for (var node in reversedSelectedNodeHierarchy) {
-      benchmarkStatusList.add({node: false});
+      benchmarkStatusMap[node] = BenchmarkTaskStatus.notStarted;
     }
 
     try {
       // Loop through the nodes in the hierarchy
       for (var node in reversedSelectedNodeHierarchy) {
+        benchmarkStatusMap[node] = BenchmarkTaskStatus.inProgress;
+
         // Create a BenchmarkTaskRequestBody
         final benchmarkTaskRequestBody = BenchmarkTaskRequestBody(
             input: node.data.task, evalId: node.data.evalId);
@@ -204,10 +207,9 @@ class SkillTreeViewModel extends ChangeNotifier {
 
         // Update the benchmarkStatusList based on the evaluation response
         bool successStatus = evaluationResponse['metrics']['success'];
-        var nodeStatus = benchmarkStatusList.firstWhere(
-          (element) => element.keys.first.id == node.id,
-        );
-        nodeStatus[node] = successStatus;
+        benchmarkStatusMap[node] = successStatus
+            ? BenchmarkTaskStatus.success
+            : BenchmarkTaskStatus.failure;
 
         // If successStatus is false, break out of the loop
         if (!successStatus) {

--- a/frontend/lib/views/task_queue/task_queue_view.dart
+++ b/frontend/lib/views/task_queue/task_queue_view.dart
@@ -1,3 +1,4 @@
+import 'package:auto_gpt_flutter_client/models/benchmark/benchmark_task_status.dart';
 import 'package:auto_gpt_flutter_client/viewmodels/chat_viewmodel.dart';
 import 'package:auto_gpt_flutter_client/viewmodels/task_viewmodel.dart';
 import 'package:flutter/material.dart';
@@ -14,10 +15,6 @@ class TaskQueueView extends StatelessWidget {
     final reversedHierarchy =
         viewModel.selectedNodeHierarchy?.reversed.toList() ?? [];
 
-    // Convert reversedHierarchy to a list of test names
-    final List<String> testNames =
-        reversedHierarchy.map((node) => node.data.name).toList();
-
     return Material(
       color: Colors.white,
       child: Stack(
@@ -27,15 +24,61 @@ class TaskQueueView extends StatelessWidget {
             itemCount: reversedHierarchy.length,
             itemBuilder: (context, index) {
               final node = reversedHierarchy[index];
+
+              // Choose the appropriate leading widget based on the task status
+              Widget leadingWidget;
+              switch (viewModel.benchmarkStatusMap[node]) {
+                case null:
+                case BenchmarkTaskStatus.notStarted:
+                  leadingWidget = CircleAvatar(
+                    radius: 12,
+                    backgroundColor: Colors.grey,
+                    child: CircleAvatar(
+                      radius: 6,
+                      backgroundColor: Colors.white,
+                    ),
+                  );
+                  break;
+                case BenchmarkTaskStatus.inProgress:
+                  leadingWidget = SizedBox(
+                    width: 24,
+                    height: 24,
+                    child: CircularProgressIndicator(
+                      strokeWidth: 2,
+                    ),
+                  );
+                  break;
+                case BenchmarkTaskStatus.success:
+                  leadingWidget = CircleAvatar(
+                    radius: 12,
+                    backgroundColor: Colors.green,
+                    child: CircleAvatar(
+                      radius: 6,
+                      backgroundColor: Colors.white,
+                    ),
+                  );
+                  break;
+                case BenchmarkTaskStatus.failure:
+                  leadingWidget = CircleAvatar(
+                    radius: 12,
+                    backgroundColor: Colors.red,
+                    child: CircleAvatar(
+                      radius: 6,
+                      backgroundColor: Colors.white,
+                    ),
+                  );
+                  break;
+              }
+
               return Container(
                 margin: EdgeInsets.fromLTRB(20, 5, 20, 5),
                 decoration: BoxDecoration(
-                  color: Colors.white, // white background
-                  border: Border.all(
-                      color: Colors.black, width: 1), // thin black border
-                  borderRadius: BorderRadius.circular(4), // small corner radius
+                  color: Colors.white,
+                  border: Border.all(color: Colors.black, width: 1),
+                  borderRadius: BorderRadius.circular(4),
                 ),
                 child: ListTile(
+                  leading: leadingWidget,
                   title: Center(child: Text('${node.label}')),
                   subtitle:
                       Center(child: Text('${node.data.info.description}')),


### PR DESCRIPTION
### Background
This PR aims to enhance the UI and backend logic for the task queue within the SkillTree. It introduces a new enum for task status and replaces `BenchmarkStatusList` with `BenchmarkStatusMap` for better efficiency and readability. Additionally, the UI now reflects the status of each task in real-time using leading widgets.

### Changes

1. **Introduced BenchmarkTaskStatus Enum**:  
  - Added a new enum `BenchmarkTaskStatus` with four states: `notStarted`, `inProgress`, `success`, and `failure`.

2. **Refactored BenchmarkStatusList to BenchmarkStatusMap in SkillTreeViewModel**:  
  - Replaced `benchmarkStatusList` with a more efficient `benchmarkStatusMap`, allowing for quick lookups and updates for each node's status.

3. **Updated TaskQueueView UI**:  
  - Added a leading widget next to each task in the `TaskQueueView`. This widget indicates the current status of the task (`notStarted`, `inProgress`, `success`, `failure`).

4. **Handled Null and Not Started as Same Case**:  
  - The leading widget accommodates `null` values, treating them as `notStarted`.

5. **Other Minor Improvements**:  
  - Adjusted the size and appearance of the leading widget and loading indicator for better user experience.

<!--
Check out our contribution guide:
https://github.com/Significant-Gravitas/Nexus/wiki/Contributing

1. Avoid duplicate work, issues, PRs etc.
2. Also consider contributing something other than code; see the [contribution guide]
   for options.
3. Clearly explain your changes.
4. Avoid making unnecessary changes, especially if they're purely based on personal
   preferences. Doing so is the maintainers' job. ;-)
-->

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [ ] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [ ] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [ ] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of Auto-GPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`
