### PR TITLE
fix(backend): Add retry and error handling to block initialization

### DIFF
--- a/autogpt_platform/backend/backend/data/block.py
+++ b/autogpt_platform/backend/backend/data/block.py
@@ -926,7 +926,7 @@ async def initialize_blocks() -> None:
             failed_blocks.append(block.name)
 
     if failed_blocks:
-        logger.warning(
+        logger.error(
             f"Failed to sync {len(failed_blocks)} block(s) to database: "
             f"{', '.join(failed_blocks)}. These blocks are still available in memory."
         )


### PR DESCRIPTION
## Summary
Adds retry logic and graceful error handling to `initialize_blocks()` to prevent transient DB errors from crashing server startup.

## Problem
When a transient database error occurs during block initialization (e.g., Prisma P1017 "Server has closed the connection"), the entire server fails to start. This is overly aggressive since:
- Blocks are already registered in memory
- The DB sync is primarily for tracking/schema storage
- One flaky connection shouldn't prevent the server from starting

**Triggered by:** [Sentry AUTOGPT-SERVER-7PW](https://significant-gravitas.sentry.io/issues/7238733543/)

## Changes
- Add `@func_retry` decorator to `sync_block_to_db()` for automatic retries with exponential backoff
- Wrap block sync in try/except to continue on failure instead of crashing
- Log warning with stack trace for individual block failures
- Log error summary of all failed blocks at the end
- Blocks remain available in memory even if DB sync fails

## Testing
- Existing block initialization behavior unchanged on success
- On transient DB errors: retries up to 5 times, then logs error and continues