### PR TITLE
fix(scheduler): connect Prisma on scheduler event loop

### DIFF
--- a/autogpt_platform/backend/backend/executor/scheduler.py
+++ b/autogpt_platform/backend/backend/executor/scheduler.py
@@ -644,7 +644,9 @@ class Scheduler(AppService):
                 logger.info("⏳ Disconnecting Prisma...")
                 run_async(db.disconnect())
         except Exception:
-            logger.warning("⚠️ Failed to disconnect Prisma during cleanup", exc_info=True)
+            logger.warning(
+                "⚠️ Failed to disconnect Prisma during cleanup", exc_info=True
+            )
 
         if _event_loop:
             logger.info("⏳ Closing event loop...")


### PR DESCRIPTION
## Summary

Fixes a bug where the Scheduler service never connected its Prisma client, causing `ClientNotConnectedError` on **every scheduled graph execution** — ~696K Sentry errors since December 5th (AUTOGPT-SERVER-6Z4).

## Root Cause

The Scheduler class never calls `db.connect()`. Unlike `DatabaseManager` (which overrides `lifespan` to connect Prisma) and `rest_api` (which connects in `lifespan_context`), the Scheduler has no Prisma initialization anywhere.

**What works:** `add_graph_execution()` in `utils.py` has a proper `if prisma.is_connected()` fallback that routes through the database manager RPC client — so graph executions themselves succeed and get published to RabbitMQ.

**What breaks:** After `add_graph_execution()` succeeds, `_execute_graph()` calls:
- `increment_onboarding_runs()` → `get_user_by_id()` → `prisma.user.find_unique()` (direct Prisma, no fallback)
- `UserOnboarding.prisma().upsert()` / `.update()` (direct Prisma, no fallback)

These hit the unconnected Prisma client and throw `ClientNotConnectedError`, caught by the generic `except Exception` handler that logs to Sentry.

Additionally, system jobs like `cleanup_expired_oauth_tokens()` use `PrismaOAuthAuthorizationCode.prisma().delete_many()` directly — also failing silently.

## Fix

Connect Prisma on the scheduler's dedicated event loop (`_event_loop`) in `run_service()`, and disconnect in `cleanup()`.

**Why `run_service()` and not `lifespan()`?** The scheduler has two event loops:
1. Uvicorn's loop (FastAPI health checks / RPC)
2. `_event_loop` (dedicated loop for scheduler jobs, runs in a separate thread)

Scheduler jobs dispatch via `run_async()` on `_event_loop`. Since httpx's AsyncClient is event-loop-bound, connecting Prisma in the FastAPI `lifespan` (Uvicorn's loop) would not help queries running on `_event_loop`. The connection must happen on `_event_loop` via `run_async(db.connect())`.

## Impact

- **Eliminates ~696K Sentry errors** (and counting — fires every minute for every scheduled graph)
- **Fixes onboarding run counters** — users' scheduled execution runs were never being counted
- **Fixes OAuth token cleanup** — expired tokens were never being cleaned up by the scheduler
- **Fixes onboarding milestone tracking** — milestones from scheduled runs were never triggered

## Testing

1. Deploy to a staging environment with scheduled graphs
2. Verify no more `ClientNotConnectedError` in scheduler logs
3. Verify `increment_onboarding_runs` succeeds (check `UserOnboarding.agentRuns` counter increments)
4. Verify `cleanup_expired_oauth_tokens` runs without errors

## Changes

- `scheduler.py`: Add `db.connect()` in `run_service()` after event loop init, add `db.disconnect()` in `cleanup()` before event loop shutdown