### PR TITLE
feat(frontend): hide children of connected array and object fields



### DIFF
--- a/autogpt_platform/frontend/src/components/renderers/InputRenderer/base/array/ArrayFieldTemplate.tsx
+++ b/autogpt_platform/frontend/src/components/renderers/InputRenderer/base/array/ArrayFieldTemplate.tsx
@@ -4,7 +4,8 @@ import {
   getTemplate,
   getUiOptions,
 } from "@rjsf/utils";
-import { getHandleId, updateUiOption } from "../../helpers";
+import { cleanUpHandleId, getHandleId, updateUiOption } from "../../helpers";
+import { useEdgeStore } from "@/app/(platform)/build/stores/edgeStore";
 
 export default function ArrayFieldTemplate(props: ArrayFieldTemplateProps) {
   const {
@@ -23,6 +24,7 @@ export default function ArrayFieldTemplate(props: ArrayFieldTemplateProps) {
   } = props;
 
   const uiOptions = getUiOptions(uiSchema);
+  const { isInputConnected } = useEdgeStore();
 
   const ArrayFieldDescriptionTemplate = getTemplate(
     "ArrayFieldDescriptionTemplate",
@@ -50,6 +52,11 @@ export default function ArrayFieldTemplate(props: ArrayFieldTemplateProps) {
   const updatedUiSchema = updateUiOption(uiSchema, {
     handleId: handleId,
   });
+
+  const shouldShowChildren = !isInputConnected(
+    registry.formContext.nodeId,
+    cleanUpHandleId(handleId),
+  );
 
   return (
     <div>
@@ -79,25 +86,29 @@ export default function ArrayFieldTemplate(props: ArrayFieldTemplateProps) {
               />
             </div>
           )}
-          <div
-            key={`array-item-list-${fieldPathId.$id}`}
-            className="m-0 mb-2 w-full p-0"
-          >
-            {!showOptionalDataControlInTitle ? optionalDataControl : undefined}
-            {items}
-            {canAdd && (
-              <div className="mt-4 flex justify-end">
-                <AddButton
-                  id={buttonId(fieldPathId, "add")}
-                  className="rjsf-array-item-add"
-                  onClick={onAddClick}
-                  disabled={disabled || readonly}
-                  uiSchema={updatedUiSchema}
-                  registry={registry}
-                />
-              </div>
-            )}
-          </div>
+          {shouldShowChildren && (
+            <div
+              key={`array-item-list-${fieldPathId.$id}`}
+              className="m-0 mb-2 w-full p-0"
+            >
+              {!showOptionalDataControlInTitle
+                ? optionalDataControl
+                : undefined}
+              {items}
+              {canAdd && (
+                <div className="mt-4 flex justify-end">
+                  <AddButton
+                    id={buttonId(fieldPathId, "add")}
+                    className="rjsf-array-item-add"
+                    onClick={onAddClick}
+                    disabled={disabled || readonly}
+                    uiSchema={updatedUiSchema}
+                    registry={registry}
+                  />
+                </div>
+              )}
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/autogpt_platform/frontend/src/components/renderers/InputRenderer/base/standard/FieldTemplate.tsx
+++ b/autogpt_platform/frontend/src/components/renderers/InputRenderer/base/standard/FieldTemplate.tsx
@@ -78,7 +78,12 @@ export default function FieldTemplate(props: FieldTemplateProps) {
     displayLabel ||
     (schema.type === "boolean" && !isAnyOfChild(uiSchema as any));
   const shouldShowTitleSection = !isAnyOfSchema(schema) && !additional;
-  const shouldShowChildren = isAnyOfSchema(schema) || !isHandleConnected;
+
+  const shouldShowChildren =
+    schema.type === "object" ||
+    schema.type === "array" ||
+    isAnyOfSchema(schema) ||
+    !isHandleConnected;
 
   const isAdvancedField = (schema as any).advanced === true;
   if (!showAdvanced && isAdvancedField && !isHandleConnected) {


### PR DESCRIPTION
### Changes 🏗️

- Added conditional rendering for array and object field children based on connection status
- Implemented `shouldShowChildren` logic in `ArrayFieldTemplate` and `ObjectFieldTemplate` components
- Modified the `shouldShowChildren` condition in `FieldTemplate` to handle different schema types
- Imported and utilized `cleanUpHandleId` and `useEdgeStore` to check if inputs are connected
- Added connection status checks to hide form fields when their inputs are connected to other nodes

![Screenshot 2026-01-15 at 12.55.32 PM.png](https://app.graphite.com/user-attachments/assets/d3fffade-872e-4fd8-a347-28d1bae3072e.png)

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Verified that object and array fields hide their children when connected to other nodes
  - [x] Confirmed that unconnected fields display their children properly
  - [x] Tested with various schema types to ensure correct rendering behavior
  - [x] Checked that the connection status is properly detected and applied