### PR TITLE
refactor(backend): remove page context from chat service

### DIFF
--- a/autogpt_platform/backend/backend/api/features/chat/service.py
+++ b/autogpt_platform/backend/backend/api/features/chat/service.py
@@ -237,18 +237,9 @@ async def stream_chat_completion(
         )
 
     if message:
-        # Build message content with context if provided
-        message_content = message
-        if context and context.get("url") and context.get("content"):
-            context_text = f"Page URL: {context['url']}\n\nPage Content:\n{context['content']}\n\n---\n\nUser Message: {message}"
-            message_content = context_text
-            logger.info(
-                f"Including page context: URL={context['url']}, content_length={len(context['content'])}"
-            )
-
         session.messages.append(
             ChatMessage(
-                role="user" if is_user_message else "assistant", content=message_content
+                role="user" if is_user_message else "assistant", content=message
             )
         )
         logger.info(


### PR DESCRIPTION
### Background
The chat service previously supported including page context (URL and content) in user messages. This functionality is being removed.

### Changes 🏗️

- Removed page context handling from `stream_chat_completion` in the chat service
- User messages are now passed directly without URL/content context injection
- Removed associated logging for page context

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Verify chat functionality works without page context
  - [x] Confirm no regressions in basic chat message handling