### PR TITLE
fix(copilot): Remove description from feature request search, add PII prevention

### DIFF
--- a/autogpt_platform/backend/backend/copilot/tools/feature_requests.py
+++ b/autogpt_platform/backend/backend/copilot/tools/feature_requests.py
@@ -33,7 +33,6 @@ query SearchFeatureRequests($term: String!, $filter: IssueFilter, $first: Int) {
       id
       identifier
       title
-      description
     }
   }
 }
@@ -205,7 +204,6 @@ class SearchFeatureRequestsTool(BaseTool):
                     id=node["id"],
                     identifier=node["identifier"],
                     title=node["title"],
-                    description=node.get("description"),
                 )
                 for node in nodes
             ]
@@ -239,7 +237,11 @@ class CreateFeatureRequestTool(BaseTool):
             "Create a new feature request or add a customer need to an existing one. "
             "Always search first with search_feature_requests to avoid duplicates. "
             "If a matching request exists, pass its ID as existing_issue_id to add "
-            "the user's need to it instead of creating a duplicate."
+            "the user's need to it instead of creating a duplicate. "
+            "IMPORTANT: Never include personally identifiable information (PII) in "
+            "the title or description — no names, emails, phone numbers, company "
+            "names, or other identifying details. Write titles and descriptions in "
+            "generic, feature-focused language."
         )
 
     @property
@@ -249,11 +251,20 @@ class CreateFeatureRequestTool(BaseTool):
             "properties": {
                 "title": {
                     "type": "string",
-                    "description": "Title for the feature request.",
+                    "description": (
+                        "Title for the feature request. Must be generic and "
+                        "feature-focused — do not include any user names, emails, "
+                        "company names, or other PII."
+                    ),
                 },
                 "description": {
                     "type": "string",
-                    "description": "Detailed description of what the user wants and why.",
+                    "description": (
+                        "Detailed description of what the user wants and why. "
+                        "Must not contain any personally identifiable information "
+                        "(PII) — describe the feature need generically without "
+                        "referencing specific users, companies, or contact details."
+                    ),
                 },
                 "existing_issue_id": {
                     "type": "string",

--- a/autogpt_platform/backend/backend/copilot/tools/feature_requests_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/feature_requests_test.py
@@ -117,13 +117,11 @@ class TestSearchFeatureRequestsTool:
                 "id": "id-1",
                 "identifier": "FR-1",
                 "title": "Dark mode",
-                "description": "Add dark mode support",
             },
             {
                 "id": "id-2",
                 "identifier": "FR-2",
                 "title": "Dark theme",
-                "description": None,
             },
         ]
         patcher, _ = _mock_linear_config(query_return=_search_response(nodes))

--- a/autogpt_platform/backend/backend/copilot/tools/models.py
+++ b/autogpt_platform/backend/backend/copilot/tools/models.py
@@ -486,7 +486,6 @@ class FeatureRequestInfo(BaseModel):
     id: str
     identifier: str
     title: str
-    description: str | None = None
 
 
 class FeatureRequestSearchResponse(ToolResponseBase):


### PR DESCRIPTION
Two targeted changes to the CoPilot feature request tools:

1. **Remove description from search results** — The `search_feature_requests` tool no longer returns issue descriptions. Only the title is needed for duplicate detection, reducing unnecessary data exposure.

2. **Prevent PII in created issues** — Updated the `create_feature_request` tool description and parameter descriptions to explicitly instruct the LLM to never include personally identifiable information (names, emails, company names, etc.) in Linear issue titles and descriptions.

Resolves [SECRT-2010](https://linear.app/autogpt/issue/SECRT-2010)