### PR TITLE
feat(blocks/revid): Add cost configs for revid video blocks

### DIFF
--- a/autogpt_platform/backend/backend/data/block_cost_config.py
+++ b/autogpt_platform/backend/backend/data/block_cost_config.py
@@ -1,7 +1,11 @@
 from typing import Type
 
 from backend.blocks.ai_music_generator import AIMusicGeneratorBlock
-from backend.blocks.ai_shortform_video_block import AIShortformVideoCreatorBlock
+from backend.blocks.ai_shortform_video_block import (
+    AIAdMakerVideoCreatorBlock,
+    AIScreenshotToVideoAdBlock,
+    AIShortformVideoCreatorBlock,
+)
 from backend.blocks.apollo.organization import SearchOrganizationsBlock
 from backend.blocks.apollo.people import SearchPeopleBlock
 from backend.blocks.apollo.person import GetPersonDetailBlock
@@ -323,7 +327,31 @@ BLOCK_COSTS: dict[Type[Block], list[BlockCost]] = {
     ],
     AIShortformVideoCreatorBlock: [
         BlockCost(
-            cost_amount=50,
+            cost_amount=307,
+            cost_filter={
+                "credentials": {
+                    "id": revid_credentials.id,
+                    "provider": revid_credentials.provider,
+                    "type": revid_credentials.type,
+                }
+            },
+        )
+    ],
+    AIAdMakerVideoCreatorBlock: [
+        BlockCost(
+            cost_amount=714,
+            cost_filter={
+                "credentials": {
+                    "id": revid_credentials.id,
+                    "provider": revid_credentials.provider,
+                    "type": revid_credentials.type,
+                }
+            },
+        )
+    ],
+    AIScreenshotToVideoAdBlock: [
+        BlockCost(
+            cost_amount=612,
             cost_filter={
                 "credentials": {
                     "id": revid_credentials.id,


### PR DESCRIPTION
  Updated block costs in `backend/backend/data/block_cost_config.py`:
  - **AIShortformVideoCreatorBlock**: Updated from 50 credits to 307
  - **AIAdMakerVideoCreatorBlock**: Added cost of 714 credits
  - **AIScreenshotToVideoAdBlock**: Added cost of 612 credits

  ### Checklist 📋

  #### For code changes:
  - [x] I have clearly listed my changes in the PR description
  - [x] I have made a test plan
  - [x] I have tested my changes according to the test plan:
    - [x] Verify AIShortformVideoCreatorBlock costs 307 credits when executed
    - [x] Verify AIAdMakerVideoCreatorBlock costs 714 credits when executed
    - [x] Verify AIScreenshotToVideoAdBlock costs 612 credits when executed