### PR TITLE
fix(backend): update test patches for validate_url → validate_url_host rename

### DIFF
--- a/autogpt_platform/backend/backend/api/features/mcp/test_routes.py
+++ b/autogpt_platform/backend/backend/api/features/mcp/test_routes.py
@@ -32,9 +32,9 @@ async def client():
 
 @pytest.fixture(autouse=True)
 def _bypass_ssrf_validation():
-    """Bypass validate_url in all route tests (test URLs don't resolve)."""
+    """Bypass validate_url_host in all route tests (test URLs don't resolve)."""
     with patch(
-        "backend.api.features.mcp.routes.validate_url",
+        "backend.api.features.mcp.routes.validate_url_host",
         new_callable=AsyncMock,
     ):
         yield
@@ -521,12 +521,12 @@ class TestStoreToken:
 
 
 class TestSSRFValidation:
-    """Verify that validate_url is enforced on all endpoints."""
+    """Verify that validate_url_host is enforced on all endpoints."""
 
     @pytest.mark.asyncio(loop_scope="session")
     async def test_discover_tools_ssrf_blocked(self, client):
         with patch(
-            "backend.api.features.mcp.routes.validate_url",
+            "backend.api.features.mcp.routes.validate_url_host",
             new_callable=AsyncMock,
             side_effect=ValueError("blocked loopback"),
         ):
@@ -541,7 +541,7 @@ class TestSSRFValidation:
     @pytest.mark.asyncio(loop_scope="session")
     async def test_oauth_login_ssrf_blocked(self, client):
         with patch(
-            "backend.api.features.mcp.routes.validate_url",
+            "backend.api.features.mcp.routes.validate_url_host",
             new_callable=AsyncMock,
             side_effect=ValueError("blocked private IP"),
         ):
@@ -556,7 +556,7 @@ class TestSSRFValidation:
     @pytest.mark.asyncio(loop_scope="session")
     async def test_store_token_ssrf_blocked(self, client):
         with patch(
-            "backend.api.features.mcp.routes.validate_url",
+            "backend.api.features.mcp.routes.validate_url_host",
             new_callable=AsyncMock,
             side_effect=ValueError("blocked loopback"),
         ):

--- a/autogpt_platform/backend/backend/copilot/tools/agent_browser_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/agent_browser_test.py
@@ -68,17 +68,18 @@ def _run_result(rc: int = 0, stdout: str = "", stderr: str = "") -> tuple:
 
 
 # ---------------------------------------------------------------------------
-# SSRF protection via shared validate_url (backend.util.request)
+# SSRF protection via shared validate_url_host (backend.util.request)
 # ---------------------------------------------------------------------------
 
-# Patch target: validate_url is imported directly into agent_browser's module scope.
-_VALIDATE_URL = "backend.copilot.tools.agent_browser.validate_url"
+# Patch target: validate_url_host is imported directly into agent_browser's
+# module scope.
+_VALIDATE_URL = "backend.copilot.tools.agent_browser.validate_url_host"
 
 
 class TestSsrfViaValidateUrl:
-    """Verify that browser_navigate uses validate_url for SSRF protection.
+    """Verify that browser_navigate uses validate_url_host for SSRF protection.
 
