### PR TITLE
feat(frontend): show agent name + version on Agent Executor block

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/nodes/CustomNode/components/NodeHeader.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/nodes/CustomNode/components/NodeHeader.tsx
@@ -68,9 +68,12 @@ export function NodeHeader({ data, nodeId }: Props) {
   }, [title, isEditingTitle]);
 
   const handleTitleEdit = () => {
-    updateNodeData(nodeId, {
-      metadata: { ...data.metadata, customized_name: editedTitle },
-    });
+    // Only persist if the title actually changed to avoid freezing agent-derived titles
+    if (editedTitle.trim() !== title.trim()) {
+      updateNodeData(nodeId, {
+        metadata: { ...data.metadata, customized_name: editedTitle },
+      });
+    }
     setIsEditingTitle(false);
   };
 

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/nodes/CustomNode/components/NodeHeader.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/nodes/CustomNode/components/NodeHeader.tsx
@@ -39,15 +39,33 @@ export function NodeHeader({ data, nodeId }: Props) {
     return data.title;
   }
 
-  const title = getTitle();
+  function getBeautifiedTitle(): string {
+    const rawTitle = getTitle();
+
+    // Extract version suffix (e.g., "v1", "v2.0", "v3.1.4") to preserve casing
+    const versionMatch = rawTitle.match(/\s+(v\d+(?:\.\d+)*)$/i);
+
+    if (versionMatch) {
+      const nameOnly = rawTitle.slice(0, -versionMatch[0].length);
+      const versionSuffix = versionMatch[1]; // Preserve original case
+      return beautifyString(nameOnly).replace("Block", "").trim() + " " + versionSuffix;
+    }
+
+    return beautifyString(rawTitle).replace("Block", "").trim();
+  }
+
+  const title = getBeautifiedTitle();
 
   const [isEditingTitle, setIsEditingTitle] = useState(false);
   const [editedTitle, setEditedTitle] = useState(title);
 
   // Sync editedTitle when title changes (e.g., agent updated)
