### PR TITLE
dx: Update Node.js versions in GitHub workflows to match frontend requirement

### DIFF
--- a/.github/workflows/claude-dependabot.yml
+++ b/.github/workflows/claude-dependabot.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "21"
+          node-version: "22"
 
       - name: Enable corepack
         run: corepack enable

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "21"
+          node-version: "22"
 
       - name: Enable corepack
         run: corepack enable

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "21"
+          node-version: "22"
 
       - name: Enable corepack
         run: corepack enable


### PR DESCRIPTION
This unbreaks the Claude Code and Copilot workflows in our repo.

- Follow-up to #11288

### Changes 🏗️

- Update `node-version` on `actions/setup-node@v4` from v21 to v22
