### PR TITLE
fix(frontend): Limit Sentry console capture to warnings and errors

### DIFF
--- a/autogpt_platform/frontend/sentry.edge.config.ts
+++ b/autogpt_platform/frontend/sentry.edge.config.ts
@@ -40,7 +40,7 @@ Sentry.init({
 
   enableLogs: true,
   integrations: [
-    Sentry.captureConsoleIntegration(),
+    Sentry.captureConsoleIntegration({ levels: ["fatal", "error", "warn"] }),
     Sentry.extraErrorDataIntegration(),
   ],
 });


### PR DESCRIPTION
Debug and info level messages are currently ending up in Sentry, polluting our issue feed.

### Changes 🏗️

- Limit Sentry console capture to warnings and worse

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - Trivial change, no test needed
