### PR TITLE
fix(copilot): preserve thinking blocks on session resume

### DIFF
--- a/autogpt_platform/backend/backend/copilot/sdk/sdk_compat_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/sdk_compat_test.py
@@ -38,10 +38,22 @@ def test_sdk_exports_message_types():
 
 
 def test_sdk_exports_content_block_types():
-    from claude_agent_sdk import TextBlock, ToolResultBlock, ToolUseBlock
+    from claude_agent_sdk import TextBlock, ThinkingBlock, ToolResultBlock, ToolUseBlock
 
-    for cls in (TextBlock, ToolResultBlock, ToolUseBlock):
+    for cls in (TextBlock, ThinkingBlock, ToolResultBlock, ToolUseBlock):
         assert inspect.isclass(cls), f"{cls.__name__} is not a class"
+
+
+def test_thinking_block_has_required_fields():
+    """ThinkingBlock must have thinking + signature for API integrity on resume."""
+    import dataclasses
+
+    from claude_agent_sdk import ThinkingBlock
+
+    assert dataclasses.is_dataclass(ThinkingBlock)
+    field_names = {f.name for f in dataclasses.fields(ThinkingBlock)}
+    assert "thinking" in field_names, "ThinkingBlock missing 'thinking' field"
+    assert "signature" in field_names, "ThinkingBlock missing 'signature' field"
 
 
 def test_sdk_exports_mcp_helpers():

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -10,6 +10,7 @@ import shutil
 import sys
 import time
 import uuid
+import dataclasses
 from collections.abc import AsyncGenerator, AsyncIterator
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, NamedTuple, cast
@@ -595,7 +596,9 @@ def _format_sdk_content_blocks(blocks: list) -> list[dict[str, Any]]:
     """Convert SDK content blocks to transcript format.
 
     Handles TextBlock, ToolUseBlock, ToolResultBlock, and ThinkingBlock.
-    Unknown block types are logged and skipped.
+    Unknown block types are preserved via dataclass/dict passthrough so that
+    the Anthropic API's integrity checks pass on session resume (thinking and
+    redacted_thinking blocks must be byte-identical to the original response).
     """
     result: list[dict[str, Any]] = []
     for block in blocks or []:
@@ -620,18 +623,55 @@ def _format_sdk_content_blocks(blocks: list) -> list[dict[str, Any]]:
                 tool_result_entry["is_error"] = True
             result.append(tool_result_entry)
         elif isinstance(block, ThinkingBlock):
-            result.append(
-                {
-                    "type": "thinking",
-                    "thinking": block.thinking,
-                    "signature": block.signature,
-                }
-            )
+            # Preserve ALL fields exactly as received — the Anthropic API
+            # validates that thinking blocks are unmodified on session resume.
+            # Using dataclasses.asdict() ensures any future fields added to
+            # ThinkingBlock are automatically preserved.
+            entry = dataclasses.asdict(block)
+            entry["type"] = "thinking"
+            result.append(entry)
         else:
-            logger.warning(
-                f"[SDK] Unknown content block type: {type(block).__name__}. "
-                f"This may indicate a new SDK version with additional block types."
-            )
+            # Preserve unknown block types (e.g. redacted_thinking) via
+            # generic passthrough rather than dropping them — dropped blocks
+            # cause index shifts that break the API's thinking block
+            # integrity check on resume.
+            if dataclasses.is_dataclass(block) and not isinstance(block, type):
+                entry = dataclasses.asdict(block)
+                if "type" not in entry:
+                    # Derive type from class name: RedactedThinkingBlock
+                    # -> redacted_thinking, etc.
+                    cls_name = type(block).__name__
+                    entry["type"] = re.sub(
+                        r"(?<=[a-z])(?=[A-Z])", "_", cls_name.removesuffix("Block")
+                    ).lower()
+                result.append(entry)
+                logger.info(
+                    "[SDK] Preserved unknown block type via passthrough: %s",
+                    type(block).__name__,
+                )
+            elif hasattr(block, "__dict__"):
+                entry = {
+                    k: v
+                    for k, v in block.__dict__.items()
+                    if not k.startswith("_")
+                }
+                if "type" not in entry:
+                    cls_name = type(block).__name__
+                    entry["type"] = re.sub(
+                        r"(?<=[a-z])(?=[A-Z])", "_", cls_name.removesuffix("Block")
+                    ).lower()
+                result.append(entry)
+                logger.info(
+                    "[SDK] Preserved unknown block type via __dict__: %s",
+                    type(block).__name__,
+                )
+            else:
+                logger.warning(
+                    "[SDK] Dropping unserializable content block type: %s. "
+                    "This may break session resume if this block type is "
+                    "subject to API integrity checks.",
+                    type(block).__name__,
+                )
     return result
 
 


### PR DESCRIPTION
## Why

CoPilot sessions using Claude models with extended thinking (e.g. Claude Opus 4) break on **every multi-turn conversation**. After turn 1 succeeds, turns 2+ fail instantly with:

```
messages.1.content.37: `thinking` or `redacted_thinking` blocks in the latest
assistant message cannot be modified. These blocks must remain as they were
in the original response.
```

This affects every extended-thinking session on resume — **34 occurrences in Sentry since March 13** (AUTOGPT-SERVER-875, severity 0.96).

## Root Cause

`_format_sdk_content_blocks()` in `service.py` had two issues:

1. **Selective field serialization for ThinkingBlock** — only `type`, `thinking`, and `signature` were explicitly copied. If the API or a future SDK version includes additional fields on thinking blocks, they would be silently dropped. The Anthropic API validates that thinking blocks are byte-identical to the original response on session resume.

2. **Unknown block types silently dropped** — any block type not in the `isinstance` chain (e.g. `redacted_thinking` blocks that may come through when routing via OpenRouter) was logged as a warning and skipped entirely. This causes content array index shifts, which the API detects as thinking block modification.

## Evidence

- **Sentry:** AUTOGPT-SERVER-875 — 34 occurrences, high severity, unresolved
- **Langfuse:** Session `31d3f08a-cb94-45eb-9fce-56b3f0287ef4` — turn 1 succeeds (`resume: false`), turns 2+3 fail instantly (`resume: true`, `duration_api_ms: 0`)
- **Model:** `claude-opus-4.6` via OpenRouter → Azure upstream
- **Server:** `autogpt-copilot-executor-7d8b688bc4-7vcjm`

## Changes

### `service.py` — `_format_sdk_content_blocks()`
- **ThinkingBlock:** Use `dataclasses.asdict()` instead of manual field picking — automatically preserves all current and future fields
- **Unknown blocks:** Generic passthrough via `dataclasses.asdict()` / `__dict__` instead of dropping — preserves blocks like `redacted_thinking` that the SDK doesn't have a typed class for yet

### `sdk_compat_test.py`
- Added `ThinkingBlock` to content block type export test (was missing)
- Added `test_thinking_block_has_required_fields` — verifies `thinking` and `signature` fields exist

## Risk

Low — the fix preserves strictly more data than before. Existing broken transcripts will still fail (they're already broken), but new sessions will work correctly.

Fixes SECRT-2173

---
Co-authored-by: Zamil Majdy (@majdyz) <zamil.majdy@agpt.co>