### PR TITLE
fix(frontend): remove fixed min-height from CoPilot message container

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatMessagesContainer/ChatMessagesContainer.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatMessagesContainer/ChatMessagesContainer.tsx
@@ -159,7 +159,7 @@ export const ChatMessagesContainer = ({
 
   return (
     <Conversation className="min-h-0 flex-1">
-      <ConversationContent className="flex min-h-screen flex-1 flex-col gap-6 px-3 py-6">
+      <ConversationContent className="flex flex-1 flex-col gap-6 px-3 py-6">
         {isLoading && messages.length === 0 && (
           <div className="flex min-h-full flex-1 items-center justify-center">
             <LoadingSpinner className="text-neutral-600" />


### PR DESCRIPTION
## Summary

Removes the `min-h-screen` class from `ConversationContent` in ChatMessagesContainer, which was causing fixed height layout issues in the CoPilot chat interface.

## Changes

- Removed `min-h-screen` from ConversationContent className

## Linear

Fixes [SECRT-1944](https://linear.app/autogpt/issue/SECRT-1944)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details><summary><h3>Greptile Summary</h3></summary>

Removes the `min-h-screen` (100vh) class from `ConversationContent` that was causing the chat message container to enforce a minimum viewport height. The parent container already handles height constraints with `h-full min-h-0` and flexbox layout, so the fixed minimum height was creating layout conflicts. The component now properly grows within its flex container using `flex-1`.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge with minimal risk
- The change removes a single problematic CSS class that was causing fixed height layout issues. The parent container already handles height constraints properly with flexbox, and removing min-h-screen allows the component to size correctly within its flex parent. This is a targeted, low-risk bug fix with no logic changes.
- No files require special attention
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->