### PR TITLE
fix(backend): Revert RabbitMQ consumer heartbeat mechanism

### DIFF
--- a/autogpt_platform/backend/backend/data/rabbitmq.py
+++ b/autogpt_platform/backend/backend/data/rabbitmq.py
@@ -25,21 +25,6 @@ logger = logging.getLogger(__name__)
 # RabbitMQ Connection Constants
 # These constants solve specific connection stability issues observed in production
 
-# HEARTBEAT_INTERVAL_SYNC (30s = 30 seconds)
-# Problem: Need to prove we're alive frequently, but also survive long network hiccups
-# Solution: Frequent heartbeats (30s) with long detection window (60s = 1min detection)
-# Use case: Long-running consumers need to stay connected but handle reconnection gracefully
-# Trade-off: More network chatter, but proves liveness while allowing reconnection time
-HEARTBEAT_INTERVAL_SYNC = 30
-
-# HEARTBEAT_INTERVAL_ASYNC (60s = 1 minute)
-# Problem: Same need for frequent proof-of-life with reasonable detection
-# Solution: Frequent enough to prove activity, not too aggressive on detection
-# Use case: Async RabbitMQ operations with good responsiveness
-# Trade-off: Regular heartbeats with 2-minute detection window
-HEARTBEAT_INTERVAL_ASYNC = 60
-
-
 # BLOCKED_CONNECTION_TIMEOUT (300s = 5 minutes)
 # Problem: Connection can hang indefinitely if RabbitMQ server is overloaded
 # Solution: Timeout and reconnect if connection is blocked for too long
@@ -159,7 +144,6 @@ class SyncRabbitMQ(RabbitMQBase):
             port=self.port,
             virtual_host=self.config.vhost,
             credentials=credentials,
-            heartbeat=HEARTBEAT_INTERVAL_SYNC,
             blocked_connection_timeout=BLOCKED_CONNECTION_TIMEOUT,
             socket_timeout=SOCKET_TIMEOUT,
             connection_attempts=CONNECTION_ATTEMPTS,
@@ -272,7 +256,6 @@ class AsyncRabbitMQ(RabbitMQBase):
             login=self.username,
             password=self.password,
             virtualhost=self.config.vhost.lstrip("/"),
-            heartbeat=HEARTBEAT_INTERVAL_ASYNC,
             blocked_connection_timeout=BLOCKED_CONNECTION_TIMEOUT,
         )
         self._channel = await self._connection.channel()

--- a/autogpt_platform/backend/backend/executor/manager.py
+++ b/autogpt_platform/backend/backend/executor/manager.py
@@ -1081,10 +1081,9 @@ class ExecutionManager(AppProcess):
     def _consume_execution_run(self):
 
         # Long-running executions are handled by:
-        # 1. Connection-level heartbeats (30s interval) with quick detection (60s)
-        # 2. Disabled consumer timeout (x-consumer-timeout: 0) allows unlimited execution time
-        # 3. Enhanced connection settings (5 retries, 1s delay) for quick reconnection
-        # 4. Process monitoring ensures failed executors release messages back to queue
+        # 1. Disabled consumer timeout (x-consumer-timeout: 0) allows unlimited execution time
+        # 2. Enhanced connection settings (5 retries, 1s delay) for quick reconnection
+        # 3. Process monitoring ensures failed executors release messages back to queue
 
         run_client = SyncRabbitMQ(create_execution_queue_config())
         run_client.connect()


### PR DESCRIPTION
The heartbeat mechanism doesn't seem to work at the moment.

### Changes 🏗️

Revert the RabbitMQ consumer heartbeat mechanism

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [x] Run agents
