### PR TITLE
fix(frontend): disable `httpOnly` for now

### DIFF
--- a/autogpt_platform/frontend/src/lib/supabase/helpers.ts
+++ b/autogpt_platform/frontend/src/lib/supabase/helpers.ts
@@ -28,7 +28,7 @@ export function getCookieSettings(): Partial<CookieOptions> {
   return {
     secure: process.env.NODE_ENV === "production",
     sameSite: "lax",
-    httpOnly: true,
+    // httpOnly: true, // Temporarily disabled until we figure out session migration
   } as const;
 }
 


### PR DESCRIPTION
## Changes 🏗️

When moving to server-only cookies 🍪 , existing sessions break unless the user logs out and login again. 

## Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Run the Front-end locally
  - [x] Login/logout and click around the app, everything works as expected
  - [x] E2E pass on the CI
