### PR TITLE
fix(blocks): prevent TypeError when auto_credentials field is empty

### DIFF
--- a/autogpt_platform/backend/backend/blocks/_base.py
+++ b/autogpt_platform/backend/backend/blocks/_base.py
@@ -706,6 +706,13 @@ class Block(ABC, Generic[BlockSchemaInputType, BlockSchemaOutputType]):
                 block_id=self.id,
             )
 
+        # Ensure auto_credentials kwargs are present (even as None) so blocks
+        # that declare e.g. `*, credentials: GoogleCredentials` as a required
+        # kwarg don't crash with TypeError when the execution context didn't
+        # resolve credentials (e.g. the GoogleDriveFile field was empty).
+        for kwarg_name in self.input_schema.get_auto_credentials_fields():
+            kwargs.setdefault(kwarg_name, None)
+
         # Use the validated input data
         async for output_name, output_data in self.run(
             self.input_schema(**{k: v for k, v in input_data.items() if v is not None}),

--- a/autogpt_platform/backend/backend/blocks/google/sheets.py
+++ b/autogpt_platform/backend/backend/blocks/google/sheets.py
@@ -326,10 +326,17 @@ class GoogleSheetsReadBlock(Block):
         )
 
     async def run(
-        self, input_data: Input, *, credentials: GoogleCredentials, **kwargs
+        self,
+        input_data: Input,
+        *,
+        credentials: GoogleCredentials | None = None,
+        **kwargs,
     ) -> BlockOutput:
         if not input_data.spreadsheet:
             yield "error", "No spreadsheet selected"
+            return
+        if not credentials:
+            yield "error", "Google credentials are required"
             return
 
         # Check if the selected file is actually a Google Sheets spreadsheet

--- a/autogpt_platform/backend/backend/blocks/google/sheets_test.py
+++ b/autogpt_platform/backend/backend/blocks/google/sheets_test.py
@@ -1,0 +1,18 @@
+"""Tests for Google Sheets blocks — edge cases around credentials handling."""
+
+import pytest
+
+from backend.blocks.google.sheets import GoogleSheetsReadBlock
+from backend.util.exceptions import BlockExecutionError
+
+
+async def test_sheets_read_no_spreadsheet_yields_clean_error():
+    """Executing GoogleSheetsReadBlock with no spreadsheet/credentials should
+    raise a clean BlockExecutionError, not a BlockUnknownError wrapping a
+    TypeError about a missing kwarg."""
+    block = GoogleSheetsReadBlock()
+    input_data = {"range": "Sheet1!A1:B2"}  # no spreadsheet, no credentials
+
+    with pytest.raises(BlockExecutionError, match="No spreadsheet selected"):
+        async for _ in block.execute(input_data):
+            pass


### PR DESCRIPTION
### Why / What / How

**Why:** `GoogleSheetsReadBlock` crashes with `BlockUnknownError` wrapping a `TypeError: missing 1 required keyword-only argument: 'credentials'` when the block is executed without a spreadsheet selected. Instead of a clean user-facing error, users see an opaque internal error.

**What:** Fix the auto_credentials injection path so blocks using `GoogleDriveFileField` don't crash when their file input is empty.

**How:** Two-layer fix:
1. **Systemic (`_base.py`):** In `_execute()`, inject `None` for any auto_credentials kwargs not already present in `kwargs` via `setdefault`. This prevents `TypeError` for *all* blocks using `GoogleDriveFileField`.
2. **Block-specific (`sheets.py`):** Make `GoogleSheetsReadBlock.run()` accept `credentials: GoogleCredentials | None = None` and add a guard that yields a clean error when credentials are missing.

### Changes 🏗️

- `backend/blocks/_base.py`: Added auto_credentials kwargs defaulting in `_execute()` before calling `self.run()`
- `backend/blocks/google/sheets.py`: Made `GoogleSheetsReadBlock.run()` credentials parameter optional with a None guard
- `backend/blocks/google/sheets_test.py`: New test verifying clean error instead of TypeError

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] New test `test_sheets_read_no_spreadsheet_yields_clean_error` passes
  - [x] Existing `test_available_blocks[GoogleSheetsReadBlock]` still passes
  - [x] `poetry run format` and `poetry run lint` clean
  - [x] `pyright` reports 0 errors on changed files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core block execution path by injecting default `None` values for auto-credential kwargs, which could subtly affect any block relying on kwargs presence/absence. Behavior change is guarded and includes a targeted Google Sheets regression test, but warrants review across other auto-credentialed blocks.
> 
> **Overview**
> Prevents blocks that use *auto-resolved credentials* (e.g. via `GoogleDriveFileField`) from crashing with a `TypeError` when the related input is empty by defaulting any missing auto-credentials kwargs to `None` in `Block._execute()`.
> 
> Updates `GoogleSheetsReadBlock` to accept optional `credentials` and emit a clean user-facing error when credentials are missing, and adds a regression test ensuring executing without a spreadsheet yields `BlockExecutionError` rather than an unknown/internal error.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 001ef93b373b5896df76fbb1c1322a2d0de08698. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->