-    We mock validate_url itself (not the low-level socket) so these tests
+    We mock validate_url_host itself (not the low-level socket) so these tests
     exercise the integration point, not the internals of request.py
     (which has its own thorough test suite in request_test.py).
     """
@@ -89,7 +90,7 @@ class TestSsrfViaValidateUrl:
 
     @pytest.mark.asyncio
     async def test_blocked_ip_returns_blocked_url_error(self):
-        """validate_url raises ValueError → tool returns blocked_url ErrorResponse."""
+        """validate_url_host raises ValueError → tool returns blocked_url ErrorResponse."""
         with patch(_VALIDATE_URL, new_callable=AsyncMock) as mock_validate:
             mock_validate.side_effect = ValueError(
                 "Access to blocked IP 10.0.0.1 is not allowed."
@@ -124,8 +125,8 @@ class TestSsrfViaValidateUrl:
         assert result.error == "blocked_url"
 
     @pytest.mark.asyncio
-    async def test_validate_url_called_with_empty_trusted_origins(self):
-        """Confirms no trusted-origins bypass is granted — all URLs are validated."""
+    async def test_validate_url_host_called_without_trusted_hostnames(self):
+        """Confirms no trusted-hostnames bypass is granted — all URLs are validated."""
         with patch(_VALIDATE_URL, new_callable=AsyncMock) as mock_validate:
             mock_validate.return_value = (object(), False, ["1.2.3.4"])
             with patch(
@@ -143,7 +144,7 @@ class TestSsrfViaValidateUrl:
                         session=self.session,
                         url="https://example.com",
                     )
-        mock_validate.assert_called_once_with("https://example.com", trusted_origins=[])
+        mock_validate.assert_called_once_with("https://example.com")
 
 
 # ---------------------------------------------------------------------------

--- a/autogpt_platform/backend/backend/copilot/tools/test_run_mcp_tool.py
+++ b/autogpt_platform/backend/backend/copilot/tools/test_run_mcp_tool.py
@@ -100,7 +100,7 @@ async def test_ssrf_blocked_url_returns_error():
     session = make_session(_USER_ID)
 
     with patch(
-        "backend.copilot.tools.run_mcp_tool.validate_url",
+        "backend.copilot.tools.run_mcp_tool.validate_url_host",
         new_callable=AsyncMock,
         side_effect=ValueError("blocked loopback"),
     ):
@@ -138,7 +138,7 @@ async def test_non_dict_tool_arguments_returns_error():
     session = make_session(_USER_ID)
 
     with patch(
-        "backend.copilot.tools.run_mcp_tool.validate_url",
+        "backend.copilot.tools.run_mcp_tool.validate_url_host",
         new_callable=AsyncMock,
     ):
         with patch(
@@ -171,7 +171,7 @@ async def test_discover_tools_returns_discovered_response():
     mock_tools = _make_tool_list("fetch", "search")
 
     with patch(
-        "backend.copilot.tools.run_mcp_tool.validate_url", new_callable=AsyncMock
+        "backend.copilot.tools.run_mcp_tool.validate_url_host", new_callable=AsyncMock
     ):
         with patch(
             "backend.copilot.tools.run_mcp_tool.auto_lookup_mcp_credential",
@@ -208,7 +208,7 @@ async def test_discover_tools_with_credentials():
     mock_tools = _make_tool_list("push_notification")
 
     with patch(
-        "backend.copilot.tools.run_mcp_tool.validate_url", new_callable=AsyncMock
+        "backend.copilot.tools.run_mcp_tool.validate_url_host", new_callable=AsyncMock
     ):
         with patch(
             "backend.copilot.tools.run_mcp_tool.auto_lookup_mcp_credential",
@@ -249,7 +249,7 @@ async def test_execute_tool_returns_output_response():
     text_result = "# Example Domain\nThis domain is for examples."
 
     with patch(
-        "backend.copilot.tools.run_mcp_tool.validate_url", new_callable=AsyncMock
+        "backend.copilot.tools.run_mcp_tool.validate_url_host", new_callable=AsyncMock
     ):
         with patch(
             "backend.copilot.tools.run_mcp_tool.auto_lookup_mcp_credential",
@@ -285,7 +285,7 @@ async def test_execute_tool_parses_json_result():
     session = make_session(_USER_ID)
 
     with patch(
-        "backend.copilot.tools.run_mcp_tool.validate_url", new_callable=AsyncMock
+        "backend.copilot.tools.run_mcp_tool.validate_url_host", new_callable=AsyncMock
     ):
         with patch(
             "backend.copilot.tools.run_mcp_tool.auto_lookup_mcp_credential",
@@ -320,7 +320,7 @@ async def test_execute_tool_image_content():
     session = make_session(_USER_ID)
 
     with patch(
-        "backend.copilot.tools.run_mcp_tool.validate_url", new_callable=AsyncMock
+        "backend.copilot.tools.run_mcp_tool.validate_url_host", new_callable=AsyncMock
     ):
         with patch(
             "backend.copilot.tools.run_mcp_tool.auto_lookup_mcp_credential",
@@ -359,7 +359,7 @@ async def test_execute_tool_resource_content():
     session = make_session(_USER_ID)
 
     with patch(
-        "backend.copilot.tools.run_mcp_tool.validate_url", new_callable=AsyncMock
+        "backend.copilot.tools.run_mcp_tool.validate_url_host", new_callable=AsyncMock
     ):
         with patch(
             "backend.copilot.tools.run_mcp_tool.auto_lookup_mcp_credential",
@@ -399,7 +399,7 @@ async def test_execute_tool_multi_item_content():
     session = make_session(_USER_ID)
 
     with patch(
-        "backend.copilot.tools.run_mcp_tool.validate_url", new_callable=AsyncMock
+        "backend.copilot.tools.run_mcp_tool.validate_url_host", new_callable=AsyncMock
     ):
         with patch(
             "backend.copilot.tools.run_mcp_tool.auto_lookup_mcp_credential",
@@ -437,7 +437,7 @@ async def test_execute_tool_empty_content_returns_none():
     session = make_session(_USER_ID)
 
     with patch(
-        "backend.copilot.tools.run_mcp_tool.validate_url", new_callable=AsyncMock
+        "backend.copilot.tools.run_mcp_tool.validate_url_host", new_callable=AsyncMock
     ):
         with patch(
             "backend.copilot.tools.run_mcp_tool.auto_lookup_mcp_credential",
@@ -470,7 +470,7 @@ async def test_execute_tool_returns_error_on_tool_failure():
     session = make_session(_USER_ID)
 
     with patch(
-        "backend.copilot.tools.run_mcp_tool.validate_url", new_callable=AsyncMock
+        "backend.copilot.tools.run_mcp_tool.validate_url_host", new_callable=AsyncMock
     ):
         with patch(
             "backend.copilot.tools.run_mcp_tool.auto_lookup_mcp_credential",
@@ -512,7 +512,7 @@ async def test_auth_required_without_creds_returns_setup_requirements():
     session = make_session(_USER_ID)
 
     with patch(
-        "backend.copilot.tools.run_mcp_tool.validate_url", new_callable=AsyncMock
+        "backend.copilot.tools.run_mcp_tool.validate_url_host", new_callable=AsyncMock
     ):
         with patch(
             "backend.copilot.tools.run_mcp_tool.auto_lookup_mcp_credential",
@@ -555,7 +555,7 @@ async def test_auth_error_with_existing_creds_returns_error():
     mock_creds.access_token = SecretStr("stale-token")
 
     with patch(
-        "backend.copilot.tools.run_mcp_tool.validate_url", new_callable=AsyncMock
+        "backend.copilot.tools.run_mcp_tool.validate_url_host", new_callable=AsyncMock
     ):
         with patch(
             "backend.copilot.tools.run_mcp_tool.auto_lookup_mcp_credential",
@@ -589,7 +589,7 @@ async def test_mcp_client_error_returns_error_response():
     session = make_session(_USER_ID)
 
     with patch(
-        "backend.copilot.tools.run_mcp_tool.validate_url", new_callable=AsyncMock
+        "backend.copilot.tools.run_mcp_tool.validate_url_host", new_callable=AsyncMock
     ):
         with patch(
             "backend.copilot.tools.run_mcp_tool.auto_lookup_mcp_credential",
@@ -621,7 +621,7 @@ async def test_unexpected_exception_returns_generic_error():
     session = make_session(_USER_ID)
 
     with patch(
-        "backend.copilot.tools.run_mcp_tool.validate_url", new_callable=AsyncMock
+        "backend.copilot.tools.run_mcp_tool.validate_url_host", new_callable=AsyncMock
     ):
         with patch(
             "backend.copilot.tools.run_mcp_tool.auto_lookup_mcp_credential",
@@ -719,7 +719,7 @@ async def test_credential_lookup_normalizes_trailing_slash():
     url_with_slash = "https://mcp.example.com/mcp/"
 
     with patch(
-        "backend.copilot.tools.run_mcp_tool.validate_url", new_callable=AsyncMock
+        "backend.copilot.tools.run_mcp_tool.validate_url_host", new_callable=AsyncMock
     ):
         with patch(
             "backend.copilot.tools.run_mcp_tool.auto_lookup_mcp_credential",


### PR DESCRIPTION
bfb843a renamed `validate_url` to `validate_url_host` in `agent_browser`, `run_mcp_tool`, and MCP routes, but the corresponding test files still patched the old name, causing `AttributeError` in CI.

Updates all mock patch targets and assertions across 3 test files:
- `agent_browser_test.py`
- `test_run_mcp_tool.py`  
- `mcp/test_routes.py`

---
Co-authored-by: Zamil Majdy (@majdyz) <zamil.majdy@agpt.co>
Co-authored-by: Reinier van der Leer (@Pwuts) <pwuts@agpt.co>