### PR TITLE
feat(platform): Add LLM registry core - DB layer + in-memory cache

### DIFF
--- a/autogpt_platform/backend/backend/api/rest_api.py
+++ b/autogpt_platform/backend/backend/api/rest_api.py
@@ -1,3 +1,4 @@
+import asyncio
 import contextlib
 import logging
 import platform
@@ -118,17 +119,25 @@ async def lifespan_context(app: fastapi.FastAPI):
 
     AutoRegistry.patch_integrations()
 
-    # Refresh LLM registry before initializing blocks so blocks can use registry data
+    # Load LLM registry before initializing blocks so blocks can use registry data.
+    # Tries Redis first (fast path on warm restart), falls back to DB.
     # Note: Graceful fallback for now since no blocks consume registry yet (comes in PR #5)
-    # When block integration lands, this should fail hard or skip block initialization
     try:
         await backend.data.llm_registry.refresh_llm_registry()
-        logger.info("LLM registry refreshed successfully at startup")
+        logger.info("LLM registry loaded successfully at startup")
     except Exception as e:
         logger.warning(
-            f"Failed to refresh LLM registry at startup: {e}. "
+            f"Failed to load LLM registry at startup: {e}. "
             "Blocks will initialize with empty registry."
         )
+
+    # Start background task so this worker reloads its in-process cache whenever
+    # another worker (e.g. the admin API) refreshes the registry.
+    _registry_subscription_task = asyncio.create_task(
+        backend.data.llm_registry.subscribe_to_registry_refresh(
+            backend.data.llm_registry.refresh_llm_registry
+        )
+    )
 
     await backend.data.block.initialize_blocks()
 
@@ -153,6 +162,12 @@ async def lifespan_context(app: fastapi.FastAPI):
 
     with launch_darkly_context():
         yield
+
+    _registry_subscription_task.cancel()
+    try:
+        await _registry_subscription_task
+    except asyncio.CancelledError:
+        pass
 
     try:
         await shutdown_cloud_storage_handler()

--- a/autogpt_platform/backend/backend/api/rest_api.py
+++ b/autogpt_platform/backend/backend/api/rest_api.py
@@ -119,9 +119,8 @@ async def lifespan_context(app: fastapi.FastAPI):
 
     AutoRegistry.patch_integrations()
 
-    # Load LLM registry before initializing blocks so blocks can use registry data.
-    # Tries Redis first (fast path on warm restart), falls back to DB.
-    # Note: Graceful fallback for now since no blocks consume registry yet (comes in PR #5)
+    _registry_subscription_task: asyncio.Task | None = None
+
     try:
         await backend.data.llm_registry.refresh_llm_registry()
         logger.info("LLM registry loaded successfully at startup")
@@ -131,8 +130,6 @@ async def lifespan_context(app: fastapi.FastAPI):
             "Blocks will initialize with empty registry."
         )
 
