### PR TITLE
fix(frontend): bypass Next.js proxy for file uploads to fix 413 error

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/copilot/useCopilotPage.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/useCopilotPage.ts
@@ -5,10 +5,9 @@ import {
   type getV2ListSessionsResponse,
 } from "@/app/api/__generated__/endpoints/chat/chat";
 import { toast } from "@/components/molecules/Toast/use-toast";
+import { uploadFileDirect } from "@/lib/direct-upload";
 import { useBreakpoint } from "@/lib/hooks/useBreakpoint";
-import { getWebSocketToken } from "@/lib/supabase/actions";
 import { useSupabase } from "@/lib/supabase/hooks/useSupabase";
-import { environment } from "@/services/environment";
 import { useQueryClient } from "@tanstack/react-query";
 import type { FileUIPart } from "ai";
 import { useEffect, useRef, useState } from "react";
@@ -129,49 +128,25 @@ export function useCopilotPage() {
     files: File[],
     sid: string,
   ): Promise<UploadedFile[]> {
-    // Upload directly to the Python backend, bypassing the Next.js serverless
-    // proxy.  Vercel's 4.5 MB function payload limit would reject larger files
-    // when routed through /api/workspace/files/upload.
-    const { token, error: tokenError } = await getWebSocketToken();
-    if (tokenError || !token) {
-      toast({
-        title: "Authentication error",
-        description: "Please sign in again.",
-        variant: "destructive",
-      });
-      return [];
-    }
-
-    const backendBase = environment.getAGPTServerBaseUrl();
-
     const results = await Promise.allSettled(
       files.map(async (file) => {
-        const formData = new FormData();
-        formData.append("file", file);
-        const url = new URL("/api/workspace/files/upload", backendBase);
-        url.searchParams.set("session_id", sid);
-        const res = await fetch(url.toString(), {
-          method: "POST",
-          headers: { Authorization: `Bearer ${token}` },
-          body: formData,
-        });
-        if (!res.ok) {
-          const err = await res.text();
+        try {
+          const data = await uploadFileDirect(file, sid);
+          if (!data.file_id) throw new Error("No file_id returned");
+          return {
+            file_id: data.file_id,
+            name: data.name || file.name,
+            mime_type: data.mime_type || "application/octet-stream",
+          } as UploadedFile;
+        } catch (err) {
           console.error("File upload failed:", err);
           toast({
             title: "File upload failed",
             description: file.name,
             variant: "destructive",
           });
-          throw new Error(err);
+          throw err;
         }
-        const data = await res.json();
-        if (!data.file_id) throw new Error("No file_id returned");
-        return {
-          file_id: data.file_id,
-          name: data.name || file.name,
-          mime_type: data.mime_type || "application/octet-stream",
-        } as UploadedFile;
       }),
     );
     return results

--- a/autogpt_platform/frontend/src/components/renderers/InputRenderer/base/standard/widgets/FileInput/useWorkspaceUpload.ts
+++ b/autogpt_platform/frontend/src/components/renderers/InputRenderer/base/standard/widgets/FileInput/useWorkspaceUpload.ts
@@ -1,15 +1,10 @@
-import {
-  usePostWorkspaceUploadFileToWorkspace,
-  useDeleteWorkspaceDeleteAWorkspaceFile,
-} from "@/app/api/__generated__/endpoints/workspace/workspace";
+import { useDeleteWorkspaceDeleteAWorkspaceFile } from "@/app/api/__generated__/endpoints/workspace/workspace";
 import { useToast } from "@/components/molecules/Toast/use-toast";
+import { uploadFileDirect } from "@/lib/direct-upload";
 import { parseWorkspaceFileID, buildWorkspaceURI } from "@/lib/workspace-uri";
 
 export function useWorkspaceUpload() {
   const { toast } = useToast();
-
-  const { mutateAsync: uploadMutation } =
-    usePostWorkspaceUploadFileToWorkspace();
 
   const { mutate: deleteMutation } = useDeleteWorkspaceDeleteAWorkspaceFile({
     mutation: {
@@ -24,11 +19,7 @@ export function useWorkspaceUpload() {
   });
 
   async function handleUploadFile(file: File) {
-    const response = await uploadMutation({ data: { file } });
-    if (response.status !== 200) {
-      throw new Error("Upload failed");
-    }
-    const d = response.data;
+    const d = await uploadFileDirect(file);
     return {
       file_name: d.name,
       size: d.size_bytes,

--- a/autogpt_platform/frontend/src/lib/direct-upload.ts
+++ b/autogpt_platform/frontend/src/lib/direct-upload.ts
@@ -1,0 +1,47 @@
+import { getWebSocketToken } from "@/lib/supabase/actions";
+import { environment } from "@/services/environment";
+
+interface UploadFileResponse {
+  file_id: string;
+  name: string;
+  path: string;
+  mime_type: string;
+  size_bytes: number;
+}
+
+/**
+ * Upload a file directly to the Python backend, bypassing the Next.js proxy.
+ * The Next.js serverless proxy has a ~4.5MB body size limit (Vercel) which
+ * rejects larger files with HTTP 413.
+ */
+export async function uploadFileDirect(
+  file: File,
+  sessionID?: string,
+): Promise<UploadFileResponse> {
+  const { token, error: tokenError } = await getWebSocketToken();
+  if (tokenError || !token) {
+    throw new Error("Authentication error — please sign in again.");
+  }
+
+  const backendBase = environment.getAGPTServerBaseUrl();
+  const url = new URL("/api/workspace/files/upload", backendBase);
+  if (sessionID) {
+    url.searchParams.set("session_id", sessionID);
+  }
+
+  const formData = new FormData();
+  formData.append("file", file);
+
+  const res = await fetch(url.toString(), {
+    method: "POST",
+    headers: { Authorization: `Bearer ${token}` },
+    body: formData,
+  });
+
+  if (!res.ok) {
+    const detail = await res.text().catch(() => res.statusText);
+    throw new Error(`Upload failed (${res.status}): ${detail}`);
+  }
+
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- File uploads routed through the Next.js API proxy (`/api/proxy/...`) fail with HTTP 413 for files >4.5MB due to Vercel's serverless function body size limit
- Created shared `uploadFileDirect` utility (`src/lib/direct-upload.ts`) that uploads files directly from the browser to the Python backend, bypassing the proxy entirely
- Updated `useWorkspaceUpload` to use direct upload instead of the generated hook (which went through the proxy)
- Deduplicated the copilot page's inline upload logic to use the same shared utility

## Changes 🏗️
- **New**: `src/lib/direct-upload.ts` — shared utility for direct-to-backend file uploads (up to 256MB)
- **Updated**: `useWorkspaceUpload.ts` — replaced proxy-based generated hook with `uploadFileDirect`
- **Updated**: `useCopilotPage.ts` — replaced inline upload logic with shared `uploadFileDirect`, removed unused imports

## Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Upload a file >5MB via workspace file input (e.g. in agent builder) — should succeed without 413
  - [x] Upload a file >5MB via copilot chat — should succeed without 413
  - [x] Upload a small file (<1MB) via both paths — should still work
  - [x] Verify file delete still works from workspace file input