### PR TITLE
feat(backend): add TypedDict schema for json_schema_extra

### DIFF
--- a/autogpt_platform/backend/backend/sdk/provider.py
+++ b/autogpt_platform/backend/backend/sdk/provider.py
@@ -81,7 +81,7 @@ class Provider:
         discriminator_values = kwargs.pop("discriminator_values", None)
 
         # Create json_schema_extra with provider information
-        json_schema_extra = {
+        json_schema_extra: dict[str, Any] = {
             "credentials_provider": [self.name],
             "credentials_types": (
                 list(self.supported_auth_types) if self.supported_auth_types else []
@@ -90,10 +90,8 @@ class Provider:
 
         # Merge any existing json_schema_extra
         if "json_schema_extra" in kwargs:
-            json_schema_extra.update(kwargs.pop("json_schema_extra"))
-
-        # Add json_schema_extra to kwargs
-        kwargs["json_schema_extra"] = json_schema_extra
+            extra: dict[str, Any] = kwargs.pop("json_schema_extra")
+            json_schema_extra.update(extra)
 
         return CredentialsField(
             required_scopes=required_scopes,
@@ -102,6 +100,7 @@ class Provider:
             discriminator_values=discriminator_values,
             title=title,
             description=description,
+            json_schema_extra=json_schema_extra,
             **kwargs,
         )
 


### PR DESCRIPTION
## Summary
- Add `AutoCredentialsConfig`, `GoogleDrivePickerConfig`, and `FieldSchemaExtra` TypedDict definitions for structured type hints
- Update `SchemaField` and `CredentialsField` to use `dict[str, Any] | None` type annotation
- Add docstrings explaining the `json_schema_extra` parameter
- Update `provider.py` to use explicit `json_schema_extra` parameter instead of kwargs

This provides better IDE support and documentation for the json_schema_extra field used across the codebase.

## Test plan
- [x] Existing tests should pass
- [x] Type checking with mypy/pyright should work

🤖 Generated with [Claude Code](https://claude.com/claude-code)