### PR TITLE
fix(backend/credit): prevent double-application of transactions due to race condition

### DIFF
--- a/autogpt_platform/backend/backend/data/credit.py
+++ b/autogpt_platform/backend/backend/data/credit.py
@@ -286,11 +286,17 @@ class UserCreditBase(ABC):
         transaction = await CreditTransaction.prisma().find_first_or_raise(
             where={"transactionKey": transaction_key, "userId": user_id}
         )
-
         if transaction.isActive:
             return
 
         async with db.locked_transaction(f"usr_trx_{user_id}"):
+
+            transaction = await CreditTransaction.prisma().find_first_or_raise(
+                where={"transactionKey": transaction_key, "userId": user_id}
+            )
+            if transaction.isActive:
+                return
+
             user_balance, _ = await self._get_credits(user_id)
             await CreditTransaction.prisma().update(
                 where={

--- a/autogpt_platform/backend/backend/server/routers/v1.py
+++ b/autogpt_platform/backend/backend/server/routers/v1.py
@@ -458,12 +458,16 @@ async def stripe_webhook(request: Request):
         event = stripe.Webhook.construct_event(
             payload, sig_header, settings.secrets.stripe_webhook_secret
         )
-    except ValueError:
+    except ValueError as e:
         # Invalid payload
-        raise HTTPException(status_code=400)
-    except stripe.SignatureVerificationError:
+        raise HTTPException(
+            status_code=400, detail=f"Invalid payload: {str(e) or type(e).__name__}"
+        )
+    except stripe.SignatureVerificationError as e:
         # Invalid signature
-        raise HTTPException(status_code=400)
+        raise HTTPException(
+            status_code=400, detail=f"Invalid signature: {str(e) or type(e).__name__}"
+        )
 
     if (
         event["type"] == "checkout.session.completed"


### PR DESCRIPTION
<!-- Clearly explain the need for these changes: -->
## 🚨 CRITICAL: Double Transaction Bug

**Critical Issue:** Top-up transactions were being applied TWICE to user balances, causing severe accounting errors.

**Example:**
- User with $160 balance tops up $50
- Expected: $210 balance  
- Actual: $260 balance (extra $50 incorrectly credited)

This compromises the financial integrity of our credit system and requires immediate fix.

### Changes 🏗️

1. **Added double-checked locking pattern in `_enable_transaction`** (backend/data/credit.py)
   - Added transaction re-check INSIDE the locked transaction block (lines 294-298)
   - Prevents race condition when concurrent requests try to activate the same transaction
   - Ensures transaction can only be activated once, even with webhook retries

2. **Enhanced error messages in Stripe webhook handler** (backend/server/routers/v1.py)
   - Added detailed error messages for better debugging of webhook failures
   - Helps identify issues with payload validation or signature verification

### Root Cause Analysis 🔍

**TOCTOU (Time-of-Check to Time-of-Use) Race Condition:**

#### BEFORE (Vulnerable Code):
```python
# backend/data/credit.py - _enable_transaction method
async def _enable_transaction(self, transaction_key, user_id, metadata, new_transaction_key):
    # Line 286-290: First check OUTSIDE the lock
    transaction = await CreditTransaction.prisma().find_first_or_raise(
        where={"transactionKey": transaction_key, "userId": user_id}
    )
    if transaction.isActive:  # ✅ Check passes if inactive
        return
    
    # ⚠️ RACE WINDOW HERE! Between line 290 and 292
    # Another request (webhook retry) can enter here and also pass the check!
    
    # Line 292: Acquire lock (but it's too late!)
    async with db.locked_transaction(f"usr_trx_{user_id}"):
        # ❌ NO RE-CHECK HERE - This was the bug!
        # Both requests will proceed to activate the transaction
        
        # Line 300-315: Both requests execute this
        user_balance, _ = await self._get_credits(user_id)
        await CreditTransaction.prisma().update(
            where={...},
            data={
                "isActive": True,  # Both set to active
                "runningBalance": user_balance + transaction.amount,  # Both add amount!
                ...
            }
        )
```

#### AFTER (Fixed Code):
```python
# backend/data/credit.py - _enable_transaction method  
async def _enable_transaction(self, transaction_key, user_id, metadata, new_transaction_key):
    # Line 286-290: First check (performance optimization - quick return)
    transaction = await CreditTransaction.prisma().find_first_or_raise(
        where={"transactionKey": transaction_key, "userId": user_id}
    )
    if transaction.isActive:  # ✅ Fast path for already-active transactions
        return
    
    # Line 292: Acquire exclusive lock
    async with db.locked_transaction(f"usr_trx_{user_id}"):
        
        # 🔥 THE FIX - Lines 294-298: CRITICAL second check INSIDE the lock!
        transaction = await CreditTransaction.prisma().find_first_or_raise(
            where={"transactionKey": transaction_key, "userId": user_id}
        )
        if transaction.isActive:  # ✅ Check again after acquiring lock!
            return  # Another process activated it while we waited for lock
        
        # Lines 300-315: Now only ONE request will reach here
        user_balance, _ = await self._get_credits(user_id)
        await CreditTransaction.prisma().update(
            where={...},
            data={
                "isActive": True,
                "runningBalance": user_balance + transaction.amount,  # Amount added only ONCE
                ...
            }
        )
```

### Race Condition Timeline 📊

**What was happening (BUG):**
```
Time | Request A (Webhook)          | Request B (Retry)            | Database State
-----|------------------------------|------------------------------|---------------
T1   | Check isActive=False ✅      |                              | isActive=False, balance=$160
T2   |                              | Check isActive=False ✅      | isActive=False, balance=$160
T3   | Acquire lock 🔒              |                              | isActive=False, balance=$160
T4   | Set isActive=True            | Waiting for lock... ⏳       | isActive=True, balance=$210
T5   | Release lock 🔓              |                              | isActive=True, balance=$210
T6   |                              | Acquire lock 🔒              | isActive=True, balance=$210
T7   |                              | Set isActive=True (again!)   | isActive=True, balance=$260 ❌
T8   |                              | Release lock 🔓              | WRONG BALANCE!
```

**What happens now (FIXED):**
```
Time | Request A (Webhook)          | Request B (Retry)            | Database State
-----|------------------------------|------------------------------|---------------
T1   | Check isActive=False ✅      |                              | isActive=False, balance=$160
T2   |                              | Check isActive=False ✅      | isActive=False, balance=$160
T3   | Acquire lock 🔒              |                              | isActive=False, balance=$160
T4   | Re-check: isActive=False ✅  | Waiting for lock... ⏳       | isActive=False, balance=$160
T5   | Set isActive=True            |                              | isActive=True, balance=$210
T6   | Release lock 🔓              |                              | isActive=True, balance=$210
T7   |                              | Acquire lock 🔒              | isActive=True, balance=$210
T8   |                              | Re-check: isActive=True ❌   | isActive=True, balance=$210
T9   |                              | Return early (no-op) ✅      | isActive=True, balance=$210 ✅
```

### Contributing Factors 🔍

1. **Webhook Retries**: Stripe automatically retries webhooks on failure/timeout
2. **@func_retry Decorator**: The `_enable_transaction` method has `@func_retry` which adds up to 5 retry attempts
3. **No Database Constraint**: No unique constraint preventing duplicate active transactions
4. **Missing Atomicity**: The check and update operations weren't atomic

### Why This Fix Works 🛡️

The **double-checked locking pattern** is a well-established concurrency pattern that:
1. **First check** (line 289): Performance optimization - avoids lock acquisition if already active
2. **Lock acquisition** (line 292): Ensures exclusive access to critical section
3. **Second check** (line 297): **CRITICAL** - Verifies state hasn't changed while waiting for lock
4. **Safe execution**: Only proceeds if transaction is still inactive after acquiring lock

This ensures **idempotency**: Multiple concurrent calls with the same transaction_key will only activate the transaction once.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [x] Verified the double-check prevents duplicate transaction activation
  - [x] Tested concurrent webhook calls - only one succeeds in activating transaction
  - [x] Confirmed balance is only incremented once per transaction
  - [x] Verified idempotency - multiple calls with same transaction_key are safe
  - [x] All existing credit system tests pass
  - [x] Tested webhook error handling with invalid payloads/signatures
  - [x] Simulated race condition with parallel requests - confirmed fix prevents double application

#### For configuration changes:
- [x] `.env.example` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes
- [x] I have included a list of my configuration changes in the PR description (under **Changes**)

*Note: No configuration changes required - this is a code-only fix*