### PR TITLE
fix(backend/scheduler): Bump `apscheduler` to DST-fixed version 3.11.1

### DIFF
--- a/autogpt_platform/backend/poetry.lock
+++ b/autogpt_platform/backend/poetry.lock
@@ -271,14 +271,16 @@ test = ["anyio[trio]", "blockbuster (>=1.5.23)", "coverage[toml] (>=7)", "except
 trio = ["trio (>=0.26.1)"]
 
 [[package]]
-name = "APScheduler"
-version = "3.11.0.post3"
+name = "apscheduler"
+version = "3.11.1"
 description = "In-process task scheduler with Cron-like capabilities"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "apscheduler-3.11.1-py3-none-any.whl", hash = "sha256:6162cb5683cb09923654fa9bdd3130c4be4bfda6ad8990971c9597ecd52965d2"},
+    {file = "apscheduler-3.11.1.tar.gz", hash = "sha256:0db77af6400c84d1747fe98a04b8b58f0080c77d11d338c4f507a9752880f221"},
+]
 
 [package.dependencies]
 tzlocal = ">=3.0"
@@ -295,12 +297,6 @@ test = ["APScheduler[etcd,mongodb,redis,rethinkdb,sqlalchemy,tornado,zookeeper]"
 tornado = ["tornado (>=4.3)"]
 twisted = ["twisted"]
 zookeeper = ["kazoo"]
-
-[package.source]
-type = "git"
-url = "https://github.com/berianjames/apscheduler.git"
-reference = "ff9a687424a23c81a72deb7331a69cc1351b0420"
-resolved_reference = "ff9a687424a23c81a72deb7331a69cc1351b0420"
 
 [[package]]
 name = "async-timeout"
@@ -7281,4 +7277,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.14"
-content-hash = "d088262266d5b1f5fabc63cf7db5257894ca12edc06c86bdb7483bdc96943849"
+content-hash = "4d7134993527a5ff91b531a4e28b36bcab7cef2db18cf00702a950e34ae9ea1d"

--- a/autogpt_platform/backend/pyproject.toml
+++ b/autogpt_platform/backend/pyproject.toml
@@ -13,8 +13,7 @@ aio-pika = "^9.5.5"
 aiohttp = "^3.10.0"
 aiodns = "^3.5.0"
 anthropic = "^0.59.0"
-# TEMPFIX until APScheduler releases a fix - https://github.com/Significant-Gravitas/AutoGPT/issues/11273
-apscheduler = { git = "https://github.com/berianjames/apscheduler.git", rev = "ff9a687424a23c81a72deb7331a69cc1351b0420" }
+apscheduler = "^3.11.1"
 autogpt-libs = { path = "../autogpt_libs", develop = true }
 bleach = { extras = ["css"], version = "^6.2.0" }
 click = "^8.2.0"


### PR DESCRIPTION
- #11273

### Changes 🏗️

- Bump `apscheduler` to v3.11.1 which contains a fix for the issue

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] "It's a rather ugly solution but the test proves that it works." ~the maintainer
  - [x] CI passes
