### PR TITLE
fix(backend): Make Redis connection lazy in cache module

### DIFF
--- a/autogpt_platform/backend/backend/util/cache.py
+++ b/autogpt_platform/backend/backend/util/cache.py
@@ -384,7 +384,8 @@ def cached(
             key = _make_hashable_key(args, kwargs)
             if shared_cache:
                 redis_key = _make_redis_key(key, target_func.__name__)
-                return _get_redis().delete(redis_key) > 0
+                deleted_count = cast(int, _get_redis().delete(redis_key))
+                return deleted_count > 0
             else:
                 if key in cache_storage:
                     del cache_storage[key]


### PR DESCRIPTION
## Summary
- Makes Redis connection lazy in the cache module - connection is only established when `shared_cache=True` is actually used
- Fixes DatabaseManager failing to start because it imports `onboarding.py` which imports `cache.py`, triggering Redis connection at module load time even though it only uses in-memory caching

## Root Cause
Commit `b01ea3fcb` (merged today) added `increment_onboarding_runs` to DatabaseManager, which imports from `onboarding.py`. That module imports `@cached` decorator from `cache.py`, which was creating a Redis connection at module import time:

```python
# Old code - ran at import time!
redis = Redis(connection_pool=_get_cache_pool())
```

Since `onboarding.py` only uses `@cached(shared_cache=False)` (in-memory caching), it doesn't actually need Redis. But the import triggered the connection attempt.

## Changes
- Wrapped Redis connection in a singleton class with lazy initialization
- Connection is only established when `_get_redis()` is first called (i.e., when `shared_cache=True` is used)
- Services using only in-memory caching can now import `cache.py` without Redis configuration

## Test plan
- [ ] Services using `shared_cache=False` work without Redis configured
- [ ] Services using `shared_cache=True` still work correctly with Redis
- [ ] Existing cache tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)