### PR TITLE
fix(backend): Unbreak `get_webhook` query

### DIFF
--- a/autogpt_platform/backend/backend/data/includes.py
+++ b/autogpt_platform/backend/backend/data/includes.py
@@ -59,9 +59,15 @@ def graph_execution_include(
     }
 
 
+AGENT_PRESET_INCLUDE: prisma.types.AgentPresetInclude = {
+    "InputPresets": True,
+    "Webhook": True,
+}
+
+
 INTEGRATION_WEBHOOK_INCLUDE: prisma.types.IntegrationWebhookInclude = {
     "AgentNodes": {"include": AGENT_NODE_INCLUDE},
-    "AgentPresets": {"include": {"InputPresets": True}},
+    "AgentPresets": {"include": AGENT_PRESET_INCLUDE},
 }
 
 
@@ -75,9 +81,3 @@ def library_agent_include(user_id: str) -> prisma.types.LibraryAgentInclude:
         },
         "Creator": True,
     }
-
-
-AGENT_PRESET_INCLUDE: prisma.types.AgentPresetInclude = {
-    "InputPresets": True,
-    "Webhook": True,
-}


### PR DESCRIPTION
- Resolves #10849

### Changes 🏗️

- Use `AGENT_PRESET_INCLUDE` in `INTEGRATION_WEBHOOK_INCLUDE` so the `AgentPreset.from_db(..)` doesn't break

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Webhook ingress works
