### PR TITLE
refactor(backend): extract context window management and fix LLM continuation

### DIFF
--- a/autogpt_platform/backend/backend/api/features/chat/service.py
+++ b/autogpt_platform/backend/backend/api/features/chat/service.py
@@ -922,7 +922,9 @@ async def _manage_context_window(
             )
         except Exception as e:
             logger.warning(f"Summarization failed, falling back to truncation: {e}")
-            messages = [system_msg] + recent_messages if has_system_prompt else recent_messages
+            messages = (
+                [system_msg] + recent_messages if has_system_prompt else recent_messages
+            )
     else:
         logger.warning(
             f"Token count {token_count} exceeds threshold but no old messages to summarize"
@@ -934,7 +936,9 @@ async def _manage_context_window(
 
     # Progressive truncation if still over limit
     if new_token_count > TOKEN_THRESHOLD:
-        logger.warning(f"Still over limit: {new_token_count} tokens. Reducing messages.")
+        logger.warning(
+            f"Still over limit: {new_token_count} tokens. Reducing messages."
+        )
         base_msgs = (
             recent_messages
             if old_messages_dict
@@ -959,7 +963,9 @@ async def _manage_context_window(
                 continue
             else:
                 reduced = _ensure_tool_pairs_intact(
-                    base_msgs[-keep_count:], base_msgs, max(0, len(base_msgs) - keep_count)
+                    base_msgs[-keep_count:],
+                    base_msgs,
+                    max(0, len(base_msgs) - keep_count),
                 )
                 messages = build_messages(reduced)
 
@@ -967,10 +973,14 @@ async def _manage_context_window(
                 _messages_to_dicts(messages), model=token_count_model
             )
             if new_token_count <= TOKEN_THRESHOLD:
-                logger.info(f"Reduced to {keep_count} messages, {new_token_count} tokens")
+                logger.info(
+                    f"Reduced to {keep_count} messages, {new_token_count} tokens"
+                )
                 break
         else:
-            logger.error(f"Cannot reduce below threshold. Final: {new_token_count} tokens")
+            logger.error(
+                f"Cannot reduce below threshold. Final: {new_token_count} tokens"
+            )
             if has_system_prompt and len(messages) > 1:
                 messages = messages[1:]
                 logger.critical("Dropped system prompt as last resort")
@@ -979,7 +989,10 @@ async def _manage_context_window(
                 )
             # No system prompt to drop - return error so callers don't proceed with oversized context
             return ContextWindowResult(
-                messages, new_token_count, True, "Unable to reduce context below token limit"
+                messages,
+                new_token_count,
+                True,
+                "Unable to reduce context below token limit",
             )
 
     return ContextWindowResult(messages, new_token_count, True)


### PR DESCRIPTION
## Summary

Fixes CoPilot becoming unresponsive after long-running tools complete, and refactors context window management into a reusable function.

## Problem

After `create_agent` completes, `_generate_llm_continuation()` was sending ALL messages to OpenRouter without any context compaction. When conversations exceeded ~50 messages, OpenRouter rejected requests with `provider_name: 'unknown'` (no provider would accept).

**Evidence:** Langfuse session [44fbb803-092e-4ebd-b288-852959f4faf5](https://cloud.langfuse.com/project/cmk5qhf210003ad079sd8utjt/sessions/44fbb803-092e-4ebd-b288-852959f4faf5) showed:
- Successful calls: 32-50 messages, known providers
- Failed calls: 52+ messages, `provider: unknown`, `completion: null`

## Changes

### Refactor: Extract reusable `_manage_context_window()`
- Counts tokens and checks against 120k threshold
- Summarizes old messages while keeping recent 15
- Ensures tool_call/tool_response pairs stay intact
- Progressive truncation if still over limit
- Returns `ContextWindowResult` dataclass with messages, token count, compaction status, and errors
- Helper `_messages_to_dicts()` reduces code duplication

### Fix: Update `_generate_llm_continuation()`
- Now calls `_manage_context_window()` before making LLM calls
- Adds retry logic with exponential backoff (matching `_stream_chat_chunks` behavior)

### Cleanup: Update `_stream_chat_chunks()`
- Replaced inline context management with call to `_manage_context_window()`
- Eliminates code duplication between the two functions

## Testing

- Syntax check: ✅
- Ruff lint: ✅
- Import verification: ✅

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have checked that my changes do not break existing functionality