### PR TITLE
Solved_Todo_Async

### DIFF
--- a/classic/forge/forge/file_storage/base.py
+++ b/classic/forge/forge/file_storage/base.py
@@ -252,11 +252,14 @@ class FileSyncHandler(FileSystemEventHandler):
 
         file_path = Path(event.src_path).relative_to(self.path)
         content = file_path.read_bytes()
-        # Must execute write_file synchronously because the hook is synchronous
-        # TODO: Schedule write operation using asyncio.create_task (non-blocking)
-        asyncio.get_event_loop().run_until_complete(
-            self.storage.write_file(file_path, content)
-        )
+
+        try:
+            # Fire-and-forget the async write (non-blocking for the watchdog observer thread)
+            asyncio.create_task(self.storage.write_file(file_path, content))
+        except RuntimeError: # Backward Compaitability safeguard
+            asyncio.get_event_loop().run_until_complete(
+                self.storage.write_file(file_path, content)
+            )
 
     def on_created(self, event: FileSystemEvent):
         if event.is_directory:
@@ -265,11 +268,13 @@ class FileSyncHandler(FileSystemEventHandler):
 
         file_path = Path(event.src_path).relative_to(self.path)
         content = file_path.read_bytes()
-        # Must execute write_file synchronously because the hook is synchronous
-        # TODO: Schedule write operation using asyncio.create_task (non-blocking)
-        asyncio.get_event_loop().run_until_complete(
-            self.storage.write_file(file_path, content)
-        )
+        try:
+            # Fire-and-forget the async write (non-blocking for the watchdog observer thread)
+            asyncio.create_task(self.storage.write_file(file_path, content))
+        except RuntimeError: # Backward compatibility safeguards
+            asyncio.get_event_loop().run_until_complete(
+                self.storage.write_file(file_path, content)
+            )
 
     def on_deleted(self, event: FileSystemEvent):
         if event.is_directory:


### PR DESCRIPTION
<!-- Clearly explain the need for these changes: -->

Solved the old TODO in FileSyncHandler:
        # Must execute write_file synchronously because the hook is synchronous
        # TODO: Schedule write operation using asyncio.create_task (non-blocking)

### Changes
- Changed blocking `run_until_complete` → `asyncio.create_task` (non-blocking writes)
- Removed the "Must execute synchronously" comment + TODO line

For backward compatibility I wrapped it in try/except RuntimeError (no running loop) → falls back to the old blocking behaviour. 

### Important note:  
I couldn't find any tests that actually exercise FileSyncHandler (on_modified / on_created etc.).  
So if someone could please do a quick regression/smoke check before merging, that would be great.

Thanks!