### PR TITLE
fix(backend): Handle LaunchDarkly init failure

### DIFF
--- a/autogpt_platform/backend/backend/util/metrics.py
+++ b/autogpt_platform/backend/backend/util/metrics.py
@@ -3,15 +3,17 @@ from enum import Enum
 
 import sentry_sdk
 from pydantic import SecretStr
+from sentry_sdk.integrations import DidNotEnable
 from sentry_sdk.integrations.anthropic import AnthropicIntegration
 from sentry_sdk.integrations.asyncio import AsyncioIntegration
 from sentry_sdk.integrations.launchdarkly import LaunchDarklyIntegration
 from sentry_sdk.integrations.logging import LoggingIntegration
 
-from backend.util.feature_flag import get_client, is_configured
+from backend.util import feature_flag
 from backend.util.settings import Settings
 
 settings = Settings()
+logger = logging.getLogger(__name__)
 
 
 class DiscordChannel(str, Enum):
@@ -22,8 +24,11 @@ class DiscordChannel(str, Enum):
 def sentry_init():
     sentry_dsn = settings.secrets.sentry_dsn
     integrations = []
-    if is_configured():
-        integrations.append(LaunchDarklyIntegration(get_client()))
+    if feature_flag.is_configured():
+        try:
+            integrations.append(LaunchDarklyIntegration(feature_flag.get_client()))
+        except DidNotEnable as e:
+            logger.error(f"Error enabling LaunchDarklyIntegration for Sentry: {e}")
     sentry_sdk.init(
         dsn=sentry_dsn,
         traces_sample_rate=1.0,


### PR DESCRIPTION
LaunchDarkly is currently down and it's keeping our executor pods from spinning up.

### Changes 🏗️

- Wrap `LaunchDarklyIntegration` init in a try/except

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - We'll see if it works once it deploys
