### PR TITLE
fix(frontend): revalidate layout after email/password login

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/login/useLoginPage.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/login/useLoginPage.ts
@@ -21,8 +21,14 @@ export function useLoginPage() {
   const [showNotAllowedModal, setShowNotAllowedModal] = useState(false);
   const isCloudEnv = environment.isCloud();
 
-  // Get redirect destination from 'next' query parameter
-  const nextUrl = searchParams.get("next");
+  // Get redirect destination from 'next' query parameter.
+  // Only allow relative paths to prevent open redirect attacks
+  // (e.g., /login?next=https://phishing.site).
+  const rawNext = searchParams.get("next");
+  const nextUrl =
+    rawNext && rawNext.startsWith("/") && !rawNext.startsWith("//")
+      ? rawNext
+      : null;
 
   useEffect(() => {
     if (isLoggedIn && !isLoggingIn) {


### PR DESCRIPTION
Requested by @ntindle

After logging in with email/password, the page navigates but renders a blank/unauthenticated state (just logo + cookie banner). A manual page refresh fixes it.

The `login` server action calls `signInWithPassword()` server-side but doesn't call `revalidatePath()`, so Next.js serves cached RSC payloads that don't reflect the new auth state. The OAuth callback route already does this correctly.

**Fix:** Add `revalidatePath(next, "layout")` after successful login, matching the OAuth callback pattern.

Closes SECRT-2059