### PR TITLE
fix(blocks): Add missing error output pins to all Firecrawl blocks

### DIFF
--- a/autogpt_platform/backend/backend/blocks/firecrawl/crawl.py
+++ b/autogpt_platform/backend/backend/blocks/firecrawl/crawl.py
@@ -55,6 +55,10 @@ class FirecrawlCrawlBlock(Block):
         change_tracking: dict[str, Any] = SchemaField(
             description="The change tracking of the crawl"
         )
+        error: str = SchemaField(
+            description="Error message if the crawl failed",
+            default="",
+        )
 
     def __init__(self):
         super().__init__(

--- a/autogpt_platform/backend/backend/blocks/firecrawl/extract.py
+++ b/autogpt_platform/backend/backend/blocks/firecrawl/extract.py
@@ -39,6 +39,10 @@ class FirecrawlExtractBlock(Block):
 
     class Output(BlockSchema):
         data: dict[str, Any] = SchemaField(description="The result of the crawl")
+        error: str = SchemaField(
+            description="Error message if the extraction failed",
+            default="",
+        )
 
     def __init__(self):
         super().__init__(

--- a/autogpt_platform/backend/backend/blocks/firecrawl/map.py
+++ b/autogpt_platform/backend/backend/blocks/firecrawl/map.py
@@ -26,6 +26,10 @@ class FirecrawlMapWebsiteBlock(Block):
         results: list[dict[str, Any]] = SchemaField(
             description="List of search results with url, title, and description"
         )
+        error: str = SchemaField(
+            description="Error message if the map failed",
+            default="",
+        )
 
     def __init__(self):
         super().__init__(

--- a/autogpt_platform/backend/backend/blocks/firecrawl/scrape.py
+++ b/autogpt_platform/backend/backend/blocks/firecrawl/scrape.py
@@ -54,6 +54,10 @@ class FirecrawlScrapeBlock(Block):
         change_tracking: dict[str, Any] = SchemaField(
             description="The change tracking of the crawl"
         )
+        error: str = SchemaField(
+            description="Error message if the scrape failed",
+            default="",
+        )
 
     def __init__(self):
         super().__init__(

--- a/autogpt_platform/backend/backend/blocks/firecrawl/search.py
+++ b/autogpt_platform/backend/backend/blocks/firecrawl/search.py
@@ -38,6 +38,10 @@ class FirecrawlSearchBlock(Block):
     class Output(BlockSchema):
         data: dict[str, Any] = SchemaField(description="The result of the search")
         site: dict[str, Any] = SchemaField(description="The site of the search")
+        error: str = SchemaField(
+            description="Error message if the search failed",
+            default="",
+        )
 
     def __init__(self):
         super().__init__(


### PR DESCRIPTION
Added error output pins to all Firecrawl blocks as standard on the AutoGPT platform. The base block execution code already handles error yielding, so no try-catch logic was needed.

- FirecrawlScrapeBlock: Added error output pin for scrape failures
- FirecrawlCrawlBlock: Added error output pin for crawl failures
- FirecrawlExtractBlock: Added error output pin for extraction failures
- FirecrawlMapBlock: Added error output pin for map failures
- FirecrawlSearchBlock: Added error output pin for search failures

Resolves #11253

<!-- Clearly explain the need for these changes: -->

### Changes 🏗️

<!-- Concisely describe all of the changes made in this pull request: -->

### Checklist 📋

#### For code changes:
- [ ] I have clearly listed my changes in the PR description
- [ ] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [ ] ...

<details>
  <summary>Example test plan</summary>
  
  - [ ] Create from scratch and execute an agent with at least 3 blocks
  - [ ] Import an agent from file upload, and confirm it executes correctly
  - [ ] Upload agent to marketplace
  - [ ] Import an agent from marketplace and confirm it executes correctly
  - [ ] Edit an agent from monitor, and confirm it executes correctly
</details>

#### For configuration changes:

- [ ] `.env.default` is updated or already compatible with my changes
- [ ] `docker-compose.yml` is updated or already compatible with my changes
- [ ] I have included a list of my configuration changes in the PR description (under **Changes**)

<details>
  <summary>Examples of configuration changes</summary>

  - Changing ports
  - Adding new services that need to communicate with each other
  - Secrets or environment variable changes
  - New or infrastructure changes such as databases
</details>
