### PR TITLE
fix(platform): Disable logging store terms

### DIFF
--- a/autogpt_platform/backend/backend/server/v2/store/db.py
+++ b/autogpt_platform/backend/backend/server/v2/store/db.py
@@ -144,9 +144,10 @@ async def get_store_agents(
         raise backend.server.v2.store.exceptions.DatabaseError(
             "Failed to fetch store agents"
         ) from e
-    finally:
-        if search_term:
-            await log_search_term(search_query=search_term)
+    # TODO: commenting this out as we concerned about potential db load issues
+    # finally:
+    #     if search_term:
+    #         await log_search_term(search_query=search_term)
 
 
 async def log_search_term(search_query: str):


### PR DESCRIPTION
There is concern that the write load on the database may derail the performance optimisations.
This hotfix comments out the code that adds the search terms to the db, so we can discuss how best to do this in a way that won't bring down the db.

### Changes 🏗️

- commented out the code to log store terms to the db

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] check search still works in dev 
