### PR TITLE
fix(frontend): resolve NaN when pasting number string into integer field

### DIFF
--- a/autogpt_platform/frontend/src/components/renderers/InputRenderer/base/standard/widgets/TextInput/TextWidget.test.tsx
+++ b/autogpt_platform/frontend/src/components/renderers/InputRenderer/base/standard/widgets/TextInput/TextWidget.test.tsx
@@ -1,0 +1,62 @@
+import { describe, expect, test, vi } from "vitest";
+import { fireEvent } from "@testing-library/react";
+import { render, screen } from "@/tests/integrations/test-utils";
+import TextWidget from "./TextWidget";
+
+function makeProps(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "test-integer-input",
+    name: "test-integer-input",
+    schema: { type: "integer", title: "Test Integer" },
+    onChange: vi.fn(),
+    onBlur: vi.fn(),
+    onFocus: vi.fn(),
+    value: undefined,
+    required: false,
+    disabled: false,
+    readonly: false,
+    placeholder: "",
+    options: {},
+    autofocus: false,
+    rawErrors: [],
+    label: "",
+    hideLabel: false,
+    multiple: false,
+    formContext: { size: "small", uiType: "default" },
+    registry: {
+      formContext: { size: "small", uiType: "default" },
+      fields: {},
+      widgets: {},
+      rootSchema: {},
+      schemaUtils: {},
+      templates: {},
+      translateString: (key: string) => key,
+    },
+    ...overrides,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+describe("TextWidget — INTEGER input", () => {
+  test("renders the integer input with htmlType=number", () => {
+    render(<TextWidget {...makeProps()} />);
+    const input = screen.getByPlaceholderText(/Enter integer value/i);
+    expect(input.getAttribute("type")).toBe("number");
+  });
+
+  test("truncates decimal input via Math.trunc when calling onChange", () => {
+    const onChange = vi.fn();
+    render(<TextWidget {...makeProps({ onChange })} />);
+    const input = screen.getByPlaceholderText(/Enter integer value/i);
+    fireEvent.change(input, { target: { value: "12.7" } });
+    expect(onChange).toHaveBeenCalledWith(12);
+  });
+
+  test("returns undefined when the value is cleared", () => {
+    const onChange = vi.fn();
+    render(<TextWidget {...makeProps({ value: 42, onChange })} />);
+    const input = screen.getByPlaceholderText(/Enter integer value/i);
+    fireEvent.change(input, { target: { value: "" } });
+    expect(onChange).toHaveBeenCalledWith(undefined);
+  });
+});

--- a/autogpt_platform/frontend/src/components/renderers/InputRenderer/base/standard/widgets/TextInput/TextWidget.tsx
+++ b/autogpt_platform/frontend/src/components/renderers/InputRenderer/base/standard/widgets/TextInput/TextWidget.tsx
@@ -48,9 +48,10 @@ export default function TextWidget(props: WidgetProps) {
       handleChange: (v: string) => (v === "" ? undefined : Number(v)),
     },
     [InputType.INTEGER]: {
-      htmlType: "account",
+      htmlType: "number",
       placeholder: "Enter integer value...",
-      handleChange: (v: string) => (v === "" ? undefined : Number(v)),
+      handleChange: (v: string) =>
+        v === "" ? undefined : Math.trunc(Number(v)),
     },
   };
 


### PR DESCRIPTION
## Summary
- Fixed the INTEGER input type using an invalid `htmlType: "account"` instead of `"number"`, which caused `filterNumberInput()` to be bypassed
- Pasting a number string (e.g. `"123"`) or mixed content (e.g. `"123abc"`) into an integer field no longer produces `NaN`
- Added `Math.trunc()` to ensure integer fields always return whole numbers (no decimals)

### Root Cause
In `TextWidget.tsx`, the `InputType.INTEGER` config had `htmlType: "account"` (invalid HTML input type). The browser falls back to `type="text"`, which skips the `filterNumberInput()` sanitizer in `useInput.ts` (only runs when `type === "number"`). Raw pasted values like `"123abc"` were passed directly to `Number()`, producing `NaN`.

### Changes
**File:** `autogpt_platform/frontend/src/components/renderers/InputRenderer/base/standard/widgets/TextInput/TextWidget.tsx`
- `htmlType: "account"` → `htmlType: "number"` — enables number input filtering
- `Number(v)` → `Math.trunc(Number(v))` — truncates decimals for integer fields

## Test plan
- [ ] Paste `"123"` into an integer field → should show `123`
- [ ] Paste `"123abc"` into an integer field → should show `123` (non-numeric chars filtered)
- [ ] Paste `"12.5"` into an integer field → should show `12` (decimals truncated)
- [ ] Type normally in integer fields → should work as before
- [ ] Number fields (non-integer) should still accept decimals

Closes #12110

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Corrected invalid `htmlType: "account"` to `htmlType: "number"` for INTEGER input fields, enabling proper number input filtering. Added `Math.trunc()` to ensure integer fields return whole numbers without decimals. Previously, the invalid HTML type caused the browser to fall back to text input, bypassing `filterNumberInput()` sanitization and allowing raw strings like `"123abc"` to be passed to `Number()`, resulting in `NaN`.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge with minimal risk
- The fix corrects an obvious typo (`htmlType: "account"` is not a valid HTML input type) with a straightforward two-line change. The logic is simple and directly addresses the root cause. `Math.trunc()` is the appropriate method for ensuring integer values.
- No files require special attention
</details>


<sub>Last reviewed commit: a1698b4</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->