### PR TITLE
fix(backend): Allow Project.content to be optional for linear search projects

### DIFF
--- a/autogpt_platform/backend/backend/blocks/linear/models.py
+++ b/autogpt_platform/backend/backend/blocks/linear/models.py
@@ -38,4 +38,4 @@ class Project(BaseModel):
     description: str
     priority: int
     progress: float
-    content: str
+    content: str | None


### PR DESCRIPTION
Changed the type of the 'content' field in the Project model to accept None, making it optional instead of required. Linear doesn't always return data here if its not set by the user.

<!-- Clearly explain the need for these changes: -->

### Changes 🏗️
- Makes the content optional
<!-- Concisely describe all of the changes made in this pull request: -->

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [x] Manually test it works with our data


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of projects with no content by making content optional.
  - Prevents validation errors during project creation, import, or sync when content is missing.
  - Enhances compatibility with integrations that may omit content fields.
  - No impact on existing projects with content; behavior remains unchanged.
  - No user action required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->