### PR TITLE
Make CoPilot todo/task list card expanded by default

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/copilot/tools/GenericTool/GenericTool.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/tools/GenericTool/GenericTool.tsx
@@ -704,6 +704,7 @@ export function GenericTool({ part }: Props) {
           title={accordionData.title}
           description={accordionData.description}
           titleClassName={isError ? "text-red-500" : undefined}
+          defaultExpanded={category === "todo"}
         >
           {accordionData.content}
         </ToolAccordion>


### PR DESCRIPTION
The todo card rendered by GenericTool was collapsed by default, requiring users to click to see their checklist items. Now passes `defaultExpanded` when the category is `"todo"` so the task list is immediately visible.

**File changed:** `autogpt_platform/frontend/src/app/(platform)/copilot/tools/GenericTool/GenericTool.tsx`

Resolves [SECRT-2017](https://linear.app/autogpt/issue/SECRT-2017)