### PR TITLE
hotfix(frontend): LD remount

### DIFF
--- a/autogpt_platform/frontend/src/services/feature-flags/feature-flag-provider.tsx
+++ b/autogpt_platform/frontend/src/services/feature-flags/feature-flag-provider.tsx
@@ -40,8 +40,6 @@ export function LaunchDarklyProvider({ children }: { children: ReactNode }) {
 
   return (
     <LDProvider
-      // Add this key prop. It will be 'anonymous' when logged out,
-      key={context.key}
       clientSideID={clientId ?? ""}
       context={context}
       timeout={LAUNCHDARKLY_INIT_TIMEOUT_MS}


### PR DESCRIPTION
## Changes 🏗️

Removes the `key` prop from `LDProvider` that was causing full remounts when user context changed.

### The Problem

The `key={context.key}` prop was forcing React to unmount and remount the entire LDProvider when switching from anonymous → logged in user:

```
1. Page loads, user loading → key="anonymous" → LD mounts → flags available ✅
2. User finishes loading → key="user-123" → React sees key changed
3. LDProvider UNMOUNTS → flags become undefined ❌
4. New LDProvider MOUNTS → initializes again → flags available ✅
```

This caused the flag values to cycle: `undefined → value → undefined → value`

### The Fix

Remove the `key` prop. The LDProvider handles context changes internally via the `context` prop, which triggers `identify()` without remounting the provider.

## Checklist 📋

- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [ ] Flag values don't flicker on page load
  - [ ] Flag values update correctly when logging in/out
  - [ ] No redirect race conditions

Related: SECRT-1845