### PR TITLE
fix(copilot): downgrade agent validation failure log from error to warning

### DIFF
--- a/autogpt_platform/backend/backend/copilot/tools/agent_generator/validator.py
+++ b/autogpt_platform/backend/backend/copilot/tools/agent_generator/validator.py
@@ -935,5 +935,5 @@ class AgentValidator:
             for i, error in enumerate(self.errors, 1):
                 error_message += f"{i}. {error}\n"
 
-            logger.error(f"Agent validation failed: {error_message}")
+            logger.warning(f"Agent validation failed: {error_message}")
             return False, error_message


### PR DESCRIPTION
Agent validation failures are expected when the LLM generates invalid agent graphs (wrong block IDs, missing required inputs, bad output field names). The validator catches these and returns proper error responses.

However, `validator.py:938` used `logger.error()`, which Sentry captures as error events — flooding #platform-alerts with non-errors.

This changes it to `logger.warning()`, keeping the log visible for debugging without triggering Sentry alerts.

Fixes SECRT-2120

---
Co-authored-by: Zamil Majdy (@majdyz) <zamil.majdy@agpt.co>