### PR TITLE
fix(frontend): consolidate graph save logic to prevent duplicate event listeners

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/build/components/BuilderActions/components/RunGraph/useRunGraph.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/BuilderActions/components/RunGraph/useRunGraph.ts
@@ -2,16 +2,16 @@ import {
   usePostV1ExecuteGraphAgent,
   usePostV1StopGraphExecution,
 } from "@/app/api/__generated__/endpoints/graphs/graphs";
-import { useNewSaveControl } from "../../../NewControlPanel/NewSaveControl/useNewSaveControl";
 import { useToast } from "@/components/molecules/Toast/use-toast";
 import { parseAsInteger, parseAsString, useQueryStates } from "nuqs";
 import { GraphExecutionMeta } from "@/app/(platform)/library/agents/[id]/components/OldAgentLibraryView/use-agent-runs";
 import { useGraphStore } from "@/app/(platform)/build/stores/graphStore";
 import { useShallow } from "zustand/react/shallow";
 import { useState } from "react";
+import { useSaveGraph } from "@/app/(platform)/build/hooks/useSaveGraph";
 
 export const useRunGraph = () => {
-  const { onSubmit: onSaveGraph, isLoading: isSaving } = useNewSaveControl({
+  const { saveGraph, isSaving } = useSaveGraph({
     showToast: false,
   });
   const { toast } = useToast();
@@ -67,7 +67,7 @@ export const useRunGraph = () => {
   });
 
   const handleRunGraph = async () => {
-    await onSaveGraph(undefined);
+    await saveGraph(undefined);
 
     if (hasInputs() || hasCredentials()) {
       setOpenRunInputDialog(true);

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/BuilderActions/components/ScheduleGraph/useScheduleGraph.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/BuilderActions/components/ScheduleGraph/useScheduleGraph.ts
@@ -1,10 +1,10 @@
 import { useGraphStore } from "@/app/(platform)/build/stores/graphStore";
 import { useShallow } from "zustand/react/shallow";
-import { useNewSaveControl } from "../../../NewControlPanel/NewSaveControl/useNewSaveControl";
 import { useState } from "react";
+import { useSaveGraph } from "@/app/(platform)/build/hooks/useSaveGraph";
 
 export const useScheduleGraph = () => {
-  const { onSubmit: onSaveGraph } = useNewSaveControl({
+  const { saveGraph } = useSaveGraph({
     showToast: false,
   });
   const hasInputs = useGraphStore(useShallow((state) => state.hasInputs));
@@ -15,7 +15,7 @@ export const useScheduleGraph = () => {
   const [openCronSchedulerDialog, setOpenCronSchedulerDialog] = useState(false);
 
   const handleScheduleGraph = async () => {
-    await onSaveGraph(undefined);
+    await saveGraph(undefined);
     if (hasInputs() || hasCredentials()) {
       setOpenScheduleInputDialog(true);
     } else {

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/NewControlPanel/NewSaveControl/NewSaveControl.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/NewControlPanel/NewSaveControl/NewSaveControl.tsx
@@ -19,10 +19,9 @@ import { Input } from "@/components/atoms/Input/Input";
 import { Button } from "@/components/atoms/Button/Button";
 
 export const NewSaveControl = () => {
-  const { form, onSubmit, isLoading, graphVersion } = useNewSaveControl({
-    showToast: true,
-  });
+  const { form, isSaving, graphVersion, handleSave } = useNewSaveControl();
   const { saveControlOpen, setSaveControlOpen } = useControlPanelStore();
+
   return (
     <Popover onOpenChange={setSaveControlOpen}>
       <Tooltip delayDuration={100}>
@@ -49,7 +48,7 @@ export const NewSaveControl = () => {
       >
         <Card className="border-none dark:bg-slate-900">
           <Form {...form}>
-            <form onSubmit={form.handleSubmit(onSubmit)}>
+            <form onSubmit={form.handleSubmit(handleSave)}>
               <CardContent className="p-0">
                 <div className="space-y-3">
                   <FormField
@@ -111,8 +110,8 @@ export const NewSaveControl = () => {
                   className="w-full dark:bg-slate-700 dark:text-slate-100 dark:hover:bg-slate-800"
                   data-id="save-control-save-agent"
                   data-testid="save-control-save-agent-button"
-                  disabled={isLoading}
-                  loading={isLoading}
+                  disabled={isSaving}
+                  loading={isSaving}
                 >
                   Save Agent
                 </Button>

--- a/autogpt_platform/frontend/src/app/(platform)/build/hooks/useSaveGraph.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/build/hooks/useSaveGraph.ts
@@ -1,0 +1,156 @@
+// Creating this hook, because we are using same saving stuff at multiple places in our builder
+
+import { useCallback } from "react";
+import { useToast } from "@/components/molecules/Toast/use-toast";
+import { useQueryClient } from "@tanstack/react-query";
+import { parseAsInteger, parseAsString, useQueryStates } from "nuqs";
+import {
+  getGetV1GetSpecificGraphQueryKey,
+  useGetV1GetSpecificGraph,
+  usePostV1CreateNewGraph,
+  usePutV1UpdateGraphVersion,
+} from "@/app/api/__generated__/endpoints/graphs/graphs";
+import { GraphModel } from "@/app/api/__generated__/models/graphModel";
+import { Graph } from "@/app/api/__generated__/models/graph";
+import { useNodeStore } from "../stores/nodeStore";
+import { useEdgeStore } from "../stores/edgeStore";
+import { graphsEquivalent } from "../components/NewControlPanel/NewSaveControl/helpers";
+
+export type SaveGraphOptions = {
+  showToast?: boolean;
+  onSuccess?: (graph: GraphModel) => void;
+  onError?: (error: any) => void;
+};
+
+export const useSaveGraph = ({
+  showToast = true,
+  onSuccess,
+  onError,
+}: SaveGraphOptions) => {
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+
+  const [{ flowID, flowVersion }, setQueryStates] = useQueryStates({
+    flowID: parseAsString,
+    flowVersion: parseAsInteger,
+  });
+
+  const { data: graph } = useGetV1GetSpecificGraph(
+    flowID ?? "",
+    flowVersion !== null ? { version: flowVersion } : {},
+    {
+      query: {
+        select: (res) => res.data as GraphModel,
+        enabled: !!flowID,
+      },
+    },
+  );
+
+  const { mutateAsync: createNewGraph, isPending: isCreating } =
+    usePostV1CreateNewGraph({
+      mutation: {
+        onSuccess: (response) => {
+          const data = response.data as GraphModel;
+          setQueryStates({
+            flowID: data.id,
+            flowVersion: data.version,
+          });
+          queryClient.refetchQueries({
+            queryKey: getGetV1GetSpecificGraphQueryKey(data.id),
+          });
+          onSuccess?.(data);
+          if (showToast) {
+            toast({
+              title: "Graph saved successfully",
+              description: "The graph has been saved successfully.",
+              variant: "default",
+            });
+          }
+        },
+        onError: (error) => {
+          onError?.(error);
+        },
+      },
+    });
+
+  const { mutateAsync: updateGraph, isPending: isUpdating } =
+    usePutV1UpdateGraphVersion({
+      mutation: {
+        onSuccess: (response) => {
+          const data = response.data as GraphModel;
+          setQueryStates({
+            flowID: data.id,
+            flowVersion: data.version,
+          });
+          queryClient.refetchQueries({
+            queryKey: getGetV1GetSpecificGraphQueryKey(data.id),
+          });
+          onSuccess?.(data);
+          if (showToast) {
+            toast({
+              title: "Graph saved successfully",
+              description: "The graph has been saved successfully.",
+              variant: "default",
+            });
+          }
+        },
+        onError: (error) => {
+          onError?.(error);
+          toast({
+            title: "Error saving graph",
+            description:
+              (error as any).message ?? "An unexpected error occurred.",
+            variant: "destructive",
+          });
+        },
+      },
+    });
+
+  const saveGraph = useCallback(
+    async (values?: { name?: string; description?: string }) => {
+      const graphNodes = useNodeStore.getState().getBackendNodes();
+      const graphLinks = useEdgeStore.getState().getBackendLinks();
+
+      if (graph && graph.id) {
+        const data: Graph = {
+          id: graph.id,
+          name:
+            values?.name ||
+            graph.name ||
+            `New Agent ${new Date().toISOString()}`,
+          description: values?.description ?? graph.description ?? "",
+          nodes: graphNodes,
+          links: graphLinks,
+        };
+
+        if (graphsEquivalent(graph, data)) {
+          if (showToast) {
+            toast({
+              title: "No changes to save",
+              description: "The graph is the same as the saved version.",
+              variant: "default",
+            });
+          }
+          return;
+        }
+
+        await updateGraph({ graphId: graph.id, data: data });
+      } else {
+        const data: Graph = {
+          name: values?.name || `New Agent ${new Date().toISOString()}`,
+          description: values?.description || "",
+          nodes: graphNodes,
+          links: graphLinks,
+        };
+
+        await createNewGraph({ data: { graph: data } });
+      }
+    },
+    [graph, toast, createNewGraph, updateGraph],
+  );
+
+  return {
+    saveGraph,
+    isSaving: isCreating || isUpdating,
+  };
+};

--- a/autogpt_platform/frontend/src/hooks/useAgentGraph.tsx
+++ b/autogpt_platform/frontend/src/hooks/useAgentGraph.tsx
@@ -766,6 +766,7 @@ export default function useAgentGraph(
   ]);
 
   const saveAgent = useCallback(async () => {
+    console.log("saveAgent");
     setIsSaving(true);
     try {
       await _saveAgent();


### PR DESCRIPTION
## Summary

This PR fixes an issue where multiple keyboard save event listeners were being registered when the same save hook was used in multiple components, causing the graph to be saved multiple times (3x) when using Ctrl/Cmd+S.

## Changes

- **Created a centralized `useSaveGraph` hook** in `/hooks/useSaveGraph.ts` that encapsulates all graph saving logic
- **Refactored `useNewSaveControl`** to use the new centralized hook instead of duplicating save logic
- **Updated `useRunGraph` and `useScheduleGraph`** to use the centralized `useSaveGraph` hook directly
- **Simplified the save control component** by removing redundant logic and using cleaner naming conventions

## Problem

The previous implementation had the save logic duplicated in `useNewSaveControl`, and when this hook was used in multiple places (NewSaveControl component, RunGraph, ScheduleGraph), each instance would register its own keyboard event listener for Ctrl/Cmd+S. This caused:
- Multiple save requests being sent simultaneously
- "Unique constraint failed on the fields: ('id', 'version')" errors from the backend
- Poor performance due to unnecessary re-renders

## Solution

By centralizing the save logic in a dedicated `useSaveGraph` hook:
- Save logic is now in one place, making it easier to maintain
- Components can use the save functionality without registering duplicate event listeners
- The keyboard shortcut listener is only registered once in the `useNewSaveControl` hook
- Other components (RunGraph, ScheduleGraph) can call `saveGraph` directly without side effects

## Testing
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Verified Ctrl/Cmd+S saves the graph only once
  - [x] Tested save functionality from Save Control popup
  - [x] Confirmed Run Graph and Schedule Graph still save before execution
  - [x] Verified no duplicate save requests in network tab
  - [x] Checked that save toast notifications appear correctly