### PR TITLE
fix(backend): downgrade user-caused LLM API errors to warning level

### DIFF
--- a/autogpt_platform/backend/backend/blocks/llm.py
+++ b/autogpt_platform/backend/backend/blocks/llm.py
@@ -894,63 +894,60 @@ async def llm_call(
         client = anthropic.AsyncAnthropic(
             api_key=credentials.api_key.get_secret_value()
         )
-        try:
-            resp = await client.messages.create(
-                model=llm_model.value,
-                system=sysprompt,
-                messages=messages,
-                max_tokens=max_tokens,
-                tools=an_tools,
-                timeout=600,
-            )
+        resp = await client.messages.create(
+            model=llm_model.value,
+            system=sysprompt,
+            messages=messages,
+            max_tokens=max_tokens,
+            tools=an_tools,
+            timeout=600,
+        )
 
-            if not resp.content:
-                raise ValueError("No content returned from Anthropic.")
+        if not resp.content:
+            raise ValueError("No content returned from Anthropic.")
 
-            tool_calls = None
-            for content_block in resp.content:
-                # Antropic is different to openai, need to iterate through
-                # the content blocks to find the tool calls
-                if content_block.type == "tool_use":
-                    if tool_calls is None:
-                        tool_calls = []
-                    tool_calls.append(
-                        ToolContentBlock(
-                            id=content_block.id,
-                            type=content_block.type,
-                            function=ToolCall(
-                                name=content_block.name,
-                                arguments=json.dumps(content_block.input),
-                            ),
-                        )
+        tool_calls = None
+        for content_block in resp.content:
+            # Antropic is different to openai, need to iterate through
+            # the content blocks to find the tool calls
+            if content_block.type == "tool_use":
+                if tool_calls is None:
+                    tool_calls = []
+                tool_calls.append(
+                    ToolContentBlock(
+                        id=content_block.id,
+                        type=content_block.type,
+                        function=ToolCall(
+                            name=content_block.name,
+                            arguments=json.dumps(content_block.input),
+                        ),
                     )
-
-            if not tool_calls and resp.stop_reason == "tool_use":
-                logger.warning(
-                    f"Tool use stop reason but no tool calls found in content. {resp}"
                 )
 
-            reasoning = None
-            for content_block in resp.content:
-                if hasattr(content_block, "type") and content_block.type == "thinking":
-                    reasoning = content_block.thinking
-                    break
-
-            return LLMResponse(
-                raw_response=resp,
-                prompt=prompt,
-                response=(
-                    resp.content[0].name
-                    if isinstance(resp.content[0], anthropic.types.ToolUseBlock)
-                    else getattr(resp.content[0], "text", "")
-                ),
-                tool_calls=tool_calls,
-                prompt_tokens=resp.usage.input_tokens,
-                completion_tokens=resp.usage.output_tokens,
-                reasoning=reasoning,
+        if not tool_calls and resp.stop_reason == "tool_use":
+            logger.warning(
+                f"Tool use stop reason but no tool calls found in content. {resp}"
             )
-        except anthropic.APIError:
-            raise
+
+        reasoning = None
+        for content_block in resp.content:
+            if hasattr(content_block, "type") and content_block.type == "thinking":
+                reasoning = content_block.thinking
+                break
+
+        return LLMResponse(
+            raw_response=resp,
+            prompt=prompt,
+            response=(
+                resp.content[0].name
+                if isinstance(resp.content[0], anthropic.types.ToolUseBlock)
+                else getattr(resp.content[0], "text", "")
+            ),
+            tool_calls=tool_calls,
+            prompt_tokens=resp.usage.input_tokens,
+            completion_tokens=resp.usage.output_tokens,
+            reasoning=reasoning,
+        )
     elif provider == "groq":
         if tools:
             raise ValueError("Groq does not support tools.")

--- a/autogpt_platform/backend/backend/blocks/test/test_llm.py
+++ b/autogpt_platform/backend/backend/blocks/test/test_llm.py
@@ -1,3 +1,4 @@
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import anthropic
@@ -5,7 +6,12 @@ import httpx
 import openai
 import pytest
 
+import backend.blocks.llm as llm
 from backend.data.model import NodeExecutionStats
+
+# TEST_CREDENTIALS_INPUT is a plain dict that satisfies AICredentials at runtime
+# but not at the type level. Cast once here to avoid per-test suppressors.
+_TEST_AI_CREDENTIALS = cast(llm.AICredentials, llm.TEST_CREDENTIALS_INPUT)
 
 
 class TestLLMStatsTracking:
@@ -697,19 +703,18 @@ class TestUserErrorStatusCodeHandling:
             call_count += 1
             raise _make_anthropic_status_error(status_code)
 
-        block.llm_call = mock_llm_call  # type: ignore
+        with patch.object(block, "llm_call", new=AsyncMock(side_effect=mock_llm_call)):
+            input_data = llm.AIStructuredResponseGeneratorBlock.Input(
+                prompt="Test",
+                expected_format={"key": "desc"},
+                model=llm.DEFAULT_LLM_MODEL,
+                credentials=_TEST_AI_CREDENTIALS,
+                retry=3,
+            )
 
-        input_data = llm.AIStructuredResponseGeneratorBlock.Input(
-            prompt="Test",
-            expected_format={"key": "desc"},
-            model=llm.DEFAULT_LLM_MODEL,
-            credentials=llm.TEST_CREDENTIALS_INPUT,  # type: ignore
-            retry=3,
-        )
-
-        with pytest.raises(RuntimeError):
-            async for _ in block.run(input_data, credentials=llm.TEST_CREDENTIALS):
-                pass
+            with pytest.raises(RuntimeError):
+                async for _ in block.run(input_data, credentials=llm.TEST_CREDENTIALS):
+                    pass
 
         assert (
             call_count == 1
@@ -729,19 +734,18 @@ class TestUserErrorStatusCodeHandling:
             call_count += 1
             raise _make_openai_status_error(status_code)
 
-        block.llm_call = mock_llm_call  # type: ignore
+        with patch.object(block, "llm_call", new=AsyncMock(side_effect=mock_llm_call)):
+            input_data = llm.AIStructuredResponseGeneratorBlock.Input(
+                prompt="Test",
+                expected_format={"key": "desc"},
+                model=llm.DEFAULT_LLM_MODEL,
+                credentials=_TEST_AI_CREDENTIALS,
+                retry=3,
+            )
 
-        input_data = llm.AIStructuredResponseGeneratorBlock.Input(
-            prompt="Test",
-            expected_format={"key": "desc"},
-            model=llm.DEFAULT_LLM_MODEL,
-            credentials=llm.TEST_CREDENTIALS_INPUT,  # type: ignore
-            retry=3,
-        )
-
-        with pytest.raises(RuntimeError):
-            async for _ in block.run(input_data, credentials=llm.TEST_CREDENTIALS):
-                pass
+            with pytest.raises(RuntimeError):
+                async for _ in block.run(input_data, credentials=llm.TEST_CREDENTIALS):
+                    pass
 
         assert (
             call_count == 1
@@ -760,19 +764,18 @@ class TestUserErrorStatusCodeHandling:
             call_count += 1
             raise _make_anthropic_status_error(500)
 
-        block.llm_call = mock_llm_call  # type: ignore
+        with patch.object(block, "llm_call", new=AsyncMock(side_effect=mock_llm_call)):
+            input_data = llm.AIStructuredResponseGeneratorBlock.Input(
+                prompt="Test",
+                expected_format={"key": "desc"},
+                model=llm.DEFAULT_LLM_MODEL,
+                credentials=_TEST_AI_CREDENTIALS,
+                retry=3,
+            )
 
-        input_data = llm.AIStructuredResponseGeneratorBlock.Input(
-            prompt="Test",
-            expected_format={"key": "desc"},
-            model=llm.DEFAULT_LLM_MODEL,
-            credentials=llm.TEST_CREDENTIALS_INPUT,  # type: ignore
-            retry=3,
-        )
-
-        with pytest.raises(RuntimeError):
-            async for _ in block.run(input_data, credentials=llm.TEST_CREDENTIALS):
-                pass
+            with pytest.raises(RuntimeError):
+                async for _ in block.run(input_data, credentials=llm.TEST_CREDENTIALS):
+                    pass
 
         assert (
             call_count > 1
@@ -788,22 +791,21 @@ class TestUserErrorStatusCodeHandling:
         async def mock_llm_call(*args, **kwargs):
             raise _make_anthropic_status_error(401)
 
-        block.llm_call = mock_llm_call  # type: ignore
+        with patch.object(block, "llm_call", new=AsyncMock(side_effect=mock_llm_call)):
+            input_data = llm.AIStructuredResponseGeneratorBlock.Input(
+                prompt="Test",
+                expected_format={"key": "desc"},
+                model=llm.DEFAULT_LLM_MODEL,
+                credentials=_TEST_AI_CREDENTIALS,
+            )
 
-        input_data = llm.AIStructuredResponseGeneratorBlock.Input(
-            prompt="Test",
-            expected_format={"key": "desc"},
-            model=llm.DEFAULT_LLM_MODEL,
-            credentials=llm.TEST_CREDENTIALS_INPUT,  # type: ignore
-        )
-
-        with (
-            patch.object(llm.logger, "warning") as mock_warning,
-            patch.object(llm.logger, "exception") as mock_exception,
-            pytest.raises(RuntimeError),
-        ):
-            async for _ in block.run(input_data, credentials=llm.TEST_CREDENTIALS):
-                pass
+            with (
+                patch.object(llm.logger, "warning") as mock_warning,
+                patch.object(llm.logger, "exception") as mock_exception,
+                pytest.raises(RuntimeError),
+            ):
+                async for _ in block.run(input_data, credentials=llm.TEST_CREDENTIALS):
+                    pass
 
         mock_warning.assert_called_once()
         mock_exception.assert_not_called()


### PR DESCRIPTION
Requested by @majdyz

Follow-up to #12513. Anthropic/OpenAI 401, 403, and 429 errors are user-caused (bad API keys, forbidden, rate limits) and should not hit Sentry as exceptions.

### Changes

**Changes in `blocks/llm.py`:**
- Anthropic `APIError` handler (line ~950): check `status_code` — use `logger.warning()` for 401/403/429, keep `logger.error()` for server errors
- Generic `Exception` handler in LLM block `run()` (line ~1467): same pattern — `logger.warning()` for user-caused status codes, `logger.exception()` for everything else
- Extracted `USER_ERROR_STATUS_CODES = (401, 403, 429)` module-level constant
- Added `break` to short-circuit retry loop for user-caused errors
- Removed double-logging from inner Anthropic handler

**Changes in `blocks/test/test_llm.py`:**
- Added 8 regression tests covering 401/403/429 fast-exit and 500 retry behavior

**Sentry issues addressed:**
- AUTOGPT-SERVER-8B6, 8B7, 8B8 — `[LLM-Block] Anthropic API error: Error code: 401 - invalid x-api-key`
- Any OpenAI 401/403/429 errors hitting the generic exception handler

Part of SECRT-2166

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan

#### Test plan:
- [x] Unit tests for 401/403/429 Anthropic errors → warning log, no retry
- [x] Unit tests for 500 Anthropic errors → error log, retry
- [x] Unit tests for 401/403/429 OpenAI errors → warning log, no retry
- [x] Unit tests for 500 OpenAI errors → error log, retry
- [x] Verified USER_ERROR_STATUS_CODES constant is used consistently
- [x] Verified no double-logging in Anthropic handler path

---
Co-authored-by: Zamil Majdy (@majdyz) <zamil.majdy@agpt.co>