### PR TITLE
fix(autopilot): Include input schema in agent discovery and validate inputs

### DIFF
--- a/autogpt_platform/backend/backend/api/features/chat/tools/models.py
+++ b/autogpt_platform/backend/backend/api/features/chat/tools/models.py
@@ -62,6 +62,10 @@ class AgentInfo(BaseModel):
     has_external_trigger: bool | None = None
     new_output: bool | None = None
     graph_id: str | None = None
+    inputs: dict[str, Any] | None = Field(
+        default=None,
+        description="Input schema for the agent, including field names, types, and defaults",
+    )
 
 
 class AgentsFoundResponse(ToolResponseBase):

--- a/autogpt_platform/backend/backend/api/features/chat/tools/run_agent.py
+++ b/autogpt_platform/backend/backend/api/features/chat/tools/run_agent.py
@@ -310,6 +310,26 @@ class RunAgentTool(BaseTool):
                     graph_version=graph.version,
                 )
 
+            # Check for unknown input fields - reject to prevent silent failures
+            valid_fields = set(input_properties.keys())
+            unknown_fields = provided_inputs - valid_fields
+            if unknown_fields:
+                credentials = extract_credentials_from_schema(
+                    graph.credentials_input_schema
+                )
+                return AgentDetailsResponse(
+                    message=(
+                        f"Unknown input field(s) provided: {', '.join(sorted(unknown_fields))}. "
+                        f"Agent was not executed. "
+                        f"Valid input fields are: {', '.join(sorted(valid_fields)) or 'none'}."
+                    ),
+                    session_id=session_id,
+                    agent=self._build_agent_details(graph, credentials),
+                    user_authenticated=True,
+                    graph_id=graph.id,
+                    graph_version=graph.version,
+                )
+
             # Step 4: Execute or Schedule
             if is_schedule:
                 return await self._schedule_agent(


### PR DESCRIPTION
## Summary
Fixes OPEN-2980: AutoPilot now includes input schemas when discovering agents and validates that user-provided inputs match the schema.

## Problem
When users asked AutoPilot to run agents, it would silently ignore unknown input fields and fall back to defaults. This caused confusion when agents didn't behave as expected.

## Solution

### 1. Include input schema in agent discovery
- Added `inputs` field to `AgentInfo` model
- Fetch input schemas for both marketplace and library agents during search
- Graceful fallback to `None` on fetch errors

### 2. Validate inputs before running
- Check that all provided input fields exist in the agent's schema
- Return clear error listing valid fields if unknown fields are provided
- Prevents silent fallback to default values

## Changes
- `autogpt_platform/backend/backend/executor/autopilot/models.py`
- `autogpt_platform/backend/backend/executor/autopilot/agent_search.py`
- `autogpt_platform/backend/backend/executor/autopilot/run_agent.py`

## Testing
Manual testing recommended with agents that have defined input schemas.