### PR TITLE
fix(ci): allow dependabot[bot] in Claude dependabot review workflow

### DIFF
--- a/.github/workflows/claude-dependabot.yml
+++ b/.github/workflows/claude-dependabot.yml
@@ -309,6 +309,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: "dependabot[bot]"
           claude_args: |
             --allowedTools "Bash(npm:*),Bash(pnpm:*),Bash(poetry:*),Bash(git:*),Edit,Replace,NotebookEditCell,mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*), Bash(gh pr diff:*), Bash(gh pr view:*)"
           prompt: |


### PR DESCRIPTION
## Summary
The `claude-dependabot.yml` workflow uses `anthropics/claude-code-action@v1` to automatically review Dependabot PRs. However, the action rejects bot actors by default with:

```
Workflow initiated by non-human actor: dependabot (type: Bot). 
Add bot to allowed_bots list or use '*' to allow all bots.
```

## Fix
Add `allowed_bots: "dependabot[bot]"` to the Claude action configuration.

## Testing
This will unblock the `dependabot-review` check on:
- #11663
- #11665  
- #11213
- All future Dependabot PRs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line CI workflow config change limited to Dependabot PRs; no production code or data handling paths are affected.
> 
> **Overview**
> Updates the `claude-dependabot.yml` GitHub Actions workflow to explicitly allow `dependabot[bot]` to run `anthropics/claude-code-action@v1` via the new `allowed_bots` configuration.
> 
> This unblocks Claude’s automated review step on Dependabot-authored PRs that were previously rejected due to a non-human actor restriction.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b5f7fc446c043a15427732a83e8468f55f32b2ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->