### PR TITLE
feat(backend): Whitelist Onboarding Agents

### DIFF
--- a/autogpt_platform/backend/backend/server/v2/store/db_test.py
+++ b/autogpt_platform/backend/backend/server/v2/store/db_test.py
@@ -42,6 +42,7 @@ async def test_get_store_agents(mocker):
             versions=["1.0"],
             updated_at=datetime.now(),
             is_available=False,
+            useForOnboarding=False,
         )
     ]
 
@@ -84,6 +85,7 @@ async def test_get_store_agent_details(mocker):
         versions=["1.0"],
         updated_at=datetime.now(),
         is_available=False,
+        useForOnboarding=False,
     )
 
     # Mock active version agent (what we want to return for active version)
@@ -105,6 +107,7 @@ async def test_get_store_agent_details(mocker):
         versions=["1.0", "2.0"],
         updated_at=datetime.now(),
         is_available=True,
+        useForOnboarding=False,
     )
 
     # Create a mock StoreListing result
@@ -248,6 +251,7 @@ async def test_create_store_submission(mocker):
                 isAvailable=True,
             )
         ],
+        useForOnboarding=False,
     )
 
     # Mock prisma calls

--- a/autogpt_platform/backend/migrations/20251013071709_add_use_for_onboarding/migration.sql
+++ b/autogpt_platform/backend/migrations/20251013071709_add_use_for_onboarding/migration.sql
@@ -1,0 +1,65 @@
+BEGIN;
+-- AlterTable
+ALTER TABLE "StoreListing" ADD COLUMN     "useForOnboarding" BOOLEAN NOT NULL DEFAULT false;
+
+-- Drop and recreate the StoreAgent view with useForOnboarding field
+DROP VIEW IF EXISTS "StoreAgent";
+
+CREATE OR REPLACE VIEW "StoreAgent" AS
+WITH latest_versions AS (
+    SELECT 
+        "storeListingId",
+        MAX(version) AS max_version
+    FROM "StoreListingVersion"
+    WHERE "submissionStatus" = 'APPROVED'
+    GROUP BY "storeListingId"
+),
+agent_versions AS (
+    SELECT 
+        "storeListingId",
+        array_agg(DISTINCT version::text ORDER BY version::text) AS versions
+    FROM "StoreListingVersion"
+    WHERE "submissionStatus" = 'APPROVED'
+    GROUP BY "storeListingId"
+)
+SELECT
+    sl.id AS listing_id,
+    slv.id AS "storeListingVersionId",
+    slv."createdAt" AS updated_at,
+    sl.slug,
+    COALESCE(slv.name, '') AS agent_name,
+    slv."videoUrl" AS agent_video,
+    COALESCE(slv."imageUrls", ARRAY[]::text[]) AS agent_image,
+    slv."isFeatured" AS featured,
+    p.username AS creator_username,  -- Allow NULL for malformed sub-agents
+    p."avatarUrl" AS creator_avatar,  -- Allow NULL for malformed sub-agents
+    slv."subHeading" AS sub_heading,
+    slv.description,
+    slv.categories,
+    COALESCE(ar.run_count, 0::bigint) AS runs,
+    COALESCE(rs.avg_rating, 0.0)::double precision AS rating,
+    COALESCE(av.versions, ARRAY[slv.version::text]) AS versions,
+    slv."isAvailable" AS is_available,
+    COALESCE(sl."useForOnboarding", false) AS "useForOnboarding"
+FROM "StoreListing" sl
+JOIN latest_versions lv 
+    ON sl.id = lv."storeListingId"
+JOIN "StoreListingVersion" slv 
+    ON slv."storeListingId" = lv."storeListingId"
+   AND slv.version = lv.max_version
+   AND slv."submissionStatus" = 'APPROVED'
+JOIN "AgentGraph" a 
+    ON slv."agentGraphId" = a.id 
+    AND slv."agentGraphVersion" = a.version
+LEFT JOIN "Profile" p 
+    ON sl."owningUserId" = p."userId"
+LEFT JOIN "mv_review_stats" rs 
+    ON sl.id = rs."storeListingId"
+LEFT JOIN "mv_agent_run_counts" ar 
+    ON a.id = ar."agentGraphId"
+LEFT JOIN agent_versions av 
+    ON sl.id = av."storeListingId"
+WHERE sl."isDeleted" = false
+  AND sl."hasApprovedVersion" = true;
+
+COMMIT;

--- a/autogpt_platform/backend/schema.prisma
+++ b/autogpt_platform/backend/schema.prisma
@@ -667,6 +667,7 @@ view StoreAgent {
   rating           Float
   versions         String[]
   is_available     Boolean  @default(true)
+  useForOnboarding Boolean  @default(false)
 
   // Materialized views used (refreshed every 15 minutes via pg_cron):
   // - mv_agent_run_counts - Pre-aggregated agent execution counts by agentGraphId
@@ -743,6 +744,9 @@ model StoreListing {
 
   // URL-friendly identifier for this agent (moved from StoreListingVersion)
   slug String
+
+  // Allow this agent to be used during onboarding
+  useForOnboarding   Boolean @default(false)
 
   // The currently active version that should be shown to users
   activeVersionId String?              @unique


### PR DESCRIPTION
Some agents aren't suitable for onboarding. This adds per-store agent setting to allow them for onboarding. In case no agent is allowed fallback to the former search.

### Changes 🏗️

- Add `useForOnboarding` to `StoreListing` model and `StoreAgent` view (with migration)
- Remove filtering of agents with empty input schema or credentials 

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Only allowed agents are displayed
  - [x] Fallback to the old system in case there aren't enough allowed agents

