### PR TITLE
Update credential error message to guide LLM behavior

### DIFF
--- a/autogpt_platform/backend/backend/copilot/tools/run_block.py
+++ b/autogpt_platform/backend/backend/copilot/tools/run_block.py
@@ -202,8 +202,11 @@ class RunBlockTool(BaseTool):
 
             return SetupRequirementsResponse(
                 message=(
-                    f"Block '{block.name}' requires credentials that are not configured. "
-                    "Please set up the required credentials before running this block."
+                    f"Block '{block.name}' requires credentials that the user has not yet connected. "
+                    "A sign-in button has appeared in the chat for the user to connect their account. "
+                    "STOP HERE and tell the user to click the sign-in button shown above in the chat. "
+                    "Do NOT send further messages, suggest workarounds, or direct them to settings. "
+                    "Wait for the user to complete sign-in before continuing."
                 ),
                 session_id=session_id,
                 setup_info=SetupInfo(


### PR DESCRIPTION
When a block requires credentials the user hasn't connected, the tool response now tells the LLM that a sign-in button is visible in the chat UI, and instructs it to stop and wait rather than suggesting workarounds or directing users to settings.

This message is never shown to the end user — the frontend suppresses the raw tool response and shows the `ChatCredentialsSetup` widget instead. The directive language speaks directly to the LLM so it knows what the user is seeing and how to behave.

**File changed:** `autogpt_platform/backend/backend/copilot/tools/run_block.py` (lines 204-209)

Resolves [SECRT-2011](https://linear.app/autogpt/issue/SECRT-2011)