### PR TITLE
fix(platform): evaluate chat flag after auth for correct redirect

### DIFF
--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/page.tsx
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/page.tsx
@@ -2,8 +2,9 @@
 import { LoadingSpinner } from "@/components/atoms/LoadingSpinner/LoadingSpinner";
 import { useRouter } from "next/navigation";
 import { useEffect } from "react";
-import { resolveResponse, shouldShowOnboarding } from "@/app/api/helpers";
+import { resolveResponse, getOnboardingStatus } from "@/app/api/helpers";
 import { getV1OnboardingState } from "@/app/api/__generated__/endpoints/onboarding/onboarding";
+import { getHomepageRoute } from "@/lib/constants";
 
 export default function OnboardingPage() {
   const router = useRouter();
@@ -11,10 +12,13 @@ export default function OnboardingPage() {
   useEffect(() => {
     async function redirectToStep() {
       try {
-        // Check if onboarding is enabled
-        const isEnabled = await shouldShowOnboarding();
-        if (!isEnabled) {
-          router.replace("/");
+        // Check if onboarding is enabled (also gets chat flag for redirect)
+        const { shouldShowOnboarding, isChatEnabled } =
+          await getOnboardingStatus();
+        const homepageRoute = getHomepageRoute(isChatEnabled);
+
+        if (!shouldShowOnboarding) {
+          router.replace(homepageRoute);
           return;
         }
 
@@ -22,7 +26,7 @@ export default function OnboardingPage() {
 
         // Handle completed onboarding
         if (onboarding.completedSteps.includes("GET_RESULTS")) {
-          router.replace("/");
+          router.replace(homepageRoute);
           return;
         }
 

--- a/autogpt_platform/frontend/src/app/(platform)/auth/callback/route.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/auth/callback/route.ts
@@ -1,8 +1,9 @@
 import { getServerSupabase } from "@/lib/supabase/server/getServerSupabase";
+import { getHomepageRoute } from "@/lib/constants";
 import BackendAPI from "@/lib/autogpt-server-api";
 import { NextResponse } from "next/server";
 import { revalidatePath } from "next/cache";
-import { shouldShowOnboarding } from "@/app/api/helpers";
+import { getOnboardingStatus } from "@/app/api/helpers";
 
 // Handle the callback to complete the user session login
 export async function GET(request: Request) {
@@ -25,11 +26,15 @@ export async function GET(request: Request) {
         const api = new BackendAPI();
         await api.createUser();
 
-        if (await shouldShowOnboarding()) {
+        // Get onboarding status from backend (includes chat flag evaluated for this user)
+        const { shouldShowOnboarding, isChatEnabled } =
+          await getOnboardingStatus();
+        if (shouldShowOnboarding) {
           next = "/onboarding";
           revalidatePath("/onboarding", "layout");
         } else {
-          revalidatePath("/", "layout");
+          next = getHomepageRoute(isChatEnabled);
+          revalidatePath(next, "layout");
         }
       } catch (createUserError) {
         console.error("Error creating user:", createUserError);

--- a/autogpt_platform/frontend/src/app/(platform)/login/actions.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/login/actions.ts
@@ -1,10 +1,11 @@
 "use server";
 
+import { getHomepageRoute } from "@/lib/constants";
 import BackendAPI from "@/lib/autogpt-server-api";
 import { getServerSupabase } from "@/lib/supabase/server/getServerSupabase";
 import { loginFormSchema } from "@/types/auth";
 import * as Sentry from "@sentry/nextjs";
-import { shouldShowOnboarding } from "../../api/helpers";
+import { getOnboardingStatus } from "../../api/helpers";
 
 export async function login(email: string, password: string) {
   try {
@@ -36,11 +37,15 @@ export async function login(email: string, password: string) {
     const api = new BackendAPI();
     await api.createUser();
 
-    const onboarding = await shouldShowOnboarding();
+    // Get onboarding status from backend (includes chat flag evaluated for this user)
+    const { shouldShowOnboarding, isChatEnabled } = await getOnboardingStatus();
+    const next = shouldShowOnboarding
+      ? "/onboarding"
+      : getHomepageRoute(isChatEnabled);
 
     return {
       success: true,
-      onboarding,
+      next,
     };
   } catch (err) {
     Sentry.captureException(err);

--- a/autogpt_platform/frontend/src/app/(platform)/login/useLoginPage.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/login/useLoginPage.ts
@@ -97,13 +97,8 @@ export function useLoginPage() {
         throw new Error(result.error || "Login failed");
       }
 
-      if (nextUrl) {
-        router.replace(nextUrl);
-      } else if (result.onboarding) {
-        router.replace("/onboarding");
-      } else {
-        router.replace(homepageRoute);
-      }
+      // Prefer URL's next parameter, then use backend-determined route
+      router.replace(nextUrl || result.next || homepageRoute);
     } catch (error) {
       toast({
         title:

--- a/autogpt_platform/frontend/src/app/(platform)/signup/actions.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/signup/actions.ts
@@ -5,14 +5,13 @@ import { getServerSupabase } from "@/lib/supabase/server/getServerSupabase";
 import { signupFormSchema } from "@/types/auth";
 import * as Sentry from "@sentry/nextjs";
 import { isWaitlistError, logWaitlistError } from "../../api/auth/utils";
-import { shouldShowOnboarding } from "../../api/helpers";
+import { getOnboardingStatus } from "../../api/helpers";
 
 export async function signup(
   email: string,
   password: string,
   confirmPassword: string,
   agreeToTerms: boolean,
-  isChatEnabled: boolean,
 ) {
   try {
     const parsed = signupFormSchema.safeParse({
@@ -59,8 +58,9 @@ export async function signup(
       await supabase.auth.setSession(data.session);
     }
 
-    const isOnboardingEnabled = await shouldShowOnboarding();
-    const next = isOnboardingEnabled
+    // Get onboarding status from backend (includes chat flag evaluated for this user)
+    const { shouldShowOnboarding, isChatEnabled } = await getOnboardingStatus();
+    const next = shouldShowOnboarding
       ? "/onboarding"
       : getHomepageRoute(isChatEnabled);
 

--- a/autogpt_platform/frontend/src/app/(platform)/signup/useSignupPage.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/signup/useSignupPage.ts
@@ -108,7 +108,6 @@ export function useSignupPage() {
         data.password,
         data.confirmPassword,
         data.agreeToTerms,
-        isChatEnabled === true,
       );
 
       setIsLoading(false);

--- a/autogpt_platform/frontend/src/app/api/helpers.ts
+++ b/autogpt_platform/frontend/src/app/api/helpers.ts
@@ -175,9 +175,12 @@ export async function resolveResponse<
   return res.data;
 }
 
-export async function shouldShowOnboarding() {
-  const isEnabled = await resolveResponse(getV1IsOnboardingEnabled());
+export async function getOnboardingStatus() {
+  const status = await resolveResponse(getV1IsOnboardingEnabled());
   const onboarding = await resolveResponse(getV1OnboardingState());
   const isCompleted = onboarding.completedSteps.includes("CONGRATS");
-  return isEnabled && !isCompleted;
+  return {
+    shouldShowOnboarding: status.is_onboarding_enabled && !isCompleted,
+    isChatEnabled: status.is_chat_enabled,
+  };
 }

--- a/autogpt_platform/frontend/src/app/api/openapi.json
+++ b/autogpt_platform/frontend/src/app/api/openapi.json
@@ -4525,8 +4525,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "boolean",
-                  "title": "Response Getv1Is Onboarding Enabled"
+                  "$ref": "#/components/schemas/OnboardingStatusResponse"
                 }
               }
             }
@@ -8729,6 +8728,19 @@
         "required": ["name", "scopes"],
         "title": "OAuthApplicationPublicInfo",
         "description": "Public information about an OAuth application (for consent screen)"
+      },
+      "OnboardingStatusResponse": {
+        "properties": {
+          "is_onboarding_enabled": {
+            "type": "boolean",
+            "title": "Is Onboarding Enabled"
+          },
+          "is_chat_enabled": { "type": "boolean", "title": "Is Chat Enabled" }
+        },
+        "type": "object",
+        "required": ["is_onboarding_enabled", "is_chat_enabled"],
+        "title": "OnboardingStatusResponse",
+        "description": "Response for onboarding status check."
       },
       "OnboardingStep": {
         "type": "string",


### PR DESCRIPTION
## Summary

Fixes an issue where users in prod were being redirected to `/library` instead of `/copilot` after signup/login.

**Root cause:** The chat flag was evaluated on the frontend *before* signup/login when the user was anonymous. Anonymous users can't match email-based LaunchDarkly segments, so they hit the default rule (Disabled in prod) → `chat=false` → `/library`.

**Fix:** The backend now returns both `is_onboarding_enabled` and `is_chat_enabled` from `/onboarding/enabled`, evaluated with the authenticated user's context after signup/login completes.

## Changes

- **Backend**: `/onboarding/enabled` now returns `OnboardingStatusResponse` with both flags
- **Frontend**: Signup, login, and OAuth callback routes now use the backend's `isChatEnabled` value for redirects
- Removed unused `isChatEnabled` parameter from signup action

## Test plan

- [x] New user signup → lands on `/copilot` (if in chat segment)
- [x] Existing user login → lands on `/copilot` (if in chat segment)
- [x] OAuth signup/login → lands on `/copilot` (if in chat segment)
- [x] Users not in chat segment → still land on `/library`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the `/onboarding/enabled` API contract from a boolean to an object and updates multiple auth/onboarding redirect flows; mismatched clients or cached OpenAPI types could cause redirect or runtime errors.
> 
> **Overview**
> **Redirect logic now uses backend-evaluated flags after authentication.** The `/onboarding/enabled` endpoint changes from returning a boolean to returning an `OnboardingStatusResponse` with both `is_onboarding_enabled` and `is_chat_enabled`, and skips legacy onboarding when chat is enabled.
> 
> Frontend auth and onboarding entrypoints (signup, login, OAuth callback, and the onboarding page) switch from `shouldShowOnboarding()` to `getOnboardingStatus()` and compute the correct homepage via `getHomepageRoute(isChatEnabled)`; the signup action also drops the unused `isChatEnabled` parameter, and the OpenAPI schema is updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 79cfd1778d2849ef8d1ae0ecc339afc1d79f36f3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->