### PR TITLE
fix(backend): prevent sub-agent execution visibility across users

### DIFF
--- a/autogpt_platform/backend/backend/executor/manager.py
+++ b/autogpt_platform/backend/backend/executor/manager.py
@@ -188,6 +188,7 @@ async def execute_node(
         _input_data.inputs = input_data
         if nodes_input_masks:
             _input_data.nodes_input_masks = nodes_input_masks
+        _input_data.user_id = user_id
         input_data = _input_data.model_dump()
     data.inputs = input_data
 


### PR DESCRIPTION
Fixes a issue where sub-agent executions triggered by one user were visible in the original agent author's execution library.
 ## Solution

Fixed the user_id attribution in `autogpt_platform/backend/backend/executor/manager.py` by ensuring that sub-agent executions always use the actual executor's user_id rather than the agent author's user_id stored in node defaults.

### Changes
- Added user_id override in `execute_node()` function when preparing AgentExecutorBlock input (line 194)
- Ensures sub-agent executions are correctly attributed to the user running them, not the agent author
- Maintains proper privacy isolation between users in marketplace agent scenarios

### Security Impact
- **Before**: When User B downloaded and ran a marketplace agent containing sub-agents owned by User A, the sub-agent executions appeared in User A's library
- **After**: Sub-agent executions now only appear in the library of the user who actually ran them
- Prevents unauthorized access to execution data and user privacy violation

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  <!-- Test plan: -->
  - [x] Create an agent with sub-agents as User A
  - [x] Publish agent to marketplace
  - [x] Run the agent as User B
  - [x] Verify User A cannot see User B's sub-agent executions in their library
  - [x] Verify User B can see their own sub-agent executions
  - [x] Verify primary agent executions remain correctly filtered