### PR TITLE
feat(platform): wire CoPilot stop button to backend task cancellation

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/copilot/useCopilotPage.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/useCopilotPage.ts
@@ -47,7 +47,14 @@ export function useCopilotPage() {
     [sessionId],
   );
 
-  const { messages, sendMessage, stop, status, error, setMessages } = useChat({
+  const {
+    messages,
+    sendMessage,
+    stop: sdkStop,
+    status,
+    error,
+    setMessages,
+  } = useChat({
     id: sessionId ?? undefined,
     transport: transport ?? undefined,
   });
@@ -71,6 +78,17 @@ export function useCopilotPage() {
     setPendingMessage(null);
     sendMessage({ text: msg });
   }, [sessionId, pendingMessage, sendMessage]);
+
+  function handleStop() {
+    sdkStop();
+    if (sessionId) {
+      fetch(`/api/chat/sessions/${sessionId}/stop`, { method: "POST" }).catch(
+        () => {
+          // Best-effort: backend task will eventually complete on its own
+        },
+      );
+    }
+  }
 
   async function onSend(message: string) {
     const trimmed = message.trim();
@@ -121,7 +139,7 @@ export function useCopilotPage() {
     messages,
     status,
     error,
-    stop,
+    stop: handleStop,
     isLoadingSession,
     isCreatingSession,
     isUserLoading,

--- a/autogpt_platform/frontend/src/app/api/chat/sessions/[sessionId]/stop/route.ts
+++ b/autogpt_platform/frontend/src/app/api/chat/sessions/[sessionId]/stop/route.ts
@@ -1,0 +1,56 @@
+import { environment } from "@/services/environment";
+import { getServerAuthToken } from "@/lib/autogpt-server-api/helpers";
+import { NextRequest } from "next/server";
+
+/**
+ * Proxy for stopping an active chat generation.
+ * Forwards to the backend POST /api/chat/sessions/{sessionId}/stop endpoint.
+ */
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ sessionId: string }> },
+) {
+  const { sessionId } = await params;
+
+  try {
+    const token = await getServerAuthToken();
+
+    const backendUrl = environment.getAGPTServerBaseUrl();
+    const stopUrl = new URL(
+      `/api/chat/sessions/${sessionId}/stop`,
+      backendUrl,
+    );
+
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+
+    if (token) {
+      headers["Authorization"] = `Bearer ${token}`;
+    }
+
+    const response = await fetch(stopUrl.toString(), {
+      method: "POST",
+      headers,
+    });
+
+    const data = await response.text();
+
+    return new Response(data, {
+      status: response.status,
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch (error) {
+    console.error("Stop proxy error:", error);
+    return new Response(
+      JSON.stringify({
+        error: "Failed to stop chat generation",
+        detail: error instanceof Error ? error.message : String(error),
+      }),
+      {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }
+}


### PR DESCRIPTION
Wire backend cancellation to CoPilot stop button. Adds Redis-based task cancellation, a stop endpoint, and frontend proxy to cancel AI generation server-side.

Closes #12111

The CoPilot stop button only called the AI SDK's client-side `stop()`, which aborts the SSE fetch but leaves the backend `asyncio.Task` running. This wires the button to also cancel the server-side task.

### Changes 🏗️

- **Backend `stream_registry.py`**: Add `request_task_cancellation()`, `is_cancellation_requested()`, and `cancel_active_task_for_session()` using Redis cancel flags + local asyncio task cancellation
- **Backend `routes.py`**: Add `POST /sessions/{session_id}/stop` endpoint; handle `CancelledError` in `run_ai_generation()` with `StreamFinish` publish; add cross-pod cancel polling every 5 chunks
- **Frontend `stop/route.ts`**: New Next.js API proxy route for the backend stop endpoint
- **Frontend `useCopilotPage.ts`**: Wire `handleStop` to call both AI SDK `stop()` and backend stop endpoint (fire-and-forget)

### Checklist 📋

#### For code changes:
  - [x] I have clearly listed my changes in the PR description
  - [x] I have made a test plan
  - [x] I have tested my changes according to the test plan:
    - [ ] Start a chat in CoPilot, click stop during streaming — verify stream stops      
    - [ ] Check backend logs for cancellation messages
    - [ ] Verify partial message is saved with [interrupted] marker
    - [ ] Verify chat remains usable after stopping (can send new messages)
    - [ ] Double-click stop — verify no errors (second call returns 404, safely ignored)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Wires the CoPilot stop button to cancel backend AI generation tasks, using a Redis-based cancellation flag for cross-pod support and local `asyncio.Task.cancel()` for same-pod cancellation. Adds a `POST /sessions/{session_id}/stop` backend endpoint, a Next.js API proxy route, and frontend integration that fires both the AI SDK `stop()` and the backend cancellation in parallel.

- **Backend cancellation flow**: `cancel_active_task_for_session()` scans Redis for the active task, sets a cancel flag (`chat:task:cancel:{task_id}` with 5-min TTL), and directly cancels the local asyncio task if present. Cross-pod cancellation is polled every 5 chunks.
- **Duplicate `StreamFinish` on cancellation**: The `CancelledError` handler explicitly publishes `StreamFinish` *before* calling `mark_task_completed()`, which also publishes `StreamFinish` internally. This should be fixed for consistency with the existing `Exception` handler pattern (see inline comment).
- **Frontend**: Clean fire-and-forget pattern — `handleStop()` calls SDK `stop()` immediately, then hits the backend proxy. The proxy route follows established patterns from the existing `stream/route.ts`.
- **Authorization**: Properly enforced — the stop endpoint requires authentication, validates session ownership via `_validate_and_get_session`, and `get_active_task_for_session` additionally checks task-level user ownership.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

- This PR is safe to merge with a minor fix to the duplicate StreamFinish event on cancellation.
- The implementation is well-structured with proper authorization, consistent patterns with the existing codebase, and a sound cross-pod cancellation design. The single issue (duplicate StreamFinish) is low-severity — it doesn't cause runtime errors but is inconsistent with the existing error handling pattern and could confuse stream replay logic. The fix is a one-line removal.
- `autogpt_platform/backend/backend/api/features/chat/routes.py` — duplicate StreamFinish event in CancelledError handler
</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User as User (Browser)
    participant FE as Frontend (useCopilotPage)
    participant Proxy as Next.js Proxy (/api/chat/.../stop)
    participant BE as Backend (routes.py)
    participant SR as StreamRegistry
    participant Redis as Redis

    User->>FE: Click Stop button
    FE->>FE: sdkStop() — abort SSE fetch
    FE->>Proxy: POST /api/chat/sessions/{id}/stop (fire-and-forget)
    Proxy->>BE: POST /api/chat/sessions/{id}/stop (with auth)
    BE->>BE: _validate_and_get_session()
    BE->>SR: cancel_active_task_for_session(session_id, user_id)
    SR->>SR: get_active_task_for_session()
    SR->>Redis: SCAN for running task with matching session_id
    Redis-->>SR: task metadata
    SR->>SR: request_task_cancellation(task_id)
    SR->>Redis: SET chat:task:cancel:{task_id} (TTL 300s)
    SR->>SR: _local_tasks[task_id].cancel()
    SR-->>BE: (success, task_id)
    BE-->>Proxy: 200 {status: "ok", task_id}
    Proxy-->>FE: 200

    Note over BE: Meanwhile, in run_ai_generation()...
    BE->>BE: CancelledError raised (local cancel or poll detects flag)
    BE->>SR: publish_chunk(StreamFinish)
    BE->>SR: mark_task_completed("failed")
    SR->>Redis: CAS status → "failed"
    SR->>Redis: XADD StreamFinish (second one — duplicate)
```
</details>


<sub>Last reviewed commit: 4dc45e6</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->