### PR TITLE
fix(frontend): auto-select credentials correctly in old builder

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/OldAgentLibraryView/components/agent-run-draft-view.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/OldAgentLibraryView/components/agent-run-draft-view.tsx
@@ -86,19 +86,19 @@ export function AgentRunDraftView({
   onCreateSchedule?: (schedule: Schedule) => void;
   className?: string;
 } & (
-    | {
+  | {
       onCreatePreset?: (preset: LibraryAgentPreset) => void;
       agentPreset?: never;
       onUpdatePreset?: never;
       doDeletePreset?: never;
     }
-    | {
+  | {
       onCreatePreset?: never;
       agentPreset: LibraryAgentPreset;
       onUpdatePreset: (preset: LibraryAgentPreset) => void;
       doDeletePreset: (presetID: LibraryAgentPresetID) => void;
     }
-  )): React.ReactNode {
+)): React.ReactNode {
   const api = useBackendAPI();
   const { toast } = useToast();
   const toastOnFail = useToastOnFail();
@@ -239,18 +239,13 @@ export function AgentRunDraftView({
     },
     [requiredCredentials, inputCredentials],
   );
-  function addChangedCredentials(
-    prev: Set<keyof LibraryAgentPresetUpdatable>,
-  ) {
+  function addChangedCredentials(prev: Set<keyof LibraryAgentPresetUpdatable>) {
     const next = new Set(prev);
     next.add("credentials");
     return next;
   }
 
-  function handleCredentialChange(
-    key: string,
-    value?: CredentialsMetaInput,
-  ) {
+  function handleCredentialChange(key: string, value?: CredentialsMetaInput) {
     setInputCredentials(function updateInputCredentials(currentCreds) {
       const next = { ...currentCreds };
       if (value === undefined) {
@@ -494,110 +489,110 @@ export function AgentRunDraftView({
       // "Regular" agent: [run] + [save as preset] buttons
       ...(!graph.has_external_trigger
         ? ([
-          {
-            label: (
-              <>
-                <CalendarClockIcon className="mr-2 size-4" /> Schedule run
-              </>
-            ),
-            variant: "accent",
-            callback: openScheduleDialog,
-            extraProps: { "data-testid": "agent-schedule-button" },
-          },
-          {
-            label: (
-              <>
-                <IconPlay className="mr-2 size-4" /> Manual run
-              </>
-            ),
-            callback: doRun,
-            extraProps: { "data-testid": "agent-run-button" },
-          },
-          // {
-          //   label: (
-          //     <>
-          //       <IconSave className="mr-2 size-4" /> Save as a preset
-          //     </>
-          //   ),
-          //   callback: doCreatePreset,
-          //   disabled: !(
-          //     presetName &&
-          //     allRequiredInputsAreSet &&
-          //     allCredentialsAreSet
-          //   ),
-          // },
-        ] satisfies ButtonAction[])
+            {
+              label: (
+                <>
+                  <CalendarClockIcon className="mr-2 size-4" /> Schedule run
+                </>
+              ),
+              variant: "accent",
+              callback: openScheduleDialog,
+              extraProps: { "data-testid": "agent-schedule-button" },
+            },
+            {
+              label: (
+                <>
+                  <IconPlay className="mr-2 size-4" /> Manual run
+                </>
+              ),
+              callback: doRun,
+              extraProps: { "data-testid": "agent-run-button" },
+            },
+            // {
+            //   label: (
+            //     <>
+            //       <IconSave className="mr-2 size-4" /> Save as a preset
+            //     </>
+            //   ),
+            //   callback: doCreatePreset,
+            //   disabled: !(
+            //     presetName &&
+            //     allRequiredInputsAreSet &&
+            //     allCredentialsAreSet
+            //   ),
+            // },
+          ] satisfies ButtonAction[])
         : []),
       // Triggered agent: [setup] button
       ...(graph.has_external_trigger && !agentPreset?.webhook_id
         ? ([
-          {
-            label: (
-              <>
-                <IconPlay className="mr-2 size-4" /> Set up trigger
-              </>
-            ),
-            variant: "accent",
-            callback: doSetupTrigger,
-            disabled: !(
-              presetName &&
-              allRequiredInputsAreSet &&
-              allCredentialsAreSet
-            ),
-          },
-        ] satisfies ButtonAction[])
+            {
+              label: (
+                <>
+                  <IconPlay className="mr-2 size-4" /> Set up trigger
+                </>
+              ),
+              variant: "accent",
+              callback: doSetupTrigger,
+              disabled: !(
+                presetName &&
+                allRequiredInputsAreSet &&
+                allCredentialsAreSet
+              ),
+            },
+          ] satisfies ButtonAction[])
         : []),
       // Existing agent trigger: [enable]/[disable] button
       ...(agentPreset?.webhook_id
         ? ([
-          agentPreset.is_active
-            ? {
-              label: (
-                <>
-                  <IconCross className="mr-2.5 size-3.5" /> Disable trigger
-                </>
-              ),
-              variant: "destructive",
-              callback: () => doSetPresetActive(false),
-            }
-            : {
-              label: (
-                <>
-                  <IconPlay className="mr-2 size-4" /> Enable trigger
-                </>
-              ),
-              variant: "accent",
-              callback: () => doSetPresetActive(true),
-            },
-        ] satisfies ButtonAction[])
+            agentPreset.is_active
+              ? {
+                  label: (
+                    <>
+                      <IconCross className="mr-2.5 size-3.5" /> Disable trigger
+                    </>
+                  ),
+                  variant: "destructive",
+                  callback: () => doSetPresetActive(false),
+                }
+              : {
+                  label: (
+                    <>
+                      <IconPlay className="mr-2 size-4" /> Enable trigger
+                    </>
+                  ),
+                  variant: "accent",
+                  callback: () => doSetPresetActive(true),
+                },
+          ] satisfies ButtonAction[])
         : []),
       // Existing agent preset/trigger: [save] and [delete] buttons
       ...(agentPreset
         ? ([
-          {
-            label: (
-              <>
-                <IconSave className="mr-2 size-4" /> Save changes
-              </>
-            ),
-            callback: doUpdatePreset,
-            disabled: !(
-              changedPresetAttributes.size > 0 &&
-              presetName &&
-              allRequiredInputsAreSet &&
-              allCredentialsAreSet
-            ),
-          },
-          {
-            label: (
-              <>
-                <Trash2Icon className="mr-2 size-4" />
-                Delete {graph.has_external_trigger ? "trigger" : "preset"}
-              </>
-            ),
-            callback: () => doDeletePreset(agentPreset.id),
-          },
-        ] satisfies ButtonAction[])
+            {
+              label: (
+                <>
+                  <IconSave className="mr-2 size-4" /> Save changes
+                </>
+              ),
+              callback: doUpdatePreset,
+              disabled: !(
+                changedPresetAttributes.size > 0 &&
+                presetName &&
+                allRequiredInputsAreSet &&
+                allCredentialsAreSet
+              ),
+            },
+            {
+              label: (
+                <>
+                  <Trash2Icon className="mr-2 size-4" />
+                  Delete {graph.has_external_trigger ? "trigger" : "preset"}
+                </>
+              ),
+              callback: () => doDeletePreset(agentPreset.id),
+            },
+          ] satisfies ButtonAction[])
         : []),
     ],
     [

--- a/autogpt_platform/frontend/src/components/contextual/CredentialsInput/components/CredentialsGroupedView/CredentialsGroupedView.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/CredentialsInput/components/CredentialsGroupedView/CredentialsGroupedView.tsx
@@ -17,7 +17,7 @@ import {
   CredentialField,
   findSavedCredentialByProviderAndType,
   hasMissingRequiredSystemCredentials,
-  splitCredentialFieldsBySystem
+  splitCredentialFieldsBySystem,
 } from "./helpers";
 
 type Props = {

--- a/autogpt_platform/frontend/src/components/contextual/CredentialsInput/components/CredentialsGroupedView/helpers.ts
+++ b/autogpt_platform/frontend/src/components/contextual/CredentialsInput/components/CredentialsGroupedView/helpers.ts
@@ -1,8 +1,5 @@
 import { CredentialsProvidersContextType } from "@/providers/agent-credentials/credentials-provider";
-import {
-  filterSystemCredentials,
-  getSystemCredentials,
-} from "../../helpers";
+import { filterSystemCredentials, getSystemCredentials } from "../../helpers";
 
 export type CredentialField = [string, any];
 

--- a/autogpt_platform/frontend/src/components/contextual/CredentialsInput/useCredentialsInput.ts
+++ b/autogpt_platform/frontend/src/components/contextual/CredentialsInput/useCredentialsInput.ts
@@ -98,33 +98,36 @@ export function useCredentialsInput({
 
   // Auto-select the first available credential on initial mount
   // Once a user has made a selection, we don't override it
-  useEffect(function autoSelectCredential() {
-    if (readOnly) return;
-    if (!credentials || !("savedCredentials" in credentials)) return;
-    if (selectedCredential?.id) return;
+  useEffect(
+    function autoSelectCredential() {
+      if (readOnly) return;
+      if (!credentials || !("savedCredentials" in credentials)) return;
+      if (selectedCredential?.id) return;
 
-    const savedCreds = credentials.savedCredentials;
-    if (savedCreds.length === 0) return;
+      const savedCreds = credentials.savedCredentials;
+      if (savedCreds.length === 0) return;
 
-    if (hasAttemptedAutoSelect.current) return;
-    hasAttemptedAutoSelect.current = true;
+      if (hasAttemptedAutoSelect.current) return;
+      hasAttemptedAutoSelect.current = true;
 
-    if (isOptional) return;
+      if (isOptional) return;
 
-    const cred = savedCreds[0];
-    onSelectCredential({
-      id: cred.id,
-      type: cred.type,
-      provider: credentials.provider,
-      title: (cred as any).title,
-    });
-  }, [
-    credentials,
-    selectedCredential?.id,
-    readOnly,
-    isOptional,
-    onSelectCredential,
-  ]);
+      const cred = savedCreds[0];
+      onSelectCredential({
+        id: cred.id,
+        type: cred.type,
+        provider: credentials.provider,
+        title: (cred as any).title,
+      });
+    },
+    [
+      credentials,
+      selectedCredential?.id,
+      readOnly,
+      isOptional,
+      onSelectCredential,
+    ],
+  );
 
   if (
     !credentials ||
@@ -222,7 +225,7 @@ export function useCredentialsInput({
             );
             setOAuthError(
               "Connection failed: the granted permissions don't match what's required. " +
-              "Please contact the application administrator.",
+                "Please contact the application administrator.",
             );
             return;
           }
@@ -237,7 +240,8 @@ export function useCredentialsInput({
       } catch (error) {
         console.error("Error in OAuth callback:", error);
         setOAuthError(
-          `Error in OAuth callback: ${error instanceof Error ? error.message : String(error)
+          `Error in OAuth callback: ${
+            error instanceof Error ? error.message : String(error)
           }`,
         );
       } finally {


### PR DESCRIPTION
## Changes 🏗️

On the **Old Builder**, when running an agent...

### Before

<img width="800" height="614" alt="Screenshot 2026-01-21 at 21 27 05" src="https://github.com/user-attachments/assets/a3b2ec17-597f-44d2-9130-9e7931599c38" />

Credentials are there, but it is not recognising them, you need to click on them to be selected

### After

<img width="1029" height="728" alt="Screenshot 2026-01-21 at 21 26 47" src="https://github.com/user-attachments/assets/c6e83846-6048-439e-919d-6807674f2d5a" />

It uses the new credentials UI and correctly auto-selects existing ones.

### Other

Fixed a small timezone display glitch on the new library view.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Run agent in old builder
  - [x] Credentials are auto-selected and using the new collapsed system credentials UI 

