### PR TITLE
fix(platform): Improve Linear Search Block

### DIFF
--- a/autogpt_platform/backend/backend/blocks/linear/models.py
+++ b/autogpt_platform/backend/backend/blocks/linear/models.py
@@ -36,12 +36,21 @@ class Project(BaseModel):
     content: str | None = None
 
 
+class State(BaseModel):
+    id: str
+    name: str
+    type: str | None = (
+        None  # Workflow state type (e.g., "triage", "backlog", "started", "completed", "canceled")
+    )
+
+
 class Issue(BaseModel):
     id: str
     identifier: str
     title: str
     description: str | None
     priority: int
+    state: State | None = None
     project: Project | None = None
     createdAt: str | None = None
     comments: list[Comment] | None = None


### PR DESCRIPTION
## Summary

Implements [SECRT-1880](https://linear.app/autogpt/issue/SECRT-1880) - Improve Linear Search Block

## Changes

### Models (`models.py`)
- Added `State` model with `id`, `name`, and `type` fields for workflow state information
- Added `state: State | None` field to `Issue` model

### API Client (`_api.py`)
- Updated `try_search_issues()` to:
  - Add `max_results` parameter (default 10, was ~50) to reduce token usage
  - Add `team_id` parameter for team filtering
  - Return `createdAt`, `state`, `project`, and `assignee` fields in results
- Fixed `try_get_team_by_name()` to return descriptive error message when team not found instead of crashing with `IndexError`

### Block (`issues.py`)
- Added `max_results` input parameter (1-100, default 10)
- Added `team_name` input parameter for optional team filtering
- Added `error` output field for graceful error handling
- Added categories (`PRODUCTIVITY`, `ISSUE_TRACKING`)
- Updated test fixtures to include new fields

## Breaking Changes

| Change | Before | After | Mitigation |
|--------|--------|-------|------------|
| Default result count | ~50 | 10 | Users can set `max_results` up to 100 if needed |

## Non-Breaking Changes

- `state` field added to `Issue` (optional, defaults to `None`)
- `max_results` param added (has default value)
- `team_name` param added (optional, defaults to `None`)
- `error` output added (follows established pattern from GitHub blocks)

## Testing

- [x] Format/lint checks pass
- [x] Unit test fixtures updated

## Linear

[SECRT-1880](https://linear.app/autogpt/issue/SECRT-1880)