### PR TITLE
fix(frontend/builder): Prevent bad graph reloads

### DIFF
--- a/autogpt_platform/frontend/src/hooks/useAgentGraph.tsx
+++ b/autogpt_platform/frontend/src/hooks/useAgentGraph.tsx
@@ -86,17 +86,6 @@ export default function useAgentGraph(
       .catch();
   }, [api]);
 
-  // Manage WebSocket connection
-  useEffect(() => {
-    api.connectWebSocket().catch((error) => {
-      console.error("Failed to connect WebSocket:", error);
-    });
-
-    return () => {
-      api.disconnectWebSocket();
-    };
-  }, [api]);
-
   // Subscribe to execution events
   useEffect(() => {
     const deregisterMessageHandler = api.onWebSocketMessage(


### PR DESCRIPTION
- Resolves #10458

### Changes 🏗️

Improve logic in `useAgentGraph`:
- Correctly handle unset `flowVersion` in checks in hooks
- Prevent unnecessary WebSocket re-connects
  - Remove redundant WebSocket connection management logic
- Untangle hooks for initial load and set-up
  - Simplify block filtering logic

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - Edit an agent in the builder
  - [x] WebSocket doesn't re-connect unnecessarily
  - [x] Graph doesn't reset on WebSocket re-connect
  - [x] Graph doesn't reset on LaunchDarkly re-connect
