### PR TITLE
fix(frontend): marketplace card description 3 lines + fallback color

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/marketplace/components/StoreCard/StoreCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/marketplace/components/StoreCard/StoreCard.tsx
@@ -79,7 +79,10 @@ export function StoreCard({
             />
           </>
         ) : (
-          <div className="absolute inset-0 rounded-xl bg-violet-50" />
+          <div
+            className="absolute inset-0 rounded-xl"
+            style={{ backgroundColor: "rgb(216, 208, 255)" }}
+          />
         )}
       </div>
 


### PR DESCRIPTION
## Summary
- Increase the marketplace StoreCard description from 2 lines to 3 lines for better readability
- Change fallback background colour for missing agent images from `bg-violet-50` to `rgb(216, 208, 255)`

<img width="933" height="458" alt="Screenshot 2026-03-25 at 20 25 41" src="https://github.com/user-attachments/assets/ea433741-1397-4585-b64c-c7c3b8109584" />
<img width="350" height="457" alt="Screenshot 2026-03-25 at 20 25 55" src="https://github.com/user-attachments/assets/e2029c09-518a-4404-aa95-e202b4064d0b" />


## Test plan
- [x] Verified `pnpm format`, `pnpm lint`, `pnpm types` all pass
- [x] Visually confirmed description shows 3 lines on marketplace cards
- [x] Visually confirmed fallback color renders correctly for cards without images

🤖 Generated with [Claude Code](https://claude.com/claude-code)
