### PR TITLE
fix(frontend): Filter out `undefined` query params in API requests

### DIFF
--- a/autogpt_platform/frontend/src/lib/autogpt-server-api/helpers.ts
+++ b/autogpt_platform/frontend/src/lib/autogpt-server-api/helpers.ts
@@ -60,12 +60,12 @@ export function buildServerUrl(path: string): string {
 
 export function buildUrlWithQuery(
   url: string,
-  payload?: Record<string, any>,
+  query?: Record<string, any>,
 ): string {
-  if (!payload) return url;
+  if (!query) return url;
 
   // Filter out undefined values to prevent them from being included as "undefined" strings
-  const filteredPayload = Object.entries(payload).reduce(
+  const filteredQuery = Object.entries(query).reduce(
     (acc, [key, value]) => {
       if (value !== undefined) {
         acc[key] = value;
@@ -75,8 +75,8 @@ export function buildUrlWithQuery(
     {} as Record<string, any>,
   );
 
-  const queryParams = new URLSearchParams(filteredPayload);
-  return `${url}?${queryParams.toString()}`;
+  const queryParams = new URLSearchParams(filteredQuery);
+  return queryParams.size > 0 ? `${url}?${queryParams.toString()}` : url;
 }
 
 export async function handleFetchError(response: Response): Promise<ApiError> {


### PR DESCRIPTION
Part of our effort to eliminate preventable warnings and errors.

- Resolves #11237

### Changes 🏗️

- Exclude `undefined` query params in API requests

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - Open the Builder without a `flowVersion` URL parameter
    - [x] -> `GET /api/library/agents/by-graph/{graph_id}` succeeds
  - Open the builder with a `flowVersion` URL parameter
    - [x] -> version is correctly included in request URL parameters
