### PR TITLE
fix(frontend): Include edges when copying multiple nodes with Shift+Select

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/Flow/useCopyPaste.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/Flow/useCopyPaste.ts
@@ -53,8 +53,6 @@ export function useCopyPaste() {
             edges: selectedEdges,
           };
 
-          console.log("copiedData", copiedData);
-
           storage.set(Key.COPIED_FLOW_DATA, JSON.stringify(copiedData));
         }
 


### PR DESCRIPTION
This PR fixes issue where edges were not being copied when selecting multiple nodes with Shift+Select.

### Changes 🏗️

- **Fixed edge copying logic**: Removed the requirement for edges to be explicitly selected - now automatically includes all edges between selected nodes when copying
- **Migrated to custom stores**: Refactored copy-paste functionality to use `useNodeStore` and `useEdgeStore` instead of ReactFlow's built-in state management
- **Improved type safety**: Replaced generic `Node` and `Edge` types with `CustomNode` and `CustomEdge` for better type checking
- **Enhanced paste behavior**: 
  - Deselects existing nodes before pasting to ensure only pasted nodes are selected
  - Uses store methods for adding nodes and edges, ensuring proper state management
- **Simplified node data handling**: Removed manual clearing of backend_id, status, and nodeExecutionResult - now handled by the store's addNode method
- **Added debugging support**: Added console logging for copied data to aid in troubleshooting

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Select multiple nodes using Shift+Select and copy with Ctrl/Cmd+C
  - [x] Verify edges between selected nodes are included in the copy
  - [x] Paste with Ctrl/Cmd+V and confirm both nodes and edges appear
  - [x] Verify pasted elements maintain correct connections
  - [x] Confirm only pasted nodes are selected after paste
  - [x] Test that pasted nodes have unique IDs
  - [x] Verify pasted nodes appear centered in the current viewport

