### PR TITLE
fix(frontend/marketplace): Fix rendering creator links without schema

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/marketplace/components/CreatorLinks/CreatorLinks.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/marketplace/components/CreatorLinks/CreatorLinks.tsx
@@ -5,6 +5,22 @@ interface CreatorLinksProps {
   links: string[];
 }
 
+function normalizeURL(url: string): string {
+  if (!url.startsWith("http://") && !url.startsWith("https://")) {
+    return `https://${url}`;
+  }
+  return url;
+}
+
+function getHostnameFromURL(url: string): string {
+  try {
+    const normalizedURL = normalizeURL(url);
+    return new URL(normalizedURL).hostname.replace("www.", "");
+  } catch {
+    return url.replace(/^(https?:\/\/)?(www\.)?/, "");
+  }
+}
+
 export const CreatorLinks = ({ links }: CreatorLinksProps) => {
   if (!links || links.length === 0) {
     return null;
@@ -12,13 +28,13 @@ export const CreatorLinks = ({ links }: CreatorLinksProps) => {
 
   const renderLinkButton = (url: string) => (
     <a
-      href={url}
+      href={normalizeURL(url)}
       target="_blank"
       rel="noopener noreferrer"
       className="flex min-w-[200px] flex-1 items-center justify-between rounded-[34px] border border-neutral-600 px-5 py-3 dark:border-neutral-400"
     >
       <div className="text-base font-medium leading-normal text-neutral-800 dark:text-neutral-200">
-        {new URL(url).hostname.replace("www.", "")}
+        {getHostnameFromURL(url)}
       </div>
       <div className="relative h-6 w-6">
         {getIconForSocial(url, {


### PR DESCRIPTION
- [OPEN-2871: TypeError: URL constructor: www.agpt.co is not a valid URL.](https://linear.app/autogpt/issue/OPEN-2871/typeerror-url-constructor-wwwagptco-is-not-a-valid-url)
- [Sentry Issue BUILDER-56D: TypeError: URL constructor: www.agpt.co is not a valid URL.](https://significant-gravitas.sentry.io/issues/7081476631/)

### Changes 🏗️

- Amend URL handling in `CreatorLinks` to correctly handle URLs with implicit schema

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - Trivial change, CI is sufficient
