### PR TITLE
feat(backend): add vercel preview cors on dev

### DIFF
--- a/autogpt_platform/backend/backend/server/rest_api.py
+++ b/autogpt_platform/backend/backend/server/rest_api.py
@@ -295,7 +295,7 @@ class AgentServer(backend.util.service.AppProcess):
             app=app,
             allow_origins=settings.config.backend_cors_allow_origins,
             allow_origin_regex=(
-                r"^https://.*\.vercel\.app$"
+                r"^https://.*-significant-gravitas\.vercel\.app$"
                 if settings.config.app_env == backend.util.settings.AppEnvironment.DEVELOPMENT
                 else None
             ),

--- a/autogpt_platform/backend/backend/server/ws_api.py
+++ b/autogpt_platform/backend/backend/server/ws_api.py
@@ -319,7 +319,7 @@ class WebsocketServer(AppProcess):
             app=app,
             allow_origins=settings.config.backend_cors_allow_origins,
             allow_origin_regex=(
-                r"^https://.*\.vercel\.app$"
+                r"^https://.*-significant-gravitas\.vercel\.app$"
                 if settings.config.app_env == AppEnvironment.DEVELOPMENT
                 else None
             ),


### PR DESCRIPTION
## Changes 🏗️

<img width="600" height="494" alt="Screenshot 2025-10-14 at 14 40 10" src="https://github.com/user-attachments/assets/46bb51a5-ac1e-408b-9f78-1ed297a75ac4" />

For the REST API and WS API deployed to Dev, allow [Vercel dynamically generated preview URLs](https://vercel.com/docs/deployments/preview-deployment-suffix) on [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CORS).

This is very helpful because it will allow us to easily test Front-end changes on PRs, so we can have a more robust process around it 🙇🏽 

## Checklist 📋

### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Once merged and I can try from a preview deployment in Vercel...

### For configuration changes:

I think none.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Development environment now permits cross-origin access from vercel.app subdomains for both REST and WebSocket APIs, enabling seamless connectivity from Vercel-hosted clients.
  * CORS behavior remains unchanged outside development environments.

* **Bug Fixes**
  * Resolves connection issues experienced by development clients hosted on vercel.app domains when accessing REST and WebSocket endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->