### PR TITLE
fix(backend/db): Keep `CreditTransaction` entries on `User` delete

### DIFF
--- a/autogpt_platform/backend/migrations/20250912164006_keep_credit_transactions_on_user_delete/migration.sql
+++ b/autogpt_platform/backend/migrations/20250912164006_keep_credit_transactions_on_user_delete/migration.sql
@@ -1,0 +1,3 @@
+-- Re-create foreign key CreditTransaction <- User with ON DELETE NO ACTION
+ALTER TABLE "CreditTransaction" DROP CONSTRAINT "CreditTransaction_userId_fkey";
+ALTER TABLE "CreditTransaction" ADD CONSTRAINT "CreditTransaction_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE NO ACTION ON UPDATE CASCADE;

--- a/autogpt_platform/backend/schema.prisma
+++ b/autogpt_platform/backend/schema.prisma
@@ -528,7 +528,7 @@ model CreditTransaction {
   createdAt      DateTime @default(now())
 
   userId String
-  User   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+  User   User?   @relation(fields: [userId], references: [id], onDelete: NoAction)
 
   amount Int
   type   CreditTransactionType


### PR DESCRIPTION
This is a non-critical improvement for bookkeeping purposes.

### Changes 🏗️

- Change `CreditTransaction` <- `User` relation to `ON DELETE NO ACTION` so that `CreditTransactions` are not automatically deleted when we delete a user's data.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Migration applies without problems
