### PR TITLE
fix(frontend): Revert ThinkingMessage progress bar delay to original values

### DIFF
--- a/autogpt_platform/frontend/src/components/contextual/Chat/components/ThinkingMessage/ThinkingMessage.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/Chat/components/ThinkingMessage/ThinkingMessage.tsx
@@ -19,13 +19,13 @@ export function ThinkingMessage({ className }: ThinkingMessageProps) {
     if (timerRef.current === null) {
       timerRef.current = setTimeout(() => {
         setShowSlowLoader(true);
-      }, 3000);
+      }, 8000);
     }
 
     if (coffeeTimerRef.current === null) {
       coffeeTimerRef.current = setTimeout(() => {
         setShowCoffeeMessage(true);
-      }, 8000);
+      }, 10000);
     }
 
     return () => {


### PR DESCRIPTION
## Summary
- Revert the progress bar display time threshold from 3 seconds back to the original values
- The delay was reduced from 8s/10s to 3s/8s in PR #11974, which causes the progress bar to appear too frequently on various tool calls, making the UX feel disingenuous ("obviously fake loading")

## Context
This is a temporary fix until SECRT-1907 is implemented, which will scope the progress bar to only show on `create_agent`/`edit_agent` tool calls.

## Changes
Single file change in `ThinkingMessage.tsx`:
- `showSlowLoader` timeout: 3000ms → 8000ms (reverted)
- `showCoffeeMessage` timeout: 8000ms → 10000ms (reverted)

## Related
- SECRT-1907 - Progress bar should only show on agent create/edit
- SECRT-1895 - Vercel AI SDK migration
- PR #11974 - Progress indicator during agent generation

## Test plan
- [ ] Open the CoPilot chat and send a message that triggers a short tool call
- [ ] Verify the progress bar does NOT appear for quick operations
- [ ] Send a message that takes >10s (e.g., agent creation)
- [ ] Verify "Taking a bit more time..." appears after ~8 seconds
- [ ] Verify progress bar with "grab a coffee" message appears after ~10 seconds