### PR TITLE
fix(test): backdate UserBalance.updatedAt in test_block_credit_reset

### DIFF
--- a/autogpt_platform/backend/backend/data/credit_test.py
+++ b/autogpt_platform/backend/backend/data/credit_test.py
@@ -178,9 +178,13 @@ async def test_block_credit_reset(server: SpinTestServer):
         assert month2_balance == 1100  # Balance persists, no reset
 
         # Now test the refill behavior when balance is low
-        # Set balance below refill threshold
+        # Set balance below refill threshold and backdate updatedAt to month2 so
+        # the month3 refill check sees a different (month2 → month3) transition.
+        # Without the explicit updatedAt, Prisma sets it to real-world NOW which
+        # may share the same calendar month as the mocked month3, suppressing refill.
         await UserBalance.prisma().update(
-            where={"userId": DEFAULT_USER_ID}, data={"balance": 400}
+            where={"userId": DEFAULT_USER_ID},
+            data={"balance": 400, "updatedAt": month2},
         )
 
         # Create a month 2 transaction to update the last transaction time


### PR DESCRIPTION
## Root cause

The test constructs `month3` using `datetime.now().replace(month=3, day=1)` — hardcoded to **March of the real current year**. When `update(balance=400)` runs, Prisma auto-sets `updatedAt` to the **real wall-clock time**.

The refill guard in `BetaUserCredit.get_credits` is:
```python
if (snapshot_time.year, snapshot_time.month) == (cur_time.year, cur_time.month):
    return balance  # same month → skip refill
```

This means the test only fails when run **during the real month of March**, because the mocked `month3` and the real `updatedAt` both land in March:

| Test runs in | `snapshot_time` (real `updatedAt`) | `cur_time` (mocked month3) | Same? | Result |
|---|---|---|---|---|
| January 2026 | `(2026, 1)` | `(2026, 3)` | ❌ | refill triggers ✅ |
| February 2026 | `(2026, 2)` | `(2026, 3)` | ❌ | refill triggers ✅ |
| **March 2026** | **`(2026, 3)`** | **`(2026, 3)`** | **✅** | **skips refill ❌** |
| April 2026 | `(2026, 4)` | `(2026, 3)` | ❌ | refill triggers ✅ |

It would silently pass again in April, then fail again next March 2027.

## Fix

Explicitly pass `updatedAt=month2` when updating the balance to 400, so the month2→month3 transition is correctly detected regardless of when the test actually runs. This matches the existing pattern used earlier in the same test for the month1 setup.

## Test plan
- [ ] `pytest backend/data/credit_test.py::test_block_credit_reset` passes
- [ ] No other credit tests broken