### PR TITLE
feat(frontend/copilot): update suggestion pill styling for readability

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/copilot/CopilotPage.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/CopilotPage.tsx
@@ -9,59 +9,17 @@ import {
 import { SidebarProvider } from "@/components/ui/sidebar";
 import { cn } from "@/lib/utils";
 import { DotsThree, UploadSimple } from "@phosphor-icons/react";
-import { useCallback, useRef, useState } from "react";
+
 import { ChatContainer } from "./components/ChatContainer/ChatContainer";
 import { ChatSidebar } from "./components/ChatSidebar/ChatSidebar";
 import { DeleteChatDialog } from "./components/DeleteChatDialog/DeleteChatDialog";
 import { MobileDrawer } from "./components/MobileDrawer/MobileDrawer";
 import { MobileHeader } from "./components/MobileHeader/MobileHeader";
 import { ScaleLoader } from "./components/ScaleLoader/ScaleLoader";
+import { useCopilotFileDrop } from "./useCopilotFileDrop";
 import { useCopilotPage } from "./useCopilotPage";
 
 export function CopilotPage() {
-  const [isDragging, setIsDragging] = useState(false);
-  const [droppedFiles, setDroppedFiles] = useState<File[]>([]);
-  const dragCounter = useRef(0);
-
-  const handleDroppedFilesConsumed = useCallback(() => {
-    setDroppedFiles([]);
-  }, []);
-
-  function handleDragEnter(e: React.DragEvent) {
-    e.preventDefault();
-    e.stopPropagation();
-    dragCounter.current += 1;
-    if (e.dataTransfer.types.includes("Files")) {
-      setIsDragging(true);
-    }
-  }
-
-  function handleDragOver(e: React.DragEvent) {
-    e.preventDefault();
-    e.stopPropagation();
-  }
-
-  function handleDragLeave(e: React.DragEvent) {
-    e.preventDefault();
-    e.stopPropagation();
-    dragCounter.current -= 1;
-    if (dragCounter.current === 0) {
-      setIsDragging(false);
-    }
-  }
-
-  function handleDrop(e: React.DragEvent) {
-    e.preventDefault();
-    e.stopPropagation();
-    dragCounter.current = 0;
-    setIsDragging(false);
-
-    const files = Array.from(e.dataTransfer.files);
-    if (files.length > 0) {
-      setDroppedFiles(files);
-    }
-  }
-
   const {
     sessionId,
     messages,
@@ -94,6 +52,16 @@ export function CopilotPage() {
     handleConfirmDelete,
     handleCancelDelete,
   } = useCopilotPage();
+
+  const {
+    isDragging,
+    droppedFiles,
+    handleDroppedFilesConsumed,
+    handleDragEnter,
+    handleDragOver,
+    handleDragLeave,
+    handleDrop,
+  } = useCopilotFileDrop();
 
   if (isUserLoading || !isLoggedIn) {
     return (

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/EmptySession/EmptySession.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/EmptySession/EmptySession.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { ChatInput } from "@/app/(platform)/copilot/components/ChatInput/ChatInput";
-import { Button } from "@/components/atoms/Button/Button";
+
 import { Text } from "@/components/atoms/Text/Text";
 import { useSupabase } from "@/lib/supabase/hooks/useSupabase";
-import { SpinnerGapIcon } from "@phosphor-icons/react";
+import { Sparkle, SpinnerGapIcon } from "@phosphor-icons/react";
 import { motion } from "framer-motion";
 import { useEffect, useState } from "react";
 import {
@@ -90,28 +90,29 @@ export function EmptySession({
           </div>
         </div>
 
-        <div className="flex flex-wrap items-center justify-center gap-3 overflow-x-auto [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+        <div className="mx-auto flex flex-col items-center divide-y divide-zinc-100 px-2">
           {quickActions.map((action) => (
-            <Button
+            <button
               key={action}
               type="button"
-              variant="outline"
-              size="small"
               onClick={() => void handleQuickActionClick(action)}
               disabled={isCreatingSession || loadingAction !== null}
               aria-busy={loadingAction === action}
-              leftIcon={
-                loadingAction === action ? (
-                  <SpinnerGapIcon
-                    className="h-4 w-4 animate-spin"
-                    weight="bold"
-                  />
-                ) : null
-              }
-              className="h-auto shrink-0 border-zinc-300 px-3 py-2 text-[.9rem] text-zinc-600"
+              className="flex items-center gap-2.5 px-1 py-3 text-[.9rem] text-zinc-600 transition-colors hover:text-zinc-900 disabled:opacity-50"
             >
+              {loadingAction === action ? (
+                <SpinnerGapIcon
+                  className="h-4 w-4 shrink-0 animate-spin text-amber-400"
+                  weight="bold"
+                />
+              ) : (
+                <Sparkle
+                  className="h-4 w-4 shrink-0 text-amber-400"
+                  weight="fill"
+                />
+              )}
               {action}
-            </Button>
+            </button>
           ))}
         </div>
       </motion.div>

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/useCopilotFileDrop.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/useCopilotFileDrop.ts
@@ -1,0 +1,56 @@
+import { useCallback, useRef, useState } from "react";
+
+export function useCopilotFileDrop() {
+  const [isDragging, setIsDragging] = useState(false);
+  const [droppedFiles, setDroppedFiles] = useState<File[]>([]);
+  const dragCounter = useRef(0);
+
+  const handleDroppedFilesConsumed = useCallback(() => {
+    setDroppedFiles([]);
+  }, []);
+
+  function handleDragEnter(e: React.DragEvent) {
+    e.preventDefault();
+    e.stopPropagation();
+    dragCounter.current += 1;
+    if (e.dataTransfer.types.includes("Files")) {
+      setIsDragging(true);
+    }
+  }
+
+  function handleDragOver(e: React.DragEvent) {
+    e.preventDefault();
+    e.stopPropagation();
+  }
+
+  function handleDragLeave(e: React.DragEvent) {
+    e.preventDefault();
+    e.stopPropagation();
+    dragCounter.current -= 1;
+    if (dragCounter.current === 0) {
+      setIsDragging(false);
+    }
+  }
+
+  function handleDrop(e: React.DragEvent) {
+    e.preventDefault();
+    e.stopPropagation();
+    dragCounter.current = 0;
+    setIsDragging(false);
+
+    const files = Array.from(e.dataTransfer.files);
+    if (files.length > 0) {
+      setDroppedFiles(files);
+    }
+  }
+
+  return {
+    isDragging,
+    droppedFiles,
+    handleDroppedFilesConsumed,
+    handleDragEnter,
+    handleDragOver,
+    handleDragLeave,
+    handleDrop,
+  };
+}

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/useCopilotPage.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/useCopilotPage.ts
@@ -27,6 +27,7 @@ interface UploadedFile {
 export function useCopilotPage() {
   const { isUserLoading, isLoggedIn } = useSupabase();
   const [isUploadingFiles, setIsUploadingFiles] = useState(false);
+
   const [pendingMessage, setPendingMessage] = useState<string | null>(null);
   const queryClient = useQueryClient();
 


### PR DESCRIPTION
## Summary
- Restyle CoPilot suggestion pills from bordered outline buttons to a clean vertical list with Sparkle icons and subtle dividers for improved readability
- Extract drag-and-drop file handling logic from `CopilotPage` into a dedicated `useCopilotFileDrop` hook for better separation of concerns

## Test plan
- [ ] Verify suggestion pills render as a vertical list with amber Sparkle icons
- [ ] Verify clicking a suggestion pill still triggers the quick action
- [ ] Verify loading spinner appears on the clicked pill while creating session
- [ ] Verify file drag-and-drop onto the CoPilot page still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)