### PR TITLE
feat: add 19 Citedy SEO Content Autopilot graph templates

### DIFF
--- a/autogpt_platform/graph_templates/citedy-gap-to-publish.agent.json
+++ b/autogpt_platform/graph_templates/citedy-gap-to-publish.agent.json
@@ -1,0 +1,606 @@
+{
+  "id": "f584bc38-4430-4113-a66e-3681ec4b2747",
+  "version": 1,
+  "is_active": true,
+  "name": "Citedy Gap Generator",
+  "description": "Generate competitor content gaps.",
+  "instructions": null,
+  "recommended_schedule_cron": null,
+  "nodes": [
+    {
+      "id": "bf157213-fe15-431d-ac0e-ea757f2794cf",
+      "block_id": "7fcd3bcb-8e1b-4e69-903d-32d3d4a92158",
+      "input_default": {
+        "name": "API Key",
+        "title": null,
+        "value": "citedy_agent_replace_me",
+        "secret": true,
+        "advanced": false,
+        "description": "Citedy API key (starts with citedy_agent_)",
+        "placeholder_values": []
+      },
+      "metadata": {
+        "position": {
+          "x": -920,
+          "y": -80
+        }
+      },
+      "input_links": [],
+      "output_links": [
+        {
+          "id": "38c5edff-f659-4be6-9563-c6f2e58876f4",
+          "source_id": "bf157213-fe15-431d-ac0e-ea757f2794cf",
+          "sink_id": "0a647e32-84e9-4e7a-a4fc-fc982db8c83c",
+          "source_name": "result",
+          "sink_name": "values_#_api_key",
+          "is_static": false
+        }
+      ],
+      "graph_id": "f584bc38-4430-4113-a66e-3681ec4b2747",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "2a8bd1e1-43c9-4878-bf5c-3b1320734c8d",
+      "block_id": "90a56ffb-7024-4b2b-ab50-e26c5e5ab8ba",
+      "input_default": {
+        "name": "Request JSON",
+        "title": null,
+        "value": "{\n  \"competitor_urls\": [\n    \"https://example1.com\",\n    \"https://example2.com\"\n  ]\n}",
+        "secret": false,
+        "advanced": false,
+        "description": "JSON payload for this endpoint.",
+        "placeholder_values": []
+      },
+      "metadata": {
+        "position": {
+          "x": -920,
+          "y": 220
+        }
+      },
+      "input_links": [],
+      "output_links": [
+        {
+          "id": "fac1667d-3e06-448b-9538-dd4a17a9253d",
+          "source_id": "2a8bd1e1-43c9-4878-bf5c-3b1320734c8d",
+          "sink_id": "a001bb46-fe19-4f53-97d8-299929a024fa",
+          "source_name": "result",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "graph_id": "f584bc38-4430-4113-a66e-3681ec4b2747",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "0a647e32-84e9-4e7a-a4fc-fc982db8c83c",
+      "block_id": "b924ddf4-de4f-4b56-9a85-358930dcbc91",
+      "input_default": {
+        "values": {}
+      },
+      "metadata": {
+        "position": {
+          "x": -520,
+          "y": -80
+        }
+      },
+      "input_links": [
+        {
+          "id": "38c5edff-f659-4be6-9563-c6f2e58876f4",
+          "source_id": "bf157213-fe15-431d-ac0e-ea757f2794cf",
+          "sink_id": "0a647e32-84e9-4e7a-a4fc-fc982db8c83c",
+          "source_name": "result",
+          "sink_name": "values_#_api_key",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "ba9d935e-0ec3-4170-9e08-aff752f7da09",
+          "source_id": "0a647e32-84e9-4e7a-a4fc-fc982db8c83c",
+          "sink_id": "178cfbbe-4496-4048-8657-a1a23f12c2c4",
+          "source_name": "dictionary",
+          "sink_name": "values",
+          "is_static": false
+        }
+      ],
+      "graph_id": "f584bc38-4430-4113-a66e-3681ec4b2747",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "178cfbbe-4496-4048-8657-a1a23f12c2c4",
+      "block_id": "db7d8f02-2f44-4c55-ab7a-eae0941f0c30",
+      "input_default": {
+        "format": "{\"Authorization\":\"Bearer {{ api_key }}\",\"Content-Type\":\"application/json\"}",
+        "values": {},
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": -140,
+          "y": -80
+        }
+      },
+      "input_links": [
+        {
+          "id": "ba9d935e-0ec3-4170-9e08-aff752f7da09",
+          "source_id": "0a647e32-84e9-4e7a-a4fc-fc982db8c83c",
+          "sink_id": "178cfbbe-4496-4048-8657-a1a23f12c2c4",
+          "source_name": "dictionary",
+          "sink_name": "values",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "341b5280-5b24-4865-a4db-7b0a4c2c374e",
+          "source_id": "178cfbbe-4496-4048-8657-a1a23f12c2c4",
+          "sink_id": "f3bd9321-6a6a-40ad-81c6-c3b0998beccb",
+          "source_name": "output",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "graph_id": "f584bc38-4430-4113-a66e-3681ec4b2747",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "f3bd9321-6a6a-40ad-81c6-c3b0998beccb",
+      "block_id": "95d1b990-ce13-4d88-9737-ba5c2070c97b",
+      "input_default": {
+        "type": "dictionary",
+        "value": null
+      },
+      "metadata": {
+        "position": {
+          "x": 180,
+          "y": -80
+        }
+      },
+      "input_links": [
+        {
+          "id": "341b5280-5b24-4865-a4db-7b0a4c2c374e",
+          "source_id": "178cfbbe-4496-4048-8657-a1a23f12c2c4",
+          "sink_id": "f3bd9321-6a6a-40ad-81c6-c3b0998beccb",
+          "source_name": "output",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "4eaf078a-66ed-4ecb-b86a-6fc80350594d",
+          "source_id": "f3bd9321-6a6a-40ad-81c6-c3b0998beccb",
+          "sink_id": "69b74f87-52c1-49f6-a6c6-089026de148b",
+          "source_name": "value",
+          "sink_name": "headers",
+          "is_static": false
+        }
+      ],
+      "graph_id": "f584bc38-4430-4113-a66e-3681ec4b2747",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "a001bb46-fe19-4f53-97d8-299929a024fa",
+      "block_id": "95d1b990-ce13-4d88-9737-ba5c2070c97b",
+      "input_default": {
+        "type": "dictionary",
+        "value": null
+      },
+      "metadata": {
+        "position": {
+          "x": -140,
+          "y": 220
+        }
+      },
+      "input_links": [
+        {
+          "id": "fac1667d-3e06-448b-9538-dd4a17a9253d",
+          "source_id": "2a8bd1e1-43c9-4878-bf5c-3b1320734c8d",
+          "sink_id": "a001bb46-fe19-4f53-97d8-299929a024fa",
+          "source_name": "result",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "a10eeb89-1297-48cf-9fb6-381b17e30c01",
+          "source_id": "a001bb46-fe19-4f53-97d8-299929a024fa",
+          "sink_id": "69b74f87-52c1-49f6-a6c6-089026de148b",
+          "source_name": "value",
+          "sink_name": "body",
+          "is_static": false
+        }
+      ],
+      "graph_id": "f584bc38-4430-4113-a66e-3681ec4b2747",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "69b74f87-52c1-49f6-a6c6-089026de148b",
+      "block_id": "6595ae1f-b924-42cb-9a41-551a0611c4b4",
+      "input_default": {
+        "url": "https://www.citedy.com/api/agent/gaps/generate",
+        "method": "POST",
+        "headers": {},
+        "json_format": true,
+        "body": null,
+        "files_name": "file",
+        "files": []
+      },
+      "metadata": {
+        "position": {
+          "x": 560,
+          "y": 70
+        }
+      },
+      "input_links": [
+        {
+          "id": "4eaf078a-66ed-4ecb-b86a-6fc80350594d",
+          "source_id": "f3bd9321-6a6a-40ad-81c6-c3b0998beccb",
+          "sink_id": "69b74f87-52c1-49f6-a6c6-089026de148b",
+          "source_name": "value",
+          "sink_name": "headers",
+          "is_static": false
+        },
+        {
+          "id": "a10eeb89-1297-48cf-9fb6-381b17e30c01",
+          "source_id": "a001bb46-fe19-4f53-97d8-299929a024fa",
+          "sink_id": "69b74f87-52c1-49f6-a6c6-089026de148b",
+          "source_name": "value",
+          "sink_name": "body",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "e7cd37ee-7c9e-4475-9128-a97257185891",
+          "source_id": "69b74f87-52c1-49f6-a6c6-089026de148b",
+          "sink_id": "be458382-d627-4135-9664-509f326d8191",
+          "source_name": "response",
+          "sink_name": "value",
+          "is_static": false
+        },
+        {
+          "id": "80479b61-ef49-4520-a9fc-2b621d86f734",
+          "source_id": "69b74f87-52c1-49f6-a6c6-089026de148b",
+          "sink_id": "d8b0ba07-7800-4a03-b983-6ff216e894d9",
+          "source_name": "client_error",
+          "sink_name": "value",
+          "is_static": false
+        },
+        {
+          "id": "eb144a58-0b14-4cca-9d2b-69154b19528e",
+          "source_id": "69b74f87-52c1-49f6-a6c6-089026de148b",
+          "sink_id": "7f8b867a-7fec-4709-b3e9-72d30abfa0e9",
+          "source_name": "server_error",
+          "sink_name": "value",
+          "is_static": false
+        },
+        {
+          "id": "6c11ea2e-5879-4bb3-9834-a06f0a23b12f",
+          "source_id": "69b74f87-52c1-49f6-a6c6-089026de148b",
+          "sink_id": "da51b44b-01d8-4d5e-a5b0-7284fc3fa4b6",
+          "source_name": "error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "graph_id": "f584bc38-4430-4113-a66e-3681ec4b2747",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "be458382-d627-4135-9664-509f326d8191",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "response",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "Successful API response payload.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": -160
+        }
+      },
+      "input_links": [
+        {
+          "id": "e7cd37ee-7c9e-4475-9128-a97257185891",
+          "source_id": "69b74f87-52c1-49f6-a6c6-089026de148b",
+          "sink_id": "be458382-d627-4135-9664-509f326d8191",
+          "source_name": "response",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "f584bc38-4430-4113-a66e-3681ec4b2747",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "d8b0ba07-7800-4a03-b983-6ff216e894d9",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "client_error",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "HTTP 4xx response payload.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": 20
+        }
+      },
+      "input_links": [
+        {
+          "id": "80479b61-ef49-4520-a9fc-2b621d86f734",
+          "source_id": "69b74f87-52c1-49f6-a6c6-089026de148b",
+          "sink_id": "d8b0ba07-7800-4a03-b983-6ff216e894d9",
+          "source_name": "client_error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "f584bc38-4430-4113-a66e-3681ec4b2747",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "7f8b867a-7fec-4709-b3e9-72d30abfa0e9",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "server_error",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "HTTP 5xx response payload.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": 200
+        }
+      },
+      "input_links": [
+        {
+          "id": "eb144a58-0b14-4cca-9d2b-69154b19528e",
+          "source_id": "69b74f87-52c1-49f6-a6c6-089026de148b",
+          "sink_id": "7f8b867a-7fec-4709-b3e9-72d30abfa0e9",
+          "source_name": "server_error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "f584bc38-4430-4113-a66e-3681ec4b2747",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "da51b44b-01d8-4d5e-a5b0-7284fc3fa4b6",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "error",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "Transport/runtime error output.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": 380
+        }
+      },
+      "input_links": [
+        {
+          "id": "6c11ea2e-5879-4bb3-9834-a06f0a23b12f",
+          "source_id": "69b74f87-52c1-49f6-a6c6-089026de148b",
+          "sink_id": "da51b44b-01d8-4d5e-a5b0-7284fc3fa4b6",
+          "source_name": "error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "f584bc38-4430-4113-a66e-3681ec4b2747",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    }
+  ],
+  "links": [
+    {
+      "id": "38c5edff-f659-4be6-9563-c6f2e58876f4",
+      "source_id": "bf157213-fe15-431d-ac0e-ea757f2794cf",
+      "sink_id": "0a647e32-84e9-4e7a-a4fc-fc982db8c83c",
+      "source_name": "result",
+      "sink_name": "values_#_api_key",
+      "is_static": false
+    },
+    {
+      "id": "ba9d935e-0ec3-4170-9e08-aff752f7da09",
+      "source_id": "0a647e32-84e9-4e7a-a4fc-fc982db8c83c",
+      "sink_id": "178cfbbe-4496-4048-8657-a1a23f12c2c4",
+      "source_name": "dictionary",
+      "sink_name": "values",
+      "is_static": false
+    },
+    {
+      "id": "341b5280-5b24-4865-a4db-7b0a4c2c374e",
+      "source_id": "178cfbbe-4496-4048-8657-a1a23f12c2c4",
+      "sink_id": "f3bd9321-6a6a-40ad-81c6-c3b0998beccb",
+      "source_name": "output",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "fac1667d-3e06-448b-9538-dd4a17a9253d",
+      "source_id": "2a8bd1e1-43c9-4878-bf5c-3b1320734c8d",
+      "sink_id": "a001bb46-fe19-4f53-97d8-299929a024fa",
+      "source_name": "result",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "4eaf078a-66ed-4ecb-b86a-6fc80350594d",
+      "source_id": "f3bd9321-6a6a-40ad-81c6-c3b0998beccb",
+      "sink_id": "69b74f87-52c1-49f6-a6c6-089026de148b",
+      "source_name": "value",
+      "sink_name": "headers",
+      "is_static": false
+    },
+    {
+      "id": "a10eeb89-1297-48cf-9fb6-381b17e30c01",
+      "source_id": "a001bb46-fe19-4f53-97d8-299929a024fa",
+      "sink_id": "69b74f87-52c1-49f6-a6c6-089026de148b",
+      "source_name": "value",
+      "sink_name": "body",
+      "is_static": false
+    },
+    {
+      "id": "e7cd37ee-7c9e-4475-9128-a97257185891",
+      "source_id": "69b74f87-52c1-49f6-a6c6-089026de148b",
+      "sink_id": "be458382-d627-4135-9664-509f326d8191",
+      "source_name": "response",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "80479b61-ef49-4520-a9fc-2b621d86f734",
+      "source_id": "69b74f87-52c1-49f6-a6c6-089026de148b",
+      "sink_id": "d8b0ba07-7800-4a03-b983-6ff216e894d9",
+      "source_name": "client_error",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "eb144a58-0b14-4cca-9d2b-69154b19528e",
+      "source_id": "69b74f87-52c1-49f6-a6c6-089026de148b",
+      "sink_id": "7f8b867a-7fec-4709-b3e9-72d30abfa0e9",
+      "source_name": "server_error",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "6c11ea2e-5879-4bb3-9834-a06f0a23b12f",
+      "source_id": "69b74f87-52c1-49f6-a6c6-089026de148b",
+      "sink_id": "da51b44b-01d8-4d5e-a5b0-7284fc3fa4b6",
+      "source_name": "error",
+      "sink_name": "value",
+      "is_static": false
+    }
+  ],
+  "forked_from_id": null,
+  "forked_from_version": null,
+  "sub_graphs": [],
+  "user_id": "",
+  "created_at": "2026-02-14T23:47:30.880Z",
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "API Key": {
+        "advanced": false,
+        "anyOf": [
+          {
+            "format": "short-text",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "secret": true,
+        "title": "API Key",
+        "description": "Citedy API key (starts with citedy_agent_)",
+        "default": "citedy_agent_replace_me"
+      },
+      "Request JSON": {
+        "advanced": false,
+        "anyOf": [
+          {
+            "format": "long-text",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "secret": false,
+        "title": "Request JSON",
+        "description": "JSON payload for the selected Citedy endpoint.",
+        "default": "{\n  \"competitor_urls\": [\n    \"https://example1.com\",\n    \"https://example2.com\"\n  ]\n}"
+      }
+    },
+    "required": ["API Key", "Request JSON"]
+  },
+  "output_schema": {
+    "type": "object",
+    "properties": {
+      "response": {
+        "title": "response",
+        "description": "Successful API response payload.",
+        "type": "object"
+      },
+      "client_error": {
+        "title": "client_error",
+        "description": "HTTP 4xx response payload.",
+        "type": "object"
+      },
+      "server_error": {
+        "title": "server_error",
+        "description": "HTTP 5xx response payload.",
+        "type": "object"
+      },
+      "error": {
+        "title": "error",
+        "description": "Transport/runtime error output.",
+        "type": "string"
+      }
+    },
+    "required": []
+  },
+  "has_external_trigger": false,
+  "has_human_in_the_loop": false,
+  "trigger_setup_info": null,
+  "credentials_input_schema": {
+    "properties": {},
+    "required": [],
+    "title": "CitedyTemplateCredentialsInputSchema",
+    "type": "object"
+  }
+}

--- a/autogpt_platform/graph_templates/citedy-ingest.agent.json
+++ b/autogpt_platform/graph_templates/citedy-ingest.agent.json
@@ -1,0 +1,606 @@
+{
+  "id": "e3737707-749e-4097-842c-97d866d5d10f",
+  "version": 1,
+  "is_active": true,
+  "name": "Citedy Content Ingestion",
+  "description": "Ingest any URL (YouTube, article, PDF, audio) into structured content.",
+  "instructions": null,
+  "recommended_schedule_cron": null,
+  "nodes": [
+    {
+      "id": "fb698d17-302b-4317-89e0-d859615d2601",
+      "block_id": "7fcd3bcb-8e1b-4e69-903d-32d3d4a92158",
+      "input_default": {
+        "name": "API Key",
+        "title": null,
+        "value": "citedy_agent_replace_me",
+        "secret": true,
+        "advanced": false,
+        "description": "Citedy API key (starts with citedy_agent_)",
+        "placeholder_values": []
+      },
+      "metadata": {
+        "position": {
+          "x": -920,
+          "y": -80
+        }
+      },
+      "input_links": [],
+      "output_links": [
+        {
+          "id": "26cc6d13-f9de-4dae-8a76-2184582f2d13",
+          "source_id": "fb698d17-302b-4317-89e0-d859615d2601",
+          "sink_id": "7b86835b-656f-495a-ab9d-09102f47dcdb",
+          "source_name": "result",
+          "sink_name": "values_#_api_key",
+          "is_static": false
+        }
+      ],
+      "graph_id": "e3737707-749e-4097-842c-97d866d5d10f",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "a621774b-501c-4038-b9b4-b1b8469630ad",
+      "block_id": "90a56ffb-7024-4b2b-ab50-e26c5e5ab8ba",
+      "input_default": {
+        "name": "Request JSON",
+        "title": null,
+        "value": "{\n  \"url\": \"https://youtube.com/watch?v=example\"\n}",
+        "secret": false,
+        "advanced": false,
+        "description": "JSON payload for this endpoint.",
+        "placeholder_values": []
+      },
+      "metadata": {
+        "position": {
+          "x": -920,
+          "y": 220
+        }
+      },
+      "input_links": [],
+      "output_links": [
+        {
+          "id": "6beba955-ca4d-4e4b-a20f-b2d44650c2a3",
+          "source_id": "a621774b-501c-4038-b9b4-b1b8469630ad",
+          "sink_id": "6ff46bca-c71d-453c-aea5-fbbe03677e4c",
+          "source_name": "result",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "graph_id": "e3737707-749e-4097-842c-97d866d5d10f",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "7b86835b-656f-495a-ab9d-09102f47dcdb",
+      "block_id": "b924ddf4-de4f-4b56-9a85-358930dcbc91",
+      "input_default": {
+        "values": {}
+      },
+      "metadata": {
+        "position": {
+          "x": -520,
+          "y": -80
+        }
+      },
+      "input_links": [
+        {
+          "id": "26cc6d13-f9de-4dae-8a76-2184582f2d13",
+          "source_id": "fb698d17-302b-4317-89e0-d859615d2601",
+          "sink_id": "7b86835b-656f-495a-ab9d-09102f47dcdb",
+          "source_name": "result",
+          "sink_name": "values_#_api_key",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "fe76bfbd-ad4f-4687-9de1-b267c07b8738",
+          "source_id": "7b86835b-656f-495a-ab9d-09102f47dcdb",
+          "sink_id": "e1fe6c6b-f442-4aa7-a9f2-f207d1626f39",
+          "source_name": "dictionary",
+          "sink_name": "values",
+          "is_static": false
+        }
+      ],
+      "graph_id": "e3737707-749e-4097-842c-97d866d5d10f",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "e1fe6c6b-f442-4aa7-a9f2-f207d1626f39",
+      "block_id": "db7d8f02-2f44-4c55-ab7a-eae0941f0c30",
+      "input_default": {
+        "format": "{\"Authorization\":\"Bearer {{ api_key }}\",\"Content-Type\":\"application/json\"}",
+        "values": {},
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": -140,
+          "y": -80
+        }
+      },
+      "input_links": [
+        {
+          "id": "fe76bfbd-ad4f-4687-9de1-b267c07b8738",
+          "source_id": "7b86835b-656f-495a-ab9d-09102f47dcdb",
+          "sink_id": "e1fe6c6b-f442-4aa7-a9f2-f207d1626f39",
+          "source_name": "dictionary",
+          "sink_name": "values",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "b12af31c-40d3-4b65-ac62-bdcb09b82cb1",
+          "source_id": "e1fe6c6b-f442-4aa7-a9f2-f207d1626f39",
+          "sink_id": "cf8be562-a21e-4b93-8127-cc1766dc7050",
+          "source_name": "output",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "graph_id": "e3737707-749e-4097-842c-97d866d5d10f",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "cf8be562-a21e-4b93-8127-cc1766dc7050",
+      "block_id": "95d1b990-ce13-4d88-9737-ba5c2070c97b",
+      "input_default": {
+        "type": "dictionary",
+        "value": null
+      },
+      "metadata": {
+        "position": {
+          "x": 180,
+          "y": -80
+        }
+      },
+      "input_links": [
+        {
+          "id": "b12af31c-40d3-4b65-ac62-bdcb09b82cb1",
+          "source_id": "e1fe6c6b-f442-4aa7-a9f2-f207d1626f39",
+          "sink_id": "cf8be562-a21e-4b93-8127-cc1766dc7050",
+          "source_name": "output",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "8acd56d9-9478-4d33-ac0c-5f79edd46661",
+          "source_id": "cf8be562-a21e-4b93-8127-cc1766dc7050",
+          "sink_id": "a244b447-019b-4412-a936-1cac3db2ae10",
+          "source_name": "value",
+          "sink_name": "headers",
+          "is_static": false
+        }
+      ],
+      "graph_id": "e3737707-749e-4097-842c-97d866d5d10f",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "6ff46bca-c71d-453c-aea5-fbbe03677e4c",
+      "block_id": "95d1b990-ce13-4d88-9737-ba5c2070c97b",
+      "input_default": {
+        "type": "dictionary",
+        "value": null
+      },
+      "metadata": {
+        "position": {
+          "x": -140,
+          "y": 220
+        }
+      },
+      "input_links": [
+        {
+          "id": "6beba955-ca4d-4e4b-a20f-b2d44650c2a3",
+          "source_id": "a621774b-501c-4038-b9b4-b1b8469630ad",
+          "sink_id": "6ff46bca-c71d-453c-aea5-fbbe03677e4c",
+          "source_name": "result",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "75348d54-5263-4aab-9b77-e6c73b6b833f",
+          "source_id": "6ff46bca-c71d-453c-aea5-fbbe03677e4c",
+          "sink_id": "a244b447-019b-4412-a936-1cac3db2ae10",
+          "source_name": "value",
+          "sink_name": "body",
+          "is_static": false
+        }
+      ],
+      "graph_id": "e3737707-749e-4097-842c-97d866d5d10f",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "a244b447-019b-4412-a936-1cac3db2ae10",
+      "block_id": "6595ae1f-b924-42cb-9a41-551a0611c4b4",
+      "input_default": {
+        "url": "https://www.citedy.com/api/agent/ingest",
+        "method": "POST",
+        "headers": {},
+        "json_format": true,
+        "body": null,
+        "files_name": "file",
+        "files": []
+      },
+      "metadata": {
+        "position": {
+          "x": 560,
+          "y": 70
+        }
+      },
+      "input_links": [
+        {
+          "id": "8acd56d9-9478-4d33-ac0c-5f79edd46661",
+          "source_id": "cf8be562-a21e-4b93-8127-cc1766dc7050",
+          "sink_id": "a244b447-019b-4412-a936-1cac3db2ae10",
+          "source_name": "value",
+          "sink_name": "headers",
+          "is_static": false
+        },
+        {
+          "id": "75348d54-5263-4aab-9b77-e6c73b6b833f",
+          "source_id": "6ff46bca-c71d-453c-aea5-fbbe03677e4c",
+          "sink_id": "a244b447-019b-4412-a936-1cac3db2ae10",
+          "source_name": "value",
+          "sink_name": "body",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "9b6b8262-34ab-413d-bbde-649d06c7f845",
+          "source_id": "a244b447-019b-4412-a936-1cac3db2ae10",
+          "sink_id": "3fb54763-5714-428d-8e95-7d08e2d52839",
+          "source_name": "response",
+          "sink_name": "value",
+          "is_static": false
+        },
+        {
+          "id": "a07ab28c-50d5-4e53-a9a7-d7e54fa0390b",
+          "source_id": "a244b447-019b-4412-a936-1cac3db2ae10",
+          "sink_id": "2b89e5cc-6ff1-475a-9055-e3f945ea15ec",
+          "source_name": "client_error",
+          "sink_name": "value",
+          "is_static": false
+        },
+        {
+          "id": "a11e9d5b-babf-4dd1-8668-c357035ef729",
+          "source_id": "a244b447-019b-4412-a936-1cac3db2ae10",
+          "sink_id": "a90ec9fe-98b0-471c-8332-61567590838d",
+          "source_name": "server_error",
+          "sink_name": "value",
+          "is_static": false
+        },
+        {
+          "id": "a4ed9a5c-95f3-44d5-a66a-cdaeefdd507f",
+          "source_id": "a244b447-019b-4412-a936-1cac3db2ae10",
+          "sink_id": "7eb2be43-8bc6-49a9-a995-94bd08e22b7e",
+          "source_name": "error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "graph_id": "e3737707-749e-4097-842c-97d866d5d10f",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "3fb54763-5714-428d-8e95-7d08e2d52839",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "response",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "Successful API response payload.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": -160
+        }
+      },
+      "input_links": [
+        {
+          "id": "9b6b8262-34ab-413d-bbde-649d06c7f845",
+          "source_id": "a244b447-019b-4412-a936-1cac3db2ae10",
+          "sink_id": "3fb54763-5714-428d-8e95-7d08e2d52839",
+          "source_name": "response",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "e3737707-749e-4097-842c-97d866d5d10f",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "2b89e5cc-6ff1-475a-9055-e3f945ea15ec",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "client_error",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "HTTP 4xx response payload.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": 20
+        }
+      },
+      "input_links": [
+        {
+          "id": "a07ab28c-50d5-4e53-a9a7-d7e54fa0390b",
+          "source_id": "a244b447-019b-4412-a936-1cac3db2ae10",
+          "sink_id": "2b89e5cc-6ff1-475a-9055-e3f945ea15ec",
+          "source_name": "client_error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "e3737707-749e-4097-842c-97d866d5d10f",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "a90ec9fe-98b0-471c-8332-61567590838d",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "server_error",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "HTTP 5xx response payload.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": 200
+        }
+      },
+      "input_links": [
+        {
+          "id": "a11e9d5b-babf-4dd1-8668-c357035ef729",
+          "source_id": "a244b447-019b-4412-a936-1cac3db2ae10",
+          "sink_id": "a90ec9fe-98b0-471c-8332-61567590838d",
+          "source_name": "server_error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "e3737707-749e-4097-842c-97d866d5d10f",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "7eb2be43-8bc6-49a9-a995-94bd08e22b7e",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "error",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "Transport/runtime error output.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": 380
+        }
+      },
+      "input_links": [
+        {
+          "id": "a4ed9a5c-95f3-44d5-a66a-cdaeefdd507f",
+          "source_id": "a244b447-019b-4412-a936-1cac3db2ae10",
+          "sink_id": "7eb2be43-8bc6-49a9-a995-94bd08e22b7e",
+          "source_name": "error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "e3737707-749e-4097-842c-97d866d5d10f",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    }
+  ],
+  "links": [
+    {
+      "id": "26cc6d13-f9de-4dae-8a76-2184582f2d13",
+      "source_id": "fb698d17-302b-4317-89e0-d859615d2601",
+      "sink_id": "7b86835b-656f-495a-ab9d-09102f47dcdb",
+      "source_name": "result",
+      "sink_name": "values_#_api_key",
+      "is_static": false
+    },
+    {
+      "id": "6beba955-ca4d-4e4b-a20f-b2d44650c2a3",
+      "source_id": "a621774b-501c-4038-b9b4-b1b8469630ad",
+      "sink_id": "6ff46bca-c71d-453c-aea5-fbbe03677e4c",
+      "source_name": "result",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "fe76bfbd-ad4f-4687-9de1-b267c07b8738",
+      "source_id": "7b86835b-656f-495a-ab9d-09102f47dcdb",
+      "sink_id": "e1fe6c6b-f442-4aa7-a9f2-f207d1626f39",
+      "source_name": "dictionary",
+      "sink_name": "values",
+      "is_static": false
+    },
+    {
+      "id": "b12af31c-40d3-4b65-ac62-bdcb09b82cb1",
+      "source_id": "e1fe6c6b-f442-4aa7-a9f2-f207d1626f39",
+      "sink_id": "cf8be562-a21e-4b93-8127-cc1766dc7050",
+      "source_name": "output",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "8acd56d9-9478-4d33-ac0c-5f79edd46661",
+      "source_id": "cf8be562-a21e-4b93-8127-cc1766dc7050",
+      "sink_id": "a244b447-019b-4412-a936-1cac3db2ae10",
+      "source_name": "value",
+      "sink_name": "headers",
+      "is_static": false
+    },
+    {
+      "id": "75348d54-5263-4aab-9b77-e6c73b6b833f",
+      "source_id": "6ff46bca-c71d-453c-aea5-fbbe03677e4c",
+      "sink_id": "a244b447-019b-4412-a936-1cac3db2ae10",
+      "source_name": "value",
+      "sink_name": "body",
+      "is_static": false
+    },
+    {
+      "id": "9b6b8262-34ab-413d-bbde-649d06c7f845",
+      "source_id": "a244b447-019b-4412-a936-1cac3db2ae10",
+      "sink_id": "3fb54763-5714-428d-8e95-7d08e2d52839",
+      "source_name": "response",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "a07ab28c-50d5-4e53-a9a7-d7e54fa0390b",
+      "source_id": "a244b447-019b-4412-a936-1cac3db2ae10",
+      "sink_id": "2b89e5cc-6ff1-475a-9055-e3f945ea15ec",
+      "source_name": "client_error",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "a11e9d5b-babf-4dd1-8668-c357035ef729",
+      "source_id": "a244b447-019b-4412-a936-1cac3db2ae10",
+      "sink_id": "a90ec9fe-98b0-471c-8332-61567590838d",
+      "source_name": "server_error",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "a4ed9a5c-95f3-44d5-a66a-cdaeefdd507f",
+      "source_id": "a244b447-019b-4412-a936-1cac3db2ae10",
+      "sink_id": "7eb2be43-8bc6-49a9-a995-94bd08e22b7e",
+      "source_name": "error",
+      "sink_name": "value",
+      "is_static": false
+    }
+  ],
+  "forked_from_id": null,
+  "forked_from_version": null,
+  "sub_graphs": [],
+  "user_id": "",
+  "created_at": "2026-02-28T12:00:00.000Z",
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "API Key": {
+        "advanced": false,
+        "anyOf": [
+          {
+            "format": "short-text",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "secret": true,
+        "title": "API Key",
+        "description": "Citedy API key (starts with citedy_agent_)",
+        "default": "citedy_agent_replace_me"
+      },
+      "Request JSON": {
+        "advanced": false,
+        "anyOf": [
+          {
+            "format": "long-text",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "secret": false,
+        "title": "Request JSON",
+        "description": "JSON payload for the selected Citedy endpoint.",
+        "default": "{\n  \"url\": \"https://youtube.com/watch?v=example\"\n}"
+      }
+    },
+    "required": ["API Key", "Request JSON"]
+  },
+  "output_schema": {
+    "type": "object",
+    "properties": {
+      "response": {
+        "title": "response",
+        "description": "Successful API response payload.",
+        "type": "object"
+      },
+      "client_error": {
+        "title": "client_error",
+        "description": "HTTP 4xx response payload.",
+        "type": "object"
+      },
+      "server_error": {
+        "title": "server_error",
+        "description": "HTTP 5xx response payload.",
+        "type": "object"
+      },
+      "error": {
+        "title": "error",
+        "description": "Transport/runtime error output.",
+        "type": "string"
+      }
+    },
+    "required": []
+  },
+  "has_external_trigger": false,
+  "has_human_in_the_loop": false,
+  "trigger_setup_info": null,
+  "credentials_input_schema": {
+    "properties": {},
+    "required": [],
+    "title": "CitedyTemplateCredentialsInputSchema",
+    "type": "object"
+  }
+}

--- a/autogpt_platform/graph_templates/citedy-lead-magnet.agent.json
+++ b/autogpt_platform/graph_templates/citedy-lead-magnet.agent.json
@@ -1,0 +1,606 @@
+{
+  "id": "80edb64c-3fc7-482b-929f-7ee407ebc572",
+  "version": 1,
+  "is_active": true,
+  "name": "Citedy Lead Magnet",
+  "description": "Generate PDF lead magnet (checklist, swipe file, framework).",
+  "instructions": null,
+  "recommended_schedule_cron": null,
+  "nodes": [
+    {
+      "id": "94b5bf2a-1523-4feb-967b-e910148dc375",
+      "block_id": "7fcd3bcb-8e1b-4e69-903d-32d3d4a92158",
+      "input_default": {
+        "name": "API Key",
+        "title": null,
+        "value": "citedy_agent_replace_me",
+        "secret": true,
+        "advanced": false,
+        "description": "Citedy API key (starts with citedy_agent_)",
+        "placeholder_values": []
+      },
+      "metadata": {
+        "position": {
+          "x": -920,
+          "y": -80
+        }
+      },
+      "input_links": [],
+      "output_links": [
+        {
+          "id": "d44b2df4-30ca-49cd-9c33-4698823cc126",
+          "source_id": "94b5bf2a-1523-4feb-967b-e910148dc375",
+          "sink_id": "78061992-1474-4e5a-a845-bd30e4e6dfe7",
+          "source_name": "result",
+          "sink_name": "values_#_api_key",
+          "is_static": false
+        }
+      ],
+      "graph_id": "80edb64c-3fc7-482b-929f-7ee407ebc572",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "caf1892d-7e50-4185-abbf-8da31a09ab12",
+      "block_id": "90a56ffb-7024-4b2b-ab50-e26c5e5ab8ba",
+      "input_default": {
+        "name": "Request JSON",
+        "title": null,
+        "value": "{\n  \"topic\": \"10-Step SEO Audit Checklist\",\n  \"type\": \"checklist\",\n  \"language\": \"en\",\n  \"generate_images\": false\n}",
+        "secret": false,
+        "advanced": false,
+        "description": "JSON payload for this endpoint.",
+        "placeholder_values": []
+      },
+      "metadata": {
+        "position": {
+          "x": -920,
+          "y": 220
+        }
+      },
+      "input_links": [],
+      "output_links": [
+        {
+          "id": "246dfd45-b9f9-4bfe-80f8-3b6dde76fab7",
+          "source_id": "caf1892d-7e50-4185-abbf-8da31a09ab12",
+          "sink_id": "05a0f661-5e37-4578-a3f8-78da1b324639",
+          "source_name": "result",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "graph_id": "80edb64c-3fc7-482b-929f-7ee407ebc572",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "78061992-1474-4e5a-a845-bd30e4e6dfe7",
+      "block_id": "b924ddf4-de4f-4b56-9a85-358930dcbc91",
+      "input_default": {
+        "values": {}
+      },
+      "metadata": {
+        "position": {
+          "x": -520,
+          "y": -80
+        }
+      },
+      "input_links": [
+        {
+          "id": "d44b2df4-30ca-49cd-9c33-4698823cc126",
+          "source_id": "94b5bf2a-1523-4feb-967b-e910148dc375",
+          "sink_id": "78061992-1474-4e5a-a845-bd30e4e6dfe7",
+          "source_name": "result",
+          "sink_name": "values_#_api_key",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "bed5032c-e1b1-49b0-af94-49a9da8a20d7",
+          "source_id": "78061992-1474-4e5a-a845-bd30e4e6dfe7",
+          "sink_id": "95981e11-2b30-494e-b11b-3de730741d4a",
+          "source_name": "dictionary",
+          "sink_name": "values",
+          "is_static": false
+        }
+      ],
+      "graph_id": "80edb64c-3fc7-482b-929f-7ee407ebc572",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "95981e11-2b30-494e-b11b-3de730741d4a",
+      "block_id": "db7d8f02-2f44-4c55-ab7a-eae0941f0c30",
+      "input_default": {
+        "format": "{\"Authorization\":\"Bearer {{ api_key }}\",\"Content-Type\":\"application/json\"}",
+        "values": {},
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": -140,
+          "y": -80
+        }
+      },
+      "input_links": [
+        {
+          "id": "bed5032c-e1b1-49b0-af94-49a9da8a20d7",
+          "source_id": "78061992-1474-4e5a-a845-bd30e4e6dfe7",
+          "sink_id": "95981e11-2b30-494e-b11b-3de730741d4a",
+          "source_name": "dictionary",
+          "sink_name": "values",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "705c173c-b7c1-4bc7-bf52-e2de72c34dcf",
+          "source_id": "95981e11-2b30-494e-b11b-3de730741d4a",
+          "sink_id": "975fcbf3-9032-4799-973c-0f0d57dea995",
+          "source_name": "output",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "graph_id": "80edb64c-3fc7-482b-929f-7ee407ebc572",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "975fcbf3-9032-4799-973c-0f0d57dea995",
+      "block_id": "95d1b990-ce13-4d88-9737-ba5c2070c97b",
+      "input_default": {
+        "type": "dictionary",
+        "value": null
+      },
+      "metadata": {
+        "position": {
+          "x": 180,
+          "y": -80
+        }
+      },
+      "input_links": [
+        {
+          "id": "705c173c-b7c1-4bc7-bf52-e2de72c34dcf",
+          "source_id": "95981e11-2b30-494e-b11b-3de730741d4a",
+          "sink_id": "975fcbf3-9032-4799-973c-0f0d57dea995",
+          "source_name": "output",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "58b8ea32-7312-46ba-94bb-2f3f64141dfa",
+          "source_id": "975fcbf3-9032-4799-973c-0f0d57dea995",
+          "sink_id": "b13f9364-c1f0-423a-888c-1ee57fcfd947",
+          "source_name": "value",
+          "sink_name": "headers",
+          "is_static": false
+        }
+      ],
+      "graph_id": "80edb64c-3fc7-482b-929f-7ee407ebc572",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "05a0f661-5e37-4578-a3f8-78da1b324639",
+      "block_id": "95d1b990-ce13-4d88-9737-ba5c2070c97b",
+      "input_default": {
+        "type": "dictionary",
+        "value": null
+      },
+      "metadata": {
+        "position": {
+          "x": -140,
+          "y": 220
+        }
+      },
+      "input_links": [
+        {
+          "id": "246dfd45-b9f9-4bfe-80f8-3b6dde76fab7",
+          "source_id": "caf1892d-7e50-4185-abbf-8da31a09ab12",
+          "sink_id": "05a0f661-5e37-4578-a3f8-78da1b324639",
+          "source_name": "result",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "6bc29aeb-7b0d-4b02-aaab-62d2feff8a02",
+          "source_id": "05a0f661-5e37-4578-a3f8-78da1b324639",
+          "sink_id": "b13f9364-c1f0-423a-888c-1ee57fcfd947",
+          "source_name": "value",
+          "sink_name": "body",
+          "is_static": false
+        }
+      ],
+      "graph_id": "80edb64c-3fc7-482b-929f-7ee407ebc572",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "b13f9364-c1f0-423a-888c-1ee57fcfd947",
+      "block_id": "6595ae1f-b924-42cb-9a41-551a0611c4b4",
+      "input_default": {
+        "url": "https://www.citedy.com/api/agent/lead-magnets",
+        "method": "POST",
+        "headers": {},
+        "json_format": true,
+        "body": null,
+        "files_name": "file",
+        "files": []
+      },
+      "metadata": {
+        "position": {
+          "x": 560,
+          "y": 70
+        }
+      },
+      "input_links": [
+        {
+          "id": "58b8ea32-7312-46ba-94bb-2f3f64141dfa",
+          "source_id": "975fcbf3-9032-4799-973c-0f0d57dea995",
+          "sink_id": "b13f9364-c1f0-423a-888c-1ee57fcfd947",
+          "source_name": "value",
+          "sink_name": "headers",
+          "is_static": false
+        },
+        {
+          "id": "6bc29aeb-7b0d-4b02-aaab-62d2feff8a02",
+          "source_id": "05a0f661-5e37-4578-a3f8-78da1b324639",
+          "sink_id": "b13f9364-c1f0-423a-888c-1ee57fcfd947",
+          "source_name": "value",
+          "sink_name": "body",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "911587e5-78cd-4b65-8d22-8432cc5d8536",
+          "source_id": "b13f9364-c1f0-423a-888c-1ee57fcfd947",
+          "sink_id": "bf38c2d5-5bd3-4a57-aff8-7a94dfe318f7",
+          "source_name": "response",
+          "sink_name": "value",
+          "is_static": false
+        },
+        {
+          "id": "36518348-6873-4a70-accf-09337f0deca7",
+          "source_id": "b13f9364-c1f0-423a-888c-1ee57fcfd947",
+          "sink_id": "48fd27e1-438f-4c6c-aece-70c1688995a6",
+          "source_name": "client_error",
+          "sink_name": "value",
+          "is_static": false
+        },
+        {
+          "id": "182af234-3b0b-4599-b1ab-b6ce25d2a768",
+          "source_id": "b13f9364-c1f0-423a-888c-1ee57fcfd947",
+          "sink_id": "e88924eb-4295-477b-b7fd-803292a094ec",
+          "source_name": "server_error",
+          "sink_name": "value",
+          "is_static": false
+        },
+        {
+          "id": "3879d534-336a-4d3f-9e7b-a8b6742abf3c",
+          "source_id": "b13f9364-c1f0-423a-888c-1ee57fcfd947",
+          "sink_id": "72fbebb4-dffa-4626-b126-5b6b4cb7276e",
+          "source_name": "error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "graph_id": "80edb64c-3fc7-482b-929f-7ee407ebc572",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "bf38c2d5-5bd3-4a57-aff8-7a94dfe318f7",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "response",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "Successful API response payload.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": -160
+        }
+      },
+      "input_links": [
+        {
+          "id": "911587e5-78cd-4b65-8d22-8432cc5d8536",
+          "source_id": "b13f9364-c1f0-423a-888c-1ee57fcfd947",
+          "sink_id": "bf38c2d5-5bd3-4a57-aff8-7a94dfe318f7",
+          "source_name": "response",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "80edb64c-3fc7-482b-929f-7ee407ebc572",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "48fd27e1-438f-4c6c-aece-70c1688995a6",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "client_error",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "HTTP 4xx response payload.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": 20
+        }
+      },
+      "input_links": [
+        {
+          "id": "36518348-6873-4a70-accf-09337f0deca7",
+          "source_id": "b13f9364-c1f0-423a-888c-1ee57fcfd947",
+          "sink_id": "48fd27e1-438f-4c6c-aece-70c1688995a6",
+          "source_name": "client_error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "80edb64c-3fc7-482b-929f-7ee407ebc572",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "e88924eb-4295-477b-b7fd-803292a094ec",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "server_error",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "HTTP 5xx response payload.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": 200
+        }
+      },
+      "input_links": [
+        {
+          "id": "182af234-3b0b-4599-b1ab-b6ce25d2a768",
+          "source_id": "b13f9364-c1f0-423a-888c-1ee57fcfd947",
+          "sink_id": "e88924eb-4295-477b-b7fd-803292a094ec",
+          "source_name": "server_error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "80edb64c-3fc7-482b-929f-7ee407ebc572",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "72fbebb4-dffa-4626-b126-5b6b4cb7276e",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "error",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "Transport/runtime error output.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": 380
+        }
+      },
+      "input_links": [
+        {
+          "id": "3879d534-336a-4d3f-9e7b-a8b6742abf3c",
+          "source_id": "b13f9364-c1f0-423a-888c-1ee57fcfd947",
+          "sink_id": "72fbebb4-dffa-4626-b126-5b6b4cb7276e",
+          "source_name": "error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "80edb64c-3fc7-482b-929f-7ee407ebc572",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    }
+  ],
+  "links": [
+    {
+      "id": "d44b2df4-30ca-49cd-9c33-4698823cc126",
+      "source_id": "94b5bf2a-1523-4feb-967b-e910148dc375",
+      "sink_id": "78061992-1474-4e5a-a845-bd30e4e6dfe7",
+      "source_name": "result",
+      "sink_name": "values_#_api_key",
+      "is_static": false
+    },
+    {
+      "id": "246dfd45-b9f9-4bfe-80f8-3b6dde76fab7",
+      "source_id": "caf1892d-7e50-4185-abbf-8da31a09ab12",
+      "sink_id": "05a0f661-5e37-4578-a3f8-78da1b324639",
+      "source_name": "result",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "bed5032c-e1b1-49b0-af94-49a9da8a20d7",
+      "source_id": "78061992-1474-4e5a-a845-bd30e4e6dfe7",
+      "sink_id": "95981e11-2b30-494e-b11b-3de730741d4a",
+      "source_name": "dictionary",
+      "sink_name": "values",
+      "is_static": false
+    },
+    {
+      "id": "705c173c-b7c1-4bc7-bf52-e2de72c34dcf",
+      "source_id": "95981e11-2b30-494e-b11b-3de730741d4a",
+      "sink_id": "975fcbf3-9032-4799-973c-0f0d57dea995",
+      "source_name": "output",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "58b8ea32-7312-46ba-94bb-2f3f64141dfa",
+      "source_id": "975fcbf3-9032-4799-973c-0f0d57dea995",
+      "sink_id": "b13f9364-c1f0-423a-888c-1ee57fcfd947",
+      "source_name": "value",
+      "sink_name": "headers",
+      "is_static": false
+    },
+    {
+      "id": "6bc29aeb-7b0d-4b02-aaab-62d2feff8a02",
+      "source_id": "05a0f661-5e37-4578-a3f8-78da1b324639",
+      "sink_id": "b13f9364-c1f0-423a-888c-1ee57fcfd947",
+      "source_name": "value",
+      "sink_name": "body",
+      "is_static": false
+    },
+    {
+      "id": "911587e5-78cd-4b65-8d22-8432cc5d8536",
+      "source_id": "b13f9364-c1f0-423a-888c-1ee57fcfd947",
+      "sink_id": "bf38c2d5-5bd3-4a57-aff8-7a94dfe318f7",
+      "source_name": "response",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "36518348-6873-4a70-accf-09337f0deca7",
+      "source_id": "b13f9364-c1f0-423a-888c-1ee57fcfd947",
+      "sink_id": "48fd27e1-438f-4c6c-aece-70c1688995a6",
+      "source_name": "client_error",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "182af234-3b0b-4599-b1ab-b6ce25d2a768",
+      "source_id": "b13f9364-c1f0-423a-888c-1ee57fcfd947",
+      "sink_id": "e88924eb-4295-477b-b7fd-803292a094ec",
+      "source_name": "server_error",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "3879d534-336a-4d3f-9e7b-a8b6742abf3c",
+      "source_id": "b13f9364-c1f0-423a-888c-1ee57fcfd947",
+      "sink_id": "72fbebb4-dffa-4626-b126-5b6b4cb7276e",
+      "source_name": "error",
+      "sink_name": "value",
+      "is_static": false
+    }
+  ],
+  "forked_from_id": null,
+  "forked_from_version": null,
+  "sub_graphs": [],
+  "user_id": "",
+  "created_at": "2026-02-28T12:00:00.000Z",
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "API Key": {
+        "advanced": false,
+        "anyOf": [
+          {
+            "format": "short-text",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "secret": true,
+        "title": "API Key",
+        "description": "Citedy API key (starts with citedy_agent_)",
+        "default": "citedy_agent_replace_me"
+      },
+      "Request JSON": {
+        "advanced": false,
+        "anyOf": [
+          {
+            "format": "long-text",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "secret": false,
+        "title": "Request JSON",
+        "description": "JSON payload for the selected Citedy endpoint.",
+        "default": "{\n  \"topic\": \"10-Step SEO Audit Checklist\",\n  \"type\": \"checklist\",\n  \"language\": \"en\",\n  \"generate_images\": false\n}"
+      }
+    },
+    "required": ["API Key", "Request JSON"]
+  },
+  "output_schema": {
+    "type": "object",
+    "properties": {
+      "response": {
+        "title": "response",
+        "description": "Successful API response payload.",
+        "type": "object"
+      },
+      "client_error": {
+        "title": "client_error",
+        "description": "HTTP 4xx response payload.",
+        "type": "object"
+      },
+      "server_error": {
+        "title": "server_error",
+        "description": "HTTP 5xx response payload.",
+        "type": "object"
+      },
+      "error": {
+        "title": "error",
+        "description": "Transport/runtime error output.",
+        "type": "string"
+      }
+    },
+    "required": []
+  },
+  "has_external_trigger": false,
+  "has_human_in_the_loop": false,
+  "trigger_setup_info": null,
+  "credentials_input_schema": {
+    "properties": {},
+    "required": [],
+    "title": "CitedyTemplateCredentialsInputSchema",
+    "type": "object"
+  }
+}

--- a/autogpt_platform/graph_templates/citedy-micro-post.agent.json
+++ b/autogpt_platform/graph_templates/citedy-micro-post.agent.json
@@ -1,0 +1,606 @@
+{
+  "id": "347995ff-809a-4e88-b511-69729204778a",
+  "version": 1,
+  "is_active": true,
+  "name": "Citedy Micro-Post",
+  "description": "Create micro social post from topic.",
+  "instructions": null,
+  "recommended_schedule_cron": null,
+  "nodes": [
+    {
+      "id": "70af94a5-8d64-46c5-beb8-a7cd4dc5121a",
+      "block_id": "7fcd3bcb-8e1b-4e69-903d-32d3d4a92158",
+      "input_default": {
+        "name": "API Key",
+        "title": null,
+        "value": "citedy_agent_replace_me",
+        "secret": true,
+        "advanced": false,
+        "description": "Citedy API key (starts with citedy_agent_)",
+        "placeholder_values": []
+      },
+      "metadata": {
+        "position": {
+          "x": -920,
+          "y": -80
+        }
+      },
+      "input_links": [],
+      "output_links": [
+        {
+          "id": "f6a29d6e-274a-4186-9847-a37555685eba",
+          "source_id": "70af94a5-8d64-46c5-beb8-a7cd4dc5121a",
+          "sink_id": "fdfeaa73-4caf-4820-b75e-0d6b917195bc",
+          "source_name": "result",
+          "sink_name": "values_#_api_key",
+          "is_static": false
+        }
+      ],
+      "graph_id": "347995ff-809a-4e88-b511-69729204778a",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "db79189c-8a33-4b70-9748-1c3f0178d1b1",
+      "block_id": "90a56ffb-7024-4b2b-ab50-e26c5e5ab8ba",
+      "input_default": {
+        "name": "Request JSON",
+        "title": null,
+        "value": "{\n  \"topic\": \"AI agents are the future of marketing\",\n  \"platforms\": [\n    \"linkedin\",\n    \"x_thread\"\n  ],\n  \"tone\": \"casual\",\n  \"contentType\": \"short\"\n}",
+        "secret": false,
+        "advanced": false,
+        "description": "JSON payload for this endpoint.",
+        "placeholder_values": []
+      },
+      "metadata": {
+        "position": {
+          "x": -920,
+          "y": 220
+        }
+      },
+      "input_links": [],
+      "output_links": [
+        {
+          "id": "72817da8-c97a-49c3-afa8-e1c1f6c4a8f2",
+          "source_id": "db79189c-8a33-4b70-9748-1c3f0178d1b1",
+          "sink_id": "8348edbe-d7ec-4230-89de-90a3e08539d6",
+          "source_name": "result",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "graph_id": "347995ff-809a-4e88-b511-69729204778a",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "fdfeaa73-4caf-4820-b75e-0d6b917195bc",
+      "block_id": "b924ddf4-de4f-4b56-9a85-358930dcbc91",
+      "input_default": {
+        "values": {}
+      },
+      "metadata": {
+        "position": {
+          "x": -520,
+          "y": -80
+        }
+      },
+      "input_links": [
+        {
+          "id": "f6a29d6e-274a-4186-9847-a37555685eba",
+          "source_id": "70af94a5-8d64-46c5-beb8-a7cd4dc5121a",
+          "sink_id": "fdfeaa73-4caf-4820-b75e-0d6b917195bc",
+          "source_name": "result",
+          "sink_name": "values_#_api_key",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "50709f59-59c4-43df-af55-41bcfd5675ab",
+          "source_id": "fdfeaa73-4caf-4820-b75e-0d6b917195bc",
+          "sink_id": "e7de20f4-97cf-4049-a223-74190801f3f0",
+          "source_name": "dictionary",
+          "sink_name": "values",
+          "is_static": false
+        }
+      ],
+      "graph_id": "347995ff-809a-4e88-b511-69729204778a",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "e7de20f4-97cf-4049-a223-74190801f3f0",
+      "block_id": "db7d8f02-2f44-4c55-ab7a-eae0941f0c30",
+      "input_default": {
+        "format": "{\"Authorization\":\"Bearer {{ api_key }}\",\"Content-Type\":\"application/json\"}",
+        "values": {},
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": -140,
+          "y": -80
+        }
+      },
+      "input_links": [
+        {
+          "id": "50709f59-59c4-43df-af55-41bcfd5675ab",
+          "source_id": "fdfeaa73-4caf-4820-b75e-0d6b917195bc",
+          "sink_id": "e7de20f4-97cf-4049-a223-74190801f3f0",
+          "source_name": "dictionary",
+          "sink_name": "values",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "b54e1399-4529-4681-bb22-79a351a8be2a",
+          "source_id": "e7de20f4-97cf-4049-a223-74190801f3f0",
+          "sink_id": "640e5023-19b2-4a03-af10-55dbc6d9dcdf",
+          "source_name": "output",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "graph_id": "347995ff-809a-4e88-b511-69729204778a",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "640e5023-19b2-4a03-af10-55dbc6d9dcdf",
+      "block_id": "95d1b990-ce13-4d88-9737-ba5c2070c97b",
+      "input_default": {
+        "type": "dictionary",
+        "value": null
+      },
+      "metadata": {
+        "position": {
+          "x": 180,
+          "y": -80
+        }
+      },
+      "input_links": [
+        {
+          "id": "b54e1399-4529-4681-bb22-79a351a8be2a",
+          "source_id": "e7de20f4-97cf-4049-a223-74190801f3f0",
+          "sink_id": "640e5023-19b2-4a03-af10-55dbc6d9dcdf",
+          "source_name": "output",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "9c3cd78f-97aa-4556-971d-31e68b3864d5",
+          "source_id": "640e5023-19b2-4a03-af10-55dbc6d9dcdf",
+          "sink_id": "b9994927-8af8-4197-9260-9eebf5f1f825",
+          "source_name": "value",
+          "sink_name": "headers",
+          "is_static": false
+        }
+      ],
+      "graph_id": "347995ff-809a-4e88-b511-69729204778a",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "8348edbe-d7ec-4230-89de-90a3e08539d6",
+      "block_id": "95d1b990-ce13-4d88-9737-ba5c2070c97b",
+      "input_default": {
+        "type": "dictionary",
+        "value": null
+      },
+      "metadata": {
+        "position": {
+          "x": -140,
+          "y": 220
+        }
+      },
+      "input_links": [
+        {
+          "id": "72817da8-c97a-49c3-afa8-e1c1f6c4a8f2",
+          "source_id": "db79189c-8a33-4b70-9748-1c3f0178d1b1",
+          "sink_id": "8348edbe-d7ec-4230-89de-90a3e08539d6",
+          "source_name": "result",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "c5d11891-a620-42cf-819f-d611e948fa18",
+          "source_id": "8348edbe-d7ec-4230-89de-90a3e08539d6",
+          "sink_id": "b9994927-8af8-4197-9260-9eebf5f1f825",
+          "source_name": "value",
+          "sink_name": "body",
+          "is_static": false
+        }
+      ],
+      "graph_id": "347995ff-809a-4e88-b511-69729204778a",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "b9994927-8af8-4197-9260-9eebf5f1f825",
+      "block_id": "6595ae1f-b924-42cb-9a41-551a0611c4b4",
+      "input_default": {
+        "url": "https://www.citedy.com/api/agent/post",
+        "method": "POST",
+        "headers": {},
+        "json_format": true,
+        "body": null,
+        "files_name": "file",
+        "files": []
+      },
+      "metadata": {
+        "position": {
+          "x": 560,
+          "y": 70
+        }
+      },
+      "input_links": [
+        {
+          "id": "9c3cd78f-97aa-4556-971d-31e68b3864d5",
+          "source_id": "640e5023-19b2-4a03-af10-55dbc6d9dcdf",
+          "sink_id": "b9994927-8af8-4197-9260-9eebf5f1f825",
+          "source_name": "value",
+          "sink_name": "headers",
+          "is_static": false
+        },
+        {
+          "id": "c5d11891-a620-42cf-819f-d611e948fa18",
+          "source_id": "8348edbe-d7ec-4230-89de-90a3e08539d6",
+          "sink_id": "b9994927-8af8-4197-9260-9eebf5f1f825",
+          "source_name": "value",
+          "sink_name": "body",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "75061866-b4ab-40ac-ae91-eca3796fc3ca",
+          "source_id": "b9994927-8af8-4197-9260-9eebf5f1f825",
+          "sink_id": "c3c02479-d48a-4b92-9cfa-e9b44a206339",
+          "source_name": "response",
+          "sink_name": "value",
+          "is_static": false
+        },
+        {
+          "id": "16a63e0e-6e80-494f-8385-d4c4d55cb9a5",
+          "source_id": "b9994927-8af8-4197-9260-9eebf5f1f825",
+          "sink_id": "3852c6d3-ba6f-49fb-bc79-728f684eeeab",
+          "source_name": "client_error",
+          "sink_name": "value",
+          "is_static": false
+        },
+        {
+          "id": "65cf1a69-73a4-48f0-95e7-ec25c85f3886",
+          "source_id": "b9994927-8af8-4197-9260-9eebf5f1f825",
+          "sink_id": "9c293e83-0a05-47f4-bd30-043beb3572ac",
+          "source_name": "server_error",
+          "sink_name": "value",
+          "is_static": false
+        },
+        {
+          "id": "d532279e-ca75-4b18-be77-da18f1d2eecf",
+          "source_id": "b9994927-8af8-4197-9260-9eebf5f1f825",
+          "sink_id": "1ec1c3c2-8db4-412f-8a6e-78ef55b7e7c3",
+          "source_name": "error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "graph_id": "347995ff-809a-4e88-b511-69729204778a",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "c3c02479-d48a-4b92-9cfa-e9b44a206339",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "response",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "Successful API response payload.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": -160
+        }
+      },
+      "input_links": [
+        {
+          "id": "75061866-b4ab-40ac-ae91-eca3796fc3ca",
+          "source_id": "b9994927-8af8-4197-9260-9eebf5f1f825",
+          "sink_id": "c3c02479-d48a-4b92-9cfa-e9b44a206339",
+          "source_name": "response",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "347995ff-809a-4e88-b511-69729204778a",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "3852c6d3-ba6f-49fb-bc79-728f684eeeab",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "client_error",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "HTTP 4xx response payload.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": 20
+        }
+      },
+      "input_links": [
+        {
+          "id": "16a63e0e-6e80-494f-8385-d4c4d55cb9a5",
+          "source_id": "b9994927-8af8-4197-9260-9eebf5f1f825",
+          "sink_id": "3852c6d3-ba6f-49fb-bc79-728f684eeeab",
+          "source_name": "client_error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "347995ff-809a-4e88-b511-69729204778a",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "9c293e83-0a05-47f4-bd30-043beb3572ac",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "server_error",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "HTTP 5xx response payload.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": 200
+        }
+      },
+      "input_links": [
+        {
+          "id": "65cf1a69-73a4-48f0-95e7-ec25c85f3886",
+          "source_id": "b9994927-8af8-4197-9260-9eebf5f1f825",
+          "sink_id": "9c293e83-0a05-47f4-bd30-043beb3572ac",
+          "source_name": "server_error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "347995ff-809a-4e88-b511-69729204778a",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "1ec1c3c2-8db4-412f-8a6e-78ef55b7e7c3",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "error",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "Transport/runtime error output.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": 380
+        }
+      },
+      "input_links": [
+        {
+          "id": "d532279e-ca75-4b18-be77-da18f1d2eecf",
+          "source_id": "b9994927-8af8-4197-9260-9eebf5f1f825",
+          "sink_id": "1ec1c3c2-8db4-412f-8a6e-78ef55b7e7c3",
+          "source_name": "error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "347995ff-809a-4e88-b511-69729204778a",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    }
+  ],
+  "links": [
+    {
+      "id": "f6a29d6e-274a-4186-9847-a37555685eba",
+      "source_id": "70af94a5-8d64-46c5-beb8-a7cd4dc5121a",
+      "sink_id": "fdfeaa73-4caf-4820-b75e-0d6b917195bc",
+      "source_name": "result",
+      "sink_name": "values_#_api_key",
+      "is_static": false
+    },
+    {
+      "id": "72817da8-c97a-49c3-afa8-e1c1f6c4a8f2",
+      "source_id": "db79189c-8a33-4b70-9748-1c3f0178d1b1",
+      "sink_id": "8348edbe-d7ec-4230-89de-90a3e08539d6",
+      "source_name": "result",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "50709f59-59c4-43df-af55-41bcfd5675ab",
+      "source_id": "fdfeaa73-4caf-4820-b75e-0d6b917195bc",
+      "sink_id": "e7de20f4-97cf-4049-a223-74190801f3f0",
+      "source_name": "dictionary",
+      "sink_name": "values",
+      "is_static": false
+    },
+    {
+      "id": "b54e1399-4529-4681-bb22-79a351a8be2a",
+      "source_id": "e7de20f4-97cf-4049-a223-74190801f3f0",
+      "sink_id": "640e5023-19b2-4a03-af10-55dbc6d9dcdf",
+      "source_name": "output",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "9c3cd78f-97aa-4556-971d-31e68b3864d5",
+      "source_id": "640e5023-19b2-4a03-af10-55dbc6d9dcdf",
+      "sink_id": "b9994927-8af8-4197-9260-9eebf5f1f825",
+      "source_name": "value",
+      "sink_name": "headers",
+      "is_static": false
+    },
+    {
+      "id": "c5d11891-a620-42cf-819f-d611e948fa18",
+      "source_id": "8348edbe-d7ec-4230-89de-90a3e08539d6",
+      "sink_id": "b9994927-8af8-4197-9260-9eebf5f1f825",
+      "source_name": "value",
+      "sink_name": "body",
+      "is_static": false
+    },
+    {
+      "id": "75061866-b4ab-40ac-ae91-eca3796fc3ca",
+      "source_id": "b9994927-8af8-4197-9260-9eebf5f1f825",
+      "sink_id": "c3c02479-d48a-4b92-9cfa-e9b44a206339",
+      "source_name": "response",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "16a63e0e-6e80-494f-8385-d4c4d55cb9a5",
+      "source_id": "b9994927-8af8-4197-9260-9eebf5f1f825",
+      "sink_id": "3852c6d3-ba6f-49fb-bc79-728f684eeeab",
+      "source_name": "client_error",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "65cf1a69-73a4-48f0-95e7-ec25c85f3886",
+      "source_id": "b9994927-8af8-4197-9260-9eebf5f1f825",
+      "sink_id": "9c293e83-0a05-47f4-bd30-043beb3572ac",
+      "source_name": "server_error",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "d532279e-ca75-4b18-be77-da18f1d2eecf",
+      "source_id": "b9994927-8af8-4197-9260-9eebf5f1f825",
+      "sink_id": "1ec1c3c2-8db4-412f-8a6e-78ef55b7e7c3",
+      "source_name": "error",
+      "sink_name": "value",
+      "is_static": false
+    }
+  ],
+  "forked_from_id": null,
+  "forked_from_version": null,
+  "sub_graphs": [],
+  "user_id": "",
+  "created_at": "2026-02-28T12:00:00.000Z",
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "API Key": {
+        "advanced": false,
+        "anyOf": [
+          {
+            "format": "short-text",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "secret": true,
+        "title": "API Key",
+        "description": "Citedy API key (starts with citedy_agent_)",
+        "default": "citedy_agent_replace_me"
+      },
+      "Request JSON": {
+        "advanced": false,
+        "anyOf": [
+          {
+            "format": "long-text",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "secret": false,
+        "title": "Request JSON",
+        "description": "JSON payload for the selected Citedy endpoint.",
+        "default": "{\n  \"topic\": \"AI agents are the future of marketing\",\n  \"platforms\": [\n    \"linkedin\",\n    \"x_thread\"\n  ],\n  \"tone\": \"casual\",\n  \"contentType\": \"short\"\n}"
+      }
+    },
+    "required": ["API Key", "Request JSON"]
+  },
+  "output_schema": {
+    "type": "object",
+    "properties": {
+      "response": {
+        "title": "response",
+        "description": "Successful API response payload.",
+        "type": "object"
+      },
+      "client_error": {
+        "title": "client_error",
+        "description": "HTTP 4xx response payload.",
+        "type": "object"
+      },
+      "server_error": {
+        "title": "server_error",
+        "description": "HTTP 5xx response payload.",
+        "type": "object"
+      },
+      "error": {
+        "title": "error",
+        "description": "Transport/runtime error output.",
+        "type": "string"
+      }
+    },
+    "required": []
+  },
+  "has_external_trigger": false,
+  "has_human_in_the_loop": false,
+  "trigger_setup_info": null,
+  "credentials_input_schema": {
+    "properties": {},
+    "required": [],
+    "title": "CitedyTemplateCredentialsInputSchema",
+    "type": "object"
+  }
+}

--- a/autogpt_platform/graph_templates/citedy-product-upload.agent.json
+++ b/autogpt_platform/graph_templates/citedy-product-upload.agent.json
@@ -1,0 +1,606 @@
+{
+  "id": "54449497-20d0-44a1-b53b-2d84c55f3d92",
+  "version": 1,
+  "is_active": true,
+  "name": "Citedy Product Knowledge",
+  "description": "Upload product document for context-aware content generation.",
+  "instructions": null,
+  "recommended_schedule_cron": null,
+  "nodes": [
+    {
+      "id": "d3a6d5e7-bd57-4778-9a6a-73e177e9f322",
+      "block_id": "7fcd3bcb-8e1b-4e69-903d-32d3d4a92158",
+      "input_default": {
+        "name": "API Key",
+        "title": null,
+        "value": "citedy_agent_replace_me",
+        "secret": true,
+        "advanced": false,
+        "description": "Citedy API key (starts with citedy_agent_)",
+        "placeholder_values": []
+      },
+      "metadata": {
+        "position": {
+          "x": -920,
+          "y": -80
+        }
+      },
+      "input_links": [],
+      "output_links": [
+        {
+          "id": "4aa2e2bf-d023-404c-bbe8-4b9cac703736",
+          "source_id": "d3a6d5e7-bd57-4778-9a6a-73e177e9f322",
+          "sink_id": "4bc3bc90-cab3-4d54-a8c5-ca69c54352f1",
+          "source_name": "result",
+          "sink_name": "values_#_api_key",
+          "is_static": false
+        }
+      ],
+      "graph_id": "54449497-20d0-44a1-b53b-2d84c55f3d92",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "a99b027d-fc2a-4b70-9357-30537302ed57",
+      "block_id": "90a56ffb-7024-4b2b-ab50-e26c5e5ab8ba",
+      "input_default": {
+        "name": "Request JSON",
+        "title": null,
+        "value": "{\n  \"title\": \"Our AI Writing Platform\",\n  \"content\": \"Product description here...\",\n  \"source_type\": \"manual\"\n}",
+        "secret": false,
+        "advanced": false,
+        "description": "JSON payload for this endpoint.",
+        "placeholder_values": []
+      },
+      "metadata": {
+        "position": {
+          "x": -920,
+          "y": 220
+        }
+      },
+      "input_links": [],
+      "output_links": [
+        {
+          "id": "ed80a58d-2f78-494f-b960-7f8ff293ef8e",
+          "source_id": "a99b027d-fc2a-4b70-9357-30537302ed57",
+          "sink_id": "21d378c9-c7a6-4c33-8e07-58a871fddf97",
+          "source_name": "result",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "graph_id": "54449497-20d0-44a1-b53b-2d84c55f3d92",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "4bc3bc90-cab3-4d54-a8c5-ca69c54352f1",
+      "block_id": "b924ddf4-de4f-4b56-9a85-358930dcbc91",
+      "input_default": {
+        "values": {}
+      },
+      "metadata": {
+        "position": {
+          "x": -520,
+          "y": -80
+        }
+      },
+      "input_links": [
+        {
+          "id": "4aa2e2bf-d023-404c-bbe8-4b9cac703736",
+          "source_id": "d3a6d5e7-bd57-4778-9a6a-73e177e9f322",
+          "sink_id": "4bc3bc90-cab3-4d54-a8c5-ca69c54352f1",
+          "source_name": "result",
+          "sink_name": "values_#_api_key",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "ed553b05-d8b4-4a4d-8502-740bc0280640",
+          "source_id": "4bc3bc90-cab3-4d54-a8c5-ca69c54352f1",
+          "sink_id": "7ff997ef-60de-4a92-83a0-9bc733e57300",
+          "source_name": "dictionary",
+          "sink_name": "values",
+          "is_static": false
+        }
+      ],
+      "graph_id": "54449497-20d0-44a1-b53b-2d84c55f3d92",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "7ff997ef-60de-4a92-83a0-9bc733e57300",
+      "block_id": "db7d8f02-2f44-4c55-ab7a-eae0941f0c30",
+      "input_default": {
+        "format": "{\"Authorization\":\"Bearer {{ api_key }}\",\"Content-Type\":\"application/json\"}",
+        "values": {},
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": -140,
+          "y": -80
+        }
+      },
+      "input_links": [
+        {
+          "id": "ed553b05-d8b4-4a4d-8502-740bc0280640",
+          "source_id": "4bc3bc90-cab3-4d54-a8c5-ca69c54352f1",
+          "sink_id": "7ff997ef-60de-4a92-83a0-9bc733e57300",
+          "source_name": "dictionary",
+          "sink_name": "values",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "0444028a-7e60-4148-b184-64c419e796c6",
+          "source_id": "7ff997ef-60de-4a92-83a0-9bc733e57300",
+          "sink_id": "7d03c3fc-1ba4-4d3f-8661-d27d1beb44d0",
+          "source_name": "output",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "graph_id": "54449497-20d0-44a1-b53b-2d84c55f3d92",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "7d03c3fc-1ba4-4d3f-8661-d27d1beb44d0",
+      "block_id": "95d1b990-ce13-4d88-9737-ba5c2070c97b",
+      "input_default": {
+        "type": "dictionary",
+        "value": null
+      },
+      "metadata": {
+        "position": {
+          "x": 180,
+          "y": -80
+        }
+      },
+      "input_links": [
+        {
+          "id": "0444028a-7e60-4148-b184-64c419e796c6",
+          "source_id": "7ff997ef-60de-4a92-83a0-9bc733e57300",
+          "sink_id": "7d03c3fc-1ba4-4d3f-8661-d27d1beb44d0",
+          "source_name": "output",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "eb72f1d3-f627-4a42-adb2-6d33c9aeed50",
+          "source_id": "7d03c3fc-1ba4-4d3f-8661-d27d1beb44d0",
+          "sink_id": "ef4acb09-3c04-4eea-b3ea-bfa05c0436fc",
+          "source_name": "value",
+          "sink_name": "headers",
+          "is_static": false
+        }
+      ],
+      "graph_id": "54449497-20d0-44a1-b53b-2d84c55f3d92",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "21d378c9-c7a6-4c33-8e07-58a871fddf97",
+      "block_id": "95d1b990-ce13-4d88-9737-ba5c2070c97b",
+      "input_default": {
+        "type": "dictionary",
+        "value": null
+      },
+      "metadata": {
+        "position": {
+          "x": -140,
+          "y": 220
+        }
+      },
+      "input_links": [
+        {
+          "id": "ed80a58d-2f78-494f-b960-7f8ff293ef8e",
+          "source_id": "a99b027d-fc2a-4b70-9357-30537302ed57",
+          "sink_id": "21d378c9-c7a6-4c33-8e07-58a871fddf97",
+          "source_name": "result",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "18cb2ee2-7bf7-48f8-af4d-97d1c8582794",
+          "source_id": "21d378c9-c7a6-4c33-8e07-58a871fddf97",
+          "sink_id": "ef4acb09-3c04-4eea-b3ea-bfa05c0436fc",
+          "source_name": "value",
+          "sink_name": "body",
+          "is_static": false
+        }
+      ],
+      "graph_id": "54449497-20d0-44a1-b53b-2d84c55f3d92",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "ef4acb09-3c04-4eea-b3ea-bfa05c0436fc",
+      "block_id": "6595ae1f-b924-42cb-9a41-551a0611c4b4",
+      "input_default": {
+        "url": "https://www.citedy.com/api/agent/products",
+        "method": "POST",
+        "headers": {},
+        "json_format": true,
+        "body": null,
+        "files_name": "file",
+        "files": []
+      },
+      "metadata": {
+        "position": {
+          "x": 560,
+          "y": 70
+        }
+      },
+      "input_links": [
+        {
+          "id": "eb72f1d3-f627-4a42-adb2-6d33c9aeed50",
+          "source_id": "7d03c3fc-1ba4-4d3f-8661-d27d1beb44d0",
+          "sink_id": "ef4acb09-3c04-4eea-b3ea-bfa05c0436fc",
+          "source_name": "value",
+          "sink_name": "headers",
+          "is_static": false
+        },
+        {
+          "id": "18cb2ee2-7bf7-48f8-af4d-97d1c8582794",
+          "source_id": "21d378c9-c7a6-4c33-8e07-58a871fddf97",
+          "sink_id": "ef4acb09-3c04-4eea-b3ea-bfa05c0436fc",
+          "source_name": "value",
+          "sink_name": "body",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "e90a5232-8096-43aa-9fd3-cc5900741e03",
+          "source_id": "ef4acb09-3c04-4eea-b3ea-bfa05c0436fc",
+          "sink_id": "fbf21036-a9f8-49e3-b3b9-0cf6ef859a25",
+          "source_name": "response",
+          "sink_name": "value",
+          "is_static": false
+        },
+        {
+          "id": "10be50e8-7eec-415b-ba92-62612d140843",
+          "source_id": "ef4acb09-3c04-4eea-b3ea-bfa05c0436fc",
+          "sink_id": "950c71d4-ad01-448d-8de7-629867a79f3e",
+          "source_name": "client_error",
+          "sink_name": "value",
+          "is_static": false
+        },
+        {
+          "id": "919eda10-fea0-4cde-834b-1667c22aa656",
+          "source_id": "ef4acb09-3c04-4eea-b3ea-bfa05c0436fc",
+          "sink_id": "6d7ae3bc-4386-46af-addf-9405133aee24",
+          "source_name": "server_error",
+          "sink_name": "value",
+          "is_static": false
+        },
+        {
+          "id": "f09efc5c-3cc4-4c04-ac98-f7d53cfdf899",
+          "source_id": "ef4acb09-3c04-4eea-b3ea-bfa05c0436fc",
+          "sink_id": "12f22cc5-1265-459d-95e4-54d5a1dd187d",
+          "source_name": "error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "graph_id": "54449497-20d0-44a1-b53b-2d84c55f3d92",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "fbf21036-a9f8-49e3-b3b9-0cf6ef859a25",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "response",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "Successful API response payload.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": -160
+        }
+      },
+      "input_links": [
+        {
+          "id": "e90a5232-8096-43aa-9fd3-cc5900741e03",
+          "source_id": "ef4acb09-3c04-4eea-b3ea-bfa05c0436fc",
+          "sink_id": "fbf21036-a9f8-49e3-b3b9-0cf6ef859a25",
+          "source_name": "response",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "54449497-20d0-44a1-b53b-2d84c55f3d92",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "950c71d4-ad01-448d-8de7-629867a79f3e",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "client_error",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "HTTP 4xx response payload.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": 20
+        }
+      },
+      "input_links": [
+        {
+          "id": "10be50e8-7eec-415b-ba92-62612d140843",
+          "source_id": "ef4acb09-3c04-4eea-b3ea-bfa05c0436fc",
+          "sink_id": "950c71d4-ad01-448d-8de7-629867a79f3e",
+          "source_name": "client_error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "54449497-20d0-44a1-b53b-2d84c55f3d92",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "6d7ae3bc-4386-46af-addf-9405133aee24",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "server_error",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "HTTP 5xx response payload.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": 200
+        }
+      },
+      "input_links": [
+        {
+          "id": "919eda10-fea0-4cde-834b-1667c22aa656",
+          "source_id": "ef4acb09-3c04-4eea-b3ea-bfa05c0436fc",
+          "sink_id": "6d7ae3bc-4386-46af-addf-9405133aee24",
+          "source_name": "server_error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "54449497-20d0-44a1-b53b-2d84c55f3d92",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "12f22cc5-1265-459d-95e4-54d5a1dd187d",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "error",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "Transport/runtime error output.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": 380
+        }
+      },
+      "input_links": [
+        {
+          "id": "f09efc5c-3cc4-4c04-ac98-f7d53cfdf899",
+          "source_id": "ef4acb09-3c04-4eea-b3ea-bfa05c0436fc",
+          "sink_id": "12f22cc5-1265-459d-95e4-54d5a1dd187d",
+          "source_name": "error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "54449497-20d0-44a1-b53b-2d84c55f3d92",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    }
+  ],
+  "links": [
+    {
+      "id": "4aa2e2bf-d023-404c-bbe8-4b9cac703736",
+      "source_id": "d3a6d5e7-bd57-4778-9a6a-73e177e9f322",
+      "sink_id": "4bc3bc90-cab3-4d54-a8c5-ca69c54352f1",
+      "source_name": "result",
+      "sink_name": "values_#_api_key",
+      "is_static": false
+    },
+    {
+      "id": "ed80a58d-2f78-494f-b960-7f8ff293ef8e",
+      "source_id": "a99b027d-fc2a-4b70-9357-30537302ed57",
+      "sink_id": "21d378c9-c7a6-4c33-8e07-58a871fddf97",
+      "source_name": "result",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "ed553b05-d8b4-4a4d-8502-740bc0280640",
+      "source_id": "4bc3bc90-cab3-4d54-a8c5-ca69c54352f1",
+      "sink_id": "7ff997ef-60de-4a92-83a0-9bc733e57300",
+      "source_name": "dictionary",
+      "sink_name": "values",
+      "is_static": false
+    },
+    {
+      "id": "0444028a-7e60-4148-b184-64c419e796c6",
+      "source_id": "7ff997ef-60de-4a92-83a0-9bc733e57300",
+      "sink_id": "7d03c3fc-1ba4-4d3f-8661-d27d1beb44d0",
+      "source_name": "output",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "eb72f1d3-f627-4a42-adb2-6d33c9aeed50",
+      "source_id": "7d03c3fc-1ba4-4d3f-8661-d27d1beb44d0",
+      "sink_id": "ef4acb09-3c04-4eea-b3ea-bfa05c0436fc",
+      "source_name": "value",
+      "sink_name": "headers",
+      "is_static": false
+    },
+    {
+      "id": "18cb2ee2-7bf7-48f8-af4d-97d1c8582794",
+      "source_id": "21d378c9-c7a6-4c33-8e07-58a871fddf97",
+      "sink_id": "ef4acb09-3c04-4eea-b3ea-bfa05c0436fc",
+      "source_name": "value",
+      "sink_name": "body",
+      "is_static": false
+    },
+    {
+      "id": "e90a5232-8096-43aa-9fd3-cc5900741e03",
+      "source_id": "ef4acb09-3c04-4eea-b3ea-bfa05c0436fc",
+      "sink_id": "fbf21036-a9f8-49e3-b3b9-0cf6ef859a25",
+      "source_name": "response",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "10be50e8-7eec-415b-ba92-62612d140843",
+      "source_id": "ef4acb09-3c04-4eea-b3ea-bfa05c0436fc",
+      "sink_id": "950c71d4-ad01-448d-8de7-629867a79f3e",
+      "source_name": "client_error",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "919eda10-fea0-4cde-834b-1667c22aa656",
+      "source_id": "ef4acb09-3c04-4eea-b3ea-bfa05c0436fc",
+      "sink_id": "6d7ae3bc-4386-46af-addf-9405133aee24",
+      "source_name": "server_error",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "f09efc5c-3cc4-4c04-ac98-f7d53cfdf899",
+      "source_id": "ef4acb09-3c04-4eea-b3ea-bfa05c0436fc",
+      "sink_id": "12f22cc5-1265-459d-95e4-54d5a1dd187d",
+      "source_name": "error",
+      "sink_name": "value",
+      "is_static": false
+    }
+  ],
+  "forked_from_id": null,
+  "forked_from_version": null,
+  "sub_graphs": [],
+  "user_id": "",
+  "created_at": "2026-02-28T12:00:00.000Z",
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "API Key": {
+        "advanced": false,
+        "anyOf": [
+          {
+            "format": "short-text",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "secret": true,
+        "title": "API Key",
+        "description": "Citedy API key (starts with citedy_agent_)",
+        "default": "citedy_agent_replace_me"
+      },
+      "Request JSON": {
+        "advanced": false,
+        "anyOf": [
+          {
+            "format": "long-text",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "secret": false,
+        "title": "Request JSON",
+        "description": "JSON payload for the selected Citedy endpoint.",
+        "default": "{\n  \"title\": \"Our AI Writing Platform\",\n  \"content\": \"Product description here...\",\n  \"source_type\": \"manual\"\n}"
+      }
+    },
+    "required": ["API Key", "Request JSON"]
+  },
+  "output_schema": {
+    "type": "object",
+    "properties": {
+      "response": {
+        "title": "response",
+        "description": "Successful API response payload.",
+        "type": "object"
+      },
+      "client_error": {
+        "title": "client_error",
+        "description": "HTTP 4xx response payload.",
+        "type": "object"
+      },
+      "server_error": {
+        "title": "server_error",
+        "description": "HTTP 5xx response payload.",
+        "type": "object"
+      },
+      "error": {
+        "title": "error",
+        "description": "Transport/runtime error output.",
+        "type": "string"
+      }
+    },
+    "required": []
+  },
+  "has_external_trigger": false,
+  "has_human_in_the_loop": false,
+  "trigger_setup_info": null,
+  "credentials_input_schema": {
+    "properties": {},
+    "required": [],
+    "title": "CitedyTemplateCredentialsInputSchema",
+    "type": "object"
+  }
+}

--- a/autogpt_platform/graph_templates/citedy-publish.agent.json
+++ b/autogpt_platform/graph_templates/citedy-publish.agent.json
@@ -1,0 +1,606 @@
+{
+  "id": "b5757d3e-6112-496c-ab9b-4c7084b2e480",
+  "version": 1,
+  "is_active": true,
+  "name": "Citedy Publish",
+  "description": "Publish or schedule a social adaptation.",
+  "instructions": null,
+  "recommended_schedule_cron": null,
+  "nodes": [
+    {
+      "id": "8c4627b4-738b-4180-98f6-19544cd4226d",
+      "block_id": "7fcd3bcb-8e1b-4e69-903d-32d3d4a92158",
+      "input_default": {
+        "name": "API Key",
+        "title": null,
+        "value": "citedy_agent_replace_me",
+        "secret": true,
+        "advanced": false,
+        "description": "Citedy API key (starts with citedy_agent_)",
+        "placeholder_values": []
+      },
+      "metadata": {
+        "position": {
+          "x": -920,
+          "y": -80
+        }
+      },
+      "input_links": [],
+      "output_links": [
+        {
+          "id": "0547df3a-66f0-44c7-b207-2f9e4fb49c67",
+          "source_id": "8c4627b4-738b-4180-98f6-19544cd4226d",
+          "sink_id": "83a0473a-9093-4f3b-a18a-fe79406afcd4",
+          "source_name": "result",
+          "sink_name": "values_#_api_key",
+          "is_static": false
+        }
+      ],
+      "graph_id": "b5757d3e-6112-496c-ab9b-4c7084b2e480",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "eeeb3bc9-de42-4964-a8c3-cf19855ce98f",
+      "block_id": "90a56ffb-7024-4b2b-ab50-e26c5e5ab8ba",
+      "input_default": {
+        "name": "Request JSON",
+        "title": null,
+        "value": "{\n  \"adaptationId\": \"uuid-replace-me\",\n  \"action\": \"now\",\n  \"platform\": \"linkedin\",\n  \"accountId\": \"uuid-replace-me\"\n}",
+        "secret": false,
+        "advanced": false,
+        "description": "JSON payload for this endpoint.",
+        "placeholder_values": []
+      },
+      "metadata": {
+        "position": {
+          "x": -920,
+          "y": 220
+        }
+      },
+      "input_links": [],
+      "output_links": [
+        {
+          "id": "10c1f2fe-adb1-4c06-9c40-4bad71c3c7ca",
+          "source_id": "eeeb3bc9-de42-4964-a8c3-cf19855ce98f",
+          "sink_id": "c1acc659-4c0b-46b6-acab-c7f3781f852a",
+          "source_name": "result",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "graph_id": "b5757d3e-6112-496c-ab9b-4c7084b2e480",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "83a0473a-9093-4f3b-a18a-fe79406afcd4",
+      "block_id": "b924ddf4-de4f-4b56-9a85-358930dcbc91",
+      "input_default": {
+        "values": {}
+      },
+      "metadata": {
+        "position": {
+          "x": -520,
+          "y": -80
+        }
+      },
+      "input_links": [
+        {
+          "id": "0547df3a-66f0-44c7-b207-2f9e4fb49c67",
+          "source_id": "8c4627b4-738b-4180-98f6-19544cd4226d",
+          "sink_id": "83a0473a-9093-4f3b-a18a-fe79406afcd4",
+          "source_name": "result",
+          "sink_name": "values_#_api_key",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "c2b9e86e-3ce8-4918-af90-d22c8463a426",
+          "source_id": "83a0473a-9093-4f3b-a18a-fe79406afcd4",
+          "sink_id": "60406f1d-dc6e-41c1-bbdf-47a89a62f687",
+          "source_name": "dictionary",
+          "sink_name": "values",
+          "is_static": false
+        }
+      ],
+      "graph_id": "b5757d3e-6112-496c-ab9b-4c7084b2e480",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "60406f1d-dc6e-41c1-bbdf-47a89a62f687",
+      "block_id": "db7d8f02-2f44-4c55-ab7a-eae0941f0c30",
+      "input_default": {
+        "format": "{\"Authorization\":\"Bearer {{ api_key }}\",\"Content-Type\":\"application/json\"}",
+        "values": {},
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": -140,
+          "y": -80
+        }
+      },
+      "input_links": [
+        {
+          "id": "c2b9e86e-3ce8-4918-af90-d22c8463a426",
+          "source_id": "83a0473a-9093-4f3b-a18a-fe79406afcd4",
+          "sink_id": "60406f1d-dc6e-41c1-bbdf-47a89a62f687",
+          "source_name": "dictionary",
+          "sink_name": "values",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "008e8efb-8348-40af-8f4d-a2c1a32a076b",
+          "source_id": "60406f1d-dc6e-41c1-bbdf-47a89a62f687",
+          "sink_id": "449f8363-1e4f-481e-a121-c9aad94f9951",
+          "source_name": "output",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "graph_id": "b5757d3e-6112-496c-ab9b-4c7084b2e480",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "449f8363-1e4f-481e-a121-c9aad94f9951",
+      "block_id": "95d1b990-ce13-4d88-9737-ba5c2070c97b",
+      "input_default": {
+        "type": "dictionary",
+        "value": null
+      },
+      "metadata": {
+        "position": {
+          "x": 180,
+          "y": -80
+        }
+      },
+      "input_links": [
+        {
+          "id": "008e8efb-8348-40af-8f4d-a2c1a32a076b",
+          "source_id": "60406f1d-dc6e-41c1-bbdf-47a89a62f687",
+          "sink_id": "449f8363-1e4f-481e-a121-c9aad94f9951",
+          "source_name": "output",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "e4aaade8-f6ad-49ae-bde3-6adb47d08c23",
+          "source_id": "449f8363-1e4f-481e-a121-c9aad94f9951",
+          "sink_id": "4d2e262f-c9c4-44ed-ac94-df8f90b668a2",
+          "source_name": "value",
+          "sink_name": "headers",
+          "is_static": false
+        }
+      ],
+      "graph_id": "b5757d3e-6112-496c-ab9b-4c7084b2e480",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "c1acc659-4c0b-46b6-acab-c7f3781f852a",
+      "block_id": "95d1b990-ce13-4d88-9737-ba5c2070c97b",
+      "input_default": {
+        "type": "dictionary",
+        "value": null
+      },
+      "metadata": {
+        "position": {
+          "x": -140,
+          "y": 220
+        }
+      },
+      "input_links": [
+        {
+          "id": "10c1f2fe-adb1-4c06-9c40-4bad71c3c7ca",
+          "source_id": "eeeb3bc9-de42-4964-a8c3-cf19855ce98f",
+          "sink_id": "c1acc659-4c0b-46b6-acab-c7f3781f852a",
+          "source_name": "result",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "9a7fe0bb-1dd0-44fa-98cd-e13b26432ffc",
+          "source_id": "c1acc659-4c0b-46b6-acab-c7f3781f852a",
+          "sink_id": "4d2e262f-c9c4-44ed-ac94-df8f90b668a2",
+          "source_name": "value",
+          "sink_name": "body",
+          "is_static": false
+        }
+      ],
+      "graph_id": "b5757d3e-6112-496c-ab9b-4c7084b2e480",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "4d2e262f-c9c4-44ed-ac94-df8f90b668a2",
+      "block_id": "6595ae1f-b924-42cb-9a41-551a0611c4b4",
+      "input_default": {
+        "url": "https://www.citedy.com/api/agent/publish",
+        "method": "POST",
+        "headers": {},
+        "json_format": true,
+        "body": null,
+        "files_name": "file",
+        "files": []
+      },
+      "metadata": {
+        "position": {
+          "x": 560,
+          "y": 70
+        }
+      },
+      "input_links": [
+        {
+          "id": "e4aaade8-f6ad-49ae-bde3-6adb47d08c23",
+          "source_id": "449f8363-1e4f-481e-a121-c9aad94f9951",
+          "sink_id": "4d2e262f-c9c4-44ed-ac94-df8f90b668a2",
+          "source_name": "value",
+          "sink_name": "headers",
+          "is_static": false
+        },
+        {
+          "id": "9a7fe0bb-1dd0-44fa-98cd-e13b26432ffc",
+          "source_id": "c1acc659-4c0b-46b6-acab-c7f3781f852a",
+          "sink_id": "4d2e262f-c9c4-44ed-ac94-df8f90b668a2",
+          "source_name": "value",
+          "sink_name": "body",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "9afdd10e-b408-4788-98ad-c39b20f414af",
+          "source_id": "4d2e262f-c9c4-44ed-ac94-df8f90b668a2",
+          "sink_id": "93143d0c-813a-4e3e-957e-6aa5f5a1bad7",
+          "source_name": "response",
+          "sink_name": "value",
+          "is_static": false
+        },
+        {
+          "id": "505f4437-9277-4f0c-b028-cac4989faded",
+          "source_id": "4d2e262f-c9c4-44ed-ac94-df8f90b668a2",
+          "sink_id": "a1f01047-e207-48d3-98a9-237166c3f673",
+          "source_name": "client_error",
+          "sink_name": "value",
+          "is_static": false
+        },
+        {
+          "id": "b810c8ac-c612-4ea5-98d9-30a3d41deeb8",
+          "source_id": "4d2e262f-c9c4-44ed-ac94-df8f90b668a2",
+          "sink_id": "a39a1b05-6349-4a1c-a25c-800403bf9cfa",
+          "source_name": "server_error",
+          "sink_name": "value",
+          "is_static": false
+        },
+        {
+          "id": "db883e0d-409d-4c18-9798-e04062c1a095",
+          "source_id": "4d2e262f-c9c4-44ed-ac94-df8f90b668a2",
+          "sink_id": "3d466a4c-08d1-4c5e-b892-825aa5e66b3e",
+          "source_name": "error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "graph_id": "b5757d3e-6112-496c-ab9b-4c7084b2e480",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "93143d0c-813a-4e3e-957e-6aa5f5a1bad7",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "response",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "Successful API response payload.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": -160
+        }
+      },
+      "input_links": [
+        {
+          "id": "9afdd10e-b408-4788-98ad-c39b20f414af",
+          "source_id": "4d2e262f-c9c4-44ed-ac94-df8f90b668a2",
+          "sink_id": "93143d0c-813a-4e3e-957e-6aa5f5a1bad7",
+          "source_name": "response",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "b5757d3e-6112-496c-ab9b-4c7084b2e480",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "a1f01047-e207-48d3-98a9-237166c3f673",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "client_error",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "HTTP 4xx response payload.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": 20
+        }
+      },
+      "input_links": [
+        {
+          "id": "505f4437-9277-4f0c-b028-cac4989faded",
+          "source_id": "4d2e262f-c9c4-44ed-ac94-df8f90b668a2",
+          "sink_id": "a1f01047-e207-48d3-98a9-237166c3f673",
+          "source_name": "client_error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "b5757d3e-6112-496c-ab9b-4c7084b2e480",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "a39a1b05-6349-4a1c-a25c-800403bf9cfa",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "server_error",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "HTTP 5xx response payload.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": 200
+        }
+      },
+      "input_links": [
+        {
+          "id": "b810c8ac-c612-4ea5-98d9-30a3d41deeb8",
+          "source_id": "4d2e262f-c9c4-44ed-ac94-df8f90b668a2",
+          "sink_id": "a39a1b05-6349-4a1c-a25c-800403bf9cfa",
+          "source_name": "server_error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "b5757d3e-6112-496c-ab9b-4c7084b2e480",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "3d466a4c-08d1-4c5e-b892-825aa5e66b3e",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "error",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "Transport/runtime error output.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": 380
+        }
+      },
+      "input_links": [
+        {
+          "id": "db883e0d-409d-4c18-9798-e04062c1a095",
+          "source_id": "4d2e262f-c9c4-44ed-ac94-df8f90b668a2",
+          "sink_id": "3d466a4c-08d1-4c5e-b892-825aa5e66b3e",
+          "source_name": "error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "b5757d3e-6112-496c-ab9b-4c7084b2e480",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    }
+  ],
+  "links": [
+    {
+      "id": "0547df3a-66f0-44c7-b207-2f9e4fb49c67",
+      "source_id": "8c4627b4-738b-4180-98f6-19544cd4226d",
+      "sink_id": "83a0473a-9093-4f3b-a18a-fe79406afcd4",
+      "source_name": "result",
+      "sink_name": "values_#_api_key",
+      "is_static": false
+    },
+    {
+      "id": "10c1f2fe-adb1-4c06-9c40-4bad71c3c7ca",
+      "source_id": "eeeb3bc9-de42-4964-a8c3-cf19855ce98f",
+      "sink_id": "c1acc659-4c0b-46b6-acab-c7f3781f852a",
+      "source_name": "result",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "c2b9e86e-3ce8-4918-af90-d22c8463a426",
+      "source_id": "83a0473a-9093-4f3b-a18a-fe79406afcd4",
+      "sink_id": "60406f1d-dc6e-41c1-bbdf-47a89a62f687",
+      "source_name": "dictionary",
+      "sink_name": "values",
+      "is_static": false
+    },
+    {
+      "id": "008e8efb-8348-40af-8f4d-a2c1a32a076b",
+      "source_id": "60406f1d-dc6e-41c1-bbdf-47a89a62f687",
+      "sink_id": "449f8363-1e4f-481e-a121-c9aad94f9951",
+      "source_name": "output",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "e4aaade8-f6ad-49ae-bde3-6adb47d08c23",
+      "source_id": "449f8363-1e4f-481e-a121-c9aad94f9951",
+      "sink_id": "4d2e262f-c9c4-44ed-ac94-df8f90b668a2",
+      "source_name": "value",
+      "sink_name": "headers",
+      "is_static": false
+    },
+    {
+      "id": "9a7fe0bb-1dd0-44fa-98cd-e13b26432ffc",
+      "source_id": "c1acc659-4c0b-46b6-acab-c7f3781f852a",
+      "sink_id": "4d2e262f-c9c4-44ed-ac94-df8f90b668a2",
+      "source_name": "value",
+      "sink_name": "body",
+      "is_static": false
+    },
+    {
+      "id": "9afdd10e-b408-4788-98ad-c39b20f414af",
+      "source_id": "4d2e262f-c9c4-44ed-ac94-df8f90b668a2",
+      "sink_id": "93143d0c-813a-4e3e-957e-6aa5f5a1bad7",
+      "source_name": "response",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "505f4437-9277-4f0c-b028-cac4989faded",
+      "source_id": "4d2e262f-c9c4-44ed-ac94-df8f90b668a2",
+      "sink_id": "a1f01047-e207-48d3-98a9-237166c3f673",
+      "source_name": "client_error",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "b810c8ac-c612-4ea5-98d9-30a3d41deeb8",
+      "source_id": "4d2e262f-c9c4-44ed-ac94-df8f90b668a2",
+      "sink_id": "a39a1b05-6349-4a1c-a25c-800403bf9cfa",
+      "source_name": "server_error",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "db883e0d-409d-4c18-9798-e04062c1a095",
+      "source_id": "4d2e262f-c9c4-44ed-ac94-df8f90b668a2",
+      "sink_id": "3d466a4c-08d1-4c5e-b892-825aa5e66b3e",
+      "source_name": "error",
+      "sink_name": "value",
+      "is_static": false
+    }
+  ],
+  "forked_from_id": null,
+  "forked_from_version": null,
+  "sub_graphs": [],
+  "user_id": "",
+  "created_at": "2026-02-28T12:00:00.000Z",
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "API Key": {
+        "advanced": false,
+        "anyOf": [
+          {
+            "format": "short-text",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "secret": true,
+        "title": "API Key",
+        "description": "Citedy API key (starts with citedy_agent_)",
+        "default": "citedy_agent_replace_me"
+      },
+      "Request JSON": {
+        "advanced": false,
+        "anyOf": [
+          {
+            "format": "long-text",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "secret": false,
+        "title": "Request JSON",
+        "description": "JSON payload for the selected Citedy endpoint.",
+        "default": "{\n  \"adaptationId\": \"uuid-replace-me\",\n  \"action\": \"now\",\n  \"platform\": \"linkedin\",\n  \"accountId\": \"uuid-replace-me\"\n}"
+      }
+    },
+    "required": ["API Key", "Request JSON"]
+  },
+  "output_schema": {
+    "type": "object",
+    "properties": {
+      "response": {
+        "title": "response",
+        "description": "Successful API response payload.",
+        "type": "object"
+      },
+      "client_error": {
+        "title": "client_error",
+        "description": "HTTP 4xx response payload.",
+        "type": "object"
+      },
+      "server_error": {
+        "title": "server_error",
+        "description": "HTTP 5xx response payload.",
+        "type": "object"
+      },
+      "error": {
+        "title": "error",
+        "description": "Transport/runtime error output.",
+        "type": "string"
+      }
+    },
+    "required": []
+  },
+  "has_external_trigger": false,
+  "has_human_in_the_loop": false,
+  "trigger_setup_info": null,
+  "credentials_input_schema": {
+    "properties": {},
+    "required": [],
+    "title": "CitedyTemplateCredentialsInputSchema",
+    "type": "object"
+  }
+}

--- a/autogpt_platform/graph_templates/citedy-reddit-to-publish.agent.json
+++ b/autogpt_platform/graph_templates/citedy-reddit-to-publish.agent.json
@@ -1,0 +1,606 @@
+{
+  "id": "e084a2f0-a8fa-4042-8348-283e020c1ede",
+  "version": 1,
+  "is_active": true,
+  "name": "Citedy Trend Scout (Reddit)",
+  "description": "Scout Reddit trends for content opportunities.",
+  "instructions": null,
+  "recommended_schedule_cron": null,
+  "nodes": [
+    {
+      "id": "b4bb3806-355f-4111-b98c-0bbc936d67e3",
+      "block_id": "7fcd3bcb-8e1b-4e69-903d-32d3d4a92158",
+      "input_default": {
+        "name": "API Key",
+        "title": null,
+        "value": "citedy_agent_replace_me",
+        "secret": true,
+        "advanced": false,
+        "description": "Citedy API key (starts with citedy_agent_)",
+        "placeholder_values": []
+      },
+      "metadata": {
+        "position": {
+          "x": -920,
+          "y": -80
+        }
+      },
+      "input_links": [],
+      "output_links": [
+        {
+          "id": "15dcef8c-a7db-4355-9791-f340f1be1010",
+          "source_id": "b4bb3806-355f-4111-b98c-0bbc936d67e3",
+          "sink_id": "0635939e-3ec3-49bf-9d59-3c7a01286343",
+          "source_name": "result",
+          "sink_name": "values_#_api_key",
+          "is_static": false
+        }
+      ],
+      "graph_id": "e084a2f0-a8fa-4042-8348-283e020c1ede",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "e6232b0b-f8b5-4367-b42e-70d817da8c0e",
+      "block_id": "90a56ffb-7024-4b2b-ab50-e26c5e5ab8ba",
+      "input_default": {
+        "name": "Request JSON",
+        "title": null,
+        "value": "{\n  \"subreddits\": [\n    \"marketing\",\n    \"seo\"\n  ],\n  \"query\": \"AI content marketing\",\n  \"limit\": 5\n}",
+        "secret": false,
+        "advanced": false,
+        "description": "JSON payload for this endpoint.",
+        "placeholder_values": []
+      },
+      "metadata": {
+        "position": {
+          "x": -920,
+          "y": 220
+        }
+      },
+      "input_links": [],
+      "output_links": [
+        {
+          "id": "552d345b-6cd4-4edf-99ea-6a08bc692e1c",
+          "source_id": "e6232b0b-f8b5-4367-b42e-70d817da8c0e",
+          "sink_id": "61c77f81-4ae8-4dfa-bfb1-a0fe31ac4385",
+          "source_name": "result",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "graph_id": "e084a2f0-a8fa-4042-8348-283e020c1ede",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "0635939e-3ec3-49bf-9d59-3c7a01286343",
+      "block_id": "b924ddf4-de4f-4b56-9a85-358930dcbc91",
+      "input_default": {
+        "values": {}
+      },
+      "metadata": {
+        "position": {
+          "x": -520,
+          "y": -80
+        }
+      },
+      "input_links": [
+        {
+          "id": "15dcef8c-a7db-4355-9791-f340f1be1010",
+          "source_id": "b4bb3806-355f-4111-b98c-0bbc936d67e3",
+          "sink_id": "0635939e-3ec3-49bf-9d59-3c7a01286343",
+          "source_name": "result",
+          "sink_name": "values_#_api_key",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "409f2beb-5697-4247-9019-4de7e63ef4a9",
+          "source_id": "0635939e-3ec3-49bf-9d59-3c7a01286343",
+          "sink_id": "13fbf808-1e5e-478d-a374-699195dd9956",
+          "source_name": "dictionary",
+          "sink_name": "values",
+          "is_static": false
+        }
+      ],
+      "graph_id": "e084a2f0-a8fa-4042-8348-283e020c1ede",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "13fbf808-1e5e-478d-a374-699195dd9956",
+      "block_id": "db7d8f02-2f44-4c55-ab7a-eae0941f0c30",
+      "input_default": {
+        "format": "{\"Authorization\":\"Bearer {{ api_key }}\",\"Content-Type\":\"application/json\"}",
+        "values": {},
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": -140,
+          "y": -80
+        }
+      },
+      "input_links": [
+        {
+          "id": "409f2beb-5697-4247-9019-4de7e63ef4a9",
+          "source_id": "0635939e-3ec3-49bf-9d59-3c7a01286343",
+          "sink_id": "13fbf808-1e5e-478d-a374-699195dd9956",
+          "source_name": "dictionary",
+          "sink_name": "values",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "c254db17-e1c7-4e31-b6b1-b70ec9238b6b",
+          "source_id": "13fbf808-1e5e-478d-a374-699195dd9956",
+          "sink_id": "9ad05922-9a6d-4498-9e7a-1e6caf8c1b18",
+          "source_name": "output",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "graph_id": "e084a2f0-a8fa-4042-8348-283e020c1ede",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "9ad05922-9a6d-4498-9e7a-1e6caf8c1b18",
+      "block_id": "95d1b990-ce13-4d88-9737-ba5c2070c97b",
+      "input_default": {
+        "type": "dictionary",
+        "value": null
+      },
+      "metadata": {
+        "position": {
+          "x": 180,
+          "y": -80
+        }
+      },
+      "input_links": [
+        {
+          "id": "c254db17-e1c7-4e31-b6b1-b70ec9238b6b",
+          "source_id": "13fbf808-1e5e-478d-a374-699195dd9956",
+          "sink_id": "9ad05922-9a6d-4498-9e7a-1e6caf8c1b18",
+          "source_name": "output",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "f9e57fa2-99e1-497e-85b2-73c0d1d1c658",
+          "source_id": "9ad05922-9a6d-4498-9e7a-1e6caf8c1b18",
+          "sink_id": "ee80efb9-a754-423a-a874-62b18ba6491d",
+          "source_name": "value",
+          "sink_name": "headers",
+          "is_static": false
+        }
+      ],
+      "graph_id": "e084a2f0-a8fa-4042-8348-283e020c1ede",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "61c77f81-4ae8-4dfa-bfb1-a0fe31ac4385",
+      "block_id": "95d1b990-ce13-4d88-9737-ba5c2070c97b",
+      "input_default": {
+        "type": "dictionary",
+        "value": null
+      },
+      "metadata": {
+        "position": {
+          "x": -140,
+          "y": 220
+        }
+      },
+      "input_links": [
+        {
+          "id": "552d345b-6cd4-4edf-99ea-6a08bc692e1c",
+          "source_id": "e6232b0b-f8b5-4367-b42e-70d817da8c0e",
+          "sink_id": "61c77f81-4ae8-4dfa-bfb1-a0fe31ac4385",
+          "source_name": "result",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "bd3389b5-6506-4340-bfd4-b1d756c21e62",
+          "source_id": "61c77f81-4ae8-4dfa-bfb1-a0fe31ac4385",
+          "sink_id": "ee80efb9-a754-423a-a874-62b18ba6491d",
+          "source_name": "value",
+          "sink_name": "body",
+          "is_static": false
+        }
+      ],
+      "graph_id": "e084a2f0-a8fa-4042-8348-283e020c1ede",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "ee80efb9-a754-423a-a874-62b18ba6491d",
+      "block_id": "6595ae1f-b924-42cb-9a41-551a0611c4b4",
+      "input_default": {
+        "url": "https://www.citedy.com/api/agent/scout/reddit",
+        "method": "POST",
+        "headers": {},
+        "json_format": true,
+        "body": null,
+        "files_name": "file",
+        "files": []
+      },
+      "metadata": {
+        "position": {
+          "x": 560,
+          "y": 70
+        }
+      },
+      "input_links": [
+        {
+          "id": "f9e57fa2-99e1-497e-85b2-73c0d1d1c658",
+          "source_id": "9ad05922-9a6d-4498-9e7a-1e6caf8c1b18",
+          "sink_id": "ee80efb9-a754-423a-a874-62b18ba6491d",
+          "source_name": "value",
+          "sink_name": "headers",
+          "is_static": false
+        },
+        {
+          "id": "bd3389b5-6506-4340-bfd4-b1d756c21e62",
+          "source_id": "61c77f81-4ae8-4dfa-bfb1-a0fe31ac4385",
+          "sink_id": "ee80efb9-a754-423a-a874-62b18ba6491d",
+          "source_name": "value",
+          "sink_name": "body",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "ca19558e-00c1-4f5e-8634-dd2bbfe5c46a",
+          "source_id": "ee80efb9-a754-423a-a874-62b18ba6491d",
+          "sink_id": "4a62ab18-9a07-436f-a066-bd6ab56d4fc6",
+          "source_name": "response",
+          "sink_name": "value",
+          "is_static": false
+        },
+        {
+          "id": "973504f4-8984-436c-a0b9-71d6fd2c4c72",
+          "source_id": "ee80efb9-a754-423a-a874-62b18ba6491d",
+          "sink_id": "90b203fe-3d62-420e-9881-eecdc9f3217c",
+          "source_name": "client_error",
+          "sink_name": "value",
+          "is_static": false
+        },
+        {
+          "id": "8d860f42-1823-43db-b01e-39ac78f9f75d",
+          "source_id": "ee80efb9-a754-423a-a874-62b18ba6491d",
+          "sink_id": "ebe78c9c-a9aa-480b-9e7b-9afb41cb1147",
+          "source_name": "server_error",
+          "sink_name": "value",
+          "is_static": false
+        },
+        {
+          "id": "31ce7a23-060f-453d-b68d-71c82c06322d",
+          "source_id": "ee80efb9-a754-423a-a874-62b18ba6491d",
+          "sink_id": "4d8f368e-57d2-4c9d-b73f-91cbb620e850",
+          "source_name": "error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "graph_id": "e084a2f0-a8fa-4042-8348-283e020c1ede",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "4a62ab18-9a07-436f-a066-bd6ab56d4fc6",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "response",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "Successful API response payload.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": -160
+        }
+      },
+      "input_links": [
+        {
+          "id": "ca19558e-00c1-4f5e-8634-dd2bbfe5c46a",
+          "source_id": "ee80efb9-a754-423a-a874-62b18ba6491d",
+          "sink_id": "4a62ab18-9a07-436f-a066-bd6ab56d4fc6",
+          "source_name": "response",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "e084a2f0-a8fa-4042-8348-283e020c1ede",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "90b203fe-3d62-420e-9881-eecdc9f3217c",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "client_error",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "HTTP 4xx response payload.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": 20
+        }
+      },
+      "input_links": [
+        {
+          "id": "973504f4-8984-436c-a0b9-71d6fd2c4c72",
+          "source_id": "ee80efb9-a754-423a-a874-62b18ba6491d",
+          "sink_id": "90b203fe-3d62-420e-9881-eecdc9f3217c",
+          "source_name": "client_error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "e084a2f0-a8fa-4042-8348-283e020c1ede",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "ebe78c9c-a9aa-480b-9e7b-9afb41cb1147",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "server_error",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "HTTP 5xx response payload.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": 200
+        }
+      },
+      "input_links": [
+        {
+          "id": "8d860f42-1823-43db-b01e-39ac78f9f75d",
+          "source_id": "ee80efb9-a754-423a-a874-62b18ba6491d",
+          "sink_id": "ebe78c9c-a9aa-480b-9e7b-9afb41cb1147",
+          "source_name": "server_error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "e084a2f0-a8fa-4042-8348-283e020c1ede",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "4d8f368e-57d2-4c9d-b73f-91cbb620e850",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "error",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "Transport/runtime error output.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": 380
+        }
+      },
+      "input_links": [
+        {
+          "id": "31ce7a23-060f-453d-b68d-71c82c06322d",
+          "source_id": "ee80efb9-a754-423a-a874-62b18ba6491d",
+          "sink_id": "4d8f368e-57d2-4c9d-b73f-91cbb620e850",
+          "source_name": "error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "e084a2f0-a8fa-4042-8348-283e020c1ede",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    }
+  ],
+  "links": [
+    {
+      "id": "15dcef8c-a7db-4355-9791-f340f1be1010",
+      "source_id": "b4bb3806-355f-4111-b98c-0bbc936d67e3",
+      "sink_id": "0635939e-3ec3-49bf-9d59-3c7a01286343",
+      "source_name": "result",
+      "sink_name": "values_#_api_key",
+      "is_static": false
+    },
+    {
+      "id": "409f2beb-5697-4247-9019-4de7e63ef4a9",
+      "source_id": "0635939e-3ec3-49bf-9d59-3c7a01286343",
+      "sink_id": "13fbf808-1e5e-478d-a374-699195dd9956",
+      "source_name": "dictionary",
+      "sink_name": "values",
+      "is_static": false
+    },
+    {
+      "id": "c254db17-e1c7-4e31-b6b1-b70ec9238b6b",
+      "source_id": "13fbf808-1e5e-478d-a374-699195dd9956",
+      "sink_id": "9ad05922-9a6d-4498-9e7a-1e6caf8c1b18",
+      "source_name": "output",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "552d345b-6cd4-4edf-99ea-6a08bc692e1c",
+      "source_id": "e6232b0b-f8b5-4367-b42e-70d817da8c0e",
+      "sink_id": "61c77f81-4ae8-4dfa-bfb1-a0fe31ac4385",
+      "source_name": "result",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "f9e57fa2-99e1-497e-85b2-73c0d1d1c658",
+      "source_id": "9ad05922-9a6d-4498-9e7a-1e6caf8c1b18",
+      "sink_id": "ee80efb9-a754-423a-a874-62b18ba6491d",
+      "source_name": "value",
+      "sink_name": "headers",
+      "is_static": false
+    },
+    {
+      "id": "bd3389b5-6506-4340-bfd4-b1d756c21e62",
+      "source_id": "61c77f81-4ae8-4dfa-bfb1-a0fe31ac4385",
+      "sink_id": "ee80efb9-a754-423a-a874-62b18ba6491d",
+      "source_name": "value",
+      "sink_name": "body",
+      "is_static": false
+    },
+    {
+      "id": "ca19558e-00c1-4f5e-8634-dd2bbfe5c46a",
+      "source_id": "ee80efb9-a754-423a-a874-62b18ba6491d",
+      "sink_id": "4a62ab18-9a07-436f-a066-bd6ab56d4fc6",
+      "source_name": "response",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "973504f4-8984-436c-a0b9-71d6fd2c4c72",
+      "source_id": "ee80efb9-a754-423a-a874-62b18ba6491d",
+      "sink_id": "90b203fe-3d62-420e-9881-eecdc9f3217c",
+      "source_name": "client_error",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "8d860f42-1823-43db-b01e-39ac78f9f75d",
+      "source_id": "ee80efb9-a754-423a-a874-62b18ba6491d",
+      "sink_id": "ebe78c9c-a9aa-480b-9e7b-9afb41cb1147",
+      "source_name": "server_error",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "31ce7a23-060f-453d-b68d-71c82c06322d",
+      "source_id": "ee80efb9-a754-423a-a874-62b18ba6491d",
+      "sink_id": "4d8f368e-57d2-4c9d-b73f-91cbb620e850",
+      "source_name": "error",
+      "sink_name": "value",
+      "is_static": false
+    }
+  ],
+  "forked_from_id": null,
+  "forked_from_version": null,
+  "sub_graphs": [],
+  "user_id": "",
+  "created_at": "2026-02-14T23:47:30.880Z",
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "API Key": {
+        "advanced": false,
+        "anyOf": [
+          {
+            "format": "short-text",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "secret": true,
+        "title": "API Key",
+        "description": "Citedy API key (starts with citedy_agent_)",
+        "default": "citedy_agent_replace_me"
+      },
+      "Request JSON": {
+        "advanced": false,
+        "anyOf": [
+          {
+            "format": "long-text",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "secret": false,
+        "title": "Request JSON",
+        "description": "JSON payload for the selected Citedy endpoint.",
+        "default": "{\n  \"subreddits\": [\n    \"marketing\",\n    \"seo\"\n  ],\n  \"query\": \"AI content marketing\",\n  \"limit\": 5\n}"
+      }
+    },
+    "required": ["API Key", "Request JSON"]
+  },
+  "output_schema": {
+    "type": "object",
+    "properties": {
+      "response": {
+        "title": "response",
+        "description": "Successful API response payload.",
+        "type": "object"
+      },
+      "client_error": {
+        "title": "client_error",
+        "description": "HTTP 4xx response payload.",
+        "type": "object"
+      },
+      "server_error": {
+        "title": "server_error",
+        "description": "HTTP 5xx response payload.",
+        "type": "object"
+      },
+      "error": {
+        "title": "error",
+        "description": "Transport/runtime error output.",
+        "type": "string"
+      }
+    },
+    "required": []
+  },
+  "has_external_trigger": false,
+  "has_human_in_the_loop": false,
+  "trigger_setup_info": null,
+  "credentials_input_schema": {
+    "properties": {},
+    "required": [],
+    "title": "CitedyTemplateCredentialsInputSchema",
+    "type": "object"
+  }
+}

--- a/autogpt_platform/graph_templates/citedy-scan.agent.json
+++ b/autogpt_platform/graph_templates/citedy-scan.agent.json
@@ -1,0 +1,606 @@
+{
+  "id": "f19193fe-97e0-4767-bd3c-20a9f6ed19ed",
+  "version": 1,
+  "is_active": true,
+  "name": "Citedy Trend Scan",
+  "description": "Fast trend scan across X, web, HackerNews, Reddit (2-8 credits).",
+  "instructions": null,
+  "recommended_schedule_cron": null,
+  "nodes": [
+    {
+      "id": "b7ad72ed-5e46-4398-b8ba-8469475d7655",
+      "block_id": "7fcd3bcb-8e1b-4e69-903d-32d3d4a92158",
+      "input_default": {
+        "name": "API Key",
+        "title": null,
+        "value": "citedy_agent_replace_me",
+        "secret": true,
+        "advanced": false,
+        "description": "Citedy API key (starts with citedy_agent_)",
+        "placeholder_values": []
+      },
+      "metadata": {
+        "position": {
+          "x": -920,
+          "y": -80
+        }
+      },
+      "input_links": [],
+      "output_links": [
+        {
+          "id": "ba05c2c9-fe7d-4238-8025-6f869579b7b8",
+          "source_id": "b7ad72ed-5e46-4398-b8ba-8469475d7655",
+          "sink_id": "bfeedad5-d11f-4370-9208-2eedd597f459",
+          "source_name": "result",
+          "sink_name": "values_#_api_key",
+          "is_static": false
+        }
+      ],
+      "graph_id": "f19193fe-97e0-4767-bd3c-20a9f6ed19ed",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "27e673b5-61bc-4f91-9c24-dbd564d167a8",
+      "block_id": "90a56ffb-7024-4b2b-ab50-e26c5e5ab8ba",
+      "input_default": {
+        "name": "Request JSON",
+        "title": null,
+        "value": "{\n  \"query\": \"AI content marketing trends\",\n  \"mode\": \"deep\",\n  \"limit\": 10\n}",
+        "secret": false,
+        "advanced": false,
+        "description": "JSON payload for this endpoint.",
+        "placeholder_values": []
+      },
+      "metadata": {
+        "position": {
+          "x": -920,
+          "y": 220
+        }
+      },
+      "input_links": [],
+      "output_links": [
+        {
+          "id": "5461d10d-fdc4-47ff-a719-6a5d44cb909c",
+          "source_id": "27e673b5-61bc-4f91-9c24-dbd564d167a8",
+          "sink_id": "044241e6-d507-44f7-99c2-5926fa78e5c8",
+          "source_name": "result",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "graph_id": "f19193fe-97e0-4767-bd3c-20a9f6ed19ed",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "bfeedad5-d11f-4370-9208-2eedd597f459",
+      "block_id": "b924ddf4-de4f-4b56-9a85-358930dcbc91",
+      "input_default": {
+        "values": {}
+      },
+      "metadata": {
+        "position": {
+          "x": -520,
+          "y": -80
+        }
+      },
+      "input_links": [
+        {
+          "id": "ba05c2c9-fe7d-4238-8025-6f869579b7b8",
+          "source_id": "b7ad72ed-5e46-4398-b8ba-8469475d7655",
+          "sink_id": "bfeedad5-d11f-4370-9208-2eedd597f459",
+          "source_name": "result",
+          "sink_name": "values_#_api_key",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "4e380579-489c-4309-8ebb-a50491668eb7",
+          "source_id": "bfeedad5-d11f-4370-9208-2eedd597f459",
+          "sink_id": "d6792432-f7fd-41a2-984b-04716dee0079",
+          "source_name": "dictionary",
+          "sink_name": "values",
+          "is_static": false
+        }
+      ],
+      "graph_id": "f19193fe-97e0-4767-bd3c-20a9f6ed19ed",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "d6792432-f7fd-41a2-984b-04716dee0079",
+      "block_id": "db7d8f02-2f44-4c55-ab7a-eae0941f0c30",
+      "input_default": {
+        "format": "{\"Authorization\":\"Bearer {{ api_key }}\",\"Content-Type\":\"application/json\"}",
+        "values": {},
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": -140,
+          "y": -80
+        }
+      },
+      "input_links": [
+        {
+          "id": "4e380579-489c-4309-8ebb-a50491668eb7",
+          "source_id": "bfeedad5-d11f-4370-9208-2eedd597f459",
+          "sink_id": "d6792432-f7fd-41a2-984b-04716dee0079",
+          "source_name": "dictionary",
+          "sink_name": "values",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "ee4463eb-dcdc-4036-84e1-68a4fa3b4d4d",
+          "source_id": "d6792432-f7fd-41a2-984b-04716dee0079",
+          "sink_id": "4d6945e1-aa5e-47db-b539-d889136f67ad",
+          "source_name": "output",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "graph_id": "f19193fe-97e0-4767-bd3c-20a9f6ed19ed",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "4d6945e1-aa5e-47db-b539-d889136f67ad",
+      "block_id": "95d1b990-ce13-4d88-9737-ba5c2070c97b",
+      "input_default": {
+        "type": "dictionary",
+        "value": null
+      },
+      "metadata": {
+        "position": {
+          "x": 180,
+          "y": -80
+        }
+      },
+      "input_links": [
+        {
+          "id": "ee4463eb-dcdc-4036-84e1-68a4fa3b4d4d",
+          "source_id": "d6792432-f7fd-41a2-984b-04716dee0079",
+          "sink_id": "4d6945e1-aa5e-47db-b539-d889136f67ad",
+          "source_name": "output",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "f5c0d6ba-2671-4824-97a0-a142817e13b6",
+          "source_id": "4d6945e1-aa5e-47db-b539-d889136f67ad",
+          "sink_id": "b976c233-cf29-497f-824a-0c16ace48e55",
+          "source_name": "value",
+          "sink_name": "headers",
+          "is_static": false
+        }
+      ],
+      "graph_id": "f19193fe-97e0-4767-bd3c-20a9f6ed19ed",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "044241e6-d507-44f7-99c2-5926fa78e5c8",
+      "block_id": "95d1b990-ce13-4d88-9737-ba5c2070c97b",
+      "input_default": {
+        "type": "dictionary",
+        "value": null
+      },
+      "metadata": {
+        "position": {
+          "x": -140,
+          "y": 220
+        }
+      },
+      "input_links": [
+        {
+          "id": "5461d10d-fdc4-47ff-a719-6a5d44cb909c",
+          "source_id": "27e673b5-61bc-4f91-9c24-dbd564d167a8",
+          "sink_id": "044241e6-d507-44f7-99c2-5926fa78e5c8",
+          "source_name": "result",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "dfc240fb-9e4d-4b87-8c50-e0f9fa8d6dad",
+          "source_id": "044241e6-d507-44f7-99c2-5926fa78e5c8",
+          "sink_id": "b976c233-cf29-497f-824a-0c16ace48e55",
+          "source_name": "value",
+          "sink_name": "body",
+          "is_static": false
+        }
+      ],
+      "graph_id": "f19193fe-97e0-4767-bd3c-20a9f6ed19ed",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "b976c233-cf29-497f-824a-0c16ace48e55",
+      "block_id": "6595ae1f-b924-42cb-9a41-551a0611c4b4",
+      "input_default": {
+        "url": "https://www.citedy.com/api/agent/scan",
+        "method": "POST",
+        "headers": {},
+        "json_format": true,
+        "body": null,
+        "files_name": "file",
+        "files": []
+      },
+      "metadata": {
+        "position": {
+          "x": 560,
+          "y": 70
+        }
+      },
+      "input_links": [
+        {
+          "id": "f5c0d6ba-2671-4824-97a0-a142817e13b6",
+          "source_id": "4d6945e1-aa5e-47db-b539-d889136f67ad",
+          "sink_id": "b976c233-cf29-497f-824a-0c16ace48e55",
+          "source_name": "value",
+          "sink_name": "headers",
+          "is_static": false
+        },
+        {
+          "id": "dfc240fb-9e4d-4b87-8c50-e0f9fa8d6dad",
+          "source_id": "044241e6-d507-44f7-99c2-5926fa78e5c8",
+          "sink_id": "b976c233-cf29-497f-824a-0c16ace48e55",
+          "source_name": "value",
+          "sink_name": "body",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "504c3cad-776e-4b12-84b2-e40931cda54d",
+          "source_id": "b976c233-cf29-497f-824a-0c16ace48e55",
+          "sink_id": "212949e3-2ecb-4819-a7de-165d452992ad",
+          "source_name": "response",
+          "sink_name": "value",
+          "is_static": false
+        },
+        {
+          "id": "a52ef8d1-76c5-4b85-8818-b453f70f4d4c",
+          "source_id": "b976c233-cf29-497f-824a-0c16ace48e55",
+          "sink_id": "c7df65e0-7749-4579-977c-3abfab00234c",
+          "source_name": "client_error",
+          "sink_name": "value",
+          "is_static": false
+        },
+        {
+          "id": "4034fa17-5657-4a6c-bf18-5f51bddcfe60",
+          "source_id": "b976c233-cf29-497f-824a-0c16ace48e55",
+          "sink_id": "e8763a40-8c43-44d2-9714-f00c37c15861",
+          "source_name": "server_error",
+          "sink_name": "value",
+          "is_static": false
+        },
+        {
+          "id": "4cdb68ff-7594-49a7-afcd-33b8e23ec5d6",
+          "source_id": "b976c233-cf29-497f-824a-0c16ace48e55",
+          "sink_id": "6c503d38-4ffd-4d6a-94f2-e33a0f81d125",
+          "source_name": "error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "graph_id": "f19193fe-97e0-4767-bd3c-20a9f6ed19ed",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "212949e3-2ecb-4819-a7de-165d452992ad",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "response",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "Successful API response payload.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": -160
+        }
+      },
+      "input_links": [
+        {
+          "id": "504c3cad-776e-4b12-84b2-e40931cda54d",
+          "source_id": "b976c233-cf29-497f-824a-0c16ace48e55",
+          "sink_id": "212949e3-2ecb-4819-a7de-165d452992ad",
+          "source_name": "response",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "f19193fe-97e0-4767-bd3c-20a9f6ed19ed",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "c7df65e0-7749-4579-977c-3abfab00234c",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "client_error",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "HTTP 4xx response payload.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": 20
+        }
+      },
+      "input_links": [
+        {
+          "id": "a52ef8d1-76c5-4b85-8818-b453f70f4d4c",
+          "source_id": "b976c233-cf29-497f-824a-0c16ace48e55",
+          "sink_id": "c7df65e0-7749-4579-977c-3abfab00234c",
+          "source_name": "client_error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "f19193fe-97e0-4767-bd3c-20a9f6ed19ed",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "e8763a40-8c43-44d2-9714-f00c37c15861",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "server_error",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "HTTP 5xx response payload.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": 200
+        }
+      },
+      "input_links": [
+        {
+          "id": "4034fa17-5657-4a6c-bf18-5f51bddcfe60",
+          "source_id": "b976c233-cf29-497f-824a-0c16ace48e55",
+          "sink_id": "e8763a40-8c43-44d2-9714-f00c37c15861",
+          "source_name": "server_error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "f19193fe-97e0-4767-bd3c-20a9f6ed19ed",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "6c503d38-4ffd-4d6a-94f2-e33a0f81d125",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "error",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "Transport/runtime error output.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": 380
+        }
+      },
+      "input_links": [
+        {
+          "id": "4cdb68ff-7594-49a7-afcd-33b8e23ec5d6",
+          "source_id": "b976c233-cf29-497f-824a-0c16ace48e55",
+          "sink_id": "6c503d38-4ffd-4d6a-94f2-e33a0f81d125",
+          "source_name": "error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "f19193fe-97e0-4767-bd3c-20a9f6ed19ed",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    }
+  ],
+  "links": [
+    {
+      "id": "ba05c2c9-fe7d-4238-8025-6f869579b7b8",
+      "source_id": "b7ad72ed-5e46-4398-b8ba-8469475d7655",
+      "sink_id": "bfeedad5-d11f-4370-9208-2eedd597f459",
+      "source_name": "result",
+      "sink_name": "values_#_api_key",
+      "is_static": false
+    },
+    {
+      "id": "5461d10d-fdc4-47ff-a719-6a5d44cb909c",
+      "source_id": "27e673b5-61bc-4f91-9c24-dbd564d167a8",
+      "sink_id": "044241e6-d507-44f7-99c2-5926fa78e5c8",
+      "source_name": "result",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "4e380579-489c-4309-8ebb-a50491668eb7",
+      "source_id": "bfeedad5-d11f-4370-9208-2eedd597f459",
+      "sink_id": "d6792432-f7fd-41a2-984b-04716dee0079",
+      "source_name": "dictionary",
+      "sink_name": "values",
+      "is_static": false
+    },
+    {
+      "id": "ee4463eb-dcdc-4036-84e1-68a4fa3b4d4d",
+      "source_id": "d6792432-f7fd-41a2-984b-04716dee0079",
+      "sink_id": "4d6945e1-aa5e-47db-b539-d889136f67ad",
+      "source_name": "output",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "f5c0d6ba-2671-4824-97a0-a142817e13b6",
+      "source_id": "4d6945e1-aa5e-47db-b539-d889136f67ad",
+      "sink_id": "b976c233-cf29-497f-824a-0c16ace48e55",
+      "source_name": "value",
+      "sink_name": "headers",
+      "is_static": false
+    },
+    {
+      "id": "dfc240fb-9e4d-4b87-8c50-e0f9fa8d6dad",
+      "source_id": "044241e6-d507-44f7-99c2-5926fa78e5c8",
+      "sink_id": "b976c233-cf29-497f-824a-0c16ace48e55",
+      "source_name": "value",
+      "sink_name": "body",
+      "is_static": false
+    },
+    {
+      "id": "504c3cad-776e-4b12-84b2-e40931cda54d",
+      "source_id": "b976c233-cf29-497f-824a-0c16ace48e55",
+      "sink_id": "212949e3-2ecb-4819-a7de-165d452992ad",
+      "source_name": "response",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "a52ef8d1-76c5-4b85-8818-b453f70f4d4c",
+      "source_id": "b976c233-cf29-497f-824a-0c16ace48e55",
+      "sink_id": "c7df65e0-7749-4579-977c-3abfab00234c",
+      "source_name": "client_error",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "4034fa17-5657-4a6c-bf18-5f51bddcfe60",
+      "source_id": "b976c233-cf29-497f-824a-0c16ace48e55",
+      "sink_id": "e8763a40-8c43-44d2-9714-f00c37c15861",
+      "source_name": "server_error",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "4cdb68ff-7594-49a7-afcd-33b8e23ec5d6",
+      "source_id": "b976c233-cf29-497f-824a-0c16ace48e55",
+      "sink_id": "6c503d38-4ffd-4d6a-94f2-e33a0f81d125",
+      "source_name": "error",
+      "sink_name": "value",
+      "is_static": false
+    }
+  ],
+  "forked_from_id": null,
+  "forked_from_version": null,
+  "sub_graphs": [],
+  "user_id": "",
+  "created_at": "2026-02-28T12:00:00.000Z",
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "API Key": {
+        "advanced": false,
+        "anyOf": [
+          {
+            "format": "short-text",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "secret": true,
+        "title": "API Key",
+        "description": "Citedy API key (starts with citedy_agent_)",
+        "default": "citedy_agent_replace_me"
+      },
+      "Request JSON": {
+        "advanced": false,
+        "anyOf": [
+          {
+            "format": "long-text",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "secret": false,
+        "title": "Request JSON",
+        "description": "JSON payload for the selected Citedy endpoint.",
+        "default": "{\n  \"query\": \"AI content marketing trends\",\n  \"mode\": \"deep\",\n  \"limit\": 10\n}"
+      }
+    },
+    "required": ["API Key", "Request JSON"]
+  },
+  "output_schema": {
+    "type": "object",
+    "properties": {
+      "response": {
+        "title": "response",
+        "description": "Successful API response payload.",
+        "type": "object"
+      },
+      "client_error": {
+        "title": "client_error",
+        "description": "HTTP 4xx response payload.",
+        "type": "object"
+      },
+      "server_error": {
+        "title": "server_error",
+        "description": "HTTP 5xx response payload.",
+        "type": "object"
+      },
+      "error": {
+        "title": "error",
+        "description": "Transport/runtime error output.",
+        "type": "string"
+      }
+    },
+    "required": []
+  },
+  "has_external_trigger": false,
+  "has_human_in_the_loop": false,
+  "trigger_setup_info": null,
+  "credentials_input_schema": {
+    "properties": {},
+    "required": [],
+    "title": "CitedyTemplateCredentialsInputSchema",
+    "type": "object"
+  }
+}

--- a/autogpt_platform/graph_templates/citedy-scout-to-publish.agent.json
+++ b/autogpt_platform/graph_templates/citedy-scout-to-publish.agent.json
@@ -1,0 +1,606 @@
+{
+  "id": "754766ac-cbd0-4240-a240-0edf18f1011f",
+  "version": 1,
+  "is_active": true,
+  "name": "Citedy Scout to Publish",
+  "description": "Extended scout preset to discover topics before autopilot generation.",
+  "instructions": null,
+  "recommended_schedule_cron": null,
+  "nodes": [
+    {
+      "id": "4ab13d7f-d8ab-43d7-93bc-4df2be807592",
+      "block_id": "7fcd3bcb-8e1b-4e69-903d-32d3d4a92158",
+      "input_default": {
+        "name": "API Key",
+        "title": null,
+        "value": "citedy_agent_replace_me",
+        "secret": true,
+        "advanced": false,
+        "description": "Citedy API key (starts with citedy_agent_)",
+        "placeholder_values": []
+      },
+      "metadata": {
+        "position": {
+          "x": -920,
+          "y": -80
+        }
+      },
+      "input_links": [],
+      "output_links": [
+        {
+          "id": "cd8acdc2-8f6f-492d-9990-f655a2ae0cda",
+          "source_id": "4ab13d7f-d8ab-43d7-93bc-4df2be807592",
+          "sink_id": "392b6410-5874-4103-83bb-739590769b5c",
+          "source_name": "result",
+          "sink_name": "values_#_api_key",
+          "is_static": false
+        }
+      ],
+      "graph_id": "754766ac-cbd0-4240-a240-0edf18f1011f",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "b0b2aef1-c487-43e8-8222-729a7e54c711",
+      "block_id": "90a56ffb-7024-4b2b-ab50-e26c5e5ab8ba",
+      "input_default": {
+        "name": "Request JSON",
+        "title": null,
+        "value": "{\n  \"query\": \"SaaS growth topics for content marketing\",\n  \"mode\": \"ultimate\",\n  \"limit\": 10\n}",
+        "secret": false,
+        "advanced": false,
+        "description": "JSON payload for this endpoint.",
+        "placeholder_values": []
+      },
+      "metadata": {
+        "position": {
+          "x": -920,
+          "y": 220
+        }
+      },
+      "input_links": [],
+      "output_links": [
+        {
+          "id": "6033a9ea-2582-45d3-a628-42918b71a581",
+          "source_id": "b0b2aef1-c487-43e8-8222-729a7e54c711",
+          "sink_id": "1d6266e4-f5e3-4ad7-9aee-61120d3f9135",
+          "source_name": "result",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "graph_id": "754766ac-cbd0-4240-a240-0edf18f1011f",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "392b6410-5874-4103-83bb-739590769b5c",
+      "block_id": "b924ddf4-de4f-4b56-9a85-358930dcbc91",
+      "input_default": {
+        "values": {}
+      },
+      "metadata": {
+        "position": {
+          "x": -520,
+          "y": -80
+        }
+      },
+      "input_links": [
+        {
+          "id": "cd8acdc2-8f6f-492d-9990-f655a2ae0cda",
+          "source_id": "4ab13d7f-d8ab-43d7-93bc-4df2be807592",
+          "sink_id": "392b6410-5874-4103-83bb-739590769b5c",
+          "source_name": "result",
+          "sink_name": "values_#_api_key",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "f7b840f6-9f77-4162-a931-3c09e4335b02",
+          "source_id": "392b6410-5874-4103-83bb-739590769b5c",
+          "sink_id": "ea9c1ef5-f39d-44f4-b100-d5b05927614e",
+          "source_name": "dictionary",
+          "sink_name": "values",
+          "is_static": false
+        }
+      ],
+      "graph_id": "754766ac-cbd0-4240-a240-0edf18f1011f",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "ea9c1ef5-f39d-44f4-b100-d5b05927614e",
+      "block_id": "db7d8f02-2f44-4c55-ab7a-eae0941f0c30",
+      "input_default": {
+        "format": "{\"Authorization\":\"Bearer {{ api_key }}\",\"Content-Type\":\"application/json\"}",
+        "values": {},
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": -140,
+          "y": -80
+        }
+      },
+      "input_links": [
+        {
+          "id": "f7b840f6-9f77-4162-a931-3c09e4335b02",
+          "source_id": "392b6410-5874-4103-83bb-739590769b5c",
+          "sink_id": "ea9c1ef5-f39d-44f4-b100-d5b05927614e",
+          "source_name": "dictionary",
+          "sink_name": "values",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "14f4b7fa-2835-455f-87bb-cf2d371b096a",
+          "source_id": "ea9c1ef5-f39d-44f4-b100-d5b05927614e",
+          "sink_id": "cfd63c3a-b19d-47f5-a056-41957a38b90a",
+          "source_name": "output",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "graph_id": "754766ac-cbd0-4240-a240-0edf18f1011f",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "cfd63c3a-b19d-47f5-a056-41957a38b90a",
+      "block_id": "95d1b990-ce13-4d88-9737-ba5c2070c97b",
+      "input_default": {
+        "type": "dictionary",
+        "value": null
+      },
+      "metadata": {
+        "position": {
+          "x": 180,
+          "y": -80
+        }
+      },
+      "input_links": [
+        {
+          "id": "14f4b7fa-2835-455f-87bb-cf2d371b096a",
+          "source_id": "ea9c1ef5-f39d-44f4-b100-d5b05927614e",
+          "sink_id": "cfd63c3a-b19d-47f5-a056-41957a38b90a",
+          "source_name": "output",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "0da0073c-0711-46ca-b933-30f51e3062ef",
+          "source_id": "cfd63c3a-b19d-47f5-a056-41957a38b90a",
+          "sink_id": "0b8dc2a3-90ca-487b-9258-8e34a1403638",
+          "source_name": "value",
+          "sink_name": "headers",
+          "is_static": false
+        }
+      ],
+      "graph_id": "754766ac-cbd0-4240-a240-0edf18f1011f",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "1d6266e4-f5e3-4ad7-9aee-61120d3f9135",
+      "block_id": "95d1b990-ce13-4d88-9737-ba5c2070c97b",
+      "input_default": {
+        "type": "dictionary",
+        "value": null
+      },
+      "metadata": {
+        "position": {
+          "x": -140,
+          "y": 220
+        }
+      },
+      "input_links": [
+        {
+          "id": "6033a9ea-2582-45d3-a628-42918b71a581",
+          "source_id": "b0b2aef1-c487-43e8-8222-729a7e54c711",
+          "sink_id": "1d6266e4-f5e3-4ad7-9aee-61120d3f9135",
+          "source_name": "result",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "c221673d-e53c-4c7b-bc72-808ae45cc628",
+          "source_id": "1d6266e4-f5e3-4ad7-9aee-61120d3f9135",
+          "sink_id": "0b8dc2a3-90ca-487b-9258-8e34a1403638",
+          "source_name": "value",
+          "sink_name": "body",
+          "is_static": false
+        }
+      ],
+      "graph_id": "754766ac-cbd0-4240-a240-0edf18f1011f",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "0b8dc2a3-90ca-487b-9258-8e34a1403638",
+      "block_id": "6595ae1f-b924-42cb-9a41-551a0611c4b4",
+      "input_default": {
+        "url": "https://www.citedy.com/api/agent/scout/x",
+        "method": "POST",
+        "headers": {},
+        "json_format": true,
+        "body": null,
+        "files_name": "file",
+        "files": []
+      },
+      "metadata": {
+        "position": {
+          "x": 560,
+          "y": 70
+        }
+      },
+      "input_links": [
+        {
+          "id": "0da0073c-0711-46ca-b933-30f51e3062ef",
+          "source_id": "cfd63c3a-b19d-47f5-a056-41957a38b90a",
+          "sink_id": "0b8dc2a3-90ca-487b-9258-8e34a1403638",
+          "source_name": "value",
+          "sink_name": "headers",
+          "is_static": false
+        },
+        {
+          "id": "c221673d-e53c-4c7b-bc72-808ae45cc628",
+          "source_id": "1d6266e4-f5e3-4ad7-9aee-61120d3f9135",
+          "sink_id": "0b8dc2a3-90ca-487b-9258-8e34a1403638",
+          "source_name": "value",
+          "sink_name": "body",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "5bc03c8d-3033-429d-975d-7c1e46ed1974",
+          "source_id": "0b8dc2a3-90ca-487b-9258-8e34a1403638",
+          "sink_id": "a94e38d0-3336-4caa-8b0c-8556f8a80893",
+          "source_name": "response",
+          "sink_name": "value",
+          "is_static": false
+        },
+        {
+          "id": "bd9e6b94-b48d-4483-9f15-9e2fffd26f03",
+          "source_id": "0b8dc2a3-90ca-487b-9258-8e34a1403638",
+          "sink_id": "585295e8-3de0-4873-951b-7853acfeabd7",
+          "source_name": "client_error",
+          "sink_name": "value",
+          "is_static": false
+        },
+        {
+          "id": "d0c4c504-8af0-49d7-8222-6d27bde45222",
+          "source_id": "0b8dc2a3-90ca-487b-9258-8e34a1403638",
+          "sink_id": "075f246b-ecd9-4c60-a784-4e431f3eb27f",
+          "source_name": "server_error",
+          "sink_name": "value",
+          "is_static": false
+        },
+        {
+          "id": "2f4fcdd8-f716-4775-9e8e-52457011fd40",
+          "source_id": "0b8dc2a3-90ca-487b-9258-8e34a1403638",
+          "sink_id": "1b1c62b3-1946-4575-9969-8ac773c9b170",
+          "source_name": "error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "graph_id": "754766ac-cbd0-4240-a240-0edf18f1011f",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "a94e38d0-3336-4caa-8b0c-8556f8a80893",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "response",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "Successful API response payload.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": -160
+        }
+      },
+      "input_links": [
+        {
+          "id": "5bc03c8d-3033-429d-975d-7c1e46ed1974",
+          "source_id": "0b8dc2a3-90ca-487b-9258-8e34a1403638",
+          "sink_id": "a94e38d0-3336-4caa-8b0c-8556f8a80893",
+          "source_name": "response",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "754766ac-cbd0-4240-a240-0edf18f1011f",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "585295e8-3de0-4873-951b-7853acfeabd7",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "client_error",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "HTTP 4xx response payload.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": 20
+        }
+      },
+      "input_links": [
+        {
+          "id": "bd9e6b94-b48d-4483-9f15-9e2fffd26f03",
+          "source_id": "0b8dc2a3-90ca-487b-9258-8e34a1403638",
+          "sink_id": "585295e8-3de0-4873-951b-7853acfeabd7",
+          "source_name": "client_error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "754766ac-cbd0-4240-a240-0edf18f1011f",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "075f246b-ecd9-4c60-a784-4e431f3eb27f",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "server_error",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "HTTP 5xx response payload.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": 200
+        }
+      },
+      "input_links": [
+        {
+          "id": "d0c4c504-8af0-49d7-8222-6d27bde45222",
+          "source_id": "0b8dc2a3-90ca-487b-9258-8e34a1403638",
+          "sink_id": "075f246b-ecd9-4c60-a784-4e431f3eb27f",
+          "source_name": "server_error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "754766ac-cbd0-4240-a240-0edf18f1011f",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "1b1c62b3-1946-4575-9969-8ac773c9b170",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "error",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "Transport/runtime error output.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": 380
+        }
+      },
+      "input_links": [
+        {
+          "id": "2f4fcdd8-f716-4775-9e8e-52457011fd40",
+          "source_id": "0b8dc2a3-90ca-487b-9258-8e34a1403638",
+          "sink_id": "1b1c62b3-1946-4575-9969-8ac773c9b170",
+          "source_name": "error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "754766ac-cbd0-4240-a240-0edf18f1011f",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    }
+  ],
+  "links": [
+    {
+      "id": "cd8acdc2-8f6f-492d-9990-f655a2ae0cda",
+      "source_id": "4ab13d7f-d8ab-43d7-93bc-4df2be807592",
+      "sink_id": "392b6410-5874-4103-83bb-739590769b5c",
+      "source_name": "result",
+      "sink_name": "values_#_api_key",
+      "is_static": false
+    },
+    {
+      "id": "f7b840f6-9f77-4162-a931-3c09e4335b02",
+      "source_id": "392b6410-5874-4103-83bb-739590769b5c",
+      "sink_id": "ea9c1ef5-f39d-44f4-b100-d5b05927614e",
+      "source_name": "dictionary",
+      "sink_name": "values",
+      "is_static": false
+    },
+    {
+      "id": "14f4b7fa-2835-455f-87bb-cf2d371b096a",
+      "source_id": "ea9c1ef5-f39d-44f4-b100-d5b05927614e",
+      "sink_id": "cfd63c3a-b19d-47f5-a056-41957a38b90a",
+      "source_name": "output",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "6033a9ea-2582-45d3-a628-42918b71a581",
+      "source_id": "b0b2aef1-c487-43e8-8222-729a7e54c711",
+      "sink_id": "1d6266e4-f5e3-4ad7-9aee-61120d3f9135",
+      "source_name": "result",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "0da0073c-0711-46ca-b933-30f51e3062ef",
+      "source_id": "cfd63c3a-b19d-47f5-a056-41957a38b90a",
+      "sink_id": "0b8dc2a3-90ca-487b-9258-8e34a1403638",
+      "source_name": "value",
+      "sink_name": "headers",
+      "is_static": false
+    },
+    {
+      "id": "c221673d-e53c-4c7b-bc72-808ae45cc628",
+      "source_id": "1d6266e4-f5e3-4ad7-9aee-61120d3f9135",
+      "sink_id": "0b8dc2a3-90ca-487b-9258-8e34a1403638",
+      "source_name": "value",
+      "sink_name": "body",
+      "is_static": false
+    },
+    {
+      "id": "5bc03c8d-3033-429d-975d-7c1e46ed1974",
+      "source_id": "0b8dc2a3-90ca-487b-9258-8e34a1403638",
+      "sink_id": "a94e38d0-3336-4caa-8b0c-8556f8a80893",
+      "source_name": "response",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "bd9e6b94-b48d-4483-9f15-9e2fffd26f03",
+      "source_id": "0b8dc2a3-90ca-487b-9258-8e34a1403638",
+      "sink_id": "585295e8-3de0-4873-951b-7853acfeabd7",
+      "source_name": "client_error",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "d0c4c504-8af0-49d7-8222-6d27bde45222",
+      "source_id": "0b8dc2a3-90ca-487b-9258-8e34a1403638",
+      "sink_id": "075f246b-ecd9-4c60-a784-4e431f3eb27f",
+      "source_name": "server_error",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "2f4fcdd8-f716-4775-9e8e-52457011fd40",
+      "source_id": "0b8dc2a3-90ca-487b-9258-8e34a1403638",
+      "sink_id": "1b1c62b3-1946-4575-9969-8ac773c9b170",
+      "source_name": "error",
+      "sink_name": "value",
+      "is_static": false
+    }
+  ],
+  "forked_from_id": null,
+  "forked_from_version": null,
+  "sub_graphs": [],
+  "user_id": "",
+  "created_at": "2026-02-14T23:47:30.880Z",
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "API Key": {
+        "advanced": false,
+        "anyOf": [
+          {
+            "format": "short-text",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "secret": true,
+        "title": "API Key",
+        "description": "Citedy API key (starts with citedy_agent_)",
+        "default": "citedy_agent_replace_me"
+      },
+      "Request JSON": {
+        "advanced": false,
+        "anyOf": [
+          {
+            "format": "long-text",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "secret": false,
+        "title": "Request JSON",
+        "description": "JSON payload for the selected Citedy endpoint.",
+        "default": "{\n  \"query\": \"SaaS growth topics for content marketing\",\n  \"mode\": \"ultimate\",\n  \"limit\": 10\n}"
+      }
+    },
+    "required": ["API Key", "Request JSON"]
+  },
+  "output_schema": {
+    "type": "object",
+    "properties": {
+      "response": {
+        "title": "response",
+        "description": "Successful API response payload.",
+        "type": "object"
+      },
+      "client_error": {
+        "title": "client_error",
+        "description": "HTTP 4xx response payload.",
+        "type": "object"
+      },
+      "server_error": {
+        "title": "server_error",
+        "description": "HTTP 5xx response payload.",
+        "type": "object"
+      },
+      "error": {
+        "title": "error",
+        "description": "Transport/runtime error output.",
+        "type": "string"
+      }
+    },
+    "required": []
+  },
+  "has_external_trigger": false,
+  "has_human_in_the_loop": false,
+  "trigger_setup_info": null,
+  "credentials_input_schema": {
+    "properties": {},
+    "required": [],
+    "title": "CitedyTemplateCredentialsInputSchema",
+    "type": "object"
+  }
+}

--- a/autogpt_platform/graph_templates/citedy-session-manager.agent.json
+++ b/autogpt_platform/graph_templates/citedy-session-manager.agent.json
@@ -1,0 +1,606 @@
+{
+  "id": "1157deb7-752f-4236-8e83-dee46ec745b4",
+  "version": 1,
+  "is_active": true,
+  "name": "Citedy Session Manager",
+  "description": "Create recurring automated content session.",
+  "instructions": null,
+  "recommended_schedule_cron": null,
+  "nodes": [
+    {
+      "id": "ceb80a4c-7870-4f02-adfd-8b062f771239",
+      "block_id": "7fcd3bcb-8e1b-4e69-903d-32d3d4a92158",
+      "input_default": {
+        "name": "API Key",
+        "title": null,
+        "value": "citedy_agent_replace_me",
+        "secret": true,
+        "advanced": false,
+        "description": "Citedy API key (starts with citedy_agent_)",
+        "placeholder_values": []
+      },
+      "metadata": {
+        "position": {
+          "x": -920,
+          "y": -80
+        }
+      },
+      "input_links": [],
+      "output_links": [
+        {
+          "id": "b7f35fe9-acf0-46d3-b18a-9adfc68fce30",
+          "source_id": "ceb80a4c-7870-4f02-adfd-8b062f771239",
+          "sink_id": "69a3a8db-74ec-4945-bf7d-86938ee35a90",
+          "source_name": "result",
+          "sink_name": "values_#_api_key",
+          "is_static": false
+        }
+      ],
+      "graph_id": "1157deb7-752f-4236-8e83-dee46ec745b4",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "5d472c17-2d76-4b00-aa39-e94b7d6e9ac5",
+      "block_id": "90a56ffb-7024-4b2b-ab50-e26c5e5ab8ba",
+      "input_default": {
+        "name": "Request JSON",
+        "title": null,
+        "value": "{\n  \"categories\": [\n    \"SaaS marketing\"\n  ],\n  \"languages\": [\n    \"en\"\n  ],\n  \"interval_minutes\": 720,\n  \"article_size\": \"mini\"\n}",
+        "secret": false,
+        "advanced": false,
+        "description": "JSON payload for this endpoint.",
+        "placeholder_values": []
+      },
+      "metadata": {
+        "position": {
+          "x": -920,
+          "y": 220
+        }
+      },
+      "input_links": [],
+      "output_links": [
+        {
+          "id": "9603009d-5ce0-49d6-8926-6e2ba15b3bdd",
+          "source_id": "5d472c17-2d76-4b00-aa39-e94b7d6e9ac5",
+          "sink_id": "7d8ffdea-5ce7-4678-b8c6-c32e1dec1895",
+          "source_name": "result",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "graph_id": "1157deb7-752f-4236-8e83-dee46ec745b4",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "69a3a8db-74ec-4945-bf7d-86938ee35a90",
+      "block_id": "b924ddf4-de4f-4b56-9a85-358930dcbc91",
+      "input_default": {
+        "values": {}
+      },
+      "metadata": {
+        "position": {
+          "x": -520,
+          "y": -80
+        }
+      },
+      "input_links": [
+        {
+          "id": "b7f35fe9-acf0-46d3-b18a-9adfc68fce30",
+          "source_id": "ceb80a4c-7870-4f02-adfd-8b062f771239",
+          "sink_id": "69a3a8db-74ec-4945-bf7d-86938ee35a90",
+          "source_name": "result",
+          "sink_name": "values_#_api_key",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "773e0d2c-ebf9-477b-b22b-b5a713172052",
+          "source_id": "69a3a8db-74ec-4945-bf7d-86938ee35a90",
+          "sink_id": "5848ea0c-bda7-40af-a17e-6d2d61d929bb",
+          "source_name": "dictionary",
+          "sink_name": "values",
+          "is_static": false
+        }
+      ],
+      "graph_id": "1157deb7-752f-4236-8e83-dee46ec745b4",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "5848ea0c-bda7-40af-a17e-6d2d61d929bb",
+      "block_id": "db7d8f02-2f44-4c55-ab7a-eae0941f0c30",
+      "input_default": {
+        "format": "{\"Authorization\":\"Bearer {{ api_key }}\",\"Content-Type\":\"application/json\"}",
+        "values": {},
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": -140,
+          "y": -80
+        }
+      },
+      "input_links": [
+        {
+          "id": "773e0d2c-ebf9-477b-b22b-b5a713172052",
+          "source_id": "69a3a8db-74ec-4945-bf7d-86938ee35a90",
+          "sink_id": "5848ea0c-bda7-40af-a17e-6d2d61d929bb",
+          "source_name": "dictionary",
+          "sink_name": "values",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "6b93b31f-9eeb-4ca3-96d5-94c805c52b3e",
+          "source_id": "5848ea0c-bda7-40af-a17e-6d2d61d929bb",
+          "sink_id": "6939bc5c-7ff4-4d0d-b4cd-c500a4b43185",
+          "source_name": "output",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "graph_id": "1157deb7-752f-4236-8e83-dee46ec745b4",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "6939bc5c-7ff4-4d0d-b4cd-c500a4b43185",
+      "block_id": "95d1b990-ce13-4d88-9737-ba5c2070c97b",
+      "input_default": {
+        "type": "dictionary",
+        "value": null
+      },
+      "metadata": {
+        "position": {
+          "x": 180,
+          "y": -80
+        }
+      },
+      "input_links": [
+        {
+          "id": "6b93b31f-9eeb-4ca3-96d5-94c805c52b3e",
+          "source_id": "5848ea0c-bda7-40af-a17e-6d2d61d929bb",
+          "sink_id": "6939bc5c-7ff4-4d0d-b4cd-c500a4b43185",
+          "source_name": "output",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "399289aa-620f-4aea-b423-5f43e19711b0",
+          "source_id": "6939bc5c-7ff4-4d0d-b4cd-c500a4b43185",
+          "sink_id": "10eb342a-0f37-470f-bdd6-6ed7d8b46459",
+          "source_name": "value",
+          "sink_name": "headers",
+          "is_static": false
+        }
+      ],
+      "graph_id": "1157deb7-752f-4236-8e83-dee46ec745b4",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "7d8ffdea-5ce7-4678-b8c6-c32e1dec1895",
+      "block_id": "95d1b990-ce13-4d88-9737-ba5c2070c97b",
+      "input_default": {
+        "type": "dictionary",
+        "value": null
+      },
+      "metadata": {
+        "position": {
+          "x": -140,
+          "y": 220
+        }
+      },
+      "input_links": [
+        {
+          "id": "9603009d-5ce0-49d6-8926-6e2ba15b3bdd",
+          "source_id": "5d472c17-2d76-4b00-aa39-e94b7d6e9ac5",
+          "sink_id": "7d8ffdea-5ce7-4678-b8c6-c32e1dec1895",
+          "source_name": "result",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "36113db6-0610-47b9-829c-1b101c3903fc",
+          "source_id": "7d8ffdea-5ce7-4678-b8c6-c32e1dec1895",
+          "sink_id": "10eb342a-0f37-470f-bdd6-6ed7d8b46459",
+          "source_name": "value",
+          "sink_name": "body",
+          "is_static": false
+        }
+      ],
+      "graph_id": "1157deb7-752f-4236-8e83-dee46ec745b4",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "10eb342a-0f37-470f-bdd6-6ed7d8b46459",
+      "block_id": "6595ae1f-b924-42cb-9a41-551a0611c4b4",
+      "input_default": {
+        "url": "https://www.citedy.com/api/agent/session",
+        "method": "POST",
+        "headers": {},
+        "json_format": true,
+        "body": null,
+        "files_name": "file",
+        "files": []
+      },
+      "metadata": {
+        "position": {
+          "x": 560,
+          "y": 70
+        }
+      },
+      "input_links": [
+        {
+          "id": "399289aa-620f-4aea-b423-5f43e19711b0",
+          "source_id": "6939bc5c-7ff4-4d0d-b4cd-c500a4b43185",
+          "sink_id": "10eb342a-0f37-470f-bdd6-6ed7d8b46459",
+          "source_name": "value",
+          "sink_name": "headers",
+          "is_static": false
+        },
+        {
+          "id": "36113db6-0610-47b9-829c-1b101c3903fc",
+          "source_id": "7d8ffdea-5ce7-4678-b8c6-c32e1dec1895",
+          "sink_id": "10eb342a-0f37-470f-bdd6-6ed7d8b46459",
+          "source_name": "value",
+          "sink_name": "body",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "1cd0c2ba-dfcf-4936-aa7b-1e4bf69440c0",
+          "source_id": "10eb342a-0f37-470f-bdd6-6ed7d8b46459",
+          "sink_id": "b972431b-d3cc-4816-a7a3-b7dcf329a591",
+          "source_name": "response",
+          "sink_name": "value",
+          "is_static": false
+        },
+        {
+          "id": "3296e0dc-59a9-4373-84c1-8004884d6eca",
+          "source_id": "10eb342a-0f37-470f-bdd6-6ed7d8b46459",
+          "sink_id": "afb8b358-ec0c-43bb-9f9e-b5547a166dd9",
+          "source_name": "client_error",
+          "sink_name": "value",
+          "is_static": false
+        },
+        {
+          "id": "5640d647-dd3a-400d-b237-a703ddd3516a",
+          "source_id": "10eb342a-0f37-470f-bdd6-6ed7d8b46459",
+          "sink_id": "f7fbc867-83a5-48ab-b7f8-5dd9b651750b",
+          "source_name": "server_error",
+          "sink_name": "value",
+          "is_static": false
+        },
+        {
+          "id": "4b565ed9-5183-4b6f-bb35-621df239fe11",
+          "source_id": "10eb342a-0f37-470f-bdd6-6ed7d8b46459",
+          "sink_id": "b418db95-f043-4c21-a7be-2ae98a8b2181",
+          "source_name": "error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "graph_id": "1157deb7-752f-4236-8e83-dee46ec745b4",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "b972431b-d3cc-4816-a7a3-b7dcf329a591",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "response",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "Successful API response payload.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": -160
+        }
+      },
+      "input_links": [
+        {
+          "id": "1cd0c2ba-dfcf-4936-aa7b-1e4bf69440c0",
+          "source_id": "10eb342a-0f37-470f-bdd6-6ed7d8b46459",
+          "sink_id": "b972431b-d3cc-4816-a7a3-b7dcf329a591",
+          "source_name": "response",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "1157deb7-752f-4236-8e83-dee46ec745b4",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "afb8b358-ec0c-43bb-9f9e-b5547a166dd9",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "client_error",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "HTTP 4xx response payload.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": 20
+        }
+      },
+      "input_links": [
+        {
+          "id": "3296e0dc-59a9-4373-84c1-8004884d6eca",
+          "source_id": "10eb342a-0f37-470f-bdd6-6ed7d8b46459",
+          "sink_id": "afb8b358-ec0c-43bb-9f9e-b5547a166dd9",
+          "source_name": "client_error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "1157deb7-752f-4236-8e83-dee46ec745b4",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "f7fbc867-83a5-48ab-b7f8-5dd9b651750b",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "server_error",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "HTTP 5xx response payload.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": 200
+        }
+      },
+      "input_links": [
+        {
+          "id": "5640d647-dd3a-400d-b237-a703ddd3516a",
+          "source_id": "10eb342a-0f37-470f-bdd6-6ed7d8b46459",
+          "sink_id": "f7fbc867-83a5-48ab-b7f8-5dd9b651750b",
+          "source_name": "server_error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "1157deb7-752f-4236-8e83-dee46ec745b4",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "b418db95-f043-4c21-a7be-2ae98a8b2181",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "error",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "Transport/runtime error output.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": 380
+        }
+      },
+      "input_links": [
+        {
+          "id": "4b565ed9-5183-4b6f-bb35-621df239fe11",
+          "source_id": "10eb342a-0f37-470f-bdd6-6ed7d8b46459",
+          "sink_id": "b418db95-f043-4c21-a7be-2ae98a8b2181",
+          "source_name": "error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "1157deb7-752f-4236-8e83-dee46ec745b4",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    }
+  ],
+  "links": [
+    {
+      "id": "b7f35fe9-acf0-46d3-b18a-9adfc68fce30",
+      "source_id": "ceb80a4c-7870-4f02-adfd-8b062f771239",
+      "sink_id": "69a3a8db-74ec-4945-bf7d-86938ee35a90",
+      "source_name": "result",
+      "sink_name": "values_#_api_key",
+      "is_static": false
+    },
+    {
+      "id": "773e0d2c-ebf9-477b-b22b-b5a713172052",
+      "source_id": "69a3a8db-74ec-4945-bf7d-86938ee35a90",
+      "sink_id": "5848ea0c-bda7-40af-a17e-6d2d61d929bb",
+      "source_name": "dictionary",
+      "sink_name": "values",
+      "is_static": false
+    },
+    {
+      "id": "6b93b31f-9eeb-4ca3-96d5-94c805c52b3e",
+      "source_id": "5848ea0c-bda7-40af-a17e-6d2d61d929bb",
+      "sink_id": "6939bc5c-7ff4-4d0d-b4cd-c500a4b43185",
+      "source_name": "output",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "9603009d-5ce0-49d6-8926-6e2ba15b3bdd",
+      "source_id": "5d472c17-2d76-4b00-aa39-e94b7d6e9ac5",
+      "sink_id": "7d8ffdea-5ce7-4678-b8c6-c32e1dec1895",
+      "source_name": "result",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "399289aa-620f-4aea-b423-5f43e19711b0",
+      "source_id": "6939bc5c-7ff4-4d0d-b4cd-c500a4b43185",
+      "sink_id": "10eb342a-0f37-470f-bdd6-6ed7d8b46459",
+      "source_name": "value",
+      "sink_name": "headers",
+      "is_static": false
+    },
+    {
+      "id": "36113db6-0610-47b9-829c-1b101c3903fc",
+      "source_id": "7d8ffdea-5ce7-4678-b8c6-c32e1dec1895",
+      "sink_id": "10eb342a-0f37-470f-bdd6-6ed7d8b46459",
+      "source_name": "value",
+      "sink_name": "body",
+      "is_static": false
+    },
+    {
+      "id": "1cd0c2ba-dfcf-4936-aa7b-1e4bf69440c0",
+      "source_id": "10eb342a-0f37-470f-bdd6-6ed7d8b46459",
+      "sink_id": "b972431b-d3cc-4816-a7a3-b7dcf329a591",
+      "source_name": "response",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "3296e0dc-59a9-4373-84c1-8004884d6eca",
+      "source_id": "10eb342a-0f37-470f-bdd6-6ed7d8b46459",
+      "sink_id": "afb8b358-ec0c-43bb-9f9e-b5547a166dd9",
+      "source_name": "client_error",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "5640d647-dd3a-400d-b237-a703ddd3516a",
+      "source_id": "10eb342a-0f37-470f-bdd6-6ed7d8b46459",
+      "sink_id": "f7fbc867-83a5-48ab-b7f8-5dd9b651750b",
+      "source_name": "server_error",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "4b565ed9-5183-4b6f-bb35-621df239fe11",
+      "source_id": "10eb342a-0f37-470f-bdd6-6ed7d8b46459",
+      "sink_id": "b418db95-f043-4c21-a7be-2ae98a8b2181",
+      "source_name": "error",
+      "sink_name": "value",
+      "is_static": false
+    }
+  ],
+  "forked_from_id": null,
+  "forked_from_version": null,
+  "sub_graphs": [],
+  "user_id": "",
+  "created_at": "2026-02-14T23:47:30.880Z",
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "API Key": {
+        "advanced": false,
+        "anyOf": [
+          {
+            "format": "short-text",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "secret": true,
+        "title": "API Key",
+        "description": "Citedy API key (starts with citedy_agent_)",
+        "default": "citedy_agent_replace_me"
+      },
+      "Request JSON": {
+        "advanced": false,
+        "anyOf": [
+          {
+            "format": "long-text",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "secret": false,
+        "title": "Request JSON",
+        "description": "JSON payload for the selected Citedy endpoint.",
+        "default": "{\n  \"categories\": [\n    \"SaaS marketing\"\n  ],\n  \"languages\": [\n    \"en\"\n  ],\n  \"interval_minutes\": 720,\n  \"article_size\": \"mini\"\n}"
+      }
+    },
+    "required": ["API Key", "Request JSON"]
+  },
+  "output_schema": {
+    "type": "object",
+    "properties": {
+      "response": {
+        "title": "response",
+        "description": "Successful API response payload.",
+        "type": "object"
+      },
+      "client_error": {
+        "title": "client_error",
+        "description": "HTTP 4xx response payload.",
+        "type": "object"
+      },
+      "server_error": {
+        "title": "server_error",
+        "description": "HTTP 5xx response payload.",
+        "type": "object"
+      },
+      "error": {
+        "title": "error",
+        "description": "Transport/runtime error output.",
+        "type": "string"
+      }
+    },
+    "required": []
+  },
+  "has_external_trigger": false,
+  "has_human_in_the_loop": false,
+  "trigger_setup_info": null,
+  "credentials_input_schema": {
+    "properties": {},
+    "required": [],
+    "title": "CitedyTemplateCredentialsInputSchema",
+    "type": "object"
+  }
+}

--- a/autogpt_platform/graph_templates/citedy-shorts-avatar.agent.json
+++ b/autogpt_platform/graph_templates/citedy-shorts-avatar.agent.json
@@ -1,0 +1,606 @@
+{
+  "id": "58856952-1d84-4575-bfb3-99ba8f261ce0",
+  "version": 1,
+  "is_active": true,
+  "name": "Citedy Shorts Avatar",
+  "description": "Generate AI avatar image for short-form video.",
+  "instructions": null,
+  "recommended_schedule_cron": null,
+  "nodes": [
+    {
+      "id": "18216d5e-4099-41b0-a025-4ec44fd759c9",
+      "block_id": "7fcd3bcb-8e1b-4e69-903d-32d3d4a92158",
+      "input_default": {
+        "name": "API Key",
+        "title": null,
+        "value": "citedy_agent_replace_me",
+        "secret": true,
+        "advanced": false,
+        "description": "Citedy API key (starts with citedy_agent_)",
+        "placeholder_values": []
+      },
+      "metadata": {
+        "position": {
+          "x": -920,
+          "y": -80
+        }
+      },
+      "input_links": [],
+      "output_links": [
+        {
+          "id": "6018f777-20f2-4589-bfb9-0c33e0dd0f5e",
+          "source_id": "18216d5e-4099-41b0-a025-4ec44fd759c9",
+          "sink_id": "7839a709-89bb-4ac9-ade6-f946191d2589",
+          "source_name": "result",
+          "sink_name": "values_#_api_key",
+          "is_static": false
+        }
+      ],
+      "graph_id": "58856952-1d84-4575-bfb3-99ba8f261ce0",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "672101ca-2f9f-41f9-97a2-e300b440da4a",
+      "block_id": "90a56ffb-7024-4b2b-ab50-e26c5e5ab8ba",
+      "input_default": {
+        "name": "Request JSON",
+        "title": null,
+        "value": "{\n  \"gender\": \"female\",\n  \"origin\": \"latin\",\n  \"age_range\": \"26-35\",\n  \"type\": \"tech_founder\",\n  \"location\": \"coffee_shop\"\n}",
+        "secret": false,
+        "advanced": false,
+        "description": "JSON payload for this endpoint.",
+        "placeholder_values": []
+      },
+      "metadata": {
+        "position": {
+          "x": -920,
+          "y": 220
+        }
+      },
+      "input_links": [],
+      "output_links": [
+        {
+          "id": "5ad25572-b519-41c8-adce-02554ccbd9bc",
+          "source_id": "672101ca-2f9f-41f9-97a2-e300b440da4a",
+          "sink_id": "d39dadda-14b4-4b9c-8ae2-a08a86d0bed9",
+          "source_name": "result",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "graph_id": "58856952-1d84-4575-bfb3-99ba8f261ce0",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "7839a709-89bb-4ac9-ade6-f946191d2589",
+      "block_id": "b924ddf4-de4f-4b56-9a85-358930dcbc91",
+      "input_default": {
+        "values": {}
+      },
+      "metadata": {
+        "position": {
+          "x": -520,
+          "y": -80
+        }
+      },
+      "input_links": [
+        {
+          "id": "6018f777-20f2-4589-bfb9-0c33e0dd0f5e",
+          "source_id": "18216d5e-4099-41b0-a025-4ec44fd759c9",
+          "sink_id": "7839a709-89bb-4ac9-ade6-f946191d2589",
+          "source_name": "result",
+          "sink_name": "values_#_api_key",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "5883f46b-c2d3-41fa-9f6f-3e91d315560e",
+          "source_id": "7839a709-89bb-4ac9-ade6-f946191d2589",
+          "sink_id": "de08d1eb-06e3-415f-b81d-293ba58bf122",
+          "source_name": "dictionary",
+          "sink_name": "values",
+          "is_static": false
+        }
+      ],
+      "graph_id": "58856952-1d84-4575-bfb3-99ba8f261ce0",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "de08d1eb-06e3-415f-b81d-293ba58bf122",
+      "block_id": "db7d8f02-2f44-4c55-ab7a-eae0941f0c30",
+      "input_default": {
+        "format": "{\"Authorization\":\"Bearer {{ api_key }}\",\"Content-Type\":\"application/json\"}",
+        "values": {},
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": -140,
+          "y": -80
+        }
+      },
+      "input_links": [
+        {
+          "id": "5883f46b-c2d3-41fa-9f6f-3e91d315560e",
+          "source_id": "7839a709-89bb-4ac9-ade6-f946191d2589",
+          "sink_id": "de08d1eb-06e3-415f-b81d-293ba58bf122",
+          "source_name": "dictionary",
+          "sink_name": "values",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "22bf9521-5541-4bca-9e23-5796139ecc55",
+          "source_id": "de08d1eb-06e3-415f-b81d-293ba58bf122",
+          "sink_id": "0b3df07b-8aab-475a-867e-4d74fb80b285",
+          "source_name": "output",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "graph_id": "58856952-1d84-4575-bfb3-99ba8f261ce0",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "0b3df07b-8aab-475a-867e-4d74fb80b285",
+      "block_id": "95d1b990-ce13-4d88-9737-ba5c2070c97b",
+      "input_default": {
+        "type": "dictionary",
+        "value": null
+      },
+      "metadata": {
+        "position": {
+          "x": 180,
+          "y": -80
+        }
+      },
+      "input_links": [
+        {
+          "id": "22bf9521-5541-4bca-9e23-5796139ecc55",
+          "source_id": "de08d1eb-06e3-415f-b81d-293ba58bf122",
+          "sink_id": "0b3df07b-8aab-475a-867e-4d74fb80b285",
+          "source_name": "output",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "95acd0e4-a124-4854-94f2-88eb88594ba8",
+          "source_id": "0b3df07b-8aab-475a-867e-4d74fb80b285",
+          "sink_id": "f7b2e12b-f465-4ac7-ae48-3c5904f48ed9",
+          "source_name": "value",
+          "sink_name": "headers",
+          "is_static": false
+        }
+      ],
+      "graph_id": "58856952-1d84-4575-bfb3-99ba8f261ce0",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "d39dadda-14b4-4b9c-8ae2-a08a86d0bed9",
+      "block_id": "95d1b990-ce13-4d88-9737-ba5c2070c97b",
+      "input_default": {
+        "type": "dictionary",
+        "value": null
+      },
+      "metadata": {
+        "position": {
+          "x": -140,
+          "y": 220
+        }
+      },
+      "input_links": [
+        {
+          "id": "5ad25572-b519-41c8-adce-02554ccbd9bc",
+          "source_id": "672101ca-2f9f-41f9-97a2-e300b440da4a",
+          "sink_id": "d39dadda-14b4-4b9c-8ae2-a08a86d0bed9",
+          "source_name": "result",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "4063c96c-0915-458d-8d86-d28dd148c5a3",
+          "source_id": "d39dadda-14b4-4b9c-8ae2-a08a86d0bed9",
+          "sink_id": "f7b2e12b-f465-4ac7-ae48-3c5904f48ed9",
+          "source_name": "value",
+          "sink_name": "body",
+          "is_static": false
+        }
+      ],
+      "graph_id": "58856952-1d84-4575-bfb3-99ba8f261ce0",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "f7b2e12b-f465-4ac7-ae48-3c5904f48ed9",
+      "block_id": "6595ae1f-b924-42cb-9a41-551a0611c4b4",
+      "input_default": {
+        "url": "https://www.citedy.com/api/agent/shorts/avatar",
+        "method": "POST",
+        "headers": {},
+        "json_format": true,
+        "body": null,
+        "files_name": "file",
+        "files": []
+      },
+      "metadata": {
+        "position": {
+          "x": 560,
+          "y": 70
+        }
+      },
+      "input_links": [
+        {
+          "id": "95acd0e4-a124-4854-94f2-88eb88594ba8",
+          "source_id": "0b3df07b-8aab-475a-867e-4d74fb80b285",
+          "sink_id": "f7b2e12b-f465-4ac7-ae48-3c5904f48ed9",
+          "source_name": "value",
+          "sink_name": "headers",
+          "is_static": false
+        },
+        {
+          "id": "4063c96c-0915-458d-8d86-d28dd148c5a3",
+          "source_id": "d39dadda-14b4-4b9c-8ae2-a08a86d0bed9",
+          "sink_id": "f7b2e12b-f465-4ac7-ae48-3c5904f48ed9",
+          "source_name": "value",
+          "sink_name": "body",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "a569d8a0-fe55-4de1-8fd9-766ae28bc716",
+          "source_id": "f7b2e12b-f465-4ac7-ae48-3c5904f48ed9",
+          "sink_id": "56f707b9-7278-4192-895d-94258144e637",
+          "source_name": "response",
+          "sink_name": "value",
+          "is_static": false
+        },
+        {
+          "id": "a1adfa2c-dd91-491f-b7b0-3d4a5494f6f3",
+          "source_id": "f7b2e12b-f465-4ac7-ae48-3c5904f48ed9",
+          "sink_id": "19a426bd-d9b4-494d-b142-f502c138f42a",
+          "source_name": "client_error",
+          "sink_name": "value",
+          "is_static": false
+        },
+        {
+          "id": "ab902c07-bb73-4ecb-91d7-cbe1871b773f",
+          "source_id": "f7b2e12b-f465-4ac7-ae48-3c5904f48ed9",
+          "sink_id": "8c69e275-7382-4a2d-8034-aee637ebbf1d",
+          "source_name": "server_error",
+          "sink_name": "value",
+          "is_static": false
+        },
+        {
+          "id": "c2cd70fc-ee83-424d-83ae-73656f949a90",
+          "source_id": "f7b2e12b-f465-4ac7-ae48-3c5904f48ed9",
+          "sink_id": "ca5886db-de36-4b09-9485-b024458c9fd9",
+          "source_name": "error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "graph_id": "58856952-1d84-4575-bfb3-99ba8f261ce0",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "56f707b9-7278-4192-895d-94258144e637",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "response",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "Successful API response payload.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": -160
+        }
+      },
+      "input_links": [
+        {
+          "id": "a569d8a0-fe55-4de1-8fd9-766ae28bc716",
+          "source_id": "f7b2e12b-f465-4ac7-ae48-3c5904f48ed9",
+          "sink_id": "56f707b9-7278-4192-895d-94258144e637",
+          "source_name": "response",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "58856952-1d84-4575-bfb3-99ba8f261ce0",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "19a426bd-d9b4-494d-b142-f502c138f42a",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "client_error",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "HTTP 4xx response payload.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": 20
+        }
+      },
+      "input_links": [
+        {
+          "id": "a1adfa2c-dd91-491f-b7b0-3d4a5494f6f3",
+          "source_id": "f7b2e12b-f465-4ac7-ae48-3c5904f48ed9",
+          "sink_id": "19a426bd-d9b4-494d-b142-f502c138f42a",
+          "source_name": "client_error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "58856952-1d84-4575-bfb3-99ba8f261ce0",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "8c69e275-7382-4a2d-8034-aee637ebbf1d",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "server_error",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "HTTP 5xx response payload.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": 200
+        }
+      },
+      "input_links": [
+        {
+          "id": "ab902c07-bb73-4ecb-91d7-cbe1871b773f",
+          "source_id": "f7b2e12b-f465-4ac7-ae48-3c5904f48ed9",
+          "sink_id": "8c69e275-7382-4a2d-8034-aee637ebbf1d",
+          "source_name": "server_error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "58856952-1d84-4575-bfb3-99ba8f261ce0",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "ca5886db-de36-4b09-9485-b024458c9fd9",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "error",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "Transport/runtime error output.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": 380
+        }
+      },
+      "input_links": [
+        {
+          "id": "c2cd70fc-ee83-424d-83ae-73656f949a90",
+          "source_id": "f7b2e12b-f465-4ac7-ae48-3c5904f48ed9",
+          "sink_id": "ca5886db-de36-4b09-9485-b024458c9fd9",
+          "source_name": "error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "58856952-1d84-4575-bfb3-99ba8f261ce0",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    }
+  ],
+  "links": [
+    {
+      "id": "6018f777-20f2-4589-bfb9-0c33e0dd0f5e",
+      "source_id": "18216d5e-4099-41b0-a025-4ec44fd759c9",
+      "sink_id": "7839a709-89bb-4ac9-ade6-f946191d2589",
+      "source_name": "result",
+      "sink_name": "values_#_api_key",
+      "is_static": false
+    },
+    {
+      "id": "5ad25572-b519-41c8-adce-02554ccbd9bc",
+      "source_id": "672101ca-2f9f-41f9-97a2-e300b440da4a",
+      "sink_id": "d39dadda-14b4-4b9c-8ae2-a08a86d0bed9",
+      "source_name": "result",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "5883f46b-c2d3-41fa-9f6f-3e91d315560e",
+      "source_id": "7839a709-89bb-4ac9-ade6-f946191d2589",
+      "sink_id": "de08d1eb-06e3-415f-b81d-293ba58bf122",
+      "source_name": "dictionary",
+      "sink_name": "values",
+      "is_static": false
+    },
+    {
+      "id": "22bf9521-5541-4bca-9e23-5796139ecc55",
+      "source_id": "de08d1eb-06e3-415f-b81d-293ba58bf122",
+      "sink_id": "0b3df07b-8aab-475a-867e-4d74fb80b285",
+      "source_name": "output",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "95acd0e4-a124-4854-94f2-88eb88594ba8",
+      "source_id": "0b3df07b-8aab-475a-867e-4d74fb80b285",
+      "sink_id": "f7b2e12b-f465-4ac7-ae48-3c5904f48ed9",
+      "source_name": "value",
+      "sink_name": "headers",
+      "is_static": false
+    },
+    {
+      "id": "4063c96c-0915-458d-8d86-d28dd148c5a3",
+      "source_id": "d39dadda-14b4-4b9c-8ae2-a08a86d0bed9",
+      "sink_id": "f7b2e12b-f465-4ac7-ae48-3c5904f48ed9",
+      "source_name": "value",
+      "sink_name": "body",
+      "is_static": false
+    },
+    {
+      "id": "a569d8a0-fe55-4de1-8fd9-766ae28bc716",
+      "source_id": "f7b2e12b-f465-4ac7-ae48-3c5904f48ed9",
+      "sink_id": "56f707b9-7278-4192-895d-94258144e637",
+      "source_name": "response",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "a1adfa2c-dd91-491f-b7b0-3d4a5494f6f3",
+      "source_id": "f7b2e12b-f465-4ac7-ae48-3c5904f48ed9",
+      "sink_id": "19a426bd-d9b4-494d-b142-f502c138f42a",
+      "source_name": "client_error",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "ab902c07-bb73-4ecb-91d7-cbe1871b773f",
+      "source_id": "f7b2e12b-f465-4ac7-ae48-3c5904f48ed9",
+      "sink_id": "8c69e275-7382-4a2d-8034-aee637ebbf1d",
+      "source_name": "server_error",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "c2cd70fc-ee83-424d-83ae-73656f949a90",
+      "source_id": "f7b2e12b-f465-4ac7-ae48-3c5904f48ed9",
+      "sink_id": "ca5886db-de36-4b09-9485-b024458c9fd9",
+      "source_name": "error",
+      "sink_name": "value",
+      "is_static": false
+    }
+  ],
+  "forked_from_id": null,
+  "forked_from_version": null,
+  "sub_graphs": [],
+  "user_id": "",
+  "created_at": "2026-02-28T12:00:00.000Z",
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "API Key": {
+        "advanced": false,
+        "anyOf": [
+          {
+            "format": "short-text",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "secret": true,
+        "title": "API Key",
+        "description": "Citedy API key (starts with citedy_agent_)",
+        "default": "citedy_agent_replace_me"
+      },
+      "Request JSON": {
+        "advanced": false,
+        "anyOf": [
+          {
+            "format": "long-text",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "secret": false,
+        "title": "Request JSON",
+        "description": "JSON payload for the selected Citedy endpoint.",
+        "default": "{\n  \"gender\": \"female\",\n  \"origin\": \"latin\",\n  \"age_range\": \"26-35\",\n  \"type\": \"tech_founder\",\n  \"location\": \"coffee_shop\"\n}"
+      }
+    },
+    "required": ["API Key", "Request JSON"]
+  },
+  "output_schema": {
+    "type": "object",
+    "properties": {
+      "response": {
+        "title": "response",
+        "description": "Successful API response payload.",
+        "type": "object"
+      },
+      "client_error": {
+        "title": "client_error",
+        "description": "HTTP 4xx response payload.",
+        "type": "object"
+      },
+      "server_error": {
+        "title": "server_error",
+        "description": "HTTP 5xx response payload.",
+        "type": "object"
+      },
+      "error": {
+        "title": "error",
+        "description": "Transport/runtime error output.",
+        "type": "string"
+      }
+    },
+    "required": []
+  },
+  "has_external_trigger": false,
+  "has_human_in_the_loop": false,
+  "trigger_setup_info": null,
+  "credentials_input_schema": {
+    "properties": {},
+    "required": [],
+    "title": "CitedyTemplateCredentialsInputSchema",
+    "type": "object"
+  }
+}

--- a/autogpt_platform/graph_templates/citedy-shorts-merge.agent.json
+++ b/autogpt_platform/graph_templates/citedy-shorts-merge.agent.json
@@ -1,0 +1,606 @@
+{
+  "id": "e380741f-358c-41c0-b2b5-8a8f49d50620",
+  "version": 1,
+  "is_active": true,
+  "name": "Citedy Shorts Merge",
+  "description": "Merge video segments with professional subtitles (5 credits).",
+  "instructions": null,
+  "recommended_schedule_cron": null,
+  "nodes": [
+    {
+      "id": "68bfca17-72fa-493d-92f0-376b513e33ff",
+      "block_id": "7fcd3bcb-8e1b-4e69-903d-32d3d4a92158",
+      "input_default": {
+        "name": "API Key",
+        "title": null,
+        "value": "citedy_agent_replace_me",
+        "secret": true,
+        "advanced": false,
+        "description": "Citedy API key (starts with citedy_agent_)",
+        "placeholder_values": []
+      },
+      "metadata": {
+        "position": {
+          "x": -920,
+          "y": -80
+        }
+      },
+      "input_links": [],
+      "output_links": [
+        {
+          "id": "59d22497-9d47-4741-91e5-0bd4ae9c5151",
+          "source_id": "68bfca17-72fa-493d-92f0-376b513e33ff",
+          "sink_id": "04f1c0c8-1a28-47a8-aa41-986575a25e01",
+          "source_name": "result",
+          "sink_name": "values_#_api_key",
+          "is_static": false
+        }
+      ],
+      "graph_id": "e380741f-358c-41c0-b2b5-8a8f49d50620",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "e6de3cdf-a33b-47b2-8efc-76c39f660216",
+      "block_id": "90a56ffb-7024-4b2b-ab50-e26c5e5ab8ba",
+      "input_default": {
+        "name": "Request JSON",
+        "title": null,
+        "value": "{\n  \"video_urls\": [\n    \"https://download.citedy.com/replace1.mp4\",\n    \"https://download.citedy.com/replace2.mp4\"\n  ],\n  \"phrases\": [\n    {\n      \"text\": \"First segment text\"\n    },\n    {\n      \"text\": \"Second segment text\"\n    }\n  ]\n}",
+        "secret": false,
+        "advanced": false,
+        "description": "JSON payload for this endpoint.",
+        "placeholder_values": []
+      },
+      "metadata": {
+        "position": {
+          "x": -920,
+          "y": 220
+        }
+      },
+      "input_links": [],
+      "output_links": [
+        {
+          "id": "0ed46b3d-4202-4d1c-8072-7b985ae95fdc",
+          "source_id": "e6de3cdf-a33b-47b2-8efc-76c39f660216",
+          "sink_id": "86c75c8f-09de-4cd1-8fb1-a44d6f99078c",
+          "source_name": "result",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "graph_id": "e380741f-358c-41c0-b2b5-8a8f49d50620",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "04f1c0c8-1a28-47a8-aa41-986575a25e01",
+      "block_id": "b924ddf4-de4f-4b56-9a85-358930dcbc91",
+      "input_default": {
+        "values": {}
+      },
+      "metadata": {
+        "position": {
+          "x": -520,
+          "y": -80
+        }
+      },
+      "input_links": [
+        {
+          "id": "59d22497-9d47-4741-91e5-0bd4ae9c5151",
+          "source_id": "68bfca17-72fa-493d-92f0-376b513e33ff",
+          "sink_id": "04f1c0c8-1a28-47a8-aa41-986575a25e01",
+          "source_name": "result",
+          "sink_name": "values_#_api_key",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "d1349995-f71d-4302-beee-691db56cae4d",
+          "source_id": "04f1c0c8-1a28-47a8-aa41-986575a25e01",
+          "sink_id": "7b21d047-59a7-4a61-bb50-2e3c6003bc9b",
+          "source_name": "dictionary",
+          "sink_name": "values",
+          "is_static": false
+        }
+      ],
+      "graph_id": "e380741f-358c-41c0-b2b5-8a8f49d50620",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "7b21d047-59a7-4a61-bb50-2e3c6003bc9b",
+      "block_id": "db7d8f02-2f44-4c55-ab7a-eae0941f0c30",
+      "input_default": {
+        "format": "{\"Authorization\":\"Bearer {{ api_key }}\",\"Content-Type\":\"application/json\"}",
+        "values": {},
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": -140,
+          "y": -80
+        }
+      },
+      "input_links": [
+        {
+          "id": "d1349995-f71d-4302-beee-691db56cae4d",
+          "source_id": "04f1c0c8-1a28-47a8-aa41-986575a25e01",
+          "sink_id": "7b21d047-59a7-4a61-bb50-2e3c6003bc9b",
+          "source_name": "dictionary",
+          "sink_name": "values",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "0d1f464a-51b8-424b-84f6-f20a0cb865f6",
+          "source_id": "7b21d047-59a7-4a61-bb50-2e3c6003bc9b",
+          "sink_id": "9a12d931-85d3-4b28-8b4f-17da846a73a8",
+          "source_name": "output",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "graph_id": "e380741f-358c-41c0-b2b5-8a8f49d50620",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "9a12d931-85d3-4b28-8b4f-17da846a73a8",
+      "block_id": "95d1b990-ce13-4d88-9737-ba5c2070c97b",
+      "input_default": {
+        "type": "dictionary",
+        "value": null
+      },
+      "metadata": {
+        "position": {
+          "x": 180,
+          "y": -80
+        }
+      },
+      "input_links": [
+        {
+          "id": "0d1f464a-51b8-424b-84f6-f20a0cb865f6",
+          "source_id": "7b21d047-59a7-4a61-bb50-2e3c6003bc9b",
+          "sink_id": "9a12d931-85d3-4b28-8b4f-17da846a73a8",
+          "source_name": "output",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "cc296ea7-a93c-406f-bd57-8c2ea78c7122",
+          "source_id": "9a12d931-85d3-4b28-8b4f-17da846a73a8",
+          "sink_id": "af60720b-cf8c-426b-98aa-c217c4dbc178",
+          "source_name": "value",
+          "sink_name": "headers",
+          "is_static": false
+        }
+      ],
+      "graph_id": "e380741f-358c-41c0-b2b5-8a8f49d50620",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "86c75c8f-09de-4cd1-8fb1-a44d6f99078c",
+      "block_id": "95d1b990-ce13-4d88-9737-ba5c2070c97b",
+      "input_default": {
+        "type": "dictionary",
+        "value": null
+      },
+      "metadata": {
+        "position": {
+          "x": -140,
+          "y": 220
+        }
+      },
+      "input_links": [
+        {
+          "id": "0ed46b3d-4202-4d1c-8072-7b985ae95fdc",
+          "source_id": "e6de3cdf-a33b-47b2-8efc-76c39f660216",
+          "sink_id": "86c75c8f-09de-4cd1-8fb1-a44d6f99078c",
+          "source_name": "result",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "62faa757-6467-4396-8e3a-1a65d917e138",
+          "source_id": "86c75c8f-09de-4cd1-8fb1-a44d6f99078c",
+          "sink_id": "af60720b-cf8c-426b-98aa-c217c4dbc178",
+          "source_name": "value",
+          "sink_name": "body",
+          "is_static": false
+        }
+      ],
+      "graph_id": "e380741f-358c-41c0-b2b5-8a8f49d50620",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "af60720b-cf8c-426b-98aa-c217c4dbc178",
+      "block_id": "6595ae1f-b924-42cb-9a41-551a0611c4b4",
+      "input_default": {
+        "url": "https://www.citedy.com/api/agent/shorts/merge",
+        "method": "POST",
+        "headers": {},
+        "json_format": true,
+        "body": null,
+        "files_name": "file",
+        "files": []
+      },
+      "metadata": {
+        "position": {
+          "x": 560,
+          "y": 70
+        }
+      },
+      "input_links": [
+        {
+          "id": "cc296ea7-a93c-406f-bd57-8c2ea78c7122",
+          "source_id": "9a12d931-85d3-4b28-8b4f-17da846a73a8",
+          "sink_id": "af60720b-cf8c-426b-98aa-c217c4dbc178",
+          "source_name": "value",
+          "sink_name": "headers",
+          "is_static": false
+        },
+        {
+          "id": "62faa757-6467-4396-8e3a-1a65d917e138",
+          "source_id": "86c75c8f-09de-4cd1-8fb1-a44d6f99078c",
+          "sink_id": "af60720b-cf8c-426b-98aa-c217c4dbc178",
+          "source_name": "value",
+          "sink_name": "body",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "dcc73a71-c9f5-463f-9885-a3fbb0ede5b9",
+          "source_id": "af60720b-cf8c-426b-98aa-c217c4dbc178",
+          "sink_id": "87010779-0c59-462b-a7de-3992cb99ee47",
+          "source_name": "response",
+          "sink_name": "value",
+          "is_static": false
+        },
+        {
+          "id": "f5ead97b-89f6-4e85-9582-3e9c41267af3",
+          "source_id": "af60720b-cf8c-426b-98aa-c217c4dbc178",
+          "sink_id": "901d92dd-00e7-49c5-8ed8-685be90c8cc2",
+          "source_name": "client_error",
+          "sink_name": "value",
+          "is_static": false
+        },
+        {
+          "id": "da9eb411-cc5d-4e4d-b6fd-6f58cf55b7c6",
+          "source_id": "af60720b-cf8c-426b-98aa-c217c4dbc178",
+          "sink_id": "1a8fd629-ffc4-4055-9bec-1cc5c4532df7",
+          "source_name": "server_error",
+          "sink_name": "value",
+          "is_static": false
+        },
+        {
+          "id": "77c94ee5-4e52-4e89-a7e8-9edd1db7da06",
+          "source_id": "af60720b-cf8c-426b-98aa-c217c4dbc178",
+          "sink_id": "e4be40a2-b8fa-44b8-9d29-ea8076895541",
+          "source_name": "error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "graph_id": "e380741f-358c-41c0-b2b5-8a8f49d50620",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "87010779-0c59-462b-a7de-3992cb99ee47",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "response",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "Successful API response payload.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": -160
+        }
+      },
+      "input_links": [
+        {
+          "id": "dcc73a71-c9f5-463f-9885-a3fbb0ede5b9",
+          "source_id": "af60720b-cf8c-426b-98aa-c217c4dbc178",
+          "sink_id": "87010779-0c59-462b-a7de-3992cb99ee47",
+          "source_name": "response",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "e380741f-358c-41c0-b2b5-8a8f49d50620",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "901d92dd-00e7-49c5-8ed8-685be90c8cc2",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "client_error",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "HTTP 4xx response payload.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": 20
+        }
+      },
+      "input_links": [
+        {
+          "id": "f5ead97b-89f6-4e85-9582-3e9c41267af3",
+          "source_id": "af60720b-cf8c-426b-98aa-c217c4dbc178",
+          "sink_id": "901d92dd-00e7-49c5-8ed8-685be90c8cc2",
+          "source_name": "client_error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "e380741f-358c-41c0-b2b5-8a8f49d50620",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "1a8fd629-ffc4-4055-9bec-1cc5c4532df7",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "server_error",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "HTTP 5xx response payload.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": 200
+        }
+      },
+      "input_links": [
+        {
+          "id": "da9eb411-cc5d-4e4d-b6fd-6f58cf55b7c6",
+          "source_id": "af60720b-cf8c-426b-98aa-c217c4dbc178",
+          "sink_id": "1a8fd629-ffc4-4055-9bec-1cc5c4532df7",
+          "source_name": "server_error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "e380741f-358c-41c0-b2b5-8a8f49d50620",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "e4be40a2-b8fa-44b8-9d29-ea8076895541",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "error",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "Transport/runtime error output.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": 380
+        }
+      },
+      "input_links": [
+        {
+          "id": "77c94ee5-4e52-4e89-a7e8-9edd1db7da06",
+          "source_id": "af60720b-cf8c-426b-98aa-c217c4dbc178",
+          "sink_id": "e4be40a2-b8fa-44b8-9d29-ea8076895541",
+          "source_name": "error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "e380741f-358c-41c0-b2b5-8a8f49d50620",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    }
+  ],
+  "links": [
+    {
+      "id": "59d22497-9d47-4741-91e5-0bd4ae9c5151",
+      "source_id": "68bfca17-72fa-493d-92f0-376b513e33ff",
+      "sink_id": "04f1c0c8-1a28-47a8-aa41-986575a25e01",
+      "source_name": "result",
+      "sink_name": "values_#_api_key",
+      "is_static": false
+    },
+    {
+      "id": "0ed46b3d-4202-4d1c-8072-7b985ae95fdc",
+      "source_id": "e6de3cdf-a33b-47b2-8efc-76c39f660216",
+      "sink_id": "86c75c8f-09de-4cd1-8fb1-a44d6f99078c",
+      "source_name": "result",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "d1349995-f71d-4302-beee-691db56cae4d",
+      "source_id": "04f1c0c8-1a28-47a8-aa41-986575a25e01",
+      "sink_id": "7b21d047-59a7-4a61-bb50-2e3c6003bc9b",
+      "source_name": "dictionary",
+      "sink_name": "values",
+      "is_static": false
+    },
+    {
+      "id": "0d1f464a-51b8-424b-84f6-f20a0cb865f6",
+      "source_id": "7b21d047-59a7-4a61-bb50-2e3c6003bc9b",
+      "sink_id": "9a12d931-85d3-4b28-8b4f-17da846a73a8",
+      "source_name": "output",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "cc296ea7-a93c-406f-bd57-8c2ea78c7122",
+      "source_id": "9a12d931-85d3-4b28-8b4f-17da846a73a8",
+      "sink_id": "af60720b-cf8c-426b-98aa-c217c4dbc178",
+      "source_name": "value",
+      "sink_name": "headers",
+      "is_static": false
+    },
+    {
+      "id": "62faa757-6467-4396-8e3a-1a65d917e138",
+      "source_id": "86c75c8f-09de-4cd1-8fb1-a44d6f99078c",
+      "sink_id": "af60720b-cf8c-426b-98aa-c217c4dbc178",
+      "source_name": "value",
+      "sink_name": "body",
+      "is_static": false
+    },
+    {
+      "id": "dcc73a71-c9f5-463f-9885-a3fbb0ede5b9",
+      "source_id": "af60720b-cf8c-426b-98aa-c217c4dbc178",
+      "sink_id": "87010779-0c59-462b-a7de-3992cb99ee47",
+      "source_name": "response",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "f5ead97b-89f6-4e85-9582-3e9c41267af3",
+      "source_id": "af60720b-cf8c-426b-98aa-c217c4dbc178",
+      "sink_id": "901d92dd-00e7-49c5-8ed8-685be90c8cc2",
+      "source_name": "client_error",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "da9eb411-cc5d-4e4d-b6fd-6f58cf55b7c6",
+      "source_id": "af60720b-cf8c-426b-98aa-c217c4dbc178",
+      "sink_id": "1a8fd629-ffc4-4055-9bec-1cc5c4532df7",
+      "source_name": "server_error",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "77c94ee5-4e52-4e89-a7e8-9edd1db7da06",
+      "source_id": "af60720b-cf8c-426b-98aa-c217c4dbc178",
+      "sink_id": "e4be40a2-b8fa-44b8-9d29-ea8076895541",
+      "source_name": "error",
+      "sink_name": "value",
+      "is_static": false
+    }
+  ],
+  "forked_from_id": null,
+  "forked_from_version": null,
+  "sub_graphs": [],
+  "user_id": "",
+  "created_at": "2026-02-28T12:00:00.000Z",
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "API Key": {
+        "advanced": false,
+        "anyOf": [
+          {
+            "format": "short-text",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "secret": true,
+        "title": "API Key",
+        "description": "Citedy API key (starts with citedy_agent_)",
+        "default": "citedy_agent_replace_me"
+      },
+      "Request JSON": {
+        "advanced": false,
+        "anyOf": [
+          {
+            "format": "long-text",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "secret": false,
+        "title": "Request JSON",
+        "description": "JSON payload for the selected Citedy endpoint.",
+        "default": "{\n  \"video_urls\": [\n    \"https://download.citedy.com/replace1.mp4\",\n    \"https://download.citedy.com/replace2.mp4\"\n  ],\n  \"phrases\": [\n    {\n      \"text\": \"First segment text\"\n    },\n    {\n      \"text\": \"Second segment text\"\n    }\n  ]\n}"
+      }
+    },
+    "required": ["API Key", "Request JSON"]
+  },
+  "output_schema": {
+    "type": "object",
+    "properties": {
+      "response": {
+        "title": "response",
+        "description": "Successful API response payload.",
+        "type": "object"
+      },
+      "client_error": {
+        "title": "client_error",
+        "description": "HTTP 4xx response payload.",
+        "type": "object"
+      },
+      "server_error": {
+        "title": "server_error",
+        "description": "HTTP 5xx response payload.",
+        "type": "object"
+      },
+      "error": {
+        "title": "error",
+        "description": "Transport/runtime error output.",
+        "type": "string"
+      }
+    },
+    "required": []
+  },
+  "has_external_trigger": false,
+  "has_human_in_the_loop": false,
+  "trigger_setup_info": null,
+  "credentials_input_schema": {
+    "properties": {},
+    "required": [],
+    "title": "CitedyTemplateCredentialsInputSchema",
+    "type": "object"
+  }
+}

--- a/autogpt_platform/graph_templates/citedy-shorts-script.agent.json
+++ b/autogpt_platform/graph_templates/citedy-shorts-script.agent.json
@@ -1,0 +1,606 @@
+{
+  "id": "d5a980c3-1047-490c-bc49-ce48c1af5487",
+  "version": 1,
+  "is_active": true,
+  "name": "Citedy Shorts Script",
+  "description": "Generate speech script for short-form AI UGC viral video.",
+  "instructions": null,
+  "recommended_schedule_cron": null,
+  "nodes": [
+    {
+      "id": "ad8d2738-4294-48ee-96b6-80540654d9c5",
+      "block_id": "7fcd3bcb-8e1b-4e69-903d-32d3d4a92158",
+      "input_default": {
+        "name": "API Key",
+        "title": null,
+        "value": "citedy_agent_replace_me",
+        "secret": true,
+        "advanced": false,
+        "description": "Citedy API key (starts with citedy_agent_)",
+        "placeholder_values": []
+      },
+      "metadata": {
+        "position": {
+          "x": -920,
+          "y": -80
+        }
+      },
+      "input_links": [],
+      "output_links": [
+        {
+          "id": "e910a39c-146a-4c4a-b643-315e82aa3a5d",
+          "source_id": "ad8d2738-4294-48ee-96b6-80540654d9c5",
+          "sink_id": "a2576d20-5b01-4748-964d-6168fa726476",
+          "source_name": "result",
+          "sink_name": "values_#_api_key",
+          "is_static": false
+        }
+      ],
+      "graph_id": "d5a980c3-1047-490c-bc49-ce48c1af5487",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "9b3be467-6b15-44ce-b83a-b828acfaa241",
+      "block_id": "90a56ffb-7024-4b2b-ab50-e26c5e5ab8ba",
+      "input_default": {
+        "name": "Request JSON",
+        "title": null,
+        "value": "{\n  \"topic\": \"AI personas let you write as Elon Musk\",\n  \"duration\": \"short\",\n  \"style\": \"hook\",\n  \"language\": \"en\"\n}",
+        "secret": false,
+        "advanced": false,
+        "description": "JSON payload for this endpoint.",
+        "placeholder_values": []
+      },
+      "metadata": {
+        "position": {
+          "x": -920,
+          "y": 220
+        }
+      },
+      "input_links": [],
+      "output_links": [
+        {
+          "id": "6fba5375-3b6d-4587-bd92-409536eca211",
+          "source_id": "9b3be467-6b15-44ce-b83a-b828acfaa241",
+          "sink_id": "6090ebb0-be04-4cb3-86bc-8e37454ceda5",
+          "source_name": "result",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "graph_id": "d5a980c3-1047-490c-bc49-ce48c1af5487",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "a2576d20-5b01-4748-964d-6168fa726476",
+      "block_id": "b924ddf4-de4f-4b56-9a85-358930dcbc91",
+      "input_default": {
+        "values": {}
+      },
+      "metadata": {
+        "position": {
+          "x": -520,
+          "y": -80
+        }
+      },
+      "input_links": [
+        {
+          "id": "e910a39c-146a-4c4a-b643-315e82aa3a5d",
+          "source_id": "ad8d2738-4294-48ee-96b6-80540654d9c5",
+          "sink_id": "a2576d20-5b01-4748-964d-6168fa726476",
+          "source_name": "result",
+          "sink_name": "values_#_api_key",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "5ffcb291-ffb1-42e3-b9ee-35f7a3046762",
+          "source_id": "a2576d20-5b01-4748-964d-6168fa726476",
+          "sink_id": "d1f9738e-ac3e-49a4-958d-d36c34b14df9",
+          "source_name": "dictionary",
+          "sink_name": "values",
+          "is_static": false
+        }
+      ],
+      "graph_id": "d5a980c3-1047-490c-bc49-ce48c1af5487",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "d1f9738e-ac3e-49a4-958d-d36c34b14df9",
+      "block_id": "db7d8f02-2f44-4c55-ab7a-eae0941f0c30",
+      "input_default": {
+        "format": "{\"Authorization\":\"Bearer {{ api_key }}\",\"Content-Type\":\"application/json\"}",
+        "values": {},
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": -140,
+          "y": -80
+        }
+      },
+      "input_links": [
+        {
+          "id": "5ffcb291-ffb1-42e3-b9ee-35f7a3046762",
+          "source_id": "a2576d20-5b01-4748-964d-6168fa726476",
+          "sink_id": "d1f9738e-ac3e-49a4-958d-d36c34b14df9",
+          "source_name": "dictionary",
+          "sink_name": "values",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "81171e6b-1e99-45f8-9c5c-f38b7e76ee81",
+          "source_id": "d1f9738e-ac3e-49a4-958d-d36c34b14df9",
+          "sink_id": "21c8d330-57f5-45aa-afc5-141c58b30b33",
+          "source_name": "output",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "graph_id": "d5a980c3-1047-490c-bc49-ce48c1af5487",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "21c8d330-57f5-45aa-afc5-141c58b30b33",
+      "block_id": "95d1b990-ce13-4d88-9737-ba5c2070c97b",
+      "input_default": {
+        "type": "dictionary",
+        "value": null
+      },
+      "metadata": {
+        "position": {
+          "x": 180,
+          "y": -80
+        }
+      },
+      "input_links": [
+        {
+          "id": "81171e6b-1e99-45f8-9c5c-f38b7e76ee81",
+          "source_id": "d1f9738e-ac3e-49a4-958d-d36c34b14df9",
+          "sink_id": "21c8d330-57f5-45aa-afc5-141c58b30b33",
+          "source_name": "output",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "f7632761-993f-4fe8-be8d-0ae77b797aad",
+          "source_id": "21c8d330-57f5-45aa-afc5-141c58b30b33",
+          "sink_id": "737656f1-9f98-474f-a04a-3258233ad991",
+          "source_name": "value",
+          "sink_name": "headers",
+          "is_static": false
+        }
+      ],
+      "graph_id": "d5a980c3-1047-490c-bc49-ce48c1af5487",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "6090ebb0-be04-4cb3-86bc-8e37454ceda5",
+      "block_id": "95d1b990-ce13-4d88-9737-ba5c2070c97b",
+      "input_default": {
+        "type": "dictionary",
+        "value": null
+      },
+      "metadata": {
+        "position": {
+          "x": -140,
+          "y": 220
+        }
+      },
+      "input_links": [
+        {
+          "id": "6fba5375-3b6d-4587-bd92-409536eca211",
+          "source_id": "9b3be467-6b15-44ce-b83a-b828acfaa241",
+          "sink_id": "6090ebb0-be04-4cb3-86bc-8e37454ceda5",
+          "source_name": "result",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "709bf389-0507-4599-99c9-627a8644e7bc",
+          "source_id": "6090ebb0-be04-4cb3-86bc-8e37454ceda5",
+          "sink_id": "737656f1-9f98-474f-a04a-3258233ad991",
+          "source_name": "value",
+          "sink_name": "body",
+          "is_static": false
+        }
+      ],
+      "graph_id": "d5a980c3-1047-490c-bc49-ce48c1af5487",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "737656f1-9f98-474f-a04a-3258233ad991",
+      "block_id": "6595ae1f-b924-42cb-9a41-551a0611c4b4",
+      "input_default": {
+        "url": "https://www.citedy.com/api/agent/shorts/script",
+        "method": "POST",
+        "headers": {},
+        "json_format": true,
+        "body": null,
+        "files_name": "file",
+        "files": []
+      },
+      "metadata": {
+        "position": {
+          "x": 560,
+          "y": 70
+        }
+      },
+      "input_links": [
+        {
+          "id": "f7632761-993f-4fe8-be8d-0ae77b797aad",
+          "source_id": "21c8d330-57f5-45aa-afc5-141c58b30b33",
+          "sink_id": "737656f1-9f98-474f-a04a-3258233ad991",
+          "source_name": "value",
+          "sink_name": "headers",
+          "is_static": false
+        },
+        {
+          "id": "709bf389-0507-4599-99c9-627a8644e7bc",
+          "source_id": "6090ebb0-be04-4cb3-86bc-8e37454ceda5",
+          "sink_id": "737656f1-9f98-474f-a04a-3258233ad991",
+          "source_name": "value",
+          "sink_name": "body",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "0e417a2b-3fb6-4190-9787-80d0a9840495",
+          "source_id": "737656f1-9f98-474f-a04a-3258233ad991",
+          "sink_id": "c69a579e-36cf-49a1-aa06-76b8114f3076",
+          "source_name": "response",
+          "sink_name": "value",
+          "is_static": false
+        },
+        {
+          "id": "a3f72c40-c255-4241-b05f-58a3098bc296",
+          "source_id": "737656f1-9f98-474f-a04a-3258233ad991",
+          "sink_id": "3d8a52a2-578b-46d0-aab2-f0b213e94c56",
+          "source_name": "client_error",
+          "sink_name": "value",
+          "is_static": false
+        },
+        {
+          "id": "efd9e22d-2e7b-4f44-9dc1-aa8c0ac69faf",
+          "source_id": "737656f1-9f98-474f-a04a-3258233ad991",
+          "sink_id": "efb80c3a-81b7-43c1-80c3-744a8ecd7d59",
+          "source_name": "server_error",
+          "sink_name": "value",
+          "is_static": false
+        },
+        {
+          "id": "8b9338af-92d2-4b01-9ae9-07dc5cb479d8",
+          "source_id": "737656f1-9f98-474f-a04a-3258233ad991",
+          "sink_id": "c01fd291-7075-4ed5-9c8a-c9ae7a02eb36",
+          "source_name": "error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "graph_id": "d5a980c3-1047-490c-bc49-ce48c1af5487",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "c69a579e-36cf-49a1-aa06-76b8114f3076",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "response",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "Successful API response payload.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": -160
+        }
+      },
+      "input_links": [
+        {
+          "id": "0e417a2b-3fb6-4190-9787-80d0a9840495",
+          "source_id": "737656f1-9f98-474f-a04a-3258233ad991",
+          "sink_id": "c69a579e-36cf-49a1-aa06-76b8114f3076",
+          "source_name": "response",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "d5a980c3-1047-490c-bc49-ce48c1af5487",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "3d8a52a2-578b-46d0-aab2-f0b213e94c56",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "client_error",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "HTTP 4xx response payload.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": 20
+        }
+      },
+      "input_links": [
+        {
+          "id": "a3f72c40-c255-4241-b05f-58a3098bc296",
+          "source_id": "737656f1-9f98-474f-a04a-3258233ad991",
+          "sink_id": "3d8a52a2-578b-46d0-aab2-f0b213e94c56",
+          "source_name": "client_error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "d5a980c3-1047-490c-bc49-ce48c1af5487",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "efb80c3a-81b7-43c1-80c3-744a8ecd7d59",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "server_error",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "HTTP 5xx response payload.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": 200
+        }
+      },
+      "input_links": [
+        {
+          "id": "efd9e22d-2e7b-4f44-9dc1-aa8c0ac69faf",
+          "source_id": "737656f1-9f98-474f-a04a-3258233ad991",
+          "sink_id": "efb80c3a-81b7-43c1-80c3-744a8ecd7d59",
+          "source_name": "server_error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "d5a980c3-1047-490c-bc49-ce48c1af5487",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "c01fd291-7075-4ed5-9c8a-c9ae7a02eb36",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "error",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "Transport/runtime error output.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": 380
+        }
+      },
+      "input_links": [
+        {
+          "id": "8b9338af-92d2-4b01-9ae9-07dc5cb479d8",
+          "source_id": "737656f1-9f98-474f-a04a-3258233ad991",
+          "sink_id": "c01fd291-7075-4ed5-9c8a-c9ae7a02eb36",
+          "source_name": "error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "d5a980c3-1047-490c-bc49-ce48c1af5487",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    }
+  ],
+  "links": [
+    {
+      "id": "e910a39c-146a-4c4a-b643-315e82aa3a5d",
+      "source_id": "ad8d2738-4294-48ee-96b6-80540654d9c5",
+      "sink_id": "a2576d20-5b01-4748-964d-6168fa726476",
+      "source_name": "result",
+      "sink_name": "values_#_api_key",
+      "is_static": false
+    },
+    {
+      "id": "6fba5375-3b6d-4587-bd92-409536eca211",
+      "source_id": "9b3be467-6b15-44ce-b83a-b828acfaa241",
+      "sink_id": "6090ebb0-be04-4cb3-86bc-8e37454ceda5",
+      "source_name": "result",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "5ffcb291-ffb1-42e3-b9ee-35f7a3046762",
+      "source_id": "a2576d20-5b01-4748-964d-6168fa726476",
+      "sink_id": "d1f9738e-ac3e-49a4-958d-d36c34b14df9",
+      "source_name": "dictionary",
+      "sink_name": "values",
+      "is_static": false
+    },
+    {
+      "id": "81171e6b-1e99-45f8-9c5c-f38b7e76ee81",
+      "source_id": "d1f9738e-ac3e-49a4-958d-d36c34b14df9",
+      "sink_id": "21c8d330-57f5-45aa-afc5-141c58b30b33",
+      "source_name": "output",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "f7632761-993f-4fe8-be8d-0ae77b797aad",
+      "source_id": "21c8d330-57f5-45aa-afc5-141c58b30b33",
+      "sink_id": "737656f1-9f98-474f-a04a-3258233ad991",
+      "source_name": "value",
+      "sink_name": "headers",
+      "is_static": false
+    },
+    {
+      "id": "709bf389-0507-4599-99c9-627a8644e7bc",
+      "source_id": "6090ebb0-be04-4cb3-86bc-8e37454ceda5",
+      "sink_id": "737656f1-9f98-474f-a04a-3258233ad991",
+      "source_name": "value",
+      "sink_name": "body",
+      "is_static": false
+    },
+    {
+      "id": "0e417a2b-3fb6-4190-9787-80d0a9840495",
+      "source_id": "737656f1-9f98-474f-a04a-3258233ad991",
+      "sink_id": "c69a579e-36cf-49a1-aa06-76b8114f3076",
+      "source_name": "response",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "a3f72c40-c255-4241-b05f-58a3098bc296",
+      "source_id": "737656f1-9f98-474f-a04a-3258233ad991",
+      "sink_id": "3d8a52a2-578b-46d0-aab2-f0b213e94c56",
+      "source_name": "client_error",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "efd9e22d-2e7b-4f44-9dc1-aa8c0ac69faf",
+      "source_id": "737656f1-9f98-474f-a04a-3258233ad991",
+      "sink_id": "efb80c3a-81b7-43c1-80c3-744a8ecd7d59",
+      "source_name": "server_error",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "8b9338af-92d2-4b01-9ae9-07dc5cb479d8",
+      "source_id": "737656f1-9f98-474f-a04a-3258233ad991",
+      "sink_id": "c01fd291-7075-4ed5-9c8a-c9ae7a02eb36",
+      "source_name": "error",
+      "sink_name": "value",
+      "is_static": false
+    }
+  ],
+  "forked_from_id": null,
+  "forked_from_version": null,
+  "sub_graphs": [],
+  "user_id": "",
+  "created_at": "2026-02-28T12:00:00.000Z",
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "API Key": {
+        "advanced": false,
+        "anyOf": [
+          {
+            "format": "short-text",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "secret": true,
+        "title": "API Key",
+        "description": "Citedy API key (starts with citedy_agent_)",
+        "default": "citedy_agent_replace_me"
+      },
+      "Request JSON": {
+        "advanced": false,
+        "anyOf": [
+          {
+            "format": "long-text",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "secret": false,
+        "title": "Request JSON",
+        "description": "JSON payload for the selected Citedy endpoint.",
+        "default": "{\n  \"topic\": \"AI personas let you write as Elon Musk\",\n  \"duration\": \"short\",\n  \"style\": \"hook\",\n  \"language\": \"en\"\n}"
+      }
+    },
+    "required": ["API Key", "Request JSON"]
+  },
+  "output_schema": {
+    "type": "object",
+    "properties": {
+      "response": {
+        "title": "response",
+        "description": "Successful API response payload.",
+        "type": "object"
+      },
+      "client_error": {
+        "title": "client_error",
+        "description": "HTTP 4xx response payload.",
+        "type": "object"
+      },
+      "server_error": {
+        "title": "server_error",
+        "description": "HTTP 5xx response payload.",
+        "type": "object"
+      },
+      "error": {
+        "title": "error",
+        "description": "Transport/runtime error output.",
+        "type": "string"
+      }
+    },
+    "required": []
+  },
+  "has_external_trigger": false,
+  "has_human_in_the_loop": false,
+  "trigger_setup_info": null,
+  "credentials_input_schema": {
+    "properties": {},
+    "required": [],
+    "title": "CitedyTemplateCredentialsInputSchema",
+    "type": "object"
+  }
+}

--- a/autogpt_platform/graph_templates/citedy-shorts-video.agent.json
+++ b/autogpt_platform/graph_templates/citedy-shorts-video.agent.json
@@ -1,0 +1,606 @@
+{
+  "id": "9221fef6-6d51-4703-a44d-78b23debf7e2",
+  "version": 1,
+  "is_active": true,
+  "name": "Citedy Shorts Video",
+  "description": "Generate AI UGC viral video segment (60-185 credits).",
+  "instructions": null,
+  "recommended_schedule_cron": null,
+  "nodes": [
+    {
+      "id": "daf51a44-a8c0-47d8-9b32-c2e21a308806",
+      "block_id": "7fcd3bcb-8e1b-4e69-903d-32d3d4a92158",
+      "input_default": {
+        "name": "API Key",
+        "title": null,
+        "value": "citedy_agent_replace_me",
+        "secret": true,
+        "advanced": false,
+        "description": "Citedy API key (starts with citedy_agent_)",
+        "placeholder_values": []
+      },
+      "metadata": {
+        "position": {
+          "x": -920,
+          "y": -80
+        }
+      },
+      "input_links": [],
+      "output_links": [
+        {
+          "id": "c41a405f-a88a-4a3b-97f5-d2f860f24b36",
+          "source_id": "daf51a44-a8c0-47d8-9b32-c2e21a308806",
+          "sink_id": "b455889c-9ce3-47d3-888a-540579d718f3",
+          "source_name": "result",
+          "sink_name": "values_#_api_key",
+          "is_static": false
+        }
+      ],
+      "graph_id": "9221fef6-6d51-4703-a44d-78b23debf7e2",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "8de7567f-abbb-4d48-ae44-ce90d9d536df",
+      "block_id": "90a56ffb-7024-4b2b-ab50-e26c5e5ab8ba",
+      "input_default": {
+        "name": "Request JSON",
+        "title": null,
+        "value": "{\n  \"prompt\": \"Close-up portrait 9:16, young woman in coffee shop. She says confidently: \\\"AI is changing content marketing.\\\" Audio: no background music.\",\n  \"avatar_url\": \"https://download.citedy.com/agent/avatars/replace_me.png\",\n  \"duration\": 10,\n  \"speech_text\": \"AI is changing content marketing.\"\n}",
+        "secret": false,
+        "advanced": false,
+        "description": "JSON payload for this endpoint.",
+        "placeholder_values": []
+      },
+      "metadata": {
+        "position": {
+          "x": -920,
+          "y": 220
+        }
+      },
+      "input_links": [],
+      "output_links": [
+        {
+          "id": "cb9f875b-8704-4018-a337-67ae80a4718b",
+          "source_id": "8de7567f-abbb-4d48-ae44-ce90d9d536df",
+          "sink_id": "66693e2a-5e82-44f5-a524-8f022f7fa96c",
+          "source_name": "result",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "graph_id": "9221fef6-6d51-4703-a44d-78b23debf7e2",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "b455889c-9ce3-47d3-888a-540579d718f3",
+      "block_id": "b924ddf4-de4f-4b56-9a85-358930dcbc91",
+      "input_default": {
+        "values": {}
+      },
+      "metadata": {
+        "position": {
+          "x": -520,
+          "y": -80
+        }
+      },
+      "input_links": [
+        {
+          "id": "c41a405f-a88a-4a3b-97f5-d2f860f24b36",
+          "source_id": "daf51a44-a8c0-47d8-9b32-c2e21a308806",
+          "sink_id": "b455889c-9ce3-47d3-888a-540579d718f3",
+          "source_name": "result",
+          "sink_name": "values_#_api_key",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "f9f3b547-e6c6-4557-b044-b7f1712772f9",
+          "source_id": "b455889c-9ce3-47d3-888a-540579d718f3",
+          "sink_id": "94bbe20e-ec85-41ec-aa54-6f77bbba129b",
+          "source_name": "dictionary",
+          "sink_name": "values",
+          "is_static": false
+        }
+      ],
+      "graph_id": "9221fef6-6d51-4703-a44d-78b23debf7e2",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "94bbe20e-ec85-41ec-aa54-6f77bbba129b",
+      "block_id": "db7d8f02-2f44-4c55-ab7a-eae0941f0c30",
+      "input_default": {
+        "format": "{\"Authorization\":\"Bearer {{ api_key }}\",\"Content-Type\":\"application/json\"}",
+        "values": {},
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": -140,
+          "y": -80
+        }
+      },
+      "input_links": [
+        {
+          "id": "f9f3b547-e6c6-4557-b044-b7f1712772f9",
+          "source_id": "b455889c-9ce3-47d3-888a-540579d718f3",
+          "sink_id": "94bbe20e-ec85-41ec-aa54-6f77bbba129b",
+          "source_name": "dictionary",
+          "sink_name": "values",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "b738f1a8-db78-4db0-abe6-8fe3b734479e",
+          "source_id": "94bbe20e-ec85-41ec-aa54-6f77bbba129b",
+          "sink_id": "98cbb578-7e7a-427f-952d-c4a3ca04fda3",
+          "source_name": "output",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "graph_id": "9221fef6-6d51-4703-a44d-78b23debf7e2",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "98cbb578-7e7a-427f-952d-c4a3ca04fda3",
+      "block_id": "95d1b990-ce13-4d88-9737-ba5c2070c97b",
+      "input_default": {
+        "type": "dictionary",
+        "value": null
+      },
+      "metadata": {
+        "position": {
+          "x": 180,
+          "y": -80
+        }
+      },
+      "input_links": [
+        {
+          "id": "b738f1a8-db78-4db0-abe6-8fe3b734479e",
+          "source_id": "94bbe20e-ec85-41ec-aa54-6f77bbba129b",
+          "sink_id": "98cbb578-7e7a-427f-952d-c4a3ca04fda3",
+          "source_name": "output",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "ba587af4-5aad-4bbc-96dc-190d9a0101f4",
+          "source_id": "98cbb578-7e7a-427f-952d-c4a3ca04fda3",
+          "sink_id": "776200b6-1371-4fc3-86f8-c169d218cfee",
+          "source_name": "value",
+          "sink_name": "headers",
+          "is_static": false
+        }
+      ],
+      "graph_id": "9221fef6-6d51-4703-a44d-78b23debf7e2",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "66693e2a-5e82-44f5-a524-8f022f7fa96c",
+      "block_id": "95d1b990-ce13-4d88-9737-ba5c2070c97b",
+      "input_default": {
+        "type": "dictionary",
+        "value": null
+      },
+      "metadata": {
+        "position": {
+          "x": -140,
+          "y": 220
+        }
+      },
+      "input_links": [
+        {
+          "id": "cb9f875b-8704-4018-a337-67ae80a4718b",
+          "source_id": "8de7567f-abbb-4d48-ae44-ce90d9d536df",
+          "sink_id": "66693e2a-5e82-44f5-a524-8f022f7fa96c",
+          "source_name": "result",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "0fc3e02b-c664-489e-b861-3b25708a71d7",
+          "source_id": "66693e2a-5e82-44f5-a524-8f022f7fa96c",
+          "sink_id": "776200b6-1371-4fc3-86f8-c169d218cfee",
+          "source_name": "value",
+          "sink_name": "body",
+          "is_static": false
+        }
+      ],
+      "graph_id": "9221fef6-6d51-4703-a44d-78b23debf7e2",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "776200b6-1371-4fc3-86f8-c169d218cfee",
+      "block_id": "6595ae1f-b924-42cb-9a41-551a0611c4b4",
+      "input_default": {
+        "url": "https://www.citedy.com/api/agent/shorts",
+        "method": "POST",
+        "headers": {},
+        "json_format": true,
+        "body": null,
+        "files_name": "file",
+        "files": []
+      },
+      "metadata": {
+        "position": {
+          "x": 560,
+          "y": 70
+        }
+      },
+      "input_links": [
+        {
+          "id": "ba587af4-5aad-4bbc-96dc-190d9a0101f4",
+          "source_id": "98cbb578-7e7a-427f-952d-c4a3ca04fda3",
+          "sink_id": "776200b6-1371-4fc3-86f8-c169d218cfee",
+          "source_name": "value",
+          "sink_name": "headers",
+          "is_static": false
+        },
+        {
+          "id": "0fc3e02b-c664-489e-b861-3b25708a71d7",
+          "source_id": "66693e2a-5e82-44f5-a524-8f022f7fa96c",
+          "sink_id": "776200b6-1371-4fc3-86f8-c169d218cfee",
+          "source_name": "value",
+          "sink_name": "body",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "cecc1608-6249-46d3-9c75-30535bfb2ba2",
+          "source_id": "776200b6-1371-4fc3-86f8-c169d218cfee",
+          "sink_id": "733d01a2-3a55-410f-8b6e-19d01fc47032",
+          "source_name": "response",
+          "sink_name": "value",
+          "is_static": false
+        },
+        {
+          "id": "c01c562e-0135-4db0-8a3e-13b191899cc6",
+          "source_id": "776200b6-1371-4fc3-86f8-c169d218cfee",
+          "sink_id": "144da775-7172-4804-bffb-16f2b3564021",
+          "source_name": "client_error",
+          "sink_name": "value",
+          "is_static": false
+        },
+        {
+          "id": "1b01a398-223d-4ccf-bc45-bdfa8fc15ccf",
+          "source_id": "776200b6-1371-4fc3-86f8-c169d218cfee",
+          "sink_id": "308c410e-becb-48f7-81df-e155f16bab91",
+          "source_name": "server_error",
+          "sink_name": "value",
+          "is_static": false
+        },
+        {
+          "id": "199a3e29-137b-4612-8249-6f507e7ef70e",
+          "source_id": "776200b6-1371-4fc3-86f8-c169d218cfee",
+          "sink_id": "401e741a-7f96-4ff8-879f-c99c91672f2b",
+          "source_name": "error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "graph_id": "9221fef6-6d51-4703-a44d-78b23debf7e2",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "733d01a2-3a55-410f-8b6e-19d01fc47032",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "response",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "Successful API response payload.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": -160
+        }
+      },
+      "input_links": [
+        {
+          "id": "cecc1608-6249-46d3-9c75-30535bfb2ba2",
+          "source_id": "776200b6-1371-4fc3-86f8-c169d218cfee",
+          "sink_id": "733d01a2-3a55-410f-8b6e-19d01fc47032",
+          "source_name": "response",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "9221fef6-6d51-4703-a44d-78b23debf7e2",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "144da775-7172-4804-bffb-16f2b3564021",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "client_error",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "HTTP 4xx response payload.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": 20
+        }
+      },
+      "input_links": [
+        {
+          "id": "c01c562e-0135-4db0-8a3e-13b191899cc6",
+          "source_id": "776200b6-1371-4fc3-86f8-c169d218cfee",
+          "sink_id": "144da775-7172-4804-bffb-16f2b3564021",
+          "source_name": "client_error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "9221fef6-6d51-4703-a44d-78b23debf7e2",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "308c410e-becb-48f7-81df-e155f16bab91",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "server_error",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "HTTP 5xx response payload.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": 200
+        }
+      },
+      "input_links": [
+        {
+          "id": "1b01a398-223d-4ccf-bc45-bdfa8fc15ccf",
+          "source_id": "776200b6-1371-4fc3-86f8-c169d218cfee",
+          "sink_id": "308c410e-becb-48f7-81df-e155f16bab91",
+          "source_name": "server_error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "9221fef6-6d51-4703-a44d-78b23debf7e2",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "401e741a-7f96-4ff8-879f-c99c91672f2b",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "error",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "Transport/runtime error output.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": 380
+        }
+      },
+      "input_links": [
+        {
+          "id": "199a3e29-137b-4612-8249-6f507e7ef70e",
+          "source_id": "776200b6-1371-4fc3-86f8-c169d218cfee",
+          "sink_id": "401e741a-7f96-4ff8-879f-c99c91672f2b",
+          "source_name": "error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "9221fef6-6d51-4703-a44d-78b23debf7e2",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    }
+  ],
+  "links": [
+    {
+      "id": "c41a405f-a88a-4a3b-97f5-d2f860f24b36",
+      "source_id": "daf51a44-a8c0-47d8-9b32-c2e21a308806",
+      "sink_id": "b455889c-9ce3-47d3-888a-540579d718f3",
+      "source_name": "result",
+      "sink_name": "values_#_api_key",
+      "is_static": false
+    },
+    {
+      "id": "cb9f875b-8704-4018-a337-67ae80a4718b",
+      "source_id": "8de7567f-abbb-4d48-ae44-ce90d9d536df",
+      "sink_id": "66693e2a-5e82-44f5-a524-8f022f7fa96c",
+      "source_name": "result",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "f9f3b547-e6c6-4557-b044-b7f1712772f9",
+      "source_id": "b455889c-9ce3-47d3-888a-540579d718f3",
+      "sink_id": "94bbe20e-ec85-41ec-aa54-6f77bbba129b",
+      "source_name": "dictionary",
+      "sink_name": "values",
+      "is_static": false
+    },
+    {
+      "id": "b738f1a8-db78-4db0-abe6-8fe3b734479e",
+      "source_id": "94bbe20e-ec85-41ec-aa54-6f77bbba129b",
+      "sink_id": "98cbb578-7e7a-427f-952d-c4a3ca04fda3",
+      "source_name": "output",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "ba587af4-5aad-4bbc-96dc-190d9a0101f4",
+      "source_id": "98cbb578-7e7a-427f-952d-c4a3ca04fda3",
+      "sink_id": "776200b6-1371-4fc3-86f8-c169d218cfee",
+      "source_name": "value",
+      "sink_name": "headers",
+      "is_static": false
+    },
+    {
+      "id": "0fc3e02b-c664-489e-b861-3b25708a71d7",
+      "source_id": "66693e2a-5e82-44f5-a524-8f022f7fa96c",
+      "sink_id": "776200b6-1371-4fc3-86f8-c169d218cfee",
+      "source_name": "value",
+      "sink_name": "body",
+      "is_static": false
+    },
+    {
+      "id": "cecc1608-6249-46d3-9c75-30535bfb2ba2",
+      "source_id": "776200b6-1371-4fc3-86f8-c169d218cfee",
+      "sink_id": "733d01a2-3a55-410f-8b6e-19d01fc47032",
+      "source_name": "response",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "c01c562e-0135-4db0-8a3e-13b191899cc6",
+      "source_id": "776200b6-1371-4fc3-86f8-c169d218cfee",
+      "sink_id": "144da775-7172-4804-bffb-16f2b3564021",
+      "source_name": "client_error",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "1b01a398-223d-4ccf-bc45-bdfa8fc15ccf",
+      "source_id": "776200b6-1371-4fc3-86f8-c169d218cfee",
+      "sink_id": "308c410e-becb-48f7-81df-e155f16bab91",
+      "source_name": "server_error",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "199a3e29-137b-4612-8249-6f507e7ef70e",
+      "source_id": "776200b6-1371-4fc3-86f8-c169d218cfee",
+      "sink_id": "401e741a-7f96-4ff8-879f-c99c91672f2b",
+      "source_name": "error",
+      "sink_name": "value",
+      "is_static": false
+    }
+  ],
+  "forked_from_id": null,
+  "forked_from_version": null,
+  "sub_graphs": [],
+  "user_id": "",
+  "created_at": "2026-02-28T12:00:00.000Z",
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "API Key": {
+        "advanced": false,
+        "anyOf": [
+          {
+            "format": "short-text",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "secret": true,
+        "title": "API Key",
+        "description": "Citedy API key (starts with citedy_agent_)",
+        "default": "citedy_agent_replace_me"
+      },
+      "Request JSON": {
+        "advanced": false,
+        "anyOf": [
+          {
+            "format": "long-text",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "secret": false,
+        "title": "Request JSON",
+        "description": "JSON payload for the selected Citedy endpoint.",
+        "default": "{\n  \"prompt\": \"Close-up portrait 9:16, young woman in coffee shop. She says confidently: \\\"AI is changing content marketing.\\\" Audio: no background music.\",\n  \"avatar_url\": \"https://download.citedy.com/agent/avatars/replace_me.png\",\n  \"duration\": 10,\n  \"speech_text\": \"AI is changing content marketing.\"\n}"
+      }
+    },
+    "required": ["API Key", "Request JSON"]
+  },
+  "output_schema": {
+    "type": "object",
+    "properties": {
+      "response": {
+        "title": "response",
+        "description": "Successful API response payload.",
+        "type": "object"
+      },
+      "client_error": {
+        "title": "client_error",
+        "description": "HTTP 4xx response payload.",
+        "type": "object"
+      },
+      "server_error": {
+        "title": "server_error",
+        "description": "HTTP 5xx response payload.",
+        "type": "object"
+      },
+      "error": {
+        "title": "error",
+        "description": "Transport/runtime error output.",
+        "type": "string"
+      }
+    },
+    "required": []
+  },
+  "has_external_trigger": false,
+  "has_human_in_the_loop": false,
+  "trigger_setup_info": null,
+  "credentials_input_schema": {
+    "properties": {},
+    "required": [],
+    "title": "CitedyTemplateCredentialsInputSchema",
+    "type": "object"
+  }
+}

--- a/autogpt_platform/graph_templates/citedy-topic-to-publish.agent.json
+++ b/autogpt_platform/graph_templates/citedy-topic-to-publish.agent.json
@@ -1,0 +1,606 @@
+{
+  "id": "b2cd3320-7c8b-4b8d-96fd-820f2976b1dd",
+  "version": 1,
+  "is_active": true,
+  "name": "Citedy Topic to Publish",
+  "description": "Generate an SEO article from topic via Citedy autopilot endpoint.",
+  "instructions": null,
+  "recommended_schedule_cron": null,
+  "nodes": [
+    {
+      "id": "24e5d91b-794d-462c-a816-c66e9bec413d",
+      "block_id": "7fcd3bcb-8e1b-4e69-903d-32d3d4a92158",
+      "input_default": {
+        "name": "API Key",
+        "title": null,
+        "value": "citedy_agent_replace_me",
+        "secret": true,
+        "advanced": false,
+        "description": "Citedy API key (starts with citedy_agent_)",
+        "placeholder_values": []
+      },
+      "metadata": {
+        "position": {
+          "x": -920,
+          "y": -80
+        }
+      },
+      "input_links": [],
+      "output_links": [
+        {
+          "id": "671ceaf2-a94f-4e9c-af3c-46a18a5561a5",
+          "source_id": "24e5d91b-794d-462c-a816-c66e9bec413d",
+          "sink_id": "c157aa6e-9f1d-40ed-b2b1-7a5f77f243f3",
+          "source_name": "result",
+          "sink_name": "values_#_api_key",
+          "is_static": false
+        }
+      ],
+      "graph_id": "b2cd3320-7c8b-4b8d-96fd-820f2976b1dd",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "753c5079-629a-4499-87c1-80b0b798576f",
+      "block_id": "90a56ffb-7024-4b2b-ab50-e26c5e5ab8ba",
+      "input_default": {
+        "name": "Request JSON",
+        "title": null,
+        "value": "{\n  \"topic\": \"AI content marketing trends 2026\",\n  \"size\": \"standard\",\n  \"mode\": \"standard\",\n  \"language\": \"en\",\n  \"persona\": null,\n  \"illustrations\": false,\n  \"audio\": false,\n  \"disable_competition\": false\n}",
+        "secret": false,
+        "advanced": false,
+        "description": "JSON payload for this endpoint.",
+        "placeholder_values": []
+      },
+      "metadata": {
+        "position": {
+          "x": -920,
+          "y": 220
+        }
+      },
+      "input_links": [],
+      "output_links": [
+        {
+          "id": "1e4cda21-0d5a-4dbc-903e-0420b8e48dea",
+          "source_id": "753c5079-629a-4499-87c1-80b0b798576f",
+          "sink_id": "9dd1ffbd-a17b-4f83-8f8f-f9ae5cfc37cf",
+          "source_name": "result",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "graph_id": "b2cd3320-7c8b-4b8d-96fd-820f2976b1dd",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "c157aa6e-9f1d-40ed-b2b1-7a5f77f243f3",
+      "block_id": "b924ddf4-de4f-4b56-9a85-358930dcbc91",
+      "input_default": {
+        "values": {}
+      },
+      "metadata": {
+        "position": {
+          "x": -520,
+          "y": -80
+        }
+      },
+      "input_links": [
+        {
+          "id": "671ceaf2-a94f-4e9c-af3c-46a18a5561a5",
+          "source_id": "24e5d91b-794d-462c-a816-c66e9bec413d",
+          "sink_id": "c157aa6e-9f1d-40ed-b2b1-7a5f77f243f3",
+          "source_name": "result",
+          "sink_name": "values_#_api_key",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "12b2048a-d3b9-43ff-b6f3-1906abcb0843",
+          "source_id": "c157aa6e-9f1d-40ed-b2b1-7a5f77f243f3",
+          "sink_id": "9f6eeb0f-f9be-460a-bad3-3189df8a3fb5",
+          "source_name": "dictionary",
+          "sink_name": "values",
+          "is_static": false
+        }
+      ],
+      "graph_id": "b2cd3320-7c8b-4b8d-96fd-820f2976b1dd",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "9f6eeb0f-f9be-460a-bad3-3189df8a3fb5",
+      "block_id": "db7d8f02-2f44-4c55-ab7a-eae0941f0c30",
+      "input_default": {
+        "format": "{\"Authorization\":\"Bearer {{ api_key }}\",\"Content-Type\":\"application/json\"}",
+        "values": {},
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": -140,
+          "y": -80
+        }
+      },
+      "input_links": [
+        {
+          "id": "12b2048a-d3b9-43ff-b6f3-1906abcb0843",
+          "source_id": "c157aa6e-9f1d-40ed-b2b1-7a5f77f243f3",
+          "sink_id": "9f6eeb0f-f9be-460a-bad3-3189df8a3fb5",
+          "source_name": "dictionary",
+          "sink_name": "values",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "4367f70e-c4a2-4fff-a1b4-28b55ddbf31d",
+          "source_id": "9f6eeb0f-f9be-460a-bad3-3189df8a3fb5",
+          "sink_id": "cb6e44b3-1091-44b6-899b-2c1d06cb2343",
+          "source_name": "output",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "graph_id": "b2cd3320-7c8b-4b8d-96fd-820f2976b1dd",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "cb6e44b3-1091-44b6-899b-2c1d06cb2343",
+      "block_id": "95d1b990-ce13-4d88-9737-ba5c2070c97b",
+      "input_default": {
+        "type": "dictionary",
+        "value": null
+      },
+      "metadata": {
+        "position": {
+          "x": 180,
+          "y": -80
+        }
+      },
+      "input_links": [
+        {
+          "id": "4367f70e-c4a2-4fff-a1b4-28b55ddbf31d",
+          "source_id": "9f6eeb0f-f9be-460a-bad3-3189df8a3fb5",
+          "sink_id": "cb6e44b3-1091-44b6-899b-2c1d06cb2343",
+          "source_name": "output",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "d1fd7a15-64d4-4d51-9d96-440bc770337c",
+          "source_id": "cb6e44b3-1091-44b6-899b-2c1d06cb2343",
+          "sink_id": "d50cef6a-569b-464e-9427-5cfd36e17b67",
+          "source_name": "value",
+          "sink_name": "headers",
+          "is_static": false
+        }
+      ],
+      "graph_id": "b2cd3320-7c8b-4b8d-96fd-820f2976b1dd",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "9dd1ffbd-a17b-4f83-8f8f-f9ae5cfc37cf",
+      "block_id": "95d1b990-ce13-4d88-9737-ba5c2070c97b",
+      "input_default": {
+        "type": "dictionary",
+        "value": null
+      },
+      "metadata": {
+        "position": {
+          "x": -140,
+          "y": 220
+        }
+      },
+      "input_links": [
+        {
+          "id": "1e4cda21-0d5a-4dbc-903e-0420b8e48dea",
+          "source_id": "753c5079-629a-4499-87c1-80b0b798576f",
+          "sink_id": "9dd1ffbd-a17b-4f83-8f8f-f9ae5cfc37cf",
+          "source_name": "result",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "9d714a58-2877-434f-a90d-01475616a8e6",
+          "source_id": "9dd1ffbd-a17b-4f83-8f8f-f9ae5cfc37cf",
+          "sink_id": "d50cef6a-569b-464e-9427-5cfd36e17b67",
+          "source_name": "value",
+          "sink_name": "body",
+          "is_static": false
+        }
+      ],
+      "graph_id": "b2cd3320-7c8b-4b8d-96fd-820f2976b1dd",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "d50cef6a-569b-464e-9427-5cfd36e17b67",
+      "block_id": "6595ae1f-b924-42cb-9a41-551a0611c4b4",
+      "input_default": {
+        "url": "https://www.citedy.com/api/agent/autopilot",
+        "method": "POST",
+        "headers": {},
+        "json_format": true,
+        "body": null,
+        "files_name": "file",
+        "files": []
+      },
+      "metadata": {
+        "position": {
+          "x": 560,
+          "y": 70
+        }
+      },
+      "input_links": [
+        {
+          "id": "d1fd7a15-64d4-4d51-9d96-440bc770337c",
+          "source_id": "cb6e44b3-1091-44b6-899b-2c1d06cb2343",
+          "sink_id": "d50cef6a-569b-464e-9427-5cfd36e17b67",
+          "source_name": "value",
+          "sink_name": "headers",
+          "is_static": false
+        },
+        {
+          "id": "9d714a58-2877-434f-a90d-01475616a8e6",
+          "source_id": "9dd1ffbd-a17b-4f83-8f8f-f9ae5cfc37cf",
+          "sink_id": "d50cef6a-569b-464e-9427-5cfd36e17b67",
+          "source_name": "value",
+          "sink_name": "body",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "32a3d7af-1ba5-4dac-b5fd-7fb056dc8c15",
+          "source_id": "d50cef6a-569b-464e-9427-5cfd36e17b67",
+          "sink_id": "165135a1-7b43-4c21-b5a0-5c4897f3bb67",
+          "source_name": "response",
+          "sink_name": "value",
+          "is_static": false
+        },
+        {
+          "id": "136a5fbd-6085-45b4-a941-5c683c868287",
+          "source_id": "d50cef6a-569b-464e-9427-5cfd36e17b67",
+          "sink_id": "bd396d45-18b9-4b16-8c0f-d373e4e34b64",
+          "source_name": "client_error",
+          "sink_name": "value",
+          "is_static": false
+        },
+        {
+          "id": "baf40921-9f2b-4475-904d-7205f6f29d10",
+          "source_id": "d50cef6a-569b-464e-9427-5cfd36e17b67",
+          "sink_id": "b379d801-84d0-4bf6-8ff1-860799ebfebe",
+          "source_name": "server_error",
+          "sink_name": "value",
+          "is_static": false
+        },
+        {
+          "id": "d8def4c2-c4fe-4029-8221-174ab0cdd4a0",
+          "source_id": "d50cef6a-569b-464e-9427-5cfd36e17b67",
+          "sink_id": "2f7f6369-efed-48af-9e79-d2cacde157fd",
+          "source_name": "error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "graph_id": "b2cd3320-7c8b-4b8d-96fd-820f2976b1dd",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "165135a1-7b43-4c21-b5a0-5c4897f3bb67",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "response",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "Successful API response payload.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": -160
+        }
+      },
+      "input_links": [
+        {
+          "id": "32a3d7af-1ba5-4dac-b5fd-7fb056dc8c15",
+          "source_id": "d50cef6a-569b-464e-9427-5cfd36e17b67",
+          "sink_id": "165135a1-7b43-4c21-b5a0-5c4897f3bb67",
+          "source_name": "response",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "b2cd3320-7c8b-4b8d-96fd-820f2976b1dd",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "bd396d45-18b9-4b16-8c0f-d373e4e34b64",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "client_error",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "HTTP 4xx response payload.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": 20
+        }
+      },
+      "input_links": [
+        {
+          "id": "136a5fbd-6085-45b4-a941-5c683c868287",
+          "source_id": "d50cef6a-569b-464e-9427-5cfd36e17b67",
+          "sink_id": "bd396d45-18b9-4b16-8c0f-d373e4e34b64",
+          "source_name": "client_error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "b2cd3320-7c8b-4b8d-96fd-820f2976b1dd",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "b379d801-84d0-4bf6-8ff1-860799ebfebe",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "server_error",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "HTTP 5xx response payload.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": 200
+        }
+      },
+      "input_links": [
+        {
+          "id": "baf40921-9f2b-4475-904d-7205f6f29d10",
+          "source_id": "d50cef6a-569b-464e-9427-5cfd36e17b67",
+          "sink_id": "b379d801-84d0-4bf6-8ff1-860799ebfebe",
+          "source_name": "server_error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "b2cd3320-7c8b-4b8d-96fd-820f2976b1dd",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "2f7f6369-efed-48af-9e79-d2cacde157fd",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "error",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "Transport/runtime error output.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": 380
+        }
+      },
+      "input_links": [
+        {
+          "id": "d8def4c2-c4fe-4029-8221-174ab0cdd4a0",
+          "source_id": "d50cef6a-569b-464e-9427-5cfd36e17b67",
+          "sink_id": "2f7f6369-efed-48af-9e79-d2cacde157fd",
+          "source_name": "error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "b2cd3320-7c8b-4b8d-96fd-820f2976b1dd",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    }
+  ],
+  "links": [
+    {
+      "id": "671ceaf2-a94f-4e9c-af3c-46a18a5561a5",
+      "source_id": "24e5d91b-794d-462c-a816-c66e9bec413d",
+      "sink_id": "c157aa6e-9f1d-40ed-b2b1-7a5f77f243f3",
+      "source_name": "result",
+      "sink_name": "values_#_api_key",
+      "is_static": false
+    },
+    {
+      "id": "12b2048a-d3b9-43ff-b6f3-1906abcb0843",
+      "source_id": "c157aa6e-9f1d-40ed-b2b1-7a5f77f243f3",
+      "sink_id": "9f6eeb0f-f9be-460a-bad3-3189df8a3fb5",
+      "source_name": "dictionary",
+      "sink_name": "values",
+      "is_static": false
+    },
+    {
+      "id": "4367f70e-c4a2-4fff-a1b4-28b55ddbf31d",
+      "source_id": "9f6eeb0f-f9be-460a-bad3-3189df8a3fb5",
+      "sink_id": "cb6e44b3-1091-44b6-899b-2c1d06cb2343",
+      "source_name": "output",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "1e4cda21-0d5a-4dbc-903e-0420b8e48dea",
+      "source_id": "753c5079-629a-4499-87c1-80b0b798576f",
+      "sink_id": "9dd1ffbd-a17b-4f83-8f8f-f9ae5cfc37cf",
+      "source_name": "result",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "d1fd7a15-64d4-4d51-9d96-440bc770337c",
+      "source_id": "cb6e44b3-1091-44b6-899b-2c1d06cb2343",
+      "sink_id": "d50cef6a-569b-464e-9427-5cfd36e17b67",
+      "source_name": "value",
+      "sink_name": "headers",
+      "is_static": false
+    },
+    {
+      "id": "9d714a58-2877-434f-a90d-01475616a8e6",
+      "source_id": "9dd1ffbd-a17b-4f83-8f8f-f9ae5cfc37cf",
+      "sink_id": "d50cef6a-569b-464e-9427-5cfd36e17b67",
+      "source_name": "value",
+      "sink_name": "body",
+      "is_static": false
+    },
+    {
+      "id": "32a3d7af-1ba5-4dac-b5fd-7fb056dc8c15",
+      "source_id": "d50cef6a-569b-464e-9427-5cfd36e17b67",
+      "sink_id": "165135a1-7b43-4c21-b5a0-5c4897f3bb67",
+      "source_name": "response",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "136a5fbd-6085-45b4-a941-5c683c868287",
+      "source_id": "d50cef6a-569b-464e-9427-5cfd36e17b67",
+      "sink_id": "bd396d45-18b9-4b16-8c0f-d373e4e34b64",
+      "source_name": "client_error",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "baf40921-9f2b-4475-904d-7205f6f29d10",
+      "source_id": "d50cef6a-569b-464e-9427-5cfd36e17b67",
+      "sink_id": "b379d801-84d0-4bf6-8ff1-860799ebfebe",
+      "source_name": "server_error",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "d8def4c2-c4fe-4029-8221-174ab0cdd4a0",
+      "source_id": "d50cef6a-569b-464e-9427-5cfd36e17b67",
+      "sink_id": "2f7f6369-efed-48af-9e79-d2cacde157fd",
+      "source_name": "error",
+      "sink_name": "value",
+      "is_static": false
+    }
+  ],
+  "forked_from_id": null,
+  "forked_from_version": null,
+  "sub_graphs": [],
+  "user_id": "",
+  "created_at": "2026-02-14T23:47:30.878Z",
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "API Key": {
+        "advanced": false,
+        "anyOf": [
+          {
+            "format": "short-text",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "secret": true,
+        "title": "API Key",
+        "description": "Citedy API key (starts with citedy_agent_)",
+        "default": "citedy_agent_replace_me"
+      },
+      "Request JSON": {
+        "advanced": false,
+        "anyOf": [
+          {
+            "format": "long-text",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "secret": false,
+        "title": "Request JSON",
+        "description": "JSON payload for the selected Citedy endpoint.",
+        "default": "{\n  \"topic\": \"AI content marketing trends 2026\",\n  \"size\": \"mini\",\n  \"language\": \"en\",\n  \"illustrations\": false,\n  \"audio\": false\n}"
+      }
+    },
+    "required": ["API Key", "Request JSON"]
+  },
+  "output_schema": {
+    "type": "object",
+    "properties": {
+      "response": {
+        "title": "response",
+        "description": "Successful API response payload.",
+        "type": "object"
+      },
+      "client_error": {
+        "title": "client_error",
+        "description": "HTTP 4xx response payload.",
+        "type": "object"
+      },
+      "server_error": {
+        "title": "server_error",
+        "description": "HTTP 5xx response payload.",
+        "type": "object"
+      },
+      "error": {
+        "title": "error",
+        "description": "Transport/runtime error output.",
+        "type": "string"
+      }
+    },
+    "required": []
+  },
+  "has_external_trigger": false,
+  "has_human_in_the_loop": false,
+  "trigger_setup_info": null,
+  "credentials_input_schema": {
+    "properties": {},
+    "required": [],
+    "title": "CitedyTemplateCredentialsInputSchema",
+    "type": "object"
+  }
+}

--- a/autogpt_platform/graph_templates/citedy-trend-to-publish.agent.json
+++ b/autogpt_platform/graph_templates/citedy-trend-to-publish.agent.json
@@ -1,0 +1,606 @@
+{
+  "id": "3bd8914b-a9a6-40df-bb6c-05815388c6a6",
+  "version": 1,
+  "is_active": true,
+  "name": "Citedy Trend Scout (X)",
+  "description": "Scout X/Twitter trends to pick publishable topics.",
+  "instructions": null,
+  "recommended_schedule_cron": null,
+  "nodes": [
+    {
+      "id": "59d6ee6c-9555-4162-8907-8a1b3c1488ea",
+      "block_id": "7fcd3bcb-8e1b-4e69-903d-32d3d4a92158",
+      "input_default": {
+        "name": "API Key",
+        "title": null,
+        "value": "citedy_agent_replace_me",
+        "secret": true,
+        "advanced": false,
+        "description": "Citedy API key (starts with citedy_agent_)",
+        "placeholder_values": []
+      },
+      "metadata": {
+        "position": {
+          "x": -920,
+          "y": -80
+        }
+      },
+      "input_links": [],
+      "output_links": [
+        {
+          "id": "a17d0830-eab1-45f0-addc-b5f17f1bb912",
+          "source_id": "59d6ee6c-9555-4162-8907-8a1b3c1488ea",
+          "sink_id": "dfaa00cb-5b30-4f6c-beab-b8716f5ccc4c",
+          "source_name": "result",
+          "sink_name": "values_#_api_key",
+          "is_static": false
+        }
+      ],
+      "graph_id": "3bd8914b-a9a6-40df-bb6c-05815388c6a6",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "e8623d52-5071-4f39-8b3d-233e51b23cc9",
+      "block_id": "90a56ffb-7024-4b2b-ab50-e26c5e5ab8ba",
+      "input_default": {
+        "name": "Request JSON",
+        "title": null,
+        "value": "{\n  \"query\": \"AI content marketing\",\n  \"mode\": \"fast\",\n  \"limit\": 5\n}",
+        "secret": false,
+        "advanced": false,
+        "description": "JSON payload for this endpoint.",
+        "placeholder_values": []
+      },
+      "metadata": {
+        "position": {
+          "x": -920,
+          "y": 220
+        }
+      },
+      "input_links": [],
+      "output_links": [
+        {
+          "id": "a28b3486-7a02-4a07-9048-5e56fa68b438",
+          "source_id": "e8623d52-5071-4f39-8b3d-233e51b23cc9",
+          "sink_id": "4a0345b9-cc77-43c0-b565-3589b2d11780",
+          "source_name": "result",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "graph_id": "3bd8914b-a9a6-40df-bb6c-05815388c6a6",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "dfaa00cb-5b30-4f6c-beab-b8716f5ccc4c",
+      "block_id": "b924ddf4-de4f-4b56-9a85-358930dcbc91",
+      "input_default": {
+        "values": {}
+      },
+      "metadata": {
+        "position": {
+          "x": -520,
+          "y": -80
+        }
+      },
+      "input_links": [
+        {
+          "id": "a17d0830-eab1-45f0-addc-b5f17f1bb912",
+          "source_id": "59d6ee6c-9555-4162-8907-8a1b3c1488ea",
+          "sink_id": "dfaa00cb-5b30-4f6c-beab-b8716f5ccc4c",
+          "source_name": "result",
+          "sink_name": "values_#_api_key",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "934fe371-db4c-488b-bd6a-f188afe3bd4e",
+          "source_id": "dfaa00cb-5b30-4f6c-beab-b8716f5ccc4c",
+          "sink_id": "97663751-a5ad-47a9-b4f5-9fb9038bea22",
+          "source_name": "dictionary",
+          "sink_name": "values",
+          "is_static": false
+        }
+      ],
+      "graph_id": "3bd8914b-a9a6-40df-bb6c-05815388c6a6",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "97663751-a5ad-47a9-b4f5-9fb9038bea22",
+      "block_id": "db7d8f02-2f44-4c55-ab7a-eae0941f0c30",
+      "input_default": {
+        "format": "{\"Authorization\":\"Bearer {{ api_key }}\",\"Content-Type\":\"application/json\"}",
+        "values": {},
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": -140,
+          "y": -80
+        }
+      },
+      "input_links": [
+        {
+          "id": "934fe371-db4c-488b-bd6a-f188afe3bd4e",
+          "source_id": "dfaa00cb-5b30-4f6c-beab-b8716f5ccc4c",
+          "sink_id": "97663751-a5ad-47a9-b4f5-9fb9038bea22",
+          "source_name": "dictionary",
+          "sink_name": "values",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "89cd06fd-a4b7-4396-869b-189d924354c2",
+          "source_id": "97663751-a5ad-47a9-b4f5-9fb9038bea22",
+          "sink_id": "a0a03884-f480-4107-904b-0fcb54cc1bf8",
+          "source_name": "output",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "graph_id": "3bd8914b-a9a6-40df-bb6c-05815388c6a6",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "a0a03884-f480-4107-904b-0fcb54cc1bf8",
+      "block_id": "95d1b990-ce13-4d88-9737-ba5c2070c97b",
+      "input_default": {
+        "type": "dictionary",
+        "value": null
+      },
+      "metadata": {
+        "position": {
+          "x": 180,
+          "y": -80
+        }
+      },
+      "input_links": [
+        {
+          "id": "89cd06fd-a4b7-4396-869b-189d924354c2",
+          "source_id": "97663751-a5ad-47a9-b4f5-9fb9038bea22",
+          "sink_id": "a0a03884-f480-4107-904b-0fcb54cc1bf8",
+          "source_name": "output",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "567b04c4-5a8c-482f-bf6b-e59ca0df2a16",
+          "source_id": "a0a03884-f480-4107-904b-0fcb54cc1bf8",
+          "sink_id": "b1940fc6-a052-4e3b-a8f6-2771fa19d9dc",
+          "source_name": "value",
+          "sink_name": "headers",
+          "is_static": false
+        }
+      ],
+      "graph_id": "3bd8914b-a9a6-40df-bb6c-05815388c6a6",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "4a0345b9-cc77-43c0-b565-3589b2d11780",
+      "block_id": "95d1b990-ce13-4d88-9737-ba5c2070c97b",
+      "input_default": {
+        "type": "dictionary",
+        "value": null
+      },
+      "metadata": {
+        "position": {
+          "x": -140,
+          "y": 220
+        }
+      },
+      "input_links": [
+        {
+          "id": "a28b3486-7a02-4a07-9048-5e56fa68b438",
+          "source_id": "e8623d52-5071-4f39-8b3d-233e51b23cc9",
+          "sink_id": "4a0345b9-cc77-43c0-b565-3589b2d11780",
+          "source_name": "result",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "1b984a27-d474-416b-b539-0a85eab475bc",
+          "source_id": "4a0345b9-cc77-43c0-b565-3589b2d11780",
+          "sink_id": "b1940fc6-a052-4e3b-a8f6-2771fa19d9dc",
+          "source_name": "value",
+          "sink_name": "body",
+          "is_static": false
+        }
+      ],
+      "graph_id": "3bd8914b-a9a6-40df-bb6c-05815388c6a6",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "b1940fc6-a052-4e3b-a8f6-2771fa19d9dc",
+      "block_id": "6595ae1f-b924-42cb-9a41-551a0611c4b4",
+      "input_default": {
+        "url": "https://www.citedy.com/api/agent/scout/x",
+        "method": "POST",
+        "headers": {},
+        "json_format": true,
+        "body": null,
+        "files_name": "file",
+        "files": []
+      },
+      "metadata": {
+        "position": {
+          "x": 560,
+          "y": 70
+        }
+      },
+      "input_links": [
+        {
+          "id": "567b04c4-5a8c-482f-bf6b-e59ca0df2a16",
+          "source_id": "a0a03884-f480-4107-904b-0fcb54cc1bf8",
+          "sink_id": "b1940fc6-a052-4e3b-a8f6-2771fa19d9dc",
+          "source_name": "value",
+          "sink_name": "headers",
+          "is_static": false
+        },
+        {
+          "id": "1b984a27-d474-416b-b539-0a85eab475bc",
+          "source_id": "4a0345b9-cc77-43c0-b565-3589b2d11780",
+          "sink_id": "b1940fc6-a052-4e3b-a8f6-2771fa19d9dc",
+          "source_name": "value",
+          "sink_name": "body",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "3399948b-d425-4fbd-b324-08fcb6cfee71",
+          "source_id": "b1940fc6-a052-4e3b-a8f6-2771fa19d9dc",
+          "sink_id": "026de409-cafc-4365-8f0e-6efa0b64aaa7",
+          "source_name": "response",
+          "sink_name": "value",
+          "is_static": false
+        },
+        {
+          "id": "894b158f-2b21-43a7-af18-b9985907b04e",
+          "source_id": "b1940fc6-a052-4e3b-a8f6-2771fa19d9dc",
+          "sink_id": "d677169b-f25d-4d0e-85bb-aee2a8b5e0de",
+          "source_name": "client_error",
+          "sink_name": "value",
+          "is_static": false
+        },
+        {
+          "id": "5a379e89-1337-4cd2-b428-6d0e38276dee",
+          "source_id": "b1940fc6-a052-4e3b-a8f6-2771fa19d9dc",
+          "sink_id": "a600627d-e434-46d8-baaa-1771f0997cbf",
+          "source_name": "server_error",
+          "sink_name": "value",
+          "is_static": false
+        },
+        {
+          "id": "2aa129e7-557b-4e35-a31c-1c5f896e1773",
+          "source_id": "b1940fc6-a052-4e3b-a8f6-2771fa19d9dc",
+          "sink_id": "3600c92a-7b3c-48b8-9dbf-ac65f7a339da",
+          "source_name": "error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "graph_id": "3bd8914b-a9a6-40df-bb6c-05815388c6a6",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "026de409-cafc-4365-8f0e-6efa0b64aaa7",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "response",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "Successful API response payload.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": -160
+        }
+      },
+      "input_links": [
+        {
+          "id": "3399948b-d425-4fbd-b324-08fcb6cfee71",
+          "source_id": "b1940fc6-a052-4e3b-a8f6-2771fa19d9dc",
+          "sink_id": "026de409-cafc-4365-8f0e-6efa0b64aaa7",
+          "source_name": "response",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "3bd8914b-a9a6-40df-bb6c-05815388c6a6",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "d677169b-f25d-4d0e-85bb-aee2a8b5e0de",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "client_error",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "HTTP 4xx response payload.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": 20
+        }
+      },
+      "input_links": [
+        {
+          "id": "894b158f-2b21-43a7-af18-b9985907b04e",
+          "source_id": "b1940fc6-a052-4e3b-a8f6-2771fa19d9dc",
+          "sink_id": "d677169b-f25d-4d0e-85bb-aee2a8b5e0de",
+          "source_name": "client_error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "3bd8914b-a9a6-40df-bb6c-05815388c6a6",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "a600627d-e434-46d8-baaa-1771f0997cbf",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "server_error",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "HTTP 5xx response payload.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": 200
+        }
+      },
+      "input_links": [
+        {
+          "id": "5a379e89-1337-4cd2-b428-6d0e38276dee",
+          "source_id": "b1940fc6-a052-4e3b-a8f6-2771fa19d9dc",
+          "sink_id": "a600627d-e434-46d8-baaa-1771f0997cbf",
+          "source_name": "server_error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "3bd8914b-a9a6-40df-bb6c-05815388c6a6",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "3600c92a-7b3c-48b8-9dbf-ac65f7a339da",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "error",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "Transport/runtime error output.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": 380
+        }
+      },
+      "input_links": [
+        {
+          "id": "2aa129e7-557b-4e35-a31c-1c5f896e1773",
+          "source_id": "b1940fc6-a052-4e3b-a8f6-2771fa19d9dc",
+          "sink_id": "3600c92a-7b3c-48b8-9dbf-ac65f7a339da",
+          "source_name": "error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "3bd8914b-a9a6-40df-bb6c-05815388c6a6",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    }
+  ],
+  "links": [
+    {
+      "id": "a17d0830-eab1-45f0-addc-b5f17f1bb912",
+      "source_id": "59d6ee6c-9555-4162-8907-8a1b3c1488ea",
+      "sink_id": "dfaa00cb-5b30-4f6c-beab-b8716f5ccc4c",
+      "source_name": "result",
+      "sink_name": "values_#_api_key",
+      "is_static": false
+    },
+    {
+      "id": "934fe371-db4c-488b-bd6a-f188afe3bd4e",
+      "source_id": "dfaa00cb-5b30-4f6c-beab-b8716f5ccc4c",
+      "sink_id": "97663751-a5ad-47a9-b4f5-9fb9038bea22",
+      "source_name": "dictionary",
+      "sink_name": "values",
+      "is_static": false
+    },
+    {
+      "id": "89cd06fd-a4b7-4396-869b-189d924354c2",
+      "source_id": "97663751-a5ad-47a9-b4f5-9fb9038bea22",
+      "sink_id": "a0a03884-f480-4107-904b-0fcb54cc1bf8",
+      "source_name": "output",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "a28b3486-7a02-4a07-9048-5e56fa68b438",
+      "source_id": "e8623d52-5071-4f39-8b3d-233e51b23cc9",
+      "sink_id": "4a0345b9-cc77-43c0-b565-3589b2d11780",
+      "source_name": "result",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "567b04c4-5a8c-482f-bf6b-e59ca0df2a16",
+      "source_id": "a0a03884-f480-4107-904b-0fcb54cc1bf8",
+      "sink_id": "b1940fc6-a052-4e3b-a8f6-2771fa19d9dc",
+      "source_name": "value",
+      "sink_name": "headers",
+      "is_static": false
+    },
+    {
+      "id": "1b984a27-d474-416b-b539-0a85eab475bc",
+      "source_id": "4a0345b9-cc77-43c0-b565-3589b2d11780",
+      "sink_id": "b1940fc6-a052-4e3b-a8f6-2771fa19d9dc",
+      "source_name": "value",
+      "sink_name": "body",
+      "is_static": false
+    },
+    {
+      "id": "3399948b-d425-4fbd-b324-08fcb6cfee71",
+      "source_id": "b1940fc6-a052-4e3b-a8f6-2771fa19d9dc",
+      "sink_id": "026de409-cafc-4365-8f0e-6efa0b64aaa7",
+      "source_name": "response",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "894b158f-2b21-43a7-af18-b9985907b04e",
+      "source_id": "b1940fc6-a052-4e3b-a8f6-2771fa19d9dc",
+      "sink_id": "d677169b-f25d-4d0e-85bb-aee2a8b5e0de",
+      "source_name": "client_error",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "5a379e89-1337-4cd2-b428-6d0e38276dee",
+      "source_id": "b1940fc6-a052-4e3b-a8f6-2771fa19d9dc",
+      "sink_id": "a600627d-e434-46d8-baaa-1771f0997cbf",
+      "source_name": "server_error",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "2aa129e7-557b-4e35-a31c-1c5f896e1773",
+      "source_id": "b1940fc6-a052-4e3b-a8f6-2771fa19d9dc",
+      "sink_id": "3600c92a-7b3c-48b8-9dbf-ac65f7a339da",
+      "source_name": "error",
+      "sink_name": "value",
+      "is_static": false
+    }
+  ],
+  "forked_from_id": null,
+  "forked_from_version": null,
+  "sub_graphs": [],
+  "user_id": "",
+  "created_at": "2026-02-14T23:47:30.879Z",
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "API Key": {
+        "advanced": false,
+        "anyOf": [
+          {
+            "format": "short-text",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "secret": true,
+        "title": "API Key",
+        "description": "Citedy API key (starts with citedy_agent_)",
+        "default": "citedy_agent_replace_me"
+      },
+      "Request JSON": {
+        "advanced": false,
+        "anyOf": [
+          {
+            "format": "long-text",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "secret": false,
+        "title": "Request JSON",
+        "description": "JSON payload for the selected Citedy endpoint.",
+        "default": "{\n  \"query\": \"AI content marketing\",\n  \"mode\": \"fast\",\n  \"limit\": 5\n}"
+      }
+    },
+    "required": ["API Key", "Request JSON"]
+  },
+  "output_schema": {
+    "type": "object",
+    "properties": {
+      "response": {
+        "title": "response",
+        "description": "Successful API response payload.",
+        "type": "object"
+      },
+      "client_error": {
+        "title": "client_error",
+        "description": "HTTP 4xx response payload.",
+        "type": "object"
+      },
+      "server_error": {
+        "title": "server_error",
+        "description": "HTTP 5xx response payload.",
+        "type": "object"
+      },
+      "error": {
+        "title": "error",
+        "description": "Transport/runtime error output.",
+        "type": "string"
+      }
+    },
+    "required": []
+  },
+  "has_external_trigger": false,
+  "has_human_in_the_loop": false,
+  "trigger_setup_info": null,
+  "credentials_input_schema": {
+    "properties": {},
+    "required": [],
+    "title": "CitedyTemplateCredentialsInputSchema",
+    "type": "object"
+  }
+}

--- a/autogpt_platform/graph_templates/citedy-turbo-article.agent.json
+++ b/autogpt_platform/graph_templates/citedy-turbo-article.agent.json
@@ -1,0 +1,606 @@
+{
+  "id": "79b4e5bb-c8c7-49b2-ab85-e007d7200ab2",
+  "version": 1,
+  "is_active": true,
+  "name": "Citedy Turbo Article",
+  "description": "Generate ultra-cheap turbo article (2-4 credits).",
+  "instructions": null,
+  "recommended_schedule_cron": null,
+  "nodes": [
+    {
+      "id": "936b942a-2515-445e-81fc-d38de3bf0694",
+      "block_id": "7fcd3bcb-8e1b-4e69-903d-32d3d4a92158",
+      "input_default": {
+        "name": "API Key",
+        "title": null,
+        "value": "citedy_agent_replace_me",
+        "secret": true,
+        "advanced": false,
+        "description": "Citedy API key (starts with citedy_agent_)",
+        "placeholder_values": []
+      },
+      "metadata": {
+        "position": {
+          "x": -920,
+          "y": -80
+        }
+      },
+      "input_links": [],
+      "output_links": [
+        {
+          "id": "909e9f2a-19d6-4c5f-aaa5-12f6094b4563",
+          "source_id": "936b942a-2515-445e-81fc-d38de3bf0694",
+          "sink_id": "c7302b82-33bc-4899-81d3-d49dc4e2b371",
+          "source_name": "result",
+          "sink_name": "values_#_api_key",
+          "is_static": false
+        }
+      ],
+      "graph_id": "79b4e5bb-c8c7-49b2-ab85-e007d7200ab2",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "a25ea12f-b415-45e9-b6c1-ab25d1475b76",
+      "block_id": "90a56ffb-7024-4b2b-ab50-e26c5e5ab8ba",
+      "input_default": {
+        "name": "Request JSON",
+        "title": null,
+        "value": "{\n  \"topic\": \"AI content marketing trends 2026\",\n  \"mode\": \"turbo\",\n  \"enable_search\": false,\n  \"language\": \"en\"\n}",
+        "secret": false,
+        "advanced": false,
+        "description": "JSON payload for this endpoint.",
+        "placeholder_values": []
+      },
+      "metadata": {
+        "position": {
+          "x": -920,
+          "y": 220
+        }
+      },
+      "input_links": [],
+      "output_links": [
+        {
+          "id": "4d24b2b9-2e67-4793-b00c-dccf8ab2a50e",
+          "source_id": "a25ea12f-b415-45e9-b6c1-ab25d1475b76",
+          "sink_id": "5c3ebc29-4d54-4cf3-86ec-ad8eded3bd3e",
+          "source_name": "result",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "graph_id": "79b4e5bb-c8c7-49b2-ab85-e007d7200ab2",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "c7302b82-33bc-4899-81d3-d49dc4e2b371",
+      "block_id": "b924ddf4-de4f-4b56-9a85-358930dcbc91",
+      "input_default": {
+        "values": {}
+      },
+      "metadata": {
+        "position": {
+          "x": -520,
+          "y": -80
+        }
+      },
+      "input_links": [
+        {
+          "id": "909e9f2a-19d6-4c5f-aaa5-12f6094b4563",
+          "source_id": "936b942a-2515-445e-81fc-d38de3bf0694",
+          "sink_id": "c7302b82-33bc-4899-81d3-d49dc4e2b371",
+          "source_name": "result",
+          "sink_name": "values_#_api_key",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "e6ca07b4-a3f3-4e2d-9248-306c83a5d1af",
+          "source_id": "c7302b82-33bc-4899-81d3-d49dc4e2b371",
+          "sink_id": "aa61adfa-1147-4a8e-b198-417bd7d6f8d6",
+          "source_name": "dictionary",
+          "sink_name": "values",
+          "is_static": false
+        }
+      ],
+      "graph_id": "79b4e5bb-c8c7-49b2-ab85-e007d7200ab2",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "aa61adfa-1147-4a8e-b198-417bd7d6f8d6",
+      "block_id": "db7d8f02-2f44-4c55-ab7a-eae0941f0c30",
+      "input_default": {
+        "format": "{\"Authorization\":\"Bearer {{ api_key }}\",\"Content-Type\":\"application/json\"}",
+        "values": {},
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": -140,
+          "y": -80
+        }
+      },
+      "input_links": [
+        {
+          "id": "e6ca07b4-a3f3-4e2d-9248-306c83a5d1af",
+          "source_id": "c7302b82-33bc-4899-81d3-d49dc4e2b371",
+          "sink_id": "aa61adfa-1147-4a8e-b198-417bd7d6f8d6",
+          "source_name": "dictionary",
+          "sink_name": "values",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "c9caa2d3-d620-40c1-ade4-c67f68164983",
+          "source_id": "aa61adfa-1147-4a8e-b198-417bd7d6f8d6",
+          "sink_id": "df59ca9e-240c-4486-a1be-3a7e3773286d",
+          "source_name": "output",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "graph_id": "79b4e5bb-c8c7-49b2-ab85-e007d7200ab2",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "df59ca9e-240c-4486-a1be-3a7e3773286d",
+      "block_id": "95d1b990-ce13-4d88-9737-ba5c2070c97b",
+      "input_default": {
+        "type": "dictionary",
+        "value": null
+      },
+      "metadata": {
+        "position": {
+          "x": 180,
+          "y": -80
+        }
+      },
+      "input_links": [
+        {
+          "id": "c9caa2d3-d620-40c1-ade4-c67f68164983",
+          "source_id": "aa61adfa-1147-4a8e-b198-417bd7d6f8d6",
+          "sink_id": "df59ca9e-240c-4486-a1be-3a7e3773286d",
+          "source_name": "output",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "c5a60414-1ffc-4221-a73a-b46a3d6299e9",
+          "source_id": "df59ca9e-240c-4486-a1be-3a7e3773286d",
+          "sink_id": "53c6a841-87ee-4848-a09d-3326bf09c935",
+          "source_name": "value",
+          "sink_name": "headers",
+          "is_static": false
+        }
+      ],
+      "graph_id": "79b4e5bb-c8c7-49b2-ab85-e007d7200ab2",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "5c3ebc29-4d54-4cf3-86ec-ad8eded3bd3e",
+      "block_id": "95d1b990-ce13-4d88-9737-ba5c2070c97b",
+      "input_default": {
+        "type": "dictionary",
+        "value": null
+      },
+      "metadata": {
+        "position": {
+          "x": -140,
+          "y": 220
+        }
+      },
+      "input_links": [
+        {
+          "id": "4d24b2b9-2e67-4793-b00c-dccf8ab2a50e",
+          "source_id": "a25ea12f-b415-45e9-b6c1-ab25d1475b76",
+          "sink_id": "5c3ebc29-4d54-4cf3-86ec-ad8eded3bd3e",
+          "source_name": "result",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "dbfde3c1-112b-47e6-a149-a5f0521d73e7",
+          "source_id": "5c3ebc29-4d54-4cf3-86ec-ad8eded3bd3e",
+          "sink_id": "53c6a841-87ee-4848-a09d-3326bf09c935",
+          "source_name": "value",
+          "sink_name": "body",
+          "is_static": false
+        }
+      ],
+      "graph_id": "79b4e5bb-c8c7-49b2-ab85-e007d7200ab2",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "53c6a841-87ee-4848-a09d-3326bf09c935",
+      "block_id": "6595ae1f-b924-42cb-9a41-551a0611c4b4",
+      "input_default": {
+        "url": "https://www.citedy.com/api/agent/autopilot",
+        "method": "POST",
+        "headers": {},
+        "json_format": true,
+        "body": null,
+        "files_name": "file",
+        "files": []
+      },
+      "metadata": {
+        "position": {
+          "x": 560,
+          "y": 70
+        }
+      },
+      "input_links": [
+        {
+          "id": "c5a60414-1ffc-4221-a73a-b46a3d6299e9",
+          "source_id": "df59ca9e-240c-4486-a1be-3a7e3773286d",
+          "sink_id": "53c6a841-87ee-4848-a09d-3326bf09c935",
+          "source_name": "value",
+          "sink_name": "headers",
+          "is_static": false
+        },
+        {
+          "id": "dbfde3c1-112b-47e6-a149-a5f0521d73e7",
+          "source_id": "5c3ebc29-4d54-4cf3-86ec-ad8eded3bd3e",
+          "sink_id": "53c6a841-87ee-4848-a09d-3326bf09c935",
+          "source_name": "value",
+          "sink_name": "body",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "e6a0d697-1cd3-4a7d-9b80-78204cd3ea98",
+          "source_id": "53c6a841-87ee-4848-a09d-3326bf09c935",
+          "sink_id": "aee38bc2-57a5-4d6c-aa92-1c152a2e751a",
+          "source_name": "response",
+          "sink_name": "value",
+          "is_static": false
+        },
+        {
+          "id": "c80eb001-ac42-48fd-ac0b-c25e629e4123",
+          "source_id": "53c6a841-87ee-4848-a09d-3326bf09c935",
+          "sink_id": "85dc2f6e-4bf8-440b-9d41-330423e9e693",
+          "source_name": "client_error",
+          "sink_name": "value",
+          "is_static": false
+        },
+        {
+          "id": "073a4a77-f5f3-400c-a9d6-5e856b53760b",
+          "source_id": "53c6a841-87ee-4848-a09d-3326bf09c935",
+          "sink_id": "273e3864-ac67-4073-9c88-32372acf4049",
+          "source_name": "server_error",
+          "sink_name": "value",
+          "is_static": false
+        },
+        {
+          "id": "f691d6ae-c997-4cd9-be9f-ff50fd07a436",
+          "source_id": "53c6a841-87ee-4848-a09d-3326bf09c935",
+          "sink_id": "5e4a391f-a44b-4319-826d-ca0d77424796",
+          "source_name": "error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "graph_id": "79b4e5bb-c8c7-49b2-ab85-e007d7200ab2",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "aee38bc2-57a5-4d6c-aa92-1c152a2e751a",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "response",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "Successful API response payload.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": -160
+        }
+      },
+      "input_links": [
+        {
+          "id": "e6a0d697-1cd3-4a7d-9b80-78204cd3ea98",
+          "source_id": "53c6a841-87ee-4848-a09d-3326bf09c935",
+          "sink_id": "aee38bc2-57a5-4d6c-aa92-1c152a2e751a",
+          "source_name": "response",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "79b4e5bb-c8c7-49b2-ab85-e007d7200ab2",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "85dc2f6e-4bf8-440b-9d41-330423e9e693",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "client_error",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "HTTP 4xx response payload.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": 20
+        }
+      },
+      "input_links": [
+        {
+          "id": "c80eb001-ac42-48fd-ac0b-c25e629e4123",
+          "source_id": "53c6a841-87ee-4848-a09d-3326bf09c935",
+          "sink_id": "85dc2f6e-4bf8-440b-9d41-330423e9e693",
+          "source_name": "client_error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "79b4e5bb-c8c7-49b2-ab85-e007d7200ab2",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "273e3864-ac67-4073-9c88-32372acf4049",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "server_error",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "HTTP 5xx response payload.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": 200
+        }
+      },
+      "input_links": [
+        {
+          "id": "073a4a77-f5f3-400c-a9d6-5e856b53760b",
+          "source_id": "53c6a841-87ee-4848-a09d-3326bf09c935",
+          "sink_id": "273e3864-ac67-4073-9c88-32372acf4049",
+          "source_name": "server_error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "79b4e5bb-c8c7-49b2-ab85-e007d7200ab2",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "5e4a391f-a44b-4319-826d-ca0d77424796",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "error",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "Transport/runtime error output.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": 380
+        }
+      },
+      "input_links": [
+        {
+          "id": "f691d6ae-c997-4cd9-be9f-ff50fd07a436",
+          "source_id": "53c6a841-87ee-4848-a09d-3326bf09c935",
+          "sink_id": "5e4a391f-a44b-4319-826d-ca0d77424796",
+          "source_name": "error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "79b4e5bb-c8c7-49b2-ab85-e007d7200ab2",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    }
+  ],
+  "links": [
+    {
+      "id": "909e9f2a-19d6-4c5f-aaa5-12f6094b4563",
+      "source_id": "936b942a-2515-445e-81fc-d38de3bf0694",
+      "sink_id": "c7302b82-33bc-4899-81d3-d49dc4e2b371",
+      "source_name": "result",
+      "sink_name": "values_#_api_key",
+      "is_static": false
+    },
+    {
+      "id": "4d24b2b9-2e67-4793-b00c-dccf8ab2a50e",
+      "source_id": "a25ea12f-b415-45e9-b6c1-ab25d1475b76",
+      "sink_id": "5c3ebc29-4d54-4cf3-86ec-ad8eded3bd3e",
+      "source_name": "result",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "e6ca07b4-a3f3-4e2d-9248-306c83a5d1af",
+      "source_id": "c7302b82-33bc-4899-81d3-d49dc4e2b371",
+      "sink_id": "aa61adfa-1147-4a8e-b198-417bd7d6f8d6",
+      "source_name": "dictionary",
+      "sink_name": "values",
+      "is_static": false
+    },
+    {
+      "id": "c9caa2d3-d620-40c1-ade4-c67f68164983",
+      "source_id": "aa61adfa-1147-4a8e-b198-417bd7d6f8d6",
+      "sink_id": "df59ca9e-240c-4486-a1be-3a7e3773286d",
+      "source_name": "output",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "c5a60414-1ffc-4221-a73a-b46a3d6299e9",
+      "source_id": "df59ca9e-240c-4486-a1be-3a7e3773286d",
+      "sink_id": "53c6a841-87ee-4848-a09d-3326bf09c935",
+      "source_name": "value",
+      "sink_name": "headers",
+      "is_static": false
+    },
+    {
+      "id": "dbfde3c1-112b-47e6-a149-a5f0521d73e7",
+      "source_id": "5c3ebc29-4d54-4cf3-86ec-ad8eded3bd3e",
+      "sink_id": "53c6a841-87ee-4848-a09d-3326bf09c935",
+      "source_name": "value",
+      "sink_name": "body",
+      "is_static": false
+    },
+    {
+      "id": "e6a0d697-1cd3-4a7d-9b80-78204cd3ea98",
+      "source_id": "53c6a841-87ee-4848-a09d-3326bf09c935",
+      "sink_id": "aee38bc2-57a5-4d6c-aa92-1c152a2e751a",
+      "source_name": "response",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "c80eb001-ac42-48fd-ac0b-c25e629e4123",
+      "source_id": "53c6a841-87ee-4848-a09d-3326bf09c935",
+      "sink_id": "85dc2f6e-4bf8-440b-9d41-330423e9e693",
+      "source_name": "client_error",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "073a4a77-f5f3-400c-a9d6-5e856b53760b",
+      "source_id": "53c6a841-87ee-4848-a09d-3326bf09c935",
+      "sink_id": "273e3864-ac67-4073-9c88-32372acf4049",
+      "source_name": "server_error",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "f691d6ae-c997-4cd9-be9f-ff50fd07a436",
+      "source_id": "53c6a841-87ee-4848-a09d-3326bf09c935",
+      "sink_id": "5e4a391f-a44b-4319-826d-ca0d77424796",
+      "source_name": "error",
+      "sink_name": "value",
+      "is_static": false
+    }
+  ],
+  "forked_from_id": null,
+  "forked_from_version": null,
+  "sub_graphs": [],
+  "user_id": "",
+  "created_at": "2026-02-28T12:00:00.000Z",
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "API Key": {
+        "advanced": false,
+        "anyOf": [
+          {
+            "format": "short-text",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "secret": true,
+        "title": "API Key",
+        "description": "Citedy API key (starts with citedy_agent_)",
+        "default": "citedy_agent_replace_me"
+      },
+      "Request JSON": {
+        "advanced": false,
+        "anyOf": [
+          {
+            "format": "long-text",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "secret": false,
+        "title": "Request JSON",
+        "description": "JSON payload for the selected Citedy endpoint.",
+        "default": "{\n  \"topic\": \"AI content marketing trends 2026\",\n  \"mode\": \"turbo\",\n  \"enable_search\": false,\n  \"language\": \"en\"\n}"
+      }
+    },
+    "required": ["API Key", "Request JSON"]
+  },
+  "output_schema": {
+    "type": "object",
+    "properties": {
+      "response": {
+        "title": "response",
+        "description": "Successful API response payload.",
+        "type": "object"
+      },
+      "client_error": {
+        "title": "client_error",
+        "description": "HTTP 4xx response payload.",
+        "type": "object"
+      },
+      "server_error": {
+        "title": "server_error",
+        "description": "HTTP 5xx response payload.",
+        "type": "object"
+      },
+      "error": {
+        "title": "error",
+        "description": "Transport/runtime error output.",
+        "type": "string"
+      }
+    },
+    "required": []
+  },
+  "has_external_trigger": false,
+  "has_human_in_the_loop": false,
+  "trigger_setup_info": null,
+  "credentials_input_schema": {
+    "properties": {},
+    "required": [],
+    "title": "CitedyTemplateCredentialsInputSchema",
+    "type": "object"
+  }
+}

--- a/autogpt_platform/graph_templates/citedy-url-to-publish.agent.json
+++ b/autogpt_platform/graph_templates/citedy-url-to-publish.agent.json
@@ -1,0 +1,606 @@
+{
+  "id": "e713102d-a5ce-42fa-bd2b-3f24f265ba9a",
+  "version": 1,
+  "is_active": true,
+  "name": "Citedy URL to Publish",
+  "description": "Generate an SEO article from source URLs via Citedy autopilot.",
+  "instructions": null,
+  "recommended_schedule_cron": null,
+  "nodes": [
+    {
+      "id": "b49a84ec-c53a-4494-8380-71e1f47cbfee",
+      "block_id": "7fcd3bcb-8e1b-4e69-903d-32d3d4a92158",
+      "input_default": {
+        "name": "API Key",
+        "title": null,
+        "value": "citedy_agent_replace_me",
+        "secret": true,
+        "advanced": false,
+        "description": "Citedy API key (starts with citedy_agent_)",
+        "placeholder_values": []
+      },
+      "metadata": {
+        "position": {
+          "x": -920,
+          "y": -80
+        }
+      },
+      "input_links": [],
+      "output_links": [
+        {
+          "id": "87fed6be-b305-4e49-bc54-62a0bfa50bd0",
+          "source_id": "b49a84ec-c53a-4494-8380-71e1f47cbfee",
+          "sink_id": "b59f3267-ac9c-44af-af49-c5f2946bc065",
+          "source_name": "result",
+          "sink_name": "values_#_api_key",
+          "is_static": false
+        }
+      ],
+      "graph_id": "e713102d-a5ce-42fa-bd2b-3f24f265ba9a",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "d0fa297e-08d8-4e7c-8385-68764d2accae",
+      "block_id": "90a56ffb-7024-4b2b-ab50-e26c5e5ab8ba",
+      "input_default": {
+        "name": "Request JSON",
+        "title": null,
+        "value": "{\n  \"source_urls\": [\n    \"https://example.com/ai-content-trends\"\n  ],\n  \"size\": \"standard\",\n  \"mode\": \"standard\",\n  \"language\": \"en\",\n  \"persona\": null,\n  \"illustrations\": false,\n  \"audio\": false,\n  \"disable_competition\": false\n}",
+        "secret": false,
+        "advanced": false,
+        "description": "JSON payload for this endpoint.",
+        "placeholder_values": []
+      },
+      "metadata": {
+        "position": {
+          "x": -920,
+          "y": 220
+        }
+      },
+      "input_links": [],
+      "output_links": [
+        {
+          "id": "938f979c-6b41-40ec-8c39-c05285a597f4",
+          "source_id": "d0fa297e-08d8-4e7c-8385-68764d2accae",
+          "sink_id": "0811710d-542d-42f4-b88d-89722e921b43",
+          "source_name": "result",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "graph_id": "e713102d-a5ce-42fa-bd2b-3f24f265ba9a",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "b59f3267-ac9c-44af-af49-c5f2946bc065",
+      "block_id": "b924ddf4-de4f-4b56-9a85-358930dcbc91",
+      "input_default": {
+        "values": {}
+      },
+      "metadata": {
+        "position": {
+          "x": -520,
+          "y": -80
+        }
+      },
+      "input_links": [
+        {
+          "id": "87fed6be-b305-4e49-bc54-62a0bfa50bd0",
+          "source_id": "b49a84ec-c53a-4494-8380-71e1f47cbfee",
+          "sink_id": "b59f3267-ac9c-44af-af49-c5f2946bc065",
+          "source_name": "result",
+          "sink_name": "values_#_api_key",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "14d824cf-ba34-49f4-88b9-fd67f069c8bc",
+          "source_id": "b59f3267-ac9c-44af-af49-c5f2946bc065",
+          "sink_id": "56636b9f-4686-44df-b675-1a332d128f06",
+          "source_name": "dictionary",
+          "sink_name": "values",
+          "is_static": false
+        }
+      ],
+      "graph_id": "e713102d-a5ce-42fa-bd2b-3f24f265ba9a",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "56636b9f-4686-44df-b675-1a332d128f06",
+      "block_id": "db7d8f02-2f44-4c55-ab7a-eae0941f0c30",
+      "input_default": {
+        "format": "{\"Authorization\":\"Bearer {{ api_key }}\",\"Content-Type\":\"application/json\"}",
+        "values": {},
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": -140,
+          "y": -80
+        }
+      },
+      "input_links": [
+        {
+          "id": "14d824cf-ba34-49f4-88b9-fd67f069c8bc",
+          "source_id": "b59f3267-ac9c-44af-af49-c5f2946bc065",
+          "sink_id": "56636b9f-4686-44df-b675-1a332d128f06",
+          "source_name": "dictionary",
+          "sink_name": "values",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "32651f94-14b0-4268-889e-e6e2ae5cd75e",
+          "source_id": "56636b9f-4686-44df-b675-1a332d128f06",
+          "sink_id": "d49eb471-5409-4aca-a7d9-9195194076a2",
+          "source_name": "output",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "graph_id": "e713102d-a5ce-42fa-bd2b-3f24f265ba9a",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "d49eb471-5409-4aca-a7d9-9195194076a2",
+      "block_id": "95d1b990-ce13-4d88-9737-ba5c2070c97b",
+      "input_default": {
+        "type": "dictionary",
+        "value": null
+      },
+      "metadata": {
+        "position": {
+          "x": 180,
+          "y": -80
+        }
+      },
+      "input_links": [
+        {
+          "id": "32651f94-14b0-4268-889e-e6e2ae5cd75e",
+          "source_id": "56636b9f-4686-44df-b675-1a332d128f06",
+          "sink_id": "d49eb471-5409-4aca-a7d9-9195194076a2",
+          "source_name": "output",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "9cecf340-29eb-41a5-b5cd-98a9cd849137",
+          "source_id": "d49eb471-5409-4aca-a7d9-9195194076a2",
+          "sink_id": "404159dc-bbee-4af7-b146-2fad3fef9a3e",
+          "source_name": "value",
+          "sink_name": "headers",
+          "is_static": false
+        }
+      ],
+      "graph_id": "e713102d-a5ce-42fa-bd2b-3f24f265ba9a",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "0811710d-542d-42f4-b88d-89722e921b43",
+      "block_id": "95d1b990-ce13-4d88-9737-ba5c2070c97b",
+      "input_default": {
+        "type": "dictionary",
+        "value": null
+      },
+      "metadata": {
+        "position": {
+          "x": -140,
+          "y": 220
+        }
+      },
+      "input_links": [
+        {
+          "id": "938f979c-6b41-40ec-8c39-c05285a597f4",
+          "source_id": "d0fa297e-08d8-4e7c-8385-68764d2accae",
+          "sink_id": "0811710d-542d-42f4-b88d-89722e921b43",
+          "source_name": "result",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "d666d070-75c7-4365-9551-ae8318dc444a",
+          "source_id": "0811710d-542d-42f4-b88d-89722e921b43",
+          "sink_id": "404159dc-bbee-4af7-b146-2fad3fef9a3e",
+          "source_name": "value",
+          "sink_name": "body",
+          "is_static": false
+        }
+      ],
+      "graph_id": "e713102d-a5ce-42fa-bd2b-3f24f265ba9a",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "404159dc-bbee-4af7-b146-2fad3fef9a3e",
+      "block_id": "6595ae1f-b924-42cb-9a41-551a0611c4b4",
+      "input_default": {
+        "url": "https://www.citedy.com/api/agent/autopilot",
+        "method": "POST",
+        "headers": {},
+        "json_format": true,
+        "body": null,
+        "files_name": "file",
+        "files": []
+      },
+      "metadata": {
+        "position": {
+          "x": 560,
+          "y": 70
+        }
+      },
+      "input_links": [
+        {
+          "id": "9cecf340-29eb-41a5-b5cd-98a9cd849137",
+          "source_id": "d49eb471-5409-4aca-a7d9-9195194076a2",
+          "sink_id": "404159dc-bbee-4af7-b146-2fad3fef9a3e",
+          "source_name": "value",
+          "sink_name": "headers",
+          "is_static": false
+        },
+        {
+          "id": "d666d070-75c7-4365-9551-ae8318dc444a",
+          "source_id": "0811710d-542d-42f4-b88d-89722e921b43",
+          "sink_id": "404159dc-bbee-4af7-b146-2fad3fef9a3e",
+          "source_name": "value",
+          "sink_name": "body",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "0588c901-0e56-4cbb-923f-5f04b4675283",
+          "source_id": "404159dc-bbee-4af7-b146-2fad3fef9a3e",
+          "sink_id": "347c9f6f-f15a-408f-816b-21f48f3397b7",
+          "source_name": "response",
+          "sink_name": "value",
+          "is_static": false
+        },
+        {
+          "id": "5811a815-0d89-4014-b31d-646ac3309aeb",
+          "source_id": "404159dc-bbee-4af7-b146-2fad3fef9a3e",
+          "sink_id": "0d80696a-3b3c-4374-b79e-70c50348df0f",
+          "source_name": "client_error",
+          "sink_name": "value",
+          "is_static": false
+        },
+        {
+          "id": "dc51b73f-de42-4716-a122-1c0b0dffb86e",
+          "source_id": "404159dc-bbee-4af7-b146-2fad3fef9a3e",
+          "sink_id": "0a7b68a4-4e60-4d1c-a60c-efd6b9387992",
+          "source_name": "server_error",
+          "sink_name": "value",
+          "is_static": false
+        },
+        {
+          "id": "220c0dea-9c42-4bb2-a509-fddc7636707d",
+          "source_id": "404159dc-bbee-4af7-b146-2fad3fef9a3e",
+          "sink_id": "4c3d13e1-21eb-4e06-b50a-e87ec2a923ea",
+          "source_name": "error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "graph_id": "e713102d-a5ce-42fa-bd2b-3f24f265ba9a",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "347c9f6f-f15a-408f-816b-21f48f3397b7",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "response",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "Successful API response payload.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": -160
+        }
+      },
+      "input_links": [
+        {
+          "id": "0588c901-0e56-4cbb-923f-5f04b4675283",
+          "source_id": "404159dc-bbee-4af7-b146-2fad3fef9a3e",
+          "sink_id": "347c9f6f-f15a-408f-816b-21f48f3397b7",
+          "source_name": "response",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "e713102d-a5ce-42fa-bd2b-3f24f265ba9a",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "0d80696a-3b3c-4374-b79e-70c50348df0f",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "client_error",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "HTTP 4xx response payload.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": 20
+        }
+      },
+      "input_links": [
+        {
+          "id": "5811a815-0d89-4014-b31d-646ac3309aeb",
+          "source_id": "404159dc-bbee-4af7-b146-2fad3fef9a3e",
+          "sink_id": "0d80696a-3b3c-4374-b79e-70c50348df0f",
+          "source_name": "client_error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "e713102d-a5ce-42fa-bd2b-3f24f265ba9a",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "0a7b68a4-4e60-4d1c-a60c-efd6b9387992",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "server_error",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "HTTP 5xx response payload.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": 200
+        }
+      },
+      "input_links": [
+        {
+          "id": "dc51b73f-de42-4716-a122-1c0b0dffb86e",
+          "source_id": "404159dc-bbee-4af7-b146-2fad3fef9a3e",
+          "sink_id": "0a7b68a4-4e60-4d1c-a60c-efd6b9387992",
+          "source_name": "server_error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "e713102d-a5ce-42fa-bd2b-3f24f265ba9a",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "4c3d13e1-21eb-4e06-b50a-e87ec2a923ea",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "error",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "Transport/runtime error output.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": 380
+        }
+      },
+      "input_links": [
+        {
+          "id": "220c0dea-9c42-4bb2-a509-fddc7636707d",
+          "source_id": "404159dc-bbee-4af7-b146-2fad3fef9a3e",
+          "sink_id": "4c3d13e1-21eb-4e06-b50a-e87ec2a923ea",
+          "source_name": "error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "e713102d-a5ce-42fa-bd2b-3f24f265ba9a",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    }
+  ],
+  "links": [
+    {
+      "id": "87fed6be-b305-4e49-bc54-62a0bfa50bd0",
+      "source_id": "b49a84ec-c53a-4494-8380-71e1f47cbfee",
+      "sink_id": "b59f3267-ac9c-44af-af49-c5f2946bc065",
+      "source_name": "result",
+      "sink_name": "values_#_api_key",
+      "is_static": false
+    },
+    {
+      "id": "14d824cf-ba34-49f4-88b9-fd67f069c8bc",
+      "source_id": "b59f3267-ac9c-44af-af49-c5f2946bc065",
+      "sink_id": "56636b9f-4686-44df-b675-1a332d128f06",
+      "source_name": "dictionary",
+      "sink_name": "values",
+      "is_static": false
+    },
+    {
+      "id": "32651f94-14b0-4268-889e-e6e2ae5cd75e",
+      "source_id": "56636b9f-4686-44df-b675-1a332d128f06",
+      "sink_id": "d49eb471-5409-4aca-a7d9-9195194076a2",
+      "source_name": "output",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "938f979c-6b41-40ec-8c39-c05285a597f4",
+      "source_id": "d0fa297e-08d8-4e7c-8385-68764d2accae",
+      "sink_id": "0811710d-542d-42f4-b88d-89722e921b43",
+      "source_name": "result",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "9cecf340-29eb-41a5-b5cd-98a9cd849137",
+      "source_id": "d49eb471-5409-4aca-a7d9-9195194076a2",
+      "sink_id": "404159dc-bbee-4af7-b146-2fad3fef9a3e",
+      "source_name": "value",
+      "sink_name": "headers",
+      "is_static": false
+    },
+    {
+      "id": "d666d070-75c7-4365-9551-ae8318dc444a",
+      "source_id": "0811710d-542d-42f4-b88d-89722e921b43",
+      "sink_id": "404159dc-bbee-4af7-b146-2fad3fef9a3e",
+      "source_name": "value",
+      "sink_name": "body",
+      "is_static": false
+    },
+    {
+      "id": "0588c901-0e56-4cbb-923f-5f04b4675283",
+      "source_id": "404159dc-bbee-4af7-b146-2fad3fef9a3e",
+      "sink_id": "347c9f6f-f15a-408f-816b-21f48f3397b7",
+      "source_name": "response",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "5811a815-0d89-4014-b31d-646ac3309aeb",
+      "source_id": "404159dc-bbee-4af7-b146-2fad3fef9a3e",
+      "sink_id": "0d80696a-3b3c-4374-b79e-70c50348df0f",
+      "source_name": "client_error",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "dc51b73f-de42-4716-a122-1c0b0dffb86e",
+      "source_id": "404159dc-bbee-4af7-b146-2fad3fef9a3e",
+      "sink_id": "0a7b68a4-4e60-4d1c-a60c-efd6b9387992",
+      "source_name": "server_error",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "220c0dea-9c42-4bb2-a509-fddc7636707d",
+      "source_id": "404159dc-bbee-4af7-b146-2fad3fef9a3e",
+      "sink_id": "4c3d13e1-21eb-4e06-b50a-e87ec2a923ea",
+      "source_name": "error",
+      "sink_name": "value",
+      "is_static": false
+    }
+  ],
+  "forked_from_id": null,
+  "forked_from_version": null,
+  "sub_graphs": [],
+  "user_id": "",
+  "created_at": "2026-02-14T23:47:30.879Z",
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "API Key": {
+        "advanced": false,
+        "anyOf": [
+          {
+            "format": "short-text",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "secret": true,
+        "title": "API Key",
+        "description": "Citedy API key (starts with citedy_agent_)",
+        "default": "citedy_agent_replace_me"
+      },
+      "Request JSON": {
+        "advanced": false,
+        "anyOf": [
+          {
+            "format": "long-text",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "secret": false,
+        "title": "Request JSON",
+        "description": "JSON payload for the selected Citedy endpoint.",
+        "default": "{\n  \"source_urls\": [\n    \"https://example.com/ai-content-trends\"\n  ],\n  \"size\": \"mini\",\n  \"language\": \"en\",\n  \"illustrations\": false,\n  \"audio\": false\n}"
+      }
+    },
+    "required": ["API Key", "Request JSON"]
+  },
+  "output_schema": {
+    "type": "object",
+    "properties": {
+      "response": {
+        "title": "response",
+        "description": "Successful API response payload.",
+        "type": "object"
+      },
+      "client_error": {
+        "title": "client_error",
+        "description": "HTTP 4xx response payload.",
+        "type": "object"
+      },
+      "server_error": {
+        "title": "server_error",
+        "description": "HTTP 5xx response payload.",
+        "type": "object"
+      },
+      "error": {
+        "title": "error",
+        "description": "Transport/runtime error output.",
+        "type": "string"
+      }
+    },
+    "required": []
+  },
+  "has_external_trigger": false,
+  "has_human_in_the_loop": false,
+  "trigger_setup_info": null,
+  "credentials_input_schema": {
+    "properties": {},
+    "required": [],
+    "title": "CitedyTemplateCredentialsInputSchema",
+    "type": "object"
+  }
+}

--- a/autogpt_platform/graph_templates/citedy-webhook-register.agent.json
+++ b/autogpt_platform/graph_templates/citedy-webhook-register.agent.json
@@ -1,0 +1,606 @@
+{
+  "id": "2751de14-3d48-4a71-8c07-45a563bccf74",
+  "version": 1,
+  "is_active": true,
+  "name": "Citedy Webhook Register",
+  "description": "Register webhook endpoint for real-time event notifications.",
+  "instructions": null,
+  "recommended_schedule_cron": null,
+  "nodes": [
+    {
+      "id": "573c46cd-e8b7-4cd6-9948-ca9cfc5b685b",
+      "block_id": "7fcd3bcb-8e1b-4e69-903d-32d3d4a92158",
+      "input_default": {
+        "name": "API Key",
+        "title": null,
+        "value": "citedy_agent_replace_me",
+        "secret": true,
+        "advanced": false,
+        "description": "Citedy API key (starts with citedy_agent_)",
+        "placeholder_values": []
+      },
+      "metadata": {
+        "position": {
+          "x": -920,
+          "y": -80
+        }
+      },
+      "input_links": [],
+      "output_links": [
+        {
+          "id": "88eee51e-574c-474b-b410-071f6b585933",
+          "source_id": "573c46cd-e8b7-4cd6-9948-ca9cfc5b685b",
+          "sink_id": "9972a21c-457f-4723-97a9-e1a7835a8f2c",
+          "source_name": "result",
+          "sink_name": "values_#_api_key",
+          "is_static": false
+        }
+      ],
+      "graph_id": "2751de14-3d48-4a71-8c07-45a563bccf74",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "f4dcb81a-1aa4-40b2-8eb5-52004a5c5701",
+      "block_id": "90a56ffb-7024-4b2b-ab50-e26c5e5ab8ba",
+      "input_default": {
+        "name": "Request JSON",
+        "title": null,
+        "value": "{\n  \"url\": \"https://your-server.com/webhooks/citedy\",\n  \"event_types\": [\n    \"article.generated\",\n    \"ingestion.completed\"\n  ],\n  \"description\": \"Production webhook\"\n}",
+        "secret": false,
+        "advanced": false,
+        "description": "JSON payload for this endpoint.",
+        "placeholder_values": []
+      },
+      "metadata": {
+        "position": {
+          "x": -920,
+          "y": 220
+        }
+      },
+      "input_links": [],
+      "output_links": [
+        {
+          "id": "2b9ad834-72d1-4cca-ba39-b727f6c41cd5",
+          "source_id": "f4dcb81a-1aa4-40b2-8eb5-52004a5c5701",
+          "sink_id": "9b7b5a04-daff-4dcd-a6a5-531060d6a0fa",
+          "source_name": "result",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "graph_id": "2751de14-3d48-4a71-8c07-45a563bccf74",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "9972a21c-457f-4723-97a9-e1a7835a8f2c",
+      "block_id": "b924ddf4-de4f-4b56-9a85-358930dcbc91",
+      "input_default": {
+        "values": {}
+      },
+      "metadata": {
+        "position": {
+          "x": -520,
+          "y": -80
+        }
+      },
+      "input_links": [
+        {
+          "id": "88eee51e-574c-474b-b410-071f6b585933",
+          "source_id": "573c46cd-e8b7-4cd6-9948-ca9cfc5b685b",
+          "sink_id": "9972a21c-457f-4723-97a9-e1a7835a8f2c",
+          "source_name": "result",
+          "sink_name": "values_#_api_key",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "adb1e1bc-38ac-4318-82f3-a5e4734b9baf",
+          "source_id": "9972a21c-457f-4723-97a9-e1a7835a8f2c",
+          "sink_id": "897daf4f-2621-49fa-8a6b-020808da627e",
+          "source_name": "dictionary",
+          "sink_name": "values",
+          "is_static": false
+        }
+      ],
+      "graph_id": "2751de14-3d48-4a71-8c07-45a563bccf74",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "897daf4f-2621-49fa-8a6b-020808da627e",
+      "block_id": "db7d8f02-2f44-4c55-ab7a-eae0941f0c30",
+      "input_default": {
+        "format": "{\"Authorization\":\"Bearer {{ api_key }}\",\"Content-Type\":\"application/json\"}",
+        "values": {},
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": -140,
+          "y": -80
+        }
+      },
+      "input_links": [
+        {
+          "id": "adb1e1bc-38ac-4318-82f3-a5e4734b9baf",
+          "source_id": "9972a21c-457f-4723-97a9-e1a7835a8f2c",
+          "sink_id": "897daf4f-2621-49fa-8a6b-020808da627e",
+          "source_name": "dictionary",
+          "sink_name": "values",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "f4b9d987-4141-432f-8349-cd1422640378",
+          "source_id": "897daf4f-2621-49fa-8a6b-020808da627e",
+          "sink_id": "35ec619a-2129-44b1-9e2f-04fcd94f6b70",
+          "source_name": "output",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "graph_id": "2751de14-3d48-4a71-8c07-45a563bccf74",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "35ec619a-2129-44b1-9e2f-04fcd94f6b70",
+      "block_id": "95d1b990-ce13-4d88-9737-ba5c2070c97b",
+      "input_default": {
+        "type": "dictionary",
+        "value": null
+      },
+      "metadata": {
+        "position": {
+          "x": 180,
+          "y": -80
+        }
+      },
+      "input_links": [
+        {
+          "id": "f4b9d987-4141-432f-8349-cd1422640378",
+          "source_id": "897daf4f-2621-49fa-8a6b-020808da627e",
+          "sink_id": "35ec619a-2129-44b1-9e2f-04fcd94f6b70",
+          "source_name": "output",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "2ba00ec7-7a58-4848-b2fa-6e8a14c23415",
+          "source_id": "35ec619a-2129-44b1-9e2f-04fcd94f6b70",
+          "sink_id": "250bba0f-bd1d-4780-b39a-1876017a3625",
+          "source_name": "value",
+          "sink_name": "headers",
+          "is_static": false
+        }
+      ],
+      "graph_id": "2751de14-3d48-4a71-8c07-45a563bccf74",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "9b7b5a04-daff-4dcd-a6a5-531060d6a0fa",
+      "block_id": "95d1b990-ce13-4d88-9737-ba5c2070c97b",
+      "input_default": {
+        "type": "dictionary",
+        "value": null
+      },
+      "metadata": {
+        "position": {
+          "x": -140,
+          "y": 220
+        }
+      },
+      "input_links": [
+        {
+          "id": "2b9ad834-72d1-4cca-ba39-b727f6c41cd5",
+          "source_id": "f4dcb81a-1aa4-40b2-8eb5-52004a5c5701",
+          "sink_id": "9b7b5a04-daff-4dcd-a6a5-531060d6a0fa",
+          "source_name": "result",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "5b5b72ed-61a9-491c-adc5-1c8e85b88a44",
+          "source_id": "9b7b5a04-daff-4dcd-a6a5-531060d6a0fa",
+          "sink_id": "250bba0f-bd1d-4780-b39a-1876017a3625",
+          "source_name": "value",
+          "sink_name": "body",
+          "is_static": false
+        }
+      ],
+      "graph_id": "2751de14-3d48-4a71-8c07-45a563bccf74",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "250bba0f-bd1d-4780-b39a-1876017a3625",
+      "block_id": "6595ae1f-b924-42cb-9a41-551a0611c4b4",
+      "input_default": {
+        "url": "https://www.citedy.com/api/agent/webhooks",
+        "method": "POST",
+        "headers": {},
+        "json_format": true,
+        "body": null,
+        "files_name": "file",
+        "files": []
+      },
+      "metadata": {
+        "position": {
+          "x": 560,
+          "y": 70
+        }
+      },
+      "input_links": [
+        {
+          "id": "2ba00ec7-7a58-4848-b2fa-6e8a14c23415",
+          "source_id": "35ec619a-2129-44b1-9e2f-04fcd94f6b70",
+          "sink_id": "250bba0f-bd1d-4780-b39a-1876017a3625",
+          "source_name": "value",
+          "sink_name": "headers",
+          "is_static": false
+        },
+        {
+          "id": "5b5b72ed-61a9-491c-adc5-1c8e85b88a44",
+          "source_id": "9b7b5a04-daff-4dcd-a6a5-531060d6a0fa",
+          "sink_id": "250bba0f-bd1d-4780-b39a-1876017a3625",
+          "source_name": "value",
+          "sink_name": "body",
+          "is_static": false
+        }
+      ],
+      "output_links": [
+        {
+          "id": "70bf3268-715e-4f70-974c-4d6962c03269",
+          "source_id": "250bba0f-bd1d-4780-b39a-1876017a3625",
+          "sink_id": "0bbce880-dd74-4000-904a-f56905fb4be1",
+          "source_name": "response",
+          "sink_name": "value",
+          "is_static": false
+        },
+        {
+          "id": "593cab07-a9de-45bd-b8ba-4670a95d57a7",
+          "source_id": "250bba0f-bd1d-4780-b39a-1876017a3625",
+          "sink_id": "d367d57e-eba8-4bc1-92f6-2f0dcd955bc6",
+          "source_name": "client_error",
+          "sink_name": "value",
+          "is_static": false
+        },
+        {
+          "id": "78e310c7-b844-442d-9ede-909f73854a79",
+          "source_id": "250bba0f-bd1d-4780-b39a-1876017a3625",
+          "sink_id": "0911b9b9-df9b-46b2-bf47-f3cf567e2cc5",
+          "source_name": "server_error",
+          "sink_name": "value",
+          "is_static": false
+        },
+        {
+          "id": "34b2342a-d091-49c1-87ea-fc7a2518e7fd",
+          "source_id": "250bba0f-bd1d-4780-b39a-1876017a3625",
+          "sink_id": "6ad9c5a1-c552-4adc-98a4-a0ee29e82ac6",
+          "source_name": "error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "graph_id": "2751de14-3d48-4a71-8c07-45a563bccf74",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "0bbce880-dd74-4000-904a-f56905fb4be1",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "response",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "Successful API response payload.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": -160
+        }
+      },
+      "input_links": [
+        {
+          "id": "70bf3268-715e-4f70-974c-4d6962c03269",
+          "source_id": "250bba0f-bd1d-4780-b39a-1876017a3625",
+          "sink_id": "0bbce880-dd74-4000-904a-f56905fb4be1",
+          "source_name": "response",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "2751de14-3d48-4a71-8c07-45a563bccf74",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "d367d57e-eba8-4bc1-92f6-2f0dcd955bc6",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "client_error",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "HTTP 4xx response payload.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": 20
+        }
+      },
+      "input_links": [
+        {
+          "id": "593cab07-a9de-45bd-b8ba-4670a95d57a7",
+          "source_id": "250bba0f-bd1d-4780-b39a-1876017a3625",
+          "sink_id": "d367d57e-eba8-4bc1-92f6-2f0dcd955bc6",
+          "source_name": "client_error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "2751de14-3d48-4a71-8c07-45a563bccf74",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "0911b9b9-df9b-46b2-bf47-f3cf567e2cc5",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "server_error",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "HTTP 5xx response payload.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": 200
+        }
+      },
+      "input_links": [
+        {
+          "id": "78e310c7-b844-442d-9ede-909f73854a79",
+          "source_id": "250bba0f-bd1d-4780-b39a-1876017a3625",
+          "sink_id": "0911b9b9-df9b-46b2-bf47-f3cf567e2cc5",
+          "source_name": "server_error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "2751de14-3d48-4a71-8c07-45a563bccf74",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    },
+    {
+      "id": "6ad9c5a1-c552-4adc-98a4-a0ee29e82ac6",
+      "block_id": "363ae599-353e-4804-937e-b2ee3cef3da4",
+      "input_default": {
+        "name": "error",
+        "title": null,
+        "value": null,
+        "format": "",
+        "secret": false,
+        "advanced": false,
+        "description": "Transport/runtime error output.",
+        "escape_html": false
+      },
+      "metadata": {
+        "position": {
+          "x": 1000,
+          "y": 380
+        }
+      },
+      "input_links": [
+        {
+          "id": "34b2342a-d091-49c1-87ea-fc7a2518e7fd",
+          "source_id": "250bba0f-bd1d-4780-b39a-1876017a3625",
+          "sink_id": "6ad9c5a1-c552-4adc-98a4-a0ee29e82ac6",
+          "source_name": "error",
+          "sink_name": "value",
+          "is_static": false
+        }
+      ],
+      "output_links": [],
+      "graph_id": "2751de14-3d48-4a71-8c07-45a563bccf74",
+      "graph_version": 1,
+      "webhook_id": null,
+      "webhook": null
+    }
+  ],
+  "links": [
+    {
+      "id": "88eee51e-574c-474b-b410-071f6b585933",
+      "source_id": "573c46cd-e8b7-4cd6-9948-ca9cfc5b685b",
+      "sink_id": "9972a21c-457f-4723-97a9-e1a7835a8f2c",
+      "source_name": "result",
+      "sink_name": "values_#_api_key",
+      "is_static": false
+    },
+    {
+      "id": "2b9ad834-72d1-4cca-ba39-b727f6c41cd5",
+      "source_id": "f4dcb81a-1aa4-40b2-8eb5-52004a5c5701",
+      "sink_id": "9b7b5a04-daff-4dcd-a6a5-531060d6a0fa",
+      "source_name": "result",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "adb1e1bc-38ac-4318-82f3-a5e4734b9baf",
+      "source_id": "9972a21c-457f-4723-97a9-e1a7835a8f2c",
+      "sink_id": "897daf4f-2621-49fa-8a6b-020808da627e",
+      "source_name": "dictionary",
+      "sink_name": "values",
+      "is_static": false
+    },
+    {
+      "id": "f4b9d987-4141-432f-8349-cd1422640378",
+      "source_id": "897daf4f-2621-49fa-8a6b-020808da627e",
+      "sink_id": "35ec619a-2129-44b1-9e2f-04fcd94f6b70",
+      "source_name": "output",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "2ba00ec7-7a58-4848-b2fa-6e8a14c23415",
+      "source_id": "35ec619a-2129-44b1-9e2f-04fcd94f6b70",
+      "sink_id": "250bba0f-bd1d-4780-b39a-1876017a3625",
+      "source_name": "value",
+      "sink_name": "headers",
+      "is_static": false
+    },
+    {
+      "id": "5b5b72ed-61a9-491c-adc5-1c8e85b88a44",
+      "source_id": "9b7b5a04-daff-4dcd-a6a5-531060d6a0fa",
+      "sink_id": "250bba0f-bd1d-4780-b39a-1876017a3625",
+      "source_name": "value",
+      "sink_name": "body",
+      "is_static": false
+    },
+    {
+      "id": "70bf3268-715e-4f70-974c-4d6962c03269",
+      "source_id": "250bba0f-bd1d-4780-b39a-1876017a3625",
+      "sink_id": "0bbce880-dd74-4000-904a-f56905fb4be1",
+      "source_name": "response",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "593cab07-a9de-45bd-b8ba-4670a95d57a7",
+      "source_id": "250bba0f-bd1d-4780-b39a-1876017a3625",
+      "sink_id": "d367d57e-eba8-4bc1-92f6-2f0dcd955bc6",
+      "source_name": "client_error",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "78e310c7-b844-442d-9ede-909f73854a79",
+      "source_id": "250bba0f-bd1d-4780-b39a-1876017a3625",
+      "sink_id": "0911b9b9-df9b-46b2-bf47-f3cf567e2cc5",
+      "source_name": "server_error",
+      "sink_name": "value",
+      "is_static": false
+    },
+    {
+      "id": "34b2342a-d091-49c1-87ea-fc7a2518e7fd",
+      "source_id": "250bba0f-bd1d-4780-b39a-1876017a3625",
+      "sink_id": "6ad9c5a1-c552-4adc-98a4-a0ee29e82ac6",
+      "source_name": "error",
+      "sink_name": "value",
+      "is_static": false
+    }
+  ],
+  "forked_from_id": null,
+  "forked_from_version": null,
+  "sub_graphs": [],
+  "user_id": "",
+  "created_at": "2026-02-28T12:00:00.000Z",
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "API Key": {
+        "advanced": false,
+        "anyOf": [
+          {
+            "format": "short-text",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "secret": true,
+        "title": "API Key",
+        "description": "Citedy API key (starts with citedy_agent_)",
+        "default": "citedy_agent_replace_me"
+      },
+      "Request JSON": {
+        "advanced": false,
+        "anyOf": [
+          {
+            "format": "long-text",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "secret": false,
+        "title": "Request JSON",
+        "description": "JSON payload for the selected Citedy endpoint.",
+        "default": "{\n  \"url\": \"https://your-server.com/webhooks/citedy\",\n  \"event_types\": [\n    \"article.generated\",\n    \"ingestion.completed\"\n  ],\n  \"description\": \"Production webhook\"\n}"
+      }
+    },
+    "required": ["API Key", "Request JSON"]
+  },
+  "output_schema": {
+    "type": "object",
+    "properties": {
+      "response": {
+        "title": "response",
+        "description": "Successful API response payload.",
+        "type": "object"
+      },
+      "client_error": {
+        "title": "client_error",
+        "description": "HTTP 4xx response payload.",
+        "type": "object"
+      },
+      "server_error": {
+        "title": "server_error",
+        "description": "HTTP 5xx response payload.",
+        "type": "object"
+      },
+      "error": {
+        "title": "error",
+        "description": "Transport/runtime error output.",
+        "type": "string"
+      }
+    },
+    "required": []
+  },
+  "has_external_trigger": false,
+  "has_human_in_the_loop": false,
+  "trigger_setup_info": null,
+  "credentials_input_schema": {
+    "properties": {},
+    "required": [],
+    "title": "CitedyTemplateCredentialsInputSchema",
+    "type": "object"
+  }
+}


### PR DESCRIPTION
## Summary

- Adds 19 importable AutoGPT graph templates for [Citedy](https://www.citedy.com) — an AI-powered SEO content automation platform
- Templates use HTTP Request blocks → Citedy API endpoints with Bearer token auth
- Free tier available, API key from citedy.com/dashboard/settings

## Templates included

| Category | Templates | Credits |
|----------|-----------|---------|
| Article Generation | topic-to-publish, url-to-publish, turbo-article | 2-48 |
| Trend Discovery | trend (X/Twitter), reddit, scout, scan | 2-70 |
| Content Ingestion | ingest (YouTube, PDF, audio, URLs) | 1-55 |
| Lead Magnets | lead-magnet (PDF checklists) | 30-100 |
| Short-Form Video | script → avatar → video → merge | 1-185 |
| Social Publishing | micro-post, publish | 1-5 |
| Competitor Analysis | gap-to-publish | 40 |
| Automation | webhook-register, session-manager, product-upload | 1 |

## How it works

1. Import any `citedy-*.agent.json` in AutoGPT
2. Set `API Key` credential (`citedy_agent_...`)
3. Run — template calls Citedy API and returns structured results

## Links

- Website: https://www.citedy.com
- GitHub: https://github.com/Citedy/citedy-seo-agent
- MCP Server: https://mcp.citedy.com/mcp
- 60+ tools, 55 languages, UGC video shorts

## Test plan

- [ ] Import each template in AutoGPT and verify graph renders
- [ ] Run topic-to-publish with test API key
- [ ] Verify error handling on invalid/missing API key