### PR TITLE
fix(backend): standardize microservice host/port configuration

### DIFF
--- a/autogpt_platform/backend/.env.default
+++ b/autogpt_platform/backend/.env.default
@@ -192,3 +192,8 @@ POSTHOG_HOST=https://eu.i.posthog.com
 
 # Other Services
 AUTOMOD_API_KEY=
+
+# Agent Generator Service
+# The Agent Generator microservice handles AI-powered agent creation from natural language
+AGENTGENERATOR_HOST=localhost
+AGENTGENERATOR_PORT=8009

--- a/autogpt_platform/backend/backend/util/settings.py
+++ b/autogpt_platform/backend/backend/util/settings.py
@@ -364,11 +364,11 @@ class Config(UpdateTrackingModel["Config"], BaseSettings):
     )
 
     agentgenerator_host: str = Field(
-        default="",
-        description="The host for the Agent Generator service (empty to use built-in)",
+        default="localhost",
+        description="The host for the Agent Generator service",
     )
     agentgenerator_port: int = Field(
-        default=8000,
+        default=8009,
         description="The port for the Agent Generator service",
     )
     agentgenerator_timeout: int = Field(


### PR DESCRIPTION
## Summary

This PR fixes inconsistencies in microservice host and port configuration defaults in `settings.py` and `.env.default`.

### Changes Made

1. **Agent Generator Host Configuration**
   - Changed `agentgenerator_host` default from `""` (empty) to `"localhost"`
   - Makes it consistent with other client services: `rabbitmq_host`, `redis_host`, `clamav_service_host`
   - Fixes the `service_not_configured` error when only `AGENTGENERATOR_PORT` is set

2. **Agent Generator Port Configuration**
   - Changed `agentgenerator_port` default from `8000` to `8009`
   - Avoids conflict with Kong gateway (which uses port 8000)
   - Follows the sequential port allocation pattern for internal services (8001-8008)

3. **Environment File Updates**
   - Added `AGENTGENERATOR_HOST=localhost` to `.env.default` for clarity
   - Added documentation comment explaining the Agent Generator service

### Configuration Pattern Analysis

**Client Services (connect TO external services):**
- Use `"localhost"` as default host
- Examples: `rabbitmq_host`, `redis_host`, `clamav_service_host`, **`agentgenerator_host`**

**Server Services (LISTEN on all interfaces):**
- Use `"0.0.0.0"` as default host
- Examples: `websocket_server_host`, `agent_api_host`

**Port Allocation:**
- 8001: websocket_server
- 8002: execution_manager
- 8003: execution_scheduler
- 8005: database_api
- 8006: agent_api
- 8007: notification_service
- 8008: copilot_executor
- **8009: agentgenerator** (NEW - avoids 8000 Kong conflict)

### Impact

- **Breaking Change**: Minimal - only affects users who haven't explicitly set `AGENTGENERATOR_HOST` or `AGENTGENERATOR_PORT`
- **Bug Fix**: Resolves "service_not_configured" error when trying to use Agent Generator with only port configured
- **Consistency**: Aligns with established patterns for other microservice configurations

### Testing

- ✅ All existing tests pass (24/24 in `test/agent_generator/test_service.py`)
- ✅ Pre-commit hooks pass
- Configuration logic properly handles new defaults

## Motivation

User reported getting `service_not_configured` error even after setting `AGENTGENERATOR_PORT=8009`. Investigation revealed:
1. The check `bool(settings.config.agentgenerator_host)` returns `False` when host is empty string
2. Port 8000 conflicts with Kong gateway
3. Inconsistent patterns across microservice configurations

This PR standardizes the configuration to follow established patterns and avoid conflicts.