### PR TITLE
feat(blocks): Add references output pin to Fact Checker block

### DIFF
--- a/autogpt_platform/backend/backend/blocks/jina/fact_checker.py
+++ b/autogpt_platform/backend/backend/blocks/jina/fact_checker.py
@@ -1,5 +1,7 @@
-from typing import List, TypedDict
+from typing import List
 from urllib.parse import quote
+
+from typing_extensions import TypedDict
 
 from backend.blocks.jina._auth import (
     JinaCredentials,


### PR DESCRIPTION
Closes #11163

## Summary
Expanded the Fact Checker block to yield its references list from the Jina AI API response.

## Changes 🏗️
- Added `Reference` TypedDict to define the structure of reference objects
- Added `references` field to the Output schema
- Modified the `run` method to extract and yield references from the API response
- Added fallback to empty list if references are not present

## Checklist 📋

### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Verified that the Fact Checker block schema includes the new references field
  - [x] Confirmed that references are properly extracted from the API response when present
  - [x] Tested the fallback behavior when references are not in the API response
  - [x] Ensured backward compatibility - existing functionality remains unchanged
  - [x] Verified the Reference TypedDict matches the expected API response structure

Generated with [Claude Code](https://claude.ai/code)

## Summary by CodeRabbit

* **New Features**
  * Fact-checking results now include a references list to support verification.
  * Each reference provides a URL, a key quote, and an indicator showing whether it supports the claim.
  * References are presented alongside factuality, result, and reasoning when available; otherwise, an empty list is returned.
  * Enhances transparency and traceability of fact-check outcomes without altering existing result fields.