### PR TITLE
fix(backend): fix broken update_agent_version_in_library and reduce the method code duplication

### DIFF
--- a/autogpt_platform/backend/backend/server/v2/library/db.py
+++ b/autogpt_platform/backend/backend/server/v2/library/db.py
@@ -523,6 +523,7 @@ async def update_agent_version_in_library(
                     },
                 },
             },
+            include={"AgentGraph": True},
         )
         if lib is None:
             raise NotFoundError(f"Library agent {library_agent.id} not found")


### PR DESCRIPTION
## Summary
Fix broken `update_agent_version_in_library` functionality by eagerly loading `AgentGraph` while loading the library, also consolidating duplicate code that updates agent version in library and configures HITL safe mode settings.

## Problem
The `update_agent_version_in_library` is currently failed with this error:
```
  File "/Users/abhi/Documents/AutoGPT/autogpt_platform/backend/backend/server/v2/library/model.py", line 110, in from_db
    raise ValueError("Associated Agent record is required.")
ValueError: Associated Agent record is required.
```

also logic was duplicated across two router endpoints with identical implementations, creating maintenance burden and potential for inconsistencies.

## Changes Made

### Created Helper Method
- Add `_update_library_agent_version_and_settings()` helper function  
- Fixes broken `update_agent_version_in_library` by centralizing the logic
- Uses proper error handling and settings merging with `model_copy()`

### Replaced Duplicate Code  
- **In `update_graph` function** (v1.py:863) - replaced 13 lines with single helper call
- **In `set_graph_active_version` function** (v1.py:920) - replaced 13 lines with single helper call

### Benefits
- **Fixes broken functionality**: Centralizes `update_agent_version_in_library` logic 
- **DRY Principle**: Eliminates code duplication across two router endpoints
- **Maintainability**: Single place to modify the library agent update logic  
- **Consistency**: Ensures both endpoints use identical logic for HITL safe mode configuration
- **Readability**: Cleaner, more focused endpoint implementations

## Technical Details
The helper method fixes broken `update_agent_version_in_library` by handling:
1. Updating agent version in library via `update_agent_version_in_library()`
2. Conditionally setting `human_in_the_loop_safe_mode: true` if graph has HITL blocks and setting is not already configured  
3. Proper settings merging to preserve existing configuration

## Testing
- [x] Code compiles and passes type checking
- [x] Pre-commit hooks pass (linting, formatting, type checking)
- [x] Both affected endpoints maintain same functionality with cleaner implementation

Fixes broken duplicate code identified in v1.py router endpoints for `update_agent_version_in_library`.