### PR TITLE
feat(blocks): Add GPT-5 models to the platform

### DIFF
--- a/autogpt_platform/backend/backend/blocks/llm.py
+++ b/autogpt_platform/backend/backend/blocks/llm.py
@@ -82,10 +82,10 @@ class LlmModel(str, Enum, metaclass=LlmModelMeta):
     O1 = "o1"
     O1_MINI = "o1-mini"
     # GPT-5 models
-    GPT5 = "gpt-5"
-    GPT5_MINI = "gpt-5-mini"
-    GPT5_NANO = "gpt-5-nano"
-    GPT5_CHAT = "gpt-5-chat"
+    GPT5 = "gpt-5-2025-08-07"
+    GPT5_MINI = "gpt-5-mini-2025-08-07"
+    GPT5_NANO = "gpt-5-nano-2025-08-07"
+    GPT5_CHAT = "gpt-5-chat-latest"
     GPT41 = "gpt-4.1-2025-04-14"
     GPT41_MINI = "gpt-4.1-mini-2025-04-14"
     GPT4O_MINI = "gpt-4o-mini"
@@ -179,10 +179,10 @@ MODEL_METADATA = {
     LlmModel.O1: ModelMetadata("openai", 200000, 100000),  # o1-2024-12-17
     LlmModel.O1_MINI: ModelMetadata("openai", 128000, 65536),  # o1-mini-2024-09-12
     # GPT-5 models
-    LlmModel.GPT5: ModelMetadata("openai", 1047576, 32768),
-    LlmModel.GPT5_MINI: ModelMetadata("openai", 1047576, 32768),
-    LlmModel.GPT5_NANO: ModelMetadata("openai", 1047576, 32768),
-    LlmModel.GPT5_CHAT: ModelMetadata("openai", 1047576, 32768),
+    LlmModel.GPT5: ModelMetadata("openai", 400000, 128000),
+    LlmModel.GPT5_MINI: ModelMetadata("openai", 400000, 128000),
+    LlmModel.GPT5_NANO: ModelMetadata("openai", 400000, 128000),
+    LlmModel.GPT5_CHAT: ModelMetadata("openai", 400000, 128000),
     LlmModel.GPT41: ModelMetadata("openai", 1047576, 32768),
     LlmModel.GPT41_MINI: ModelMetadata("openai", 1047576, 32768),
     LlmModel.GPT4O_MINI: ModelMetadata(

--- a/autogpt_platform/backend/backend/data/block_cost_config.py
+++ b/autogpt_platform/backend/backend/data/block_cost_config.py
@@ -49,10 +49,10 @@ MODEL_COST: dict[LlmModel, int] = {
     LlmModel.O1: 16,  # $15 / $60
     LlmModel.O1_MINI: 4,
     # GPT-5 models
-    LlmModel.GPT5: 5,
-    LlmModel.GPT5_MINI: 5,
-    LlmModel.GPT5_NANO: 5,
-    LlmModel.GPT5_CHAT: 5,
+    LlmModel.GPT5: 2,
+    LlmModel.GPT5_MINI: 1,
+    LlmModel.GPT5_NANO: 1,
+    LlmModel.GPT5_CHAT: 2,
     LlmModel.GPT41: 2,
     LlmModel.GPT41_MINI: 1,
     LlmModel.GPT4O_MINI: 1,


### PR DESCRIPTION
This adds the latest chatGPT models, gpt 5 to the platform, this is ahead of its release, the prices and context limits are still to be properly set but for now i set them to be the same as gpt4.1, the price is set at 5 for now till we know more

This adds the following models
- gpt-5
- gpt-5-mini
- gpt-5-nano
- gpt-5-chat

### Changes 🏗️

<!-- Concisely describe all of the changes made in this pull request:
-->

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
- [x] Test all of the models to make sure they work
