### PR TITLE
fix(backend): Disable LaunchDarkly integration in metrics.py

### DIFF
--- a/autogpt_platform/backend/backend/util/metrics.py
+++ b/autogpt_platform/backend/backend/util/metrics.py
@@ -8,7 +8,7 @@ from sentry_sdk.integrations.asyncio import AsyncioIntegration
 from sentry_sdk.integrations.launchdarkly import LaunchDarklyIntegration
 from sentry_sdk.integrations.logging import LoggingIntegration
 
-from backend.util.feature_flag import get_client, is_configured
+# from backend.util.feature_flag import get_client, is_configured
 from backend.util.settings import Settings
 
 settings = Settings()
@@ -22,8 +22,8 @@ class DiscordChannel(str, Enum):
 def sentry_init():
     sentry_dsn = settings.secrets.sentry_dsn
     integrations = []
-    if is_configured():
-        integrations.append(LaunchDarklyIntegration(get_client()))
+    # if is_configured():
+    #     integrations.append(LaunchDarklyIntegration(get_client()))
     sentry_sdk.init(
         dsn=sentry_dsn,
         traces_sample_rate=1.0,


### PR DESCRIPTION
Comment out LaunchDarkly integration and related imports to ensure we don't hit init errors

<!-- Clearly explain the need for these changes: -->

### Changes 🏗️
comments out LD
<!-- Concisely describe all of the changes made in this pull request: -->

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [x] This is bringing prod down so testing live


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled LaunchDarkly integration from the metrics module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->