### PR TITLE
fix(blocks): validate non-empty input in AIConversationBlock before LLM call

### DIFF
--- a/autogpt_platform/backend/backend/blocks/llm.py
+++ b/autogpt_platform/backend/backend/blocks/llm.py
@@ -1999,9 +1999,11 @@ class AIConversationBlock(AIBlockBase):
     async def run(
         self, input_data: Input, *, credentials: APIKeyCredentials, **kwargs
     ) -> BlockOutput:
-        has_messages = bool(input_data.messages) and any(
-            isinstance(m, dict) and bool(m.get("content", "").strip())
-            for m in input_data.messages
+        has_messages = any(
+            isinstance(m, dict)
+            and isinstance(m.get("content"), str)
+            and bool(m["content"].strip())
+            for m in (input_data.messages or [])
         )
         has_prompt = bool(input_data.prompt and input_data.prompt.strip())
         if not has_messages and not has_prompt:

--- a/autogpt_platform/backend/backend/blocks/test/test_llm.py
+++ b/autogpt_platform/backend/backend/blocks/test/test_llm.py
@@ -619,6 +619,22 @@ class TestAIConversationBlockValidation:
             async for _ in block.run(input_data, credentials=llm.TEST_CREDENTIALS):
                 pass
 
+    @pytest.mark.asyncio
+    async def test_messages_with_none_content_raises_error(self):
+        """Messages with content=None should not crash with AttributeError."""
+        block = llm.AIConversationBlock()
+
+        input_data = llm.AIConversationBlock.Input(
+            messages=[{"role": "user", "content": None}],
+            prompt="",
+            model=llm.DEFAULT_LLM_MODEL,
+            credentials=_TEST_AI_CREDENTIALS,
+        )
+
+        with pytest.raises(ValueError, match="no messages and no prompt"):
+            async for _ in block.run(input_data, credentials=llm.TEST_CREDENTIALS):
+                pass
+
 
 class TestAITextSummarizerValidation:
     """Test that AITextSummarizerBlock validates LLM responses are strings."""


### PR DESCRIPTION
### Why / What / How

**Why:** When `AIConversationBlock` receives an empty messages list and an empty prompt, the block blindly forwards the empty array to the downstream LLM API, which returns a cryptic `400 Bad Request` error: `"Invalid 'messages': empty array. Expected an array with minimum length 1."` This is confusing for users who don't understand why their agent failed.

**What:** Add early input validation in `AIConversationBlock.run()` that raises a clear `ValueError` when both `messages` and `prompt` are empty. Also add three unit tests covering the validation logic.

**How:** A simple guard clause at the top of the `run` method checks `if not input_data.messages and not input_data.prompt` before the LLM call is made. If both are empty, a descriptive `ValueError` is raised. If either one has content, the block proceeds normally.

### Changes

- `autogpt_platform/backend/backend/blocks/llm.py`: Add validation guard in `AIConversationBlock.run()` to reject empty messages + empty prompt before calling the LLM
- `autogpt_platform/backend/backend/blocks/test/test_llm.py`: Add `TestAIConversationBlockValidation` with three tests:
  - `test_empty_messages_and_empty_prompt_raises_error` — validates the guard clause
  - `test_empty_messages_with_prompt_succeeds` — ensures prompt-only usage still works
  - `test_nonempty_messages_with_empty_prompt_succeeds` — ensures messages-only usage still works

### Checklist

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Lint passes (`ruff check`)
  - [x] Formatting passes (`ruff format`)
  - [x] New unit tests validate the empty-input guard and the happy paths

Closes #11875
