### PR TITLE
fix(backend): add in-memory block search fallback when embeddings unavailable

### DIFF
--- a/autogpt_platform/backend/backend/api/features/builder/db.py
+++ b/autogpt_platform/backend/backend/api/features/builder/db.py
@@ -427,6 +427,38 @@ async def _hybrid_search_blocks(
         min_score=0.10,
     )
 
+    # Fallback: if hybrid search returned no results (e.g. no block rows in
+    # UnifiedContentEmbedding because OpenAI credentials are unavailable),
+    # use in-memory text search over the block registry.
+    if not search_results:
+        logger.info(
+            "Hybrid block search returned no results, "
+            "falling back to in-memory text search"
+        )
+        all_results, block_count, integration_count = _collect_block_results(
+            include_blocks=include_blocks,
+            include_integrations=include_integrations,
+        )
+        # Re-score with text relevance instead of flat BLOCK_SCORE_BOOST
+        for item in all_results:
+            block_info = item.item
+            assert isinstance(block_info, BlockInfo)
+            name = block_info.name.lower()
+            description = (block_info.description or "").lower()
+            score = _score_primary_fields(name, description, normalized_query)
+            if score >= MIN_SCORE_FOR_FILTERED_RESULTS:
+                results.append(
+                    _ScoredItem(
+                        item=block_info,
+                        filter_type=item.filter_type,
+                        score=score + BLOCK_SCORE_BOOST,
+                        sort_key=name,
+                    )
+                )
+        block_count = sum(1 for r in results if r.filter_type == "blocks")
+        integration_count = sum(1 for r in results if r.filter_type == "integrations")
+        return results, block_count, integration_count
+
     # Load all blocks for getting BlockInfo
     all_blocks = load_all_blocks()
 


### PR DESCRIPTION
When `UnifiedContentEmbedding` has no block rows (e.g. fork PRs without OpenAI credentials for embedding generation), `unified_hybrid_search` returns zero results — there are no rows to match lexically or semantically.

### Changes 🏗️

- Add in-memory text search fallback in `_hybrid_search_blocks` when hybrid search returns no block results
- Uses `_collect_block_results` (same block registry iteration used for no-query listing) with `_score_primary_fields` for relevance scoring
- No schema changes or embedding table modifications needed

### Context

Fork PRs don't have access to `OPENAI_INTERNAL_API_KEY`, so the embedding backfill fails entirely (`RuntimeError: openai_internal_api_key not set`). Without any rows in `UnifiedContentEmbedding`, even lexical search has nothing to match against, causing builder block search to return zero results and breaking all `build.spec.ts` e2e tests.

### Checklist 📋
- [x] My PR is small and focused on a single change
- [x] I have tested my changes
- [ ] My code follows the project's code style

---
Co-authored-by: Reinier van der Leer (@Pwuts) <pwuts@agpt.co>