### PR TITLE
Fix integer input using invalid HTML type causing paste issues

### DIFF
--- a/autogpt_platform/frontend/src/components/renderers/InputRenderer/base/standard/widgets/TextInput/TextWidget.tsx
+++ b/autogpt_platform/frontend/src/components/renderers/InputRenderer/base/standard/widgets/TextInput/TextWidget.tsx
@@ -48,7 +48,7 @@ export default function TextWidget(props: WidgetProps) {
       handleChange: (v: string) => (v === "" ? undefined : Number(v)),
     },
     [InputType.INTEGER]: {
-      htmlType: "account",
+      htmlType: "number",
       placeholder: "Enter integer value...",
       handleChange: (v: string) => (v === "" ? undefined : Number(v)),
     },


### PR DESCRIPTION
Fixes #12110. The htmlType for INTEGER inputs was incorrectly set to 'account' which is not a valid HTML input type. This caused browsers to treat the input as text, preventing proper numeric keyboard on mobile devices and bypassing number input filtering. When users pasted numeric strings like '123' into integer fields, the value would not parse correctly and result in NaN being displayed.

Changed the htmlType from 'account' to 'number' to match the expected HTML input type for numeric values.