### PR TITLE
fix(builder): Show X button on edge line hover, not just button hover

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/edges/CustomEdge.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/edges/CustomEdge.tsx
@@ -63,7 +63,6 @@ const CustomEdge = ({
 
   return (
     <>
-      {/* Invisible interaction path - wider hit area for hover detection */}
       <path
         d={edgePath}
         fill="none"
@@ -76,6 +75,7 @@ const CustomEdge = ({
       />
       <BaseEdge
         path={edgePath}
+        interactionWidth={0}
         markerEnd={markerEnd}
         className={cn(
           isStatic && "!stroke-[1.5px] [stroke-dasharray:6]",


### PR DESCRIPTION
## Summary

Fixes the issue where the X button for removing connections between nodes only appears when hovering directly over the button itself. Users now see the button when hovering anywhere on the connection line.

## Changes

- Added an invisible interaction path along the edge with a 20px stroke width
- The path triggers the same hover state as the button
- This makes the X button visible when hovering the line OR the button
- Preserves existing behavior for broken edges (always visible)

## Testing

1. Hover over an edge line (not the button) → X button should appear
2. Move from line to button → button should stay visible  
3. Move away from both → button should fade out
4. Broken edges should still show X button always

## Linear

Fixes SECRT-1943

## Screenshots

This is a UX improvement - no visual changes except the button now appears on line hover.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details><summary><h3>Greptile Summary</h3></summary>

This PR improves the UX for edge deletion by adding an invisible interaction path with a 20px stroke width that makes the delete button (X) appear when hovering anywhere along the connection line, not just when hovering directly over the button.

**Key Changes:**
- Added invisible `<path>` element before `BaseEdge` with `stroke="transparent"` and `strokeWidth={20}`
- Path has `onMouseEnter` and `onMouseLeave` handlers that trigger the same `setIsHovered` state used by the delete button
- Delete button visibility logic remains unchanged: fades in when `isHovered` is true (or always visible for broken edges)
- Works uniformly for all edge types (regular, static, and broken edges)

**How It Works:**
The invisible path creates a wider hit area (20px) around the edge curve, making it much easier for users to trigger the hover state. When the mouse enters this area, `isHovered` becomes true, which causes the delete button to fade in (via the existing opacity transition logic). The button itself also has hover handlers, so moving from the line to the button maintains the visible state smoothly.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge with minimal risk - it's a small, focused UX improvement with no logic changes
- The implementation is clean and focused: adds only 9 lines of code, uses existing state management (`isHovered`), and doesn't modify any deletion logic. The invisible path is a standard SVG/React pattern for expanding hit areas, and the approach is consistent with how the delete button already handles hover events. No breaking changes, no side effects.
- No files require special attention
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->