### PR TITLE
fix(test): fix timing bug in test_block_credit_reset

### DIFF
--- a/autogpt_platform/backend/backend/data/credit_test.py
+++ b/autogpt_platform/backend/backend/data/credit_test.py
@@ -134,6 +134,16 @@ async def test_block_credit_reset(server: SpinTestServer):
         month1 = datetime.now(timezone.utc).replace(month=1, day=1)
         user_credit.time_now = lambda: month1
 
+        # IMPORTANT: Set updatedAt to December of previous year to ensure it's
+        # in a different month than month1 (January). This fixes a timing bug
+        # where if the test runs in early February, 35 days ago would be January,
+        # matching the mocked month1 and preventing the refill from triggering.
+        dec_previous_year = month1.replace(year=month1.year - 1, month=12, day=15)
+        await UserBalance.prisma().update(
+            where={"userId": DEFAULT_USER_ID},
+            data={"updatedAt": dec_previous_year},
+        )
+
         # First call in month 1 should trigger refill
         balance = await user_credit.get_credits(DEFAULT_USER_ID)
         assert balance == REFILL_VALUE  # Should get 1000 credits


### PR DESCRIPTION
## Summary
Fixes the flaky `test_block_credit_reset` test that was failing on multiple PRs with `assert 0 == 1000`.

## Root Cause
The test calls `disable_test_user_transactions()` which sets `updatedAt` to 35 days ago from the **actual current time**. It then mocks `time_now` to January 1st.

**The bug**: If the test runs in early February, 35 days ago is January — the **same month** as the mocked `time_now`. The credit refill logic only triggers when the balance snapshot is from a *different* month, so no refill happens and the balance stays at 0.

## Fix
After calling `disable_test_user_transactions()`, explicitly set `updatedAt` to December of the previous year. This ensures it's always in a different month than the mocked `month1` (January), regardless of when the test runs.

## Testing
CI will verify the fix.