### PR TITLE
fix(frontend): allow lazy loading of images

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/library/components/LibraryAgentCard/LibraryAgentCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/components/LibraryAgentCard/LibraryAgentCard.tsx
@@ -51,7 +51,6 @@ export default function LibraryAgentCard({
             alt={`${name} preview image`}
             fill
             className="object-cover"
-            priority
           />
         )}
         <div className="absolute bottom-4 left-4">

--- a/autogpt_platform/frontend/src/app/(platform)/marketplace/components/CreatorCard/CreatorCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/marketplace/components/CreatorCard/CreatorCard.tsx
@@ -33,7 +33,6 @@ export const CreatorCard = ({
               width={64}
               height={64}
               className="h-full w-full object-cover"
-              priority
             />
           ) : (
             <div className="h-full w-full bg-neutral-300 dark:bg-neutral-600" />

--- a/autogpt_platform/frontend/src/app/(platform)/marketplace/components/StoreCard/StoreCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/marketplace/components/StoreCard/StoreCard.tsx
@@ -51,7 +51,6 @@ export const StoreCard: React.FC<StoreCardProps> = ({
             alt={`${agentName} preview image`}
             fill
             className="object-cover"
-            priority
           />
         )}
         {!hideAvatar && (


### PR DESCRIPTION
The `next/image` component has inbuilt lazy loading enabled, but in some components, we are bypassing it using a priority flag. So, I have reverted this in this PR. 

### Checklist 📋
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Lazy loading is working perfectly locally.