### PR TITLE
feat(backend): Include default input values in graph export

### DIFF
--- a/autogpt_platform/backend/backend/data/graph.py
+++ b/autogpt_platform/backend/backend/data/graph.py
@@ -129,11 +129,20 @@ class NodeModel(Node):
         Returns a copy of the node model, stripped of any non-transferable properties
         """
         stripped_node = self.model_copy(deep=True)
-        # Remove credentials from node input
+
+        # Remove credentials and other (possible) secrets from node input
         if stripped_node.input_default:
             stripped_node.input_default = NodeModel._filter_secrets_from_node_input(
                 stripped_node.input_default, self.block.input_schema.jsonschema()
             )
+
+        # Remove default secret value from secret input nodes
+        if (
+            stripped_node.block.block_type == BlockType.INPUT
+            and stripped_node.input_default.get("secret", False) is True
+            and "value" in stripped_node.input_default
+        ):
+            del stripped_node.input_default["value"]
 
         # Remove webhook info
         stripped_node.webhook_id = None
@@ -150,8 +159,10 @@ class NodeModel(Node):
         result = {}
         for key, value in input_data.items():
             field_schema: dict | None = field_schemas.get(key)
-            if (field_schema and field_schema.get("secret", False)) or any(
-                sensitive_key in key.lower() for sensitive_key in sensitive_keys
+            if (field_schema and field_schema.get("secret", False)) or (
+                any(sensitive_key in key.lower() for sensitive_key in sensitive_keys)
+                # Prevent removing `secret` flag on input nodes
+                and type(value) is not bool
             ):
                 # This is a secret value -> filter this key-value pair out
                 continue

--- a/autogpt_platform/backend/backend/data/graph_test.py
+++ b/autogpt_platform/backend/backend/data/graph_test.py
@@ -201,23 +201,54 @@ async def test_get_input_schema(server: SpinTestServer, snapshot: Snapshot):
 @pytest.mark.asyncio(loop_scope="session")
 async def test_clean_graph(server: SpinTestServer):
     """
-    Test the clean_graph function that:
-    1. Clears input block values
-    2. Removes credentials from nodes
+    Test the stripped_for_export function that:
+    1. Removes sensitive/secret fields from node inputs
+    2. Removes webhook information
+    3. Preserves non-sensitive data including input block values
     """
-    # Create a graph with input blocks and credentials
+    # Create a graph with input blocks containing both sensitive and normal data
     graph = Graph(
         id="test_clean_graph",
         name="Test Clean Graph",
         description="Test graph cleaning",
         nodes=[
             Node(
-                id="input_node",
                 block_id=AgentInputBlock().id,
                 input_default={
+                    "_test_id": "input_node",
                     "name": "test_input",
-                    "value": "test value",
+                    "value": "test value",  # This should be preserved
                     "description": "Test input description",
+                },
+            ),
+            Node(
+                block_id=AgentInputBlock().id,
+                input_default={
+                    "_test_id": "input_node_secret",
+                    "name": "secret_input",
+                    "value": "another value",
+                    "secret": True,  # This makes the input secret
+                },
+            ),
+            Node(
+                block_id=StoreValueBlock().id,
+                input_default={
+                    "_test_id": "node_with_secrets",
+                    "input": "normal_value",
+                    "control_test_input": "should be preserved",
+                    "api_key": "secret_api_key_123",  # Should be filtered
+                    "password": "secret_password_456",  # Should be filtered
+                    "token": "secret_token_789",  # Should be filtered
+                    "credentials": {  # Should be filtered
+                        "id": "fake-github-credentials-id",
+                        "provider": "github",
+                        "type": "api_key",
+                    },
+                    "anthropic_credentials": {  # Should be filtered
+                        "id": "fake-anthropic-credentials-id",
+                        "provider": "anthropic",
+                        "type": "api_key",
+                    },
                 },
             ),
         ],
@@ -231,15 +262,54 @@ async def test_clean_graph(server: SpinTestServer):
     )
 
     # Clean the graph
-    created_graph = await server.agent_server.test_get_graph(
+    cleaned_graph = await server.agent_server.test_get_graph(
         created_graph.id, created_graph.version, DEFAULT_USER_ID, for_export=True
     )
 
-    # # Verify input block value is cleared
+    # Verify sensitive fields are removed but normal fields are preserved
     input_node = next(
-        n for n in created_graph.nodes if n.block_id == AgentInputBlock().id
+        n for n in cleaned_graph.nodes if n.input_default["_test_id"] == "input_node"
     )
-    assert input_node.input_default["value"] == ""
+
+    # Non-sensitive fields should be preserved
+    assert input_node.input_default["name"] == "test_input"
+    assert input_node.input_default["value"] == "test value"  # Should be preserved now
+    assert input_node.input_default["description"] == "Test input description"
+
+    # Sensitive fields should be filtered out
+    assert "api_key" not in input_node.input_default
+    assert "password" not in input_node.input_default
+
+    # Verify secret input node preserves non-sensitive fields but removes secret value
+    secret_node = next(
+        n
+        for n in cleaned_graph.nodes
+        if n.input_default["_test_id"] == "input_node_secret"
+    )
+    assert secret_node.input_default["name"] == "secret_input"
+    assert "value" not in secret_node.input_default  # Secret default should be removed
+    assert secret_node.input_default["secret"] is True
+
+    # Verify sensitive fields are filtered from nodes with secrets
+    secrets_node = next(
+        n
+        for n in cleaned_graph.nodes
+        if n.input_default["_test_id"] == "node_with_secrets"
+    )
+    # Normal fields should be preserved
+    assert secrets_node.input_default["input"] == "normal_value"
+    assert secrets_node.input_default["control_test_input"] == "should be preserved"
+    # Sensitive fields should be filtered out
+    assert "api_key" not in secrets_node.input_default
+    assert "password" not in secrets_node.input_default
+    assert "token" not in secrets_node.input_default
+    assert "credentials" not in secrets_node.input_default
+    assert "anthropic_credentials" not in secrets_node.input_default
+
+    # Verify webhook info is removed (if any nodes had it)
+    for node in cleaned_graph.nodes:
+        assert node.webhook_id is None
+        assert node.webhook is None
 
 
 @pytest.mark.asyncio(loop_scope="session")


### PR DESCRIPTION
Since #10323, one-time graph inputs are no longer stored on the input nodes (#9139), so we can reasonably assume that the default value set by the graph creator will be safe to export.

### Changes 🏗️

- Don't strip the default value from input nodes in `NodeModel.stripped_for_export(..)`, except for inputs marked as `secret`
- Update and expand tests for graph export secrets stripping mechanism

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Expanded tests pass
  - Relatively simple change with good test coverage, no manual test needed
