### PR TITLE
fix(frontend): sync flowVersion to URL when loading graph from Library

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/Flow/useFlow.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/Flow/useFlow.ts
@@ -42,11 +42,12 @@ export const useFlow = () => {
   const setBlockMenuOpen = useControlPanelStore(
     useShallow((state) => state.setBlockMenuOpen),
   );
-  const [{ flowID, flowVersion, flowExecutionID }] = useQueryStates({
-    flowID: parseAsString,
-    flowVersion: parseAsInteger,
-    flowExecutionID: parseAsString,
-  });
+  const [{ flowID, flowVersion, flowExecutionID }, setQueryStates] =
+    useQueryStates({
+      flowID: parseAsString,
+      flowVersion: parseAsInteger,
+      flowExecutionID: parseAsString,
+    });
 
   const { data: executionDetails } = useGetV1GetExecutionDetails(
     flowID || "",
@@ -102,6 +103,9 @@ export const useFlow = () => {
   // load graph schemas
   useEffect(() => {
     if (graph) {
+      setQueryStates({
+        flowVersion: graph.version ?? 1,
+      });
       setGraphSchemas(
         graph.input_schema as Record<string, any> | null,
         graph.credentials_input_schema as Record<string, any> | null,


### PR DESCRIPTION
<!-- Clearly explain the need for these changes: -->

When opening a graph from the Library, the `flowVersion` query parameter was not being set in the URL. This caused issues when the graph data didn't contain an internal `graphVersion`, resulting in the builder failing and graphs breaking when running.

The `useGetV1GetSpecificGraph` hook relies on the `flowVersion` query parameter to fetch the correct graph version. Without it being properly set in the URL, the graph loading logic fails when the version information is missing from the graph data itself.

### Changes 🏗️

- Added `setQueryStates` to the `useQueryStates` hook return value in `useFlow.ts`
- Added logic to sync `flowVersion` to the URL query parameters when a graph is loaded
- When `graph.version` is available, it now updates the `flowVersion` query parameter in the URL (defaults to `1` if version is undefined)

This ensures the URL stays in sync with the loaded graph's version, preventing builder failures and execution issues.

### Checklist 📋

#### For code changes:

- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Open a graph from the Library that doesn't have a version in the URL
  - [x] Verify that `flowVersion` is automatically added to the URL query parameters
  - [x] Verify that the graph loads correctly and can be executed
  - [x] Verify that graphs with existing `flowVersion` in URL continue to work correctly
  - [x] Verify that graphs opened from Library with version information sync correctly