### PR TITLE
fix(backend): Handle StreamHeartbeat in CoPilot stream handler

### DIFF
--- a/autogpt_platform/backend/backend/api/features/chat/service.py
+++ b/autogpt_platform/backend/backend/api/features/chat/service.py
@@ -607,6 +607,9 @@ async def stream_chat_completion(
                         total_tokens=chunk.totalTokens,
                     )
                 )
+            elif isinstance(chunk, StreamHeartbeat):
+                # Pass through heartbeat to keep SSE connection alive
+                yield chunk
             else:
                 logger.error(f"Unknown chunk type: {type(chunk)}", exc_info=True)
 


### PR DESCRIPTION
### Changes 🏗️

Fixes **AUTOGPT-SERVER-7JA** (123 events since Jan 27, 2026).

#### Problem

`StreamHeartbeat` was added to keep SSE connections alive during long-running tool executions (yielded every 15s while waiting). However, the main `stream_chat_completion` handler's `elif` chain didn't have a case for it:

```
StreamTextStart → ✅ handled
StreamTextDelta → ✅ handled
StreamTextEnd → ✅ handled
StreamToolInputStart → ✅ handled
StreamToolInputAvailable → ✅ handled
StreamToolOutputAvailable → ✅ handled
StreamFinish → ✅ handled
StreamError → ✅ handled
StreamUsage → ✅ handled
StreamHeartbeat → ❌ fell through to 'Unknown chunk type' error
```

This meant every heartbeat during tool execution generated a Sentry error instead of keeping the connection alive.

#### Fix

Add `StreamHeartbeat` to the `elif` chain and yield it through. The route handler already calls `to_sse()` on all yielded chunks, and `StreamHeartbeat.to_sse()` correctly returns `: heartbeat\n\n` (SSE comment format, ignored by clients but keeps proxies/load balancers happy).

**1 file changed, 3 insertions.**