### PR TITLE
fix(frontend/builder): Fix unnecessary graph re-saving

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/build/components/legacy-builder/CustomNode/CustomNode.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/legacy-builder/CustomNode/CustomNode.tsx
@@ -23,6 +23,7 @@ import {
 import {
   beautifyString,
   cn,
+  fillObjectDefaultsFromSchema,
   getValue,
   hasNonNullNonObjectValue,
   isObject,
@@ -158,37 +159,6 @@ export const CustomNode = React.memo(
       setIsAnyModalOpen?.(isModalOpen || isOutputModalOpen);
     }, [isModalOpen, isOutputModalOpen, data, setIsAnyModalOpen]);
 
-    const fillDefaults = useCallback((obj: any, schema: any) => {
-      // Iterate over the schema properties
-      for (const key in schema.properties) {
-        if (schema.properties.hasOwnProperty(key)) {
-          const propertySchema = schema.properties[key];
-
-          // If the property is not in the object, initialize it with the default value
-          if (!obj.hasOwnProperty(key)) {
-            if (propertySchema.default !== undefined) {
-              obj[key] = propertySchema.default;
-            } else if (propertySchema.type === "object") {
-              // Recursively fill defaults for nested objects
-              obj[key] = fillDefaults({}, propertySchema);
-            } else if (propertySchema.type === "array") {
-              // Recursively fill defaults for arrays
-              obj[key] = fillDefaults([], propertySchema);
-            }
-          } else {
-            // If the property exists, recursively fill defaults for nested objects/arrays
-            if (propertySchema.type === "object") {
-              obj[key] = fillDefaults(obj[key], propertySchema);
-            } else if (propertySchema.type === "array") {
-              obj[key] = fillDefaults(obj[key], propertySchema);
-            }
-          }
-        }
-      }
-
-      return obj;
-    }, []);
-
     const setHardcodedValues = useCallback(
       (values: any) => {
         updateNodeData(id, { hardcodedValues: values });
@@ -231,17 +201,19 @@ export const CustomNode = React.memo(
 
     useEffect(() => {
       isInitialSetup.current = false;
+      if (data.backend_id) return;  // don't auto-modify existing nodes
+
       if (data.uiType === BlockUIType.AGENT) {
         setHardcodedValues({
           ...data.hardcodedValues,
-          inputs: fillDefaults(
+          inputs: fillObjectDefaultsFromSchema(
             data.hardcodedValues.inputs ?? {},
             data.inputSchema,
           ),
         });
       } else {
         setHardcodedValues(
-          fillDefaults(data.hardcodedValues, data.inputSchema),
+          fillObjectDefaultsFromSchema(data.hardcodedValues, data.inputSchema),
         );
       }
     }, []);

--- a/autogpt_platform/frontend/src/hooks/useAgentGraph.tsx
+++ b/autogpt_platform/frontend/src/hooks/useAgentGraph.tsx
@@ -21,11 +21,7 @@ import {
   Node,
 } from "@/lib/autogpt-server-api";
 import { useBackendAPI } from "@/lib/autogpt-server-api/context";
-import {
-  deepEquals,
-  getTypeColor,
-  removeEmptyStringsAndNulls,
-} from "@/lib/utils";
+import { deepEquals, getTypeColor, pruneEmptyValues } from "@/lib/utils";
 import { MarkerType } from "@xyflow/react";
 import { default as NextLink } from "next/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
@@ -598,7 +594,10 @@ export default function useAgentGraph(
         return {};
       }
 
-      return rebuildObjectUsingSchema(blockSchema, node.data.hardcodedValues);
+      return rebuildObjectUsingSchema(
+        blockSchema,
+        pruneEmptyValues(node.data.hardcodedValues),
+      );
     },
     [availableBlocks],
   );
@@ -711,9 +710,6 @@ export default function useAgentGraph(
                 position,
                 data: {
                   ...frontendNode.data,
-                  hardcodedValues: removeEmptyStringsAndNulls(
-                    frontendNode.data.hardcodedValues,
-                  ),
                   // NOTE: we don't update `node.id` because it would also require
                   //  updating many references in other places. Instead, we keep the
                   //  backend node ID in `node.data.backend_id`.

--- a/autogpt_platform/frontend/src/lib/utils.ts
+++ b/autogpt_platform/frontend/src/lib/utils.ts
@@ -2,7 +2,11 @@ import { type ClassValue, clsx } from "clsx";
 import { isEmpty as _isEmpty } from "lodash";
 import { twMerge } from "tailwind-merge";
 
-import { Category } from "@/lib/autogpt-server-api/types";
+import {
+  BlockIOObjectSubSchema,
+  BlockIORootSchema,
+  Category,
+} from "@/lib/autogpt-server-api/types";
 import { NodeDimension } from "@/app/(platform)/build/components/legacy-builder/Flow/Flow";
 
 export function cn(...inputs: ClassValue[]) {
@@ -177,32 +181,73 @@ export function setNestedProperty(obj: any, path: string, value: any) {
   current[keys[keys.length - 1]] = value;
 }
 
-export function removeEmptyStringsAndNulls(obj: any): any {
+export function pruneEmptyValues(
+  obj: any,
+  removeEmptyStrings: boolean = true,
+): any {
   if (Array.isArray(obj)) {
     // If obj is an array, recursively check each element,
     // but element removal is avoided to prevent index changes.
     return obj.map((item) =>
       item === undefined || item === null
         ? ""
-        : removeEmptyStringsAndNulls(item),
+        : pruneEmptyValues(item, removeEmptyStrings),
     );
   } else if (typeof obj === "object" && obj !== null) {
     // If obj is an object, recursively remove empty strings and nulls from its properties
     for (const key in obj) {
-      if (obj.hasOwnProperty(key)) {
-        const value = obj[key];
-        if (
-          value === null ||
-          value === undefined ||
-          (typeof value === "string" && value === "")
-        ) {
-          delete obj[key];
-        } else {
-          obj[key] = removeEmptyStringsAndNulls(value);
+      if (!obj.hasOwnProperty(key)) continue;
+
+      const value = obj[key];
+      if (
+        value === null ||
+        value === undefined ||
+        (typeof value === "string" && value === "" && removeEmptyStrings)
+      ) {
+        delete obj[key];
+      } else if (typeof value === "object") {
+        obj[key] = pruneEmptyValues(value, removeEmptyStrings);
+      }
+    }
+  }
+  return obj;
+}
+
+export function fillObjectDefaultsFromSchema(
+  obj: Record<any, any>,
+  schema: BlockIORootSchema | BlockIOObjectSubSchema,
+) {
+  for (const key in schema.properties) {
+    if (!schema.properties.hasOwnProperty(key)) continue;
+
+    const propertySchema = schema.properties[key];
+
+    if ("default" in propertySchema && propertySchema.default !== undefined) {
+      // Apply simple default values
+      obj[key] ??= propertySchema.default;
+    } else if (
+      propertySchema.type === "object" &&
+      "properties" in propertySchema
+    ) {
+      // Recursively fill defaults for nested objects
+      obj[key] = fillObjectDefaultsFromSchema(obj[key] ?? {}, propertySchema);
+    } else if (propertySchema.type === "array") {
+      obj[key] ??= [];
+      // If the array items are objects, fill their defaults as well
+      if (
+        Array.isArray(obj[key]) &&
+        propertySchema.items?.type === "object" &&
+        "properties" in propertySchema.items
+      ) {
+        for (const item of obj[key]) {
+          if (typeof item === "object" && item !== null) {
+            fillObjectDefaultsFromSchema(item, propertySchema.items);
+          }
         }
       }
     }
   }
+
   return obj;
 }
 


### PR DESCRIPTION
- Resolves #10980
- 2nd attempt after #11075 broke some things

Fixes unnecessary graph re-saving when no changes were made after initial save. More specifically, this PR fixes two causes of this issue:
- Frontend node IDs were being compared to backend IDs, which won't match if the graph has been modified and saved since loading.
- `fillDefaults` was being applied to all nodes (including existing ones) on element creation, and empty values were being stripped *post-save* with `removeEmptyStringsAndNulls`. This invisible auto-modification of node input data meant that in some common cases the graph would never be in sync with the backend.

### Changes 🏗️

- Fix node ID handling
  - Use `node.data.backend_id ?? node.id` instead of `node.id` in `prepareSaveableGraph`
    - Also map link source/sink IDs to their corresponding backend IDs
  - Add note about `node.data.backend_id` to `_saveAgent`
  - Use `node.data.backend_id || node.id` as display ID in `CustomNode`

- Prevent auto-modification of node input data on existing nodes
  - Prune empty values (`undefined`, `null`, `""`) from node input data *pre-save* instead of post-save
  - Related: improve typing and functionality of `fillObjectDefaultsFromSchema` (moved and renamed from `fillDefaults`)

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Node display ID updates on save
  - [x] Clicking save a second time (without making more changes) doesn't cause re-save
  - [x] Updating nodes with dynamic input links (e.g. Create Dictionary Block) doesn't make the links disappear


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unintended auto-modification of existing nodes during editing
  * Improved consistency of node and connection identifiers in saved graphs

* **Improvements**
  * Enhanced node title display logic for clearer node identification
  * Optimized data cleanup utilities for more robust input processing in the builder

<!-- end of auto-generated comment: release notes by coderabbit.ai -->