### PR TITLE
fix(backend): prevent error message leak

### DIFF
--- a/autogpt_platform/backend/backend/server/v2/store/routes.py
+++ b/autogpt_platform/backend/backend/server/v2/store/routes.py
@@ -551,7 +551,7 @@ async def create_submission(
         logger.warning("Slug already in use: %s", str(e))
         return fastapi.responses.JSONResponse(
             status_code=409,
-            content={"detail": str(e)},
+            content={"detail": "Slug already in use. Please choose a different slug."},
         )
     except Exception:
         logger.exception("Exception occurred whilst creating store submission")


### PR DESCRIPTION
Potential fix for [https://github.com/Significant-Gravitas/AutoGPT/security/code-scanning/155](https://github.com/Significant-Gravitas/AutoGPT/security/code-scanning/155)

To fix this vulnerability, avoid returning the raw exception message from SlugAlreadyInUseError in the API response. Instead, return a generic, non-revealing error message suitable for the end user. Log the original exception and its message on the server as a warning, so developers can still access the necessary diagnostic information. This change should be made solely in the exception handler for SlugAlreadyInUseError, replacing `{"detail": str(e)}` with a safe, constant message like `{"detail": "Slug already in use. Please choose a different slug."}`. This preserves the intended business logic (409 Conflict) and user feedback, but without leaking potentially sensitive data.

No new dependencies or imports are needed; we can keep the existing logging and response handling.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
