### PR TITLE
fix(frontend): Handle object values in FileInput component

### DIFF
--- a/autogpt_platform/frontend/src/components/atoms/FileInput/FileInput.tsx
+++ b/autogpt_platform/frontend/src/components/atoms/FileInput/FileInput.tsx
@@ -104,7 +104,28 @@ export function FileInput(props: Props) {
     return false;
   }
 
-  const getFileLabelFromValue = (val: string) => {
+  const getFileLabelFromValue = (val: unknown): string => {
+    // Handle object format from external API: { name, type, size, data }
+    if (val && typeof val === "object") {
+      const obj = val as Record<string, unknown>;
+      if (typeof obj.name === "string") {
+        return getFileLabel(obj.name, (obj.type as string) || "");
+      }
+      if (typeof obj.type === "string") {
+        const mimeParts = obj.type.split("/");
+        if (mimeParts.length > 1) {
+          return `${mimeParts[1].toUpperCase()} file`;
+        }
+        return `${obj.type} file`;
+      }
+      return "File";
+    }
+
+    // Handle string values (data URIs or file paths)
+    if (typeof val !== "string") {
+      return "File";
+    }
+
     if (val.startsWith("data:")) {
       const matches = val.match(/^data:([^;]+);/);
       if (matches?.[1]) {


### PR DESCRIPTION
### Changes 🏗️

Fixes #11800

The `FileInput` component crashed with `TypeError: e.startsWith is not a function` when the `value` prop was an object (from external API calls) instead of a string.

#### Problem

When executing a graph via the external API with file input as an object:
```json
{
  "node_input": {
    "input_image": {
      "name": "image.jpeg",
      "type": "image/jpeg",
      "size": 131147,
      "data": "/9j/4QAW..."
    }
  }
}
```

Navigating to `/library/{graph-id}` to view the run would crash the page because `getFileLabelFromValue()` called `.startsWith()` on the object.

#### Fix

Updated `getFileLabelFromValue()` to:
1. Check if value is an object and extract `name` or `type` properties
2. Add type guard before calling string methods
3. Graceful fallback to "File" for edge cases (null, undefined, empty object)

**1 file changed, 22 insertions, 1 deletion.**