### PR TITLE
fix(frontend): allow to close toasts

### DIFF
--- a/autogpt_platform/frontend/src/components/molecules/Toast/styles.module.css
+++ b/autogpt_platform/frontend/src/components/molecules/Toast/styles.module.css
@@ -39,7 +39,8 @@ html body .toastDescription {
 }
 
 /* Position close button on the right */
-:global(html body [data-sonner-toast] [data-close-button="true"]) {
+/* stylelint-disable-next-line selector-pseudo-class-no-unknown */
+#root [data-sonner-toast] [data-close-button="true"] {
   left: unset !important;
   right: -18px !important;
   top: -3px !important;

--- a/autogpt_platform/frontend/src/components/molecules/Toast/toaster.tsx
+++ b/autogpt_platform/frontend/src/components/molecules/Toast/toaster.tsx
@@ -21,6 +21,7 @@ export function Toaster() {
           info: styles.toastInfo,
         },
       }}
+      className="custom__toast"
       icons={{
         success: <CheckCircle className="h-4 w-4" color="#fff" weight="fill" />,
         error: <XCircle className="h-4 w-4" color="#fff" weight="fill" />,


### PR DESCRIPTION
## Changes 🏗️

<img width="795" height="275" alt="Screenshot 2025-12-04 at 21 05 55" src="https://github.com/user-attachments/assets/e7572635-3976-4822-89ea-3e5e26196ab8" />

Allow to close toasts 🍞 

## Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Run Storybook locally
  - [x] Toast have a close button top-right 

