### PR TITLE
fix(frontend): prevent NodeHandle error when array schema items is undefined

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/build/components/legacy-builder/NodeInputs.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/legacy-builder/NodeInputs.tsx
@@ -981,15 +981,17 @@ const NodeArrayInput: FC<{
           );
         return (
           <div key={entryKey}>
-            <NodeHandle
-              title={`#${index + 1}`}
-              className="text-sm text-gray-500"
-              keyName={entryKey}
-              schema={schema.items!}
-              isConnected={isConnected}
-              isRequired={false}
-              side="left"
-            />
+            {schema.items && (
+              <NodeHandle
+                title={`#${index + 1}`}
+                className="text-sm text-gray-500"
+                keyName={entryKey}
+                schema={schema.items}
+                isConnected={isConnected}
+                isRequired={false}
+                side="left"
+              />
+            )}
             <div className="mb-2 flex space-x-2">
               {!isConnected &&
                 (schema.items ? (


### PR DESCRIPTION
- Added conditional rendering in `NodeArrayInput` component to only render `NodeHandle` when `schema.items` is defined
- This prevents the error when array schemas don't have an `items` property defined
- The input field rendering logic already had proper null checks, so only the handle rendering needed to be fixed

### Checklist 📋

#### For code changes:

- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Open the legacy builder and create a new agent
  - [x] Add a Smart Decision block to the agent
  - [x] Verify that the `conversation_history` field renders without errors
  - [x] Verify that array fields with defined `items` still render correctly (e.g., test with other blocks that use arrays)
  - [x] Verify that connecting/disconnecting handles to the conversation_history field works correctly
  - [x] Verify that the field can accept input values when not connected