### PR TITLE
fix(frontend): exclude schemas with enum from anyOf detection

### DIFF
--- a/autogpt_platform/frontend/src/components/renderers/InputRenderer/FormRenderer.tsx
+++ b/autogpt_platform/frontend/src/components/renderers/InputRenderer/FormRenderer.tsx
@@ -30,8 +30,6 @@ export const FormRenderer = ({
     return generateUiSchemaForCustomFields(preprocessedSchema, uiSchema);
   }, [preprocessedSchema, uiSchema]);
 
-  console.log("preprocessedSchema", preprocessedSchema);
-
   return (
     <div className={"mb-6 mt-4"}>
       <Form


### PR DESCRIPTION
### Changes 🏗️

Fixed the `isAnyOfSchema` function in schema-utils.ts to exclude schemas that have an `enum` property. This prevents incorrect schema processing for enums that also have anyOf definitions. Added a console.log statement in FormRenderer.tsx to help debug schema preprocessing.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Verified that forms with enum values render correctly
  - [x] Confirmed that anyOf schemas are properly identified and processed
  - [x] Tested with various schema combinations to ensure the fix doesn't break existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved validation logic for form field schemas to correctly handle edge cases when multiple constraint types are defined.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->