### PR TITLE
feat(copilot): add Langfuse tracing to baseline LLM path

### DIFF
--- a/autogpt_platform/backend/backend/copilot/baseline/service.py
+++ b/autogpt_platform/backend/backend/copilot/baseline/service.py
@@ -13,6 +13,7 @@ from collections.abc import AsyncGenerator
 from typing import Any
 
 import orjson
+from langfuse import propagate_attributes
 
 from backend.copilot.model import (
     ChatMessage,
@@ -197,6 +198,20 @@ async def stream_chat_completion_baseline(
     tools = get_available_tools()
 
     yield StreamStart(messageId=message_id, sessionId=session_id)
+
+    # Propagate user/session context to Langfuse so all LLM calls within
+    # this request are grouped under a single trace with proper attribution.
+    _trace_ctx: Any = None
+    try:
+        _trace_ctx = propagate_attributes(
+            user_id=user_id,
+            session_id=session_id,
+            trace_name="copilot-baseline",
+            tags=["baseline"],
+        )
+        _trace_ctx.__enter__()
+    except Exception:
+        logger.warning("[Baseline] Langfuse trace context setup failed")
 
     assistant_text = ""
     text_block_id = str(uuid.uuid4())
@@ -385,6 +400,13 @@ async def stream_chat_completion_baseline(
         yield StreamError(errorText=error_msg, code="baseline_error")
         # Still persist whatever we got
     finally:
+        # Close Langfuse trace context
+        if _trace_ctx is not None:
+            try:
+                _trace_ctx.__exit__(None, None, None)
+            except Exception:
+                logger.warning("[Baseline] Langfuse trace context teardown failed")
+
         # Persist assistant response
         if assistant_text:
             session.messages.append(

--- a/autogpt_platform/backend/backend/copilot/service.py
+++ b/autogpt_platform/backend/backend/copilot/service.py
@@ -11,8 +11,10 @@ import asyncio
 import logging
 from typing import Any
 
-import openai
 from langfuse import get_client
+from langfuse.openai import (
+    AsyncOpenAI as LangfuseAsyncOpenAI,  # pyright: ignore[reportPrivateImportUsage]
+)
 
 from backend.data.db_accessors import understanding_db
 from backend.data.understanding import format_understanding_for_prompt
@@ -26,7 +28,7 @@ logger = logging.getLogger(__name__)
 
 config = ChatConfig()
 settings = Settings()
-client = openai.AsyncOpenAI(api_key=config.api_key, base_url=config.base_url)
+client = LangfuseAsyncOpenAI(api_key=config.api_key, base_url=config.base_url)
 
 
 langfuse = get_client()


### PR DESCRIPTION
## Summary
Depends on #12276 (baseline code).

- Swap shared OpenAI client to `langfuse.openai.AsyncOpenAI` — auto-captures all LLM calls (token usage, latency, model, prompts) as Langfuse generations when configured
- Add `propagate_attributes()` context in baseline streaming for `user_id`/`session_id` attribution, matching the SDK path's OTEL tracing
- No-op when Langfuse is not configured — `langfuse.openai.AsyncOpenAI` falls back to standard `openai.AsyncOpenAI` behavior

## Observability parity

| Aspect | SDK path | Baseline path (after this PR) |
|--------|----------|-------------------------------|
| LLM call tracing | OTEL via `configure_claude_agent_sdk()` | `langfuse.openai.AsyncOpenAI` auto-instrumentation |
| User/session context | `propagate_attributes()` | `propagate_attributes()` |
| Langfuse prompts | Shared `_build_system_prompt()` | Shared `_build_system_prompt()` |
| Token/cost tracking | Via OTEL spans | Via Langfuse generation objects |

## Test plan
- [x] `poetry run format` passes (pyright, ruff, black, isort)
- [ ] Verify Langfuse traces appear for baseline path with `CHAT_USE_CLAUDE_AGENT_SDK=false`
- [ ] Verify SDK path tracing is unaffected