### PR TITLE
feat(backend/db): add UserInvite model with allowed_users trigger

### DIFF
--- a/autogpt_platform/backend/migrations/20260323084228_user_invites/migration.sql
+++ b/autogpt_platform/backend/migrations/20260323084228_user_invites/migration.sql
@@ -5,7 +5,7 @@ CREATE TYPE "TallyComputationStatus" AS ENUM ('PENDING', 'RUNNING', 'READY', 'FA
 CREATE TABLE "UserInvite" (
     "email" TEXT NOT NULL,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "userId" TEXT,
     "tallyUnderstanding" JSONB,
     "tallyStatus" "TallyComputationStatus" NOT NULL DEFAULT 'PENDING',

--- a/autogpt_platform/backend/schema.prisma
+++ b/autogpt_platform/backend/schema.prisma
@@ -84,7 +84,7 @@ enum TallyComputationStatus {
 model UserInvite {
   email              String                 @id
   createdAt          DateTime               @default(now())
-  updatedAt          DateTime               @updatedAt
+  updatedAt          DateTime               @default(now()) @updatedAt
   userId             String?                @unique
   User               User?                  @relation(fields: [userId], references: [id], onDelete: Cascade)
   tallyUnderstanding Json?


### PR DESCRIPTION
## Summary
- Add `UserInvite` model and `TallyComputationStatus` enum to track invited users and their onboarding tally computation state
- Create `allowed_users` table with a Postgres trigger (`trg_create_invite`) that automatically inserts a `UserInvite` record whenever a new email is added to `allowed_users`

## Changes
- **`schema.prisma`**: Add `TallyComputationStatus` enum (`PENDING`, `RUNNING`, `READY`, `FAILED`) and `UserInvite` model keyed by email, linked to `User` via optional `userId`
- **Migration SQL**: Create `UserInvite` table, `allowed_users` table, and `create_invite()` trigger function

## Test plan
- [ ] Run `poetry run prisma migrate dev` and verify migration applies cleanly
- [ ] Insert a row into `allowed_users` and confirm a corresponding `UserInvite` row is created in the `platform` schema
- [ ] Verify the foreign key constraint works: linking a `UserInvite` to an existing `User` succeeds, and cascading delete removes the invite when the user is deleted
