### PR TITLE
fix(onboarding): Prevent frontend errors when less than 2 agents are returned

### DIFF
--- a/autogpt_platform/backend/backend/data/onboarding.py
+++ b/autogpt_platform/backend/backend/data/onboarding.py
@@ -315,6 +315,11 @@ async def get_recommended_agents(user_id: str) -> list[StoreAgentDetails]:
     agent_points.sort(key=lambda x: x[1], reverse=True)
     recommended_agents = [agent for agent, _ in agent_points[:2]]
 
+    # Only return agents if we have at least 2 as frontend expects at least 2 agents
+    # This prevents the frontend from trying to display a partial selection
+    if len(recommended_agents) < 2:
+        return []
+
     return [
         StoreAgentDetails(
             store_listing_version_id=agent.storeListingVersionId,

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/4-agent/page.tsx
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/4-agent/page.tsx
@@ -67,12 +67,15 @@ export default function Page() {
                 agents[0]?.store_listing_version_id
               : false
           }
-          onClick={() =>
-            updateState({
-              selectedStoreListingVersionId: agents[0].store_listing_version_id,
-              agentInput: {},
-            })
-          }
+          onClick={() => {
+            if (agents[0]) {
+              updateState({
+                selectedStoreListingVersionId:
+                  agents[0].store_listing_version_id,
+                agentInput: {},
+              });
+            }
+          }}
         />
         <OnboardingAgentCard
           agent={agents[1]}
@@ -82,11 +85,14 @@ export default function Page() {
                 agents[1]?.store_listing_version_id
               : false
           }
-          onClick={() =>
-            updateState({
-              selectedStoreListingVersionId: agents[1].store_listing_version_id,
-            })
-          }
+          onClick={() => {
+            if (agents[1]) {
+              updateState({
+                selectedStoreListingVersionId:
+                  agents[1].store_listing_version_id,
+              });
+            }
+          }}
         />
       </div>
 


### PR DESCRIPTION
### Changes 🏗️

- Prevents the frontend from trying to display a partial selection of agents when less than 2 agents are returned from the backend.
- Adds a check in the backend to only return agents if we have at least 2.
- Adds a check in the frontend to ensure that the agent exists before attempting to update the state.
- Fixes [BUILDER-45E](https://sentry.io/organizations/significant-gravitas/issues/6953457243/).

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [ ] Ensure that the frontend does not error when the backend returns fewer than 2 agents.
  - [ ] Ensure that the frontend correctly displays agents when the backend returns 2 or more agents.

