### PR TITLE
fix(frontend): remove double flag check on homepage redirect

### DIFF
--- a/autogpt_platform/frontend/src/app/page.tsx
+++ b/autogpt_platform/frontend/src/app/page.tsx
@@ -1,14 +1,20 @@
 "use client";
 
-import { FeatureFlagRedirect } from "@/services/feature-flags/FeatureFlagRedirect";
-import { Flag } from "@/services/feature-flags/use-get-flag";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
 
+/**
+ * Root page always redirects to /copilot.
+ * The /copilot page handles the feature flag check and redirects to /library if needed.
+ * This single-check approach avoids race conditions with LaunchDarkly initialization.
+ * See: SECRT-1845
+ */
 export default function Page() {
-  return (
-    <FeatureFlagRedirect
-      flag={Flag.CHAT}
-      whenEnabled="/copilot"
-      whenDisabled="/library"
-    />
-  );
+  const router = useRouter();
+
+  useEffect(() => {
+    router.replace("/copilot");
+  }, [router]);
+
+  return null;
 }


### PR DESCRIPTION
## Changes 🏗️

Fixes the hard refresh redirect bug (SECRT-1845) by removing the double feature flag check.

### Before (buggy)
```
/                    → checks flag → /copilot or /library
/copilot (layout)    → checks flag → /library if OFF
```

On hard refresh, two sequential LD checks created a race condition window.

### After (fixed)
```
/                    → always redirects to /copilot
/copilot (layout)    → single flag check via FeatureFlagPage
```

Single check point = no double-check race condition.

## Root Cause

As identified by @0ubbe: the root page and copilot layout were both checking the feature flag. On hard refresh with network latency, the second check could fire before LaunchDarkly fully initialized, causing users to be bounced to `/library`.

## Test Plan

- [ ] Hard refresh on `/` → should go to `/copilot` (flag ON)
- [ ] Hard refresh on `/copilot` → should stay on `/copilot` (flag ON)  
- [ ] With flag OFF → should redirect to `/library`
- [ ] Normal navigation still works

Fixes: SECRT-1845

cc @0ubbe