### PR TITLE
fix(frontend): ensure node selection state is set before copying in context menu

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/nodes/CustomNode/components/NodeContextMenu.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/nodes/CustomNode/components/NodeContextMenu.tsx
@@ -28,6 +28,7 @@ export const NodeContextMenu = ({
       })),
     }));
 
+    useCopyPasteStore.getState().copySelectedNodes();
     useCopyPasteStore.getState().pasteNodes();
   };
 


### PR DESCRIPTION
<!-- Clearly explain the need for these changes: -->

Fixes an issue where copying a node via the context menu dialog fails on the first attempt in a new session. The problem occurs because the node selection state update and the copy operation happen in quick succession, causing a race condition where `copySelectedNodes()` reads the store before the selection state is properly updated.


### Checklist 📋

- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Start a new browser session (or clear storage)
  - [x] Open the flow editor
  - [x] Right-click on a node and select "Copy Node" from the context menu
  - [x] Verify the node is successfully copied on the first attempt