### PR TITLE
hotfix(frontend): use server redirect

### DIFF
--- a/autogpt_platform/frontend/src/app/page.tsx
+++ b/autogpt_platform/frontend/src/app/page.tsx
@@ -1,7 +1,4 @@
-"use client";
-
-import { useRouter } from "next/navigation";
-import { useEffect } from "react";
+import { redirect } from "next/navigation";
 
 /**
  * Root page always redirects to /copilot.
@@ -10,11 +7,5 @@ import { useEffect } from "react";
  * See: SECRT-1845
  */
 export default function Page() {
-  const router = useRouter();
-
-  useEffect(() => {
-    router.replace("/copilot");
-  }, [router]);
-
-  return null;
+  redirect("/copilot");
 }


### PR DESCRIPTION
### Changes 🏗️

The page used a client-side redirect (`useEffect` + `router.replace`) which only works after JavaScript loads and hydrates. On deployed sites, if there's any delay or failure in JS execution, users see an empty/black page because the component returns null.

**Fix:** Converted to a server-side redirect using redirect() from next/navigation. This is a server component now, so:

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Tested locally but will see it fully working once deployed
