### PR TITLE
fix(frontend): improve UX for expired or duplicate password reset links

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/reset-password/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/reset-password/page.tsx
@@ -2,6 +2,7 @@
 import { Button } from "@/components/atoms/Button/Button";
 import { Input } from "@/components/atoms/Input/Input";
 import { AuthCard } from "@/components/auth/AuthCard";
+import { ExpiredLinkMessage } from "@/components/auth/ExpiredLinkMessage";
 import Turnstile from "@/components/auth/Turnstile";
 import { Form, FormField } from "@/components/__legacy__/ui/form";
 import LoadingBox from "@/components/__legacy__/ui/loading";
@@ -25,18 +26,41 @@ function ResetPasswordContent() {
   const [disabled, setDisabled] = useState(false);
   const [sendEmailCaptchaKey, setSendEmailCaptchaKey] = useState(0);
   const [changePasswordCaptchaKey, setChangePasswordCaptchaKey] = useState(0);
+  const [showExpiredMessage, setShowExpiredMessage] = useState(false);
+  const [linkSent, setLinkSent] = useState(false);
 
   useEffect(() => {
     const error = searchParams.get("error");
-    if (error) {
-      toast({
-        title: "Password Reset Failed",
-        description: error,
-        variant: "destructive",
-      });
+    const errorCode = searchParams.get("error_code");
+    const errorDescription = searchParams.get("error_description");
 
+    if (error || errorCode) {
+      // Check if this is an expired/used link error
+      const isExpiredOrUsed =
+        error === "link_expired" ||
+        errorCode === "otp_expired" ||
+        error === "access_denied" ||
+        errorDescription?.toLowerCase().includes("expired") ||
+        errorDescription?.toLowerCase().includes("invalid");
+
+      if (isExpiredOrUsed) {
+        setShowExpiredMessage(true);
+      } else {
+        // Show toast for other errors
+        const errorMessage =
+          errorDescription || error || "Password reset failed";
+        toast({
+          title: "Password Reset Failed",
+          description: errorMessage,
+          variant: "destructive",
+        });
+      }
+
+      // Clear all error params from URL
       const newUrl = new URL(window.location.href);
       newUrl.searchParams.delete("error");
+      newUrl.searchParams.delete("error_code");
+      newUrl.searchParams.delete("error_description");
       router.replace(newUrl.pathname + newUrl.search);
     }
   }, [searchParams, toast, router]);
@@ -113,6 +137,7 @@ function ResetPasswordContent() {
         return;
       }
       setDisabled(true);
+      setLinkSent(true);
       toast({
         title: "Email Sent",
         description:
@@ -122,6 +147,11 @@ function ResetPasswordContent() {
     },
     [sendEmailForm, sendEmailTurnstile, resetSendEmailCaptcha, toast],
   );
+
+  const handleSendNewLink = useCallback(() => {
+    // Show the normal form to collect email and CAPTCHA
+    setShowExpiredMessage(false);
+  }, []);
 
   const onChangePassword = useCallback(
     async (data: z.infer<typeof changePasswordFormSchema>) => {
@@ -179,6 +209,21 @@ function ResetPasswordContent() {
     return (
       <div>
         User accounts are disabled because Supabase client is unavailable
+      </div>
+    );
+  }
+
+  // Show expired link message if detected
+  if (showExpiredMessage && !user) {
+    return (
+      <div className="flex h-full min-h-[85vh] w-full flex-col items-center justify-center">
+        <AuthCard title="Reset Password">
+          <ExpiredLinkMessage
+            onSendNewLink={handleSendNewLink}
+            isLoading={isLoading}
+            linkSent={linkSent}
+          />
+        </AuthCard>
       </div>
     );
   }

--- a/autogpt_platform/frontend/src/app/api/auth/callback/reset-password/route.ts
+++ b/autogpt_platform/frontend/src/app/api/auth/callback/reset-password/route.ts
@@ -26,8 +26,21 @@ export async function GET(request: NextRequest) {
     const result = await exchangePasswordResetCode(supabase, code);
 
     if (!result.success) {
+      // Check for expired or used link errors
+      const errorMessage = result.error?.toLowerCase() || "";
+      const isExpiredOrUsed =
+        errorMessage.includes("expired") ||
+        errorMessage.includes("invalid") ||
+        errorMessage.includes("otp_expired") ||
+        errorMessage.includes("already") ||
+        errorMessage.includes("used");
+
+      const errorParam = isExpiredOrUsed
+        ? "link_expired"
+        : encodeURIComponent(result.error || "Password reset failed");
+
       return NextResponse.redirect(
-        `${origin}/reset-password?error=${encodeURIComponent(result.error || "Password reset failed")}`,
+        `${origin}/reset-password?error=${errorParam}`,
       );
     }
 

--- a/autogpt_platform/frontend/src/components/auth/ExpiredLinkMessage.tsx
+++ b/autogpt_platform/frontend/src/components/auth/ExpiredLinkMessage.tsx
@@ -1,0 +1,49 @@
+import { Button } from "../atoms/Button/Button";
+import { Link } from "../atoms/Link/Link";
+import { Text } from "../atoms/Text/Text";
+
+interface Props {
+  onSendNewLink: () => void;
+  isLoading?: boolean;
+  linkSent?: boolean;
+}
+
+export function ExpiredLinkMessage({
+  onSendNewLink,
+  isLoading = false,
+  linkSent = false,
+}: Props) {
+  return (
+    <div className="flex flex-col items-center gap-6">
+      <Text variant="h3" className="text-center">
+        This password reset link has expired or already been used
+      </Text>
+      <div className="flex flex-col gap-4 text-center">
+        <Text variant="large" className="text-center text-muted-foreground">
+          Don&apos;t worry – this can happen if the link is opened more than
+          once or has timed out.
+        </Text>
+        <Text variant="large" className="text-center text-muted-foreground">
+          Click below to request a new password reset link.
+        </Text>
+      </div>
+      <Button
+        variant="primary"
+        onClick={onSendNewLink}
+        loading={isLoading}
+        disabled={linkSent}
+        className="w-full max-w-sm"
+      >
+        {linkSent ? "Link Sent!" : "Send Me a New Link"}
+      </Button>
+      <div className="mt-2 flex items-center gap-1">
+        <Text variant="small" className="text-muted-foreground">
+          Already have access?
+        </Text>
+        <Link href="/login" variant="secondary">
+          Log in here
+        </Link>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Improves the user experience when a password reset link has expired or been used, replacing the confusing generic error with a clean, helpful message.

Will be set as a draft for now as i am waiting for a review from design.

## Changes
- Added `ExpiredLinkMessage` component that displays a user-friendly error state
- Updated reset password page to detect expired/used links from both:
  - Supabase error format (`error=access_denied&error_code=otp_expired&error_description=...`)
  - Internal clean format (`error=link_expired`)
- Enhanced callback route to detect and map expired/invalid link errors
- Clear, actionable UI with:
  - Friendly error message explaining what happened
  - "Send Me a New Link" button to request a new reset email
  - Login link for users who already have access

## Before
Users saw a confusing URL with error parameters and an unclear form:
``http://localhost:3000/reset-password?error=access_denied&error_code=otp_expired&error_description=Email+link+is+invalid+or+has+expired``

## After
Users see a clean, helpful message explaining the issue and how to fix it.

<img width="563" height="485" alt="image" src="https://github.com/user-attachments/assets/0db9ca21-d51b-45b8-bafb-67de048fea87" />

<img width="1800" height="851" alt="image" src="https://github.com/user-attachments/assets/15e358e5-0dcd-4f4c-ae68-342ab6344e65" />

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [x] Navigate to `http://localhost:3000/reset-password?error=access_denied&error_code=otp_expired&error_description=Email+link+is+invalid+or+has+expired` and Verify the `ExpiredLinkMessage` component appears with proper messaging
  - [x] Click "Send Me a New Link" and verify the email form appears
 