### PR TITLE
fix(blocks): validate email recipients in Gmail blocks before API call

### DIFF
--- a/autogpt_platform/backend/backend/blocks/google/gmail.py
+++ b/autogpt_platform/backend/backend/blocks/google/gmail.py
@@ -9,7 +9,7 @@ from email.mime.text import MIMEText
 from email.policy import SMTP
 from email.utils import getaddresses, parseaddr
 from pathlib import Path
-from typing import List, Literal, Optional
+from typing import List, Literal, Optional, Protocol, runtime_checkable
 
 from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import build
@@ -70,7 +70,14 @@ def validate_email_recipients(recipients: list[str], field_name: str = "to") -> 
         )
 
 
-def validate_all_recipients(input_data) -> None:
+@runtime_checkable
+class HasRecipients(Protocol):
+    to: list[str]
+    cc: list[str]
+    bcc: list[str]
+
+
+def validate_all_recipients(input_data: HasRecipients) -> None:
     """Validate to/cc/bcc recipient fields on an input namespace.
 
     Calls ``validate_email_recipients`` for ``to`` (required) and
@@ -138,7 +145,6 @@ async def create_mime_message(
 ) -> str:
     """Create a MIME message with attachments and return base64-encoded raw message."""
 
-    # Validate all recipient lists before building the MIME message
     validate_all_recipients(input_data)
 
     message = MIMEMultipart()
@@ -1208,7 +1214,6 @@ async def _build_reply_message(
         references.append(headers["message-id"])
 
     # Create MIME message
-    # Validate all recipient lists before building the MIME message
     validate_all_recipients(input_data)
 
     msg = MIMEMultipart()

--- a/autogpt_platform/backend/test/blocks/test_gmail.py
+++ b/autogpt_platform/backend/test/blocks/test_gmail.py
@@ -6,7 +6,9 @@ from unittest.mock import Mock, patch
 import pytest
 
 from backend.blocks.google.gmail import (
+    GmailForwardBlock,
     GmailReadBlock,
+    HasRecipients,
     _build_reply_message,
     create_mime_message,
     validate_all_recipients,
@@ -305,26 +307,32 @@ class TestValidateAllRecipients:
     """Test cases for validate_all_recipients."""
 
     def test_valid_all_fields(self):
-        data = SimpleNamespace(to=["a@b.com"], cc=["c@d.com"], bcc=["e@f.com"])
+        data = cast(
+            HasRecipients,
+            SimpleNamespace(to=["a@b.com"], cc=["c@d.com"], bcc=["e@f.com"]),
+        )
         validate_all_recipients(data)
 
     def test_invalid_to_raises(self):
-        data = SimpleNamespace(to=["bad"], cc=[], bcc=[])
+        data = cast(HasRecipients, SimpleNamespace(to=["bad"], cc=[], bcc=[]))
         with pytest.raises(ValueError, match="'to'"):
             validate_all_recipients(data)
 
     def test_invalid_cc_raises(self):
-        data = SimpleNamespace(to=["a@b.com"], cc=["bad"], bcc=[])
+        data = cast(HasRecipients, SimpleNamespace(to=["a@b.com"], cc=["bad"], bcc=[]))
         with pytest.raises(ValueError, match="'cc'"):
             validate_all_recipients(data)
 
     def test_invalid_bcc_raises(self):
-        data = SimpleNamespace(to=["a@b.com"], cc=["c@d.com"], bcc=["bad"])
+        data = cast(
+            HasRecipients,
+            SimpleNamespace(to=["a@b.com"], cc=["c@d.com"], bcc=["bad"]),
+        )
         with pytest.raises(ValueError, match="'bcc'"):
             validate_all_recipients(data)
 
     def test_empty_cc_bcc_skipped(self):
-        data = SimpleNamespace(to=["a@b.com"], cc=[], bcc=[])
+        data = cast(HasRecipients, SimpleNamespace(to=["a@b.com"], cc=[], bcc=[]))
         validate_all_recipients(data)
 
 
@@ -414,3 +422,83 @@ class TestBuildReplyMessageValidation:
 
         with pytest.raises(ValueError, match="Invalid email address"):
             await _build_reply_message(mock_service, input_data, exec_ctx)
+
+
+class TestForwardMessageValidation:
+    """Test that _forward_message() raises ValueError for invalid recipients."""
+
+    @staticmethod
+    def _make_input(
+        to: list[str] | None = None,
+        cc: list[str] | None = None,
+        bcc: list[str] | None = None,
+    ) -> "GmailForwardBlock.Input":
+        mock = Mock(spec=GmailForwardBlock.Input)
+        mock.messageId = "m1"
+        mock.to = to or []
+        mock.cc = cc or []
+        mock.bcc = bcc or []
+        mock.subject = ""
+        mock.forwardMessage = "FYI"
+        mock.includeAttachments = False
+        mock.content_type = None
+        mock.additionalAttachments = []
+        mock.credentials = None
+        return mock
+
+    @staticmethod
+    def _exec_ctx():
+        return ExecutionContext(user_id="u1", graph_exec_id="g1")
+
+    @staticmethod
+    def _mock_service():
+        """Build a mock Gmail service that returns a parent message."""
+        parent_message = {
+            "id": "m1",
+            "payload": {
+                "headers": [
+                    {"name": "Subject", "value": "Original subject"},
+                    {"name": "From", "value": "sender@example.com"},
+                    {"name": "To", "value": "me@example.com"},
+                    {"name": "Date", "value": "Mon, 31 Mar 2026 00:00:00 +0000"},
+                ],
+                "mimeType": "text/plain",
+                "body": {
+                    "data": base64.urlsafe_b64encode(b"Hello world").decode(),
+                },
+                "parts": [],
+            },
+        }
+        svc = Mock()
+        svc.users().messages().get().execute.return_value = parent_message
+        return svc
+
+    @pytest.mark.asyncio
+    async def test_invalid_to_raises(self):
+        block = GmailForwardBlock()
+        with pytest.raises(ValueError, match="Invalid email address.*'to'"):
+            await block._forward_message(
+                self._mock_service(),
+                self._make_input(to=["bad-addr"]),
+                self._exec_ctx(),
+            )
+
+    @pytest.mark.asyncio
+    async def test_invalid_cc_raises(self):
+        block = GmailForwardBlock()
+        with pytest.raises(ValueError, match="Invalid email address.*'cc'"):
+            await block._forward_message(
+                self._mock_service(),
+                self._make_input(to=["valid@example.com"], cc=["not-valid"]),
+                self._exec_ctx(),
+            )
+
+    @pytest.mark.asyncio
+    async def test_invalid_bcc_raises(self):
+        block = GmailForwardBlock()
+        with pytest.raises(ValueError, match="Invalid email address.*'bcc'"):
+            await block._forward_message(
+                self._mock_service(),
+                self._make_input(to=["valid@example.com"], bcc=["nope"]),
+                self._exec_ctx(),
+            )


### PR DESCRIPTION
### Why / What / How

**Why:** When a user or LLM supplies a malformed recipient string (e.g. a bare username, a JSON blob, or an empty value) to `GmailSendBlock`, `GmailCreateDraftBlock`, or any reply block, the Gmail API returns an opaque `HttpError 400: "Invalid To header"`. This surfaces as a `BlockUnknownError` with no actionable guidance, making it impossible for the LLM to self-correct. (Fixes #11954)

**What:** Adds a lightweight `validate_email_recipients()` function that checks every recipient against a simplified RFC 5322 pattern (`local@domain.tld`) and raises a clear `ValueError` listing all invalid entries before any API call is made.

**How:** The validation is called in two shared code paths — `create_mime_message()` (used by send and draft blocks) and `_build_reply_message()` (used by reply blocks) — so all Gmail blocks that compose outgoing email benefit from it with zero per-block changes. The regex is intentionally permissive (any `x@y.z` passes) to avoid false positives on unusual but valid addresses.

### Changes 🏗️

- Added `validate_email_recipients()` helper in `gmail.py` with a compiled regex
- Hooked validation into `create_mime_message()` for `to`, `cc`, and `bcc` fields
- Hooked validation into `_build_reply_message()` for reply/draft-reply blocks
- Added `TestValidateEmailRecipients` test class covering valid, invalid, mixed, empty, JSON-string, and field-name scenarios

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Verified `validate_email_recipients` correctly accepts valid emails (`user@example.com`, `a@b.com`, `test@sub.domain.co`)
  - [x] Verified it rejects malformed entries (bare names, missing domain dot, empty strings, JSON strings)
  - [x] Verified error messages include the field name and all invalid entries
  - [x] Verified empty recipient lists pass without error
  - [x] Confirmed `gmail.py` and test file parse correctly (AST check)
