### PR TITLE
fix(frontend/builder): make Select widget full-width in list[enum] fields

### DIFF
--- a/autogpt_platform/frontend/src/components/atoms/Select/Select.tsx
+++ b/autogpt_platform/frontend/src/components/atoms/Select/Select.tsx
@@ -119,7 +119,7 @@ export function Select({
   );
 
   const selectWithError = (
-    <div className={cn("relative mb-6", wrapperClassName)}>
+    <div className={cn("relative mb-6 w-full", wrapperClassName)}>
       {select}
       <Text
         variant="small-medium"


### PR DESCRIPTION
Requested by @itsababseh

The `Select` atom's wrapper `<div>` used `relative mb-6` but lacked `w-full`, causing select dropdowns inside array items (`list[enum]` fields) to not stretch to fill the available width, making the UI look broken/cramped.

## Change

Added `w-full` to the wrapper div in `Select.tsx`:

```diff
- <div className={cn("relative mb-6", wrapperClassName)}>
+ <div className={cn("relative mb-6 w-full", wrapperClassName)}>
```

## Before/After

⚠️ Screenshots needed — I couldn't auth into the dev environment to capture them. @Abhi1992002 could you add before/after screenshots? Any block with a `list[enum]` field should show the difference (e.g. Apollo blocks with seniority levels or contact email statuses).

Resolves SECRT-2165

---
Co-authored-by: Abhimanyu Yadav (@Abhi1992002) <122007096+Abhi1992002@users.noreply.github.com>