### PR TITLE
feat(frontend): add nice scrollable tabs on Selected Run view

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/modals/AgentInputsReadOnly/AgentInputsReadOnly.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/modals/AgentInputsReadOnly/AgentInputsReadOnly.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { LibraryAgent } from "@/app/api/__generated__/models/libraryAgent";
+import { Text } from "@/components/atoms/Text/Text";
 import type { CredentialsMetaInput } from "@/lib/autogpt-server-api/types";
 import { CredentialsInput } from "../CredentialsInputs/CredentialsInputs";
 import { RunAgentInputs } from "../RunAgentInputs/RunAgentInputs";
@@ -34,7 +35,11 @@ export function AgentInputsReadOnly({
   const hasCredentials = credentialInputs && credentialFieldEntries.length > 0;
 
   if (!hasInputs && !hasCredentials) {
-    return <div className="text-neutral-600">No input for this run.</div>;
+    return (
+      <Text variant="body" className="text-zinc-700">
+        No input for this run.
+      </Text>
+    );
   }
 
   return (

--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/selected-views/SelectedRunView/SelectedRunView.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/selected-views/SelectedRunView/SelectedRunView.tsx
@@ -6,12 +6,17 @@ import { LoadingSpinner } from "@/components/atoms/LoadingSpinner/LoadingSpinner
 import { Text } from "@/components/atoms/Text/Text";
 import { ErrorCard } from "@/components/molecules/ErrorCard/ErrorCard";
 import { InformationTooltip } from "@/components/molecules/InformationTooltip/InformationTooltip";
+import {
+  ScrollableTabs,
+  ScrollableTabsContent,
+  ScrollableTabsList,
+  ScrollableTabsTrigger,
+} from "@/components/molecules/ScrollableTabs/ScrollableTabs";
 import { PendingReviewsList } from "@/components/organisms/PendingReviewsList/PendingReviewsList";
 import { usePendingReviewsForExecution } from "@/hooks/usePendingReviews";
 import { isLargeScreen, useBreakpoint } from "@/lib/hooks/useBreakpoint";
 import { useEffect } from "react";
 import { AgentInputsReadOnly } from "../../modals/AgentInputsReadOnly/AgentInputsReadOnly";
-import { AnchorLinksWrap } from "../AnchorLinksWrap";
 import { LoadingSelectedContent } from "../LoadingSelectedContent";
 import { RunDetailCard } from "../RunDetailCard/RunDetailCard";
 import { RunDetailHeader } from "../RunDetailHeader/RunDetailHeader";
@@ -21,9 +26,6 @@ import { RunSummary } from "./components/RunSummary";
 import { SelectedRunActions } from "./components/SelectedRunActions/SelectedRunActions";
 import { WebhookTriggerSection } from "./components/WebhookTriggerSection";
 import { useSelectedRunView } from "./useSelectedRunView";
-
-const anchorStyles =
-  "border-b-2 border-transparent pb-1 text-sm font-medium text-slate-600 transition-colors hover:text-slate-900 hover:border-slate-900";
 
 interface Props {
   agent: LibraryAgent;
@@ -58,13 +60,6 @@ export function SelectedRunView({
 
   const withSummary = run?.stats?.activity_status;
   const withReviews = run?.status === AgentExecutionStatus.REVIEW;
-
-  function scrollToSection(id: string) {
-    const element = document.getElementById(id);
-    if (element) {
-      element.scrollIntoView({ behavior: "smooth", block: "start" });
-    }
-  }
 
   if (responseError || httpError) {
     return (
@@ -106,115 +101,116 @@ export function SelectedRunView({
                 />
               )}
 
-            {/* Navigation Links */}
-            <AnchorLinksWrap>
-              {withSummary && (
-                <button
-                  onClick={() => scrollToSection("summary")}
-                  className={anchorStyles}
-                >
-                  Summary
-                </button>
-              )}
-              <button
-                onClick={() => scrollToSection("output")}
-                className={anchorStyles}
-              >
-                Output
-              </button>
-              <button
-                onClick={() => scrollToSection("input")}
-                className={anchorStyles}
-              >
-                Your input
-              </button>
-              {withReviews && (
-                <button
-                  onClick={() => scrollToSection("reviews")}
-                  className={anchorStyles}
-                >
-                  Reviews ({pendingReviews.length})
-                </button>
-              )}
-            </AnchorLinksWrap>
-
-            {/* Summary Section */}
-            {withSummary && (
-              <div id="summary" className="scroll-mt-4">
-                <RunDetailCard
-                  title={
-                    <div className="flex items-center gap-1">
-                      <Text variant="lead-semibold">Summary</Text>
-                      <InformationTooltip
-                        iconSize={20}
-                        description="This AI-generated summary describes how the agent handled your task. It's an experimental feature and may occasionally be inaccurate."
-                      />
-                    </div>
-                  }
-                >
-                  <RunSummary run={run} />
-                </RunDetailCard>
-              </div>
-            )}
-
-            {/* Output Section */}
-            <div id="output" className="scroll-mt-4">
-              <RunDetailCard title="Output">
-                {isLoading ? (
-                  <div className="text-neutral-500">
-                    <LoadingSpinner />
-                  </div>
-                ) : run && "outputs" in run ? (
-                  <RunOutputs outputs={run.outputs as any} />
-                ) : (
-                  <Text variant="body" className="text-neutral-600">
-                    No output from this run.
-                  </Text>
+            <ScrollableTabs
+              defaultValue="output"
+              className="-mt-2 flex flex-col"
+            >
+              <ScrollableTabsList className="px-4">
+                {withSummary && (
+                  <ScrollableTabsTrigger value="summary">
+                    Summary
+                  </ScrollableTabsTrigger>
                 )}
-              </RunDetailCard>
-            </div>
-
-            {/* Input Section */}
-            <div id="input" className="scroll-mt-4">
-              <RunDetailCard
-                title={
-                  <div className="flex items-center gap-1">
-                    <Text variant="lead-semibold">Your input</Text>
-                    <InformationTooltip
-                      iconSize={20}
-                      description="This is the input that was provided to the agent for running this task."
-                    />
-                  </div>
-                }
-              >
-                <AgentInputsReadOnly
-                  agent={agent}
-                  inputs={run?.inputs}
-                  credentialInputs={run?.credential_inputs}
-                />
-              </RunDetailCard>
-            </div>
-
-            {/* Reviews Section */}
-            {withReviews && (
-              <div id="reviews" className="scroll-mt-4">
-                <RunDetailCard>
-                  {reviewsLoading ? (
-                    <div className="text-neutral-500">Loading reviews…</div>
-                  ) : pendingReviews.length > 0 ? (
-                    <PendingReviewsList
-                      reviews={pendingReviews}
-                      onReviewComplete={refetchReviews}
-                      emptyMessage="No pending reviews for this execution"
-                    />
-                  ) : (
-                    <div className="text-neutral-600">
-                      No pending reviews for this execution
+                <ScrollableTabsTrigger value="output">
+                  Output
+                </ScrollableTabsTrigger>
+                <ScrollableTabsTrigger value="input">
+                  Your input
+                </ScrollableTabsTrigger>
+                {withReviews && (
+                  <ScrollableTabsTrigger value="reviews">
+                    Reviews ({pendingReviews.length})
+                  </ScrollableTabsTrigger>
+                )}
+              </ScrollableTabsList>
+              <div className="my-6 flex flex-col gap-6">
+                {/* Summary Section */}
+                {withSummary && (
+                  <ScrollableTabsContent value="summary">
+                    <div className="scroll-mt-4">
+                      <RunDetailCard
+                        title={
+                          <div className="flex items-center gap-1">
+                            <Text variant="lead-semibold">Summary</Text>
+                            <InformationTooltip
+                              iconSize={20}
+                              description="This AI-generated summary describes how the agent handled your task. It's an experimental feature and may occasionally be inaccurate."
+                            />
+                          </div>
+                        }
+                      >
+                        <RunSummary run={run} />
+                      </RunDetailCard>
                     </div>
-                  )}
-                </RunDetailCard>
+                  </ScrollableTabsContent>
+                )}
+
+                {/* Output Section */}
+                <ScrollableTabsContent value="output">
+                  <div className="scroll-mt-4">
+                    <RunDetailCard title="Output">
+                      {isLoading ? (
+                        <div className="text-neutral-500">
+                          <LoadingSpinner />
+                        </div>
+                      ) : run && "outputs" in run ? (
+                        <RunOutputs outputs={run.outputs as any} />
+                      ) : (
+                        <Text variant="body" className="text-neutral-600">
+                          No output from this run.
+                        </Text>
+                      )}
+                    </RunDetailCard>
+                  </div>
+                </ScrollableTabsContent>
+
+                {/* Input Section */}
+                <ScrollableTabsContent value="input">
+                  <div id="input" className="scroll-mt-4">
+                    <RunDetailCard
+                      title={
+                        <div className="flex items-center gap-1">
+                          <Text variant="lead-semibold">Your input</Text>
+                          <InformationTooltip
+                            iconSize={20}
+                            description="This is the input that was provided to the agent for running this task."
+                          />
+                        </div>
+                      }
+                    >
+                      <AgentInputsReadOnly
+                        agent={agent}
+                        inputs={run?.inputs}
+                        credentialInputs={run?.credential_inputs}
+                      />
+                    </RunDetailCard>
+                  </div>
+                </ScrollableTabsContent>
+
+                {/* Reviews Section */}
+                {withReviews && (
+                  <ScrollableTabsContent value="reviews">
+                    <div className="scroll-mt-4">
+                      <RunDetailCard>
+                        {reviewsLoading ? (
+                          <LoadingSpinner size="small" />
+                        ) : pendingReviews.length > 0 ? (
+                          <PendingReviewsList
+                            reviews={pendingReviews}
+                            onReviewComplete={refetchReviews}
+                            emptyMessage="No pending reviews for this execution"
+                          />
+                        ) : (
+                          <Text variant="body" className="text-zinc-700">
+                            No pending reviews for this execution
+                          </Text>
+                        )}
+                      </RunDetailCard>
+                    </div>
+                  </ScrollableTabsContent>
+                )}
               </div>
-            )}
+            </ScrollableTabs>
           </div>
         </SelectedViewLayout>
       </div>

--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/selected-views/SelectedScheduleView/SelectedScheduleView.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/selected-views/SelectedScheduleView/SelectedScheduleView.tsx
@@ -9,16 +9,12 @@ import { humanizeCronExpression } from "@/lib/cron-expression-utils";
 import { isLargeScreen, useBreakpoint } from "@/lib/hooks/useBreakpoint";
 import { formatInTimezone, getTimezoneDisplayName } from "@/lib/timezone-utils";
 import { AgentInputsReadOnly } from "../../modals/AgentInputsReadOnly/AgentInputsReadOnly";
-import { AnchorLinksWrap } from "../AnchorLinksWrap";
 import { LoadingSelectedContent } from "../LoadingSelectedContent";
 import { RunDetailCard } from "../RunDetailCard/RunDetailCard";
 import { RunDetailHeader } from "../RunDetailHeader/RunDetailHeader";
 import { SelectedViewLayout } from "../SelectedViewLayout";
 import { SelectedScheduleActions } from "./components/SelectedScheduleActions";
 import { useSelectedScheduleView } from "./useSelectedScheduleView";
-
-const anchorStyles =
-  "border-b-2 border-transparent pb-1 text-sm font-medium text-slate-600 transition-colors hover:text-slate-900 hover:border-slate-900";
 
 interface Props {
   agent: LibraryAgent;
@@ -44,13 +40,6 @@ export function SelectedScheduleView({
 
   const breakpoint = useBreakpoint();
   const isLgScreenUp = isLargeScreen(breakpoint);
-
-  function scrollToSection(id: string) {
-    const element = document.getElementById(id);
-    if (element) {
-      element.scrollIntoView({ behavior: "smooth", block: "start" });
-    }
-  }
 
   if (error) {
     return (
@@ -107,22 +96,6 @@ export function SelectedScheduleView({
                 </div>
               ) : null}
             </div>
-
-            {/* Navigation Links */}
-            <AnchorLinksWrap>
-              <button
-                onClick={() => scrollToSection("schedule")}
-                className={anchorStyles}
-              >
-                Schedule
-              </button>
-              <button
-                onClick={() => scrollToSection("input")}
-                className={anchorStyles}
-              >
-                Your input
-              </button>
-            </AnchorLinksWrap>
 
             {/* Schedule Section */}
             <div id="schedule" className="scroll-mt-4">

--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/selected-views/SelectedScheduleView/components/SelectedScheduleActions.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/selected-views/SelectedScheduleView/components/SelectedScheduleActions.tsx
@@ -25,9 +25,10 @@ export function SelectedScheduleActions({ agent, scheduleId }: Props) {
           <Button
             variant="icon"
             size="icon"
-            aria-label="Open in builder"
             as="NextLink"
             href={openInBuilderHref}
+            target="_blank"
+            aria-label="View scheduled task details"
           >
             <EyeIcon weight="bold" size={18} className="text-zinc-700" />
           </Button>

--- a/autogpt_platform/frontend/src/components/molecules/ScrollableTabs/ScrollableTabs.stories.tsx
+++ b/autogpt_platform/frontend/src/components/molecules/ScrollableTabs/ScrollableTabs.stories.tsx
@@ -1,0 +1,437 @@
+import type { Meta, StoryObj } from "@storybook/nextjs";
+import {
+  ScrollableTabs,
+  ScrollableTabsContent,
+  ScrollableTabsList,
+  ScrollableTabsTrigger,
+} from "./ScrollableTabs";
+
+const meta = {
+  title: "Molecules/ScrollableTabs",
+  component: ScrollableTabs,
+  parameters: {
+    layout: "fullscreen",
+  },
+  tags: ["autodocs"],
+  argTypes: {},
+} satisfies Meta<typeof ScrollableTabs>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function ScrollableTabsDemo() {
+  return (
+    <div className="flex flex-col gap-8 p-8">
+      <h2 className="text-2xl font-bold">ScrollableTabs Examples</h2>
+
+      <div className="space-y-6">
+        <div>
+          <h3 className="mb-4 text-lg font-semibold">
+            Short Content (Tabs Hidden)
+          </h3>
+          <div className="h-[300px] overflow-y-auto border border-zinc-200">
+            <ScrollableTabs defaultValue="tab1" className="h-full">
+              <ScrollableTabsList>
+                <ScrollableTabsTrigger value="tab1">
+                  Account
+                </ScrollableTabsTrigger>
+                <ScrollableTabsTrigger value="tab2">
+                  Password
+                </ScrollableTabsTrigger>
+                <ScrollableTabsTrigger value="tab3">
+                  Settings
+                </ScrollableTabsTrigger>
+              </ScrollableTabsList>
+              <ScrollableTabsContent value="tab1">
+                <div className="p-4 text-sm">
+                  Make changes to your account here. Click save when you&apos;re
+                  done.
+                </div>
+              </ScrollableTabsContent>
+              <ScrollableTabsContent value="tab2">
+                <div className="p-4 text-sm">
+                  Change your password here. After saving, you&apos;ll be logged
+                  out.
+                </div>
+              </ScrollableTabsContent>
+              <ScrollableTabsContent value="tab3">
+                <div className="p-4 text-sm">
+                  Update your preferences and settings here.
+                </div>
+              </ScrollableTabsContent>
+            </ScrollableTabs>
+          </div>
+        </div>
+
+        <div>
+          <h3 className="mb-4 text-lg font-semibold">
+            Long Content (Tabs Visible)
+          </h3>
+          <div className="h-[400px] overflow-y-auto border border-zinc-200">
+            <ScrollableTabs defaultValue="tab1" className="h-full">
+              <ScrollableTabsList>
+                <ScrollableTabsTrigger value="tab1">
+                  Account
+                </ScrollableTabsTrigger>
+                <ScrollableTabsTrigger value="tab2">
+                  Password
+                </ScrollableTabsTrigger>
+                <ScrollableTabsTrigger value="tab3">
+                  Settings
+                </ScrollableTabsTrigger>
+              </ScrollableTabsList>
+              <ScrollableTabsContent value="tab1">
+                <div className="p-8 text-sm">
+                  <h4 className="mb-4 text-lg font-semibold">
+                    Account Settings
+                  </h4>
+                  <p className="mb-4">
+                    Make changes to your account here. Click save when
+                    you&apos;re done.
+                  </p>
+                  <p className="mb-4">
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Ut enim ad minim veniam, quis nostrud exercitation
+                    ullamco laboris.
+                  </p>
+                  <p className="mb-4">
+                    Duis aute irure dolor in reprehenderit in voluptate velit
+                    esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+                    occaecat cupidatat non proident.
+                  </p>
+                  <p>
+                    Sed ut perspiciatis unde omnis iste natus error sit
+                    voluptatem accusantium doloremque laudantium, totam rem
+                    aperiam.
+                  </p>
+                </div>
+              </ScrollableTabsContent>
+              <ScrollableTabsContent value="tab2">
+                <div className="p-8 text-sm">
+                  <h4 className="mb-4 text-lg font-semibold">
+                    Password Settings
+                  </h4>
+                  <p className="mb-4">
+                    Change your password here. After saving, you&apos;ll be
+                    logged out.
+                  </p>
+                  <p className="mb-4">
+                    At vero eos et accusamus et iusto odio dignissimos ducimus
+                    qui blanditiis praesentium voluptatum deleniti atque
+                    corrupti quos dolores et quas molestias excepturi sint
+                    occaecati cupiditate.
+                  </p>
+                  <p className="mb-4">
+                    Et harum quidem rerum facilis est et expedita distinctio.
+                    Nam libero tempore, cum soluta nobis est eligendi optio
+                    cumque nihil impedit quo minus.
+                  </p>
+                  <p>
+                    Temporibus autem quibusdam et aut officiis debitis aut rerum
+                    necessitatibus saepe eveniet ut et voluptates repudiandae
+                    sint.
+                  </p>
+                </div>
+              </ScrollableTabsContent>
+              <ScrollableTabsContent value="tab3">
+                <div className="p-8 text-sm">
+                  <h4 className="mb-4 text-lg font-semibold">
+                    General Settings
+                  </h4>
+                  <p className="mb-4">
+                    Update your preferences and settings here.
+                  </p>
+                  <p className="mb-4">
+                    Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut
+                    odit aut fugit, sed quia consequuntur magni dolores eos qui
+                    ratione voluptatem sequi nesciunt.
+                  </p>
+                  <p className="mb-4">
+                    Neque porro quisquam est, qui dolorem ipsum quia dolor sit
+                    amet, consectetur, adipisci velit, sed quia non numquam eius
+                    modi tempora incidunt ut labore et dolore magnam aliquam
+                    quaerat voluptatem.
+                  </p>
+                  <p>
+                    Ut enim ad minima veniam, quis nostrum exercitationem ullam
+                    corporis suscipit laboriosam, nisi ut aliquid ex ea commodi
+                    consequatur.
+                  </p>
+                </div>
+              </ScrollableTabsContent>
+            </ScrollableTabs>
+          </div>
+        </div>
+
+        <div>
+          <h3 className="mb-4 text-lg font-semibold">Many Tabs</h3>
+          <div className="h-[500px] overflow-y-auto border border-zinc-200">
+            <ScrollableTabs defaultValue="overview" className="h-full">
+              <ScrollableTabsList>
+                <ScrollableTabsTrigger value="overview">
+                  Overview
+                </ScrollableTabsTrigger>
+                <ScrollableTabsTrigger value="analytics">
+                  Analytics
+                </ScrollableTabsTrigger>
+                <ScrollableTabsTrigger value="reports">
+                  Reports
+                </ScrollableTabsTrigger>
+                <ScrollableTabsTrigger value="notifications">
+                  Notifications
+                </ScrollableTabsTrigger>
+                <ScrollableTabsTrigger value="integrations">
+                  Integrations
+                </ScrollableTabsTrigger>
+                <ScrollableTabsTrigger value="billing">
+                  Billing
+                </ScrollableTabsTrigger>
+              </ScrollableTabsList>
+              <ScrollableTabsContent value="overview">
+                <div className="p-8 text-sm">
+                  <h4 className="mb-4 text-lg font-semibold">
+                    Dashboard Overview
+                  </h4>
+                  <p className="mb-4">
+                    Dashboard overview with key metrics and recent activity.
+                  </p>
+                  <p className="mb-4">
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua.
+                  </p>
+                  <p>
+                    Ut enim ad minim veniam, quis nostrud exercitation ullamco
+                    laboris nisi ut aliquip ex ea commodo consequat.
+                  </p>
+                </div>
+              </ScrollableTabsContent>
+              <ScrollableTabsContent value="analytics">
+                <div className="p-8 text-sm">
+                  <h4 className="mb-4 text-lg font-semibold">Analytics</h4>
+                  <p className="mb-4">
+                    Detailed analytics and performance metrics.
+                  </p>
+                  <p className="mb-4">
+                    Duis aute irure dolor in reprehenderit in voluptate velit
+                    esse cillum dolore eu fugiat nulla pariatur.
+                  </p>
+                  <p>
+                    Excepteur sint occaecat cupidatat non proident, sunt in
+                    culpa qui officia deserunt mollit anim id est laborum.
+                  </p>
+                </div>
+              </ScrollableTabsContent>
+              <ScrollableTabsContent value="reports">
+                <div className="p-8 text-sm">
+                  <h4 className="mb-4 text-lg font-semibold">Reports</h4>
+                  <p className="mb-4">
+                    Generate and view reports for your account.
+                  </p>
+                  <p className="mb-4">
+                    Sed ut perspiciatis unde omnis iste natus error sit
+                    voluptatem accusantium doloremque laudantium.
+                  </p>
+                  <p>
+                    Totam rem aperiam, eaque ipsa quae ab illo inventore
+                    veritatis et quasi architecto beatae vitae dicta sunt
+                    explicabo.
+                  </p>
+                </div>
+              </ScrollableTabsContent>
+              <ScrollableTabsContent value="notifications">
+                <div className="p-8 text-sm">
+                  <h4 className="mb-4 text-lg font-semibold">Notifications</h4>
+                  <p className="mb-4">Manage your notification preferences.</p>
+                  <p className="mb-4">
+                    Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut
+                    odit aut fugit.
+                  </p>
+                  <p>
+                    Sed quia consequuntur magni dolores eos qui ratione
+                    voluptatem sequi nesciunt.
+                  </p>
+                </div>
+              </ScrollableTabsContent>
+              <ScrollableTabsContent value="integrations">
+                <div className="p-8 text-sm">
+                  <h4 className="mb-4 text-lg font-semibold">Integrations</h4>
+                  <p className="mb-4">
+                    Connect and manage third-party integrations.
+                  </p>
+                  <p className="mb-4">
+                    Neque porro quisquam est, qui dolorem ipsum quia dolor sit
+                    amet.
+                  </p>
+                  <p>
+                    Consectetur, adipisci velit, sed quia non numquam eius modi
+                    tempora incidunt.
+                  </p>
+                </div>
+              </ScrollableTabsContent>
+              <ScrollableTabsContent value="billing">
+                <div className="p-8 text-sm">
+                  <h4 className="mb-4 text-lg font-semibold">Billing</h4>
+                  <p className="mb-4">
+                    View and manage your billing information.
+                  </p>
+                  <p className="mb-4">
+                    Ut enim ad minima veniam, quis nostrum exercitationem ullam
+                    corporis suscipit laboriosam.
+                  </p>
+                  <p>
+                    Nisi ut aliquid ex ea commodi consequatur? Quis autem vel
+                    eum iure reprehenderit qui in ea voluptate velit esse.
+                  </p>
+                </div>
+              </ScrollableTabsContent>
+            </ScrollableTabs>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export const Default = {
+  render: () => <ScrollableTabsDemo />,
+} satisfies Story;
+
+export const ShortContent = {
+  render: () => (
+    <div className="p-8">
+      <div className="h-[200px] overflow-y-auto border border-zinc-200">
+        <ScrollableTabs defaultValue="account" className="h-full">
+          <ScrollableTabsList>
+            <ScrollableTabsTrigger value="account">
+              Account
+            </ScrollableTabsTrigger>
+            <ScrollableTabsTrigger value="password">
+              Password
+            </ScrollableTabsTrigger>
+          </ScrollableTabsList>
+          <ScrollableTabsContent value="account">
+            <div className="p-4 text-sm">
+              Make changes to your account here. Click save when you&apos;re
+              done.
+            </div>
+          </ScrollableTabsContent>
+          <ScrollableTabsContent value="password">
+            <div className="p-4 text-sm">
+              Change your password here. After saving, you&apos;ll be logged
+              out.
+            </div>
+          </ScrollableTabsContent>
+        </ScrollableTabs>
+      </div>
+    </div>
+  ),
+} satisfies Story;
+
+export const LongContent = {
+  render: () => (
+    <div className="p-8">
+      <div className="h-[600px] overflow-y-auto border border-zinc-200">
+        <ScrollableTabs defaultValue="tab1" className="h-full">
+          <ScrollableTabsList>
+            <ScrollableTabsTrigger value="tab1">Account</ScrollableTabsTrigger>
+            <ScrollableTabsTrigger value="tab2">Password</ScrollableTabsTrigger>
+            <ScrollableTabsTrigger value="tab3">Settings</ScrollableTabsTrigger>
+          </ScrollableTabsList>
+          <ScrollableTabsContent value="tab1">
+            <div className="p-8 text-sm">
+              <h4 className="mb-4 text-lg font-semibold">Account Settings</h4>
+              <p className="mb-4">
+                Make changes to your account here. Click save when you&apos;re
+                done.
+              </p>
+              <p className="mb-4">
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do
+                eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
+                enim ad minim veniam, quis nostrud exercitation ullamco laboris
+                nisi ut aliquip ex ea commodo consequat.
+              </p>
+              <p className="mb-4">
+                Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum.
+              </p>
+              <p className="mb-4">
+                Sed ut perspiciatis unde omnis iste natus error sit voluptatem
+                accusantium doloremque laudantium, totam rem aperiam, eaque ipsa
+                quae ab illo inventore veritatis et quasi architecto beatae
+                vitae dicta sunt explicabo.
+              </p>
+              <p>
+                Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit
+                aut fugit, sed quia consequuntur magni dolores eos qui ratione
+                voluptatem sequi nesciunt.
+              </p>
+            </div>
+          </ScrollableTabsContent>
+          <ScrollableTabsContent value="tab2">
+            <div className="p-8 text-sm">
+              <h4 className="mb-4 text-lg font-semibold">Password Settings</h4>
+              <p className="mb-4">
+                Change your password here. After saving, you&apos;ll be logged
+                out.
+              </p>
+              <p className="mb-4">
+                At vero eos et accusamus et iusto odio dignissimos ducimus qui
+                blanditiis praesentium voluptatum deleniti atque corrupti quos
+                dolores et quas molestias excepturi sint occaecati cupiditate
+                non provident.
+              </p>
+              <p className="mb-4">
+                Similique sunt in culpa qui officia deserunt mollitia animi, id
+                est laborum et dolorum fuga. Et harum quidem rerum facilis est
+                et expedita distinctio.
+              </p>
+              <p className="mb-4">
+                Nam libero tempore, cum soluta nobis est eligendi optio cumque
+                nihil impedit quo minus id quod maxime placeat facere possimus,
+                omnis voluptas assumenda est, omnis dolor repellendus.
+              </p>
+              <p>
+                Temporibus autem quibusdam et aut officiis debitis aut rerum
+                necessitatibus saepe eveniet ut et voluptates repudiandae sint
+                et molestiae non recusandae.
+              </p>
+            </div>
+          </ScrollableTabsContent>
+          <ScrollableTabsContent value="tab3">
+            <div className="p-8 text-sm">
+              <h4 className="mb-4 text-lg font-semibold">General Settings</h4>
+              <p className="mb-4">Update your preferences and settings here.</p>
+              <p className="mb-4">
+                Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet,
+                consectetur, adipisci velit, sed quia non numquam eius modi
+                tempora incidunt ut labore et dolore magnam aliquam quaerat
+                voluptatem.
+              </p>
+              <p className="mb-4">
+                Ut enim ad minima veniam, quis nostrum exercitationem ullam
+                corporis suscipit laboriosam, nisi ut aliquid ex ea commodi
+                consequatur? Quis autem vel eum iure reprehenderit qui in ea
+                voluptate velit esse quam nihil molestiae consequatur.
+              </p>
+              <p className="mb-4">
+                Vel illum qui dolorem eum fugiat quo voluptas nulla pariatur? At
+                vero eos et accusamus et iusto odio dignissimos ducimus qui
+                blanditiis praesentium voluptatum deleniti atque corrupti quos
+                dolores.
+              </p>
+              <p>
+                Et quas molestias excepturi sint occaecati cupiditate non
+                provident, similique sunt in culpa qui officia deserunt mollitia
+                animi, id est laborum et dolorum fuga.
+              </p>
+            </div>
+          </ScrollableTabsContent>
+        </ScrollableTabs>
+      </div>
+    </div>
+  ),
+} satisfies Story;

--- a/autogpt_platform/frontend/src/components/molecules/ScrollableTabs/ScrollableTabs.tsx
+++ b/autogpt_platform/frontend/src/components/molecules/ScrollableTabs/ScrollableTabs.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { Children } from "react";
+import { ScrollableTabsContent } from "./components/ScrollableTabsContent";
+import { ScrollableTabsList } from "./components/ScrollableTabsList";
+import { ScrollableTabsTrigger } from "./components/ScrollableTabsTrigger";
+import { ScrollableTabsContext } from "./context";
+import { findContentElements, findListElement } from "./helpers";
+import { useScrollableTabsInternal } from "./useScrollableTabs";
+
+interface Props {
+  children?: React.ReactNode;
+  className?: string;
+  defaultValue?: string;
+}
+
+export function ScrollableTabs({ children, className, defaultValue }: Props) {
+  const {
+    activeValue,
+    setActiveValue,
+    registerContent,
+    scrollToSection,
+    scrollContainer,
+    contentContainerRef,
+  } = useScrollableTabsInternal({ defaultValue });
+
+  const childrenArray = Children.toArray(children);
+  const listElement = findListElement(childrenArray);
+  const contentElements = findContentElements(childrenArray);
+
+  return (
+    <ScrollableTabsContext.Provider
+      value={{
+        activeValue,
+        setActiveValue,
+        registerContent,
+        scrollToSection,
+        scrollContainer,
+      }}
+    >
+      <div className={cn("relative flex flex-col", className)}>
+        {listElement}
+        <div
+          ref={(node) => {
+            if (contentContainerRef) {
+              contentContainerRef.current = node;
+            }
+          }}
+          className="max-h-[64rem] overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-zinc-300 dark:scrollbar-thumb-zinc-700"
+        >
+          <div className="min-h-full pb-[200px]">{contentElements}</div>
+        </div>
+      </div>
+    </ScrollableTabsContext.Provider>
+  );
+}
+
+export { ScrollableTabsContent, ScrollableTabsList, ScrollableTabsTrigger };

--- a/autogpt_platform/frontend/src/components/molecules/ScrollableTabs/components/ScrollableTabsContent.tsx
+++ b/autogpt_platform/frontend/src/components/molecules/ScrollableTabs/components/ScrollableTabsContent.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import * as React from "react";
+import { useScrollableTabs } from "../context";
+
+interface Props extends React.HTMLAttributes<HTMLDivElement> {
+  value: string;
+}
+
+export const ScrollableTabsContent = React.forwardRef<HTMLDivElement, Props>(
+  function ScrollableTabsContent(
+    { className, value, children, ...props },
+    ref,
+  ) {
+    const { registerContent } = useScrollableTabs();
+    const contentRef = React.useRef<HTMLDivElement>(null);
+
+    React.useEffect(() => {
+      if (contentRef.current) {
+        registerContent(value, contentRef.current);
+      }
+      return () => {
+        registerContent(value, null);
+      };
+    }, [value, registerContent]);
+
+    return (
+      <div
+        ref={(node) => {
+          if (typeof ref === "function") ref(node);
+          else if (ref) ref.current = node;
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
+          contentRef.current = node;
+        }}
+        data-scrollable-tab-content
+        data-value={value}
+        className={cn("focus-visible:outline-none", className)}
+        {...props}
+      >
+        {children}
+      </div>
+    );
+  },
+);
+
+ScrollableTabsContent.displayName = "ScrollableTabsContent";

--- a/autogpt_platform/frontend/src/components/molecules/ScrollableTabs/components/ScrollableTabsList.tsx
+++ b/autogpt_platform/frontend/src/components/molecules/ScrollableTabs/components/ScrollableTabsList.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import * as React from "react";
+import { useScrollableTabs } from "../context";
+
+export const ScrollableTabsList = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(function ScrollableTabsList({ className, children, ...props }, ref) {
+  const { activeValue } = useScrollableTabs();
+  const [activeTabElement, setActiveTabElement] =
+    React.useState<HTMLElement | null>(null);
+
+  React.useEffect(() => {
+    const activeButton = Array.from(
+      document.querySelectorAll<HTMLElement>(
+        '[data-scrollable-tab-trigger][data-value="' + activeValue + '"]',
+      ),
+    )[0];
+
+    if (activeButton) {
+      setActiveTabElement(activeButton);
+    }
+  }, [activeValue]);
+
+  return (
+    <div className="relative" ref={ref}>
+      <div
+        className={cn(
+          "inline-flex w-full items-center justify-start border-b border-zinc-100",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </div>
+      {activeTabElement && (
+        <div
+          className="transition-left transition-right absolute bottom-0 h-0.5 bg-purple-600 duration-200 ease-in-out"
+          style={{
+            left: activeTabElement.offsetLeft,
+            width: activeTabElement.offsetWidth,
+            willChange: "left, width",
+          }}
+        />
+      )}
+    </div>
+  );
+});
+
+ScrollableTabsList.displayName = "ScrollableTabsList";

--- a/autogpt_platform/frontend/src/components/molecules/ScrollableTabs/components/ScrollableTabsTrigger.tsx
+++ b/autogpt_platform/frontend/src/components/molecules/ScrollableTabs/components/ScrollableTabsTrigger.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import * as React from "react";
+import { useScrollableTabs } from "../context";
+
+interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  value: string;
+}
+
+export const ScrollableTabsTrigger = React.forwardRef<HTMLButtonElement, Props>(
+  function ScrollableTabsTrigger(
+    { className, value, children, ...props },
+    ref,
+  ) {
+    const { activeValue, scrollToSection } = useScrollableTabs();
+    const elementRef = React.useRef<HTMLButtonElement>(null);
+    const isActive = activeValue === value;
+
+    function handleClick(e: React.MouseEvent<HTMLButtonElement>) {
+      e.preventDefault();
+      e.stopPropagation();
+      scrollToSection(value);
+      props.onClick?.(e);
+    }
+
+    return (
+      <button
+        type="button"
+        ref={(node) => {
+          if (typeof ref === "function") ref(node);
+          else if (ref) ref.current = node;
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
+          elementRef.current = node;
+        }}
+        data-scrollable-tab-trigger
+        data-value={value}
+        onClick={handleClick}
+        className={cn(
+          "relative inline-flex items-center justify-center whitespace-nowrap px-3 py-3 font-sans text-[0.875rem] font-medium leading-[1.5rem] text-zinc-700 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-400 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+          isActive && "text-purple-600",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </button>
+    );
+  },
+);
+
+ScrollableTabsTrigger.displayName = "ScrollableTabsTrigger";

--- a/autogpt_platform/frontend/src/components/molecules/ScrollableTabs/context.ts
+++ b/autogpt_platform/frontend/src/components/molecules/ScrollableTabs/context.ts
@@ -1,0 +1,22 @@
+import * as React from "react";
+import { createContext, useContext } from "react";
+
+interface ScrollableTabsContextValue {
+  activeValue: string | null;
+  setActiveValue: React.Dispatch<React.SetStateAction<string | null>>;
+  registerContent: (value: string, element: HTMLElement | null) => void;
+  scrollToSection: (value: string) => void;
+  scrollContainer: HTMLElement | null;
+}
+
+export const ScrollableTabsContext = createContext<
+  ScrollableTabsContextValue | undefined
+>(undefined);
+
+export function useScrollableTabs() {
+  const context = useContext(ScrollableTabsContext);
+  if (!context) {
+    throw new Error("useScrollableTabs must be used within a ScrollableTabs");
+  }
+  return context;
+}

--- a/autogpt_platform/frontend/src/components/molecules/ScrollableTabs/helpers.ts
+++ b/autogpt_platform/frontend/src/components/molecules/ScrollableTabs/helpers.ts
@@ -1,0 +1,48 @@
+import * as React from "react";
+
+const HEADER_OFFSET = 100;
+
+export function calculateScrollPosition(
+  elementRect: DOMRect,
+  containerRect: DOMRect,
+  currentScrollTop: number,
+): number {
+  const elementTopRelativeToContainer =
+    elementRect.top - containerRect.top + currentScrollTop - HEADER_OFFSET;
+
+  return Math.max(0, elementTopRelativeToContainer);
+}
+
+function hasDisplayName(
+  type: unknown,
+  displayName: string,
+): type is { displayName: string } {
+  return (
+    typeof type === "object" &&
+    type !== null &&
+    "displayName" in type &&
+    (type as { displayName: unknown }).displayName === displayName
+  );
+}
+
+export function findListElement(
+  children: React.ReactNode[],
+): React.ReactElement | undefined {
+  return children.find(
+    (child) =>
+      React.isValidElement(child) &&
+      hasDisplayName(child.type, "ScrollableTabsList"),
+  ) as React.ReactElement | undefined;
+}
+
+export function findContentElements(
+  children: React.ReactNode[],
+): React.ReactNode[] {
+  return children.filter(
+    (child) =>
+      !(
+        React.isValidElement(child) &&
+        hasDisplayName(child.type, "ScrollableTabsList")
+      ),
+  );
+}

--- a/autogpt_platform/frontend/src/components/molecules/ScrollableTabs/useScrollableTabs.ts
+++ b/autogpt_platform/frontend/src/components/molecules/ScrollableTabs/useScrollableTabs.ts
@@ -1,0 +1,60 @@
+import { useCallback, useRef, useState } from "react";
+import { calculateScrollPosition } from "./helpers";
+
+interface Args {
+  defaultValue?: string;
+}
+
+export function useScrollableTabsInternal({ defaultValue }: Args) {
+  const [activeValue, setActiveValue] = useState<string | null>(
+    defaultValue || null,
+  );
+  const contentRefs = useRef<Map<string, HTMLElement>>(new Map());
+  const contentContainerRef = useRef<HTMLDivElement | null>(null);
+
+  function registerContent(value: string, element: HTMLElement | null) {
+    if (element) {
+      contentRefs.current.set(value, element);
+    } else {
+      contentRefs.current.delete(value);
+    }
+  }
+
+  function scrollToSection(value: string) {
+    const element = contentRefs.current.get(value);
+    const scrollContainer = contentContainerRef.current;
+    if (!element || !scrollContainer) return;
+
+    setActiveValue(value);
+
+    const containerRect = scrollContainer.getBoundingClientRect();
+    const elementRect = element.getBoundingClientRect();
+    const currentScrollTop = scrollContainer.scrollTop;
+    const scrollTop = calculateScrollPosition(
+      elementRect,
+      containerRect,
+      currentScrollTop,
+    );
+
+    const maxScrollTop =
+      scrollContainer.scrollHeight - scrollContainer.clientHeight;
+    const clampedScrollTop = Math.min(Math.max(0, scrollTop), maxScrollTop);
+
+    scrollContainer.scrollTo({
+      top: clampedScrollTop,
+      behavior: "smooth",
+    });
+  }
+
+  const memoizedRegisterContent = useCallback(registerContent, []);
+  const memoizedScrollToSection = useCallback(scrollToSection, []);
+
+  return {
+    activeValue,
+    setActiveValue,
+    registerContent: memoizedRegisterContent,
+    scrollToSection: memoizedScrollToSection,
+    scrollContainer: contentContainerRef.current,
+    contentContainerRef,
+  };
+}


### PR DESCRIPTION
## Changes 🏗️

https://github.com/user-attachments/assets/7e49ed5b-c818-4aa3-b5d6-4fa86fada7ee

When the content of Summary + Outputs + Inputs is long enough, it will show in this new `<ScrollableTabs />` component, which auto-scrolls the content as you click on a tab.

## Checklist 📋

### For code changes

- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Run the app locally
  - [x] Check the new page with scrollable tabs 

