### PR TITLE
fix(backend): handle UniqueViolationError in workspace upsert race

### DIFF
--- a/autogpt_platform/backend/backend/data/workspace.py
+++ b/autogpt_platform/backend/backend/data/workspace.py
@@ -9,6 +9,7 @@ from datetime import datetime, timezone
 from typing import Optional
 
 import pydantic
+from prisma.errors import UniqueViolationError
 from prisma.models import UserWorkspace, UserWorkspaceFile
 from prisma.types import UserWorkspaceFileWhereInput
 
@@ -84,13 +85,26 @@ async def get_or_create_workspace(user_id: str) -> Workspace:
     Returns:
         Workspace instance
     """
-    workspace = await UserWorkspace.prisma().upsert(
-        where={"userId": user_id},
-        data={
-            "create": {"userId": user_id},
-            "update": {},  # No updates needed if exists
-        },
-    )
+    try:
+        workspace = await UserWorkspace.prisma().upsert(
+            where={"userId": user_id},
+            data={
+                "create": {"userId": user_id},
+                "update": {},  # No updates needed if exists
+            },
+        )
+    except UniqueViolationError:
+        # Prisma upsert can still race under concurrent requests for the same
+        # user — the workspace was created by another request between the
+        # "not found" check and the "create" step.  Just fetch it.
+        logger.debug(
+            "UniqueViolationError on workspace upsert for user %s, "
+            "fetching existing workspace",
+            user_id,
+        )
+        workspace = await UserWorkspace.prisma().find_unique(where={"userId": user_id})
+        if workspace is None:
+            raise  # Should not happen — re-raise if the row truly doesn't exist
 
     return Workspace.from_db(workspace)
 


### PR DESCRIPTION
Requested by @majdyz

Prisma's `upsert` is not truly atomic — under the hood it does SELECT then INSERT/UPDATE. When two concurrent requests both see "not found" and both attempt INSERT, one hits the unique constraint on `userId`. This returns a 500 to the user on file upload.

## Problem

Sentry: **AUTOGPT-SERVER-8BK** — `UniqueViolationError: Unique constraint failed on the fields: (userId)`

Actively firing in production on `/api/workspace/files/upload` — happens when `get_or_create_workspace` races under concurrent requests for the same user.

## Fix

Catch `UniqueViolationError` after the upsert and fall back to `find_unique` to fetch the workspace that was created by the concurrent request. Single file, minimal change.

Resolves SECRT-2170

---
Co-authored-by: Zamil Majdy (@majdyz) <zamil.majdy@agpt.co>