### PR TITLE
fix(frontend): upload/keep sourcemaps

### DIFF
--- a/autogpt_platform/frontend/next.config.mjs
+++ b/autogpt_platform/frontend/next.config.mjs
@@ -54,8 +54,13 @@ export default isDevelopmentBuild
         NEXT_PUBLIC_VERCEL_ENV: process.env.VERCEL_ENV,
       },
 
-      // Only print logs for uploading source maps in CI
-      silent: !process.env.CI,
+      // Enable debug logging if SENTRY_LOG_LEVEL is set to debug
+      // This helps troubleshoot sourcemap upload issues
+      debug: process.env.SENTRY_LOG_LEVEL === "debug",
+
+      // Show logs in CI/Vercel builds to help debug sourcemap upload issues
+      // Set silent to false to see upload progress and any errors
+      silent: !process.env.CI && process.env.SENTRY_LOG_LEVEL !== "debug",
 
       // For all available options, see:
       // https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/
@@ -83,8 +88,14 @@ export default isDevelopmentBuild
         disable: false, // Source maps are enabled by default
         assets: ["**/*.js", "**/*.js.map"], // Specify which files to upload
         ignore: ["**/node_modules/**"], // Files to exclude
-        deleteSourcemapsAfterUpload: true, // Security: delete after upload
+        // Keep sourcemaps available for browser debugging (source is public anyway)
+        deleteSourcemapsAfterUpload: false,
       },
+
+      // For monorepo: explicitly set the URL prefix where files will be served
+      // Next.js serves static files from /_next/static/ regardless of monorepo structure
+      // This ensures Sentry can correctly map sourcemaps to the served files
+      urlPrefix: "~/_next/static",
 
       // Automatically tree-shake Sentry logger statements to reduce bundle size
       disableLogger: true,

--- a/autogpt_platform/frontend/src/services/feature-flags/feature-flag-provider.tsx
+++ b/autogpt_platform/frontend/src/services/feature-flags/feature-flag-provider.tsx
@@ -1,10 +1,10 @@
 "use client";
 
+import { useSupabase } from "@/lib/supabase/hooks/useSupabase";
+import * as Sentry from "@sentry/nextjs";
 import { LDProvider } from "launchdarkly-react-client-sdk";
 import type { ReactNode } from "react";
 import { useMemo } from "react";
-import { useSupabase } from "@/lib/supabase/hooks/useSupabase";
-import * as Sentry from "@sentry/nextjs";
 import { environment } from "../environment";
 
 const clientId = process.env.NEXT_PUBLIC_LAUNCHDARKLY_CLIENT_ID;


### PR DESCRIPTION
## Changes 🏗️

Keep the sourcemaps on the browser ( our code is open source anyway ) 

<img width="1705" height="87" alt="Screenshot 2025-11-13 at 20 35 25" src="https://github.com/user-attachments/assets/3120772d-0bbc-4115-a4c1-937961797188" />

To prevent all the noise related to it. Sourcemaps are being uploaded fine according to the logs, but keep `debug` just in case there are actual hidden issues...

## Checklist 📋

### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] we will see once this is deployed

