### PR TITLE
feat(builder): collapse unconnected object sub-outputs

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/nodes/OutputHandler.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/nodes/OutputHandler.tsx
@@ -1,6 +1,6 @@
 import { Button } from "@/components/atoms/Button/Button";
 import { Text } from "@/components/atoms/Text/Text";
-import { CaretDownIcon, InfoIcon } from "@phosphor-icons/react";
+import { CaretDownIcon, CaretRightIcon, InfoIcon } from "@phosphor-icons/react";
 import { RJSFSchema } from "@rjsf/utils";
 import { useState } from "react";
 
@@ -12,10 +12,15 @@ import {
   TooltipTrigger,
 } from "@/components/atoms/Tooltip/BaseTooltip";
 import { useEdgeStore } from "@/app/(platform)/build/stores/edgeStore";
+import { useNodeStore } from "@/app/(platform)/build/stores/nodeStore";
 import { getTypeDisplayInfo } from "./helpers";
 import { BlockUIType } from "../../types";
 import { cn } from "@/lib/utils";
 import { useBrokenOutputs } from "./useBrokenOutputs";
+import {
+  buildVisibleOutputTree,
+  VisibleOutputTreeNode,
+} from "./output-visibility";
 
 export const OutputHandler = ({
   outputSchema,
@@ -26,94 +31,143 @@ export const OutputHandler = ({
   nodeId: string;
   uiType: BlockUIType;
 }) => {
-  const { isOutputConnected } = useEdgeStore();
-  const properties = outputSchema?.properties || {};
+  const edges = useEdgeStore((state) => state.edges);
+  const nodeOutputCollapsedStates = useNodeStore(
+    (state) => state.nodeOutputCollapsedStates,
+  );
+  const getOutputCollapsed = useNodeStore((state) => state.getOutputCollapsed);
+  const toggleOutputCollapsed = useNodeStore(
+    (state) => state.toggleOutputCollapsed,
+  );
+  const properties = (outputSchema?.properties || {}) as Record<
+    string,
+    RJSFSchema
+  >;
   const [isOutputVisible, setIsOutputVisible] = useState(true);
   const brokenOutputs = useBrokenOutputs(nodeId);
 
   const showHandles = uiType !== BlockUIType.OUTPUT;
+  const connectedSourceHandles = new Set(
+    edges
+      .filter((edge) => edge.source === nodeId && edge.sourceHandle)
+      .map((edge) => edge.sourceHandle as string),
+  );
 
-  const renderOutputHandles = (
-    schema: RJSFSchema,
-    keyPrefix: string = "",
-    titlePrefix: string = "",
-  ): React.ReactNode[] => {
-    return Object.entries(schema).map(
-      ([key, fieldSchema]: [string, RJSFSchema]) => {
-        const fullKey = keyPrefix ? `${keyPrefix}_#_${key}` : key;
-        const fieldTitle = titlePrefix + (fieldSchema?.title || key);
+  function isHandleConnected(handleId: string): boolean {
+    return connectedSourceHandles.has(handleId);
+  }
 
-        const isConnected = isOutputConnected(nodeId, fullKey);
-        const shouldShow = isConnected || isOutputVisible;
-        const { displayType, colorClass, hexColor } =
-          getTypeDisplayInfo(fieldSchema);
-        const isBroken = brokenOutputs.has(fullKey);
+  function isOutputCollapsed(handleId: string): boolean {
+    const collapseStateForNode = nodeOutputCollapsedStates[nodeId];
+    if (
+      collapseStateForNode &&
+      Object.prototype.hasOwnProperty.call(collapseStateForNode, handleId)
+    ) {
+      return collapseStateForNode[handleId];
+    }
 
-        return shouldShow ? (
-          <div
-            key={fullKey}
-            className="flex flex-col items-end gap-2"
-            data-tutorial-id={`output-handler-${nodeId}-${fieldTitle}`}
-          >
-            <div className="relative flex items-center gap-2">
-              {fieldSchema?.description && (
-                <TooltipProvider>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <span
-                        style={{ marginLeft: 6, cursor: "pointer" }}
-                        aria-label="info"
-                        tabIndex={0}
-                      >
-                        <InfoIcon />
-                      </span>
-                    </TooltipTrigger>
-                    <TooltipContent>{fieldSchema?.description}</TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
-              )}
-              <Text
-                variant="body"
-                className={cn(
-                  "text-slate-700",
-                  isBroken && "text-red-500 line-through",
-                )}
-              >
-                {fieldTitle}
-              </Text>
-              <Text
-                variant="small"
-                as="span"
-                className={cn(
-                  colorClass,
-                  isBroken && "!text-red-500 line-through",
-                )}
-              >
-                ({displayType})
-              </Text>
+    return getOutputCollapsed(nodeId, handleId);
+  }
 
-              {showHandles && (
-                <OutputNodeHandle
-                  isBroken={isBroken}
-                  field_name={fullKey}
-                  nodeId={nodeId}
-                  hexColor={hexColor}
-                />
-              )}
-            </div>
+  const outputTree = buildVisibleOutputTree({
+    properties,
+    isHandleConnected,
+    isCollapsed: isOutputCollapsed,
+  });
 
-            {/* Recursively render nested properties */}
-            {fieldSchema?.properties &&
-              renderOutputHandles(
-                fieldSchema.properties,
-                fullKey,
-                `${fieldTitle}.`,
-              )}
-          </div>
-        ) : null;
-      },
+  function renderOutputNode(node: VisibleOutputTreeNode): React.ReactNode {
+    const shouldShowNode =
+      isOutputVisible || node.isConnected || node.hasConnectedDescendant;
+    if (!shouldShowNode) {
+      return null;
+    }
+
+    const { displayType, colorClass, hexColor } = getTypeDisplayInfo(
+      node.schema,
     );
-  };
+    const isBroken = brokenOutputs.has(node.fullKey);
+    const canToggleChildren = node.isObject && node.totalChildrenCount > 0;
+    const rowIsCollapsed = isOutputCollapsed(node.fullKey);
+
+    return (
+      <div
+        key={node.fullKey}
+        className="flex flex-col items-end gap-2"
+        data-tutorial-id={`output-handler-${nodeId}-${node.title}`}
+      >
+        <div className="relative flex items-center gap-2">
+          {node.schema?.description && (
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span
+                    style={{ marginLeft: 6, cursor: "pointer" }}
+                    aria-label="info"
+                    tabIndex={0}
+                  >
+                    <InfoIcon />
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent>{node.schema?.description}</TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          )}
+
+          {canToggleChildren && (
+            <button
+              type="button"
+              aria-label={`${rowIsCollapsed ? "Expand" : "Collapse"} ${node.title}`}
+              aria-expanded={!rowIsCollapsed}
+              className="flex items-center justify-center rounded-sm p-0.5 text-slate-500 hover:bg-zinc-100"
+              onClick={() => toggleOutputCollapsed(nodeId, node.fullKey)}
+            >
+              {rowIsCollapsed ? (
+                <CaretRightIcon size={12} weight="bold" />
+              ) : (
+                <CaretDownIcon size={12} weight="bold" />
+              )}
+            </button>
+          )}
+
+          <Text
+            variant="body"
+            className={cn(
+              "text-slate-700",
+              isBroken && "text-red-500 line-through",
+            )}
+          >
+            {node.title}
+          </Text>
+          <Text
+            variant="small"
+            as="span"
+            className={cn(colorClass, isBroken && "!text-red-500 line-through")}
+          >
+            ({displayType})
+          </Text>
+
+          {canToggleChildren &&
+            rowIsCollapsed &&
+            node.hiddenChildrenCount > 0 && (
+              <Text variant="small" as="span" className="text-slate-500">
+                ({node.hiddenChildrenCount})
+              </Text>
+            )}
+
+          {showHandles && (
+            <OutputNodeHandle
+              isBroken={isBroken}
+              field_name={node.fullKey}
+              nodeId={nodeId}
+              hexColor={hexColor}
+            />
+          )}
+        </div>
+
+        {node.children.map((child) => renderOutputNode(child))}
+      </div>
+    );
+  }
 
   return (
     <div className="flex flex-col items-end justify-between gap-2 rounded-b-xlarge border-t border-zinc-200 bg-white py-3.5">
@@ -136,7 +190,7 @@ export const OutputHandler = ({
       </Button>
 
       <div className="flex flex-col items-end gap-2">
-        {renderOutputHandles(properties)}
+        {outputTree.map((node) => renderOutputNode(node))}
       </div>
     </div>
   );

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/nodes/output-visibility.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/nodes/output-visibility.test.tsx
@@ -1,0 +1,111 @@
+import { describe, expect, test } from "vitest";
+import { RJSFSchema } from "@rjsf/utils";
+import { buildVisibleOutputTree } from "./output-visibility";
+
+const outputProperties: Record<string, RJSFSchema> = {
+  main_result: {
+    type: "object",
+    title: "Main Result",
+    properties: {
+      text: {
+        type: "string",
+        title: "Text",
+      },
+      metadata: {
+        type: "object",
+        title: "Metadata",
+        properties: {
+          score: {
+            type: "number",
+            title: "Score",
+          },
+          debug: {
+            type: "string",
+            title: "Debug",
+          },
+        },
+      },
+    },
+  },
+  status: {
+    type: "string",
+    title: "Status",
+  },
+};
+
+function getVisibleHandles(
+  connectedHandles: Set<string>,
+  collapsedHandles: Record<string, boolean> = {},
+) {
+  const tree = buildVisibleOutputTree({
+    properties: outputProperties,
+    isHandleConnected: (handleId) => connectedHandles.has(handleId),
+    isCollapsed: (handleId) => collapsedHandles[handleId] ?? true,
+  });
+
+  return flattenHandles(tree);
+}
+
+function flattenHandles(
+  nodes: ReturnType<typeof buildVisibleOutputTree>,
+): string[] {
+  const handles: string[] = [];
+
+  function walk(currentNodes: ReturnType<typeof buildVisibleOutputTree>) {
+    currentNodes.forEach((node) => {
+      handles.push(node.fullKey);
+      walk(node.children);
+    });
+  }
+
+  walk(nodes);
+  return handles;
+}
+
+describe("buildVisibleOutputTree", () => {
+  test("keeps disconnected top-level outputs visible", () => {
+    const visibleHandles = getVisibleHandles(new Set());
+
+    expect(visibleHandles).toContain("main_result");
+    expect(visibleHandles).toContain("status");
+    expect(visibleHandles).not.toContain("main_result_#_text");
+  });
+
+  test("keeps connected sub-output visible when parent object is collapsed", () => {
+    const visibleHandles = getVisibleHandles(new Set(["main_result_#_text"]));
+
+    expect(visibleHandles).toContain("main_result");
+    expect(visibleHandles).toContain("main_result_#_text");
+  });
+
+  test("keeps object ancestor visible when a deep descendant is connected", () => {
+    const visibleHandles = getVisibleHandles(
+      new Set(["main_result_#_metadata_#_score"]),
+    );
+
+    expect(visibleHandles).toContain("main_result");
+    expect(visibleHandles).toContain("main_result_#_metadata");
+    expect(visibleHandles).toContain("main_result_#_metadata_#_score");
+    expect(visibleHandles).not.toContain("main_result_#_text");
+  });
+
+  test("shows disconnected children when object output is expanded", () => {
+    const visibleHandles = getVisibleHandles(new Set(), { main_result: false });
+
+    expect(visibleHandles).toContain("main_result_#_text");
+    expect(visibleHandles).toContain("main_result_#_metadata");
+  });
+
+  test("shows only connected nested branch when parents are collapsed", () => {
+    const visibleHandles = getVisibleHandles(
+      new Set(["main_result_#_metadata_#_score"]),
+      {
+        main_result: true,
+        "main_result_#_metadata": true,
+      },
+    );
+
+    expect(visibleHandles).toContain("main_result_#_metadata_#_score");
+    expect(visibleHandles).not.toContain("main_result_#_metadata_#_debug");
+  });
+});

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/nodes/output-visibility.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/nodes/output-visibility.ts
@@ -1,0 +1,132 @@
+import { RJSFSchema } from "@rjsf/utils";
+
+type OutputSchemaProperties = Record<string, RJSFSchema>;
+
+type OutputTreeNode = {
+  fullKey: string;
+  title: string;
+  schema: RJSFSchema;
+  isTopLevel: boolean;
+  isObject: boolean;
+  children: OutputTreeNode[];
+};
+
+export type VisibleOutputTreeNode = {
+  fullKey: string;
+  title: string;
+  schema: RJSFSchema;
+  isTopLevel: boolean;
+  isObject: boolean;
+  isCollapsed: boolean;
+  isConnected: boolean;
+  hasConnectedDescendant: boolean;
+  isVisible: boolean;
+  totalChildrenCount: number;
+  hiddenChildrenCount: number;
+  children: VisibleOutputTreeNode[];
+};
+
+function getSchemaProperties(schema: RJSFSchema): OutputSchemaProperties {
+  if (!schema || !schema.properties) {
+    return {};
+  }
+
+  return schema.properties as OutputSchemaProperties;
+}
+
+function isObjectOutput(schema: RJSFSchema): boolean {
+  return schema.type === "object" || Boolean(schema.properties);
+}
+
+export function buildOutputTree(
+  properties: OutputSchemaProperties,
+  keyPrefix = "",
+  titlePrefix = "",
+  isTopLevel = true,
+): OutputTreeNode[] {
+  return Object.entries(properties).map(([key, fieldSchema]) => {
+    const fullKey = keyPrefix ? `${keyPrefix}_#_${key}` : key;
+    const fieldTitle = `${titlePrefix}${fieldSchema.title || key}`;
+    const childProperties = getSchemaProperties(fieldSchema);
+
+    return {
+      fullKey,
+      title: fieldTitle,
+      schema: fieldSchema,
+      isTopLevel,
+      isObject: isObjectOutput(fieldSchema),
+      children: buildOutputTree(
+        childProperties,
+        fullKey,
+        `${fieldTitle}.`,
+        false,
+      ),
+    };
+  });
+}
+
+function buildVisibleNode(
+  node: OutputTreeNode,
+  isHandleConnected: (handleId: string) => boolean,
+  isCollapsed: (handleId: string) => boolean,
+  isHiddenByCollapsedAncestor: boolean,
+): VisibleOutputTreeNode {
+  const nodeIsConnected = isHandleConnected(node.fullKey);
+  const nodeIsCollapsed = node.isObject ? isCollapsed(node.fullKey) : false;
+
+  const childHiddenByCollapsedAncestor =
+    isHiddenByCollapsedAncestor || (node.isObject && nodeIsCollapsed);
+
+  const children = node.children.map((child) =>
+    buildVisibleNode(
+      child,
+      isHandleConnected,
+      isCollapsed,
+      childHiddenByCollapsedAncestor,
+    ),
+  );
+
+  const hasConnectedDescendant = children.some(
+    (child) => child.isConnected || child.hasConnectedDescendant,
+  );
+
+  const isVisible =
+    node.isTopLevel ||
+    !isHiddenByCollapsedAncestor ||
+    nodeIsConnected ||
+    hasConnectedDescendant;
+
+  const visibleChildren = children.filter((child) => child.isVisible);
+
+  return {
+    fullKey: node.fullKey,
+    title: node.title,
+    schema: node.schema,
+    isTopLevel: node.isTopLevel,
+    isObject: node.isObject,
+    isCollapsed: nodeIsCollapsed,
+    isConnected: nodeIsConnected,
+    hasConnectedDescendant,
+    isVisible,
+    totalChildrenCount: children.length,
+    hiddenChildrenCount: children.length - visibleChildren.length,
+    children: visibleChildren,
+  };
+}
+
+export function buildVisibleOutputTree({
+  properties,
+  isHandleConnected,
+  isCollapsed,
+}: {
+  properties: OutputSchemaProperties;
+  isHandleConnected: (handleId: string) => boolean;
+  isCollapsed: (handleId: string) => boolean;
+}): VisibleOutputTreeNode[] {
+  const outputTree = buildOutputTree(properties);
+  return outputTree
+    .map((node) =>
+      buildVisibleNode(node, isHandleConnected, isCollapsed, false),
+    )
+    .filter((node) => node.isVisible);
+}

--- a/autogpt_platform/frontend/src/app/(platform)/build/stores/nodeStore.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/build/stores/nodeStore.ts
@@ -33,6 +33,7 @@ type NodeStore = {
   nodeCounter: number;
   setNodeCounter: (nodeCounter: number) => void;
   nodeAdvancedStates: Record<string, boolean>;
+  nodeOutputCollapsedStates: Record<string, Record<string, boolean>>;
 
   latestNodeInputData: Record<string, NodeExecutionResultInputData | undefined>;
   latestNodeOutputData: Record<
@@ -55,6 +56,13 @@ type NodeStore = {
   toggleAdvanced: (nodeId: string) => void;
   setShowAdvanced: (nodeId: string, show: boolean) => void;
   getShowAdvanced: (nodeId: string) => boolean;
+  setOutputCollapsed: (
+    nodeId: string,
+    outputHandleId: string,
+    collapsed: boolean,
+  ) => void;
+  toggleOutputCollapsed: (nodeId: string, outputHandleId: string) => void;
+  getOutputCollapsed: (nodeId: string, outputHandleId: string) => boolean;
   addNodes: (nodes: CustomNode[]) => void;
   getHardCodedValues: (nodeId: string) => Record<string, any>;
   convertCustomNodeToBackendNode: (node: CustomNode) => Node;
@@ -126,6 +134,7 @@ export const useNodeStore = create<NodeStore>((set, get) => ({
   nodeCounter: 0,
   setNodeCounter: (nodeCounter) => set({ nodeCounter }),
   nodeAdvancedStates: {},
+  nodeOutputCollapsedStates: {},
   latestNodeInputData: {},
   latestNodeOutputData: {},
   accumulatedNodeInputData: {},
@@ -283,6 +292,33 @@ export const useNodeStore = create<NodeStore>((set, get) => ({
     })),
   getShowAdvanced: (nodeId: string) =>
     get().nodeAdvancedStates[nodeId] || false,
+  setOutputCollapsed: (nodeId, outputHandleId, collapsed) =>
+    set((state) => ({
+      nodeOutputCollapsedStates: {
+        ...state.nodeOutputCollapsedStates,
+        [nodeId]: {
+          ...state.nodeOutputCollapsedStates[nodeId],
+          [outputHandleId]: collapsed,
+        },
+      },
+    })),
+  toggleOutputCollapsed: (nodeId, outputHandleId) =>
+    set((state) => {
+      const nodeCollapsedStates = state.nodeOutputCollapsedStates[nodeId] || {};
+      const currentValue = nodeCollapsedStates[outputHandleId] ?? true;
+
+      return {
+        nodeOutputCollapsedStates: {
+          ...state.nodeOutputCollapsedStates,
+          [nodeId]: {
+            ...nodeCollapsedStates,
+            [outputHandleId]: !currentValue,
+          },
+        },
+      };
+    }),
+  getOutputCollapsed: (nodeId, outputHandleId) =>
+    get().nodeOutputCollapsedStates[nodeId]?.[outputHandleId] ?? true,
   addNodes: (nodes: CustomNode[]) => {
     nodes.forEach((node) => {
       get().addNode(node);

--- a/autogpt_platform/frontend/src/services/feature-flags/use-get-flag.ts
+++ b/autogpt_platform/frontend/src/services/feature-flags/use-get-flag.ts
@@ -20,15 +20,21 @@ export enum Flag {
 }
 
 const isPwMockEnabled = process.env.NEXT_PUBLIC_PW_TEST === "true";
+const isNewFlowEditorEnvEnabled =
+  process.env.NEXT_PUBLIC_NEW_FLOW_EDITOR === "true";
+const isBuilderViewSwitchEnvEnabled =
+  process.env.NEXT_PUBLIC_BUILDER_VIEW_SWITCH === "true";
 
+// Local dev override: these env vars can force-enable FlowEditor flags when
+// LaunchDarkly is unavailable. Defaults remain false when env vars are unset.
 const defaultFlags = {
   [Flag.BETA_BLOCKS]: [],
   [Flag.NEW_BLOCK_MENU]: false,
   [Flag.NEW_AGENT_RUNS]: false,
   [Flag.GRAPH_SEARCH]: false,
   [Flag.ENABLE_ENHANCED_OUTPUT_HANDLING]: false,
-  [Flag.NEW_FLOW_EDITOR]: false,
-  [Flag.BUILDER_VIEW_SWITCH]: false,
+  [Flag.NEW_FLOW_EDITOR]: isNewFlowEditorEnvEnabled,
+  [Flag.BUILDER_VIEW_SWITCH]: isBuilderViewSwitchEnvEnabled,
   [Flag.SHARE_EXECUTION_RESULTS]: false,
   [Flag.AGENT_FAVORITING]: false,
   [Flag.MARKETPLACE_SEARCH_TERMS]: DEFAULT_SEARCH_TERMS,


### PR DESCRIPTION
The Builder nodes often expose object outputs as many sub-outputs (e.g., `Main Result.Text`, `Main Result.Html`, …). When those sub-outputs are unconnected, they take up significant canvas space and reduce usability. This PR collapses unconnected object sub-outputs by default while keeping connected outputs visible and allowing users to expand/collapse as needed.

### Changes 🏗️
- Collapse unconnected, non-top-level sub-outputs of object outputs by default in the Builder **FlowEditor** node output list.
- Add an expand/collapse chevron on object outputs plus a hidden-child count when collapsed.
- Keep connected sub-outputs visible even when the parent object output is collapsed.
- Persist collapse state per `nodeId + outputHandleId` in the FlowEditor store.
- Add unit tests covering output visibility/collapse behavior.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `pnpm lint`
  - [x] `pnpm test:unit`
  - [x] Manual UI verification:
    - [x] Open `/build` (FlowEditor) and add **Execute Code** block
    - [x] Confirm `Main Result (object)` is collapsed by default and shows a chevron + hidden count
    - [x] Expand `Main Result` and verify sub-outputs appear
    - [x] Connect one `Main Result.*` sub-output, collapse parent, verify connected output remains visible

#### For configuration changes:
- [x] `.env.default` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes
- [x] I have included a list of my configuration changes in the PR description (under **Changes**)

Configuration changes:
- None (frontend-only UI behavior change)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds collapse/expand behavior for unconnected object sub-outputs in the FlowEditor, reducing visual clutter on the canvas. It also adds env var overrides for the `NEW_FLOW_EDITOR` and `BUILDER_VIEW_SWITCH` feature flags.

- Introduces `output-visibility.ts` — a well-structured pure-function module that builds a visibility tree from output schemas, accounting for collapse state and connected edges
- Refactors `OutputHandler.tsx` to use the new tree-based rendering with expand/collapse chevrons and hidden-child counts
- Adds `nodeOutputCollapsedStates` to the Zustand `nodeStore` with `set`, `toggle`, and `get` actions (defaults to collapsed)
- Adds unit tests (`output-visibility.test.tsx`) covering core visibility scenarios
- Modifies feature flag defaults to allow env var overrides for `NEW_FLOW_EDITOR` and `BUILDER_VIEW_SWITCH`

The logic separation into `output-visibility.ts` is clean and testable. The main areas to watch are the edge store subscription granularity (subscribes to all edges rather than node-specific ones) and the feature flag default changes which also affect Playwright mock mode.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

- This PR is safe to merge — the core logic is well-tested and the changes are frontend-only with no data model impact.
- Score of 4 reflects well-structured code with clean logic separation and unit tests covering key scenarios. Minor deductions for: subscribing to the full edges array (performance consideration, though consistent with prior behavior), redundant collapsed-state lookup logic, and subtle feature flag behavior change in Playwright mock mode. None of these are blockers.
- Pay attention to `use-get-flag.ts` — the default flag changes also affect Playwright mock mode behavior if the new env vars are set in CI.
</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[OutputHandler Component] -->|reads| B[edgeStore.edges]
    A -->|reads| C[nodeStore.nodeOutputCollapsedStates]
    A -->|calls| D[buildVisibleOutputTree]
    D -->|step 1| E[buildOutputTree - Parse schema into tree]
    D -->|step 2| F[buildVisibleNode - Apply collapse and connection logic]
    E -->|produces| G[OutputTreeNode list]
    G -->|input to| F
    F -->|produces| H[VisibleOutputTreeNode list]
    H -->|rendered by| I[renderOutputNode]
    I -->|if object with children| J[Show chevron toggle]
    I -->|if collapsed with hidden| K[Show hidden count badge]
    I -->|recursively render| L[Visible children]
    J -->|onClick| M[nodeStore.toggleOutputCollapsed]
    M -->|updates| C
```
</details>


<sub>Last reviewed commit: f5aba01</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context from `dashboard` - autogpt_platform/CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=6e9dc5dc-8942-47df-8677-e60062ec8c3a))
- Context from `dashboard` - autogpt_platform/frontend/CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=39861924-d320-41ba-a1a7-a8bff44f780a))
- Context from `dashboard` - autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/ARCHITECTURE_FLOW_EDITOR.md ([source](https://app.greptile.com/review/custom-context?memory=0c5511fe-9aeb-4cf1-bbe9-798f2093b748))
</details>


<!-- /greptile_comment -->