### PR TITLE
Fix typo: seperate -> separate

### DIFF
--- a/autogpt_platform/backend/backend/integrations/ayrshare.py
+++ b/autogpt_platform/backend/backend/integrations/ayrshare.py
@@ -502,7 +502,7 @@ class AyrshareClient:
         # It seems like there is only ever one post in the array, and within that
         # there are multiple postIds
 
-        # There is a seperate endpoint for bulk posting, so feels safe to just take
+        # There is a separate endpoint for bulk posting, so feels safe to just take
         # the first post from the array
 
         if len(response_data["posts"]) == 0:


### PR DESCRIPTION
Fixed typo in ayrshare.py

```diff
- # There is a seperate endpoint for bulk posting, so feels safe to just take
+ # There is a separate endpoint for bulk posting, so feels safe to just take
```