### PR TITLE
fix(frontend): remove agent activity flag

### DIFF
--- a/autogpt_platform/frontend/src/components/layout/Navbar/components/AgentActivityDropdown/AgentActivityDropdown.tsx
+++ b/autogpt_platform/frontend/src/components/layout/Navbar/components/AgentActivityDropdown/AgentActivityDropdown.tsx
@@ -18,14 +18,9 @@ export function AgentActivityDropdown() {
     recentFailures,
     isOpen,
     setIsOpen,
-    isAgentActivityEnabled,
   } = useAgentActivityDropdown();
 
   const activeCount = activeExecutions.length;
-
-  if (!isAgentActivityEnabled) {
-    return null;
-  }
 
   return (
     <Popover open={isOpen} onOpenChange={setIsOpen}>

--- a/autogpt_platform/frontend/src/components/layout/Navbar/components/AgentActivityDropdown/useAgentActivityDropdown.ts
+++ b/autogpt_platform/frontend/src/components/layout/Navbar/components/AgentActivityDropdown/useAgentActivityDropdown.ts
@@ -11,7 +11,6 @@ import {
   categorizeExecutions,
   handleExecutionUpdate,
 } from "./helpers";
-import { Flag, useGetFlag } from "@/services/feature-flags/use-get-flag";
 
 type AgentInfoMap = Map<
   string,
@@ -19,7 +18,6 @@ type AgentInfoMap = Map<
 >;
 
 export function useAgentActivityDropdown() {
-  const isAgentActivityEnabled = useGetFlag(Flag.AGENT_ACTIVITY);
   const [isOpen, setIsOpen] = useState(false);
 
   const [api] = useState(() => new BackendAPI());
@@ -162,6 +160,5 @@ export function useAgentActivityDropdown() {
     error: executionsError || agentsError,
     isOpen,
     setIsOpen,
-    isAgentActivityEnabled,
   };
 }

--- a/autogpt_platform/frontend/src/services/feature-flags/use-get-flag.ts
+++ b/autogpt_platform/frontend/src/services/feature-flags/use-get-flag.ts
@@ -5,7 +5,6 @@ import { useFlags } from "launchdarkly-react-client-sdk";
 
 export enum Flag {
   BETA_BLOCKS = "beta-blocks",
-  AGENT_ACTIVITY = "agent-activity",
   NEW_BLOCK_MENU = "new-block-menu",
   NEW_AGENT_RUNS = "new-agent-runs",
   GRAPH_SEARCH = "graph-search",
@@ -18,7 +17,6 @@ export enum Flag {
 
 export type FlagValues = {
   [Flag.BETA_BLOCKS]: string[];
-  [Flag.AGENT_ACTIVITY]: boolean;
   [Flag.NEW_BLOCK_MENU]: boolean;
   [Flag.NEW_AGENT_RUNS]: boolean;
   [Flag.GRAPH_SEARCH]: boolean;
@@ -33,7 +31,6 @@ const isPwMockEnabled = process.env.NEXT_PUBLIC_PW_TEST === "true";
 
 const mockFlags = {
   [Flag.BETA_BLOCKS]: [],
-  [Flag.AGENT_ACTIVITY]: true,
   [Flag.NEW_BLOCK_MENU]: false,
   [Flag.NEW_AGENT_RUNS]: false,
   [Flag.GRAPH_SEARCH]: true,


### PR DESCRIPTION
## Changes 🏗️

The Agent Activity Dropdown is now stable, it has been 100% exposed to users on production for a few weeks, no need to have it behind a flag anymore.

## Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Login to AutoGPT
  - [x] The bell on the navbar is always present even if the flag on Launch Darkly is turned off 

### For configuration changes:

None
