### PR TITLE
fix(backend/executor): make graph execution permission check version-agnostic

### DIFF
--- a/autogpt_platform/backend/backend/data/graph.py
+++ b/autogpt_platform/backend/backend/data/graph.py
@@ -1122,7 +1122,11 @@ async def validate_graph_execution_permissions(
     Args:
         graph_id: The ID of the graph to check
         user_id: The ID of the user
-        graph_version: Optional specific version to check
+        graph_version: Optional specific version to check. If None (recommended),
+                      performs version-agnostic check allowing execution of any
+                      version as long as the graph is in the user's library.
+                      This is important for sub-graphs that may reference older
+                      versions no longer in the library.
 
     Raises:
         GraphNotInLibraryError: If the graph is not in the user's library (deleted/archived)

--- a/autogpt_platform/backend/backend/executor/utils.py
+++ b/autogpt_platform/backend/backend/executor/utils.py
@@ -517,10 +517,12 @@ async def validate_and_construct_node_execution_input(
     # Validate that the user has permission to execute this graph
     # This checks both library membership and execution permissions,
     # raising specific exceptions for appropriate error handling
+    # Note: Version-agnostic check to allow execution of graphs that reference
+    # older versions of sub-graphs that may no longer be in the library
     await gdb.validate_graph_execution_permissions(
         graph_id=graph_id,
         user_id=user_id,
-        graph_version=graph.version,
+        # graph_version omitted for version-agnostic permission check
     )
 
     nodes_input_masks = _merge_nodes_input_masks(


### PR DESCRIPTION
## Summary
Fix critical issue where pre-execution permission validation broke execution of graphs that reference older versions of sub-graphs.

## Problem
The `validate_graph_execution_permissions` function was checking for the specific version of a graph in the user's library. This caused failures when:
1. A parent graph references an older version of a sub-graph  
2. The user updates the sub-graph to a newer version
3. The older version is no longer in their library
4. Execution of the parent graph fails with `GraphNotInLibraryError`

## Root Cause
In `backend/executor/utils.py` line 523, the function was checking for the exact version, but sub-graphs legitimately reference older versions that may no longer be in the library.

## Solution

### 1. Remove Version-Specific Check (backend/executor/utils.py)
- Remove `graph_version=graph.version` parameter from validation call
- Add explanatory comment about version-agnostic behavior
- Now only checks that the graph ID exists in user's library (any version)

### 2. Enhance Documentation (backend/data/graph.py)  
- Update function docstring to explain version-agnostic behavior
- Document that `None` (now default) allows execution of any version
- Clarify this is important for sub-graph version compatibility

## Technical Details
The `validate_graph_execution_permissions` function was already designed to handle version-agnostic checks when `graph_version=None`. By omitting the version parameter, we skip the version check and only verify:
- Graph exists in user's library  
- Graph is not deleted/archived
- User has execution permissions

## Impact
- ✅ Parent graphs can execute even when they reference older sub-graph versions
- ✅ Sub-graph updates don't break existing parent graphs  
- ✅ Maintains security: still checks library membership and permissions
- ✅ No breaking changes: version-specific validation still available when needed

## Example Scenario Fixed
1. User creates parent graph that uses sub-graph v1
2. User updates sub-graph to v2 (v1 removed from library)  
3. Parent graph still references sub-graph v1
4. **Before**: Execution fails with `GraphNotInLibraryError`
5. **After**: Execution succeeds (version-agnostic permission check)

## Testing
- [x] Code formatting and linting passes
- [x] Type checking passes
- [x] No breaking changes to existing functionality
- [x] Security still maintained through library membership checks

## Files Changed
- `backend/executor/utils.py`: Remove version-specific permission check
- `backend/data/graph.py`: Enhanced documentation for version-agnostic behavior

Closes #[issue-number-if-applicable]