### PR TITLE
fix(frontend): restore broken tutorial in builder

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/tutorial/helpers/blocks.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/tutorial/helpers/blocks.ts
@@ -75,7 +75,7 @@ export const getSecondCalculatorNode = () => {
 export const getFormContainerSelector = (blockId: string): string | null => {
   const node = getNodeByBlockId(blockId);
   if (node) {
-    return `[data-id="form-creator-container-${node.id}"]`;
+    return `[data-id="form-creator-container-${node.id}-node"]`;
   }
   return null;
 };

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/tutorial/styles.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/tutorial/styles.ts
@@ -7,6 +7,7 @@
  *
  * Typography (body, small, action, info, tip, warning) uses Tailwind utilities directly in steps.ts
  */
+import "shepherd.js/dist/css/shepherd.css";
 import "./tutorial.css";
 
 export const injectTutorialStyles = () => {

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/tutorial/tutorial.css
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/tutorial/tutorial.css
@@ -1,3 +1,14 @@
+.new-builder-tutorial-disable {
+  opacity: 0.3 !important;
+  pointer-events: none !important;
+  filter: grayscale(100%) !important;
+}
+
+.new-builder-tutorial-highlight {
+  position: relative;
+  z-index: 10;
+}
+
 .new-builder-tutorial-highlight * {
   opacity: 1 !important;
   filter: none !important;


### PR DESCRIPTION
### Changes
- Restored missing `shepherd.js/dist/css/shepherd.css` base styles import
- Added missing .new-builder-tutorial-disable and .new-builder-tutorial-highlight CSS classes to
  tutorial.css
- Fixed getFormContainerSelector() to include -node suffix matching the actual DOM attribute

###  What broke
  The old legacy-builder/tutorial.ts was the only file importing Shepherd's base CSS. When #12082 removed
   the legacy builder, the new tutorial lost all base Shepherd styles (close button positioning, modal
  overlay, tooltip layout). The new tutorial's custom CSS overrides depended on these base styles
  existing.

  Test plan
  - [x] Start the tutorial from the builder (click the chalkboard icon)
  - [x] Verify the close (X) button is positioned correctly in the top-right of the popover
  - [x] Verify the modal overlay dims the background properly
  - [x] Verify element highlighting works when the tutorial points to blocks/buttons
  - [x] Verify non-target blocks are grayed out during the "select calculator" step
  - [x] Complete the full tutorial flow end-to-end (add block → configure → connect → save → run)