### PR TITLE
fix(backend): use admin route for store downloads

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
       "type": "node-terminal",
       "request": "launch",
       "cwd": "${workspaceFolder}/autogpt_platform/frontend",
-      "command": "yarn dev"
+      "command": "pnpm dev"
     },
     {
       "name": "Frontend: Client Side",
@@ -19,7 +19,7 @@
       "type": "node-terminal",
 
       "request": "launch",
-      "command": "yarn dev",
+      "command": "pnpm dev",
       "cwd": "${workspaceFolder}/autogpt_platform/frontend",
       "serverReadyAction": {
         "pattern": "- Local:.+(https?://.+)",

--- a/autogpt_platform/backend/backend/server/v2/admin/store_admin_routes.py
+++ b/autogpt_platform/backend/backend/server/v2/admin/store_admin_routes.py
@@ -131,7 +131,7 @@ async def admin_download_agent_file(
     Raises:
         HTTPException: If the agent is not found or an unexpected error occurs.
     """
-    graph_data = await backend.server.v2.store.db.get_agent(
+    graph_data = await backend.server.v2.store.db.get_agent_as_admin(
         user_id=user.user_id,
         store_listing_version_id=store_listing_version_id,
     )


### PR DESCRIPTION
<!-- Clearly explain the need for these changes: -->
Store downloading requires an admin to do it, so lets tell them we're an admin like we're supposed to

### Changes 🏗️
swaps getting the graph to the admin version like it is supposed to be
<!-- Concisely describe all of the changes made in this pull request: -->

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [x] deployed to test environment and tested with debugging tools attached
