### PR TITLE
feat(blocks): add ConcatenateListsBlock for list concatenation

### DIFF
--- a/autogpt_platform/backend/backend/blocks/basic.py
+++ b/autogpt_platform/backend/backend/blocks/basic.py
@@ -1,4 +1,5 @@
 import enum
+import itertools
 from typing import Any
 
 from backend.data.block import (
@@ -271,12 +272,15 @@ class ConcatenateListsBlock(Block):
         )
 
     async def run(self, input_data: Input, **kwargs) -> BlockOutput:
-        result = (
-            list(input_data.list1)
-            + list(input_data.list2)
-            + list(input_data.list3)
-            + list(input_data.list4)
-            + list(input_data.list5)
+        # Use itertools.chain for efficient memory usage with large lists
+        result = list(
+            itertools.chain(
+                input_data.list1,
+                input_data.list2,
+                input_data.list3,
+                input_data.list4,
+                input_data.list5,
+            )
         )
         yield "concatenated_list", result
         yield "total_length", len(result)


### PR DESCRIPTION
## Summary

Implements a new block that concatenates two or more lists into a single list.

- Two required inputs (`list1`, `list2`) for basic use
- Three optional advanced inputs (`list3`, `list4`, `list5`) for more complex scenarios
- Preserves element order during concatenation
- Outputs both the concatenated result and total element count

## Test plan

- [x] Block includes built-in test_input and test_output for automated testing
- [x] Code passes format and lint checks

Fixes #11139