### PR TITLE
feat(copilot): add copy button to user prompt messages [SECRT-2172]

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatMessagesContainer/ChatMessagesContainer.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatMessagesContainer/ChatMessagesContainer.tsx
@@ -246,7 +246,7 @@ export function ChatMessagesContainer({
                 )}
               </MessageContent>
               {message.role === "user" && textParts.length > 0 && (
-                <MessageActions className="mt-1 justify-end opacity-0 transition-opacity group-hover:opacity-100">
+                <MessageActions className="mt-1 justify-end opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100">
                   <CopyButton text={textParts.map((p) => p.text).join("\n")} />
                 </MessageActions>
               )}

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatMessagesContainer/components/CopyButton.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatMessagesContainer/components/CopyButton.tsx
@@ -2,7 +2,7 @@
 
 import { MessageAction } from "@/components/ai-elements/message";
 import { toast } from "@/components/molecules/Toast/use-toast";
-import { Check, Copy } from "@phosphor-icons/react";
+import { Check, CopySimple } from "@phosphor-icons/react";
 import { useState } from "react";
 
 interface Props {
@@ -33,8 +33,10 @@ export function CopyButton({ text }: Props) {
     <MessageAction
       tooltip={copied ? "Copied!" : "Copy"}
       onClick={handleCopy}
+      variant="ghost"
+      size="icon-sm"
     >
-      {copied ? <Check size={16} /> : <Copy size={16} />}
+      {copied ? <Check size={16} /> : <CopySimple size={16} weight="regular" />}
     </MessageAction>
   );
 }


### PR DESCRIPTION
Requested by @itsababseh

Users can copy assistant output messages but not their own prompts. This adds the same copy button to user messages — appears on hover, right-aligned, using the existing `CopyButton` component.

## Why

Users write long prompts and need to copy them to reuse or share. Currently requires manual text selection. ChatGPT shows copy on hover for user messages — this matches that pattern.

## What

- Added `CopyButton` to user prompt messages in `ChatMessagesContainer.tsx`
- Shows on hover (`group-hover:opacity-100`), positioned right-aligned below the message
- Reuses the existing `CopyButton` and `MessageActions` components — zero new code

## How

One file changed, 11 lines added:
1. Import `MessageActions` and `CopyButton`
2. Render them after user `MessageContent`, gated on `message.role === "user"` and having text parts

---
Co-authored-by: itsababseh (@itsababseh) <36419647+itsababseh@users.noreply.github.com>