### PR TITLE
fix(backend): Support dynamic values_#_* fields in CreateDictionaryBlock

### DIFF
--- a/autogpt_platform/backend/backend/blocks/smart_decision_maker.py
+++ b/autogpt_platform/backend/backend/blocks/smart_decision_maker.py
@@ -291,9 +291,32 @@ class SmartDecisionMakerBlock(Block):
 
         for link in links:
             sink_name = SmartDecisionMakerBlock.cleanup(link.sink_name)
-            properties[sink_name] = sink_block_input_schema.get_field_schema(
-                link.sink_name
-            )
+
+            # Handle dynamic fields (e.g., values_#_*, items_$_*, etc.)
+            # These are fields that get merged by the executor into their base field
+            if (
+                "_#_" in link.sink_name
+                or "_$_" in link.sink_name
+                or "_@_" in link.sink_name
+            ):
+                # For dynamic fields, provide a generic string schema
+                # The executor will handle merging these into the appropriate structure
+                properties[sink_name] = {
+                    "type": "string",
+                    "description": f"Dynamic value for {link.sink_name}",
+                }
+            else:
+                # For regular fields, use the block's schema
+                try:
+                    properties[sink_name] = sink_block_input_schema.get_field_schema(
+                        link.sink_name
+                    )
+                except (KeyError, AttributeError):
+                    # If the field doesn't exist in the schema, provide a generic schema
+                    properties[sink_name] = {
+                        "type": "string",
+                        "description": f"Value for {link.sink_name}",
+                    }
 
         tool_function["parameters"] = {
             **block.input_schema.jsonschema(),

--- a/autogpt_platform/backend/backend/blocks/test/test_smart_decision_maker_dict.py
+++ b/autogpt_platform/backend/backend/blocks/test/test_smart_decision_maker_dict.py
@@ -1,0 +1,130 @@
+from unittest.mock import Mock
+
+import pytest
+
+from backend.blocks.data_manipulation import AddToListBlock, CreateDictionaryBlock
+from backend.blocks.smart_decision_maker import SmartDecisionMakerBlock
+
+
+@pytest.mark.asyncio
+async def test_smart_decision_maker_handles_dynamic_dict_fields():
+    """Test Smart Decision Maker can handle dynamic dictionary fields (_#_) for any block"""
+
+    # Create a mock node for CreateDictionaryBlock
+    mock_node = Mock()
+    mock_node.block = CreateDictionaryBlock()
+    mock_node.block_id = CreateDictionaryBlock().id
+    mock_node.input_default = {}
+
+    # Create mock links with dynamic dictionary fields
+    mock_links = [
+        Mock(
+            source_name="tools_^_create_dict_~_name",
+            sink_name="values_#_name",  # Dynamic dict field
+            sink_id="dict_node_id",
+            source_id="smart_decision_node_id",
+        ),
+        Mock(
+            source_name="tools_^_create_dict_~_age",
+            sink_name="values_#_age",  # Dynamic dict field
+            sink_id="dict_node_id",
+            source_id="smart_decision_node_id",
+        ),
+        Mock(
+            source_name="tools_^_create_dict_~_city",
+            sink_name="values_#_city",  # Dynamic dict field
+            sink_id="dict_node_id",
+            source_id="smart_decision_node_id",
+        ),
+    ]
+
+    # Generate function signature
+    signature = await SmartDecisionMakerBlock._create_block_function_signature(
+        mock_node, mock_links  # type: ignore
+    )
+
+    # Verify the signature was created successfully
+    assert signature["type"] == "function"
+    assert "parameters" in signature["function"]
+    assert "properties" in signature["function"]["parameters"]
+
+    # Check that dynamic fields are handled
+    properties = signature["function"]["parameters"]["properties"]
+    assert len(properties) == 3  # Should have all three fields
+
+    # Each dynamic field should have proper schema
+    for prop_value in properties.values():
+        assert "type" in prop_value
+        assert prop_value["type"] == "string"  # Dynamic fields get string type
+        assert "description" in prop_value
+        assert "Dynamic value for" in prop_value["description"]
+
+
+@pytest.mark.asyncio
+async def test_smart_decision_maker_handles_dynamic_list_fields():
+    """Test Smart Decision Maker can handle dynamic list fields (_$_) for any block"""
+
+    # Create a mock node for AddToListBlock
+    mock_node = Mock()
+    mock_node.block = AddToListBlock()
+    mock_node.block_id = AddToListBlock().id
+    mock_node.input_default = {}
+
+    # Create mock links with dynamic list fields
+    mock_links = [
+        Mock(
+            source_name="tools_^_add_to_list_~_0",
+            sink_name="entries_$_0",  # Dynamic list field
+            sink_id="list_node_id",
+            source_id="smart_decision_node_id",
+        ),
+        Mock(
+            source_name="tools_^_add_to_list_~_1",
+            sink_name="entries_$_1",  # Dynamic list field
+            sink_id="list_node_id",
+            source_id="smart_decision_node_id",
+        ),
+    ]
+
+    # Generate function signature
+    signature = await SmartDecisionMakerBlock._create_block_function_signature(
+        mock_node, mock_links  # type: ignore
+    )
+
+    # Verify dynamic list fields are handled properly
+    assert signature["type"] == "function"
+    properties = signature["function"]["parameters"]["properties"]
+    assert len(properties) == 2  # Should have both list items
+
+    # Each dynamic field should have proper schema
+    for prop_value in properties.values():
+        assert prop_value["type"] == "string"
+        assert "Dynamic value for" in prop_value["description"]
+
+
+@pytest.mark.asyncio
+async def test_create_dict_block_with_dynamic_values():
+    """Test CreateDictionaryBlock processes dynamic values correctly"""
+
+    block = CreateDictionaryBlock()
+
+    # Simulate what happens when executor merges dynamic fields
+    # The executor merges values_#_* fields into the values dict
+    input_data = block.input_schema(
+        values={
+            "existing": "value",
+            "name": "Alice",  # This would come from values_#_name
+            "age": 25,  # This would come from values_#_age
+        }
+    )
+
+    # Run the block
+    result = {}
+    async for output_name, output_value in block.run(input_data):
+        result[output_name] = output_value
+
+    # Check the result
+    assert "dictionary" in result
+    assert result["dictionary"]["existing"] == "value"
+    assert result["dictionary"]["name"] == "Alice"
+    assert result["dictionary"]["age"] == 25


### PR DESCRIPTION
## Summary

Fixed Smart Decision Maker's function signature generation to properly handle dynamic fields (e.g., `values_#_*`, `items_$_*`) when connecting to any block as a tool.

### Context

When Smart Decision Maker calls other blocks as tools, it needs to generate OpenAI-compatible function signatures. Previously, when connected to blocks via dynamic fields (which get merged by the executor at runtime), the signature generation would fail because blocks don't inherently know about these dynamic field patterns.

### Changes 🏗️

- **Modified `SmartDecisionMakerBlock._create_block_function_signature()`** to detect and handle dynamic fields:
  - Detects fields containing `_#_` (dict merge), `_$_` (list merge), or `_@_` (object merge)
  - Provides generic string schema for dynamic fields (OpenAI API compatible)
  - Falls back gracefully for unknown fields
- **Added comprehensive tests** for dynamic field handling with both dictionary and list patterns
- **No changes needed to individual blocks** - this solution works universally

### Why This Approach

Instead of modifying every block to handle dynamic fields (original PR approach), we handle it centrally in Smart Decision Maker where the function signatures are generated. This is cleaner and more maintainable.

### Test Plan 📋

- [x] Created test cases for Smart Decision Maker generating function signatures with dynamic dict fields (`_#_`)
- [x] Created test cases for Smart Decision Maker generating function signatures with dynamic list fields (`_$_`)
- [x] Verified Smart Decision Maker can successfully call blocks like CreateDictionaryBlock via dynamic connections
- [x] All existing Smart Decision Maker tests pass
- [x] Linting and formatting pass