### PR TITLE
feat(frontend): add selecting UI for custom node in new builder

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/nodes/CustomNode.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/nodes/CustomNode.tsx
@@ -8,6 +8,7 @@ import { Switch } from "@/components/atoms/Switch/Switch";
 import { preprocessInputSchema } from "../processors/input-schema-pre-processor";
 import { OutputHandler } from "./OutputHandler";
 import { useNodeStore } from "../../../stores/nodeStore";
+import { cn } from "@/lib/utils";
 
 export type CustomNodeData = {
   hardcodedValues: {
@@ -22,14 +23,19 @@ export type CustomNodeData = {
 export type CustomNode = XYNode<CustomNodeData, "custom">;
 
 export const CustomNode: React.FC<NodeProps<CustomNode>> = React.memo(
-  ({ data, id }) => {
+  ({ data, id, selected }) => {
     const showAdvanced = useNodeStore(
       (state) => state.nodeAdvancedStates[id] || false,
     );
     const setShowAdvanced = useNodeStore((state) => state.setShowAdvanced);
 
     return (
-      <div className="rounded-xl border border-slate-200/60 bg-gradient-to-br from-white to-slate-50/30 shadow-lg shadow-slate-900/5 backdrop-blur-sm">
+      <div
+        className={cn(
+          "rounded-xl border border-slate-200/60 bg-gradient-to-br from-white to-slate-50/30 shadow-lg shadow-slate-900/5 backdrop-blur-sm",
+          selected && "border-2 border-slate-200 shadow-2xl",
+        )}
+      >
         {/* Header */}
         <div className="flex h-14 items-center justify-center rounded-xl border-b border-slate-200/50 bg-gradient-to-r from-slate-50/80 to-white/90">
           <Text


### PR DESCRIPTION
React Flow has built-in functionality to select multiple nodes by using `cmd` + click. You can also select using rectangle selection by holding the shift key. However, we need to design a custom node after it’s selected.

<img width="845" height="510" alt="Screenshot 2025-10-06 at 12 41 16 PM" src="https://github.com/user-attachments/assets/c91f22e3-2211-46b6-b3d3-fbc89148e99a" />

### Tests
- [x]  Selecting Ui is visible after selecting a node, using cmd + click, and after rectangle selection.