### PR TITLE
fix(frontend): prevent crash on /library with 401 error from pagination helper

### DIFF
--- a/autogpt_platform/frontend/src/app/api/helpers.ts
+++ b/autogpt_platform/frontend/src/app/api/helpers.ts
@@ -53,6 +53,8 @@ export function getPaginationNextPageNumber(
   if (!hasValidPaginationInfo(lastPage)) return undefined;
 
   const { pagination } = lastPage.data;
+  if (!pagination) return undefined;
+
   const hasMore =
     pagination.current_page * pagination.page_size < pagination.total_items;
   return hasMore ? pagination.current_page + 1 : undefined;


### PR DESCRIPTION
## Changes                                                                                                                                                                                                                                 
Fixes crash on `/library` page when backend returns a 401 authentication error.

### Problem

When the backend returns a 401 error, React Query still calls `getNextPageParam` with the error response. The response doesn't have the expected pagination structure, causing `pagination` to be `undefined`. The code then crashes trying
 to access `pagination.current_page`.

Error:
TypeError: Cannot read properties of undefined (reading 'current_page')
    at Object.getNextPageParam

### Solution

Added a defensive null check in `getPaginationNextPageNumber()` to handle cases where `pagination` is undefined:

```typescript
const { pagination } = lastPage.data;
if (!pagination) return undefined;
```
When undefined is returned, React Query interprets this as "no next page available" and gracefully stops pagination instead of crashing.

Testing

- Manual testing: Verify /library page handles 401 errors without crashing
- The fix is defensive and doesn't change behavior for successful responses

Related Issues

Closes OPEN-2684
