### PR TITLE
feat(blocks): add MiniMax as LLM provider

### DIFF
--- a/autogpt_platform/backend/.env.default
+++ b/autogpt_platform/backend/.env.default
@@ -49,6 +49,7 @@ MEDIA_GCS_BUCKET_NAME=
 # All API keys below are optional - only add what you need
 
 # AI/LLM Services
+MINIMAX_API_KEY=
 OPENAI_API_KEY=
 ANTHROPIC_API_KEY=
 GROQ_API_KEY=

--- a/autogpt_platform/backend/backend/blocks/llm.py
+++ b/autogpt_platform/backend/backend/blocks/llm.py
@@ -56,6 +56,7 @@ LLMProviderName = Literal[
     ProviderName.AIML_API,
     ProviderName.ANTHROPIC,
     ProviderName.GROQ,
+    ProviderName.MINIMAX,
     ProviderName.OLLAMA,
     ProviderName.OPENAI,
     ProviderName.OPEN_ROUTER,
@@ -202,6 +203,9 @@ class LlmModel(str, Enum, metaclass=LlmModelMeta):
     V0_1_5_MD = "v0-1.5-md"
     V0_1_5_LG = "v0-1.5-lg"
     V0_1_0_MD = "v0-1.0-md"
+    # MiniMax models
+    MINIMAX_M2_5 = "MiniMax-M2.5"
+    MINIMAX_M2_5_HIGHSPEED = "MiniMax-M2.5-highspeed"
 
     @classmethod
     def __get_pydantic_json_schema__(cls, schema, handler):
@@ -647,6 +651,13 @@ MODEL_METADATA = {
     LlmModel.V0_1_5_MD: ModelMetadata("v0", 128000, 64000, "v0 1.5 MD", "V0", "V0", 1),
     LlmModel.V0_1_5_LG: ModelMetadata("v0", 512000, 64000, "v0 1.5 LG", "V0", "V0", 1),
     LlmModel.V0_1_0_MD: ModelMetadata("v0", 128000, 64000, "v0 1.0 MD", "V0", "V0", 1),
+    # https://platform.minimaxi.com/document/Models
+    LlmModel.MINIMAX_M2_5: ModelMetadata(
+        "minimax", 204000, 64000, "MiniMax M2.5", "MiniMax", "MiniMax", 2
+    ),
+    LlmModel.MINIMAX_M2_5_HIGHSPEED: ModelMetadata(
+        "minimax", 204000, 64000, "MiniMax M2.5 Highspeed", "MiniMax", "MiniMax", 1
+    ),
 }
 
 DEFAULT_LLM_MODEL = LlmModel.GPT5_2
@@ -870,7 +881,6 @@ async def llm_call(
             reasoning=reasoning,
         )
     elif provider == "anthropic":
-
         an_tools = convert_openai_tool_fmt_to_anthropic(tools)
 
         system_messages = [p["content"] for p in prompt if p["role"] == "system"]
@@ -1131,6 +1141,48 @@ async def llm_call(
             tools=tools_param,  # type: ignore
             parallel_tool_calls=parallel_tool_calls_param,
         )
+
+        tool_calls = extract_openai_tool_calls(response)
+        reasoning = extract_openai_reasoning(response)
+
+        return LLMResponse(
+            raw_response=response.choices[0].message,
+            prompt=prompt,
+            response=response.choices[0].message.content or "",
+            tool_calls=tool_calls,
+            prompt_tokens=response.usage.prompt_tokens if response.usage else 0,
+            completion_tokens=response.usage.completion_tokens if response.usage else 0,
+            reasoning=reasoning,
+        )
+    elif provider == "minimax":
+        tools_param = tools if tools else openai.NOT_GIVEN
+        client = openai.AsyncOpenAI(
+            base_url="https://api.minimax.io/v1",
+            api_key=credentials.api_key.get_secret_value(),
+        )
+
+        response_format = None
+        if force_json_output:
+            response_format = {"type": "json_object"}
+
+        parallel_tool_calls_param = get_parallel_tool_calls_param(
+            llm_model, parallel_tool_calls
+        )
+
+        response = await client.chat.completions.create(
+            model=llm_model.value,
+            messages=prompt,  # type: ignore
+            response_format=response_format,  # type: ignore
+            max_tokens=max_tokens,
+            tools=tools_param,  # type: ignore
+            parallel_tool_calls=parallel_tool_calls_param,
+        )
+
+        if not response.choices:
+            if response:
+                raise ValueError(f"MiniMax API error: {response}")
+            else:
+                raise ValueError("No response from MiniMax API.")
 
         tool_calls = extract_openai_tool_calls(response)
         reasoning = extract_openai_reasoning(response)

--- a/autogpt_platform/backend/backend/data/block_cost_config.py
+++ b/autogpt_platform/backend/backend/data/block_cost_config.py
@@ -151,6 +151,8 @@ MODEL_COST: dict[LlmModel, int] = {
     LlmModel.V0_1_5_MD: 1,
     LlmModel.V0_1_5_LG: 2,
     LlmModel.V0_1_0_MD: 1,
+    LlmModel.MINIMAX_M2_5: 1,
+    LlmModel.MINIMAX_M2_5_HIGHSPEED: 1,
 }
 
 for model in LlmModel:

--- a/autogpt_platform/backend/backend/data/block_cost_config.py
+++ b/autogpt_platform/backend/backend/data/block_cost_config.py
@@ -49,6 +49,7 @@ from backend.integrations.credentials_store import (
     ideogram_credentials,
     jina_credentials,
     llama_api_credentials,
+    minimax_credentials,
     open_router_credentials,
     openai_credentials,
     replicate_credentials,
@@ -275,6 +276,23 @@ LLM_COST = (
         )
         for model, cost in MODEL_COST.items()
         if MODEL_METADATA[model].provider == "aiml_api"
+    ]
+    # MiniMax Models
+    + [
+        BlockCost(
+            cost_type=BlockCostType.RUN,
+            cost_filter={
+                "model": model,
+                "credentials": {
+                    "id": minimax_credentials.id,
+                    "provider": minimax_credentials.provider,
+                    "type": minimax_credentials.type,
+                },
+            },
+            cost_amount=cost,
+        )
+        for model, cost in MODEL_COST.items()
+        if MODEL_METADATA[model].provider == "minimax"
     ]
 )
 

