### PR TITLE
fix(frontend): handle websocket disconnect issue

### DIFF
--- a/autogpt_platform/frontend/src/lib/autogpt-server-api/client.ts
+++ b/autogpt_platform/frontend/src/lib/autogpt-server-api/client.ts
@@ -1152,8 +1152,10 @@ export default class BackendAPI {
           console.info(
             "[BackendAPI] Skipping WebSocket connect: no auth token available",
           );
-          this.wsConnecting = null;
+          // Resolve first, then clear wsConnecting to avoid races for awaiters
           resolve();
+          this.wsConnecting = null;
+          this.webSocket = null;
           return;
         }
 
@@ -1193,6 +1195,9 @@ export default class BackendAPI {
           if (!wasIntentional) {
             this.wsOnDisconnectHandlers.forEach((handler) => handler());
             setTimeout(() => this.connectWebSocket().then(resolve), 1000);
+          } else {
+            // Ensure pending connect calls settle on intentional close
+            resolve();
           }
         };
 


### PR DESCRIPTION
## Changes 🏗️

I found that if I logged out while an agent was running, sometimes Webscokets would keep open connections but fail to connect ( given there is no token anymore ) and cause strange behavior down the line on the login screen.

Two root causes behind after inspecting the browser logs 🧐 
- WebSocket connections were attempted with an empty token right after logout, yielding `wss://.../ws?token=` and repeated `1006/connection` refused loops.
- During logout, sockets in `CONNECTING` state weren’t being closed, so the browser kept trying to finish the handshake and were reattempted shortly after failing

Trying to fix this like:
- Guard `connectWebSocket()` to no-op if a logout/disconnect intent is set, and to skip connecting when no token is available.
- Treat `CONNECTING` sockets as closeable in `disconnectWebSocket()` and clear `wsConnecting` to avoid stale pending Promises
- Left existing heartbeat/reconnect logic intact, but it now won’t run when we’re logging out or when we can’t get a token.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Login and run an agent that takes long to run
  - [x] Logout
  - [x] Check the browser console and you don't see any socket errors
  - [x] The login screen behaves ok   

### For configuration changes:

Noop