### PR TITLE
Fix CoPilot stop button by cancelling backend chat stream

### DIFF
--- a/autogpt_platform/backend/backend/api/features/chat/routes.py
+++ b/autogpt_platform/backend/backend/api/features/chat/routes.py
@@ -137,6 +137,13 @@ class OperationCompleteRequest(BaseModel):
     error: str | None = None
 
 
+class StopSessionStreamResponse(BaseModel):
+    """Response model for stopping an active session stream."""
+
+    stopped: bool
+    task_id: str | None = None
+
+
 # ========== Routes ==========
 
 
@@ -725,6 +732,40 @@ async def resume_session_stream(
             "X-Accel-Buffering": "no",
             "x-vercel-ai-ui-message-stream": "v1",
         },
+    )
+
+
+@router.post(
+    "/sessions/{session_id}/stop",
+)
+async def stop_session_stream(
+    session_id: str,
+    user_id: str | None = Depends(auth.get_user_id),
+) -> StopSessionStreamResponse:
+    """Stop the active stream for a chat session.
+
+    Cancels the backend task currently streaming for the given session.
+    If no active stream exists, returns ``stopped=False``.
+
+    Args:
+        session_id: The chat session identifier.
+        user_id: Optional authenticated user ID.
+
+    Returns:
+        StopSessionStreamResponse indicating whether a task was stopped.
+    """
+    await _validate_and_get_session(session_id, user_id)
+
+    active_task, _last_id = await stream_registry.get_active_task_for_session(
+        session_id, user_id
+    )
+    if not active_task:
+        return StopSessionStreamResponse(stopped=False, task_id=None)
+
+    was_stopped = await stream_registry.cancel_task(active_task.task_id, user_id)
+    return StopSessionStreamResponse(
+        stopped=was_stopped,
+        task_id=active_task.task_id if was_stopped else None,
     )
 
 

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/useCopilotPage.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/useCopilotPage.ts
@@ -74,6 +74,19 @@ export function useCopilotPage() {
     return () => clearTimeout(timer);
   }, [status]);
 
