### PR TITLE
fix(frontend): collapse navbar text to icons below 1280px

### DIFF
--- a/autogpt_platform/frontend/src/components/layout/Navbar/components/FeedbackButton.tsx
+++ b/autogpt_platform/frontend/src/components/layout/Navbar/components/FeedbackButton.tsx
@@ -27,8 +27,8 @@ export function FeedbackButton() {
       }
     >
       <div className="rounded-full bg-gradient-to-r from-indigo-100 to-indigo-300 to-zinc-400 p-[1px]">
-        <div className="flex items-center gap-1.5 rounded-full bg-[#FAFAFA]/80 px-3 py-1.5 text-sm font-medium text-neutral-700 backdrop-blur-xl transition-colors duration-150 ease-out group-hover:bg-zinc-100/90">
-          Give Feedback
+        <div className="flex items-center gap-1.5 whitespace-nowrap rounded-full bg-[#FAFAFA]/80 px-3 py-1.5 text-sm font-medium text-neutral-700 backdrop-blur-xl transition-colors duration-150 ease-out group-hover:bg-zinc-100/90">
+          <span className="hidden xl:inline">Give Feedback</span>
           <ChatCircleDotsIcon size={16} />
         </div>
       </div>

--- a/autogpt_platform/frontend/src/components/layout/Navbar/components/NavbarLink.tsx
+++ b/autogpt_platform/frontend/src/components/layout/Navbar/components/NavbarLink.tsx
@@ -98,7 +98,7 @@ export function NavbarLink({ name, href }: Props) {
         <Text
           variant="h5"
           className={cn(
-            "hidden !font-poppins leading-none lg:block",
+            "hidden !font-poppins leading-none xl:block",
             isActive ? "!text-white" : "!text-black",
           )}
         >

--- a/autogpt_platform/frontend/src/components/layout/Navbar/components/Wallet/Wallet.tsx
+++ b/autogpt_platform/frontend/src/components/layout/Navbar/components/Wallet/Wallet.tsx
@@ -299,9 +299,9 @@ export function Wallet() {
             className="group relative flex flex-nowrap items-center gap-2 rounded-md bg-zinc-50 px-3 py-2 text-sm"
             onClick={onWalletOpen}
           >
-            <WalletIcon size={20} className="inline-block md:hidden" />
+            <WalletIcon size={20} className="inline-block xl:hidden" />
             <div>
-              <span className="mr-1 hidden md:inline-block">Earn credits </span>
+              <span className="mr-1 hidden xl:inline-block">Earn credits </span>
               <span className="text-sm font-semibold">
                 {formatCredits(credits)}
               </span>


### PR DESCRIPTION
## Summary

<img width="400" height="339" alt="Screenshot 2026-03-19 at 22 53 23" src="https://github.com/user-attachments/assets/2fa76b8f-424d-4764-90ac-b7a331f5f610" />

<img width="600" height="595" alt="Screenshot 2026-03-19 at 22 53 31" src="https://github.com/user-attachments/assets/23f51cc7-b01e-4d83-97ba-2c43683877db" />

<img width="800" height="523" alt="Screenshot 2026-03-19 at 22 53 36" src="https://github.com/user-attachments/assets/1e447b9a-1cca-428c-bccd-1730f1670b8e" />

Now that we have the `Give feedback` button on the Navigation bar, collpase some of the links below `1280px` so there is more space and they don't collide with each other...

- Collapse navbar link text to icon-only below 1280px (`xl` breakpoint) to prevent crowding
- Wallet button shows only the wallet icon below 1280px instead of "Earn credits" text
- Feedback button shows only the chat icon below 1280px instead of "Give Feedback" text
- Added `whitespace-nowrap` to feedback button to prevent wrapping

## Changes
- `NavbarLink.tsx`: `lg:block` → `xl:block` for link text
- `Wallet.tsx`: `md:hidden`/`md:inline-block` → `xl:hidden`/`xl:inline-block`
- `FeedbackButton.tsx`: wrap text in `hidden xl:inline` span, add `whitespace-nowrap`

## Test plan
- [ ] Resize browser between 1024px–1280px and verify navbar shows only icons
- [ ] At 1280px+ verify full text labels appear for links, wallet, and feedback
- [ ] Verify mobile navbar still works correctly below `md` breakpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)
