### PR TITLE
fix: add virus scanning to WorkspaceManager.write_file()

### DIFF
--- a/autogpt_platform/backend/backend/util/workspace.py
+++ b/autogpt_platform/backend/backend/util/workspace.py
@@ -22,6 +22,7 @@ from backend.data.workspace import (
     soft_delete_workspace_file,
 )
 from backend.util.settings import Config
+from backend.util.virus_scanner import scan_content_safe
 from backend.util.workspace_storage import compute_file_checksum, get_workspace_storage
 
 logger = logging.getLogger(__name__)
@@ -186,6 +187,9 @@ class WorkspaceManager:
                 f"File too large: {len(content)} bytes exceeds "
                 f"{Config().max_file_size_mb}MB limit"
             )
+
+        # Virus scan content before persisting (defense in depth)
+        await scan_content_safe(content, filename=filename)
 
         # Determine path with session scoping
         if path is None:


### PR DESCRIPTION
## Summary

Adds virus scanning at the `WorkspaceManager.write_file()` layer for defense in depth.

## Problem

Previously, virus scanning was only performed at entry points:
- `store_media_file()` in `backend/util/file.py`
- `WriteWorkspaceFileTool` in `backend/api/features/chat/tools/workspace_files.py`

This created a trust boundary where any new caller of `WorkspaceManager.write_file()` would need to remember to scan first.

## Solution

Add `scan_content_safe()` call directly in `WorkspaceManager.write_file()` before persisting to storage. This ensures all content is scanned regardless of the caller.

## Changes

- Added import for `scan_content_safe` from `backend.util.virus_scanner`
- Added virus scan call after file size validation, before storage

## Testing

Existing tests should pass. The scan is a no-op in test environments where ClamAV isn't running.

Closes https://linear.app/autogpt/issue/OPEN-2993

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new required async scan step in the workspace write path, which can add latency or cause new failures if the scanner/ClamAV is misconfigured or unavailable.
> 
> **Overview**
> Adds a **defense-in-depth** virus scan to `WorkspaceManager.write_file()` by invoking `scan_content_safe()` after file-size validation and before any storage/database persistence.
> 
> This centralizes scanning so any caller writing workspace files gets the same malware check without relying on upstream entry points to remember to scan.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f5ac68b92319b7fcc4c49625d1acd845bf87b13. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->