### PR TITLE
ci(claude): add free disk space step to prevent runner out of space

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -44,6 +44,12 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          large-packages: false  # slow
+          docker-images: false  # limited benefit
+
       # Backend Python/Poetry setup (mirrors platform-backend-ci.yml)
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary
- Add `jlumbroso/free-disk-space@v1.3.1` action to claude.yml workflow
- Frees up disk space on Ubuntu runner before heavy Docker and dependency setup
- Skips `large-packages` (slow) and `docker-images` (needed for workflow)

## Test plan
- [x] Verify claude.yml workflow runs successfully without disk space errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)