### PR TITLE
fix(frontend): show specific error messages for store image upload failures

### DIFF
--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentInfoStep/components/useThumbnailImages.ts
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentInfoStep/components/useThumbnailImages.ts
@@ -110,10 +110,12 @@ export function useThumbnailImages({
       if (!selectedImage) {
         setSelectedImage(imageUrl);
       }
-    } catch (_error) {
+    } catch (error) {
+      const detail =
+        error instanceof Error ? error.message : "Please try again.";
       toast({
         title: "Upload failed",
-        description: "Failed to upload image. Please try again.",
+        description: detail,
         variant: "destructive",
       });
     }


### PR DESCRIPTION

### Changes
- Surface backend error details (file size limit, invalid file type, virus detected, etc.) in the upload failed toast instead of showing a generic "Upload Failed" message
- The backend already returns specific error messages (e.g., "File too large. Maximum size is 50MB") but the frontend was discarding them with a catch-all handler
  
<img width="1222" height="411" alt="Screenshot 2026-03-11 at 9 13 30 AM" src="https://github.com/user-attachments/assets/34ab3d90-fffa-4788-917a-fe2a7f4144b9" />

  ## Test plan
  - [x] Upload an image larger than 50MB to a store submission → should see "File too large. Maximum size is 50MB"
  - [x] Upload an unsupported file type → should see file type error message
  - [x] Upload a valid image → should still work normally

  Resolves SECRT-2093