### PR TITLE
fix(frontend): Preserve customized_name only when explicitly set in node metadata

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/build/stores/nodeStore.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/build/stores/nodeStore.ts
@@ -163,9 +163,10 @@ export const useNodeStore = create<NodeStore>((set, get) => ({
       block_id: node.data.block_id,
       input_default: node.data.hardcodedValues,
       metadata: {
-        // TODO: Add more metadata
         position: node.position,
-        customized_name: node.data.metadata?.customized_name,
+        ...(node.data.metadata?.customized_name !== undefined && {
+          customized_name: node.data.metadata.customized_name,
+        }),
       },
     };
   },


### PR DESCRIPTION
This PR fixes an issue where undefined `customized_name` values were being included in node metadata, which could cause issues with data persistence and agent exports. The fix ensures that the `customized_name` property is only included when it has been explicitly set by the user.

### Changes 🏗️

- **Fixed metadata serialization**: Modified `getNodeAsGraphNode` to only include `customized_name` in the metadata when it has been explicitly set (not undefined)
- **Improved data structure**: Uses object spread syntax to conditionally include the `customized_name` property, preventing undefined values from being stored
- **Cleaned up code**: Removed unnecessary TODO comment and improved code readability

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Create a new agent and verify metadata doesn't include undefined customized_name
  - [x] Customize a block name and verify it's properly saved in metadata
  - [x] Export an agent and verify the JSON doesn't contain undefined customized_name fields
  - [x] Import an agent with customized names and verify they are preserved
  - [x] Save and reload an agent to ensure metadata persistence works correctly
