### PR TITLE
dx(frontend): enable Next.js sourcemaps for Sentry

### DIFF
--- a/autogpt_platform/frontend/next.config.mjs
+++ b/autogpt_platform/frontend/next.config.mjs
@@ -2,6 +2,7 @@ import { withSentryConfig } from "@sentry/nextjs";
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  productionBrowserSourceMaps: true,
   images: {
     domains: [
       "images.unsplash.com",
@@ -12,7 +13,6 @@ const nextConfig = {
       "ideogram.ai", // for generated images
       "picsum.photos", // for placeholder images
     ],
-    productionBrowserSourceMaps: true,
     remotePatterns: [
       {
         protocol: "https",


### PR DESCRIPTION
## Changes 🏗️

Next.js Sourcemaps aren't working on production, followed:

- https://docs.sentry.io/platforms/javascript/guides/nextjs/sourcemaps/
- https://docs.sentry.io/organization/integrations/deployment/vercel/

## Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] We will see once deployed ...

### For configuration changes:

None
