### PR TITLE
fix(backend/copilot): Route workspace through db_accessors, fix transcript upload

### DIFF
--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -693,7 +693,15 @@ async def stream_chat_completion_sdk(
                     await asyncio.sleep(0.5)
                     raw_transcript = read_transcript_file(captured_transcript.path)
                     if raw_transcript:
-                        await _upload_transcript_bg(user_id, session_id, raw_transcript)
+                        try:
+                            async with asyncio.timeout(30):
+                                await _upload_transcript_bg(
+                                    user_id, session_id, raw_transcript
+                                )
+                        except asyncio.TimeoutError:
+                            logger.warning(
+                                f"[SDK] Transcript upload timed out for {session_id}"
+                            )
                     else:
                         logger.debug("[SDK] Stop hook fired but transcript not usable")
 

--- a/autogpt_platform/backend/backend/data/db_manager.py
+++ b/autogpt_platform/backend/backend/data/db_manager.py
@@ -93,7 +93,15 @@ from backend.data.user import (
     get_user_notification_preference,
     update_user_integrations,
 )
-from backend.data.workspace import get_or_create_workspace
+from backend.data.workspace import (
+    count_workspace_files,
+    create_workspace_file,
+    get_or_create_workspace,
+    get_workspace_file,
+    get_workspace_file_by_path,
+    list_workspace_files,
+    soft_delete_workspace_file,
+)
 from backend.util.service import (
     AppService,
     AppServiceClient,
@@ -274,7 +282,13 @@ class DatabaseManager(AppService):
     get_user_execution_summary_data = _(get_user_execution_summary_data)
 
     # ============ Workspace ============ #
+    count_workspace_files = _(count_workspace_files)
+    create_workspace_file = _(create_workspace_file)
     get_or_create_workspace = _(get_or_create_workspace)
+    get_workspace_file = _(get_workspace_file)
+    get_workspace_file_by_path = _(get_workspace_file_by_path)
+    list_workspace_files = _(list_workspace_files)
+    soft_delete_workspace_file = _(soft_delete_workspace_file)
 
     # ============ Understanding ============ #
     get_business_understanding = _(get_business_understanding)
@@ -438,7 +452,13 @@ class DatabaseManagerAsyncClient(AppServiceClient):
     get_user_execution_summary_data = d.get_user_execution_summary_data
 
     # ============ Workspace ============ #
+    count_workspace_files = d.count_workspace_files
+    create_workspace_file = d.create_workspace_file
     get_or_create_workspace = d.get_or_create_workspace
+    get_workspace_file = d.get_workspace_file
+    get_workspace_file_by_path = d.get_workspace_file_by_path
+    list_workspace_files = d.list_workspace_files
+    soft_delete_workspace_file = d.soft_delete_workspace_file
 
     # ============ Understanding ============ #
     get_business_understanding = d.get_business_understanding

--- a/autogpt_platform/backend/backend/data/workspace.py
+++ b/autogpt_platform/backend/backend/data/workspace.py
@@ -164,21 +164,23 @@ async def create_workspace_file(
 
 async def get_workspace_file(
     file_id: str,
-    workspace_id: Optional[str] = None,
+    workspace_id: str,
 ) -> Optional[WorkspaceFile]:
     """
     Get a workspace file by ID.
 
     Args:
         file_id: The file ID
-        workspace_id: Optional workspace ID for validation
+        workspace_id: Workspace ID for scoping (required)
 
     Returns:
         WorkspaceFile instance or None
     """
-    where_clause: dict = {"id": file_id, "isDeleted": False}
-    if workspace_id:
-        where_clause["workspaceId"] = workspace_id
+    where_clause: UserWorkspaceFileWhereInput = {
+        "id": file_id,
+        "isDeleted": False,
+        "workspaceId": workspace_id,
+    }
 
     file = await UserWorkspaceFile.prisma().find_first(where=where_clause)
     return WorkspaceFile.from_db(file) if file else None
@@ -268,7 +270,7 @@ async def count_workspace_files(
     Returns:
         Number of files
     """
-    where_clause: dict = {"workspaceId": workspace_id}
+    where_clause: UserWorkspaceFileWhereInput = {"workspaceId": workspace_id}
     if not include_deleted:
         where_clause["isDeleted"] = False
 
@@ -283,7 +285,7 @@ async def count_workspace_files(
 
 async def soft_delete_workspace_file(
     file_id: str,
-    workspace_id: Optional[str] = None,
+    workspace_id: str,
 ) -> Optional[WorkspaceFile]:
     """
     Soft-delete a workspace file.
@@ -293,7 +295,7 @@ async def soft_delete_workspace_file(
 
     Args:
         file_id: The file ID
-        workspace_id: Optional workspace ID for validation
+        workspace_id: Workspace ID for scoping (required)
 
     Returns:
         Updated WorkspaceFile instance or None if not found

--- a/autogpt_platform/backend/backend/util/service.py
+++ b/autogpt_platform/backend/backend/util/service.py
@@ -28,7 +28,7 @@ from typing import (
 import httpx
 import uvicorn
 from fastapi import FastAPI, Request, responses
-from prisma.errors import DataError
+from prisma.errors import DataError, UniqueViolationError
 from pydantic import BaseModel, TypeAdapter, create_model
 
 import backend.util.exceptions as exceptions
@@ -201,6 +201,7 @@ EXCEPTION_MAPPING = {
         UnhealthyServiceError,
         HTTPClientError,
         HTTPServerError,
+        UniqueViolationError,
         *[
             ErrorType
             for _, ErrorType in inspect.getmembers(exceptions)
@@ -417,6 +418,9 @@ class AppService(BaseAppService, ABC):
             DataError, self._handle_internal_http_error(400)
         )
         self.fastapi_app.add_exception_handler(
+            UniqueViolationError, self._handle_internal_http_error(400)
+        )
+        self.fastapi_app.add_exception_handler(
             Exception, self._handle_internal_http_error(500)
         )
 
@@ -478,6 +482,7 @@ def get_service_client(
                 # Don't retry these specific exceptions that won't be fixed by retrying
                 ValueError,  # Invalid input/parameters
                 DataError,  # Prisma data integrity errors (foreign key, unique constraints)
+                UniqueViolationError,  # Unique constraint violations
                 KeyError,  # Missing required data
                 TypeError,  # Wrong data types
                 AttributeError,  # Missing attributes


### PR DESCRIPTION
## Summary

Fixes two bugs in the copilot executor:

### SECRT-2008: WorkspaceManager bypasses db_accessors
`backend/util/workspace.py` imported 6 workspace functions directly from `backend/data/workspace.py`, which call `prisma()` directly. In the copilot executor (no Prisma connection), these fail.

**Fix:** Replace direct imports with `workspace_db()` from `db_accessors`, routing through the database_manager HTTP client when Prisma is unavailable. Also:
- Register all 6 workspace functions in `DatabaseManager` and `DatabaseManagerAsyncClient`
- Add `UniqueViolationError` to the service `EXCEPTION_MAPPING` so it is properly re-raised over HTTP (needed for race-condition retry logic)
- Add `UniqueViolationError` FastAPI exception handler (returns 400 instead of falling through to 500)
- Add `UniqueViolationError` to retry `exclude_exceptions` (no point retrying constraint violations)
- Bind `workspace_db()` to a local variable once per method for consistent connection state
- Make `workspace_id` required (not optional) on `get_workspace_file` and `soft_delete_workspace_file` to enforce workspace scoping at the data layer
- Use `UserWorkspaceFileWhereInput` type instead of bare `dict` for where clauses

### SECRT-2009: Transcript upload asyncio.timeout error
`asyncio.create_task()` at line 696 of `service.py` creates an orphaned background task in the executor's thread event loop. `gcloud-aio-storage`'s `asyncio.timeout()` fails in this context.

**Fix:** Replace `create_task` with direct `await`, wrapped in a 30s timeout to prevent the SSE connection from hanging on slow GCS uploads. The upload runs after streaming completes (all chunks already yielded), so no user-facing latency impact. The function already has internal try/except error handling.