### PR TITLE
feat(skills): add dynamic `!command` injection to Claude Code skills

### DIFF
--- a/.claude/skills/pr-address/SKILL.md
+++ b/.claude/skills/pr-address/SKILL.md
@@ -10,6 +10,14 @@ metadata:
 
 # PR Address
 
+## Current State
+
+- **Branch:** `!git branch --show-current`
+- **PR:** `!gh pr list --head $(git branch --show-current) --repo Significant-Gravitas/AutoGPT --json number,url,title -q '.[0] | "\(.number) \(.url) \(.title)"' 2>/dev/null || echo "no PR found for current branch"`
+- **CI:** `!gh pr checks $(gh pr list --head $(git branch --show-current) --repo Significant-Gravitas/AutoGPT -q '.[0].number' 2>/dev/null) --repo Significant-Gravitas/AutoGPT --json bucket,name -q '[.[] | select(.bucket != "pass" and .bucket != "skipping")] | length | tostring + " failing/pending checks"' 2>/dev/null || echo "unknown"`
+
+Use the context above to skip the "Find the PR" step if a PR number is already shown.
+
 ## Find the PR
 
 ```bash

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -10,6 +10,13 @@ metadata:
 
 # PR Review
 
+## Current State
+
+- **Branch:** `!git branch --show-current`
+- **PR:** `!gh pr list --head $(git branch --show-current) --repo Significant-Gravitas/AutoGPT --json number,url,title -q '.[0] | "\(.number) \(.url) \(.title)"' 2>/dev/null || echo "no PR found for current branch"`
+
+Use the context above to skip the "Find the PR" step if a PR number is already shown.
+
 ## Find the PR
 
 ```bash

--- a/.claude/skills/worktree/SKILL.md
+++ b/.claude/skills/worktree/SKILL.md
@@ -10,6 +10,13 @@ metadata:
 
 # Worktree Setup
 
+## Current State
+
+- **Existing worktrees:**
+`!git worktree list 2>/dev/null || echo "not in a git repo"`
+
+Use the list above to pick the next available `AutoGPT<N>` name and avoid conflicts.
+
 ## Create the worktree
 
 Derive paths from the git toplevel. If a name is provided as argument, use it. Otherwise, check `git worktree list` and pick the next `AutoGPT<N>`.


### PR DESCRIPTION
Requested by @ntindle

Add `!command` blocks to pr-address, pr-review, and worktree skills so Claude Code injects runtime context directly into the prompt at invocation time. The model sees branch info, PR status, CI state, and existing worktrees before it starts working — no extra tool calls needed.

### Changes

**pr-address** — Injects current branch, PR number/URL/title, and failing/pending CI check count. Skips the "Find the PR" step when context is already available.

**pr-review** — Injects current branch and PR number/URL/title. Skips the "Find the PR" step.

**worktree** — Injects the current worktree list so the next `AutoGPT<N>` name can be picked without an extra `git worktree list` call.

All commands use fallback patterns (`2>/dev/null || echo ...`) for graceful degradation (detached HEAD, no PR, not in a git repo).

### Not Changed

- backend-check, frontend-check, vercel-react-best-practices — static recipes where the commands are the steps, not context
- No skill logic or rules changed, only added context sections

Resolves SECRT-2147

---
Co-authored-by: Nicholas Tindle (@ntindle) <nicholas.tindle@agpt.co>