### PR TITLE
fix(frontend/builder): Fix agent block input value key

### DIFF
--- a/autogpt_platform/frontend/src/components/CustomNode.tsx
+++ b/autogpt_platform/frontend/src/components/CustomNode.tsx
@@ -268,7 +268,7 @@ export const CustomNode = React.memo(
 
         default:
           const getInputPropKey = (key: string) =>
-            nodeType == BlockUIType.AGENT ? `data.${key}` : key;
+            nodeType == BlockUIType.AGENT ? `inputs.${key}` : key;
 
           return keys.map(([propKey, propSchema]) => {
             const isRequired = data.inputSchema.required?.includes(propKey);


### PR DESCRIPTION
- Follow-up fix to #9862
- Resolves #10097

In #9862, the `AgentExecutorBlock`'s nested input field was renamed from `data` to `input`, but apparently the frontend also had a reference to this field and was now broken.

### Changes 🏗️

- Update `getInputPropKey` in `CustomNode` to use `inputs.{key}` instead of `data.{key}`

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - Create an agent with at least one input
  - Use the agent with at least one input inside another agent
  - Set a default value on the input on the agent block
  - Save the graph
  - [x] -> default input value is saved
