### PR TITLE
feat(blocks): add dedicated Perplexity block

### DIFF
--- a/autogpt_platform/backend/backend/blocks/perplexity.py
+++ b/autogpt_platform/backend/backend/blocks/perplexity.py
@@ -162,12 +162,13 @@ class PerplexityBlock(Block):
             if hasattr(response.choices[0].message, "annotations"):
                 # If annotations are directly available
                 annotations = response.choices[0].message.annotations
-            elif hasattr(response.choices[0].message, "_raw_response"):
+            else:
                 # Check if there's a raw response with annotations
-                raw = response.choices[0].message._raw_response
+                raw = getattr(response.choices[0].message, "_raw_response", None)
                 if isinstance(raw, dict) and "annotations" in raw:
                     annotations = raw["annotations"]
-            elif hasattr(response, "model_extra"):
+
+            if not annotations and hasattr(response, "model_extra"):
                 # Check model_extra for annotations
                 model_extra = response.model_extra
                 if isinstance(model_extra, dict):
@@ -178,8 +179,8 @@ class PerplexityBlock(Block):
                             annotations = choice["message"]["annotations"]
 
             # Also check the raw response object for annotations
-            if not annotations and hasattr(response, "_raw_response"):
-                raw = response._raw_response
+            if not annotations:
+                raw = getattr(response, "_raw_response", None)
                 if isinstance(raw, dict):
                     # Check various possible locations for annotations
                     if "annotations" in raw:


### PR DESCRIPTION
Fixes #11162

## Summary

Implements a new Perplexity block that allows users to query Perplexity's sonar models via OpenRouter with support for extracting URL citations and annotations.

## Changes

- Add new block for Perplexity sonar models (sonar, sonar-pro, sonar-deep-research)
- Support model selection for all three Perplexity models
- Implement annotations output pin for URL citations and source references
- Integrate with OpenRouter API for accessing Perplexity models
- Follow existing block patterns from AI text generator block

## Test Plan

✅ Block successfully instantiates
✅ Block is properly loaded by the dynamic loading system
✅ Output fields include response and annotations as required

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a Perplexity integration block to query Sonar models via OpenRouter.
  - Supports multiple model options, optional system prompt, and adjustable max tokens.
  - Returns concise responses with citation-style annotations extracted from the model output.
  - Provides clear error messages when requests fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->