### PR TITLE
fix(frontend): Remove hardcoded bypass of billing feature flag

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/profile/(user)/layout.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/profile/(user)/layout.tsx
@@ -29,7 +29,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
           href: "/profile/dashboard",
           icon: <StorefrontIcon className="size-5" />,
         },
-        ...(isPaymentEnabled || true
+        ...(isPaymentEnabled
           ? [
               {
                 text: "Billing",


### PR DESCRIPTION
## Summary

Fixes a critical security issue where the billing button in the settings sidebar was always visible to all users, bypassing the `ENABLE_PLATFORM_PAYMENT` feature flag.

## Changes 🏗️

- Removed hardcoded `|| true` condition in `frontend/src/app/(platform)/profile/(user)/layout.tsx:32` that was bypassing the feature flag check
- The billing button is now properly gated by the `ENABLE_PLATFORM_PAYMENT` feature flag as intended

## Root Cause

The `|| true` was accidentally left in commit 3dbc03e488b90ffaf2b478b1fca842032fc9e8bb (PR #11617 - OAuth API & Single Sign-On) from December 19, 2025. It was likely added temporarily during development/testing to always show the billing button, but was not removed before merging.

## Test Plan

1. Verify feature flag is set to disabled in LaunchDarkly
2. Navigate to settings page (`/profile/settings`)
3. Confirm billing button is NOT visible in the sidebar
4. Enable feature flag in LaunchDarkly
5. Refresh page and confirm billing button IS now visible
6. Verify billing page (`/profile/credits`) is still accessible via direct URL when feature flag is disabled

## Checklist 📋

### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan

Fixes SECRT-1791

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The Billing link in the profile sidebar now respects the payment feature flag configuration and will only display when payment functionality is enabled.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->