### PR TITLE
feat(blocks): add AI Image Customizer block using Google Gemini 2.5 Flash Image

### DIFF
--- a/autogpt_platform/backend/backend/blocks/ai_image_customizer.py
+++ b/autogpt_platform/backend/backend/blocks/ai_image_customizer.py
@@ -64,6 +64,10 @@ class AIImageCustomizerBlock(Block):
             description="List of input images (optional)",
             default=None,
             title="Images",
+            json_schema_extra={
+                "type": "array",
+                "items": {"type": "string", "format": "uri"},
+            },
         )
         output_format: OutputFormat = SchemaField(
             description="Format of the output image",


### PR DESCRIPTION
Add new AutoGPT Platform Block that uses google/gemini-2.5-flash-image model via Replicate API.

Features:
- Text prompt input for image generation
- Optional list of image URLs as input
- Configurable output format (jpg/png, defaults to png)
- Single model option: google/gemini-2.5-flash-image
- Returns image_url output for generated images

Fixes #10815

Generated with [Claude Code](https://claude.ai/code)

- [x] tested everything really well