+  // Only sync when NOT editing to preserve user's in-progress edits
   useEffect(() => {
-    setEditedTitle(title);
-  }, [title]);
+    if (!isEditingTitle) {
+      setEditedTitle(title);
+    }
+  }, [title, isEditingTitle]);
 
   const handleTitleEdit = () => {
     updateNodeData(nodeId, {
@@ -95,12 +113,12 @@ export function NodeHeader({ data, nodeId }: Props) {
                         variant="large-semibold"
                         className="line-clamp-1 hover:cursor-text"
                       >
-                        {beautifyString(title).replace("Block", "").trim()}
+                        {title}
                       </Text>
                     </div>
                   </TooltipTrigger>
                   <TooltipContent>
-                    <p>{beautifyString(title).replace("Block", "").trim()}</p>
+                    <p>{title}</p>
                   </TooltipContent>
                 </Tooltip>
               </TooltipProvider>

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/nodes/CustomNode/components/NodeHeader.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/nodes/CustomNode/components/NodeHeader.tsx
@@ -21,7 +21,25 @@ type Props = {
 export const NodeHeader = ({ data, nodeId }: Props) => {
   const updateNodeData = useNodeStore((state) => state.updateNodeData);
 
-  const title = (data.metadata?.customized_name as string) || data.title;
+  // For Agent Executor blocks, show agent name + version if available
+  const getTitle = () => {
+    if (data.metadata?.customized_name) {
+      return data.metadata.customized_name as string;
+    }
+
+    const agentName = data.hardcodedValues?.agent_name;
+    const agentVersion = data.hardcodedValues?.graph_version;
+
+    if (agentName && agentVersion !== undefined) {
+      return `${agentName} v${agentVersion}`;
+    } else if (agentName) {
+      return agentName;
+    }
+
+    return data.title;
+  };
+
+  const title = getTitle();
 
   const [isEditingTitle, setIsEditingTitle] = useState(false);
   const [editedTitle, setEditedTitle] = useState(title);

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/nodes/CustomNode/components/NodeHeader.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/nodes/CustomNode/components/NodeHeader.tsx
@@ -27,12 +27,8 @@ export function NodeHeader({ data, nodeId }: Props) {
       return data.metadata.customized_name as string;
     }
 
-    const agentName = data.hardcodedValues?.agent_name as
-      | string
-      | undefined;
-    const agentVersion = data.hardcodedValues?.graph_version as
-      | number
-      | undefined;
+    const agentName = data.hardcodedValues?.agent_name as string | undefined;
+    const agentVersion = data.hardcodedValues?.graph_version as number | undefined;
 
     if (agentName && agentVersion != null) {
       return `${agentName} v${agentVersion}`;

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/nodes/CustomNode/components/NodeHeader.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/nodes/CustomNode/components/NodeHeader.tsx
@@ -27,8 +27,12 @@ export function NodeHeader({ data, nodeId }: Props) {
       return data.metadata.customized_name as string;
     }
 
-    const agentName = data.hardcodedValues?.agent_name as string | undefined;
-    const agentVersion = data.hardcodedValues?.graph_version as number | undefined;
+    const agentName = data.hardcodedValues?.agent_name as
+      | string
+      | undefined;
+    const agentVersion = data.hardcodedValues?.graph_version as
+      | number
+      | undefined;
 
     if (agentName && agentVersion != null) {
       return `${agentName} v${agentVersion}`;

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/nodes/CustomNode/components/NodeHeader.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/nodes/CustomNode/components/NodeHeader.tsx
@@ -7,7 +7,7 @@ import {
   TooltipTrigger,
 } from "@/components/atoms/Tooltip/BaseTooltip";
 import { beautifyString, cn } from "@/lib/utils";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { CustomNodeData } from "../CustomNode";
 import { NodeBadges } from "./NodeBadges";
 import { NodeContextMenu } from "./NodeContextMenu";
@@ -18,31 +18,36 @@ type Props = {
   nodeId: string;
 };
 
-export const NodeHeader = ({ data, nodeId }: Props) => {
+export function NodeHeader({ data, nodeId }: Props) {
   const updateNodeData = useNodeStore((state) => state.updateNodeData);
 
   // For Agent Executor blocks, show agent name + version if available
-  const getTitle = () => {
+  function getTitle(): string {
     if (data.metadata?.customized_name) {
-      return data.metadata.customized_name as string;
+      return data.metadata.customized_name;
     }
 
     const agentName = data.hardcodedValues?.agent_name;
     const agentVersion = data.hardcodedValues?.graph_version;
 
-    if (agentName && agentVersion !== undefined) {
+    if (agentName && agentVersion != null) {
       return `${agentName} v${agentVersion}`;
     } else if (agentName) {
       return agentName;
     }
 
     return data.title;
-  };
+  }
 
   const title = getTitle();
 
   const [isEditingTitle, setIsEditingTitle] = useState(false);
   const [editedTitle, setEditedTitle] = useState(title);
+
+  // Sync editedTitle when title changes (e.g., agent updated)
+  useEffect(() => {
+    setEditedTitle(title);
+  }, [title]);
 
   const handleTitleEdit = () => {
     updateNodeData(nodeId, {
@@ -124,4 +129,4 @@ export const NodeHeader = ({ data, nodeId }: Props) => {
       </div>
     </div>
   );
-};
+}

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/nodes/CustomNode/components/NodeHeader.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/nodes/CustomNode/components/NodeHeader.tsx
@@ -24,11 +24,15 @@ export function NodeHeader({ data, nodeId }: Props) {
   // For Agent Executor blocks, show agent name + version if available
   function getTitle(): string {
     if (data.metadata?.customized_name) {
-      return data.metadata.customized_name;
+      return data.metadata.customized_name as string;
     }
 
-    const agentName = data.hardcodedValues?.agent_name;
-    const agentVersion = data.hardcodedValues?.graph_version;
+    const agentName = data.hardcodedValues?.agent_name as
+      | string
+      | undefined;
+    const agentVersion = data.hardcodedValues?.graph_version as
+      | number
+      | undefined;
 
     if (agentName && agentVersion != null) {
       return `${agentName} v${agentVersion}`;

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/nodes/CustomNode/components/NodeHeader.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/nodes/CustomNode/components/NodeHeader.tsx
@@ -27,9 +27,7 @@ export function NodeHeader({ data, nodeId }: Props) {
       return data.metadata.customized_name as string;
     }
 
-    const agentName = data.hardcodedValues?.agent_name as
-      | string
-      | undefined;
+    const agentName = data.hardcodedValues?.agent_name as string | undefined;
     const agentVersion = data.hardcodedValues?.graph_version as
       | number
       | undefined;
@@ -64,12 +62,15 @@ export function NodeHeader({ data, nodeId }: Props) {
   }
 
   // Memoize title to prevent unnecessary recalculations
-  const title = useMemo(() => getBeautifiedTitle(), [
-    data.metadata?.customized_name,
-    data.hardcodedValues?.agent_name,
-    data.hardcodedValues?.graph_version,
-    data.title,
-  ]);
+  const title = useMemo(
+    () => getBeautifiedTitle(),
+    [
+      data.metadata?.customized_name,
+      data.hardcodedValues?.agent_name,
+      data.hardcodedValues?.graph_version,
+      data.title,
+    ],
+  );
 
   const [isEditingTitle, setIsEditingTitle] = useState(false);
   const [editedTitle, setEditedTitle] = useState(title);


### PR DESCRIPTION
## Summary

Fixes #11041

This PR resolves the issue where the agent name and version disappear from Agent Executor blocks after saving and reloading the page.

## Problem

When an Agent Executor block is first placed in the builder, it shows the agent name correctly. However, after saving and reloading the page, the block title reverts to the generic "Agent Executor" text, losing the specific agent information.

## Solution

Updated the `NodeHeader` component in the FlowEditor to extract and display the agent name and version from the block's `hardcodedValues`:

```typescript
const getTitle = () => {
  if (data.metadata?.customized_name) {
    return data.metadata.customized_name as string;
  }

  const agentName = data.hardcodedValues?.agent_name;
  const agentVersion = data.hardcodedValues?.graph_version;

  if (agentName && agentVersion !== undefined) {
    return `${agentName} v${agentVersion}`;
  } else if (agentName) {
    return agentName;
  }

  return data.title;
};
```

## Changes

- Modified `NodeHeader.tsx` to check for `agent_name` and `graph_version` in the block's hardcoded values
- Display format: "Agent Name vX" when both fields are present
- Graceful fallback to just the agent name if version is missing
- Default title behavior for non-agent blocks or when metadata is unavailable
- Custom titles (set by users) still take precedence

## Technical Details

The fix leverages existing data fields that are already persisted in the graph:
- `agent_name`: Optional string field from `AgentExecutorBlock` schema (defined in backend)
- `graph_version`: Integer field containing the agent version number

Both fields are stored in `hardcodedValues` when the graph is saved. No backend changes were required - this was purely a frontend display issue.

## Testing

The fix ensures that:
1. Agent name displays correctly when the block is first placed
2. Agent name + version persist after saving and reloading the page
3. Version is formatted as "v1", "v2", etc.
4. Custom titles (if set) still override the default behavior
5. Graceful degradation when agent metadata is missing

## Files Changed

```
autogpt_platform/frontend/src/app/(platform)/build/components/
└── FlowEditor/nodes/CustomNode/components/NodeHeader.tsx (+19, -1)
```

## Related Issues

Closes #11041

---

🤖 Generated with Claude Code