### PR TITLE
feat(backend): setup logging utilities

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -139,6 +139,15 @@ repos:
         types: [file, python]
         language: system
 
+  - repo: local
+    hooks:
+      - id: check-loggers
+        name: Check for plain loggers
+        entry: poetry -C autogpt_platform/backend run python check_logging.py
+        files: ^autogpt_platform/backend/backend/
+        language: system
+        pass_filenames: false
+
   - repo: https://github.com/psf/black
     rev: 24.10.0
     # Black has sensible defaults, doesn't need package context, and ignores

--- a/autogpt_platform/README.md
+++ b/autogpt_platform/README.md
@@ -115,6 +115,17 @@ Here are some common scenarios where you might use multiple Docker Compose comma
 
 These scenarios demonstrate how to use Docker Compose commands in combination to manage your AutoGPT Platform effectively.
 
+### Logging
+The backend configures logging by calling `configure_logging()` at startup.
+Logs use the format:
+
+```
+YYYY-MM-DD HH:MM:SS LEVEL [PREFIX] message {"json_fields": {...}}
+```
+
+When creating loggers for user-facing modules, wrap them with
+`TruncatedLogger(logging.getLogger(__name__), "[Component]")` to truncate long
+messages and include optional metadata.
 
 ### Persisting Data
 

--- a/autogpt_platform/backend/backend/app.py
+++ b/autogpt_platform/backend/backend/app.py
@@ -4,7 +4,9 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from backend.util.process import AppProcess
 
-logger = logging.getLogger(__name__)
+from backend.util.logging import TruncatedLogger, configure_logging
+
+logger = TruncatedLogger(logging.getLogger(__name__), "[App]")
 
 
 def run_processes(*processes: "AppProcess", **kwargs):
@@ -31,6 +33,7 @@ def main(**kwargs):
     """
     Run all the processes required for the AutoGPT-server (REST and WebSocket APIs).
     """
+    configure_logging()
 
     from backend.executor import DatabaseManager, ExecutionManager, Scheduler
     from backend.notifications import NotificationManager

--- a/autogpt_platform/backend/backend/exec.py
+++ b/autogpt_platform/backend/backend/exec.py
@@ -1,11 +1,13 @@
 from backend.app import run_processes
 from backend.executor import ExecutionManager
+from backend.util.logging import configure_logging
 
 
 def main():
     """
     Run all the processes required for the AutoGPT-server REST API.
     """
+    configure_logging()
     run_processes(ExecutionManager())
 
 

--- a/autogpt_platform/backend/backend/rest.py
+++ b/autogpt_platform/backend/backend/rest.py
@@ -2,12 +2,14 @@ from backend.app import run_processes
 from backend.executor import DatabaseManager
 from backend.notifications.notifications import NotificationManager
 from backend.server.rest_api import AgentServer
+from backend.util.logging import configure_logging
 
 
 def main():
     """
     Run all the processes required for the AutoGPT-server REST API.
     """
+    configure_logging()
     run_processes(
         NotificationManager(),
         DatabaseManager(),

--- a/autogpt_platform/backend/backend/scheduler.py
+++ b/autogpt_platform/backend/backend/scheduler.py
@@ -1,11 +1,13 @@
 from backend.app import run_processes
 from backend.executor.scheduler import Scheduler
+from backend.util.logging import configure_logging
 
 
 def main():
     """
     Run all the processes required for the AutoGPT-server Scheduling System.
     """
+    configure_logging()
     run_processes(Scheduler())
 
 

--- a/autogpt_platform/backend/backend/ws.py
+++ b/autogpt_platform/backend/backend/ws.py
@@ -1,11 +1,13 @@
 from backend.app import run_processes
 from backend.server.ws_api import WebsocketServer
+from backend.util.logging import configure_logging
 
 
 def main():
     """
     Run all the processes required for the AutoGPT-server WebSocket API.
     """
+    configure_logging()
     run_processes(WebsocketServer())
 
 

--- a/autogpt_platform/backend/check_logging.py
+++ b/autogpt_platform/backend/check_logging.py
@@ -1,0 +1,17 @@
+import pathlib
+import re
+
+PATTERN = re.compile(r"logging\.getLogger\(")
+ROOT = pathlib.Path(__file__).resolve().parent / "backend"
+
+errors = []
+
+for path in ROOT.rglob("*.py"):
+    if path.name == "logging.py":
+        continue
+    text = path.read_text()
+    if PATTERN.search(text) and "TruncatedLogger" not in text:
+        errors.append(str(path.relative_to(ROOT)))
+
+if errors:
+    print("Plain logging.getLogger usage detected in:\n" + "\n".join(errors))

--- a/autogpt_platform/backend/linter.py
+++ b/autogpt_platform/backend/linter.py
@@ -30,6 +30,7 @@ def lint():
         ["ruff", "format", "--diff", "--check", LIBS_DIR],
         ["isort", "--diff", "--check", "--profile", "black", BACKEND_DIR],
         ["black", "--diff", "--check", BACKEND_DIR],
+        ["python", "check_logging.py"],
         ["pyright", *TARGET_DIRS],
     ]
     lint_error = None


### PR DESCRIPTION
## Summary
- initialize backend logging in entry point scripts
- document log format and logger usage
- add pre-commit hook to warn on plain logger instantiation

## Testing
- `poetry -C autogpt_platform/backend run format`
- `poetry -C autogpt_platform/backend run lint`
- `poetry -C autogpt_platform/backend run test` *(fails: Error 111 connecting to localhost:6379)*