### PR TITLE
ci: Adds a GitHub Actions workflow to handle PR deployments based on comments and PR state

### DIFF
--- a/.github/workflows/platform-dev-deploy-event-dispatcher.yml
+++ b/.github/workflows/platform-dev-deploy-event-dispatcher.yml
@@ -1,0 +1,198 @@
+name: AutoGPT Platform - Dev Deploy PR Event Dispatcher
+
+on:
+  pull_request:
+    types: [closed]
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check comment permissions and deployment status
+        id: check_status
+        if: github.event_name == 'issue_comment' && github.event.issue.pull_request
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const commentBody = context.payload.comment.body.trim();
+            const commentUser = context.payload.comment.user.login;
+            const prAuthor = context.payload.issue.user.login;
+            const authorAssociation = context.payload.comment.author_association;
+            
+            // Check permissions
+            const hasPermission = (
+              authorAssociation === 'OWNER' ||
+              authorAssociation === 'MEMBER' ||
+              authorAssociation === 'COLLABORATOR'
+            );
+            
+            core.setOutput('comment_body', commentBody);
+            core.setOutput('has_permission', hasPermission);
+            
+            if (!hasPermission && (commentBody === '!deploy' || commentBody === '!undeploy')) {
+              core.setOutput('permission_denied', 'true');
+              return;
+            }
+            
+            if (commentBody !== '!deploy' && commentBody !== '!undeploy') {
+              return;
+            }
+            
+            // Process deploy command
+            if (commentBody === '!deploy') {
+              core.setOutput('should_deploy', 'true');
+            }
+            // Process undeploy command
+            else if (commentBody === '!undeploy') {
+              core.setOutput('should_undeploy', 'true');
+            }
+
+      - name: Post permission denied comment
+        if: steps.check_status.outputs.permission_denied == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `❌ **Permission denied**: Only the repository owners, members, or collaborators can use deployment commands.`
+            });
+
+      - name: Get PR details for deployment
+        id: pr_details
+        if: steps.check_status.outputs.should_deploy == 'true' || steps.check_status.outputs.should_undeploy == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+            core.setOutput('pr_number', pr.data.number);
+            core.setOutput('pr_title', pr.data.title);
+            core.setOutput('pr_state', pr.data.state);
+          
+      - name: Dispatch Deploy Event
+        if: steps.check_status.outputs.should_deploy == 'true'
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.DISPATCH_TOKEN }}
+          repository: Significant-Gravitas/AutoGPT_cloud_infrastructure
+          event-type: pr-event
+          client-payload: |
+            {
+              "action": "deploy",
+              "pr_number": "${{ steps.pr_details.outputs.pr_number }}",
+              "pr_title": "${{ steps.pr_details.outputs.pr_title }}",
+              "pr_state": "${{ steps.pr_details.outputs.pr_state }}",
+              "repo": "${{ github.repository }}"
+            }
+
+      - name: Post deploy success comment
+        if: steps.check_status.outputs.should_deploy == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `🚀 **Deploying PR #${{ steps.pr_details.outputs.pr_number }}** to development environment...`
+            });
+
+      - name: Dispatch Undeploy Event (from comment)
+        if: steps.check_status.outputs.should_undeploy == 'true'
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.DISPATCH_TOKEN }}
+          repository: Significant-Gravitas/AutoGPT_cloud_infrastructure
+          event-type: pr-event
+          client-payload: |
+            {
+              "action": "undeploy",
+              "pr_number": "${{ steps.pr_details.outputs.pr_number }}",
+              "pr_title": "${{ steps.pr_details.outputs.pr_title }}",
+              "pr_state": "${{ steps.pr_details.outputs.pr_state }}",
+              "repo": "${{ github.repository }}"
+            }
+
+      - name: Post undeploy success comment
+        if: steps.check_status.outputs.should_undeploy == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `🗑️ **Undeploying PR #${{ steps.pr_details.outputs.pr_number }}** from development environment...`
+            });
+
+      - name: Check deployment status on PR close
+        id: check_pr_close
+        if: github.event_name == 'pull_request' && github.event.action == 'closed'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number
+            });
+            
+            let lastDeployIndex = -1;
+            let lastUndeployIndex = -1;
+            
+            comments.data.forEach((comment, index) => {
+              if (comment.body.trim() === '!deploy') {
+                lastDeployIndex = index;
+              } else if (comment.body.trim() === '!undeploy') {
+                lastUndeployIndex = index;
+              }
+            });
+            
+            // Should undeploy if there's a !deploy without a subsequent !undeploy
+            const shouldUndeploy = lastDeployIndex !== -1 && lastDeployIndex > lastUndeployIndex;
+            core.setOutput('should_undeploy', shouldUndeploy);
+            
+      - name: Dispatch Undeploy Event (PR closed with active deployment)
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.event.action == 'closed' &&
+          steps.check_pr_close.outputs.should_undeploy == 'true'
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.DISPATCH_TOKEN }}
+          repository: Significant-Gravitas/AutoGPT_cloud_infrastructure
+          event-type: pr-event
+          client-payload: |
+            {
+              "action": "undeploy",
+              "pr_number": "${{ github.event.pull_request.number }}",
+              "pr_title": "${{ github.event.pull_request.title }}",
+              "pr_state": "${{ github.event.pull_request.state }}",
+              "repo": "${{ github.repository }}"
+            }
+
+      - name: Post PR close undeploy comment
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.event.action == 'closed' &&
+          steps.check_pr_close.outputs.should_undeploy == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `🧹 **Auto-undeploying**: PR closed with active deployment. Cleaning up development environment for PR #${{ github.event.pull_request.number }}.`
+            });


### PR DESCRIPTION
This hotfix adds a GitHub Actions workflow to automate deployment and undeployment of platform PRs to the development environment through repository dispatch events.

### Changes 🏗️

- **Added new GitHub Actions workflow**: `.github/workflows/platform-dev-deploy-event-dispatcher.yml`
  - Handles `\!deploy` and `\!undeploy` comment commands on PRs
  - Implements permission checks (only owners, members, and collaborators can deploy)
  - Automatically undeploys when PRs are closed with active deployments
  - Dispatches events to the cloud infrastructure repository for actual deployment/undeployment
  - Provides user feedback through GitHub comments

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Verify workflow triggers on PR comment creation
  - [x] Test permission validation for unauthorized users
  - [x] Confirm `\!deploy` command dispatches correct event payload
  - [x] Confirm `\!undeploy` command dispatches correct event payload  
  - [x] Test auto-undeploy on PR closure with active deployment
  - [x] Verify appropriate GitHub comments are posted for each action

#### For configuration changes:
- [x] `.env.example` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes
- [x] I have included a list of my configuration changes in the PR description (under **Changes**)

**Configuration changes:**
- Requires `DISPATCH_TOKEN` secret to be configured for repository dispatch to cloud infrastructure repo
- Workflow uses `issues: write` and `pull-requests: write` permissions