+  async function stopStreaming() {
+    // Always stop client-side stream immediately for responsiveness.
+    stop();
+
+    if (!sessionId) return;
+
+    try {
+      await fetch(`/api/chat/sessions/${sessionId}/stop`, { method: "POST" });
+    } catch {
+      // Best-effort server cancellation; client stream is already stopped above.
+    }
+  }
+
   useEffect(() => {
     if (!hydratedMessages || hydratedMessages.length === 0) return;
     setMessages((prev) => {
@@ -148,7 +161,7 @@ export function useCopilotPage() {
     messages,
     status,
     error,
-    stop,
+    stop: stopStreaming,
     isLoadingSession,
     isCreatingSession,
     isUserLoading,

--- a/autogpt_platform/frontend/src/app/api/chat/sessions/[sessionId]/stop/route.ts
+++ b/autogpt_platform/frontend/src/app/api/chat/sessions/[sessionId]/stop/route.ts
@@ -1,0 +1,55 @@
+import { getServerAuthToken } from "@/lib/autogpt-server-api/helpers";
+import { environment } from "@/services/environment";
+import { NextRequest } from "next/server";
+
+/**
+ * Stop an active chat stream for a session.
+ *
+ * Proxies to backend with server-side auth token injection.
+ */
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ sessionId: string }> },
+) {
+  const { sessionId } = await params;
+
+  try {
+    const token = await getServerAuthToken();
+
+    const backendUrl = environment.getAGPTServerBaseUrl();
+    const stopUrl = new URL(`/api/chat/sessions/${sessionId}/stop`, backendUrl);
+
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+
+    if (token) {
+      headers["Authorization"] = `Bearer ${token}`;
+    }
+
+    const response = await fetch(stopUrl.toString(), {
+      method: "POST",
+      headers,
+    });
+
+    const bodyText = await response.text();
+
+    return new Response(bodyText || null, {
+      status: response.status,
+      headers: {
+        "Content-Type": response.headers.get("content-type") ?? "application/json",
+      },
+    });
+  } catch (error) {
+    return new Response(
+      JSON.stringify({
+        error: "Failed to stop chat stream",
+        detail: error instanceof Error ? error.message : String(error),
+      }),
+      {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }
+}

--- a/autogpt_platform/frontend/src/app/api/chat/sessions/[sessionId]/stop/route.ts
+++ b/autogpt_platform/frontend/src/app/api/chat/sessions/[sessionId]/stop/route.ts
@@ -23,7 +23,7 @@ export async function POST(
       "Content-Type": "application/json",
     };
 
-    if (token) {
+    if (token && token !== "no-token-found") {
       headers["Authorization"] = `Bearer ${token}`;
     }
 

--- a/autogpt_platform/frontend/src/app/api/chat/sessions/[sessionId]/stop/route.ts
+++ b/autogpt_platform/frontend/src/app/api/chat/sessions/[sessionId]/stop/route.ts
@@ -37,7 +37,8 @@ export async function POST(
     return new Response(bodyText || null, {
       status: response.status,
       headers: {
-        "Content-Type": response.headers.get("content-type") ?? "application/json",
+        "Content-Type":
+          response.headers.get("content-type") ?? "application/json",
       },
     });
   } catch (error) {

--- a/autogpt_platform/frontend/src/app/api/openapi.json
+++ b/autogpt_platform/frontend/src/app/api/openapi.json
@@ -1232,6 +1232,46 @@
         }
       }
     },
+    "/api/chat/sessions/{session_id}/stop": {
+      "post": {
+        "tags": ["v2", "chat", "chat"],
+        "summary": "Stop Session Stream",
+        "description": "Stop the active stream for a chat session.\n\nCancels the backend task currently streaming for the given session.\nIf no active stream exists, returns ``stopped=False``.\n\nArgs:\n    session_id: The chat session identifier.\n    user_id: Optional authenticated user ID.\n\nReturns:\n    StopSessionStreamResponse indicating whether a task was stopped.",
+        "operationId": "postV2StopSessionStream",
+        "security": [{ "HTTPBearerJWT": [] }],
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Session Id" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StopSessionStreamResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/chat/sessions/{session_id}/stream": {
       "get": {
         "tags": ["v2", "chat", "chat"],
@@ -11187,6 +11227,19 @@
         "additionalProperties": true,
         "type": "object",
         "title": "Stats"
+      },
+      "StopSessionStreamResponse": {
+        "properties": {
+          "stopped": { "type": "boolean", "title": "Stopped" },
+          "task_id": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Task Id"
+          }
+        },
+        "type": "object",
+        "required": ["stopped"],
+        "title": "StopSessionStreamResponse",
+        "description": "Response model for stopping an active session stream."
       },
       "StoreAgent": {
         "properties": {


### PR DESCRIPTION
## Summary
This PR fixes issue #12111 by ensuring the CoPilot Stop button aborts backend processing, not only client-side streaming.

## Root cause
The CoPilot UI called `useChat().stop()` which stops local stream consumption, but there was no backend endpoint to cancel the active server-side chat task for the session.

## Changes
- Backend (`chat/routes.py`)
  - Added `POST /chat/sessions/{session_id}/stop` to stop the active stream task for a session.
  - Validates session access and returns `{ stopped, task_id }`.
- Backend (`chat/stream_registry.py`)
  - Added `cancel_task(task_id, user_id)` to cancel running local asyncio task when present.
  - Marks task status as `cancelled` and publishes finish event to close SSE cleanly.
  - Extended task status literals to include `cancelled`.
- Frontend (`useCopilotPage.ts`)
  - Wrapped stop action so clicking Stop now:
    1. immediately stops client-side stream for responsiveness
    2. sends `POST /api/chat/sessions/{sessionId}/stop` as best-effort backend cancellation

## Notes
- Scope is intentionally minimal and focused on CoPilot stop semantics.
- Existing behavior is preserved when no active backend task exists (`stopped=false`).

Fixes #12111

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Added backend task cancellation to make CoPilot Stop button actually stop backend processing, not just client-side streaming.

**Key changes:**
- Backend: new `POST /sessions/{id}/stop` endpoint validates session and cancels active task
- Backend: `cancel_task()` function cancels local asyncio task (if on same pod), marks as "cancelled" in Redis, and publishes finish event
- Frontend: `stopStreaming()` stops client stream immediately, then sends best-effort cancellation request to backend

**Considerations:**
- In multi-pod deployments, if the task runs on a different pod, only the Redis status is updated to "cancelled" - the actual asyncio task on the other pod won't receive active cancellation (it will continue until it checks Redis status). This is acknowledged in the implementation and is acceptable for the stated scope.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

- This PR is safe to merge with minor style considerations
- The implementation correctly addresses the issue with proper validation, error handling, and graceful degradation. The logic is sound: validates session ownership, checks for active tasks, attempts cancellation with proper timeout handling, and updates Redis state. The frontend stops the client stream immediately for responsiveness. One minor style guideline violation (using `useCallback` unnecessarily) doesn't affect functionality. The distributed cancellation limitation is acknowledged and acceptable for the stated scope.
- No files require special attention - the style issue in `useCopilotPage.ts` is minor
</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant Frontend as Frontend (useCopilotPage)
    participant StopAPI as POST /sessions/{id}/stop
    participant Registry as stream_registry
    participant Redis
    participant AsyncTask as Local asyncio.Task

    User->>Frontend: Click Stop button
    Frontend->>Frontend: Call stop() - stop client stream
    Note over Frontend: Client stream stops immediately
    Frontend->>StopAPI: POST /sessions/{sessionId}/stop
    StopAPI->>StopAPI: Validate session access
    StopAPI->>Registry: get_active_task_for_session(session_id, user_id)
    Registry->>Redis: Scan for running tasks
    Redis-->>Registry: Return active task (if exists)
    
    alt No active task found
        Registry-->>StopAPI: Return (None, last_id)
        StopAPI-->>Frontend: {stopped: false, task_id: null}
    else Active task exists
        Registry-->>StopAPI: Return (ActiveTask, last_id)
        StopAPI->>Registry: cancel_task(task_id, user_id)
        Registry->>Registry: Get task from Redis
        Registry->>Registry: Validate ownership & status
        
        alt Task on this pod
            Registry->>AsyncTask: task.cancel()
            Registry->>AsyncTask: await task (5s timeout)
            AsyncTask-->>Registry: CancelledError
        else Task on another pod
            Note over Registry,AsyncTask: No local task reference<br/>but still mark as cancelled
        end
        
        Registry->>Redis: mark_task_completed(task_id, "cancelled")
        Registry->>Redis: Publish StreamFinish event
        Redis-->>Registry: Success
        Registry-->>StopAPI: Return true
        StopAPI-->>Frontend: {stopped: true, task_id: "..."}
    end
    
    Note over Frontend: Best-effort: ignores errors
```
</details>


<sub>Last reviewed commit: da80d1f</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - autogpt_platform/frontend/CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=39861924-d320-41ba-a1a7-a8bff44f780a))

<!-- /greptile_comment -->