### PR TITLE
docs: fix typo in README (in-developlemt -> in-development)

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ These examples show just a glimpse of what you can achieve with AutoGPT! You can
 ### **License Overview:**
 
 🛡️ **Polyform Shield License:**
-All code and content within the `autogpt_platform` folder is licensed under the Polyform Shield License. This new project is our in-developlemt platform for building, deploying and managing agents.</br>_[Read more about this effort](https://agpt.co/blog/introducing-the-autogpt-platform)_
+All code and content within the `autogpt_platform` folder is licensed under the Polyform Shield License. This new project is our in-development platform for building, deploying and managing agents.</br>_[Read more about this effort](https://agpt.co/blog/introducing-the-autogpt-platform)_
 
 🦉 **MIT License:**
 All other portions of the AutoGPT repository (i.e., everything outside the `autogpt_platform` folder) are licensed under the MIT License. This includes the original stand-alone AutoGPT Agent, along with projects such as [Forge](https://github.com/Significant-Gravitas/AutoGPT/tree/master/classic/forge), [agbenchmark](https://github.com/Significant-Gravitas/AutoGPT/tree/master/classic/benchmark) and the [AutoGPT Classic GUI](https://github.com/Significant-Gravitas/AutoGPT/tree/master/classic/frontend).</br>We also publish additional work under the MIT Licence in other repositories, such as [GravitasML](https://github.com/Significant-Gravitas/gravitasml) which is developed for and used in the AutoGPT Platform. See also our MIT Licenced [Code Ability](https://github.com/Significant-Gravitas/AutoGPT-Code-Ability) project.


### PR DESCRIPTION
Fixed a small typo in the License Overview section of README.md:
- `in-developlemt` → `in-development`