### PR TITLE
fix(backend): Remove pgvector schema prefix, use unqualified vector type

### DIFF
--- a/autogpt_platform/backend/backend/api/features/store/hybrid_search.py
+++ b/autogpt_platform/backend/backend/api/features/store/hybrid_search.py
@@ -295,7 +295,7 @@ async def unified_hybrid_search(
                 FROM {{schema_prefix}}"UnifiedContentEmbedding" uce
                 WHERE uce."contentType" = ANY({content_types_param}::{{schema_prefix}}"ContentType"[])
                 {user_filter}
-                ORDER BY uce.embedding OPERATOR({{pgvector_schema}}.<=>)  {embedding_param}::{{pgvector_schema}}.vector
+                ORDER BY uce.embedding <=> {embedding_param}::{{schema}}.vector
                 LIMIT 200
             )
         ),
@@ -307,7 +307,7 @@ async def unified_hybrid_search(
                 uce.metadata,
                 uce."updatedAt" as updated_at,
                 -- Semantic score: cosine similarity (1 - distance)
-                COALESCE(1 - (uce.embedding OPERATOR({{pgvector_schema}}.<=>)  {embedding_param}::{{pgvector_schema}}.vector), 0) as semantic_score,
+                COALESCE(1 - (uce.embedding <=> {embedding_param}::{{schema}}.vector), 0) as semantic_score,
                 -- Lexical score: ts_rank_cd
                 COALESCE(ts_rank_cd(uce.search, plainto_tsquery('english', {query_param})), 0) as lexical_raw,
                 -- Category match from metadata
@@ -583,7 +583,7 @@ async def hybrid_search(
                 WHERE uce."contentType" = 'STORE_AGENT'::{{schema_prefix}}"ContentType"
                 AND uce."userId" IS NULL
                 AND {where_clause}
-                ORDER BY uce.embedding OPERATOR({{pgvector_schema}}.<=>)  {embedding_param}::{{pgvector_schema}}.vector
+                ORDER BY uce.embedding <=> {embedding_param}::{{schema}}.vector
                 LIMIT 200
             ) uce
         ),
@@ -605,7 +605,7 @@ async def hybrid_search(
                 -- Searchable text for BM25 reranking
                 COALESCE(sa.agent_name, '') || ' ' || COALESCE(sa.sub_heading, '') || ' ' || COALESCE(sa.description, '') as searchable_text,
                 -- Semantic score
-                COALESCE(1 - (uce.embedding OPERATOR({{pgvector_schema}}.<=>)  {embedding_param}::{{pgvector_schema}}.vector), 0) as semantic_score,
+                COALESCE(1 - (uce.embedding <=> {embedding_param}::{{schema}}.vector), 0) as semantic_score,
                 -- Lexical score (raw, will normalize)
                 COALESCE(ts_rank_cd(uce.search, plainto_tsquery('english', {query_param})), 0) as lexical_raw,
                 -- Category match

--- a/autogpt_platform/backend/backend/data/db.py
+++ b/autogpt_platform/backend/backend/data/db.py
@@ -120,11 +120,10 @@ async def _raw_with_schema(
 
     Supports placeholders:
         - {schema_prefix}: Table/type prefix (e.g., "platform".)
-        - {schema}: Raw schema name for application tables (e.g., platform)
-        - {pgvector_schema}: Schema where pgvector is installed (defaults to "public")
+        - {schema}: Raw schema name (e.g., platform) for pgvector types
 
     Args:
-        query_template: SQL query with {schema_prefix}, {schema}, and/or {pgvector_schema} placeholders
+        query_template: SQL query with {schema_prefix} and/or {schema} placeholders
         *args: Query parameters
         execute: If False, executes SELECT query. If True, executes INSERT/UPDATE/DELETE.
         client: Optional Prisma client for transactions (only used when execute=True).
@@ -133,23 +132,16 @@ async def _raw_with_schema(
         - list[dict] if execute=False (query results)
         - int if execute=True (number of affected rows)
 
-    Example with vector type:
+    Example:
         await execute_raw_with_schema(
-            'INSERT INTO {schema_prefix}"Embedding" (vec) VALUES ($1::{pgvector_schema}.vector)',
+            'INSERT INTO {schema_prefix}"Embedding" (vec) VALUES ($1::{schema}.vector)',
             embedding_data
         )
     """
     schema = get_database_schema()
     schema_prefix = f'"{schema}".' if schema != "public" else ""
-    # pgvector extension is typically installed in "public" schema
-    # On Supabase it may be in "extensions" but "public" is the common default
-    pgvector_schema = "public"
 
-    formatted_query = query_template.format(
-        schema_prefix=schema_prefix,
-        schema=schema,
-        pgvector_schema=pgvector_schema,
-    )
+    formatted_query = query_template.format(schema_prefix=schema_prefix, schema=schema)
 
     import prisma as prisma_module
 


### PR DESCRIPTION
## Summary
- Fix "type 'public.vector' does not exist" error in hybrid search
- The pgvector extension is accessible via search_path (set in DATABASE_URL), so explicit schema qualification is not needed
- Simplify code by removing `{pgvector_schema}` placeholder

## Changes
- Remove `pgvector_schema` variable from `db.py`
- Use unqualified `::vector` type cast instead of `::{pgvector_schema}.vector`
- Use unqualified `<=>` operator instead of `OPERATOR({pgvector_schema}.<=>)`

## Test plan
- [x] Tested unqualified `vector` and `<=>` on local - works
- [x] Tested unqualified `vector` and `<=>` on dev via kubectl exec - works
- [ ] Deploy and verify hybrid search works without errors

## Related Issues
Fixes: AUTOGPT-SERVER-76B