### PR TITLE
fix(backend): Only try to initialize LaunchDarkly once

### DIFF
--- a/autogpt_platform/backend/backend/util/feature_flag.py
+++ b/autogpt_platform/backend/backend/util/feature_flag.py
@@ -63,9 +63,9 @@ def initialize_launchdarkly() -> None:
     config = Config(sdk_key)
     ldclient.set_config(config)
 
+    global _is_initialized
+    _is_initialized = True
     if ldclient.get().is_initialized():
-        global _is_initialized
-        _is_initialized = True
         logger.info("LaunchDarkly client initialized successfully")
     else:
         logger.error("LaunchDarkly client failed to initialize")
@@ -218,7 +218,8 @@ def feature_flag(
 
                 if not get_client().is_initialized():
                     logger.warning(
-                        f"LaunchDarkly not initialized, using default={default}"
+                        "LaunchDarkly not initialized, "
+                        f"using default {flag_key}={repr(default)}"
                     )
                     is_enabled = default
                 else:
@@ -232,8 +233,9 @@ def feature_flag(
                     else:
                         # Log warning and use default for non-boolean values
                         logger.warning(
-                            f"Feature flag {flag_key} returned non-boolean value: {flag_value} (type: {type(flag_value).__name__}). "
-                            f"Using default={default}"
+                            f"Feature flag {flag_key} returned non-boolean value: "
+                            f"{repr(flag_value)} (type: {type(flag_value).__name__}). "
+                            f"Using default value {repr(default)}"
                         )
                         is_enabled = default
 


### PR DESCRIPTION
We currently try to re-init the LaunchDarkly client every time a feature flag is checked.
This causes 5 second extra latency on the flag check when LD is down, such as now.
Since flag checks are performed on every block execution, this currently cripples the platform's executors.

- Follow-up to #11221

### Changes 🏗️

- Only try to init LaunchDarkly once
- Improve surrounding log statements in the `feature_flag` module

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - This is a critical hotfix; we'll see its effect once deployed
