### PR TITLE
fix(platform): load env vars in docker compose

### DIFF
--- a/autogpt_platform/db/docker/docker-compose.yml
+++ b/autogpt_platform/db/docker/docker-compose.yml
@@ -7,10 +7,15 @@
 
 name: supabase
 
+x-envfile: &env_file
+  env_file:
+    - .env
+
 services:
 
   studio:
     container_name: supabase-studio
+    <<: *env_file
     image: supabase/studio:20250224-d10db0f
     restart: unless-stopped
     healthcheck:
@@ -51,6 +56,7 @@ services:
 
   kong:
     container_name: supabase-kong
+    <<: *env_file
     image: kong:2.8.1
     restart: unless-stopped
     ports:
@@ -79,6 +85,7 @@ services:
 
   auth:
     container_name: supabase-auth
+    <<: *env_file
     image: supabase/gotrue:v2.170.0
     restart: unless-stopped
     healthcheck:
@@ -162,6 +169,7 @@ services:
 
   rest:
     container_name: supabase-rest
+    <<: *env_file
     image: postgrest/postgrest:v12.2.8
     restart: unless-stopped
     depends_on:
@@ -186,6 +194,7 @@ services:
   realtime:
     # This container name looks inconsistent but is correct because realtime constructs tenant id by parsing the subdomain
     container_name: realtime-dev.supabase-realtime
+    <<: *env_file
     image: supabase/realtime:v2.34.40
     restart: unless-stopped
     depends_on:
@@ -231,6 +240,7 @@ services:
   # To use S3 backed storage: docker compose -f docker-compose.yml -f docker-compose.s3.yml up
   storage:
     container_name: supabase-storage
+    <<: *env_file
     image: supabase/storage-api:v1.19.3
     restart: unless-stopped
     volumes:
@@ -274,6 +284,7 @@ services:
 
   imgproxy:
     container_name: supabase-imgproxy
+    <<: *env_file
     image: darthsim/imgproxy:v3.8.0
     restart: unless-stopped
     volumes:
@@ -296,6 +307,7 @@ services:
 
   meta:
     container_name: supabase-meta
+    <<: *env_file
     image: supabase/postgres-meta:v0.86.1
     restart: unless-stopped
     depends_on:
@@ -314,6 +326,7 @@ services:
 
   functions:
     container_name: supabase-edge-functions
+    <<: *env_file
     image: supabase/edge-runtime:v1.67.2
     restart: unless-stopped
     volumes:
@@ -338,6 +351,7 @@ services:
 
   analytics:
     container_name: supabase-analytics
+    <<: *env_file
     image: supabase/logflare:1.12.5
     restart: unless-stopped
     ports:
@@ -386,6 +400,7 @@ services:
   # Comment out everything below this point if you are using an external Postgres database
   db:
     container_name: supabase-db
+    <<: *env_file
     image: supabase/postgres:15.8.1.049
     restart: unless-stopped
     volumes:
@@ -443,6 +458,7 @@ services:
 
   vector:
     container_name: supabase-vector
+    <<: *env_file
     image: timberio/vector:0.28.1-alpine
     restart: unless-stopped
     volumes:
@@ -472,6 +488,7 @@ services:
   # Update the DATABASE_URL if you are using an external Postgres database
   supavisor:
     container_name: supabase-pooler
+    <<: *env_file
     image: supabase/supavisor:2.4.12
     restart: unless-stopped
     ports:


### PR DESCRIPTION
## Summary
- DRY `.env` reference in Supabase docker-compose using YAML anchor

## Testing
- `poetry run format`
- `poetry run test` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'docker')*
- `yarn format`
- `yarn test` *(fails: Failed to fetch `Poppins` from Google Fonts)*