### PR TITLE
fix(frontend): fix 'Open link' button text color to white for contrast

### DIFF
--- a/autogpt_platform/frontend/src/app/globals.css
+++ b/autogpt_platform/frontend/src/app/globals.css
@@ -183,7 +183,7 @@ body[data-google-picker-open="true"] [data-dialog-content] {
 
 /* Streamdown external link dialog: "Open link" button */
 [data-streamdown="link-safety-modal"] button:last-of-type {
-  color: black;
+  color: white;
 }
 
 /* CoPilot chat table styling — remove left/right borders, increase padding */


### PR DESCRIPTION
Requested by @ntindle

The Streamdown external link safety modal's "Open link" button had dark text (`color: black`) on a dark background, making it unreadable. Changed to `color: white` for proper contrast per our design system.

**File:** `autogpt_platform/frontend/src/app/globals.css`

Resolves SECRT-2061

---
Co-authored-by: Nick Tindle (@ntindle)