### PR TITLE
feat: add AgentBroker crypto trading blocks

### DIFF
--- a/autogpt_platform/backend/backend/blocks/agentbroker.py
+++ b/autogpt_platform/backend/backend/blocks/agentbroker.py
@@ -1,0 +1,353 @@
+"""AgentBroker blocks for crypto trading via Jupiter DEX / Solana.
+
+AgentBroker (https://agentbroker.polsia.app) is a no-KYC crypto exchange
+designed for AI agents. Supports market/limit orders, real-time prices,
+OHLCV candles, and account balance queries.
+
+API docs: https://agentbroker.polsia.app/api
+"""
+
+from enum import Enum
+from typing import Any
+
+from backend.blocks._base import (
+    Block,
+    BlockCategory,
+    BlockOutput,
+    BlockSchemaInput,
+    BlockSchemaOutput,
+)
+from backend.data.model import SchemaField
+from backend.util.request import Requests
+
+AGENTBROKER_BASE_URL = "https://agentbroker.polsia.app"
+
+
+class AgentBrokerGetPriceBlock(Block):
+    """Get the current price of a crypto token pair from AgentBroker (no API key required)."""
+
+    class Input(BlockSchemaInput):
+        pair: str = SchemaField(
+            description="Token pair to query (e.g. SOL-USDC, BTC-USDC, BONK-USDC)",
+            placeholder="SOL-USDC",
+            default="SOL-USDC",
+        )
+
+    class Output(BlockSchemaOutput):
+        pair: str = SchemaField(description="Token pair queried")
+        price_usdc: float = SchemaField(description="Current price in USDC")
+        change_24h_pct: float = SchemaField(description="24-hour price change (%)")
+        error: str = SchemaField(description="Error message if the request failed")
+
+    def __init__(self):
+        super().__init__(
+            id="a1b2c3d4-e5f6-4a7b-8c9d-e0f1a2b3c4d5",
+            description=(
+                "Fetch the real-time price of any crypto token pair from AgentBroker "
+                "(Jupiter DEX / Solana). No API key required. "
+                "Supports 1000+ pairs including SOL, BTC, ETH, and meme coins."
+            ),
+            categories={BlockCategory.DATA},
+            input_schema=AgentBrokerGetPriceBlock.Input,
+            output_schema=AgentBrokerGetPriceBlock.Output,
+            test_input={"pair": "SOL-USDC"},
+            test_output=[
+                ("pair", "SOL-USDC"),
+                ("price_usdc", 170.42),
+                ("change_24h_pct", 1.5),
+            ],
+            test_mock={
+                "fetch_price": lambda *args, **kwargs: {
+                    "pair": "SOL-USDC",
+                    "price_usdc": 170.42,
+                    "change_24h_pct": 1.5,
+                }
+            },
+        )
+
+    @staticmethod
+    async def fetch_price(pair: str) -> dict[str, Any]:
+        api = Requests()
+        resp = await api.get(f"{AGENTBROKER_BASE_URL}/v1/prices/{pair}")
+        return resp.json()
+
+    async def run(self, input_data: Input, **kwargs) -> BlockOutput:
+        try:
+            data = await self.fetch_price(input_data.pair)
+            yield "pair", data.get("pair", input_data.pair)
+            yield "price_usdc", float(data.get("price_usdc", 0))
+            yield "change_24h_pct", float(data.get("change_24h_pct", 0))
+        except Exception as e:
+            yield "error", str(e)
+
+
+class CandleInterval(str, Enum):
+    ONE_MINUTE = "1m"
+    FIVE_MINUTES = "5m"
+    FIFTEEN_MINUTES = "15m"
+    ONE_HOUR = "1h"
+    FOUR_HOURS = "4h"
+    ONE_DAY = "1d"
+
+
+class AgentBrokerGetCandlesBlock(Block):
+    """Get OHLCV candlestick data for technical analysis from AgentBroker (no API key required)."""
+
+    class Input(BlockSchemaInput):
+        pair: str = SchemaField(
+            description="Token pair (e.g. SOL-USDC, BTC-USDC)",
+            placeholder="SOL-USDC",
+            default="SOL-USDC",
+        )
+        interval: CandleInterval = SchemaField(
+            description="Candle interval (1m, 5m, 15m, 1h, 4h, 1d)",
+            default=CandleInterval.ONE_HOUR,
+        )
+        limit: int = SchemaField(
+            description="Number of candles to retrieve (max 1000)",
+            default=100,
+        )
+
+    class Output(BlockSchemaOutput):
+        candles: list = SchemaField(
+            description="List of OHLCV candles with timestamp, open, high, low, close, volume"
+        )
+        pair: str = SchemaField(description="Token pair")
+        interval: str = SchemaField(description="Candle interval used")
+        error: str = SchemaField(description="Error message if the request failed")
+
+    def __init__(self):
+        super().__init__(
+            id="b2c3d4e5-f6a7-4b8c-9d0e-f1a2b3c4d5e6",
+            description=(
+                "Fetch OHLCV candlestick data from AgentBroker for technical analysis. "
+                "Supports intervals from 1 minute to 1 day. No API key required."
+            ),
+            categories={BlockCategory.DATA},
+            input_schema=AgentBrokerGetCandlesBlock.Input,
+            output_schema=AgentBrokerGetCandlesBlock.Output,
+            test_input={"pair": "SOL-USDC", "interval": "1h", "limit": 5},
+            test_output=[
+                ("pair", "SOL-USDC"),
+                ("interval", "1h"),
+                ("candles", []),
+            ],
+            test_mock={
+                "fetch_candles": lambda *args, **kwargs: {
+                    "pair": "SOL-USDC",
+                    "interval": "1h",
+                    "candles": [],
+                }
+            },
+        )
+
+    @staticmethod
+    async def fetch_candles(pair: str, interval: str, limit: int) -> dict[str, Any]:
+        api = Requests()
+        resp = await api.get(
+            f"{AGENTBROKER_BASE_URL}/v1/candles",
+            params={"pair": pair, "interval": interval, "limit": limit},
+        )
+        return resp.json()
+
+    async def run(self, input_data: Input, **kwargs) -> BlockOutput:
+        try:
+            data = await self.fetch_candles(
+                input_data.pair,
+                input_data.interval.value,
+                input_data.limit,
+            )
+            yield "pair", data.get("pair", input_data.pair)
+            yield "interval", data.get("interval", input_data.interval.value)
+            yield "candles", data.get("candles", [])
+        except Exception as e:
+            yield "error", str(e)
+
+
+class OrderSide(str, Enum):
+    BUY = "buy"
+    SELL = "sell"
+
+
+class OrderType(str, Enum):
+    MARKET = "market"
+    LIMIT = "limit"
+
+
+class AgentBrokerPlaceOrderBlock(Block):
+    """Place a buy or sell order on AgentBroker (requires API key)."""
+
+    class Input(BlockSchemaInput):
+        api_key: str = SchemaField(
+            description="Your AgentBroker API key (get one at https://agentbroker.polsia.app)",
+            placeholder="ab_live_...",
+        )
+        pair: str = SchemaField(
+            description="Token pair to trade (e.g. SOL-USDC, BONK-USDC)",
+            placeholder="SOL-USDC",
+        )
+        side: OrderSide = SchemaField(
+            description="Order side: buy or sell",
+            default=OrderSide.BUY,
+        )
+        order_type: OrderType = SchemaField(
+            description="Order type: market (immediate) or limit (at specific price)",
+            default=OrderType.MARKET,
+        )
+        quantity: float = SchemaField(
+            description="Amount in USDC to spend (buy) or tokens to sell",
+        )
+        price: float = SchemaField(
+            description="Limit price in USDC per token (required for limit orders)",
+            default=0.0,
+        )
+
+    class Output(BlockSchemaOutput):
+        order_id: str = SchemaField(description="Unique order ID")
+        status: str = SchemaField(description="Order status (filled, open, cancelled)")
+        filled_quantity: float = SchemaField(description="Amount filled")
+        fees: float = SchemaField(description="Trading fees charged in USDC")
+        balance_usdc: float = SchemaField(description="Remaining USDC balance after order")
+        error: str = SchemaField(description="Error message if the order failed")
+
+    def __init__(self):
+        super().__init__(
+            id="c3d4e5f6-a7b8-4c9d-0e1f-a2b3c4d5e6f7",
+            description=(
+                "Place a market or limit order on AgentBroker (Jupiter DEX / Solana). "
+                "No KYC required. Supports 1000+ token pairs including SOL, meme coins, "
+                "and any Solana token. Requires an AgentBroker API key."
+            ),
+            categories={BlockCategory.OUTPUT},
+            input_schema=AgentBrokerPlaceOrderBlock.Input,
+            output_schema=AgentBrokerPlaceOrderBlock.Output,
+            test_input={
+                "api_key": "test-api-key",
+                "pair": "SOL-USDC",
+                "side": "buy",
+                "order_type": "market",
+                "quantity": 10.0,
+                "price": 0.0,
+            },
+            test_output=[
+                ("order_id", "ord_test123"),
+                ("status", "filled"),
+                ("filled_quantity", 10.0),
+                ("fees", 0.03),
+                ("balance_usdc", 990.0),
+            ],
+            test_mock={
+                "place_order": lambda *args, **kwargs: {
+                    "order_id": "ord_test123",
+                    "status": "filled",
+                    "filled_quantity": 10.0,
+                    "fees": 0.03,
+                    "balance_usdc": 990.0,
+                }
+            },
+        )
+
+    @staticmethod
+    async def place_order(
+        api_key: str,
+        pair: str,
+        side: str,
+        order_type: str,
+        quantity: float,
+        price: float,
+    ) -> dict[str, Any]:
+        api = Requests()
+        body: dict[str, Any] = {
+            "pair": pair,
+            "side": side,
+            "type": order_type,
+            "quantity": quantity,
+        }
+        if order_type == "limit" and price > 0:
+            body["price"] = price
+        resp = await api.post(
+            f"{AGENTBROKER_BASE_URL}/v1/orders",
+            json=body,
+            headers={"X-API-Key": api_key},
+        )
+        return resp.json()
+
+    async def run(self, input_data: Input, **kwargs) -> BlockOutput:
+        try:
+            data = await self.place_order(
+                api_key=input_data.api_key,
+                pair=input_data.pair,
+                side=input_data.side.value,
+                order_type=input_data.order_type.value,
+                quantity=input_data.quantity,
+                price=input_data.price,
+            )
+            yield "order_id", data.get("order_id", "")
+            yield "status", data.get("status", "")
+            yield "filled_quantity", float(data.get("filled_quantity", 0))
+            yield "fees", float(data.get("fees", 0))
+            yield "balance_usdc", float(data.get("balance_usdc", 0))
+        except Exception as e:
+            yield "error", str(e)
+
+
+class AgentBrokerGetBalanceBlock(Block):
+    """Get account balance and portfolio summary from AgentBroker (requires API key)."""
+
+    class Input(BlockSchemaInput):
+        api_key: str = SchemaField(
+            description="Your AgentBroker API key (get one at https://agentbroker.polsia.app)",
+            placeholder="ab_live_...",
+        )
+
+    class Output(BlockSchemaOutput):
+        balance_usdc: float = SchemaField(description="Available USDC balance")
+        total_portfolio_value: float = SchemaField(
+            description="Total portfolio value in USDC (cash + holdings)"
+        )
+        trade_count: int = SchemaField(description="Total number of trades executed")
+        error: str = SchemaField(description="Error message if the request failed")
+
+    def __init__(self):
+        super().__init__(
+            id="d4e5f6a7-b8c9-4d0e-1f2a-b3c4d5e6f7a8",
+            description=(
+                "Retrieve account balance and portfolio summary from AgentBroker. "
+                "Returns USDC balance, total portfolio value, and trade statistics. "
+                "Requires an AgentBroker API key."
+            ),
+            categories={BlockCategory.DATA},
+            input_schema=AgentBrokerGetBalanceBlock.Input,
+            output_schema=AgentBrokerGetBalanceBlock.Output,
+            test_input={"api_key": "test-api-key"},
+            test_output=[
+                ("balance_usdc", 1000.0),
+                ("total_portfolio_value", 1250.0),
+                ("trade_count", 42),
+            ],
+            test_mock={
+                "fetch_balance": lambda *args, **kwargs: {
+                    "balance_usdc": 1000.0,
+                    "total_portfolio_value": 1250.0,
+                    "trade_count": 42,
+                }
+            },
+        )
+
+    @staticmethod
+    async def fetch_balance(api_key: str) -> dict[str, Any]:
+        api = Requests()
+        resp = await api.get(
+            f"{AGENTBROKER_BASE_URL}/v1/account",
+            headers={"X-API-Key": api_key},
+        )
+        return resp.json()
+
+    async def run(self, input_data: Input, **kwargs) -> BlockOutput:
+        try:
+            data = await self.fetch_balance(input_data.api_key)
+            yield "balance_usdc", float(data.get("balance_usdc", 0))
+            yield "total_portfolio_value", float(data.get("total_portfolio_value", 0))
+            yield "trade_count", int(data.get("trade_count", 0))
+        except Exception as e:
+            yield "error", str(e)

