### PR TITLE
feat(platform/blocks): implement ConcatenateListsBlock

### DIFF
--- a/autogpt_platform/backend/backend/blocks/concatenate_lists.py
+++ b/autogpt_platform/backend/backend/blocks/concatenate_lists.py
@@ -1,0 +1,36 @@
+from itertools import chain
+from backend.data.block import BlockIOBase, BlockIOType, SchemaField
+from backend.data.block_decorator import block
+
+@block(
+    name="Concatenate Lists",
+    description="Concatenates two or more lists into one",
+    category="Lists",
+    input_schema={
+        "lists": SchemaField(
+            type=BlockIOType.LIST,
+            description="List of lists to concatenate",
+        ),
+    },
+    output_schema={
+        "result": SchemaField(
+            type=BlockIOType.LIST,
+            description="Concatenated list result",
+        ),
+    },
+)
+class ConcatenateListsBlock(BlockIOBase):
+    def run(self, lists: list) -> dict:
+        try:
+            if not isinstance(lists, list):
+                raise ValueError("Input must be a list of lists")
+
+            for lst in lists:
+                if not isinstance(lst, list):
+                    raise ValueError("All elements inside 'lists' must be lists")
+
+            result = list(chain.from_iterable(lists))
+            return {"result": result}
+
+        except Exception as e:
+            return {"error": str(e)}

--- a/autogpt_platform/backend/test/blocks/test_concatenate_lists.py
+++ b/autogpt_platform/backend/test/blocks/test_concatenate_lists.py
@@ -1,0 +1,16 @@
+from autogpt_platform.backend.backend.blocks.concatenate_lists import ConcatenateListsBlock
+
+def test_concatenate_lists_basic():
+    block = ConcatenateListsBlock()
+    result = block.run([[1, 2], [3, 4]])
+    assert result["result"] == [1, 2, 3, 4]
+
+def test_concatenate_lists_empty_lists():
+    block = ConcatenateListsBlock()
+    result = block.run([[], [], []])
+    assert result["result"] == []
+
+def test_concatenate_lists_invalid_input():
+    block = ConcatenateListsBlock()
+    out = block.run("invalid")
+    assert "error" in out


### PR DESCRIPTION
**Summary**

This pull request introduces the ConcatenateListsBlock, a new block that merges multiple lists into a single flattened list. The implementation uses itertools.chain for efficient concatenation and includes input validation to ensure the input structure is correct.

**Changes Included**
Added concatenate_lists.py under backend/backend/blocks/
Added unit tests under backend/test/blocks/
Tests cover normal list merging, empty list handling, and invalid input cases

**Test Plan**

The block was validated using the included unit tests. All unit tests were executed locally under Python 3.12 in a virtual environment using pytest -q.


**Notes**

This PR contains only the block implementation and its corresponding tests. No unrelated code changes or dependency updates are included.