### PR TITLE
fix(frontend): Remove dead Tutorial button from TallyPopup

### DIFF
--- a/autogpt_platform/frontend/src/components/molecules/TallyPoup/TallyPopup.tsx
+++ b/autogpt_platform/frontend/src/components/molecules/TallyPoup/TallyPopup.tsx
@@ -3,14 +3,9 @@
 import React from "react";
 import { useTallyPopup } from "./useTallyPopup";
 import { Button } from "@/components/atoms/Button/Button";
-import { usePathname, useSearchParams } from "next/navigation";
 
 export function TallyPopupSimple() {
-  const { state, handlers } = useTallyPopup();
-  const searchParams = useSearchParams();
-  const pathname = usePathname();
-  const isNewBuilder =
-    pathname.includes("build") && searchParams.get("view") === "new";
+  const { state } = useTallyPopup();
 
   if (state.isFormVisible) {
     return null;
@@ -18,15 +13,6 @@ export function TallyPopupSimple() {
 
   return (
     <div className="fixed bottom-1 right-0 z-20 hidden select-none items-center gap-4 p-3 transition-all duration-300 ease-in-out md:flex">
-      {state.showTutorial && !isNewBuilder && (
-        <Button
-          variant="primary"
-          onClick={handlers.handleResetTutorial}
-          className="mb-0 h-14 w-28 rounded-2xl bg-[rgba(65,65,64,1)] text-left font-sans text-lg font-medium leading-6"
-        >
-          Tutorial
-        </Button>
-      )}
       <Button
         variant="primary"
         data-tally-open="3yx2L0"

--- a/autogpt_platform/frontend/src/components/molecules/TallyPoup/useTallyPopup.ts
+++ b/autogpt_platform/frontend/src/components/molecules/TallyPoup/useTallyPopup.ts
@@ -1,4 +1,4 @@
-import { usePathname, useRouter } from "next/navigation";
+import { usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
 import * as Sentry from "@sentry/nextjs";
 import { getCurrentUser } from "@/lib/supabase/actions";
@@ -11,14 +11,7 @@ export function useTallyPopup() {
   const [userAgent, setUserAgent] = useState("");
   const [isAuthenticated, setIsAuthenticated] = useState<boolean | null>(null);
   const [userEmail, setUserEmail] = useState<string>("");
-  const router = useRouter();
   const pathname = usePathname();
-
-  const [showTutorial, setShowTutorial] = useState(false);
-
-  useEffect(() => {
-    setShowTutorial(pathname.includes("build"));
-  }, [pathname]);
 
   useEffect(() => {
     // Set client-side values
@@ -104,13 +97,8 @@ export function useTallyPopup() {
     };
   }, []);
 
-  function handleResetTutorial() {
-    router.push("/build?resetTutorial=true");
-  }
-
   return {
     state: {
-      showTutorial,
       sentryReplayId,
       replayUrl,
       pageUrl,
@@ -119,8 +107,6 @@ export function useTallyPopup() {
       isFormVisible,
       userEmail,
     },
-    handlers: {
-      handleResetTutorial,
-    },
+    handlers: {},
   };
 }


### PR DESCRIPTION
After the legacy builder was removed in #12082, the TallyPopup component still showed a "Tutorial" button (bottom-right, next to "Give Feedback") that navigated to `/build?resetTutorial=true`. Nothing handles that param anymore, so clicking it did nothing.

This removes the dead button and its associated state/handler from TallyPopup and useTallyPopup. The working tutorial (Shepherd.js chalkboard icon in CustomControls) is unaffected.

**Changes:**
- `TallyPopup.tsx`: Remove Tutorial button JSX, unused imports (`usePathname`, `useSearchParams`), and `isNewBuilder` check
- `useTallyPopup.ts`: Remove `showTutorial` state, `handleResetTutorial` handler, unused `useRouter` import

Resolves SECRT-2109

---
Co-authored-by: Reinier van der Leer (@Pwuts) <pwuts@agpt.co>