### PR TITLE
fix(frontend): truncate marketplace card description to 2 lines

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/marketplace/components/StoreCard/StoreCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/marketplace/components/StoreCard/StoreCard.tsx
@@ -144,7 +144,7 @@ export function StoreCard({
 
         {/* Third Section: Description */}
         <div className="mt-2.5 flex w-full flex-col">
-          <Text variant="body" className="line-clamp-3 leading-normal">
+          <Text variant="body" className="line-clamp-2 leading-normal">
             {description}
           </Text>
         </div>


### PR DESCRIPTION
Reduces `line-clamp` from 3 to 2 on the marketplace `StoreCard` description to prevent text from overlapping with the absolutely-positioned run count and +Add button at the bottom of the card.

Resolves SECRT-2156.

---
Co-authored-by: Abhimanyu Yadav (@Abhi1992002) <122007096+Abhi1992002@users.noreply.github.com>