### PR TITLE
fix: ensure cross-platform utf-8 encoding in LocalFileStorage

### DIFF
--- a/classic/forge/forge/file_storage/local.py
+++ b/classic/forge/forge/file_storage/local.py
@@ -77,7 +77,10 @@ class LocalFileStorage(FileStorage):
         full_path = self.get_path(path)
         if any(m in mode for m in ("w", "a", "x")):
             full_path.parent.mkdir(parents=True, exist_ok=True)
-        return open(full_path, mode)  # type: ignore
+        
+        # Ensure utf-8 encoding for text files to maintain cross-platform compatibility
+        encoding = None if "b" in mode else "utf-8"
+        return open(full_path, mode, encoding=encoding)  # type: ignore
 
     @overload
     def read_file(self, path: str | Path, binary: Literal[False] = False) -> str:


### PR DESCRIPTION
This PR fixes a potential encoding issue on Windows systems by enforcing utf-8 when opening text files in LocalFileStorage. 
- Added conditional encoding to _open_file. 
- Prevents cp1252 corruption in non-unix environments.

---
**Bounty Claim:** 150 USDT
**Wallet Polygon:** 0xD9D9300003b141D825cB7f217162be01F5fe3871