### PR TITLE
fix(backend): allow admins to download submitted agents pending review

### DIFF
--- a/autogpt_platform/backend/backend/data/graph.py
+++ b/autogpt_platform/backend/backend/data/graph.py
@@ -1207,13 +1207,9 @@ async def get_graph_as_admin(
         order={"version": "desc"},
     )
 
-    # For access, the graph must be owned by the user or listed in the store
-    if graph is None or (
-        graph.userId != user_id
-        and not await is_graph_published_in_marketplace(
-            graph_id, version or graph.version
-        )
-    ):
+    # Admin access bypasses ownership and marketplace checks — route-level
+    # auth already ensures only admins can call this function.
+    if graph is None:
         return None
 
     if for_export:


### PR DESCRIPTION
## Why

Admins cannot download submitted agents from the Admin Marketplace Management page (`/admin/marketplace`). Clicking the "Download" button fails silently with a Server Components render error in the console. This blocks Toran from reviewing agents that companies have submitted.

## What

The `get_graph_as_admin()` function in `backend/data/graph.py` had an access check that required the graph to be either **owned by the requesting user** or **published (APPROVED) in the marketplace**:

### Before (broken)
```python
# For access, the graph must be owned by the user or listed in the store
if graph is None or (
    graph.userId != user_id
    and not await is_graph_published_in_marketplace(
        graph_id, version or graph.version
    )
):
    return None
```

When an admin (who is not the agent creator) tries to download a submitted-but-not-yet-approved agent:
1. `graph.userId != user_id` → `True` (admin ≠ creator)
2. `is_graph_published_in_marketplace()` → `False` (requires `submissionStatus: APPROVED`)
3. Both conditions true → returns `None` → `NotFoundError` → RSC serialization error

### After (fixed)
```python
# Admin access bypasses ownership and marketplace checks — route-level
# auth already ensures only admins can call this function.
if graph is None:
    return None
```

## How

Removed the ownership/marketplace check from `get_graph_as_admin()`, keeping only the null guard. This is safe because:

- `get_graph_as_admin()` is **only** called from `store/db.py` → `get_agent_as_admin()` → admin-protected route
- Route-level auth (`fastapi.Security(autogpt_libs.auth.get_user_id)` + admin role) already ensures only admins can access these endpoints
- The function name and its warning log make clear it bypasses normal access control

---
Co-authored-by: Abhimanyu Yadav (@Abhi1992002) <122007096+Abhi1992002@users.noreply.github.com>