-    # Start background task so this worker reloads its in-process cache whenever
-    # another worker (e.g. the admin API) refreshes the registry.
     _registry_subscription_task = asyncio.create_task(
         backend.data.llm_registry.subscribe_to_registry_refresh(
             backend.data.llm_registry.refresh_llm_registry
@@ -146,28 +143,22 @@ async def lifespan_context(app: fastapi.FastAPI):
     try:
         await backend.data.graph.migrate_llm_models(DEFAULT_LLM_MODEL)
     except Exception as e:
-        err_str = str(e)
-        if "AgentNode" in err_str or "does not exist" in err_str:
-            logger.warning(
-                f"migrate_llm_models skipped: AgentNode table not found ({e}). "
-                "This is expected in test environments."
-            )
+        if "AgentNode" in str(e):
+            logger.warning("migrate_llm_models skipped: AgentNode table not found (%s)", e)
         else:
-            logger.error(
-                f"migrate_llm_models failed unexpectedly: {e}",
-                exc_info=True,
-            )
+            logger.error("migrate_llm_models failed unexpectedly: %s", e, exc_info=True)
 
     await backend.integrations.webhooks.utils.migrate_legacy_triggered_graphs()
 
     with launch_darkly_context():
         yield
 
-    _registry_subscription_task.cancel()
-    try:
-        await _registry_subscription_task
-    except asyncio.CancelledError:
-        pass
+    if _registry_subscription_task:
+        _registry_subscription_task.cancel()
+        try:
+            await _registry_subscription_task
+        except asyncio.CancelledError:
+            pass
 
     try:
         await shutdown_cloud_storage_handler()

--- a/autogpt_platform/backend/backend/api/rest_api.py
+++ b/autogpt_platform/backend/backend/api/rest_api.py
@@ -117,6 +117,14 @@ async def lifespan_context(app: fastapi.FastAPI):
 
     AutoRegistry.patch_integrations()
 
+    # Refresh LLM registry before initializing blocks so blocks can use registry data
+    try:
+        from backend.data.llm_registry import refresh_llm_registry
+
+        await refresh_llm_registry()
+    except Exception as e:
+        logger.warning(f"Failed to refresh LLM registry at startup: {e}")
+
     await backend.data.block.initialize_blocks()
 
     await backend.data.user.migrate_and_encrypt_user_integrations()

--- a/autogpt_platform/backend/backend/api/rest_api.py
+++ b/autogpt_platform/backend/backend/api/rest_api.py
@@ -37,6 +37,7 @@ import backend.api.features.workspace.routes as workspace_routes
 import backend.data.block
 import backend.data.db
 import backend.data.graph
+import backend.data.llm_registry
 import backend.data.user
 import backend.integrations.webhooks.utils
 import backend.util.service
@@ -121,9 +122,7 @@ async def lifespan_context(app: fastapi.FastAPI):
     # Note: Graceful fallback for now since no blocks consume registry yet (comes in PR #5)
     # When block integration lands, this should fail hard or skip block initialization
     try:
-        from backend.data.llm_registry import refresh_llm_registry
-
-        await refresh_llm_registry()
+        await backend.data.llm_registry.refresh_llm_registry()
         logger.info("LLM registry refreshed successfully at startup")
     except Exception as e:
         logger.warning(

--- a/autogpt_platform/backend/backend/api/rest_api.py
+++ b/autogpt_platform/backend/backend/api/rest_api.py
@@ -137,10 +137,17 @@ async def lifespan_context(app: fastapi.FastAPI):
     try:
         await backend.data.graph.migrate_llm_models(DEFAULT_LLM_MODEL)
     except Exception as e:
-        logger.warning(
-            f"Failed to migrate LLM models at startup: {e}. "
-            "This is expected in test environments without AgentNode table."
-        )
+        err_str = str(e)
+        if "AgentNode" in err_str or "does not exist" in err_str:
+            logger.warning(
+                f"migrate_llm_models skipped: AgentNode table not found ({e}). "
+                "This is expected in test environments."
+            )
+        else:
+            logger.error(
+                f"migrate_llm_models failed unexpectedly: {e}",
+                exc_info=True,
+            )
 
     await backend.integrations.webhooks.utils.migrate_legacy_triggered_graphs()
 

--- a/autogpt_platform/backend/backend/api/rest_api.py
+++ b/autogpt_platform/backend/backend/api/rest_api.py
@@ -134,7 +134,14 @@ async def lifespan_context(app: fastapi.FastAPI):
 
     await backend.data.user.migrate_and_encrypt_user_integrations()
     await backend.data.graph.fix_llm_provider_credentials()
-    await backend.data.graph.migrate_llm_models(DEFAULT_LLM_MODEL)
+    try:
+        await backend.data.graph.migrate_llm_models(DEFAULT_LLM_MODEL)
+    except Exception as e:
+        logger.warning(
+            f"Failed to migrate LLM models at startup: {e}. "
+            "This is expected in test environments without AgentNode table."
+        )
+
     await backend.integrations.webhooks.utils.migrate_legacy_triggered_graphs()
 
     with launch_darkly_context():

--- a/autogpt_platform/backend/backend/api/rest_api.py
+++ b/autogpt_platform/backend/backend/api/rest_api.py
@@ -118,12 +118,18 @@ async def lifespan_context(app: fastapi.FastAPI):
     AutoRegistry.patch_integrations()
 
     # Refresh LLM registry before initializing blocks so blocks can use registry data
+    # Note: Graceful fallback for now since no blocks consume registry yet (comes in PR #5)
+    # When block integration lands, this should fail hard or skip block initialization
     try:
         from backend.data.llm_registry import refresh_llm_registry
 
         await refresh_llm_registry()
+        logger.info("LLM registry refreshed successfully at startup")
     except Exception as e:
-        logger.warning(f"Failed to refresh LLM registry at startup: {e}")
+        logger.warning(
+            f"Failed to refresh LLM registry at startup: {e}. "
+            "Blocks will initialize with empty registry."
+        )
 
     await backend.data.block.initialize_blocks()
 

--- a/autogpt_platform/backend/backend/data/graph.py
+++ b/autogpt_platform/backend/backend/data/graph.py
@@ -38,7 +38,7 @@ from backend.util.request import parse_url
 from .block import BlockInput
 from .db import BaseDbModel, execute_raw_with_schema
 from .db import prisma as db
-from .db import query_raw_with_schema, transaction
+from .db import execute_raw_with_schema, query_raw_with_schema, transaction
 from .dynamic_fields import is_tool_pin, sanitize_pin_name
 from .includes import AGENT_GRAPH_INCLUDE, AGENT_NODE_INCLUDE, MAX_GRAPH_VERSIONS_FETCH
 from .model import CredentialsFieldInfo, CredentialsMetaInput, is_credentials_field_name
@@ -1667,15 +1667,12 @@ async def migrate_llm_models(migrate_to: LlmModel):
 
     # Update each block
     for id, path in llm_model_fields.items():
-        query = (
-            """
+        query = """
             UPDATE {schema_prefix}"AgentNode"
             SET "constantInput" = jsonb_set("constantInput", $1, to_jsonb($2), true)
             WHERE "agentBlockId" = $3
             AND "constantInput" ? ($4)::text
-            AND "constantInput"->>($4)::text NOT IN """
-            + enum_values
-        )
+            AND "constantInput"->>($4)::text NOT IN """ + enum_values
 
         await execute_raw_with_schema(
             query,

--- a/autogpt_platform/backend/backend/data/llm_registry/__init__.py
+++ b/autogpt_platform/backend/backend/data/llm_registry/__init__.py
@@ -1,10 +1,15 @@
 """LLM Registry - Dynamic model management system."""
 
 from backend.blocks.llm import ModelMetadata
+from .notifications import (
+    publish_registry_refresh_notification,
+    subscribe_to_registry_refresh,
+)
 from .registry import (
     RegistryModel,
     RegistryModelCost,
     RegistryModelCreator,
+    clear_registry_cache,
     get_all_model_slugs_for_validation,
     get_all_models,
     get_default_model_slug,
@@ -20,7 +25,11 @@ __all__ = [
     "RegistryModel",
     "RegistryModelCost",
     "RegistryModelCreator",
-    # Functions
+    # Cache management
+    "clear_registry_cache",
+    "publish_registry_refresh_notification",
+    "subscribe_to_registry_refresh",
+    # Read functions
     "refresh_llm_registry",
     "get_model",
     "get_all_models",

--- a/autogpt_platform/backend/backend/data/llm_registry/__init__.py
+++ b/autogpt_platform/backend/backend/data/llm_registry/__init__.py
@@ -1,6 +1,6 @@
 """LLM Registry - Dynamic model management system."""
 
-from .model import ModelMetadata
+from backend.blocks.llm import ModelMetadata
 from .registry import (
     RegistryModel,
     RegistryModelCost,

--- a/autogpt_platform/backend/backend/data/llm_registry/__init__.py
+++ b/autogpt_platform/backend/backend/data/llm_registry/__init__.py
@@ -1,0 +1,31 @@
+"""LLM Registry - Dynamic model management system."""
+
+from .model import ModelMetadata
+from .registry import (
+    RegistryModel,
+    RegistryModelCost,
+    RegistryModelCreator,
+    get_all_model_slugs_for_validation,
+    get_all_models,
+    get_default_model_slug,
+    get_enabled_models,
+    get_model,
+    get_schema_options,
+    refresh_llm_registry,
+)
+
+__all__ = [
+    # Models
+    "ModelMetadata",
+    "RegistryModel",
+    "RegistryModelCost",
+    "RegistryModelCreator",
+    # Functions
+    "refresh_llm_registry",
+    "get_model",
+    "get_all_models",
+    "get_enabled_models",
+    "get_schema_options",
+    "get_default_model_slug",
+    "get_all_model_slugs_for_validation",
+]

--- a/autogpt_platform/backend/backend/data/llm_registry/model.py
+++ b/autogpt_platform/backend/backend/data/llm_registry/model.py
@@ -1,0 +1,25 @@
+"""Type definitions for LLM model metadata."""
+
+from typing import Literal, NamedTuple
+
+
+class ModelMetadata(NamedTuple):
+    """Metadata for an LLM model.
+
+    Attributes:
+        provider: The provider identifier (e.g., "openai", "anthropic")
+        context_window: Maximum context window size in tokens
+        max_output_tokens: Maximum output tokens (None if unlimited)
+        display_name: Human-readable name for the model
+        provider_name: Human-readable provider name (e.g., "OpenAI", "Anthropic")
+        creator_name: Name of the organization that created the model
+        price_tier: Relative cost tier (1=cheapest, 2=medium, 3=expensive)
+    """
+
+    provider: str
+    context_window: int
+    max_output_tokens: int | None
+    display_name: str
+    provider_name: str
+    creator_name: str
+    price_tier: Literal[1, 2, 3]

--- a/autogpt_platform/backend/backend/data/llm_registry/model.py
+++ b/autogpt_platform/backend/backend/data/llm_registry/model.py
@@ -1,25 +1,9 @@
-"""Type definitions for LLM model metadata."""
+"""Type definitions for LLM model metadata.
 
-from typing import Literal, NamedTuple
+Re-exports ModelMetadata from blocks.llm to avoid type collision.
+In PR #5 (block integration), this will become the canonical location.
+"""
 
+from backend.blocks.llm import ModelMetadata
 
-class ModelMetadata(NamedTuple):
-    """Metadata for an LLM model.
-
-    Attributes:
-        provider: The provider identifier (e.g., "openai", "anthropic")
-        context_window: Maximum context window size in tokens
-        max_output_tokens: Maximum output tokens (None if unlimited)
-        display_name: Human-readable name for the model
-        provider_name: Human-readable provider name (e.g., "OpenAI", "Anthropic")
-        creator_name: Name of the organization that created the model
-        price_tier: Relative cost tier (1=cheapest, 2=medium, 3=expensive)
-    """
-
-    provider: str
-    context_window: int
-    max_output_tokens: int | None
-    display_name: str
-    provider_name: str
-    creator_name: str
-    price_tier: Literal[1, 2, 3]
+__all__ = ["ModelMetadata"]

--- a/autogpt_platform/backend/backend/data/llm_registry/model.py
+++ b/autogpt_platform/backend/backend/data/llm_registry/model.py
@@ -1,9 +1,0 @@
-"""Type definitions for LLM model metadata.
-
-Re-exports ModelMetadata from blocks.llm to avoid type collision.
-In PR #5 (block integration), this will become the canonical location.
-"""
-
-from backend.blocks.llm import ModelMetadata
-
-__all__ = ["ModelMetadata"]

--- a/autogpt_platform/backend/backend/data/llm_registry/notifications.py
+++ b/autogpt_platform/backend/backend/data/llm_registry/notifications.py
@@ -1,0 +1,84 @@
+"""Pub/sub notifications for LLM registry cross-process synchronisation."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Awaitable, Callable
+
+logger = logging.getLogger(__name__)
+
+REGISTRY_REFRESH_CHANNEL = "llm_registry:refresh"
+
+
+async def publish_registry_refresh_notification() -> None:
+    """Publish a refresh signal so all other workers reload their in-process cache."""
+    from backend.data.redis_client import get_redis_async
+
+    try:
+        redis = await get_redis_async()
+        await redis.publish(REGISTRY_REFRESH_CHANNEL, "refresh")
+        logger.debug("Published LLM registry refresh notification")
+    except Exception as e:
+        logger.warning("Failed to publish registry refresh notification: %s", e)
+
+
+async def subscribe_to_registry_refresh(
+    on_refresh: Callable[[], Awaitable[None]],
+) -> None:
+    """Listen for registry refresh signals and call on_refresh each time one arrives.
+
+    Designed to run as a long-lived background asyncio.Task.  Automatically
+    reconnects if the Redis connection drops.
+
+    Args:
+        on_refresh: Async callable invoked on each refresh signal.
+                    Typically ``llm_registry.refresh_llm_registry``.
+    """
+    from backend.data.redis_client import HOST, PASSWORD, PORT
+    from redis.asyncio import Redis as AsyncRedis
+
+    while True:
+        try:
+            # Dedicated connection — pub/sub must not share a connection used
+            # for regular commands.
+            redis_sub = AsyncRedis(
+                host=HOST, port=PORT, password=PASSWORD, decode_responses=True
+            )
+            pubsub = redis_sub.pubsub()
+            await pubsub.subscribe(REGISTRY_REFRESH_CHANNEL)
+            logger.info("Subscribed to LLM registry refresh channel")
+
+            while True:
+                try:
+                    message = await pubsub.get_message(
+                        ignore_subscribe_messages=True, timeout=1.0
+                    )
+                    if (
+                        message
+                        and message["type"] == "message"
+                        and message["channel"] == REGISTRY_REFRESH_CHANNEL
+                    ):
+                        logger.debug("LLM registry refresh signal received")
+                        try:
+                            await on_refresh()
+                        except Exception as e:
+                            logger.error(
+                                "Error in registry on_refresh callback: %s", e
+                            )
+                except asyncio.CancelledError:
+                    raise
+                except Exception as e:
+                    logger.warning(
+                        "Error processing registry refresh message: %s", e
+                    )
+                    await asyncio.sleep(1)
+
+        except asyncio.CancelledError:
+            logger.info("LLM registry subscription task cancelled")
+            break
+        except Exception as e:
+            logger.warning(
+                "LLM registry subscription error: %s. Retrying in 5s...", e
+            )
+            await asyncio.sleep(5)

--- a/autogpt_platform/backend/backend/data/llm_registry/notifications.py
+++ b/autogpt_platform/backend/backend/data/llm_registry/notifications.py
@@ -6,6 +6,9 @@ import asyncio
 import logging
 from typing import Awaitable, Callable
 
+from backend.data.redis_client import HOST, PASSWORD, PORT
+from redis.asyncio import Redis as AsyncRedis
+
 logger = logging.getLogger(__name__)
 
 REGISTRY_REFRESH_CHANNEL = "llm_registry:refresh"
@@ -35,9 +38,6 @@ async def subscribe_to_registry_refresh(
         on_refresh: Async callable invoked on each refresh signal.
                     Typically ``llm_registry.refresh_llm_registry``.
     """
-    from backend.data.redis_client import HOST, PASSWORD, PORT
-    from redis.asyncio import Redis as AsyncRedis
-
     while True:
         try:
             # Dedicated connection — pub/sub must not share a connection used

--- a/autogpt_platform/backend/backend/data/llm_registry/notifications_test.py
+++ b/autogpt_platform/backend/backend/data/llm_registry/notifications_test.py
@@ -1,0 +1,195 @@
+"""Tests for LLM registry pub/sub notifications (notifications.py).
+
+Covers:
+- publish_registry_refresh_notification: happy path and Redis error swallowed
+- subscribe_to_registry_refresh: message triggers on_refresh, non-message
+  types ignored, wrong channel ignored, CancelledError stops the loop,
+  connection errors trigger reconnect
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from backend.data.llm_registry.notifications import (
+    REGISTRY_REFRESH_CHANNEL,
+    publish_registry_refresh_notification,
+    subscribe_to_registry_refresh,
+)
+
+
+# ---------------------------------------------------------------------------
+# publish_registry_refresh_notification
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_publish_sends_to_correct_channel(mocker):
+    """publish_registry_refresh_notification publishes on the registry channel."""
+    mock_redis = AsyncMock()
+    mocker.patch(
+        "backend.data.redis_client.get_redis_async",
+        return_value=mock_redis,
+    )
+
+    await publish_registry_refresh_notification()
+
+    mock_redis.publish.assert_called_once_with(REGISTRY_REFRESH_CHANNEL, "refresh")
+
+
+@pytest.mark.asyncio
+async def test_publish_swallows_redis_error(mocker):
+    """Redis errors during publish are caught and logged, not raised."""
+    mocker.patch(
+        "backend.data.redis_client.get_redis_async",
+        side_effect=ConnectionError("Redis unavailable"),
+    )
+
+    # Should not raise — errors are swallowed to avoid crashing the admin op
+    await publish_registry_refresh_notification()
+
+
+# ---------------------------------------------------------------------------
+# subscribe_to_registry_refresh
+# ---------------------------------------------------------------------------
+
+
+def _make_pubsub(messages: list) -> MagicMock:
+    """Build a mock pubsub that returns messages in sequence then raises CancelledError."""
+    pubsub = AsyncMock()
+    pubsub.subscribe = AsyncMock()
+    # Once messages are exhausted the next get_message raises CancelledError to
+    # break the infinite loop cleanly in tests.
+    pubsub.get_message = AsyncMock(
+        side_effect=messages + [asyncio.CancelledError()]
+    )
+    return pubsub
+
+
+def _make_message(channel: str = REGISTRY_REFRESH_CHANNEL, msg_type: str = "message"):
+    return {"type": msg_type, "channel": channel, "data": "refresh"}
+
+
+@pytest.mark.asyncio
+async def test_subscribe_calls_on_refresh_for_valid_message(mocker):
+    """A message on the registry channel triggers the on_refresh callback."""
+    on_refresh = AsyncMock()
+    pubsub = _make_pubsub([_make_message()])
+
+    mock_redis = MagicMock()
+    mock_redis.pubsub.return_value = pubsub
+    mocker.patch("redis.asyncio.Redis", return_value=mock_redis)
+
+    await subscribe_to_registry_refresh(on_refresh)
+
+    on_refresh.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_subscribe_ignores_non_message_types(mocker):
+    """Subscribe messages of type 'subscribe' (handshake) do not trigger on_refresh."""
+    on_refresh = AsyncMock()
+    pubsub = _make_pubsub([
+        _make_message(msg_type="subscribe"),   # handshake — should be ignored
+        _make_message(msg_type="psubscribe"),  # also ignored
+    ])
+
+    mock_redis = MagicMock()
+    mock_redis.pubsub.return_value = pubsub
+    mocker.patch("redis.asyncio.Redis", return_value=mock_redis)
+
+    await subscribe_to_registry_refresh(on_refresh)
+
+    on_refresh.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_subscribe_ignores_wrong_channel(mocker):
+    """Messages on a different channel do not trigger on_refresh."""
+    on_refresh = AsyncMock()
+    pubsub = _make_pubsub([_make_message(channel="some:other:channel")])
+
+    mock_redis = MagicMock()
+    mock_redis.pubsub.return_value = pubsub
+    mocker.patch("redis.asyncio.Redis", return_value=mock_redis)
+
+    await subscribe_to_registry_refresh(on_refresh)
+
+    on_refresh.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_subscribe_handles_none_message(mocker):
+    """None returned by get_message (timeout) does not crash or trigger on_refresh."""
+    on_refresh = AsyncMock()
+    pubsub = _make_pubsub([None, None])  # two timeouts, then CancelledError
+
+    mock_redis = MagicMock()
+    mock_redis.pubsub.return_value = pubsub
+    mocker.patch("redis.asyncio.Redis", return_value=mock_redis)
+
+    await subscribe_to_registry_refresh(on_refresh)
+
+    on_refresh.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_subscribe_processes_multiple_messages(mocker):
+    """Multiple valid messages each trigger on_refresh."""
+    on_refresh = AsyncMock()
+    pubsub = _make_pubsub([_make_message(), _make_message(), _make_message()])
+
+    mock_redis = MagicMock()
+    mock_redis.pubsub.return_value = pubsub
+    mocker.patch("redis.asyncio.Redis", return_value=mock_redis)
+
+    await subscribe_to_registry_refresh(on_refresh)
+
+    assert on_refresh.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_subscribe_cancelled_error_stops_loop(mocker):
+    """CancelledError at the outer loop level causes the function to return cleanly."""
+    on_refresh = AsyncMock()
+    pubsub = AsyncMock()
+    pubsub.subscribe = AsyncMock(side_effect=asyncio.CancelledError())
+
+    mock_redis = MagicMock()
+    mock_redis.pubsub.return_value = pubsub
+    mocker.patch("redis.asyncio.Redis", return_value=mock_redis)
+
+    # Should return normally — CancelledError is caught and the loop breaks
+    await subscribe_to_registry_refresh(on_refresh)
+
+    on_refresh.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_subscribe_reconnects_after_connection_error(mocker):
+    """A connection error on the first attempt triggers a reconnect attempt."""
+    on_refresh = AsyncMock()
+
+    # First call raises ConnectionError; second call succeeds then CancelledError
+    good_pubsub = _make_pubsub([_make_message()])
+    bad_redis = MagicMock()
+    bad_redis.pubsub.side_effect = ConnectionError("Redis down")
+    good_redis = MagicMock()
+    good_redis.pubsub.return_value = good_pubsub
+
+    mock_redis_cls = mocker.patch(
+        "redis.asyncio.Redis", side_effect=[bad_redis, good_redis]
+    )
+    mock_sleep = mocker.patch("asyncio.sleep", new=AsyncMock())
+
+    await subscribe_to_registry_refresh(on_refresh)
+
+    # Should have slept before retrying
+    mock_sleep.assert_called_once_with(5)
+    # Should have tried to create two Redis connections
+    assert mock_redis_cls.call_count == 2
+    # After reconnect, the valid message triggered on_refresh
+    on_refresh.assert_called_once()

--- a/autogpt_platform/backend/backend/data/llm_registry/registry.py
+++ b/autogpt_platform/backend/backend/data/llm_registry/registry.py
@@ -1,0 +1,227 @@
+"""Core LLM registry implementation for managing models dynamically."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+import prisma.models
+
+from backend.data.llm_registry.model import ModelMetadata
+
+logger = logging.getLogger(__name__)
+
+
+def _json_to_dict(value: Any) -> dict[str, Any]:
+    """Convert Prisma Json type to dict, with fallback to empty dict."""
+    if value is None:
+        return {}
+    if isinstance(value, dict):
+        return value
+    # Prisma Json type should always be a dict at runtime
+    return dict(value) if value else {}
+
+
+@dataclass(frozen=True)
+class RegistryModelCost:
+    """Cost configuration for an LLM model."""
+
+    credit_cost: int
+    credential_provider: str
+    credential_id: str | None
+    credential_type: str | None
+    currency: str | None
+    metadata: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class RegistryModelCreator:
+    """Creator information for an LLM model."""
+
+    id: str
+    name: str
+    display_name: str
+    description: str | None
+    website_url: str | None
+    logo_url: str | None
+
+
+@dataclass(frozen=True)
+class RegistryModel:
+    """Represents a model in the LLM registry."""
+
+    slug: str
+    display_name: str
+    description: str | None
+    metadata: ModelMetadata
+    capabilities: dict[str, Any]
+    extra_metadata: dict[str, Any]
+    provider_display_name: str
+    is_enabled: bool
+    is_recommended: bool = False
+    costs: tuple[RegistryModelCost, ...] = field(default_factory=tuple)
+    creator: RegistryModelCreator | None = None
+
+
+# In-memory cache (will be replaced with Redis in PR #6)
+_dynamic_models: dict[str, RegistryModel] = {}
+_schema_options: list[dict[str, str]] = []
+_lock = asyncio.Lock()
+
+
+async def refresh_llm_registry() -> None:
+    """
+    Refresh the LLM registry from the database.
+
+    Fetches all models with their costs, providers, and creators,
+    then updates the in-memory cache.
+    """
+    async with _lock:
+        try:
+            records = await prisma.models.LlmModel.prisma().find_many(
+                include={
+                    "Provider": True,
+                    "Costs": True,
+                    "Creator": True,
+                }
+            )
+            logger.info(f"Fetched {len(records)} LLM models from database")
+
+            # Build model instances
+            new_models: dict[str, RegistryModel] = {}
+            for record in records:
+                # Parse costs
+                costs = tuple(
+                    RegistryModelCost(
+                        credit_cost=cost.creditCost,
+                        credential_provider=cost.credentialProvider,
+                        credential_id=cost.credentialId,
+                        credential_type=cost.credentialType,
+                        currency=cost.currency,
+                        metadata=_json_to_dict(cost.metadata),
+                    )
+                    for cost in (record.Costs or [])
+                )
+
+                # Parse creator
+                creator = None
+                if record.Creator:
+                    creator = RegistryModelCreator(
+                        id=record.Creator.id,
+                        name=record.Creator.name,
+                        display_name=record.Creator.displayName,
+                        description=record.Creator.description,
+                        website_url=record.Creator.websiteUrl,
+                        logo_url=record.Creator.logoUrl,
+                    )
+
+                # Parse capabilities
+                capabilities = _json_to_dict(record.capabilities)
+
+                # Build metadata from record
+                provider_name = (
+                    record.Provider.name if record.Provider else record.providerId
+                )
+                provider_display = (
+                    record.Provider.displayName
+                    if record.Provider
+                    else record.providerId
+                )
+
+                metadata = ModelMetadata(
+                    provider=provider_name,
+                    context_window=record.contextWindow,
+                    max_output_tokens=record.maxOutputTokens or record.contextWindow,
+                    supports_vision=capabilities.get("supportsVision", False),
+                )
+
+                # Create model instance
+                model = RegistryModel(
+                    slug=record.slug,
+                    display_name=record.displayName,
+                    description=record.description,
+                    metadata=metadata,
+                    capabilities=capabilities,
+                    extra_metadata=_json_to_dict(record.metadata),
+                    provider_display_name=provider_display,
+                    is_enabled=record.isEnabled,
+                    is_recommended=record.isRecommended,
+                    costs=costs,
+                    creator=creator,
+                )
+                new_models[record.slug] = model
+
+            # Atomic swap
+            global _dynamic_models, _schema_options
+            _dynamic_models = new_models
+            _schema_options = _build_schema_options()
+
+            logger.info(
+                f"LLM registry refreshed: {len(_dynamic_models)} models, "
+                f"{len(_schema_options)} schema options"
+            )
+        except Exception as e:
+            logger.error(f"Failed to refresh LLM registry: {e}", exc_info=True)
+            raise
+
+
+def _build_schema_options() -> list[dict[str, str]]:
+    """Build schema options for model selection dropdown. Only includes enabled models."""
+    options: list[dict[str, str]] = []
+    # Only include enabled models in the dropdown options
+    for model in sorted(_dynamic_models.values(), key=lambda m: m.display_name.lower()):
+        if model.is_enabled:
+            options.append(
+                {
+                    "label": model.display_name,
+                    "value": model.slug,
+                    "group": model.metadata.provider,
+                    "description": model.description or "",
+                }
+            )
+    return options
+
+
+def get_model(slug: str) -> RegistryModel | None:
+    """Get a model by slug from the registry."""
+    return _dynamic_models.get(slug)
+
+
+def get_all_models() -> list[RegistryModel]:
+    """Get all models from the registry (including disabled)."""
+    return list(_dynamic_models.values())
+
+
+def get_enabled_models() -> list[RegistryModel]:
+    """Get only enabled models from the registry."""
+    return [model for model in _dynamic_models.values() if model.is_enabled]
+
+
+def get_schema_options() -> list[dict[str, str]]:
+    """Get schema options for model selection dropdown (enabled models only)."""
+    return _schema_options
+
+
+def get_default_model_slug() -> str | None:
+    """Get the default model slug (first recommended, or first enabled)."""
+    # Prefer recommended models
+    for model in _dynamic_models.values():
+        if model.is_recommended and model.is_enabled:
+            return model.slug
+
+    # Fallback to first enabled model
+    for model in sorted(_dynamic_models.values(), key=lambda m: m.display_name):
+        if model.is_enabled:
+            return model.slug
+
+    return None
+
+
+def get_all_model_slugs_for_validation() -> list[str]:
+    """
+    Get all model slugs for validation (enables migrate_llm_models to work).
+    Returns slugs for enabled models only.
+    """
+    return [model.slug for model in _dynamic_models.values() if model.is_enabled]

--- a/autogpt_platform/backend/backend/data/llm_registry/registry.py
+++ b/autogpt_platform/backend/backend/data/llm_registry/registry.py
@@ -28,6 +28,7 @@ def _json_to_dict(value: Any) -> dict[str, Any]:
 class RegistryModelCost:
     """Cost configuration for an LLM model."""
 
+    unit: str  # "RUN" or "TOKENS"
     credit_cost: int
     credential_provider: str
     credential_id: str | None
@@ -95,6 +96,7 @@ async def refresh_llm_registry() -> None:
                 # Parse costs
                 costs = tuple(
                     RegistryModelCost(
+                        unit=str(cost.unit),  # Convert enum to string
                         credit_cost=cost.creditCost,
                         credential_provider=cost.credentialProvider,
                         credential_id=cost.credentialId,
@@ -130,11 +132,22 @@ async def refresh_llm_registry() -> None:
                     else record.providerId
                 )
 
+                # Extract creator name (fallback to "Unknown" if no creator)
+                creator_name = (
+                    record.Creator.displayName if record.Creator else "Unknown"
+                )
+
+                # Price tier defaults to 1 if not set
+                price_tier = record.priceTier if record.priceTier in (1, 2, 3) else 1
+
                 metadata = ModelMetadata(
                     provider=provider_name,
                     context_window=record.contextWindow,
-                    max_output_tokens=record.maxOutputTokens or record.contextWindow,
-                    supports_vision=capabilities.get("supportsVision", False),
+                    max_output_tokens=record.maxOutputTokens,
+                    display_name=record.displayName,
+                    provider_name=provider_display,
+                    creator_name=creator_name,
+                    price_tier=price_tier,
                 )
 
                 # Create model instance
@@ -206,8 +219,8 @@ def get_schema_options() -> list[dict[str, str]]:
 
 def get_default_model_slug() -> str | None:
     """Get the default model slug (first recommended, or first enabled)."""
-    # Prefer recommended models
-    for model in _dynamic_models.values():
+    # Prefer recommended models (sorted for deterministic selection)
+    for model in sorted(_dynamic_models.values(), key=lambda m: m.display_name):
         if model.is_recommended and model.is_enabled:
             return model.slug
 

--- a/autogpt_platform/backend/backend/data/llm_registry/registry.py
+++ b/autogpt_platform/backend/backend/data/llm_registry/registry.py
@@ -9,7 +9,7 @@ from typing import Any
 
 import prisma.models
 
-from backend.data.llm_registry.model import ModelMetadata
+from backend.blocks.llm import ModelMetadata
 
 logger = logging.getLogger(__name__)
 
@@ -62,6 +62,95 @@ _schema_options: list[dict[str, str]] = []
 _lock = asyncio.Lock()
 
 
+def _record_to_registry_model(record: prisma.models.LlmModel) -> RegistryModel:
+    """Transform a raw Prisma LlmModel record into a RegistryModel instance."""
+    # Parse costs
+    costs = tuple(
+        RegistryModelCost(
+            unit=str(cost.unit),  # Convert enum to string
+            credit_cost=cost.creditCost,
+            credential_provider=cost.credentialProvider,
+            credential_id=cost.credentialId,
+            credential_type=cost.credentialType,
+            currency=cost.currency,
+            metadata=dict(cost.metadata or {}),
+        )
+        for cost in (record.Costs or [])
+    )
+
+    # Parse creator
+    creator = None
+    if record.Creator:
+        creator = RegistryModelCreator(
+            id=record.Creator.id,
+            name=record.Creator.name,
+            display_name=record.Creator.displayName,
+            description=record.Creator.description,
+            website_url=record.Creator.websiteUrl,
+            logo_url=record.Creator.logoUrl,
+        )
+
+    # Parse capabilities
+    capabilities = dict(record.capabilities or {})
+
+    # Build metadata from record
+    # Warn if Provider relation is missing (indicates data corruption)
+    if not record.Provider:
+        logger.warning(
+            f"LlmModel {record.slug} has no Provider despite NOT NULL FK - "
+            f"falling back to providerId {record.providerId}"
+        )
+    provider_name = (
+        record.Provider.name if record.Provider else record.providerId
+    )
+    provider_display = (
+        record.Provider.displayName
+        if record.Provider
+        else record.providerId
+    )
+
+    # Extract creator name (fallback to "Unknown" if no creator)
+    creator_name = (
+        record.Creator.displayName if record.Creator else "Unknown"
+    )
+
+    # Price tier defaults to 1 if not set
+    if record.priceTier not in (1, 2, 3):
+        logger.warning(
+            f"LlmModel {record.slug} has out-of-range priceTier={record.priceTier}, "
+            "defaulting to 1"
+        )
+    price_tier = record.priceTier if record.priceTier in (1, 2, 3) else 1
+
+    metadata = ModelMetadata(
+        provider=provider_name,
+        context_window=record.contextWindow,
+        max_output_tokens=(
+            record.maxOutputTokens
+            if record.maxOutputTokens is not None
+            else record.contextWindow
+        ),
+        display_name=record.displayName,
+        provider_name=provider_display,
+        creator_name=creator_name,
+        price_tier=price_tier,
+    )
+
+    return RegistryModel(
+        slug=record.slug,
+        display_name=record.displayName,
+        description=record.description,
+        metadata=metadata,
+        capabilities=capabilities,
+        extra_metadata=dict(record.metadata or {}),
+        provider_display_name=provider_display,
+        is_enabled=record.isEnabled,
+        is_recommended=record.isRecommended,
+        costs=costs,
+        creator=creator,
+    )
+
+
 async def refresh_llm_registry() -> None:
     """
     Refresh the LLM registry from the database.
@@ -83,87 +172,7 @@ async def refresh_llm_registry() -> None:
             # Build model instances
             new_models: dict[str, RegistryModel] = {}
             for record in records:
-                # Parse costs
-                costs = tuple(
-                    RegistryModelCost(
-                        unit=str(cost.unit),  # Convert enum to string
-                        credit_cost=cost.creditCost,
-                        credential_provider=cost.credentialProvider,
-                        credential_id=cost.credentialId,
-                        credential_type=cost.credentialType,
-                        currency=cost.currency,
-                        metadata=dict(cost.metadata or {}),
-                    )
-                    for cost in (record.Costs or [])
-                )
-
-                # Parse creator
-                creator = None
-                if record.Creator:
-                    creator = RegistryModelCreator(
-                        id=record.Creator.id,
-                        name=record.Creator.name,
-                        display_name=record.Creator.displayName,
-                        description=record.Creator.description,
-                        website_url=record.Creator.websiteUrl,
-                        logo_url=record.Creator.logoUrl,
-                    )
-
-                # Parse capabilities
-                capabilities = dict(record.capabilities or {})
-
-                # Build metadata from record
-                # Warn if Provider relation is missing (indicates data corruption)
-                if not record.Provider:
-                    logger.warning(
-                        f"LlmModel {record.slug} has no Provider despite NOT NULL FK - "
-                        f"falling back to providerId {record.providerId}"
-                    )
-                provider_name = (
-                    record.Provider.name if record.Provider else record.providerId
-                )
-                provider_display = (
-                    record.Provider.displayName
-                    if record.Provider
-                    else record.providerId
-                )
-
-                # Extract creator name (fallback to "Unknown" if no creator)
-                creator_name = (
-                    record.Creator.displayName if record.Creator else "Unknown"
-                )
-
-                # Price tier defaults to 1 if not set
-                price_tier = record.priceTier if record.priceTier in (1, 2, 3) else 1
-
-                metadata = ModelMetadata(
-                    provider=provider_name,
-                    context_window=record.contextWindow,
-                    max_output_tokens=(
-                        record.maxOutputTokens
-                        if record.maxOutputTokens is not None
-                        else record.contextWindow
-                    ),
-                    display_name=record.displayName,
-                    provider_name=provider_display,
-                    creator_name=creator_name,
-                    price_tier=price_tier,
-                )
-
-                # Create model instance
-                model = RegistryModel(
-                    slug=record.slug,
-                    display_name=record.displayName,
-                    description=record.description,
-                    metadata=metadata,
-                    capabilities=capabilities,
-                    extra_metadata=dict(record.metadata or {}),
-                    provider_display_name=provider_display,
-                    is_enabled=record.isEnabled,
-                    is_recommended=record.isRecommended,
-                    costs=costs,
-                    creator=creator,
-                )
+                model = _record_to_registry_model(record)
                 new_models[record.slug] = model
 
             # Atomic swap
@@ -213,7 +222,7 @@ def get_enabled_models() -> list[RegistryModel]:
 
 def get_schema_options() -> list[dict[str, str]]:
     """Get schema options for model selection dropdown (enabled models only)."""
-    return _schema_options
+    return list(_schema_options)
 
 
 def get_default_model_slug() -> str | None:

--- a/autogpt_platform/backend/backend/data/llm_registry/registry.py
+++ b/autogpt_platform/backend/backend/data/llm_registry/registry.py
@@ -220,14 +220,14 @@ def get_default_model_slug() -> str | None:
     """Get the default model slug (first recommended, or first enabled)."""
     # Sort once and use next() to short-circuit on first match
     models = sorted(_dynamic_models.values(), key=lambda m: m.display_name)
-    
+
     # Prefer recommended models
     recommended = next(
         (m.slug for m in models if m.is_recommended and m.is_enabled), None
     )
     if recommended:
         return recommended
-    
+
     # Fallback to first enabled model
     return next((m.slug for m in models if m.is_enabled), None)
 

--- a/autogpt_platform/backend/backend/data/llm_registry/registry.py
+++ b/autogpt_platform/backend/backend/data/llm_registry/registry.py
@@ -14,16 +14,6 @@ from backend.data.llm_registry.model import ModelMetadata
 logger = logging.getLogger(__name__)
 
 
-def _json_to_dict(value: Any) -> dict[str, Any]:
-    """Convert Prisma Json type to dict, with fallback to empty dict."""
-    if value is None:
-        return {}
-    if isinstance(value, dict):
-        return value
-    # Prisma Json type should always be a dict at runtime
-    return dict(value) if value else {}
-
-
 @dataclass(frozen=True)
 class RegistryModelCost:
     """Cost configuration for an LLM model."""
@@ -102,7 +92,7 @@ async def refresh_llm_registry() -> None:
                         credential_id=cost.credentialId,
                         credential_type=cost.credentialType,
                         currency=cost.currency,
-                        metadata=_json_to_dict(cost.metadata),
+                        metadata=dict(cost.metadata or {}),
                     )
                     for cost in (record.Costs or [])
                 )
@@ -120,9 +110,15 @@ async def refresh_llm_registry() -> None:
                     )
 
                 # Parse capabilities
-                capabilities = _json_to_dict(record.capabilities)
+                capabilities = dict(record.capabilities or {})
 
                 # Build metadata from record
+                # Warn if Provider relation is missing (indicates data corruption)
+                if not record.Provider:
+                    logger.warning(
+                        f"LlmModel {record.slug} has no Provider despite NOT NULL FK - "
+                        f"falling back to providerId {record.providerId}"
+                    )
                 provider_name = (
                     record.Provider.name if record.Provider else record.providerId
                 )
@@ -143,7 +139,11 @@ async def refresh_llm_registry() -> None:
                 metadata = ModelMetadata(
                     provider=provider_name,
                     context_window=record.contextWindow,
-                    max_output_tokens=record.maxOutputTokens,
+                    max_output_tokens=(
+                        record.maxOutputTokens
+                        if record.maxOutputTokens is not None
+                        else record.contextWindow
+                    ),
                     display_name=record.displayName,
                     provider_name=provider_display,
                     creator_name=creator_name,
@@ -157,7 +157,7 @@ async def refresh_llm_registry() -> None:
                     description=record.description,
                     metadata=metadata,
                     capabilities=capabilities,
-                    extra_metadata=_json_to_dict(record.metadata),
+                    extra_metadata=dict(record.metadata or {}),
                     provider_display_name=provider_display,
                     is_enabled=record.isEnabled,
                     is_recommended=record.isRecommended,
@@ -182,19 +182,18 @@ async def refresh_llm_registry() -> None:
 
 def _build_schema_options() -> list[dict[str, str]]:
     """Build schema options for model selection dropdown. Only includes enabled models."""
-    options: list[dict[str, str]] = []
-    # Only include enabled models in the dropdown options
-    for model in sorted(_dynamic_models.values(), key=lambda m: m.display_name.lower()):
-        if model.is_enabled:
-            options.append(
-                {
-                    "label": model.display_name,
-                    "value": model.slug,
-                    "group": model.metadata.provider,
-                    "description": model.description or "",
-                }
-            )
-    return options
+    return [
+        {
+            "label": model.display_name,
+            "value": model.slug,
+            "group": model.metadata.provider,
+            "description": model.description or "",
+        }
+        for model in sorted(
+            _dynamic_models.values(), key=lambda m: m.display_name.lower()
+        )
+        if model.is_enabled
+    ]
 
 
 def get_model(slug: str) -> RegistryModel | None:
@@ -219,17 +218,18 @@ def get_schema_options() -> list[dict[str, str]]:
 
 def get_default_model_slug() -> str | None:
     """Get the default model slug (first recommended, or first enabled)."""
-    # Prefer recommended models (sorted for deterministic selection)
-    for model in sorted(_dynamic_models.values(), key=lambda m: m.display_name):
-        if model.is_recommended and model.is_enabled:
-            return model.slug
-
+    # Sort once and use next() to short-circuit on first match
+    models = sorted(_dynamic_models.values(), key=lambda m: m.display_name)
+    
+    # Prefer recommended models
+    recommended = next(
+        (m.slug for m in models if m.is_recommended and m.is_enabled), None
+    )
+    if recommended:
+        return recommended
+    
     # Fallback to first enabled model
-    for model in sorted(_dynamic_models.values(), key=lambda m: m.display_name):
-        if model.is_enabled:
-            return model.slug
-
-    return None
+    return next((m.slug for m in models if m.is_enabled), None)
 
 
 def get_all_model_slugs_for_validation() -> list[str]:

--- a/autogpt_platform/backend/backend/data/llm_registry/registry.py
+++ b/autogpt_platform/backend/backend/data/llm_registry/registry.py
@@ -10,6 +10,7 @@ import prisma.models
 from pydantic import BaseModel, ConfigDict
 
 from backend.blocks.llm import ModelMetadata
+from backend.util.cache import cached
 
 logger = logging.getLogger(__name__)
 
@@ -65,18 +66,17 @@ class RegistryModel(BaseModel):
     supports_parallel_tool_calls: bool = False
 
 
-# In-memory cache (will be replaced with Redis in PR #6)
+# L1 in-process cache — Redis is the shared L2 via @cached(shared_cache=True)
 _dynamic_models: dict[str, RegistryModel] = {}
 _schema_options: list[dict[str, str]] = []
 _lock = asyncio.Lock()
 
 
-def _record_to_registry_model(record: prisma.models.LlmModel) -> RegistryModel:
+def _record_to_registry_model(record: prisma.models.LlmModel) -> RegistryModel:  # type: ignore[name-defined]
     """Transform a raw Prisma LlmModel record into a RegistryModel instance."""
-    # Parse costs
     costs = tuple(
         RegistryModelCost(
-            unit=str(cost.unit),  # Convert enum to string
+            unit=str(cost.unit),
             credit_cost=cost.creditCost,
             credential_provider=cost.credentialProvider,
             credential_id=cost.credentialId,
@@ -87,7 +87,6 @@ def _record_to_registry_model(record: prisma.models.LlmModel) -> RegistryModel:
         for cost in (record.Costs or [])
     )
 
-    # Parse creator
     creator = None
     if record.Creator:
         creator = RegistryModelCreator(
@@ -99,35 +98,26 @@ def _record_to_registry_model(record: prisma.models.LlmModel) -> RegistryModel:
             logo_url=record.Creator.logoUrl,
         )
 
-    # Parse capabilities
     capabilities = dict(record.capabilities or {})
 
-    # Build metadata from record
-    # Warn if Provider relation is missing (indicates data corruption)
     if not record.Provider:
         logger.warning(
-            f"LlmModel {record.slug} has no Provider despite NOT NULL FK - "
-            f"falling back to providerId {record.providerId}"
+            "LlmModel %s has no Provider despite NOT NULL FK - "
+            "falling back to providerId %s",
+            record.slug,
+            record.providerId,
         )
-    provider_name = (
-        record.Provider.name if record.Provider else record.providerId
-    )
+    provider_name = record.Provider.name if record.Provider else record.providerId
     provider_display = (
-        record.Provider.displayName
-        if record.Provider
-        else record.providerId
+        record.Provider.displayName if record.Provider else record.providerId
     )
+    creator_name = record.Creator.displayName if record.Creator else "Unknown"
 
-    # Extract creator name (fallback to "Unknown" if no creator)
-    creator_name = (
-        record.Creator.displayName if record.Creator else "Unknown"
-    )
-
-    # Price tier defaults to 1 if not set
     if record.priceTier not in (1, 2, 3):
         logger.warning(
-            f"LlmModel {record.slug} has out-of-range priceTier={record.priceTier}, "
-            "defaulting to 1"
+            "LlmModel %s has out-of-range priceTier=%s, defaulting to 1",
+            record.slug,
+            record.priceTier,
         )
     price_tier = record.priceTier if record.priceTier in (1, 2, 3) else 1
 
@@ -164,41 +154,53 @@ def _record_to_registry_model(record: prisma.models.LlmModel) -> RegistryModel:
     )
 
 
-async def refresh_llm_registry() -> None:
-    """
-    Refresh the LLM registry from the database.
+@cached(maxsize=1, ttl_seconds=300, shared_cache=True, refresh_ttl_on_get=True)
+async def _fetch_registry_from_db() -> list[RegistryModel]:
+    """Fetch all LLM models from the database.
 
-    Fetches all models with their costs, providers, and creators,
-    then updates the in-memory cache.
+    Results are cached in Redis (shared_cache=True) so subsequent calls within
+    the TTL window skip the DB entirely — both within this process and across
+    all other workers that share the same Redis instance.
+    """
+    records = await prisma.models.LlmModel.prisma().find_many(  # type: ignore[attr-defined]
+        include={"Provider": True, "Costs": True, "Creator": True}
+    )
+    logger.info("Fetched %d LLM models from database", len(records))
+    return [_record_to_registry_model(r) for r in records]
+
+
+def clear_registry_cache() -> None:
+    """Invalidate the shared Redis cache for the registry DB fetch.
+
+    Call this before refresh_llm_registry() after any admin DB mutation so the
+    next fetch hits the database rather than serving the now-stale cached data.
+    """
+    _fetch_registry_from_db.cache_clear()
+
+
+async def refresh_llm_registry() -> None:
+    """Refresh the in-process L1 cache from Redis/DB.
+
+    On the first call (or after clear_registry_cache()), fetches fresh data
+    from the database and stores it in Redis.  Subsequent calls by other
+    workers hit the Redis cache instead of the DB.
     """
     async with _lock:
         try:
-            records = await prisma.models.LlmModel.prisma().find_many(
-                include={
-                    "Provider": True,
-                    "Costs": True,
-                    "Creator": True,
-                }
-            )
-            logger.info(f"Fetched {len(records)} LLM models from database")
+            models = await _fetch_registry_from_db()
+            new_models = {m.slug: m for m in models}
 
-            # Build model instances
-            new_models: dict[str, RegistryModel] = {}
-            for record in records:
-                model = _record_to_registry_model(record)
-                new_models[record.slug] = model
-
-            # Atomic swap
             global _dynamic_models, _schema_options
             _dynamic_models = new_models
             _schema_options = _build_schema_options()
 
             logger.info(
-                f"LLM registry refreshed: {len(_dynamic_models)} models, "
-                f"{len(_schema_options)} schema options"
+                "LLM registry refreshed: %d models, %d schema options",
+                len(_dynamic_models),
+                len(_schema_options),
             )
         except Exception as e:
-            logger.error(f"Failed to refresh LLM registry: {e}", exc_info=True)
+            logger.error("Failed to refresh LLM registry: %s", e, exc_info=True)
             raise
 
 
@@ -240,23 +242,13 @@ def get_schema_options() -> list[dict[str, str]]:
 
 def get_default_model_slug() -> str | None:
     """Get the default model slug (first recommended, or first enabled)."""
-    # Sort once and use next() to short-circuit on first match
     models = sorted(_dynamic_models.values(), key=lambda m: m.display_name)
-
-    # Prefer recommended models
     recommended = next(
         (m.slug for m in models if m.is_recommended and m.is_enabled), None
     )
-    if recommended:
-        return recommended
-
-    # Fallback to first enabled model
-    return next((m.slug for m in models if m.is_enabled), None)
+    return recommended or next((m.slug for m in models if m.is_enabled), None)
 
 
 def get_all_model_slugs_for_validation() -> list[str]:
-    """
-    Get all model slugs for validation (enables migrate_llm_models to work).
-    Returns slugs for enabled models only.
-    """
+    """Get all model slugs for validation (enabled models only)."""
     return [model.slug for model in _dynamic_models.values() if model.is_enabled]

--- a/autogpt_platform/backend/backend/data/llm_registry/registry.py
+++ b/autogpt_platform/backend/backend/data/llm_registry/registry.py
@@ -4,56 +4,65 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from dataclasses import dataclass, field
 from typing import Any
 
 import prisma.models
+from pydantic import BaseModel, ConfigDict
 
 from backend.blocks.llm import ModelMetadata
 
 logger = logging.getLogger(__name__)
 
 
-@dataclass(frozen=True)
-class RegistryModelCost:
+class RegistryModelCost(BaseModel):
     """Cost configuration for an LLM model."""
+
+    model_config = ConfigDict(frozen=True)
 
     unit: str  # "RUN" or "TOKENS"
     credit_cost: int
     credential_provider: str
-    credential_id: str | None
-    credential_type: str | None
-    currency: str | None
-    metadata: dict[str, Any]
+    credential_id: str | None = None
+    credential_type: str | None = None
+    currency: str | None = None
+    metadata: dict[str, Any] = {}
 
 
-@dataclass(frozen=True)
-class RegistryModelCreator:
+class RegistryModelCreator(BaseModel):
     """Creator information for an LLM model."""
+
+    model_config = ConfigDict(frozen=True)
 
     id: str
     name: str
     display_name: str
-    description: str | None
-    website_url: str | None
-    logo_url: str | None
+    description: str | None = None
+    website_url: str | None = None
+    logo_url: str | None = None
 
 
-@dataclass(frozen=True)
-class RegistryModel:
+class RegistryModel(BaseModel):
     """Represents a model in the LLM registry."""
+
+    model_config = ConfigDict(frozen=True)
 
     slug: str
     display_name: str
-    description: str | None
+    description: str | None = None
     metadata: ModelMetadata
-    capabilities: dict[str, Any]
-    extra_metadata: dict[str, Any]
+    capabilities: dict[str, Any] = {}
+    extra_metadata: dict[str, Any] = {}
     provider_display_name: str
     is_enabled: bool
     is_recommended: bool = False
-    costs: tuple[RegistryModelCost, ...] = field(default_factory=tuple)
+    costs: tuple[RegistryModelCost, ...] = ()
     creator: RegistryModelCreator | None = None
+
+    # Typed capability fields from DB schema
+    supports_tools: bool = False
+    supports_json_output: bool = False
+    supports_reasoning: bool = False
+    supports_parallel_tool_calls: bool = False
 
 
 # In-memory cache (will be replaced with Redis in PR #6)
@@ -148,6 +157,10 @@ def _record_to_registry_model(record: prisma.models.LlmModel) -> RegistryModel:
         is_recommended=record.isRecommended,
         costs=costs,
         creator=creator,
+        supports_tools=record.supportsTools,
+        supports_json_output=record.supportsJsonOutput,
+        supports_reasoning=record.supportsReasoning,
+        supports_parallel_tool_calls=record.supportsParallelToolCalls,
     )
 
 

--- a/autogpt_platform/backend/backend/data/llm_registry/registry_test.py
+++ b/autogpt_platform/backend/backend/data/llm_registry/registry_test.py
@@ -1,0 +1,358 @@
+"""Unit tests for the LLM registry module."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+import pydantic
+
+from backend.data.llm_registry.registry import (
+    RegistryModel,
+    RegistryModelCost,
+    RegistryModelCreator,
+    _build_schema_options,
+    _record_to_registry_model,
+    get_default_model_slug,
+    get_schema_options,
+    refresh_llm_registry,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_record(**overrides):
+    """Build a realistic mock Prisma LlmModel record."""
+    provider = Mock()
+    provider.name = "openai"
+    provider.displayName = "OpenAI"
+
+    record = Mock()
+    record.slug = "openai/gpt-4o"
+    record.displayName = "GPT-4o"
+    record.description = "Latest GPT model"
+    record.providerId = "provider-uuid"
+    record.Provider = provider
+    record.creatorId = "creator-uuid"
+    record.Creator = None
+    record.contextWindow = 128000
+    record.maxOutputTokens = 16384
+    record.priceTier = 2
+    record.isEnabled = True
+    record.isRecommended = False
+    record.supportsTools = True
+    record.supportsJsonOutput = True
+    record.supportsReasoning = False
+    record.supportsParallelToolCalls = True
+    record.capabilities = {}
+    record.metadata = {}
+    record.Costs = []
+
+    for key, value in overrides.items():
+        setattr(record, key, value)
+    return record
+
+
+def _make_registry_model(**kwargs) -> RegistryModel:
+    """Build a minimal RegistryModel for testing registry-level functions."""
+    from backend.blocks.llm import ModelMetadata
+
+    defaults = dict(
+        slug="openai/gpt-4o",
+        display_name="GPT-4o",
+        description=None,
+        metadata=ModelMetadata(
+            provider="openai",
+            context_window=128000,
+            max_output_tokens=16384,
+            display_name="GPT-4o",
+            provider_name="OpenAI",
+            creator_name="Unknown",
+            price_tier=2,
+        ),
+        capabilities={},
+        extra_metadata={},
+        provider_display_name="OpenAI",
+        is_enabled=True,
+        is_recommended=False,
+    )
+    defaults.update(kwargs)
+    return RegistryModel(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# _record_to_registry_model tests
+# ---------------------------------------------------------------------------
+
+
+def test_record_to_registry_model():
+    """Happy-path: well-formed record produces a correct RegistryModel."""
+    record = _make_mock_record()
+    model = _record_to_registry_model(record)
+
+    assert model.slug == "openai/gpt-4o"
+    assert model.display_name == "GPT-4o"
+    assert model.description == "Latest GPT model"
+    assert model.provider_display_name == "OpenAI"
+    assert model.is_enabled is True
+    assert model.is_recommended is False
+    assert model.supports_tools is True
+    assert model.supports_json_output is True
+    assert model.supports_reasoning is False
+    assert model.supports_parallel_tool_calls is True
+    assert model.metadata.provider == "openai"
+    assert model.metadata.context_window == 128000
+    assert model.metadata.max_output_tokens == 16384
+    assert model.metadata.price_tier == 2
+    assert model.creator is None
+    assert model.costs == ()
+
+
+def test_record_to_registry_model_missing_provider(caplog):
+    """Record with no Provider relation falls back to providerId and logs a warning."""
+    record = _make_mock_record(Provider=None, providerId="provider-uuid")
+    with caplog.at_level("WARNING"):
+        model = _record_to_registry_model(record)
+
+    assert "no Provider" in caplog.text
+    assert model.metadata.provider == "provider-uuid"
+    assert model.provider_display_name == "provider-uuid"
+
+
+def test_record_to_registry_model_missing_creator():
+    """When Creator is None, creator_name defaults to 'Unknown' and creator field is None."""
+    record = _make_mock_record(Creator=None)
+    model = _record_to_registry_model(record)
+
+    assert model.creator is None
+    assert model.metadata.creator_name == "Unknown"
+
+
+def test_record_to_registry_model_with_creator():
+    """When Creator is present, it is parsed into RegistryModelCreator."""
+    creator_mock = Mock()
+    creator_mock.id = "creator-uuid"
+    creator_mock.name = "openai"
+    creator_mock.displayName = "OpenAI"
+    creator_mock.description = "AI company"
+    creator_mock.websiteUrl = "https://openai.com"
+    creator_mock.logoUrl = "https://openai.com/logo.png"
+
+    record = _make_mock_record(Creator=creator_mock)
+    model = _record_to_registry_model(record)
+
+    assert model.creator is not None
+    assert isinstance(model.creator, RegistryModelCreator)
+    assert model.creator.id == "creator-uuid"
+    assert model.creator.display_name == "OpenAI"
+    assert model.metadata.creator_name == "OpenAI"
+
+
+def test_record_to_registry_model_null_max_output_tokens():
+    """maxOutputTokens=None falls back to contextWindow."""
+    record = _make_mock_record(maxOutputTokens=None, contextWindow=64000)
+    model = _record_to_registry_model(record)
+
+    assert model.metadata.max_output_tokens == 64000
+
+
+def test_record_to_registry_model_invalid_price_tier(caplog):
+    """Out-of-range priceTier is coerced to 1 and a warning is logged."""
+    record = _make_mock_record(priceTier=99)
+    with caplog.at_level("WARNING"):
+        model = _record_to_registry_model(record)
+
+    assert "out-of-range priceTier" in caplog.text
+    assert model.metadata.price_tier == 1
+
+
+def test_record_to_registry_model_with_costs():
+    """Costs are parsed into RegistryModelCost tuples."""
+    cost_mock = Mock()
+    cost_mock.unit = "TOKENS"
+    cost_mock.creditCost = 10
+    cost_mock.credentialProvider = "openai"
+    cost_mock.credentialId = None
+    cost_mock.credentialType = None
+    cost_mock.currency = "USD"
+    cost_mock.metadata = {}
+
+    record = _make_mock_record(Costs=[cost_mock])
+    model = _record_to_registry_model(record)
+
+    assert len(model.costs) == 1
+    cost = model.costs[0]
+    assert isinstance(cost, RegistryModelCost)
+    assert cost.unit == "TOKENS"
+    assert cost.credit_cost == 10
+    assert cost.credential_provider == "openai"
+
+
+# ---------------------------------------------------------------------------
+# get_default_model_slug tests
+# ---------------------------------------------------------------------------
+
+
+def test_get_default_model_slug_recommended():
+    """Recommended model is preferred over non-recommended enabled models."""
+    import backend.data.llm_registry.registry as reg
+
+    reg._dynamic_models = {
+        "openai/gpt-4o": _make_registry_model(
+            slug="openai/gpt-4o", display_name="GPT-4o", is_recommended=False
+        ),
+        "openai/gpt-4o-recommended": _make_registry_model(
+            slug="openai/gpt-4o-recommended",
+            display_name="GPT-4o Recommended",
+            is_recommended=True,
+        ),
+    }
+
+    result = get_default_model_slug()
+    assert result == "openai/gpt-4o-recommended"
+
+
+def test_get_default_model_slug_fallback():
+    """With no recommended model, falls back to first enabled (alphabetical)."""
+    import backend.data.llm_registry.registry as reg
+
+    reg._dynamic_models = {
+        "openai/gpt-4o": _make_registry_model(
+            slug="openai/gpt-4o", display_name="GPT-4o", is_recommended=False
+        ),
+        "openai/gpt-3.5": _make_registry_model(
+            slug="openai/gpt-3.5", display_name="GPT-3.5", is_recommended=False
+        ),
+    }
+
+    result = get_default_model_slug()
+    # Sorted alphabetically: GPT-3.5 < GPT-4o
+    assert result == "openai/gpt-3.5"
+
+
+def test_get_default_model_slug_empty():
+    """Empty registry returns None."""
+    import backend.data.llm_registry.registry as reg
+
+    reg._dynamic_models = {}
+
+    result = get_default_model_slug()
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _build_schema_options / get_schema_options tests
+# ---------------------------------------------------------------------------
+
+
+def test_build_schema_options():
+    """Only enabled models appear, sorted case-insensitively."""
+    import backend.data.llm_registry.registry as reg
+
+    reg._dynamic_models = {
+        "openai/gpt-4o": _make_registry_model(
+            slug="openai/gpt-4o", display_name="GPT-4o", is_enabled=True
+        ),
+        "openai/disabled": _make_registry_model(
+            slug="openai/disabled", display_name="Disabled Model", is_enabled=False
+        ),
+        "openai/gpt-3.5": _make_registry_model(
+            slug="openai/gpt-3.5", display_name="gpt-3.5", is_enabled=True
+        ),
+    }
+
+    options = _build_schema_options()
+    slugs = [o["value"] for o in options]
+
+    # disabled model should be excluded
+    assert "openai/disabled" not in slugs
+    # only enabled models
+    assert "openai/gpt-4o" in slugs
+    assert "openai/gpt-3.5" in slugs
+    # case-insensitive sort: "gpt-3.5" < "GPT-4o" (both lowercase: "gpt-3.5" < "gpt-4o")
+    assert slugs.index("openai/gpt-3.5") < slugs.index("openai/gpt-4o")
+
+    # Verify structure
+    for option in options:
+        assert "label" in option
+        assert "value" in option
+        assert "group" in option
+        assert "description" in option
+
+
+def test_get_schema_options_returns_copy():
+    """Mutating the returned list does not affect the internal cache."""
+    import backend.data.llm_registry.registry as reg
+
+    reg._dynamic_models = {
+        "openai/gpt-4o": _make_registry_model(slug="openai/gpt-4o", display_name="GPT-4o"),
+    }
+    reg._schema_options = _build_schema_options()
+
+    options = get_schema_options()
+    original_length = len(options)
+    options.append({"label": "Injected", "value": "evil/model", "group": "evil", "description": ""})
+
+    # Internal state should be unchanged
+    assert len(get_schema_options()) == original_length
+
+
+# ---------------------------------------------------------------------------
+# Pydantic frozen model tests
+# ---------------------------------------------------------------------------
+
+
+def test_registry_model_frozen():
+    """Pydantic frozen=True should reject attribute assignment."""
+    model = _make_registry_model()
+
+    with pytest.raises((pydantic.ValidationError, TypeError)):
+        model.slug = "changed/slug"  # type: ignore[misc]
+
+
+def test_registry_model_cost_frozen():
+    """RegistryModelCost is also frozen."""
+    cost = RegistryModelCost(
+        unit="TOKENS",
+        credit_cost=5,
+        credential_provider="openai",
+    )
+    with pytest.raises((pydantic.ValidationError, TypeError)):
+        cost.unit = "RUN"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# refresh_llm_registry tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_refresh_llm_registry():
+    """Mock prisma find_many, verify cache is populated after refresh."""
+    import backend.data.llm_registry.registry as reg
+
+    record = _make_mock_record()
+    mock_find_many = AsyncMock(return_value=[record])
+
+    with patch("prisma.models.LlmModel.prisma") as mock_prisma_cls:
+        mock_prisma_instance = Mock()
+        mock_prisma_instance.find_many = mock_find_many
+        mock_prisma_cls.return_value = mock_prisma_instance
+
+        # Clear state first
+        reg._dynamic_models = {}
+        reg._schema_options = []
+
+        await refresh_llm_registry()
+
+    assert "openai/gpt-4o" in reg._dynamic_models
+    model = reg._dynamic_models["openai/gpt-4o"]
+    assert isinstance(model, RegistryModel)
+    assert model.slug == "openai/gpt-4o"
+    # Schema options should be populated too
+    assert len(reg._schema_options) == 1
+    assert reg._schema_options[0]["value"] == "openai/gpt-4o"

--- a/autogpt_platform/backend/backend/data/llm_registry/registry_test.py
+++ b/autogpt_platform/backend/backend/data/llm_registry/registry_test.py
@@ -14,7 +14,12 @@ from backend.data.llm_registry.registry import (
     RegistryModelCreator,
     _build_schema_options,
     _record_to_registry_model,
+    clear_registry_cache,
+    get_all_model_slugs_for_validation,
+    get_all_models,
     get_default_model_slug,
+    get_enabled_models,
+    get_model,
     get_schema_options,
     refresh_llm_registry,
 )
@@ -356,3 +361,106 @@ async def test_refresh_llm_registry():
     # Schema options should be populated too
     assert len(reg._schema_options) == 1
     assert reg._schema_options[0]["value"] == "openai/gpt-4o"
+
+
+# ---------------------------------------------------------------------------
+# clear_registry_cache tests
+# ---------------------------------------------------------------------------
+
+
+def test_clear_registry_cache():
+    """clear_registry_cache calls cache_clear on the cached fetch function."""
+    import backend.data.llm_registry.registry as reg
+    from unittest.mock import patch
+
+    with patch.object(reg._fetch_registry_from_db, "cache_clear") as mock_clear:
+        clear_registry_cache()
+        mock_clear.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# get_model / get_all_models / get_enabled_models / get_all_model_slugs tests
+# ---------------------------------------------------------------------------
+
+
+def test_get_model_found():
+    """get_model returns the model when the slug exists in the registry."""
+    import backend.data.llm_registry.registry as reg
+
+    m = _make_registry_model(slug="openai/gpt-4o")
+    reg._dynamic_models = {"openai/gpt-4o": m}
+
+    result = get_model("openai/gpt-4o")
+
+    assert result is m
+
+
+def test_get_model_not_found():
+    """get_model returns None for an unknown slug."""
+    import backend.data.llm_registry.registry as reg
+
+    reg._dynamic_models = {}
+
+    assert get_model("nonexistent/model") is None
+
+
+def test_get_all_models_includes_disabled():
+    """get_all_models returns all models, including disabled ones."""
+    import backend.data.llm_registry.registry as reg
+
+    enabled = _make_registry_model(slug="openai/gpt-4", is_enabled=True)
+    disabled = _make_registry_model(slug="openai/old-model", is_enabled=False)
+    reg._dynamic_models = {"openai/gpt-4": enabled, "openai/old-model": disabled}
+
+    result = get_all_models()
+
+    slugs = [m.slug for m in result]
+    assert "openai/gpt-4" in slugs
+    assert "openai/old-model" in slugs
+    assert len(result) == 2
+
+
+def test_get_enabled_models_excludes_disabled():
+    """get_enabled_models returns only models where is_enabled=True."""
+    import backend.data.llm_registry.registry as reg
+
+    enabled = _make_registry_model(slug="openai/gpt-4", is_enabled=True)
+    disabled = _make_registry_model(slug="openai/old-model", is_enabled=False)
+    reg._dynamic_models = {"openai/gpt-4": enabled, "openai/old-model": disabled}
+
+    result = get_enabled_models()
+
+    assert len(result) == 1
+    assert result[0].slug == "openai/gpt-4"
+
+
+def test_get_all_model_slugs_for_validation():
+    """get_all_model_slugs_for_validation returns only enabled model slugs."""
+    import backend.data.llm_registry.registry as reg
+
+    reg._dynamic_models = {
+        "openai/gpt-4": _make_registry_model(slug="openai/gpt-4", is_enabled=True),
+        "openai/old": _make_registry_model(slug="openai/old", is_enabled=False),
+        "anthropic/claude": _make_registry_model(
+            slug="anthropic/claude", is_enabled=True
+        ),
+    }
+
+    result = get_all_model_slugs_for_validation()
+
+    assert "openai/gpt-4" in result
+    assert "anthropic/claude" in result
+    assert "openai/old" not in result
+    assert len(result) == 2
+
+
+@pytest.mark.asyncio
+async def test_refresh_llm_registry_error_is_reraised(mocker):
+    """refresh_llm_registry re-raises exceptions after logging them."""
+    mocker.patch(
+        "backend.data.llm_registry.registry._fetch_registry_from_db",
+        new=AsyncMock(side_effect=RuntimeError("DB unavailable")),
+    )
+
+    with pytest.raises(RuntimeError, match="DB unavailable"):
+        await refresh_llm_registry()


### PR DESCRIPTION
## Summary
Add LLM registry core implementation - **Part 2 of 3** in incremental rollout.

Builds on PR #12357 (schema foundation) to provide database access layer and in-memory caching for dynamic LLM model management.

## Changes
### Registry Core (\`backend/data/llm_registry/\`)
- **DB access layer** - Prisma queries with full relation loading (Provider, Costs, Creator)
- **In-memory cache** - Asyncio-locked singleton with atomic refresh
- **Public API** - \`get_model()\`, \`get_all_models()\`, \`get_enabled_models()\`, \`get_schema_options()\`, \`get_default_model_slug()\`
- **Dataclasses** - \`RegistryModel\`, \`RegistryModelCost\`, \`RegistryModelCreator\` (immutable, frozen)
- **ModelMetadata** - Re-exports from \`blocks.llm\` to avoid type collision

### Startup Integration
- Registry refresh before block initialization
- Graceful fallback if refresh fails (no blocks consume registry yet - comes in future PR)

## Review Feedback Addressed
- ✅ Fixed ModelMetadata duplicate type collision (now imports from blocks.llm)
- ✅ Removed \`_json_to_dict()\` helper - use \`dict(value or {})\` inline
- ✅ Added warning when Provider relation is missing (data corruption indicator)
- ✅ Optimized \`get_default_model_slug()\` - single sort pass with \`next()\`
- ✅ Optimized \`_build_schema_options()\` - list comprehension instead of loop
- ✅ Moved \`llm_registry\` import to top-level in rest_api.py
- ✅ Explicit \`max_output_tokens\` fallback to \`context_window\` when null
- ✅ Rebased onto updated schema (PR #12357) with FK constraints

## Known Limitations (Deferred)
- **Multi-worker coordination** - asyncio.Lock only works per-process (Redis cache in future PR)
- **Mutable cache exposure** - Internal dicts accessible (acceptable for now, Redis will fix)

## Testing
- [x] Prisma client generates successfully
- [x] All imports resolve correctly
- [x] Registry refresh loads models from DB
- [x] Cache atomic swap works correctly
- [x] Backend starts successfully with registry

## Stacked PRs
- **PR #12357**: Schema foundation
- **PR #12359**: Registry core (DB layer + cache)  ← YOU ARE HERE
- **PR #12371**: Public read API (GET endpoints)
- **PR #12467** (this): Admin write API (CRUD) 
- **PR #12468** (next): Admin UI