### PR TITLE
fix(frontend/copilot): hide New Chat button on Autopilot homepage

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatSidebar/ChatSidebar.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatSidebar/ChatSidebar.tsx
@@ -202,7 +202,7 @@ export function ChatSidebar() {
             >
               <div className="flex flex-col items-center gap-2">
                 <SidebarTrigger />
-                {sessionId && (
+                {sessionId ? (
                   <Button
                     variant="ghost"
                     onClick={handleNewChat}
@@ -211,7 +211,7 @@ export function ChatSidebar() {
                     <PlusCircleIcon className="!size-5" />
                     <span className="sr-only">New Chat</span>
                   </Button>
-                )}
+                ) : null}
               </div>
             </motion.div>
           </SidebarHeader>
@@ -232,7 +232,7 @@ export function ChatSidebar() {
                   <SidebarTrigger />
                 </div>
               </div>
-              {sessionId && (
+              {sessionId ? (
                 <Button
                   variant="primary"
                   size="small"
@@ -242,7 +242,7 @@ export function ChatSidebar() {
                 >
                   New Chat
                 </Button>
-              )}
+              ) : null}
             </motion.div>
           </SidebarHeader>
         )}

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/MobileDrawer/MobileDrawer.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/MobileDrawer/MobileDrawer.tsx
@@ -71,7 +71,7 @@ export function MobileDrawer({
                 <X width="1rem" height="1rem" />
               </Button>
             </div>
-            {currentSessionId && (
+            {currentSessionId ? (
               <div className="mt-2">
                 <Button
                   variant="primary"
@@ -83,7 +83,7 @@ export function MobileDrawer({
                   New Chat
                 </Button>
               </div>
-            )}
+            ) : null}
           </div>
           <div
             className={cn(


### PR DESCRIPTION
Requested by @0ubbe

The **New Chat** button was visible on the Autopilot homepage where clicking it has no effect (since `sessionId` is already `null`). This hides the button when no chat session is active, so it only appears when the user is viewing a conversation and wants to start a new one.

**Changes:**
- `ChatSidebar.tsx` — hide button in both collapsed and expanded sidebar states when `sessionId` is null
- `MobileDrawer.tsx` — same fix for mobile drawer

---
Co-authored-by: Ubbe <ubbe@users.noreply.github.com>