### PR TITLE
feat(backend/blocks): add Discord create thread block

### DIFF
--- a/autogpt_platform/backend/backend/blocks/discord/bot_blocks.py
+++ b/autogpt_platform/backend/backend/blocks/discord/bot_blocks.py
@@ -1183,7 +1183,7 @@ class DiscordChannelInfoBlock(Block):
 
 
 class CreateDiscordThreadBlock(Block):
-    class Input(BlockSchema):
+    class Input(BlockSchemaInput):
         credentials: DiscordCredentials = DiscordCredentialsField()
         channel_name: str = SchemaField(
             description="Channel ID or channel name to create the thread in"
@@ -1209,7 +1209,7 @@ class CreateDiscordThreadBlock(Block):
             default="",
         )
 
-    class Output(BlockSchema):
+    class Output(BlockSchemaOutput):
         status: str = SchemaField(description="Operation status")
         thread_id: str = SchemaField(description="ID of the created thread")
         thread_name: str = SchemaField(description="Name of the created thread")


### PR DESCRIPTION
Adds a new Discord block that allows users to create threads in Discord channels. This addresses issue OPEN-2666 which requested the ability to create Discord threads from workflows.

## Solution

Implemented `CreateDiscordThreadBlock` in `autogpt_platform/backend/backend/blocks/discord/bot_blocks.py` with the
following features:

- Create public or private threads in Discord channels via bot token
- Support for both channel ID and channel name lookup (with optional server name)
- Configurable thread type (public/private toggle)
- Configurable auto-archive duration (60, 1440, 4320, or 10080 minutes)
- Optional initial message to send in the newly created thread
- Outputs: status, thread_id, and thread_name for workflow chaining

The block follows the existing Discord block patterns and includes proper error handling for permissions, channel not found, and login failures.

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [x] Verify block appears in the workflow builder UI
  - [x] Test creating a public thread with valid bot token and channel ID
  - [x] Test creating a private thread with valid bot token and channel name
  - [x] Test with invalid channel ID/name to verify error handling
  - [x] Test with bot lacking thread creation permissions
  - [x] Verify thread_id output can be chained to subsequent blocks
  - [x] Test auto-archive duration options (60, 1440, 4320, 10080 minutes)
  - [x] Test sending initial message in newly created thread

Video to show the blocks working!


https://github.com/user-attachments/assets/f248f315-05b3-47e2-bd6b-4c64d53c35fc