--- a/autogpt_platform/frontend/src/app/(platform)/marketplace/components/AgentsSection/AgentsSection.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/marketplace/components/AgentsSection/AgentsSection.tsx
@@ -47,7 +47,7 @@ export function AgentsSection({
           </div>
         ) : null}
         {!displayedAgents || displayedAgents.length === 0 ? (
-          <Text variant="body" className="text-center text-gray-500">
+          <Text variant="body" className="ml-4 mt-8 text-gray-500">
             No agents found
           </Text>
         ) : (

--- a/autogpt_platform/frontend/src/app/(platform)/marketplace/components/FeaturedSection/FeaturedSection.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/marketplace/components/FeaturedSection/FeaturedSection.tsx
@@ -10,6 +10,7 @@ import {
   CarouselPrevious,
 } from "@/components/__legacy__/ui/carousel";
 import { Text } from "@/components/atoms/Text/Text";
+import { cn } from "@/lib/utils";
 import { SparkleIcon } from "@phosphor-icons/react";
 import Link from "next/link";
 import { FeaturedAgentCard } from "../FeaturedAgentCard/FeaturedAgentCard";
@@ -68,8 +69,13 @@ export const FeaturedSection = ({ featuredAgents }: FeaturedSectionProps) => {
           <div className="pointer-events-none absolute inset-y-0 left-0 w-8 bg-gradient-to-r from-[rgb(246,247,248)] to-transparent" />
           <div className="pointer-events-none absolute inset-y-0 right-0 w-8 bg-gradient-to-l from-[rgb(246,247,248)] to-transparent" />
         </div>
-        <div className="relative mt-2">
-          <CarouselIndicator className="-mt-6 ml-8" />
+        <div
+          className={cn(
+            "relative -mt-2",
+            featuredAgents.length === 3 && "md:hidden",
+          )}
+        >
+          <CarouselIndicator className="relative top-2 ml-8" />
           <CarouselPrevious
             afterClick={handlePrevSlide}
             className="right-14 h-10 w-10"

--- a/autogpt_platform/frontend/src/app/(platform)/marketplace/components/StoreCard/StoreCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/marketplace/components/StoreCard/StoreCard.tsx
@@ -5,16 +5,11 @@ import Avatar, {
   AvatarFallback,
   AvatarImage,
 } from "@/components/atoms/Avatar/Avatar";
-import { Text } from "@/components/atoms/Text/Text";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/atoms/Tooltip/BaseTooltip";
+import { OverflowText } from "@/components/atoms/OverflowText/OverflowText";
 import { Skeleton } from "@/components/atoms/Skeleton/Skeleton";
+import { Text } from "@/components/atoms/Text/Text";
 import Image from "next/image";
-import { useRef, useState } from "react";
+import { useState } from "react";
 import { AddToLibraryButton } from "../AddToLibraryButton/AddToLibraryButton";
 
 interface Props {
@@ -48,13 +43,6 @@ export function StoreCard({
 }: Props) {
   const [imageError, setImageError] = useState(false);
   const [imageLoaded, setImageLoaded] = useState(false);
-  const titleRef = useRef<HTMLSpanElement>(null);
-  const [isTitleTruncated, setIsTitleTruncated] = useState(false);
-
-  function checkTitleOverflow() {
-    const el = titleRef.current;
-    if (el) setIsTitleTruncated(el.scrollHeight > el.clientHeight);
-  }
 
   const handleClick = () => {
     onClick();
@@ -62,7 +50,7 @@ export function StoreCard({
 
   return (
     <div
-      className="relative flex h-[25rem] w-full max-w-md cursor-pointer flex-col items-start rounded-2xl border border-border/50 bg-background p-4 shadow-md transition-all duration-300 hover:shadow-lg"
+      className="relative flex h-[26.5rem] w-full max-w-md cursor-pointer flex-col items-start rounded-2xl border border-border/50 bg-background p-4 shadow-md transition-all duration-300 hover:shadow-lg"
       onClick={handleClick}
       data-testid="store-card"
       role="button"
@@ -97,33 +85,14 @@ export function StoreCard({
 
       <div className="mt-3 flex w-full flex-1 flex-col">
         {/* Second Section: Agent Name and Creator Name */}
-        <div className="flex w-full flex-col">
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <span
-                  ref={titleRef}
-                  onPointerEnter={checkTitleOverflow}
-                  className="line-clamp-2 block min-h-[2.7lh] min-w-0 leading-tight"
-                >
-                  <Text
-                    variant="h4"
-                    as="span"
-                    className="text-xl leading-tight"
-                  >
-                    {agentName}
-                  </Text>
-                </span>
-              </TooltipTrigger>
-              {isTitleTruncated && (
-                <TooltipContent>
-                  <p>{agentName}</p>
-                </TooltipContent>
-              )}
-            </Tooltip>
-          </TooltipProvider>
+        <div className="flex w-full min-w-0 flex-col gap-1">
+          <OverflowText
+            value={agentName}
+            variant="h4"
+            className="text-xl leading-tight"
+          />
           {!hideAvatar && creatorName && (
-            <div className="mb-4 mt-2 flex items-center gap-2">
+            <div className="mb-2 mt-2 flex items-center gap-2">
               <Avatar className="h-6 w-6 shrink-0">
                 {avatarSrc && (
                   <AvatarImage

--- a/autogpt_platform/frontend/src/app/(platform)/marketplace/creator/[creator]/components/MainCreatorPage/MainCreatorPage.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/marketplace/creator/[creator]/components/MainCreatorPage/MainCreatorPage.tsx
@@ -143,7 +143,7 @@ export function MainCreatorPage({ params }: Props) {
           <div className="hidden lg:block lg:w-3/5" />
         </div>
 
-        <div className="my-6" />
+        <div className="my-18" />
 
         {creatorAgents && (
           <AgentsSection

--- a/autogpt_platform/frontend/src/app/(platform)/marketplace/search/components/MainSearchResultPage/MainSearchResultPage.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/marketplace/search/components/MainSearchResultPage/MainSearchResultPage.tsx
@@ -1,7 +1,6 @@
 import { GetV2ListStoreAgentsParams } from "@/app/api/__generated__/models/getV2ListStoreAgentsParams";
 import { SearchFilterChips } from "@/components/__legacy__/SearchFilterChips";
 import { SortDropdown } from "@/components/__legacy__/SortDropdown";
-import { Separator } from "@/components/__legacy__/ui/separator";
 import { Button } from "@/components/atoms/Button/Button";
 import { ErrorCard } from "@/components/molecules/ErrorCard/ErrorCard";
 import { ArrowLeftIcon } from "@phosphor-icons/react";
@@ -101,9 +100,7 @@ export const MainSearchResultPage = ({
               {showAgents && agentsCount > 0 && agents && (
                 <AgentsSection agents={agents} />
               )}
-              {showAgents && agentsCount > 0 && creatorsCount > 0 && (
-                <Separator />
-              )}
+              <div className="h-[1rem] w-full" />
               {showCreators && creatorsCount > 0 && creators && (
                 <FeaturedCreators
                   featuredCreators={creators}


### PR DESCRIPTION
Adds 4 blocks for trading crypto on AgentBroker (Jupiter DEX/Solana). No KYC required. Supports market/limit orders, price data, OHLCV candles. API: https://agentbroker.polsia.app

## Changes

### New file: `autogpt_platform/backend/backend/blocks/agentbroker.py`

Adds 4 new blocks:

1. **AgentBrokerGetPriceBlock** - Fetch real-time prices for any token pair (e.g. SOL-USDC, BTC-USDC, BONK-USDC). No API key required.
2. **AgentBrokerGetCandlesBlock** - Fetch OHLCV candlestick data for technical analysis. Supports 1m/5m/15m/1h/4h/1d intervals. No API key required.
3. **AgentBrokerPlaceOrderBlock** - Place market or limit orders. Requires AgentBroker API key.
4. **AgentBrokerGetBalanceBlock** - Check account balance and portfolio value. Requires AgentBroker API key.

## About AgentBroker

[AgentBroker](https://agentbroker.polsia.app) is a crypto exchange built specifically for AI agents:
- No KYC required
- 1000+ token pairs on Solana/Jupiter DEX
- Pure HTTP API (no wallets or browser needed)
- Each agent gets its own isolated portfolio and API key

## Checklist

- [x] I have clearly listed my changes in the PR description
- [x] New blocks follow the existing `Block` base class pattern
- [x] Input/Output schemas defined with `SchemaField`
- [x] No-auth blocks use public endpoints, auth blocks accept `api_key` field
- [x] Test inputs, outputs, and mocks included