### PR TITLE
Update nodejs to 22.22.0 to fix CVE-2025-59466

### DIFF
--- a/autogpt_platform/frontend/Dockerfile
+++ b/autogpt_platform/frontend/Dockerfile
@@ -1,5 +1,5 @@
 # Base stage for both dev and prod
-FROM node:22.22.0-alpine AS base
+FROM node:22-alpine AS base
 WORKDIR /app
 RUN corepack enable
 COPY autogpt_platform/frontend/package.json autogpt_platform/frontend/pnpm-lock.yaml ./
@@ -29,7 +29,7 @@ RUN pnpm run generate:api
 RUN if [ "$NEXT_PUBLIC_PW_TEST" = "true" ]; then NEXT_PUBLIC_PW_TEST=true NODE_OPTIONS="--max-old-space-size=4096" pnpm build; else NODE_OPTIONS="--max-old-space-size=4096" pnpm build; fi
 
 # Prod stage - based on NextJS reference Dockerfile https://github.com/vercel/next.js/blob/64271354533ed16da51be5dce85f0dbd15f17517/examples/with-docker/Dockerfile
-FROM node:22.22.0-alpine AS prod
+FROM node:22-alpine AS prod
 ENV NODE_ENV=production
 ENV HOSTNAME=0.0.0.0
 WORKDIR /app


### PR DESCRIPTION
Fix CVE-2025-59466

### Changes 🏗️

Update nodejs for front-end due to:
https://nodejs.org/en/blog/vulnerability/january-2026-dos-mitigation-async-hooks

