### PR TITLE
fix(frontend): login not visible mobile

### DIFF
--- a/autogpt_platform/frontend/src/components/layout/Navbar/components/NavbarView.tsx
+++ b/autogpt_platform/frontend/src/components/layout/Navbar/components/NavbarView.tsx
@@ -45,8 +45,8 @@ export const NavbarView = ({ isLoggedIn }: NavbarViewProps) => {
         </div>
 
         {/* Right section */}
-        <div className="flex flex-1 items-center justify-end gap-4">
-          {isLoggedIn ? (
+        {isLoggedIn ? (
+          <div className="hidden flex-1 items-center justify-end gap-4 md:flex">
             <div className="flex items-center gap-4">
               <AgentActivityDropdown />
               {profile && <Wallet />}
@@ -57,11 +57,13 @@ export const NavbarView = ({ isLoggedIn }: NavbarViewProps) => {
                 menuItemGroups={dynamicMenuItems}
               />
             </div>
-          ) : (
+          </div>
+        ) : (
+          <div className="flex w-full items-center justify-end">
             <LoginButton />
-          )}
-          {/* <ThemeToggle /> */}
-        </div>
+          </div>
+        )}
+        {/* <ThemeToggle /> */}
       </nav>
       {/* Mobile Navbar - Adjust positioning */}
       <>


### PR DESCRIPTION
## Changes 🏗️

The mobile 📱 experience is still a mess but this helps a little.

### Before

<img width="350" height="395" alt="Screenshot 2025-10-24 at 18 26 18" src="https://github.com/user-attachments/assets/75eab232-8c37-41e7-a51d-dbe07db336a0" />

### After

<img width="350" height="406" alt="Screenshot 2025-10-24 at 18 25 54" src="https://github.com/user-attachments/assets/ecbd8bbd-8a94-4775-b990-c8b51de48cf9" />


## Checklist 📋

### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Load the app
  - [x] Check the Tally popup button copy
  - [x] The button still works  

