### PR TITLE
fix(blocks): Unhide "Add to Dictionary" block's `dictionary` input

### DIFF
--- a/autogpt_platform/backend/backend/blocks/data_manipulation.py
+++ b/autogpt_platform/backend/backend/blocks/data_manipulation.py
@@ -66,6 +66,7 @@ class AddToDictionaryBlock(Block):
         dictionary: dict[Any, Any] = SchemaField(
             default_factory=dict,
             description="The dictionary to add the entry to. If not provided, a new dictionary will be created.",
+            advanced=False,
         )
         key: str = SchemaField(
             default="",


### PR DESCRIPTION
The `dictionary` input on the Add to Dictionary block is hidden, even though it is the main input.

### Changes 🏗️

- Mark `dictionary` explicitly as not advanced (so not hidden by default)

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - Trivial change, no test needed
