### PR TITLE
feat(frontend): Make Give Feedback button translucent for better content visibility

### DIFF
--- a/autogpt_platform/frontend/src/components/molecules/TallyPoup/TallyPopup.tsx
+++ b/autogpt_platform/frontend/src/components/molecules/TallyPoup/TallyPopup.tsx
@@ -22,7 +22,7 @@ export function TallyPopupSimple() {
         <Button
           variant="primary"
           onClick={handlers.handleResetTutorial}
-          className="mb-0 h-14 w-28 rounded-2xl bg-[rgba(65,65,64,1)] text-left font-sans text-lg font-medium leading-6"
+          className="mb-0 h-14 w-28 rounded-2xl bg-[rgba(65,65,64,0.55)] text-left font-sans text-lg font-medium leading-6 backdrop-blur-md border border-white/10 shadow-lg"
         >
           Tutorial
         </Button>
@@ -42,7 +42,7 @@ export function TallyPopupSimple() {
             : String(state.isAuthenticated)
         }
         data-email={state.userEmail || "not-authenticated"}
-        className="mb-0 h-14 rounded-2xl bg-[rgba(65,65,64,1)] text-center font-sans text-lg font-medium leading-6"
+        className="mb-0 h-14 rounded-2xl bg-[rgba(65,65,64,0.55)] text-center font-sans text-lg font-medium leading-6 backdrop-blur-md border border-white/10 shadow-lg"
       >
         Give Feedback
       </Button>


### PR DESCRIPTION
## Summary

Makes the floating "Give Feedback" (and "Tutorial") button translucent using a glassmorphism (frosted glass) effect, so users can see text content underneath it.

## Changes

**File:** `autogpt_platform/frontend/src/components/molecules/TallyPoup/TallyPopup.tsx`

- **Background opacity:** `rgba(65,65,64,1)` → `rgba(65,65,64,0.55)` (55% opacity)
- **Backdrop blur:** Added `backdrop-blur-md` for frosted glass effect
- **Border:** Added `border border-white/10` for subtle depth
- **Shadow:** Added `shadow-lg` for elevation

Both the "Give Feedback" and "Tutorial" buttons are updated consistently.

## Design Principles Applied

- **Glassmorphism:** Modern translucent UI pattern used by Apple, Microsoft, etc.
- **55% opacity** strikes the right balance — content is visible underneath while the button text remains clearly readable
- **Backdrop blur** ensures the button still has visual separation from content
- **Subtle white border** adds depth without being distracting

## Before / After

**Before:** Fully opaque dark button blocks all content underneath
**After:** Translucent frosted glass button — text underneath is visible through it