### PR TITLE
Improve developer contribution documentation clarity (fixes #5191)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,3 +36,7 @@ hop on our Discord. See you there! :-)
 ❤️ & 🔆
 The team @ AutoGPT
 https://discord.gg/autogpt
+
+## Additional Setup Tip for Contributors
+
+Before contributing, ensure that your Python environment meets the required version specified in the installation instructions. Using an incompatible Python version may result in dependency or runtime errors. Always install dependencies before attempting to run or modify the project.


### PR DESCRIPTION
## Changes
This pull request improves the developer contribution documentation by adding an additional setup tip for contributors. This clarification helps ensure contributors use a compatible Python environment and install dependencies before attempting to modify the project.

## Purpose
This change improves the clarity of the developer documentation and helps prevent common setup and environment errors for new contributors.

## Related Issue
Fixes #5191 – Developer documentation improvements.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR appends a short "Additional Setup Tip for Contributors" paragraph to `CONTRIBUTING.md`, advising contributors to use a compatible Python version and install dependencies before working on the project.

While the intent to help new contributors avoid environment issues is valid, the added section is too vague to be actionable:

- It references "the required version specified in the installation instructions" without linking to those instructions or stating the actual required version (Python 3.10+).
- The information already exists — and with more specificity — in `docs/platform/getting-started.md`, which covers the Python version, Poetry installation, and `poetry install --with dev` command in detail.
- The section placement (after the closing "The team @ AutoGPT" sign-off) feels out of place structurally.

The tip as written adds noise rather than clarity. It would be more valuable if it included the specific Python version, a link to `Poetry`, and a reference to the getting-started guide.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

- Safe to merge — documentation-only change with no risk to code correctness or security.
- The change is limited to a single markdown file and introduces no executable code. The only concern is documentation quality: the added section is vague and partially duplicates existing, more specific documentation. This is a minor content issue, not a blocking defect.
- CONTRIBUTING.md — the new section should either be made more specific (link to setup guide, state Python 3.10+) or removed to avoid redundancy.
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
flowchart TD
    A[Contributor reads CONTRIBUTING.md] --> B[Reads 'In short' checklist]
    B --> C[Reads 'Additional Setup Tip' - NEW]
    C --> D{Tip references 'installation instructions'\nbut provides no link}
    D -->|Confused| E[Searches manually for setup docs]
    D -->|Finds it| F[Reads docs/platform/getting-started.md]
    F --> G[Gets specific: Python 3.10+, Poetry install]
    E --> F
```
</details>


<sub>Last reviewed commit: 4d83c26</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->