### PR TITLE
fix(frontend): Prevent node drag when selecting text in object editor key input

### DIFF
--- a/autogpt_platform/frontend/src/components/renderers/InputRenderer/base/object/WrapIfAdditionalTemplate.tsx
+++ b/autogpt_platform/frontend/src/components/renderers/InputRenderer/base/object/WrapIfAdditionalTemplate.tsx
@@ -80,7 +80,7 @@ export default function WrapIfAdditionalTemplate(
           uiSchema={uiSchema}
         />
         {!isHandleConnected && (
-          <div className="flex flex-1 items-center gap-2">
+          <div className="nodrag flex flex-1 items-center gap-2">
             <Input
               label={""}
               hideLabel={true}


### PR DESCRIPTION
## Summary
- Add `nodrag` class to the key name input wrapper in `WrapIfAdditionalTemplate.tsx`
- This prevents the node from being dragged when users try to select text in the key name input field
- Follows the same pattern used by other input components like `TextWidget.tsx`

## Test plan
- [x] Open the new builder
- [x] Add a custom node with an Object input field
- [x] Try to select text in the key name input by clicking and dragging
- [x] Verify that text selection works without moving the block