### PR TITLE
fix(backend): Use db_manager for workspace in add_graph_execution

### DIFF
--- a/autogpt_platform/backend/backend/executor/utils.py
+++ b/autogpt_platform/backend/backend/executor/utils.py
@@ -32,7 +32,7 @@ from backend.data.execution import (
 from backend.data.graph import GraphModel, Node
 from backend.data.model import USER_TIMEZONE_NOT_SET, CredentialsMetaInput, GraphInput
 from backend.data.rabbitmq import Exchange, ExchangeType, Queue, RabbitMQConfig
-from backend.data.workspace import get_or_create_workspace
+from backend.data import workspace as workspace_db
 from backend.util.clients import (
     get_async_execution_event_bus,
     get_async_execution_queue,
@@ -831,8 +831,9 @@ async def add_graph_execution(
         udb = user_db
         gdb = graph_db
         odb = onboarding_db
+        wdb = workspace_db
     else:
-        edb = udb = gdb = odb = get_database_manager_async_client()
+        edb = udb = gdb = odb = wdb = get_database_manager_async_client()
 
     # Get or create the graph execution
     if graph_exec_id:
@@ -892,7 +893,7 @@ async def add_graph_execution(
     if execution_context is None:
         user = await udb.get_user_by_id(user_id)
         settings = await gdb.get_graph_settings(user_id=user_id, graph_id=graph_id)
-        workspace = await get_or_create_workspace(user_id)
+        workspace = await wdb.get_or_create_workspace(user_id)
 
         execution_context = ExecutionContext(
             # Execution identity

--- a/autogpt_platform/backend/backend/executor/utils_test.py
+++ b/autogpt_platform/backend/backend/executor/utils_test.py
@@ -371,7 +371,7 @@ async def test_add_graph_execution_is_repeatable(mocker: MockerFixture):
     mock_workspace = mocker.MagicMock()
     mock_workspace.id = "test-workspace-id"
     mocker.patch(
-        "backend.executor.utils.get_or_create_workspace",
+        "backend.executor.utils.workspace_db.get_or_create_workspace",
         new=mocker.AsyncMock(return_value=mock_workspace),
     )
 
@@ -652,7 +652,7 @@ async def test_add_graph_execution_with_nodes_to_skip(mocker: MockerFixture):
     mock_workspace = mocker.MagicMock()
     mock_workspace.id = "test-workspace-id"
     mocker.patch(
-        "backend.executor.utils.get_or_create_workspace",
+        "backend.executor.utils.workspace_db.get_or_create_workspace",
         new=mocker.AsyncMock(return_value=mock_workspace),
     )
 


### PR DESCRIPTION
When `add_graph_execution` is called from a context where the global Prisma client isn't connected (e.g. CoPilot tools, external API), the call to `get_or_create_workspace(user_id)` crashes with `ClientNotConnectedError` because it directly accesses `UserWorkspace.prisma()`.

The fix adds `workspace_db` to the existing `if prisma.is_connected()` fallback pattern, consistent with how all other DB calls in the function already work.

**Sentry:** AUTOGPT-SERVER-83T (and ~15 related issues going back to Jan 2026)

---
Co-authored-by: Reinier van der Leer (@Pwuts) <pwuts@agpt.co>