### PR TITLE
hotfix(frontend): chat should be disabled by default

### DIFF
--- a/autogpt_platform/frontend/src/services/feature-flags/use-get-flag.ts
+++ b/autogpt_platform/frontend/src/services/feature-flags/use-get-flag.ts
@@ -48,7 +48,7 @@ const mockFlags = {
   [Flag.AGENT_FAVORITING]: false,
   [Flag.MARKETPLACE_SEARCH_TERMS]: DEFAULT_SEARCH_TERMS,
   [Flag.ENABLE_PLATFORM_PAYMENT]: false,
-  [Flag.CHAT]: true,
+  [Flag.CHAT]: false,
 };
 
 export function useGetFlag<T extends Flag>(flag: T): FlagValues[T] | null {


### PR DESCRIPTION
### Changes 🏗️

Chat should be disabled by default; otherwise, it flashes, and if Launch Darkly fails to fail, it is dangerous.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Run locally with Launch Darkly disabled and test the above