--- a/autogpt_platform/backend/backend/integrations/credentials_store.py
+++ b/autogpt_platform/backend/backend/integrations/credentials_store.py
@@ -221,6 +221,14 @@ llama_api_credentials = APIKeyCredentials(
     expires_at=None,
 )
 
+minimax_credentials = APIKeyCredentials(
+    id="3f5d7a2e-8b1c-4e9f-a6d3-7c2b1e0f5a8d",
+    provider="minimax",
+    api_key=SecretStr(settings.secrets.minimax_api_key),
+    title="Use Credits for MiniMax",
+    expires_at=None,
+)
+
 v0_credentials = APIKeyCredentials(
     id="c4e6d1a0-3b5f-4789-a8e2-9b123456789f",
     provider="v0",
@@ -278,6 +286,7 @@ DEFAULT_CREDENTIALS = [
     zerobounce_credentials,
     google_maps_credentials,
     llama_api_credentials,
+    minimax_credentials,
     v0_credentials,
     webshare_proxy_credentials,
     openweathermap_credentials,
@@ -387,6 +396,8 @@ class IntegrationCredentialsStore:
             all_credentials.append(google_maps_credentials)
         if settings.secrets.llama_api_key:
             all_credentials.append(llama_api_credentials)
+        if settings.secrets.minimax_api_key:
+            all_credentials.append(minimax_credentials)
         if settings.secrets.v0_api_key:
             all_credentials.append(v0_credentials)
         if (

--- a/autogpt_platform/backend/backend/integrations/providers.py
+++ b/autogpt_platform/backend/backend/integrations/providers.py
@@ -33,6 +33,7 @@ class ProviderName(str, Enum):
     MCP = "mcp"
     MEDIUM = "medium"
     MEM0 = "mem0"
+    MINIMAX = "minimax"
     NOTION = "notion"
     NVIDIA = "nvidia"
     OLLAMA = "ollama"

--- a/autogpt_platform/backend/backend/util/settings.py
+++ b/autogpt_platform/backend/backend/util/settings.py
@@ -620,6 +620,7 @@ class Secrets(UpdateTrackingModel["Secrets"], BaseSettings):
     groq_api_key: str = Field(default="", description="Groq API key")
     open_router_api_key: str = Field(default="", description="Open Router API Key")
     llama_api_key: str = Field(default="", description="Llama API Key")
+    minimax_api_key: str = Field(default="", description="MiniMax API key")
     v0_api_key: str = Field(default="", description="v0 by Vercel API key")
     webshare_proxy_username: str = Field(
         default="", description="Webshare Proxy Username"

--- a/docs/integrations/guides/llm-providers.md
+++ b/docs/integrations/guides/llm-providers.md
@@ -14,3 +14,28 @@ Try the Llama API provider by selecting any of the following LLM Model names fro
 * Llama-4-Maverick-17B-128E-Instruct-FP8
 * Llama-3.3-8B-Instruct
 * Llama-3-70B-Instruct
+
+## MiniMax
+
+[MiniMax](https://www.minimaxi.com/) is an AI technology company that offers powerful foundation models. MiniMax provides an OpenAI-compatible API, making it easy to integrate their models into AutoGPT.
+
+Get your API key from the [MiniMax Platform](https://platform.minimaxi.com/).
+
+Try the MiniMax provider by selecting any of the following LLM Model names from the AI blocks:
+
+* MiniMax-M2.5
+* MiniMax-M2.5-highspeed
+
+### How It Works
+
+When an AI block is configured with a MiniMax model, AutoGPT routes requests through the OpenAI-compatible MiniMax endpoint (`https://api.minimax.io/v1`) using your configured provider credentials. The block sends the prompt/messages payload and enforces the selected response mode, including standard text, JSON-object output, and tool-calling when enabled.
+
+The block also applies normal runtime safeguards before sending the request: prompt compression for long inputs, output token budgeting against model limits, and explicit empty-response checks. If the provider returns tool calls, AutoGPT maps them into the platform's internal tool-call structure so downstream blocks can execute them consistently.
+
+### Use Case
+
+**Structured extraction at scale:** Convert long documents into validated JSON outputs for downstream automation.
+
+**Agentic workflows with tools:** Let the model choose and invoke tools while preserving consistent tool-call handling in AI blocks.
+
+**Long-context synthesis:** Analyze large multi-message contexts and generate concise summaries or decisions in one pass.


### PR DESCRIPTION
## Summary

Add [MiniMax](https://www.minimaxi.com/) as a new LLM provider for AutoGPT Platform.

> Supersedes #12405 (recreated to fix CLA signing issue with bot-authored commits).

## Changes

### What's included

- **Provider registration**: Added `MINIMAX` to `ProviderName` enum and `LLMProviderName` literal
- **Model definitions**: Added two models to `LlmModel` enum:
  - `MiniMax-M2.5` — flagship model with 204K context window
  - `MiniMax-M2.5-highspeed` — optimized for speed with 204K context window
- **Model metadata**: Context window (204K), max output tokens (64K), pricing tiers
- **Provider routing**: OpenAI-compatible integration via `https://api.minimax.io/v1` with support for tool calling, JSON output, and parallel tool calls
- **Credential store**: MiniMax API key registration following existing provider pattern
- **Cost configuration**: Added MODEL_COST entries for both MiniMax models
- **Documentation**: Added MiniMax section to `docs/integrations/guides/llm-providers.md`

### Why MiniMax?

MiniMax offers competitive foundation models with a large 204K context window. Their API is OpenAI-compatible, making integration straightforward and consistent with existing providers like Llama API, V0, and AI/ML API.

## How to test

1. Get an API key from [MiniMax Platform](https://platform.minimaxi.com/)
2. Select `MiniMax M2.5` or `MiniMax M2.5 Highspeed` from the model dropdown in any AI block
3. Provide your MiniMax API key as credentials
4. Run the block — it should work with text generation, JSON output, and tool calling

## Files changed

- `autogpt_platform/backend/.env.default` — Added `MINIMAX_API_KEY`
- `autogpt_platform/backend/backend/blocks/llm.py` — Added models, metadata, and provider routing
- `autogpt_platform/backend/backend/integrations/credentials_store.py` — Added MiniMax credentials
- `autogpt_platform/backend/backend/integrations/providers.py` — Added `MINIMAX` provider
- `autogpt_platform/backend/backend/util/settings.py` — Added `minimax_api_key` setting
- `autogpt_platform/backend/backend/data/block_cost_config.py` — Added MiniMax model costs
- `docs/integrations/guides/llm-providers.md` — Added MiniMax documentation
