### PR TITLE
fix(backend): prevent logging sensitive data in SafeJson fallback

### DIFF
--- a/autogpt_platform/backend/backend/util/json.py
+++ b/autogpt_platform/backend/backend/util/json.py
@@ -165,11 +165,10 @@ def sanitize_json(data: Any) -> Any:
         # Log the failure and fall back to string representation
         logger.error(
             "SafeJson fallback to string representation due to serialization error: %s (%s). "
-            "Data type: %s, Data preview: %s",
+            "Data type: %s",
             type(e).__name__,
             truncate(str(e), 200),
             type(data).__name__,
-            truncate(str(data), 100),
         )
 
         # Ultimate fallback: convert to string representation and sanitize


### PR DESCRIPTION
### Why / What / How

**Why:** GitHub's code scanning detected a HIGH severity security vulnerability in `/autogpt_platform/backend/backend/util/json.py:172`. The error handler in `sanitize_json()` was logging sensitive data (potentially including secrets, API keys, credentials) as clear text when serialization fails.

**What:** This PR removes the logging of actual data content from the error handler while preserving useful debugging metadata (error type, error message, and data type).

**How:** Removed the `"Data preview: %s"` format parameter and the corresponding `truncate(str(data), 100)` argument from the logger.error() call. The error handler now logs only safe metadata that helps debugging without exposing sensitive information.

### Changes 🏗️

- **Security Fix**: Modified `sanitize_json()` function in `backend/util/json.py`
  - Removed logging of data content (`truncate(str(data), 100)`) from the error handler
  - Retained logging of error type (`type(e).__name__`)
  - Retained logging of truncated error message (`truncate(str(e), 200)`)
  - Retained logging of data type (`type(data).__name__`)
  - Error handler still provides useful debugging information without exposing secrets

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Verified the code passes type checking (`poetry run pyright backend/util/json.py`)
  - [x] Verified the code passes linting (`poetry run ruff check backend/util/json.py`)
  - [x] Verified all pre-commit hooks pass
  - [x] Reviewed the diff to ensure only the sensitive data logging was removed
  - [x] Confirmed that useful debugging information (error type, error message, data type) is still logged

#### For configuration changes:
- N/A - No configuration changes required
