### PR TITLE
open 12072 inline autogpt libs

### DIFF
--- a/.branchlet.json
+++ b/.branchlet.json
@@ -27,7 +27,6 @@
   ],
   "worktreePathTemplate": "$BASE_PATH.worktree",
   "postCreateCmd": [
-    "cd autogpt_platform/autogpt_libs && poetry install",
     "cd autogpt_platform/backend && poetry install && poetry run prisma generate",
     "cd autogpt_platform/frontend && pnpm install"
   ],

--- a/.claude/skills/worktree/SKILL.md
+++ b/.claude/skills/worktree/SKILL.md
@@ -46,7 +46,6 @@ done
 
 ```bash
 TARGET="$(dirname "$(git rev-parse --show-toplevel)")/<NAME>"
-cd "$TARGET/autogpt_platform/autogpt_libs" && poetry install
 cd "$TARGET/autogpt_platform/backend" && poetry install && poetry run prisma generate
 cd "$TARGET/autogpt_platform/frontend" && pnpm install
 ```

--- a/.dockerignore
+++ b/.dockerignore
@@ -4,9 +4,6 @@
 # Documentation (for embeddings/search)
 !docs/
 
-# Platform - Libs
-!autogpt_platform/autogpt_libs/
-
 # Platform - Backend
 !autogpt_platform/backend/
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -128,7 +128,7 @@ pnpm storybook                      # Start component development server
   - `src/app/` - App Router pages and layouts
   - `src/components/` - Reusable React components
   - `src/lib/` - Utilities and configurations
-- `autogpt_libs/` - Shared Python utilities
+- `backend/backend/libs/` - Shared Python utilities
 - `docker-compose.yml` - Development stack orchestration
 
 **Key Configuration Files:**

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,29 +1,5 @@
 version: 2
 updates:
-  # autogpt_libs (Poetry project)
-  - package-ecosystem: "pip"
-    directory: "autogpt_platform/autogpt_libs"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
-    target-branch: "dev"
-    commit-message:
-      prefix: "chore(libs/deps)"
-      prefix-development: "chore(libs/deps-dev)"
-    ignore:
-      - dependency-name: "poetry"
-    groups:
-      production-dependencies:
-        dependency-type: "production"
-        update-types:
-          - "minor"
-          - "patch"
-      development-dependencies:
-        dependency-type: "development"
-        update-types:
-          - "minor"
-          - "patch"
-
   # backend (Poetry project)
   - package-ecosystem: "pip"
     directory: "autogpt_platform/backend"

--- a/.github/workflows/platform-backend-ci.yml
+++ b/.github/workflows/platform-backend-ci.yml
@@ -7,14 +7,12 @@ on:
       - ".github/workflows/platform-backend-ci.yml"
       - ".github/workflows/scripts/get_package_version_from_lockfile.py"
       - "autogpt_platform/backend/**"
-      - "autogpt_platform/autogpt_libs/**"
   pull_request:
     branches: [master, dev, release-*]
     paths:
       - ".github/workflows/platform-backend-ci.yml"
       - ".github/workflows/scripts/get_package_version_from_lockfile.py"
       - "autogpt_platform/backend/**"
-      - "autogpt_platform/autogpt_libs/**"
   merge_group:
 
 concurrency:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,32 +34,14 @@ repos:
       - id: poetry-install
         name: Check & Install dependencies - AutoGPT Platform - Backend
         alias: poetry-install-platform-backend
-        # include autogpt_libs source (since it's a path dependency)
         entry: >
           bash -c '
           if [ -n "$PRE_COMMIT_FROM_REF" ]; then
             git diff --name-only "$PRE_COMMIT_FROM_REF" "$PRE_COMMIT_TO_REF"
           else
             git diff --cached --name-only
-          fi | grep -qE "^autogpt_platform/(backend|autogpt_libs)/poetry\.lock$" || exit 0;
+          fi | grep -qE "^autogpt_platform/backend/poetry\.lock$" || exit 0;
           poetry -C autogpt_platform/backend install
-          '
-        always_run: true
-        language: system
-        pass_filenames: false
-        stages: [pre-commit, post-checkout]
-
-      - id: poetry-install
-        name: Check & Install dependencies - AutoGPT Platform - Libs
-        alias: poetry-install-platform-libs
-        entry: >
-          bash -c '
-          if [ -n "$PRE_COMMIT_FROM_REF" ]; then
-            git diff --name-only "$PRE_COMMIT_FROM_REF" "$PRE_COMMIT_TO_REF"
-          else
-            git diff --cached --name-only
-          fi | grep -qE "^autogpt_platform/autogpt_libs/poetry\.lock$" || exit 0;
-          poetry -C autogpt_platform/autogpt_libs install
           '
         always_run: true
         language: system
@@ -147,12 +129,12 @@ repos:
             git diff --name-only "$PRE_COMMIT_FROM_REF" "$PRE_COMMIT_TO_REF"
           else
             git diff --cached --name-only
-          fi | grep -qE "^autogpt_platform/((backend|autogpt_libs)/poetry\.lock|backend/schema\.prisma)$" || exit 0;
+          fi | grep -qE "^autogpt_platform/(backend/poetry\.lock|backend/schema\.prisma)$" || exit 0;
           cd autogpt_platform/backend
           && poetry run prisma generate
           && poetry run gen-prisma-stub
           '
-        # include everything that triggers poetry install + the prisma schema
+        # include everything that triggers backend dependency install + the prisma schema
         always_run: true
         language: system
         pass_filenames: false
@@ -198,17 +180,6 @@ repos:
         alias: ruff-lint-platform-backend
         files: ^autogpt_platform/backend/
         args: [--fix]
-
-      - id: ruff
-        name: Lint (Ruff) - AutoGPT Platform - Libs
-        alias: ruff-lint-platform-libs
-        files: ^autogpt_platform/autogpt_libs/
-        args: [--fix]
-
-      - id: ruff-format
-        name: Format (Ruff) - AutoGPT Platform - Libs
-        alias: ruff-lint-platform-libs
-        files: ^autogpt_platform/autogpt_libs/
 
   - repo: local
     # isort needs the context of which packages are installed to function, so we
@@ -295,17 +266,7 @@ repos:
         name: Typecheck - AutoGPT Platform - Backend
         alias: pyright-platform-backend
         entry: poetry -C autogpt_platform/backend run pyright
-        # include forge source (since it's a path dependency) but exclude *_test.py files:
-        files: ^autogpt_platform/(backend/((backend|test)/|(\w+\.py|poetry\.lock)$)|autogpt_libs/(autogpt_libs/.*(?<!_test)\.py|poetry\.lock)$)
-        types: [file]
-        language: system
-        pass_filenames: false
-
-      - id: pyright
-        name: Typecheck - AutoGPT Platform - Libs
-        alias: pyright-platform-libs
-        entry: poetry -C autogpt_platform/autogpt_libs run pyright
-        files: ^autogpt_platform/autogpt_libs/(autogpt_libs/|poetry\.lock$)
+        files: ^autogpt_platform/backend/((backend|test)/|(\w+\.py|poetry\.lock)$)
         types: [file]
         language: system
         pass_filenames: false
@@ -354,8 +315,7 @@ repos:
   #       name: Run tests - AutoGPT Platform - Backend
   #       alias: pytest-platform-backend
   #       entry: bash -c 'cd autogpt_platform/backend && poetry run pytest'
-  #       # include autogpt_libs source (since it's a path dependency) but exclude *_test.py files:
-  #       files: ^autogpt_platform/(backend/((backend|test)/|poetry\.lock$)|autogpt_libs/(autogpt_libs/.*(?<!_test)\.py|poetry\.lock)$)
+  #       files: ^autogpt_platform/backend/((backend|test)/|poetry\.lock$)
   #       language: system
   #       pass_filenames: false
 

--- a/autogpt_platform/CLAUDE.md
+++ b/autogpt_platform/CLAUDE.md
@@ -8,7 +8,7 @@ AutoGPT Platform is a monorepo containing:
 
 - **Backend** (`backend`): Python FastAPI server with async support
 - **Frontend** (`frontend`): Next.js React application
-- **Shared Libraries** (`autogpt_libs`): Common Python utilities
+- **Backend Libraries** (`backend/backend/libs`): Common Python utilities
 
 ## Component Documentation
 

--- a/autogpt_platform/backend/Dockerfile
+++ b/autogpt_platform/backend/Dockerfile
@@ -42,7 +42,6 @@ ENV PATH=/opt/poetry/bin:$PATH
 RUN pip3 install poetry --break-system-packages
 
 # Copy and install dependencies
-COPY autogpt_platform/autogpt_libs /app/autogpt_platform/autogpt_libs
 COPY autogpt_platform/backend/poetry.lock autogpt_platform/backend/pyproject.toml /app/autogpt_platform/backend/
 WORKDIR /app/autogpt_platform/backend
 RUN poetry install --no-ansi --no-root
@@ -143,8 +142,7 @@ WORKDIR /app/autogpt_platform/backend
 COPY --from=builder /app/autogpt_platform/backend/.venv ./.venv
 ENV PATH="/app/autogpt_platform/backend/.venv/bin:$PATH"
 
-# Copy dependency files + autogpt_libs (path dependency)
-COPY autogpt_platform/autogpt_libs /app/autogpt_platform/autogpt_libs
+# Copy dependency files
 COPY autogpt_platform/backend/poetry.lock autogpt_platform/backend/pyproject.toml ./
 
 # Copy backend code + docs (for Copilot docs search)

--- a/autogpt_platform/backend/TESTING.md
+++ b/autogpt_platform/backend/TESTING.md
@@ -132,7 +132,7 @@ def test_endpoint_success(snapshot: Snapshot):
 
 ### Testing with Authentication
 
-For the main API routes that use JWT authentication, auth is provided by the `autogpt_libs.auth` module. If the test actually uses the `user_id`, the recommended approach for testing is to mock the `get_jwt_payload` function, which underpins all higher-level auth functions used in the API (`requires_user`, `requires_admin_user`, `get_user_id`).
+For the main API routes that use JWT authentication, auth is provided by the `backend.libs.auth` module. If the test actually uses the `user_id`, the recommended approach for testing is to mock the `get_jwt_payload` function, which underpins all higher-level auth functions used in the API (`requires_user`, `requires_admin_user`, `get_user_id`).
 
 If the test doesn't need the `user_id` specifically, mocking is not necessary as during tests auth is disabled anyway (see `conftest.py`).
 
@@ -158,7 +158,7 @@ client = fastapi.testclient.TestClient(app)
 @pytest.fixture(autouse=True)
 def setup_app_auth(mock_jwt_user):
     """Setup auth overrides for all tests in this module"""
-    from autogpt_libs.auth.jwt_utils import get_jwt_payload
+    from backend.libs.auth.jwt_utils import get_jwt_payload
 
     app.dependency_overrides[get_jwt_payload] = mock_jwt_user['get_jwt_payload']
     yield
@@ -171,7 +171,7 @@ For admin-only endpoints, use `mock_jwt_admin` instead:
 @pytest.fixture(autouse=True)
 def setup_app_auth(mock_jwt_admin):
     """Setup auth overrides for admin tests"""
-    from autogpt_libs.auth.jwt_utils import get_jwt_payload
+    from backend.libs.auth.jwt_utils import get_jwt_payload
 
     app.dependency_overrides[get_jwt_payload] = mock_jwt_admin['get_jwt_payload']
     yield

--- a/autogpt_platform/backend/backend/api/features/admin/credit_admin_routes.py
+++ b/autogpt_platform/backend/backend/api/features/admin/credit_admin_routes.py
@@ -1,11 +1,11 @@
 import logging
 import typing
 
-from backend.libs.auth import get_user_id, requires_admin_user
 from fastapi import APIRouter, Body, Security
 from prisma.enums import CreditTransactionType
 
 from backend.data.credit import admin_get_user_history, get_user_credit_model
+from backend.libs.auth import get_user_id, requires_admin_user
 from backend.util.json import SafeJson
 
 from .model import AddUserCreditsResponse, UserHistoryResponse

--- a/autogpt_platform/backend/backend/api/features/admin/credit_admin_routes.py
+++ b/autogpt_platform/backend/backend/api/features/admin/credit_admin_routes.py
@@ -1,7 +1,7 @@
 import logging
 import typing
 
-from autogpt_libs.auth import get_user_id, requires_admin_user
+from backend.libs.auth import get_user_id, requires_admin_user
 from fastapi import APIRouter, Body, Security
 from prisma.enums import CreditTransactionType
 

--- a/autogpt_platform/backend/backend/api/features/admin/credit_admin_routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/admin/credit_admin_routes_test.py
@@ -6,10 +6,10 @@ import fastapi.testclient
 import prisma.enums
 import pytest
 import pytest_mock
-from backend.libs.auth.jwt_utils import get_jwt_payload
 from pytest_snapshot.plugin import Snapshot
 
 from backend.data.model import UserTransaction
+from backend.libs.auth.jwt_utils import get_jwt_payload
 from backend.util.json import SafeJson
 from backend.util.models import Pagination
 

--- a/autogpt_platform/backend/backend/api/features/admin/credit_admin_routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/admin/credit_admin_routes_test.py
@@ -6,7 +6,7 @@ import fastapi.testclient
 import prisma.enums
 import pytest
 import pytest_mock
-from autogpt_libs.auth.jwt_utils import get_jwt_payload
+from backend.libs.auth.jwt_utils import get_jwt_payload
 from pytest_snapshot.plugin import Snapshot
 
 from backend.data.model import UserTransaction

--- a/autogpt_platform/backend/backend/api/features/admin/execution_analytics_routes.py
+++ b/autogpt_platform/backend/backend/api/features/admin/execution_analytics_routes.py
@@ -3,7 +3,6 @@ import logging
 from datetime import datetime
 from typing import Optional
 
-from backend.libs.auth import get_user_id, requires_admin_user
 from fastapi import APIRouter, HTTPException, Security
 from pydantic import BaseModel, Field
 
@@ -25,6 +24,7 @@ from backend.executor.activity_status_generator import (
     generate_activity_status_for_execution,
 )
 from backend.executor.manager import get_db_async_client
+from backend.libs.auth import get_user_id, requires_admin_user
 from backend.util.settings import Settings
 
 logger = logging.getLogger(__name__)

--- a/autogpt_platform/backend/backend/api/features/admin/execution_analytics_routes.py
+++ b/autogpt_platform/backend/backend/api/features/admin/execution_analytics_routes.py
@@ -3,7 +3,7 @@ import logging
 from datetime import datetime
 from typing import Optional
 
-from autogpt_libs.auth import get_user_id, requires_admin_user
+from backend.libs.auth import get_user_id, requires_admin_user
 from fastapi import APIRouter, HTTPException, Security
 from pydantic import BaseModel, Field
 

--- a/autogpt_platform/backend/backend/api/features/admin/store_admin_routes.py
+++ b/autogpt_platform/backend/backend/api/features/admin/store_admin_routes.py
@@ -2,7 +2,6 @@ import logging
 import tempfile
 import typing
 
-import backend.libs.auth
 import fastapi
 import fastapi.responses
 import prisma.enums
@@ -12,6 +11,7 @@ import backend.api.features.library.model as library_model
 import backend.api.features.store.cache as store_cache
 import backend.api.features.store.db as store_db
 import backend.api.features.store.model as store_model
+import backend.libs.auth
 import backend.util.json
 
 logger = logging.getLogger(__name__)

--- a/autogpt_platform/backend/backend/api/features/admin/store_admin_routes.py
+++ b/autogpt_platform/backend/backend/api/features/admin/store_admin_routes.py
@@ -2,7 +2,7 @@ import logging
 import tempfile
 import typing
 
-import autogpt_libs.auth
+import backend.libs.auth
 import fastapi
 import fastapi.responses
 import prisma.enums
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 router = fastapi.APIRouter(
     prefix="/admin",
     tags=["store", "admin"],
-    dependencies=[fastapi.Security(autogpt_libs.auth.requires_admin_user)],
+    dependencies=[fastapi.Security(backend.libs.auth.requires_admin_user)],
 )
 
 
@@ -64,7 +64,7 @@ async def get_admin_listings_with_versions(
 async def review_submission(
     store_listing_version_id: str,
     request: store_model.ReviewSubmissionRequest,
-    user_id: str = fastapi.Security(autogpt_libs.auth.get_user_id),
+    user_id: str = fastapi.Security(backend.libs.auth.get_user_id),
 ) -> store_model.StoreSubmissionAdminView:
     """
     Review a store listing submission.
@@ -101,7 +101,7 @@ async def review_submission(
     tags=["store", "admin"],
 )
 async def admin_download_agent_file(
-    user_id: str = fastapi.Security(autogpt_libs.auth.get_user_id),
+    user_id: str = fastapi.Security(backend.libs.auth.get_user_id),
     store_listing_version_id: str = fastapi.Path(
         ..., description="The ID of the agent to download"
     ),
@@ -158,7 +158,7 @@ async def admin_preview_submission(
 )
 async def admin_add_agent_to_library(
     store_listing_version_id: str,
-    user_id: str = fastapi.Security(autogpt_libs.auth.get_user_id),
+    user_id: str = fastapi.Security(backend.libs.auth.get_user_id),
 ) -> library_model.LibraryAgent:
     """
     Add a pending marketplace agent to the admin's library for review.

--- a/autogpt_platform/backend/backend/api/features/admin/store_admin_routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/admin/store_admin_routes_test.py
@@ -15,9 +15,9 @@ import fastapi.responses
 import fastapi.testclient
 import pytest
 import pytest_mock
-from backend.libs.auth.jwt_utils import get_jwt_payload
 
 from backend.data.graph import get_graph_as_admin
+from backend.libs.auth.jwt_utils import get_jwt_payload
 from backend.util.exceptions import NotFoundError
 
 from .store_admin_routes import router as store_admin_router

--- a/autogpt_platform/backend/backend/api/features/admin/store_admin_routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/admin/store_admin_routes_test.py
@@ -15,7 +15,7 @@ import fastapi.responses
 import fastapi.testclient
 import pytest
 import pytest_mock
-from autogpt_libs.auth.jwt_utils import get_jwt_payload
+from backend.libs.auth.jwt_utils import get_jwt_payload
 
 from backend.data.graph import get_graph_as_admin
 from backend.util.exceptions import NotFoundError

--- a/autogpt_platform/backend/backend/api/features/analytics.py
+++ b/autogpt_platform/backend/backend/api/features/analytics.py
@@ -5,10 +5,10 @@ from typing import Annotated
 
 import fastapi
 import pydantic
-from backend.libs.auth import get_user_id
-from backend.libs.auth.dependencies import requires_user
 
 import backend.data.analytics
+from backend.libs.auth import get_user_id
+from backend.libs.auth.dependencies import requires_user
 
 router = fastapi.APIRouter(dependencies=[fastapi.Security(requires_user)])
 logger = logging.getLogger(__name__)

--- a/autogpt_platform/backend/backend/api/features/analytics.py
+++ b/autogpt_platform/backend/backend/api/features/analytics.py
@@ -5,8 +5,8 @@ from typing import Annotated
 
 import fastapi
 import pydantic
-from autogpt_libs.auth import get_user_id
-from autogpt_libs.auth.dependencies import requires_user
+from backend.libs.auth import get_user_id
+from backend.libs.auth.dependencies import requires_user
 
 import backend.data.analytics
 

--- a/autogpt_platform/backend/backend/api/features/analytics_test.py
+++ b/autogpt_platform/backend/backend/api/features/analytics_test.py
@@ -20,7 +20,7 @@ client = fastapi.testclient.TestClient(app)
 @pytest.fixture(autouse=True)
 def setup_app_auth(mock_jwt_user):
     """Setup auth overrides for all tests in this module."""
-    from autogpt_libs.auth.jwt_utils import get_jwt_payload
+    from backend.libs.auth.jwt_utils import get_jwt_payload
 
     app.dependency_overrides[get_jwt_payload] = mock_jwt_user["get_jwt_payload"]
     yield

--- a/autogpt_platform/backend/backend/api/features/builder/routes.py
+++ b/autogpt_platform/backend/backend/api/features/builder/routes.py
@@ -2,7 +2,7 @@ import logging
 from typing import Annotated, Sequence, cast, get_args
 
 import fastapi
-from autogpt_libs.auth.dependencies import get_user_id, requires_user
+from backend.libs.auth.dependencies import get_user_id, requires_user
 
 from backend.integrations.providers import ProviderName
 from backend.util.models import Pagination

--- a/autogpt_platform/backend/backend/api/features/builder/routes.py
+++ b/autogpt_platform/backend/backend/api/features/builder/routes.py
@@ -2,9 +2,9 @@ import logging
 from typing import Annotated, Sequence, cast, get_args
 
 import fastapi
-from backend.libs.auth.dependencies import get_user_id, requires_user
 
 from backend.integrations.providers import ProviderName
+from backend.libs.auth.dependencies import get_user_id, requires_user
 from backend.util.models import Pagination
 
 from . import db as builder_db

--- a/autogpt_platform/backend/backend/api/features/chat/routes.py
+++ b/autogpt_platform/backend/backend/api/features/chat/routes.py
@@ -7,7 +7,7 @@ from collections.abc import AsyncGenerator
 from typing import Annotated
 from uuid import uuid4
 
-from autogpt_libs import auth
+from backend.libs import auth
 from fastapi import APIRouter, HTTPException, Query, Response, Security
 from fastapi.responses import StreamingResponse
 from prisma.models import UserWorkspaceFile

--- a/autogpt_platform/backend/backend/api/features/chat/routes.py
+++ b/autogpt_platform/backend/backend/api/features/chat/routes.py
@@ -7,7 +7,6 @@ from collections.abc import AsyncGenerator
 from typing import Annotated
 from uuid import uuid4
 
-from backend.libs import auth
 from fastapi import APIRouter, HTTPException, Query, Response, Security
 from fastapi.responses import StreamingResponse
 from prisma.models import UserWorkspaceFile
@@ -61,6 +60,7 @@ from backend.copilot.tools.models import (
 from backend.copilot.tracking import track_user_message
 from backend.data.redis_client import get_redis_async
 from backend.data.workspace import get_or_create_workspace
+from backend.libs import auth
 from backend.util.exceptions import NotFoundError
 
 config = ChatConfig()

--- a/autogpt_platform/backend/backend/api/features/chat/routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/chat/routes_test.py
@@ -21,7 +21,7 @@ TEST_USER_ID = "3e53486c-cf57-477e-ba2a-cb02dc828e1a"
 @pytest.fixture(autouse=True)
 def setup_app_auth(mock_jwt_user):
     """Setup auth overrides for all tests in this module"""
-    from autogpt_libs.auth.jwt_utils import get_jwt_payload
+    from backend.libs.auth.jwt_utils import get_jwt_payload
 
     app.dependency_overrides[get_jwt_payload] = mock_jwt_user["get_jwt_payload"]
     yield

--- a/autogpt_platform/backend/backend/api/features/executions/review/review_routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/executions/review/review_routes_test.py
@@ -25,7 +25,7 @@ FIXED_NOW = datetime.datetime(2023, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
 @pytest_asyncio.fixture(loop_scope="session")
 async def client(server, mock_jwt_user) -> AsyncGenerator[httpx.AsyncClient, None]:
     """Create async HTTP client with auth overrides"""
-    from autogpt_libs.auth.jwt_utils import get_jwt_payload
+    from backend.libs.auth.jwt_utils import get_jwt_payload
 
     # Override get_jwt_payload dependency to return our test user
     app.dependency_overrides[get_jwt_payload] = mock_jwt_user["get_jwt_payload"]

--- a/autogpt_platform/backend/backend/api/features/executions/review/routes.py
+++ b/autogpt_platform/backend/backend/api/features/executions/review/routes.py
@@ -2,10 +2,10 @@ import asyncio
 import logging
 from typing import Any, List
 
-import backend.libs.auth as autogpt_auth_lib
 from fastapi import APIRouter, HTTPException, Query, Security, status
 from prisma.enums import ReviewStatus
 
+import backend.libs.auth as autogpt_auth_lib
 from backend.copilot.constants import (
     is_copilot_synthetic_id,
     parse_node_id_from_exec_id,

--- a/autogpt_platform/backend/backend/api/features/executions/review/routes.py
+++ b/autogpt_platform/backend/backend/api/features/executions/review/routes.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 from typing import Any, List
 
-import autogpt_libs.auth as autogpt_auth_lib
+import backend.libs.auth as autogpt_auth_lib
 from fastapi import APIRouter, HTTPException, Query, Security, status
 from prisma.enums import ReviewStatus
 

--- a/autogpt_platform/backend/backend/api/features/integrations/router.py
+++ b/autogpt_platform/backend/backend/api/features/integrations/router.py
@@ -3,7 +3,7 @@ import logging
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Annotated, Any, List, Literal
 
-from autogpt_libs.auth import get_user_id
+from backend.libs.auth import get_user_id
 from fastapi import (
     APIRouter,
     Body,

--- a/autogpt_platform/backend/backend/api/features/integrations/router.py
+++ b/autogpt_platform/backend/backend/api/features/integrations/router.py
@@ -3,7 +3,6 @@ import logging
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Annotated, Any, List, Literal
 
-from backend.libs.auth import get_user_id
 from fastapi import (
     APIRouter,
     Body,
@@ -48,6 +47,7 @@ from backend.integrations.creds_manager import (
 from backend.integrations.oauth import CREDENTIALS_BY_PROVIDER, HANDLERS_BY_NAME
 from backend.integrations.providers import ProviderName
 from backend.integrations.webhooks import get_webhook_manager
+from backend.libs.auth import get_user_id
 from backend.util.exceptions import (
     GraphNotInLibraryError,
     MissingConfigError,

--- a/autogpt_platform/backend/backend/api/features/integrations/router_test.py
+++ b/autogpt_platform/backend/backend/api/features/integrations/router_test.py
@@ -74,7 +74,7 @@ def _make_sdk_default_cred(provider: str = "openai"):
 
 @pytest.fixture(autouse=True)
 def setup_auth(mock_jwt_user):
-    from autogpt_libs.auth.jwt_utils import get_jwt_payload
+    from backend.libs.auth.jwt_utils import get_jwt_payload
 
     app.dependency_overrides[get_jwt_payload] = mock_jwt_user["get_jwt_payload"]
     yield

--- a/autogpt_platform/backend/backend/api/features/library/routes/agents.py
+++ b/autogpt_platform/backend/backend/api/features/library/routes/agents.py
@@ -1,10 +1,10 @@
 from typing import Literal, Optional
 
-import backend.libs.auth as autogpt_auth_lib
 from fastapi import APIRouter, Body, HTTPException, Query, Security, status
 from fastapi.responses import Response
 from prisma.enums import OnboardingStep
 
+import backend.libs.auth as autogpt_auth_lib
 from backend.data.onboarding import complete_onboarding_step
 
 from .. import db as library_db

--- a/autogpt_platform/backend/backend/api/features/library/routes/agents.py
+++ b/autogpt_platform/backend/backend/api/features/library/routes/agents.py
@@ -1,6 +1,6 @@
 from typing import Literal, Optional
 
-import autogpt_libs.auth as autogpt_auth_lib
+import backend.libs.auth as autogpt_auth_lib
 from fastapi import APIRouter, Body, HTTPException, Query, Security, status
 from fastapi.responses import Response
 from prisma.enums import OnboardingStep

--- a/autogpt_platform/backend/backend/api/features/library/routes/folders.py
+++ b/autogpt_platform/backend/backend/api/features/library/routes/folders.py
@@ -1,8 +1,9 @@
 from typing import Optional
 
-import backend.libs.auth as autogpt_auth_lib
 from fastapi import APIRouter, Query, Security, status
 from fastapi.responses import Response
+
+import backend.libs.auth as autogpt_auth_lib
 
 from .. import db as library_db
 from .. import model as library_model

--- a/autogpt_platform/backend/backend/api/features/library/routes/folders.py
+++ b/autogpt_platform/backend/backend/api/features/library/routes/folders.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-import autogpt_libs.auth as autogpt_auth_lib
+import backend.libs.auth as autogpt_auth_lib
 from fastapi import APIRouter, Query, Security, status
 from fastapi.responses import Response
 

--- a/autogpt_platform/backend/backend/api/features/library/routes/presets.py
+++ b/autogpt_platform/backend/backend/api/features/library/routes/presets.py
@@ -1,9 +1,9 @@
 import logging
 from typing import Any, Optional
 
-import backend.libs.auth as autogpt_auth_lib
 from fastapi import APIRouter, Body, HTTPException, Query, Security, status
 
+import backend.libs.auth as autogpt_auth_lib
 from backend.data.execution import GraphExecutionMeta
 from backend.data.graph import get_graph
 from backend.data.integrations import get_webhook

--- a/autogpt_platform/backend/backend/api/features/library/routes/presets.py
+++ b/autogpt_platform/backend/backend/api/features/library/routes/presets.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any, Optional
 
-import autogpt_libs.auth as autogpt_auth_lib
+import backend.libs.auth as autogpt_auth_lib
 from fastapi import APIRouter, Body, HTTPException, Query, Security, status
 
 from backend.data.execution import GraphExecutionMeta

--- a/autogpt_platform/backend/backend/api/features/library/routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/library/routes_test.py
@@ -23,7 +23,7 @@ FIXED_NOW = datetime.datetime(2023, 1, 1, 0, 0, 0)
 @pytest.fixture(autouse=True)
 def setup_app_auth(mock_jwt_user):
     """Setup auth overrides for all tests in this module"""
-    from autogpt_libs.auth.jwt_utils import get_jwt_payload
+    from backend.libs.auth.jwt_utils import get_jwt_payload
 
     app.dependency_overrides[get_jwt_payload] = mock_jwt_user["get_jwt_payload"]
     yield

--- a/autogpt_platform/backend/backend/api/features/mcp/routes.py
+++ b/autogpt_platform/backend/backend/api/features/mcp/routes.py
@@ -9,7 +9,6 @@ import logging
 from typing import Annotated, Any
 
 import fastapi
-from backend.libs.auth import get_user_id
 from fastapi import Security
 from pydantic import BaseModel, Field, SecretStr
 
@@ -24,6 +23,7 @@ from backend.blocks.mcp.oauth import MCPOAuthHandler
 from backend.data.model import OAuth2Credentials
 from backend.integrations.creds_manager import IntegrationCredentialsManager
 from backend.integrations.providers import ProviderName
+from backend.libs.auth import get_user_id
 from backend.util.request import HTTPClientError, Requests, validate_url_host
 from backend.util.settings import Settings
 

--- a/autogpt_platform/backend/backend/api/features/mcp/routes.py
+++ b/autogpt_platform/backend/backend/api/features/mcp/routes.py
@@ -9,7 +9,7 @@ import logging
 from typing import Annotated, Any
 
 import fastapi
-from autogpt_libs.auth import get_user_id
+from backend.libs.auth import get_user_id
 from fastapi import Security
 from pydantic import BaseModel, Field, SecretStr
 

--- a/autogpt_platform/backend/backend/api/features/mcp/test_routes.py
+++ b/autogpt_platform/backend/backend/api/features/mcp/test_routes.py
@@ -10,7 +10,7 @@ import fastapi
 import httpx
 import pytest
 import pytest_asyncio
-from autogpt_libs.auth import get_user_id
+from backend.libs.auth import get_user_id
 from pydantic import SecretStr
 
 from backend.api.features.mcp.routes import router

--- a/autogpt_platform/backend/backend/api/features/mcp/test_routes.py
+++ b/autogpt_platform/backend/backend/api/features/mcp/test_routes.py
@@ -10,12 +10,12 @@ import fastapi
 import httpx
 import pytest
 import pytest_asyncio
-from backend.libs.auth import get_user_id
 from pydantic import SecretStr
 
 from backend.api.features.mcp.routes import router
 from backend.blocks.mcp.client import MCPClientError, MCPTool
 from backend.data.model import OAuth2Credentials
+from backend.libs.auth import get_user_id
 from backend.util.request import HTTPClientError
 
 app = fastapi.FastAPI()

--- a/autogpt_platform/backend/backend/api/features/oauth.py
+++ b/autogpt_platform/backend/backend/api/features/oauth.py
@@ -21,7 +21,7 @@ from datetime import datetime
 from typing import Literal, Optional
 from urllib.parse import urlencode
 
-from autogpt_libs.auth import get_user_id
+from backend.libs.auth import get_user_id
 from fastapi import APIRouter, Body, HTTPException, Security, UploadFile, status
 from gcloud.aio import storage as async_storage
 from PIL import Image

--- a/autogpt_platform/backend/backend/api/features/oauth.py
+++ b/autogpt_platform/backend/backend/api/features/oauth.py
@@ -21,7 +21,6 @@ from datetime import datetime
 from typing import Literal, Optional
 from urllib.parse import urlencode
 
-from backend.libs.auth import get_user_id
 from fastapi import APIRouter, Body, HTTPException, Security, UploadFile, status
 from gcloud.aio import storage as async_storage
 from PIL import Image
@@ -49,6 +48,7 @@ from backend.data.auth.oauth import (
     validate_redirect_uri,
     validate_scopes,
 )
+from backend.libs.auth import get_user_id
 from backend.util.settings import Settings
 from backend.util.virus_scanner import scan_content_safe
 

--- a/autogpt_platform/backend/backend/api/features/oauth_test.py
+++ b/autogpt_platform/backend/backend/api/features/oauth_test.py
@@ -21,7 +21,7 @@ from typing import AsyncGenerator
 import httpx
 import pytest
 import pytest_asyncio
-from autogpt_libs.api_key.keysmith import APIKeySmith
+from backend.libs.api_key.keysmith import APIKeySmith
 from prisma.enums import APIKeyPermission
 from prisma.models import OAuthAccessToken as PrismaOAuthAccessToken
 from prisma.models import OAuthApplication as PrismaOAuthApplication
@@ -134,7 +134,7 @@ async def client(server, test_user: str) -> AsyncGenerator[httpx.AsyncClient, No
     Depends on `server` to ensure the DB is connected and `test_user` to ensure
     the user exists in the database before running tests.
     """
-    from autogpt_libs.auth import get_user_id
+    from backend.libs.auth import get_user_id
 
     # Override get_user_id dependency to return our test user
     def override_get_user_id():

--- a/autogpt_platform/backend/backend/api/features/oauth_test.py
+++ b/autogpt_platform/backend/backend/api/features/oauth_test.py
@@ -21,7 +21,6 @@ from typing import AsyncGenerator
 import httpx
 import pytest
 import pytest_asyncio
-from backend.libs.api_key.keysmith import APIKeySmith
 from prisma.enums import APIKeyPermission
 from prisma.models import OAuthAccessToken as PrismaOAuthAccessToken
 from prisma.models import OAuthApplication as PrismaOAuthApplication
@@ -30,6 +29,7 @@ from prisma.models import OAuthRefreshToken as PrismaOAuthRefreshToken
 from prisma.models import User as PrismaUser
 
 from backend.api.rest_api import app
+from backend.libs.api_key.keysmith import APIKeySmith
 
 keysmith = APIKeySmith()
 

--- a/autogpt_platform/backend/backend/api/features/otto/routes.py
+++ b/autogpt_platform/backend/backend/api/features/otto/routes.py
@@ -1,6 +1,6 @@
 import logging
 
-from autogpt_libs.auth import get_user_id, requires_user
+from backend.libs.auth import get_user_id, requires_user
 from fastapi import APIRouter, HTTPException, Security
 
 from .models import ApiResponse, ChatRequest

--- a/autogpt_platform/backend/backend/api/features/otto/routes.py
+++ b/autogpt_platform/backend/backend/api/features/otto/routes.py
@@ -1,7 +1,8 @@
 import logging
 
-from backend.libs.auth import get_user_id, requires_user
 from fastapi import APIRouter, HTTPException, Security
+
+from backend.libs.auth import get_user_id, requires_user
 
 from .models import ApiResponse, ChatRequest
 from .service import OttoService

--- a/autogpt_platform/backend/backend/api/features/otto/routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/otto/routes_test.py
@@ -19,7 +19,7 @@ client = fastapi.testclient.TestClient(app)
 @pytest.fixture(autouse=True)
 def setup_app_auth(mock_jwt_user):
     """Setup auth overrides for all tests in this module"""
-    from autogpt_libs.auth.jwt_utils import get_jwt_payload
+    from backend.libs.auth.jwt_utils import get_jwt_payload
 
     app.dependency_overrides[get_jwt_payload] = mock_jwt_user["get_jwt_payload"]
     yield

--- a/autogpt_platform/backend/backend/api/features/store/routes.py
+++ b/autogpt_platform/backend/backend/api/features/store/routes.py
@@ -1,7 +1,6 @@
 import logging
 import urllib.parse
 
-import backend.libs.auth
 import fastapi
 import fastapi.responses
 import prisma.enums
@@ -9,6 +8,7 @@ from fastapi import Query, Security
 from pydantic import BaseModel
 
 import backend.data.graph
+import backend.libs.auth
 import backend.util.json
 from backend.util.exceptions import NotFoundError
 from backend.util.models import Pagination

--- a/autogpt_platform/backend/backend/api/features/store/routes.py
+++ b/autogpt_platform/backend/backend/api/features/store/routes.py
@@ -1,7 +1,7 @@
 import logging
 import urllib.parse
 
-import autogpt_libs.auth
+import backend.libs.auth
 import fastapi
 import fastapi.responses
 import prisma.enums
@@ -34,10 +34,10 @@ router = fastapi.APIRouter()
     "/profile",
     summary="Get user profile",
     tags=["store", "private"],
-    dependencies=[Security(autogpt_libs.auth.requires_user)],
+    dependencies=[Security(backend.libs.auth.requires_user)],
 )
 async def get_profile(
-    user_id: str = Security(autogpt_libs.auth.get_user_id),
+    user_id: str = Security(backend.libs.auth.get_user_id),
 ) -> store_model.ProfileDetails:
     """Get the profile details for the authenticated user."""
     profile = await store_db.get_user_profile(user_id)
@@ -50,11 +50,11 @@ async def get_profile(
     "/profile",
     summary="Update user profile",
     tags=["store", "private"],
-    dependencies=[Security(autogpt_libs.auth.requires_user)],
+    dependencies=[Security(backend.libs.auth.requires_user)],
 )
 async def update_or_create_profile(
     profile: store_model.Profile,
-    user_id: str = Security(autogpt_libs.auth.get_user_id),
+    user_id: str = Security(backend.libs.auth.get_user_id),
 ) -> store_model.ProfileDetails:
     """Update the store profile for the authenticated user."""
     updated_profile = await store_db.update_profile(user_id=user_id, profile=profile)
@@ -80,7 +80,7 @@ async def unified_search(
     page: int = Query(ge=1, default=1),
     page_size: int = Query(ge=1, default=20),
     user_id: str | None = Security(
-        autogpt_libs.auth.get_optional_user_id, use_cache=False
+        backend.libs.auth.get_optional_user_id, use_cache=False
     ),
 ) -> store_model.UnifiedSearchResponse:
     """
@@ -203,13 +203,13 @@ async def get_agent_by_name(
     "/agents/{username}/{agent_name}/review",
     summary="Create agent review",
     tags=["store"],
-    dependencies=[Security(autogpt_libs.auth.requires_user)],
+    dependencies=[Security(backend.libs.auth.requires_user)],
 )
 async def post_user_review_for_agent(
     username: str,
     agent_name: str,
     review: store_model.StoreReviewCreate,
-    user_id: str = Security(autogpt_libs.auth.get_user_id),
+    user_id: str = Security(backend.libs.auth.get_user_id),
 ) -> store_model.StoreReview:
     """Post a user review on a marketplace agent listing"""
     username = urllib.parse.unquote(username).lower()
@@ -228,7 +228,7 @@ async def post_user_review_for_agent(
     "/listings/versions/{store_listing_version_id}",
     summary="Get agent by version",
     tags=["store"],
-    dependencies=[Security(autogpt_libs.auth.requires_user)],
+    dependencies=[Security(backend.libs.auth.requires_user)],
 )
 async def get_agent_by_listing_version(
     store_listing_version_id: str,
@@ -241,7 +241,7 @@ async def get_agent_by_listing_version(
     "/listings/versions/{store_listing_version_id}/graph",
     summary="Get agent graph",
     tags=["store"],
-    dependencies=[Security(autogpt_libs.auth.requires_user)],
+    dependencies=[Security(backend.libs.auth.requires_user)],
 )
 async def get_graph_meta_by_store_listing_version_id(
     store_listing_version_id: str,
@@ -325,10 +325,10 @@ async def get_creator(username: str) -> store_model.CreatorDetails:
     "/my-unpublished-agents",
     summary="Get my agents",
     tags=["store", "private"],
-    dependencies=[Security(autogpt_libs.auth.requires_user)],
+    dependencies=[Security(backend.libs.auth.requires_user)],
 )
 async def get_my_unpublished_agents(
-    user_id: str = Security(autogpt_libs.auth.get_user_id),
+    user_id: str = Security(backend.libs.auth.get_user_id),
     page: int = Query(ge=1, default=1),
     page_size: int = Query(ge=1, default=20),
 ) -> store_model.MyUnpublishedAgentsResponse:
@@ -341,11 +341,11 @@ async def get_my_unpublished_agents(
     "/submissions/{submission_id}",
     summary="Delete store submission",
     tags=["store", "private"],
-    dependencies=[Security(autogpt_libs.auth.requires_user)],
+    dependencies=[Security(backend.libs.auth.requires_user)],
 )
 async def delete_submission(
     submission_id: str,
-    user_id: str = Security(autogpt_libs.auth.get_user_id),
+    user_id: str = Security(backend.libs.auth.get_user_id),
 ) -> bool:
     """Delete a marketplace listing submission"""
     result = await store_db.delete_store_submission(
@@ -359,10 +359,10 @@ async def delete_submission(
     "/submissions",
     summary="List my submissions",
     tags=["store", "private"],
-    dependencies=[Security(autogpt_libs.auth.requires_user)],
+    dependencies=[Security(backend.libs.auth.requires_user)],
 )
 async def get_submissions(
-    user_id: str = Security(autogpt_libs.auth.get_user_id),
+    user_id: str = Security(backend.libs.auth.get_user_id),
     page: int = Query(ge=1, default=1),
     page_size: int = Query(ge=1, default=20),
 ) -> store_model.StoreSubmissionsResponse:
@@ -379,11 +379,11 @@ async def get_submissions(
     "/submissions",
     summary="Create store submission",
     tags=["store", "private"],
-    dependencies=[Security(autogpt_libs.auth.requires_user)],
+    dependencies=[Security(backend.libs.auth.requires_user)],
 )
 async def create_submission(
     submission_request: store_model.StoreSubmissionRequest,
-    user_id: str = Security(autogpt_libs.auth.get_user_id),
+    user_id: str = Security(backend.libs.auth.get_user_id),
 ) -> store_model.StoreSubmission:
     """Submit a new marketplace listing for review"""
     result = await store_db.create_store_submission(
@@ -409,12 +409,12 @@ async def create_submission(
     "/submissions/{store_listing_version_id}",
     summary="Edit store submission",
     tags=["store", "private"],
-    dependencies=[Security(autogpt_libs.auth.requires_user)],
+    dependencies=[Security(backend.libs.auth.requires_user)],
 )
 async def edit_submission(
     store_listing_version_id: str,
     submission_request: store_model.StoreSubmissionEditRequest,
-    user_id: str = Security(autogpt_libs.auth.get_user_id),
+    user_id: str = Security(backend.libs.auth.get_user_id),
 ) -> store_model.StoreSubmission:
     """Update a pending marketplace listing submission"""
     result = await store_db.edit_store_submission(
@@ -438,11 +438,11 @@ async def edit_submission(
     "/submissions/media",
     summary="Upload submission media",
     tags=["store", "private"],
-    dependencies=[Security(autogpt_libs.auth.requires_user)],
+    dependencies=[Security(backend.libs.auth.requires_user)],
 )
 async def upload_submission_media(
     file: fastapi.UploadFile,
-    user_id: str = Security(autogpt_libs.auth.get_user_id),
+    user_id: str = Security(backend.libs.auth.get_user_id),
 ) -> str:
     """Upload media for a marketplace listing submission"""
     media_url = await store_media.upload_media(user_id=user_id, file=file)
@@ -457,11 +457,11 @@ class ImageURLResponse(BaseModel):
     "/submissions/generate_image",
     summary="Generate submission image",
     tags=["store", "private"],
-    dependencies=[Security(autogpt_libs.auth.requires_user)],
+    dependencies=[Security(backend.libs.auth.requires_user)],
 )
 async def generate_image(
     graph_id: str,
-    user_id: str = Security(autogpt_libs.auth.get_user_id),
+    user_id: str = Security(backend.libs.auth.get_user_id),
 ) -> ImageURLResponse:
     """
     Generate an image for a marketplace listing submission based on the properties

--- a/autogpt_platform/backend/backend/api/features/store/routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/store/routes_test.py
@@ -26,7 +26,7 @@ client = fastapi.testclient.TestClient(app)
 @pytest.fixture(autouse=True)
 def setup_app_auth(mock_jwt_user):
     """Setup auth overrides for all tests in this module"""
-    from autogpt_libs.auth.jwt_utils import get_jwt_payload
+    from backend.libs.auth.jwt_utils import get_jwt_payload
 
     app.dependency_overrides[get_jwt_payload] = mock_jwt_user["get_jwt_payload"]
     yield

--- a/autogpt_platform/backend/backend/api/features/v1.py
+++ b/autogpt_platform/backend/backend/api/features/v1.py
@@ -9,8 +9,8 @@ from typing import Annotated, Any, Sequence, get_args
 
 import pydantic
 import stripe
-from autogpt_libs.auth import get_user_id, requires_user
-from autogpt_libs.auth.jwt_utils import get_jwt_payload
+from backend.libs.auth import get_user_id, requires_user
+from backend.libs.auth.jwt_utils import get_jwt_payload
 from fastapi import (
     APIRouter,
     Body,

--- a/autogpt_platform/backend/backend/api/features/v1.py
+++ b/autogpt_platform/backend/backend/api/features/v1.py
@@ -9,8 +9,6 @@ from typing import Annotated, Any, Sequence, get_args
 
 import pydantic
 import stripe
-from backend.libs.auth import get_user_id, requires_user
-from backend.libs.auth.jwt_utils import get_jwt_payload
 from fastapi import (
     APIRouter,
     Body,
@@ -83,6 +81,8 @@ from backend.integrations.webhooks.graph_lifecycle_hooks import (
     on_graph_activate,
     on_graph_deactivate,
 )
+from backend.libs.auth import get_user_id, requires_user
+from backend.libs.auth.jwt_utils import get_jwt_payload
 from backend.monitoring.instrumentation import (
     record_block_execution,
     record_graph_execution,

--- a/autogpt_platform/backend/backend/api/features/v1_test.py
+++ b/autogpt_platform/backend/backend/api/features/v1_test.py
@@ -25,7 +25,7 @@ client = fastapi.testclient.TestClient(app)
 @pytest.fixture(autouse=True)
 def setup_app_auth(mock_jwt_user, setup_test_user):
     """Setup auth overrides for all tests in this module"""
-    from autogpt_libs.auth.jwt_utils import get_jwt_payload
+    from backend.libs.auth.jwt_utils import get_jwt_payload
 
     # setup_test_user fixture already executed and user is created in database
     # It returns the user_id which we don't need to await

--- a/autogpt_platform/backend/backend/api/features/workspace/routes.py
+++ b/autogpt_platform/backend/backend/api/features/workspace/routes.py
@@ -9,7 +9,6 @@ from typing import Annotated
 from urllib.parse import quote
 
 import fastapi
-from backend.libs.auth.dependencies import get_user_id, requires_user
 from fastapi import Query, UploadFile
 from fastapi.responses import Response
 from pydantic import BaseModel
@@ -23,6 +22,7 @@ from backend.data.workspace import (
     get_workspace_total_size,
     soft_delete_workspace_file,
 )
+from backend.libs.auth.dependencies import get_user_id, requires_user
 from backend.util.settings import Config
 from backend.util.virus_scanner import scan_content_safe
 from backend.util.workspace import WorkspaceManager

--- a/autogpt_platform/backend/backend/api/features/workspace/routes.py
+++ b/autogpt_platform/backend/backend/api/features/workspace/routes.py
@@ -9,7 +9,7 @@ from typing import Annotated
 from urllib.parse import quote
 
 import fastapi
-from autogpt_libs.auth.dependencies import get_user_id, requires_user
+from backend.libs.auth.dependencies import get_user_id, requires_user
 from fastapi import Query, UploadFile
 from fastapi.responses import Response
 from pydantic import BaseModel

--- a/autogpt_platform/backend/backend/api/features/workspace/routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/workspace/routes_test.py
@@ -46,7 +46,7 @@ MOCK_FILE = WorkspaceFile(
 
 @pytest.fixture(autouse=True)
 def setup_app_auth(mock_jwt_user):
-    from autogpt_libs.auth.jwt_utils import get_jwt_payload
+    from backend.libs.auth.jwt_utils import get_jwt_payload
 
     app.dependency_overrides[get_jwt_payload] = mock_jwt_user["get_jwt_payload"]
     yield

--- a/autogpt_platform/backend/backend/api/rest_api.py
+++ b/autogpt_platform/backend/backend/api/rest_api.py
@@ -9,8 +9,6 @@ import fastapi.responses
 import pydantic
 import starlette.middleware.cors
 import uvicorn
-from backend.libs.auth import add_auth_responses_to_openapi
-from backend.libs.auth import verify_settings as verify_auth_settings
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.routing import APIRoute
@@ -48,6 +46,8 @@ from backend.api.features.library.exceptions import (
 from backend.blocks.llm import DEFAULT_LLM_MODEL
 from backend.data.model import Credentials
 from backend.integrations.providers import ProviderName
+from backend.libs.auth import add_auth_responses_to_openapi
+from backend.libs.auth import verify_settings as verify_auth_settings
 from backend.monitoring.instrumentation import instrument_fastapi
 from backend.util import json
 from backend.util.cloud_storage import shutdown_cloud_storage_handler

--- a/autogpt_platform/backend/backend/api/rest_api.py
+++ b/autogpt_platform/backend/backend/api/rest_api.py
@@ -9,8 +9,8 @@ import fastapi.responses
 import pydantic
 import starlette.middleware.cors
 import uvicorn
-from autogpt_libs.auth import add_auth_responses_to_openapi
-from autogpt_libs.auth import verify_settings as verify_auth_settings
+from backend.libs.auth import add_auth_responses_to_openapi
+from backend.libs.auth import verify_settings as verify_auth_settings
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.routing import APIRoute
@@ -71,7 +71,7 @@ from .utils.openapi import sort_openapi
 settings = backend.util.settings.Settings()
 logger = logging.getLogger(__name__)
 
-logging.getLogger("autogpt_libs").setLevel(logging.INFO)
+logging.getLogger("backend.libs").setLevel(logging.INFO)
 
 
 @contextlib.contextmanager

--- a/autogpt_platform/backend/backend/api/ws_api.py
+++ b/autogpt_platform/backend/backend/api/ws_api.py
@@ -5,7 +5,6 @@ from typing import Protocol
 
 import pydantic
 import uvicorn
-from backend.libs.auth.jwt_utils import parse_jwt_token
 from fastapi import Depends, FastAPI, WebSocket, WebSocketDisconnect
 from starlette.middleware.cors import CORSMiddleware
 
@@ -20,6 +19,7 @@ from backend.api.utils.cors import build_cors_params
 from backend.data.execution import AsyncRedisExecutionEventBus
 from backend.data.notification_bus import AsyncRedisNotificationEventBus
 from backend.data.user import DEFAULT_USER_ID
+from backend.libs.auth.jwt_utils import parse_jwt_token
 from backend.monitoring.instrumentation import (
     instrument_fastapi,
     update_websocket_connections,

--- a/autogpt_platform/backend/backend/api/ws_api.py
+++ b/autogpt_platform/backend/backend/api/ws_api.py
@@ -5,7 +5,7 @@ from typing import Protocol
 
 import pydantic
 import uvicorn
-from autogpt_libs.auth.jwt_utils import parse_jwt_token
+from backend.libs.auth.jwt_utils import parse_jwt_token
 from fastapi import Depends, FastAPI, WebSocket, WebSocketDisconnect
 from starlette.middleware.cors import CORSMiddleware
 

--- a/autogpt_platform/backend/backend/cli/oauth_tool.py
+++ b/autogpt_platform/backend/backend/cli/oauth_tool.py
@@ -40,8 +40,9 @@ from typing import Optional
 from urllib.parse import urlparse
 
 import click
-from backend.libs.api_key.keysmith import APIKeySmith
 from prisma.enums import APIKeyPermission
+
+from backend.libs.api_key.keysmith import APIKeySmith
 
 keysmith = APIKeySmith()
 

--- a/autogpt_platform/backend/backend/cli/oauth_tool.py
+++ b/autogpt_platform/backend/backend/cli/oauth_tool.py
@@ -40,7 +40,7 @@ from typing import Optional
 from urllib.parse import urlparse
 
 import click
-from autogpt_libs.api_key.keysmith import APIKeySmith
+from backend.libs.api_key.keysmith import APIKeySmith
 from prisma.enums import APIKeyPermission
 
 keysmith = APIKeySmith()

--- a/autogpt_platform/backend/backend/data/auth/api_key.py
+++ b/autogpt_platform/backend/backend/data/auth/api_key.py
@@ -3,13 +3,13 @@ import uuid
 from datetime import datetime, timezone
 from typing import Literal, Optional
 
-from backend.libs.api_key.keysmith import APIKeySmith
 from prisma.enums import APIKeyPermission, APIKeyStatus
 from prisma.models import APIKey as PrismaAPIKey
 from prisma.types import APIKeyWhereUniqueInput
 from pydantic import Field
 
 from backend.data.includes import MAX_USER_API_KEYS_FETCH
+from backend.libs.api_key.keysmith import APIKeySmith
 from backend.util.exceptions import NotAuthorizedError, NotFoundError
 
 from .base import APIAuthorizationInfo

--- a/autogpt_platform/backend/backend/data/auth/api_key.py
+++ b/autogpt_platform/backend/backend/data/auth/api_key.py
@@ -3,7 +3,7 @@ import uuid
 from datetime import datetime, timezone
 from typing import Literal, Optional
 
-from autogpt_libs.api_key.keysmith import APIKeySmith
+from backend.libs.api_key.keysmith import APIKeySmith
 from prisma.enums import APIKeyPermission, APIKeyStatus
 from prisma.models import APIKey as PrismaAPIKey
 from prisma.types import APIKeyWhereUniqueInput

--- a/autogpt_platform/backend/backend/data/auth/oauth.py
+++ b/autogpt_platform/backend/backend/data/auth/oauth.py
@@ -16,7 +16,7 @@ import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Literal, Optional
 
-from autogpt_libs.api_key.keysmith import APIKeySmith
+from backend.libs.api_key.keysmith import APIKeySmith
 from prisma.enums import APIKeyPermission as APIPermission
 from prisma.models import OAuthAccessToken as PrismaOAuthAccessToken
 from prisma.models import OAuthApplication as PrismaOAuthApplication

--- a/autogpt_platform/backend/backend/data/auth/oauth.py
+++ b/autogpt_platform/backend/backend/data/auth/oauth.py
@@ -16,7 +16,6 @@ import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Literal, Optional
 
-from backend.libs.api_key.keysmith import APIKeySmith
 from prisma.enums import APIKeyPermission as APIPermission
 from prisma.models import OAuthAccessToken as PrismaOAuthAccessToken
 from prisma.models import OAuthApplication as PrismaOAuthApplication
@@ -24,6 +23,8 @@ from prisma.models import OAuthAuthorizationCode as PrismaOAuthAuthorizationCode
 from prisma.models import OAuthRefreshToken as PrismaOAuthRefreshToken
 from prisma.types import OAuthApplicationUpdateInput
 from pydantic import BaseModel, Field, SecretStr
+
+from backend.libs.api_key.keysmith import APIKeySmith
 
 from .base import APIAuthorizationInfo
 

--- a/autogpt_platform/backend/backend/data/user.py
+++ b/autogpt_platform/backend/backend/data/user.py
@@ -6,7 +6,6 @@ from datetime import datetime, timedelta
 from typing import Optional, cast
 from urllib.parse import quote_plus
 
-from backend.libs.auth.models import DEFAULT_USER_ID
 from fastapi import HTTPException
 from prisma.enums import NotificationType
 from prisma.models import User as PrismaUser
@@ -15,6 +14,7 @@ from prisma.types import JsonFilter, UserCreateInput, UserUpdateInput
 from backend.data.db import prisma
 from backend.data.model import User, UserIntegrations, UserMetadata
 from backend.data.notifications import NotificationPreference, NotificationPreferenceDTO
+from backend.libs.auth.models import DEFAULT_USER_ID
 from backend.util.cache import cached
 from backend.util.encryption import JSONCryptor
 from backend.util.exceptions import DatabaseError

--- a/autogpt_platform/backend/backend/data/user.py
+++ b/autogpt_platform/backend/backend/data/user.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta
 from typing import Optional, cast
 from urllib.parse import quote_plus
 
-from autogpt_libs.auth.models import DEFAULT_USER_ID
+from backend.libs.auth.models import DEFAULT_USER_ID
 from fastapi import HTTPException
 from prisma.enums import NotificationType
 from prisma.models import User as PrismaUser

--- a/autogpt_platform/backend/backend/integrations/credentials_store.py
+++ b/autogpt_platform/backend/backend/integrations/credentials_store.py
@@ -5,7 +5,6 @@ from contextlib import asynccontextmanager
 from datetime import datetime, timedelta, timezone
 from typing import Optional
 
-from backend.libs.utils.synchronize import AsyncRedisKeyedMutex
 from pydantic import SecretStr
 
 from backend.data.db import prisma
@@ -18,6 +17,7 @@ from backend.data.model import (
     UserPasswordCredentials,
 )
 from backend.data.redis_client import get_redis_async
+from backend.libs.utils.synchronize import AsyncRedisKeyedMutex
 from backend.util.settings import Settings
 
 settings = Settings()

--- a/autogpt_platform/backend/backend/integrations/credentials_store.py
+++ b/autogpt_platform/backend/backend/integrations/credentials_store.py
@@ -5,7 +5,7 @@ from contextlib import asynccontextmanager
 from datetime import datetime, timedelta, timezone
 from typing import Optional
 
-from autogpt_libs.utils.synchronize import AsyncRedisKeyedMutex
+from backend.libs.utils.synchronize import AsyncRedisKeyedMutex
 from pydantic import SecretStr
 
 from backend.data.db import prisma

--- a/autogpt_platform/backend/backend/integrations/creds_manager.py
+++ b/autogpt_platform/backend/backend/integrations/creds_manager.py
@@ -4,7 +4,7 @@ from contextlib import asynccontextmanager
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Callable, Coroutine
 
-from autogpt_libs.utils.synchronize import AsyncRedisKeyedMutex
+from backend.libs.utils.synchronize import AsyncRedisKeyedMutex
 from redis.asyncio.lock import Lock as AsyncRedisLock
 
 from backend.data.model import Credentials, OAuth2Credentials

--- a/autogpt_platform/backend/backend/integrations/creds_manager.py
+++ b/autogpt_platform/backend/backend/integrations/creds_manager.py
@@ -4,7 +4,6 @@ from contextlib import asynccontextmanager
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Callable, Coroutine
 
-from backend.libs.utils.synchronize import AsyncRedisKeyedMutex
 from redis.asyncio.lock import Lock as AsyncRedisLock
 
 from backend.data.model import Credentials, OAuth2Credentials
@@ -15,6 +14,7 @@ from backend.integrations.credentials_store import (
 )
 from backend.integrations.oauth import CREDENTIALS_BY_PROVIDER, HANDLERS_BY_NAME
 from backend.integrations.providers import ProviderName
+from backend.libs.utils.synchronize import AsyncRedisKeyedMutex
 from backend.util.exceptions import MissingConfigError
 from backend.util.settings import Settings
 

--- a/autogpt_platform/backend/backend/libs/api_key/keysmith.py
+++ b/autogpt_platform/backend/backend/libs/api_key/keysmith.py
@@ -1,0 +1,81 @@
+import hashlib
+import secrets
+from typing import NamedTuple
+
+from cryptography.hazmat.primitives.kdf.scrypt import Scrypt
+
+
+class APIKeyContainer(NamedTuple):
+    """Container for API key parts."""
+
+    key: str
+    head: str
+    tail: str
+    hash: str
+    salt: str
+
+
+class APIKeySmith:
+    PREFIX: str = "agpt_"
+    HEAD_LENGTH: int = 8
+    TAIL_LENGTH: int = 8
+
+    def generate_key(self) -> APIKeyContainer:
+        """Generate a new API key with secure hashing."""
+        raw_key = f"{self.PREFIX}{secrets.token_urlsafe(32)}"
+        hash, salt = self.hash_key(raw_key)
+
+        return APIKeyContainer(
+            key=raw_key,
+            head=raw_key[: self.HEAD_LENGTH],
+            tail=raw_key[-self.TAIL_LENGTH :],
+            hash=hash,
+            salt=salt,
+        )
+
+    def verify_key(
+        self, provided_key: str, known_hash: str, known_salt: str | None = None
+    ) -> bool:
+        """
+        Verify an API key against a known hash (+ salt).
+        Supports verifying both legacy SHA256 and secure Scrypt hashes.
+        """
+        if not provided_key.startswith(self.PREFIX):
+            return False
+
+        # Handle legacy SHA256 hashes (migration support)
+        if known_salt is None:
+            legacy_hash = hashlib.sha256(provided_key.encode()).hexdigest()
+            return secrets.compare_digest(legacy_hash, known_hash)
+
+        try:
+            salt_bytes = bytes.fromhex(known_salt)
+            provided_hash = self._hash_key_with_salt(provided_key, salt_bytes)
+            return secrets.compare_digest(provided_hash, known_hash)
+        except (ValueError, TypeError):
+            return False
+
+    def hash_key(self, raw_key: str) -> tuple[str, str]:
+        """Migrate a legacy hash to secure hash format."""
+        if not raw_key.startswith(self.PREFIX):
+            raise ValueError("Key without 'agpt_' prefix would fail validation")
+
+        salt = self._generate_salt()
+        hash = self._hash_key_with_salt(raw_key, salt)
+        return hash, salt.hex()
+
+    def _generate_salt(self) -> bytes:
+        """Generate a random salt for hashing."""
+        return secrets.token_bytes(32)
+
+    def _hash_key_with_salt(self, raw_key: str, salt: bytes) -> str:
+        """Hash API key using Scrypt with salt."""
+        kdf = Scrypt(
+            length=32,
+            salt=salt,
+            n=2**14,  # CPU/memory cost parameter
+            r=8,  # Block size parameter
+            p=1,  # Parallelization parameter
+        )
+        key_hash = kdf.derive(raw_key.encode())
+        return key_hash.hex()

--- a/autogpt_platform/backend/backend/libs/api_key/test_keysmith.py
+++ b/autogpt_platform/backend/backend/libs/api_key/test_keysmith.py
@@ -1,0 +1,79 @@
+import hashlib
+
+from backend.libs.api_key.keysmith import APIKeySmith
+
+
+def test_generate_api_key():
+    keysmith = APIKeySmith()
+    key = keysmith.generate_key()
+
+    assert key.key.startswith(keysmith.PREFIX)
+    assert key.head == key.key[: keysmith.HEAD_LENGTH]
+    assert key.tail == key.key[-keysmith.TAIL_LENGTH :]
+    assert len(key.hash) == 64  # 32 bytes hex encoded
+    assert len(key.salt) == 64  # 32 bytes hex encoded
+
+
+def test_verify_new_secure_key():
+    keysmith = APIKeySmith()
+    key = keysmith.generate_key()
+
+    # Test correct key validates
+    assert keysmith.verify_key(key.key, key.hash, key.salt) is True
+
+    # Test wrong key fails
+    wrong_key = f"{keysmith.PREFIX}wrongkey123"
+    assert keysmith.verify_key(wrong_key, key.hash, key.salt) is False
+
+
+def test_verify_legacy_key():
+    keysmith = APIKeySmith()
+    legacy_key = f"{keysmith.PREFIX}legacykey123"
+    legacy_hash = hashlib.sha256(legacy_key.encode()).hexdigest()
+
+    # Test legacy key validates without salt
+    assert keysmith.verify_key(legacy_key, legacy_hash) is True
+
+    # Test wrong legacy key fails
+    wrong_key = f"{keysmith.PREFIX}wronglegacy"
+    assert keysmith.verify_key(wrong_key, legacy_hash) is False
+
+
+def test_rehash_existing_key():
+    keysmith = APIKeySmith()
+    legacy_key = f"{keysmith.PREFIX}migratekey123"
+
+    # Migrate the legacy key
+    new_hash, new_salt = keysmith.hash_key(legacy_key)
+
+    # Verify migrated key works
+    assert keysmith.verify_key(legacy_key, new_hash, new_salt) is True
+
+    # Verify different key fails with migrated hash
+    wrong_key = f"{keysmith.PREFIX}wrongkey"
+    assert keysmith.verify_key(wrong_key, new_hash, new_salt) is False
+
+
+def test_invalid_key_prefix():
+    keysmith = APIKeySmith()
+    key = keysmith.generate_key()
+
+    # Test key without proper prefix fails
+    invalid_key = "invalid_prefix_key"
+    assert keysmith.verify_key(invalid_key, key.hash, key.salt) is False
+
+
+def test_secure_hash_requires_salt():
+    keysmith = APIKeySmith()
+    key = keysmith.generate_key()
+
+    # Secure hash without salt should fail
+    assert keysmith.verify_key(key.key, key.hash) is False
+
+
+def test_invalid_salt_format():
+    keysmith = APIKeySmith()
+    key = keysmith.generate_key()
+
+    # Invalid salt format should fail gracefully
+    assert keysmith.verify_key(key.key, key.hash, "invalid_hex") is False

--- a/autogpt_platform/backend/backend/libs/auth/__init__.py
+++ b/autogpt_platform/backend/backend/libs/auth/__init__.py
@@ -1,0 +1,19 @@
+from .config import verify_settings
+from .dependencies import (
+    get_optional_user_id,
+    get_user_id,
+    requires_admin_user,
+    requires_user,
+)
+from .helpers import add_auth_responses_to_openapi
+from .models import User
+
+__all__ = [
+    "verify_settings",
+    "get_user_id",
+    "requires_admin_user",
+    "requires_user",
+    "get_optional_user_id",
+    "add_auth_responses_to_openapi",
+    "User",
+]

--- a/autogpt_platform/backend/backend/libs/auth/config.py
+++ b/autogpt_platform/backend/backend/libs/auth/config.py
@@ -1,0 +1,90 @@
+import logging
+import os
+
+from jwt.algorithms import get_default_algorithms, has_crypto
+
+logger = logging.getLogger(__name__)
+
+
+class AuthConfigError(ValueError):
+    """Raised when authentication configuration is invalid."""
+
+    pass
+
+
+ALGO_RECOMMENDATION = (
+    "We highly recommend using an asymmetric algorithm such as ES256, "
+    "because when leaked, a shared secret would allow anyone to "
+    "forge valid tokens and impersonate users. "
+    "More info: https://supabase.com/docs/guides/auth/signing-keys#choosing-the-right-signing-algorithm"  # noqa
+)
+
+
+class Settings:
+    def __init__(self):
+        self.JWT_VERIFY_KEY: str = os.getenv(
+            "JWT_VERIFY_KEY", os.getenv("SUPABASE_JWT_SECRET", "")
+        ).strip()
+        self.JWT_ALGORITHM: str = os.getenv("JWT_SIGN_ALGORITHM", "HS256").strip()
+
+        self.validate()
+
+    def validate(self):
+        if not self.JWT_VERIFY_KEY:
+            raise AuthConfigError(
+                "JWT_VERIFY_KEY must be set. "
+                "An empty JWT secret would allow anyone to forge valid tokens."
+            )
+
+        if len(self.JWT_VERIFY_KEY) < 32:
+            logger.warning(
+                "⚠️ JWT_VERIFY_KEY appears weak (less than 32 characters). "
+                "Consider using a longer, cryptographically secure secret."
+            )
+
+        supported_algorithms = get_default_algorithms().keys()
+
+        if not has_crypto:
+            logger.warning(
+                "⚠️ Asymmetric JWT verification is not available "
+                "because the 'cryptography' package is not installed. "
+                + ALGO_RECOMMENDATION
+            )
+
+        if (
+            self.JWT_ALGORITHM not in supported_algorithms
+            or self.JWT_ALGORITHM == "none"
+        ):
+            raise AuthConfigError(
+                f"Invalid JWT_SIGN_ALGORITHM: '{self.JWT_ALGORITHM}'. "
+                "Supported algorithms are listed on "
+                "https://pyjwt.readthedocs.io/en/stable/algorithms.html"
+            )
+
+        if self.JWT_ALGORITHM.startswith("HS"):
+            logger.warning(
+                f"⚠️ JWT_SIGN_ALGORITHM is set to '{self.JWT_ALGORITHM}', "
+                "a symmetric shared-key signature algorithm. " + ALGO_RECOMMENDATION
+            )
+
+
+_settings: Settings = None  # type: ignore
+
+
+def get_settings() -> Settings:
+    global _settings
+
+    if not _settings:
+        _settings = Settings()
+
+    return _settings
+
+
+def verify_settings() -> None:
+    global _settings
+
+    if not _settings:
+        _settings = Settings()  # calls validation indirectly
+        return
+
+    _settings.validate()

--- a/autogpt_platform/backend/backend/libs/auth/config_test.py
+++ b/autogpt_platform/backend/backend/libs/auth/config_test.py
@@ -1,0 +1,306 @@
+"""
+Comprehensive tests for auth configuration to ensure 100% line and branch coverage.
+These tests verify critical security checks preventing JWT token forgery.
+"""
+
+import logging
+import os
+
+import pytest
+from pytest_mock import MockerFixture
+
+from backend.libs.auth.config import AuthConfigError, Settings
+
+
+def test_environment_variable_precedence(mocker: MockerFixture):
+    """Test that environment variables take precedence over defaults."""
+    secret = "environment-secret-key-with-proper-length-123456"
+    mocker.patch.dict(os.environ, {"JWT_VERIFY_KEY": secret}, clear=True)
+
+    settings = Settings()
+    assert settings.JWT_VERIFY_KEY == secret
+
+
+def test_environment_variable_backwards_compatible(mocker: MockerFixture):
+    """Test that SUPABASE_JWT_SECRET is read if JWT_VERIFY_KEY is not set."""
+    secret = "environment-secret-key-with-proper-length-123456"
+    mocker.patch.dict(os.environ, {"SUPABASE_JWT_SECRET": secret}, clear=True)
+
+    settings = Settings()
+    assert settings.JWT_VERIFY_KEY == secret
+
+
+def test_auth_config_error_inheritance():
+    """Test that AuthConfigError is properly defined as an Exception."""
+    assert issubclass(AuthConfigError, Exception)
+    error = AuthConfigError("test message")
+    assert str(error) == "test message"
+
+
+def test_settings_static_after_creation(mocker: MockerFixture):
+    """Test that settings maintain their values after creation."""
+    secret = "immutable-secret-key-with-proper-length-12345"
+    mocker.patch.dict(os.environ, {"JWT_VERIFY_KEY": secret}, clear=True)
+
+    settings = Settings()
+    original_secret = settings.JWT_VERIFY_KEY
+
+    # Changing environment after creation shouldn't affect settings
+    os.environ["JWT_VERIFY_KEY"] = "different-secret"
+
+    assert settings.JWT_VERIFY_KEY == original_secret
+
+
+def test_settings_load_with_valid_secret(mocker: MockerFixture):
+    """Test auth enabled with a valid JWT secret."""
+    valid_secret = "a" * 32  # 32 character secret
+    mocker.patch.dict(os.environ, {"JWT_VERIFY_KEY": valid_secret}, clear=True)
+
+    settings = Settings()
+    assert settings.JWT_VERIFY_KEY == valid_secret
+
+
+def test_settings_load_with_strong_secret(mocker: MockerFixture):
+    """Test auth enabled with a cryptographically strong secret."""
+    strong_secret = "super-secret-jwt-token-with-at-least-32-characters-long"
+    mocker.patch.dict(os.environ, {"JWT_VERIFY_KEY": strong_secret}, clear=True)
+
+    settings = Settings()
+    assert settings.JWT_VERIFY_KEY == strong_secret
+    assert len(settings.JWT_VERIFY_KEY) >= 32
+
+
+def test_secret_empty_raises_error(mocker: MockerFixture):
+    """Test that auth enabled with empty secret raises AuthConfigError."""
+    mocker.patch.dict(os.environ, {"JWT_VERIFY_KEY": ""}, clear=True)
+
+    with pytest.raises(Exception) as exc_info:
+        Settings()
+    assert "JWT_VERIFY_KEY" in str(exc_info.value)
+
+
+def test_secret_missing_raises_error(mocker: MockerFixture):
+    """Test that auth enabled without secret env var raises AuthConfigError."""
+    mocker.patch.dict(os.environ, {}, clear=True)
+
+    with pytest.raises(Exception) as exc_info:
+        Settings()
+    assert "JWT_VERIFY_KEY" in str(exc_info.value)
+
+
+@pytest.mark.parametrize("secret", [" ", "  ", "\t", "\n", " \t\n "])
+def test_secret_only_whitespace_raises_error(mocker: MockerFixture, secret: str):
+    """Test that auth enabled with whitespace-only secret raises error."""
+    mocker.patch.dict(os.environ, {"JWT_VERIFY_KEY": secret}, clear=True)
+
+    with pytest.raises(ValueError):
+        Settings()
+
+
+def test_secret_weak_logs_warning(
+    mocker: MockerFixture, caplog: pytest.LogCaptureFixture
+):
+    """Test that weak JWT secret triggers warning log."""
+    weak_secret = "short"  # Less than 32 characters
+    mocker.patch.dict(os.environ, {"JWT_VERIFY_KEY": weak_secret}, clear=True)
+
+    with caplog.at_level(logging.WARNING):
+        settings = Settings()
+        assert settings.JWT_VERIFY_KEY == weak_secret
+        assert "key appears weak" in caplog.text.lower()
+        assert "less than 32 characters" in caplog.text
+
+
+def test_secret_31_char_logs_warning(
+    mocker: MockerFixture, caplog: pytest.LogCaptureFixture
+):
+    """Test that 31-character secret triggers warning (boundary test)."""
+    secret_31 = "a" * 31  # Exactly 31 characters
+    mocker.patch.dict(os.environ, {"JWT_VERIFY_KEY": secret_31}, clear=True)
+
+    with caplog.at_level(logging.WARNING):
+        settings = Settings()
+        assert len(settings.JWT_VERIFY_KEY) == 31
+        assert "key appears weak" in caplog.text.lower()
+
+
+def test_secret_32_char_no_warning(
+    mocker: MockerFixture, caplog: pytest.LogCaptureFixture
+):
+    """Test that 32-character secret does not trigger warning (boundary test)."""
+    secret_32 = "a" * 32  # Exactly 32 characters
+    mocker.patch.dict(os.environ, {"JWT_VERIFY_KEY": secret_32}, clear=True)
+
+    with caplog.at_level(logging.WARNING):
+        settings = Settings()
+        assert len(settings.JWT_VERIFY_KEY) == 32
+        assert "JWT secret appears weak" not in caplog.text
+
+
+def test_secret_whitespace_stripped(mocker: MockerFixture):
+    """Test that JWT secret whitespace is stripped."""
+    secret = "a" * 32
+    mocker.patch.dict(os.environ, {"JWT_VERIFY_KEY": f"  {secret}  "}, clear=True)
+
+    settings = Settings()
+    assert settings.JWT_VERIFY_KEY == secret
+
+
+def test_secret_with_special_characters(mocker: MockerFixture):
+    """Test JWT secret with special characters."""
+    special_secret = "!@#$%^&*()_+-=[]{}|;:,.<>?`~" + "a" * 10  # 40 chars total
+    mocker.patch.dict(os.environ, {"JWT_VERIFY_KEY": special_secret}, clear=True)
+
+    settings = Settings()
+    assert settings.JWT_VERIFY_KEY == special_secret
+
+
+def test_secret_with_unicode(mocker: MockerFixture):
+    """Test JWT secret with unicode characters."""
+    unicode_secret = "秘密🔐キー" + "a" * 25  # Ensure >32 bytes
+    mocker.patch.dict(os.environ, {"JWT_VERIFY_KEY": unicode_secret}, clear=True)
+
+    settings = Settings()
+    assert settings.JWT_VERIFY_KEY == unicode_secret
+
+
+def test_secret_very_long(mocker: MockerFixture):
+    """Test JWT secret with excessive length."""
+    long_secret = "a" * 1000  # 1000 character secret
+    mocker.patch.dict(os.environ, {"JWT_VERIFY_KEY": long_secret}, clear=True)
+
+    settings = Settings()
+    assert settings.JWT_VERIFY_KEY == long_secret
+    assert len(settings.JWT_VERIFY_KEY) == 1000
+
+
+def test_secret_with_newline(mocker: MockerFixture):
+    """Test JWT secret containing newlines."""
+    multiline_secret = "secret\nwith\nnewlines" + "a" * 20
+    mocker.patch.dict(os.environ, {"JWT_VERIFY_KEY": multiline_secret}, clear=True)
+
+    settings = Settings()
+    assert settings.JWT_VERIFY_KEY == multiline_secret
+
+
+def test_secret_base64_encoded(mocker: MockerFixture):
+    """Test JWT secret that looks like base64."""
+    base64_secret = "dGhpc19pc19hX3NlY3JldF9rZXlfd2l0aF9wcm9wZXJfbGVuZ3Ro"
+    mocker.patch.dict(os.environ, {"JWT_VERIFY_KEY": base64_secret}, clear=True)
+
+    settings = Settings()
+    assert settings.JWT_VERIFY_KEY == base64_secret
+
+
+def test_secret_numeric_only(mocker: MockerFixture):
+    """Test JWT secret with only numbers."""
+    numeric_secret = "1234567890" * 4  # 40 character numeric secret
+    mocker.patch.dict(os.environ, {"JWT_VERIFY_KEY": numeric_secret}, clear=True)
+
+    settings = Settings()
+    assert settings.JWT_VERIFY_KEY == numeric_secret
+
+
+def test_algorithm_default_hs256(mocker: MockerFixture):
+    """Test that JWT algorithm defaults to HS256."""
+    mocker.patch.dict(os.environ, {"JWT_VERIFY_KEY": "a" * 32}, clear=True)
+
+    settings = Settings()
+    assert settings.JWT_ALGORITHM == "HS256"
+
+
+def test_algorithm_whitespace_stripped(mocker: MockerFixture):
+    """Test that JWT algorithm whitespace is stripped."""
+    secret = "a" * 32
+    mocker.patch.dict(
+        os.environ,
+        {"JWT_VERIFY_KEY": secret, "JWT_SIGN_ALGORITHM": "  HS256  "},
+        clear=True,
+    )
+
+    settings = Settings()
+    assert settings.JWT_ALGORITHM == "HS256"
+
+
+def test_no_crypto_warning(mocker: MockerFixture, caplog: pytest.LogCaptureFixture):
+    """Test warning when crypto package is not available."""
+    secret = "a" * 32
+    mocker.patch.dict(os.environ, {"JWT_VERIFY_KEY": secret}, clear=True)
+
+    # Mock has_crypto to return False
+    mocker.patch("backend.libs.auth.config.has_crypto", False)
+
+    with caplog.at_level(logging.WARNING):
+        Settings()
+        assert "Asymmetric JWT verification is not available" in caplog.text
+        assert "cryptography" in caplog.text
+
+
+def test_algorithm_invalid_raises_error(mocker: MockerFixture):
+    """Test that invalid JWT algorithm raises AuthConfigError."""
+    secret = "a" * 32
+    mocker.patch.dict(
+        os.environ,
+        {"JWT_VERIFY_KEY": secret, "JWT_SIGN_ALGORITHM": "INVALID_ALG"},
+        clear=True,
+    )
+
+    with pytest.raises(AuthConfigError) as exc_info:
+        Settings()
+    assert "Invalid JWT_SIGN_ALGORITHM" in str(exc_info.value)
+    assert "INVALID_ALG" in str(exc_info.value)
+
+
+def test_algorithm_none_raises_error(mocker: MockerFixture):
+    """Test that 'none' algorithm raises AuthConfigError."""
+    secret = "a" * 32
+    mocker.patch.dict(
+        os.environ,
+        {"JWT_VERIFY_KEY": secret, "JWT_SIGN_ALGORITHM": "none"},
+        clear=True,
+    )
+
+    with pytest.raises(AuthConfigError) as exc_info:
+        Settings()
+    assert "Invalid JWT_SIGN_ALGORITHM" in str(exc_info.value)
+
+
+@pytest.mark.parametrize("algorithm", ["HS256", "HS384", "HS512"])
+def test_algorithm_symmetric_warning(
+    mocker: MockerFixture, caplog: pytest.LogCaptureFixture, algorithm: str
+):
+    """Test warning for symmetric algorithms (HS256, HS384, HS512)."""
+    secret = "a" * 32
+    mocker.patch.dict(
+        os.environ,
+        {"JWT_VERIFY_KEY": secret, "JWT_SIGN_ALGORITHM": algorithm},
+        clear=True,
+    )
+
+    with caplog.at_level(logging.WARNING):
+        settings = Settings()
+        assert algorithm in caplog.text
+        assert "symmetric shared-key signature algorithm" in caplog.text
+        assert settings.JWT_ALGORITHM == algorithm
+
+
+@pytest.mark.parametrize(
+    "algorithm",
+    ["ES256", "ES384", "ES512", "RS256", "RS384", "RS512", "PS256", "PS384", "PS512"],
+)
+def test_algorithm_asymmetric_no_warning(
+    mocker: MockerFixture, caplog: pytest.LogCaptureFixture, algorithm: str
+):
+    """Test that asymmetric algorithms do not trigger warning."""
+    secret = "a" * 32
+    mocker.patch.dict(
+        os.environ,
+        {"JWT_VERIFY_KEY": secret, "JWT_SIGN_ALGORITHM": algorithm},
+        clear=True,
+    )
+
+    with caplog.at_level(logging.WARNING):
+        settings = Settings()
+        # Should not contain the symmetric algorithm warning
+        assert "symmetric shared-key signature algorithm" not in caplog.text
+        assert settings.JWT_ALGORITHM == algorithm

--- a/autogpt_platform/backend/backend/libs/auth/dependencies.py
+++ b/autogpt_platform/backend/backend/libs/auth/dependencies.py
@@ -1,0 +1,117 @@
+"""
+FastAPI dependency functions for JWT-based authentication and authorization.
+
+These are the high-level dependency functions used in route definitions.
+"""
+
+import logging
+
+import fastapi
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+from .jwt_utils import get_jwt_payload, verify_user
+from .models import User
+
+optional_bearer = HTTPBearer(auto_error=False)
+
+# Header name for admin impersonation
+IMPERSONATION_HEADER_NAME = "X-Act-As-User-Id"
+
+logger = logging.getLogger(__name__)
+
+
+def get_optional_user_id(
+    credentials: HTTPAuthorizationCredentials | None = fastapi.Security(
+        optional_bearer
+    ),
+) -> str | None:
+    """
+    Attempts to extract the user ID ("sub" claim) from a Bearer JWT if provided.
+
+    This dependency allows for both authenticated and anonymous access. If a valid bearer token is
+    supplied, it parses the JWT and extracts the user ID. If the token is missing or invalid, it returns None,
+    treating the request as anonymous.
+
+    Args:
+        credentials: Optional HTTPAuthorizationCredentials object from FastAPI Security dependency.
+
+    Returns:
+        The user ID (str) extracted from the JWT "sub" claim, or None if no valid token is present.
+    """
+    if not credentials:
+        return None
+
+    try:
+        # Parse JWT token to get user ID
+        from backend.libs.auth.jwt_utils import parse_jwt_token
+
+        payload = parse_jwt_token(credentials.credentials)
+        return payload.get("sub")
+    except Exception as e:
+        logger.debug(f"Auth token validation failed (anonymous access): {e}")
+        return None
+
+
+async def requires_user(jwt_payload: dict = fastapi.Security(get_jwt_payload)) -> User:
+    """
+    FastAPI dependency that requires a valid authenticated user.
+
+    Raises:
+        HTTPException: 401 for authentication failures
+    """
+    return verify_user(jwt_payload, admin_only=False)
+
+
+async def requires_admin_user(
+    jwt_payload: dict = fastapi.Security(get_jwt_payload),
+) -> User:
+    """
+    FastAPI dependency that requires a valid admin user.
+
+    Raises:
+        HTTPException: 401 for authentication failures, 403 for insufficient permissions
+    """
+    return verify_user(jwt_payload, admin_only=True)
+
+
+async def get_user_id(
+    request: fastapi.Request, jwt_payload: dict = fastapi.Security(get_jwt_payload)
+) -> str:
+    """
+    FastAPI dependency that returns the ID of the authenticated user.
+
+    Supports admin impersonation via X-Act-As-User-Id header:
+    - If the header is present and user is admin, returns the impersonated user ID
+    - Otherwise returns the authenticated user's own ID
+    - Logs all impersonation actions for audit trail
+
+    Raises:
+        HTTPException: 401 for authentication failures or missing user ID
+        HTTPException: 403 if non-admin tries to use impersonation
+    """
+    # Get the authenticated user's ID from JWT
+    user_id = jwt_payload.get("sub")
+    if not user_id:
+        raise fastapi.HTTPException(
+            status_code=401, detail="User ID not found in token"
+        )
+
+    # Check for admin impersonation header
+    impersonate_header = request.headers.get(IMPERSONATION_HEADER_NAME, "").strip()
+    if impersonate_header:
+        # Verify the authenticated user is an admin
+        authenticated_user = verify_user(jwt_payload, admin_only=False)
+        if authenticated_user.role != "admin":
+            raise fastapi.HTTPException(
+                status_code=403, detail="Only admin users can impersonate other users"
+            )
+
+        # Log the impersonation for audit trail
+        logger.info(
+            f"Admin impersonation: {authenticated_user.user_id} ({authenticated_user.email}) "
+            f"acting as user {impersonate_header} for requesting {request.method} {request.url}"
+        )
+
+        return impersonate_header
+
+    return user_id

--- a/autogpt_platform/backend/backend/libs/auth/dependencies_test.py
+++ b/autogpt_platform/backend/backend/libs/auth/dependencies_test.py
@@ -1,0 +1,554 @@
+"""
+Comprehensive integration tests for authentication dependencies.
+Tests the full authentication flow from HTTP requests to user validation.
+"""
+
+import os
+from unittest.mock import Mock
+
+import pytest
+from fastapi import FastAPI, HTTPException, Request, Security
+from fastapi.testclient import TestClient
+from pytest_mock import MockerFixture
+
+from backend.libs.auth.dependencies import (
+    get_user_id,
+    requires_admin_user,
+    requires_user,
+)
+from backend.libs.auth.models import User
+
+
+class TestAuthDependencies:
+    """Test suite for authentication dependency functions."""
+
+    @pytest.fixture
+    def app(self):
+        """Create a test FastAPI application."""
+        app = FastAPI()
+
+        @app.get("/user")
+        def get_user_endpoint(user: User = Security(requires_user)):
+            return {"user_id": user.user_id, "role": user.role}
+
+        @app.get("/admin")
+        def get_admin_endpoint(user: User = Security(requires_admin_user)):
+            return {"user_id": user.user_id, "role": user.role}
+
+        @app.get("/user-id")
+        def get_user_id_endpoint(user_id: str = Security(get_user_id)):
+            return {"user_id": user_id}
+
+        return app
+
+    @pytest.fixture
+    def client(self, app):
+        """Create a test client."""
+        return TestClient(app)
+
+    @pytest.mark.asyncio
+    async def test_requires_user_with_valid_jwt_payload(self, mocker: MockerFixture):
+        """Test requires_user with valid JWT payload."""
+        jwt_payload = {"sub": "user-123", "role": "user", "email": "user@example.com"}
+
+        # Mock get_jwt_payload to return our test payload
+        mocker.patch(
+            "backend.libs.auth.dependencies.get_jwt_payload", return_value=jwt_payload
+        )
+        user = await requires_user(jwt_payload)
+        assert isinstance(user, User)
+        assert user.user_id == "user-123"
+        assert user.role == "user"
+
+    @pytest.mark.asyncio
+    async def test_requires_user_with_admin_jwt_payload(self, mocker: MockerFixture):
+        """Test requires_user accepts admin users."""
+        jwt_payload = {
+            "sub": "admin-456",
+            "role": "admin",
+            "email": "admin@example.com",
+        }
+
+        mocker.patch(
+            "backend.libs.auth.dependencies.get_jwt_payload", return_value=jwt_payload
+        )
+        user = await requires_user(jwt_payload)
+        assert user.user_id == "admin-456"
+        assert user.role == "admin"
+
+    @pytest.mark.asyncio
+    async def test_requires_user_missing_sub(self):
+        """Test requires_user with missing user ID."""
+        jwt_payload = {"role": "user", "email": "user@example.com"}
+
+        with pytest.raises(HTTPException) as exc_info:
+            await requires_user(jwt_payload)
+        assert exc_info.value.status_code == 401
+        assert "User ID not found" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def test_requires_user_empty_sub(self):
+        """Test requires_user with empty user ID."""
+        jwt_payload = {"sub": "", "role": "user"}
+
+        with pytest.raises(HTTPException) as exc_info:
+            await requires_user(jwt_payload)
+        assert exc_info.value.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_requires_admin_user_with_admin(self, mocker: MockerFixture):
+        """Test requires_admin_user with admin role."""
+        jwt_payload = {
+            "sub": "admin-789",
+            "role": "admin",
+            "email": "admin@example.com",
+        }
+
+        mocker.patch(
+            "backend.libs.auth.dependencies.get_jwt_payload", return_value=jwt_payload
+        )
+        user = await requires_admin_user(jwt_payload)
+        assert user.user_id == "admin-789"
+        assert user.role == "admin"
+
+    @pytest.mark.asyncio
+    async def test_requires_admin_user_with_regular_user(self):
+        """Test requires_admin_user rejects regular users."""
+        jwt_payload = {"sub": "user-123", "role": "user", "email": "user@example.com"}
+
+        with pytest.raises(HTTPException) as exc_info:
+            await requires_admin_user(jwt_payload)
+        assert exc_info.value.status_code == 403
+        assert "Admin access required" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def test_requires_admin_user_missing_role(self):
+        """Test requires_admin_user with missing role."""
+        jwt_payload = {"sub": "user-123", "email": "user@example.com"}
+
+        with pytest.raises(KeyError):
+            await requires_admin_user(jwt_payload)
+
+    @pytest.mark.asyncio
+    async def test_get_user_id_with_valid_payload(self, mocker: MockerFixture):
+        """Test get_user_id extracts user ID correctly."""
+        request = Mock(spec=Request)
+        request.headers = {}
+        jwt_payload = {"sub": "user-id-xyz", "role": "user"}
+
+        mocker.patch(
+            "backend.libs.auth.dependencies.get_jwt_payload", return_value=jwt_payload
+        )
+        user_id = await get_user_id(request, jwt_payload)
+        assert user_id == "user-id-xyz"
+
+    @pytest.mark.asyncio
+    async def test_get_user_id_missing_sub(self):
+        """Test get_user_id with missing user ID."""
+        request = Mock(spec=Request)
+        request.headers = {}
+        jwt_payload = {"role": "user"}
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_user_id(request, jwt_payload)
+        assert exc_info.value.status_code == 401
+        assert "User ID not found" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def test_get_user_id_none_sub(self):
+        """Test get_user_id with None user ID."""
+        request = Mock(spec=Request)
+        request.headers = {}
+        jwt_payload = {"sub": None, "role": "user"}
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_user_id(request, jwt_payload)
+        assert exc_info.value.status_code == 401
+
+
+class TestAuthDependenciesIntegration:
+    """Integration tests for auth dependencies with FastAPI."""
+
+    acceptable_jwt_secret = "test-secret-with-proper-length-123456"
+
+    @pytest.fixture
+    def create_token(self, mocker: MockerFixture):
+        """Helper to create JWT tokens."""
+        import jwt
+
+        mocker.patch.dict(
+            os.environ,
+            {"JWT_VERIFY_KEY": self.acceptable_jwt_secret},
+            clear=True,
+        )
+
+        def _create_token(payload, secret=self.acceptable_jwt_secret):
+            return jwt.encode(payload, secret, algorithm="HS256")
+
+        return _create_token
+
+    @pytest.mark.asyncio
+    async def test_endpoint_auth_enabled_no_token(self):
+        """Test endpoints require token when auth is enabled."""
+        app = FastAPI()
+
+        @app.get("/test")
+        def test_endpoint(user: User = Security(requires_user)):
+            return {"user_id": user.user_id}
+
+        client = TestClient(app)
+
+        # Should fail without auth header
+        response = client.get("/test")
+        assert response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_endpoint_with_valid_token(self, create_token):
+        """Test endpoint with valid JWT token."""
+        app = FastAPI()
+
+        @app.get("/test")
+        def test_endpoint(user: User = Security(requires_user)):
+            return {"user_id": user.user_id, "role": user.role}
+
+        client = TestClient(app)
+
+        token = create_token(
+            {"sub": "test-user", "role": "user", "aud": "authenticated"},
+            secret=self.acceptable_jwt_secret,
+        )
+
+        response = client.get("/test", headers={"Authorization": f"Bearer {token}"})
+        assert response.status_code == 200
+        assert response.json()["user_id"] == "test-user"
+
+    @pytest.mark.asyncio
+    async def test_admin_endpoint_requires_admin_role(self, create_token):
+        """Test admin endpoint rejects non-admin users."""
+        app = FastAPI()
+
+        @app.get("/admin")
+        def admin_endpoint(user: User = Security(requires_admin_user)):
+            return {"user_id": user.user_id}
+
+        client = TestClient(app)
+
+        # Regular user token
+        user_token = create_token(
+            {"sub": "regular-user", "role": "user", "aud": "authenticated"},
+            secret=self.acceptable_jwt_secret,
+        )
+
+        response = client.get(
+            "/admin", headers={"Authorization": f"Bearer {user_token}"}
+        )
+        assert response.status_code == 403
+
+        # Admin token
+        admin_token = create_token(
+            {"sub": "admin-user", "role": "admin", "aud": "authenticated"},
+            secret=self.acceptable_jwt_secret,
+        )
+
+        response = client.get(
+            "/admin", headers={"Authorization": f"Bearer {admin_token}"}
+        )
+        assert response.status_code == 200
+        assert response.json()["user_id"] == "admin-user"
+
+
+class TestAuthDependenciesEdgeCases:
+    """Edge case tests for authentication dependencies."""
+
+    @pytest.mark.asyncio
+    async def test_dependency_with_complex_payload(self):
+        """Test dependencies handle complex JWT payloads."""
+        complex_payload = {
+            "sub": "user-123",
+            "role": "admin",
+            "email": "test@example.com",
+            "app_metadata": {"provider": "email", "providers": ["email"]},
+            "user_metadata": {
+                "full_name": "Test User",
+                "avatar_url": "https://example.com/avatar.jpg",
+            },
+            "aud": "authenticated",
+            "iat": 1234567890,
+            "exp": 9999999999,
+        }
+
+        user = await requires_user(complex_payload)
+        assert user.user_id == "user-123"
+        assert user.email == "test@example.com"
+
+        admin = await requires_admin_user(complex_payload)
+        assert admin.role == "admin"
+
+    @pytest.mark.asyncio
+    async def test_dependency_with_unicode_in_payload(self):
+        """Test dependencies handle unicode in JWT payloads."""
+        unicode_payload = {
+            "sub": "user-😀-123",
+            "role": "user",
+            "email": "测试@example.com",
+            "name": "日本語",
+        }
+
+        user = await requires_user(unicode_payload)
+        assert "😀" in user.user_id
+        assert user.email == "测试@example.com"
+
+    @pytest.mark.asyncio
+    async def test_dependency_with_null_values(self):
+        """Test dependencies handle null values in payload."""
+        null_payload = {
+            "sub": "user-123",
+            "role": "user",
+            "email": None,
+            "phone": None,
+            "metadata": None,
+        }
+
+        user = await requires_user(null_payload)
+        assert user.user_id == "user-123"
+        assert user.email is None
+
+    @pytest.mark.asyncio
+    async def test_concurrent_requests_isolation(self):
+        """Test that concurrent requests don't interfere with each other."""
+        payload1 = {"sub": "user-1", "role": "user"}
+        payload2 = {"sub": "user-2", "role": "admin"}
+
+        # Simulate concurrent processing
+        user1 = await requires_user(payload1)
+        user2 = await requires_admin_user(payload2)
+
+        assert user1.user_id == "user-1"
+        assert user2.user_id == "user-2"
+        assert user1.role == "user"
+        assert user2.role == "admin"
+
+    @pytest.mark.parametrize(
+        "payload,expected_error,admin_only",
+        [
+            (None, "Authorization header is missing", False),
+            ({}, "User ID not found", False),
+            ({"sub": ""}, "User ID not found", False),
+            ({"role": "user"}, "User ID not found", False),
+            ({"sub": "user", "role": "user"}, "Admin access required", True),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_dependency_error_cases(
+        self, payload, expected_error: str, admin_only: bool
+    ):
+        """Test that errors propagate correctly through dependencies."""
+        # Import verify_user to test it directly since dependencies use FastAPI Security
+        from backend.libs.auth.jwt_utils import verify_user
+
+        with pytest.raises(HTTPException) as exc_info:
+            verify_user(payload, admin_only=admin_only)
+        assert expected_error in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def test_dependency_valid_user(self):
+        """Test valid user case for dependency."""
+        # Import verify_user to test it directly since dependencies use FastAPI Security
+        from backend.libs.auth.jwt_utils import verify_user
+
+        # Valid case
+        user = verify_user({"sub": "user", "role": "user"}, admin_only=False)
+        assert user.user_id == "user"
+
+
+class TestAdminImpersonation:
+    """Test suite for admin user impersonation functionality."""
+
+    @pytest.mark.asyncio
+    async def test_admin_impersonation_success(self, mocker: MockerFixture):
+        """Test admin successfully impersonating another user."""
+        request = Mock(spec=Request)
+        request.headers = {"X-Act-As-User-Id": "target-user-123"}
+        jwt_payload = {
+            "sub": "admin-456",
+            "role": "admin",
+            "email": "admin@example.com",
+        }
+
+        # Mock verify_user to return admin user data
+        mock_verify_user = mocker.patch("backend.libs.auth.dependencies.verify_user")
+        mock_verify_user.return_value = Mock(
+            user_id="admin-456", email="admin@example.com", role="admin"
+        )
+
+        # Mock logger to verify audit logging
+        mock_logger = mocker.patch("backend.libs.auth.dependencies.logger")
+
+        mocker.patch(
+            "backend.libs.auth.dependencies.get_jwt_payload", return_value=jwt_payload
+        )
+
+        user_id = await get_user_id(request, jwt_payload)
+
+        # Should return the impersonated user ID
+        assert user_id == "target-user-123"
+
+        # Should log the impersonation attempt
+        mock_logger.info.assert_called_once()
+        log_call = mock_logger.info.call_args[0][0]
+        assert "Admin impersonation:" in log_call
+        assert "admin@example.com" in log_call
+        assert "target-user-123" in log_call
+
+    @pytest.mark.asyncio
+    async def test_non_admin_impersonation_attempt(self, mocker: MockerFixture):
+        """Test non-admin user attempting impersonation returns 403."""
+        request = Mock(spec=Request)
+        request.headers = {"X-Act-As-User-Id": "target-user-123"}
+        jwt_payload = {
+            "sub": "regular-user",
+            "role": "user",
+            "email": "user@example.com",
+        }
+
+        # Mock verify_user to return regular user data
+        mock_verify_user = mocker.patch("backend.libs.auth.dependencies.verify_user")
+        mock_verify_user.return_value = Mock(
+            user_id="regular-user", email="user@example.com", role="user"
+        )
+
+        mocker.patch(
+            "backend.libs.auth.dependencies.get_jwt_payload", return_value=jwt_payload
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_user_id(request, jwt_payload)
+
+        assert exc_info.value.status_code == 403
+        assert "Only admin users can impersonate other users" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def test_impersonation_empty_header(self, mocker: MockerFixture):
+        """Test impersonation with empty header falls back to regular user ID."""
+        request = Mock(spec=Request)
+        request.headers = {"X-Act-As-User-Id": ""}
+        jwt_payload = {
+            "sub": "admin-456",
+            "role": "admin",
+            "email": "admin@example.com",
+        }
+
+        mocker.patch(
+            "backend.libs.auth.dependencies.get_jwt_payload", return_value=jwt_payload
+        )
+
+        user_id = await get_user_id(request, jwt_payload)
+
+        # Should fall back to the admin's own user ID
+        assert user_id == "admin-456"
+
+    @pytest.mark.asyncio
+    async def test_impersonation_missing_header(self, mocker: MockerFixture):
+        """Test normal behavior when impersonation header is missing."""
+        request = Mock(spec=Request)
+        request.headers = {}  # No impersonation header
+        jwt_payload = {
+            "sub": "admin-456",
+            "role": "admin",
+            "email": "admin@example.com",
+        }
+
+        mocker.patch(
+            "backend.libs.auth.dependencies.get_jwt_payload", return_value=jwt_payload
+        )
+
+        user_id = await get_user_id(request, jwt_payload)
+
+        # Should return the admin's own user ID
+        assert user_id == "admin-456"
+
+    @pytest.mark.asyncio
+    async def test_impersonation_audit_logging_details(self, mocker: MockerFixture):
+        """Test that impersonation audit logging includes all required details."""
+        request = Mock(spec=Request)
+        request.headers = {"X-Act-As-User-Id": "victim-user-789"}
+        jwt_payload = {
+            "sub": "admin-999",
+            "role": "admin",
+            "email": "superadmin@company.com",
+        }
+
+        # Mock verify_user to return admin user data
+        mock_verify_user = mocker.patch("backend.libs.auth.dependencies.verify_user")
+        mock_verify_user.return_value = Mock(
+            user_id="admin-999", email="superadmin@company.com", role="admin"
+        )
+
+        # Mock logger to capture audit trail
+        mock_logger = mocker.patch("backend.libs.auth.dependencies.logger")
+
+        mocker.patch(
+            "backend.libs.auth.dependencies.get_jwt_payload", return_value=jwt_payload
+        )
+
+        user_id = await get_user_id(request, jwt_payload)
+
+        # Verify all audit details are logged
+        assert user_id == "victim-user-789"
+        mock_logger.info.assert_called_once()
+
+        log_message = mock_logger.info.call_args[0][0]
+        assert "Admin impersonation:" in log_message
+        assert "superadmin@company.com" in log_message
+        assert "victim-user-789" in log_message
+
+    @pytest.mark.asyncio
+    async def test_impersonation_header_case_sensitivity(self, mocker: MockerFixture):
+        """Test that impersonation header is case-sensitive."""
+        request = Mock(spec=Request)
+        # Use wrong case - should not trigger impersonation
+        request.headers = {"x-act-as-user-id": "target-user-123"}
+        jwt_payload = {
+            "sub": "admin-456",
+            "role": "admin",
+            "email": "admin@example.com",
+        }
+
+        mocker.patch(
+            "backend.libs.auth.dependencies.get_jwt_payload", return_value=jwt_payload
+        )
+
+        user_id = await get_user_id(request, jwt_payload)
+
+        # Should fall back to admin's own ID (header case mismatch)
+        assert user_id == "admin-456"
+
+    @pytest.mark.asyncio
+    async def test_impersonation_with_whitespace_header(self, mocker: MockerFixture):
+        """Test impersonation with whitespace in header value."""
+        request = Mock(spec=Request)
+        request.headers = {"X-Act-As-User-Id": "  target-user-123  "}
+        jwt_payload = {
+            "sub": "admin-456",
+            "role": "admin",
+            "email": "admin@example.com",
+        }
+
+        # Mock verify_user to return admin user data
+        mock_verify_user = mocker.patch("backend.libs.auth.dependencies.verify_user")
+        mock_verify_user.return_value = Mock(
+            user_id="admin-456", email="admin@example.com", role="admin"
+        )
+
+        # Mock logger
+        mock_logger = mocker.patch("backend.libs.auth.dependencies.logger")
+
+        mocker.patch(
+            "backend.libs.auth.dependencies.get_jwt_payload", return_value=jwt_payload
+        )
+
+        user_id = await get_user_id(request, jwt_payload)
+
+        # Should strip whitespace and impersonate successfully
+        assert user_id == "target-user-123"
+        mock_logger.info.assert_called_once()

--- a/autogpt_platform/backend/backend/libs/auth/helpers.py
+++ b/autogpt_platform/backend/backend/libs/auth/helpers.py
@@ -1,0 +1,64 @@
+from fastapi import FastAPI
+
+from .jwt_utils import bearer_jwt_auth
+
+
+def add_auth_responses_to_openapi(app: FastAPI) -> None:
+    """
+    Patch a FastAPI instance's `openapi()` method to add 401 responses
+    to all authenticated endpoints.
+
+    This is needed when using HTTPBearer with auto_error=False to get proper
+    401 responses instead of 403, but FastAPI only automatically adds security
+    responses when auto_error=True.
+    """
+    # Wrap current method to allow stacking OpenAPI schema modifiers like this
+    wrapped_openapi = app.openapi
+
+    def custom_openapi():
+        if app.openapi_schema:
+            return app.openapi_schema
+
+        openapi_schema = wrapped_openapi()
+
+        # Add 401 response to all endpoints that have security requirements
+        for path, methods in openapi_schema["paths"].items():
+            for method, details in methods.items():
+                security_schemas = [
+                    schema
+                    for auth_option in details.get("security", [])
+                    for schema in auth_option.keys()
+                ]
+                if bearer_jwt_auth.scheme_name not in security_schemas:
+                    continue
+
+                if "responses" not in details:
+                    details["responses"] = {}
+
+                details["responses"]["401"] = {
+                    "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
+                }
+
+        # Ensure #/components/responses exists
+        if "components" not in openapi_schema:
+            openapi_schema["components"] = {}
+        if "responses" not in openapi_schema["components"]:
+            openapi_schema["components"]["responses"] = {}
+
+        # Define 401 response
+        openapi_schema["components"]["responses"]["HTTP401NotAuthenticatedError"] = {
+            "description": "Authentication required",
+            "content": {
+                "application/json": {
+                    "schema": {
+                        "type": "object",
+                        "properties": {"detail": {"type": "string"}},
+                    }
+                }
+            },
+        }
+
+        app.openapi_schema = openapi_schema
+        return app.openapi_schema
+
+    app.openapi = custom_openapi

--- a/autogpt_platform/backend/backend/libs/auth/helpers_test.py
+++ b/autogpt_platform/backend/backend/libs/auth/helpers_test.py
@@ -1,0 +1,435 @@
+"""
+Comprehensive tests for auth helpers module to achieve 100% coverage.
+Tests OpenAPI schema generation and authentication response handling.
+"""
+
+from unittest import mock
+
+from fastapi import FastAPI
+from fastapi.openapi.utils import get_openapi
+
+from backend.libs.auth.helpers import add_auth_responses_to_openapi
+from backend.libs.auth.jwt_utils import bearer_jwt_auth
+
+
+def test_add_auth_responses_to_openapi_basic():
+    """Test adding 401 responses to OpenAPI schema."""
+    app = FastAPI(title="Test App", version="1.0.0")
+
+    # Add some test endpoints with authentication
+    from fastapi import Depends
+
+    from backend.libs.auth.dependencies import requires_user
+
+    @app.get("/protected", dependencies=[Depends(requires_user)])
+    def protected_endpoint():
+        return {"message": "Protected"}
+
+    @app.get("/public")
+    def public_endpoint():
+        return {"message": "Public"}
+
+    # Apply the OpenAPI customization
+    add_auth_responses_to_openapi(app)
+
+    # Get the OpenAPI schema
+    schema = app.openapi()
+
+    # Verify basic schema properties
+    assert schema["info"]["title"] == "Test App"
+    assert schema["info"]["version"] == "1.0.0"
+
+    # Verify 401 response component is added
+    assert "components" in schema
+    assert "responses" in schema["components"]
+    assert "HTTP401NotAuthenticatedError" in schema["components"]["responses"]
+
+    # Verify 401 response structure
+    error_response = schema["components"]["responses"]["HTTP401NotAuthenticatedError"]
+    assert error_response["description"] == "Authentication required"
+    assert "application/json" in error_response["content"]
+    assert "schema" in error_response["content"]["application/json"]
+
+    # Verify schema properties
+    response_schema = error_response["content"]["application/json"]["schema"]
+    assert response_schema["type"] == "object"
+    assert "detail" in response_schema["properties"]
+    assert response_schema["properties"]["detail"]["type"] == "string"
+
+
+def test_add_auth_responses_to_openapi_with_security():
+    """Test that 401 responses are added only to secured endpoints."""
+    app = FastAPI()
+
+    # Mock endpoint with security
+    from fastapi import Security
+
+    from backend.libs.auth.dependencies import get_user_id
+
+    @app.get("/secured")
+    def secured_endpoint(user_id: str = Security(get_user_id)):
+        return {"user_id": user_id}
+
+    @app.post("/also-secured")
+    def another_secured(user_id: str = Security(get_user_id)):
+        return {"status": "ok"}
+
+    @app.get("/unsecured")
+    def unsecured_endpoint():
+        return {"public": True}
+
+    # Apply OpenAPI customization
+    add_auth_responses_to_openapi(app)
+
+    # Get schema
+    schema = app.openapi()
+
+    # Check that secured endpoints have 401 responses
+    if "/secured" in schema["paths"]:
+        if "get" in schema["paths"]["/secured"]:
+            secured_get = schema["paths"]["/secured"]["get"]
+            if "responses" in secured_get:
+                assert "401" in secured_get["responses"]
+                assert (
+                    secured_get["responses"]["401"]["$ref"]
+                    == "#/components/responses/HTTP401NotAuthenticatedError"
+                )
+
+    if "/also-secured" in schema["paths"]:
+        if "post" in schema["paths"]["/also-secured"]:
+            secured_post = schema["paths"]["/also-secured"]["post"]
+            if "responses" in secured_post:
+                assert "401" in secured_post["responses"]
+
+    # Check that unsecured endpoint does not have 401 response
+    if "/unsecured" in schema["paths"]:
+        if "get" in schema["paths"]["/unsecured"]:
+            unsecured_get = schema["paths"]["/unsecured"]["get"]
+            if "responses" in unsecured_get:
+                assert "401" not in unsecured_get.get("responses", {})
+
+
+def test_add_auth_responses_to_openapi_cached_schema():
+    """Test that OpenAPI schema is cached after first generation."""
+    app = FastAPI()
+
+    # Apply customization
+    add_auth_responses_to_openapi(app)
+
+    # Get schema twice
+    schema1 = app.openapi()
+    schema2 = app.openapi()
+
+    # Should return the same cached object
+    assert schema1 is schema2
+
+
+def test_add_auth_responses_to_openapi_existing_responses():
+    """Test handling endpoints that already have responses defined."""
+    app = FastAPI()
+
+    from fastapi import Security
+
+    from backend.libs.auth.jwt_utils import get_jwt_payload
+
+    @app.get(
+        "/with-responses",
+        responses={
+            200: {"description": "Success"},
+            404: {"description": "Not found"},
+        },
+    )
+    def endpoint_with_responses(jwt: dict = Security(get_jwt_payload)):
+        return {"data": "test"}
+
+    # Apply customization
+    add_auth_responses_to_openapi(app)
+
+    schema = app.openapi()
+
+    # Check that existing responses are preserved and 401 is added
+    if "/with-responses" in schema["paths"]:
+        if "get" in schema["paths"]["/with-responses"]:
+            responses = schema["paths"]["/with-responses"]["get"].get("responses", {})
+            # Original responses should be preserved
+            if "200" in responses:
+                assert responses["200"]["description"] == "Success"
+            if "404" in responses:
+                assert responses["404"]["description"] == "Not found"
+            # 401 should be added
+            if "401" in responses:
+                assert (
+                    responses["401"]["$ref"]
+                    == "#/components/responses/HTTP401NotAuthenticatedError"
+                )
+
+
+def test_add_auth_responses_to_openapi_no_security_endpoints():
+    """Test with app that has no secured endpoints."""
+    app = FastAPI()
+
+    @app.get("/public1")
+    def public1():
+        return {"message": "public1"}
+
+    @app.post("/public2")
+    def public2():
+        return {"message": "public2"}
+
+    # Apply customization
+    add_auth_responses_to_openapi(app)
+
+    schema = app.openapi()
+
+    # Component should still be added for consistency
+    assert "HTTP401NotAuthenticatedError" in schema["components"]["responses"]
+
+    # But no endpoints should have 401 responses
+    for path in schema["paths"].values():
+        for method in path.values():
+            if isinstance(method, dict) and "responses" in method:
+                assert "401" not in method["responses"]
+
+
+def test_add_auth_responses_to_openapi_multiple_security_schemes():
+    """Test endpoints with multiple security requirements."""
+    app = FastAPI()
+
+    from fastapi import Security
+
+    from backend.libs.auth.dependencies import requires_admin_user, requires_user
+    from backend.libs.auth.models import User
+
+    @app.get("/multi-auth")
+    def multi_auth(
+        user: User = Security(requires_user),
+        admin: User = Security(requires_admin_user),
+    ):
+        return {"status": "super secure"}
+
+    # Apply customization
+    add_auth_responses_to_openapi(app)
+
+    schema = app.openapi()
+
+    # Should have 401 response
+    if "/multi-auth" in schema["paths"]:
+        if "get" in schema["paths"]["/multi-auth"]:
+            responses = schema["paths"]["/multi-auth"]["get"].get("responses", {})
+            if "401" in responses:
+                assert (
+                    responses["401"]["$ref"]
+                    == "#/components/responses/HTTP401NotAuthenticatedError"
+                )
+
+
+def test_add_auth_responses_to_openapi_empty_components():
+    """Test when OpenAPI schema has no components section initially."""
+    app = FastAPI()
+
+    # Mock get_openapi to return schema without components
+    original_get_openapi = get_openapi
+
+    def mock_get_openapi(*args, **kwargs):
+        schema = original_get_openapi(*args, **kwargs)
+        # Remove components if it exists
+        if "components" in schema:
+            del schema["components"]
+        return schema
+
+    with mock.patch("backend.libs.auth.helpers.get_openapi", mock_get_openapi):
+        # Apply customization
+        add_auth_responses_to_openapi(app)
+
+        schema = app.openapi()
+
+        # Components should be created
+        assert "components" in schema
+        assert "responses" in schema["components"]
+        assert "HTTP401NotAuthenticatedError" in schema["components"]["responses"]
+
+
+def test_add_auth_responses_to_openapi_all_http_methods():
+    """Test that all HTTP methods are handled correctly."""
+    app = FastAPI()
+
+    from fastapi import Security
+
+    from backend.libs.auth.jwt_utils import get_jwt_payload
+
+    @app.get("/resource")
+    def get_resource(jwt: dict = Security(get_jwt_payload)):
+        return {"method": "GET"}
+
+    @app.post("/resource")
+    def post_resource(jwt: dict = Security(get_jwt_payload)):
+        return {"method": "POST"}
+
+    @app.put("/resource")
+    def put_resource(jwt: dict = Security(get_jwt_payload)):
+        return {"method": "PUT"}
+
+    @app.patch("/resource")
+    def patch_resource(jwt: dict = Security(get_jwt_payload)):
+        return {"method": "PATCH"}
+
+    @app.delete("/resource")
+    def delete_resource(jwt: dict = Security(get_jwt_payload)):
+        return {"method": "DELETE"}
+
+    # Apply customization
+    add_auth_responses_to_openapi(app)
+
+    schema = app.openapi()
+
+    # All methods should have 401 response
+    if "/resource" in schema["paths"]:
+        for method in ["get", "post", "put", "patch", "delete"]:
+            if method in schema["paths"]["/resource"]:
+                method_spec = schema["paths"]["/resource"][method]
+                if "responses" in method_spec:
+                    assert "401" in method_spec["responses"]
+
+
+def test_bearer_jwt_auth_scheme_config():
+    """Test that bearer_jwt_auth is configured correctly."""
+    assert bearer_jwt_auth.scheme_name == "HTTPBearerJWT"
+    assert bearer_jwt_auth.auto_error is False
+
+
+def test_add_auth_responses_with_no_routes():
+    """Test OpenAPI generation with app that has no routes."""
+    app = FastAPI(title="Empty App")
+
+    # Apply customization to empty app
+    add_auth_responses_to_openapi(app)
+
+    schema = app.openapi()
+
+    # Should still have basic structure
+    assert schema["info"]["title"] == "Empty App"
+    assert "components" in schema
+    assert "responses" in schema["components"]
+    assert "HTTP401NotAuthenticatedError" in schema["components"]["responses"]
+
+
+def test_custom_openapi_function_replacement():
+    """Test that the custom openapi function properly replaces the default."""
+    app = FastAPI()
+
+    # Store original function
+    original_openapi = app.openapi
+
+    # Apply customization
+    add_auth_responses_to_openapi(app)
+
+    # Function should be replaced
+    assert app.openapi != original_openapi
+    assert callable(app.openapi)
+
+
+def test_endpoint_without_responses_section():
+    """Test endpoint that has security but no responses section initially."""
+    app = FastAPI()
+
+    from fastapi import Security
+    from fastapi.openapi.utils import get_openapi as original_get_openapi
+
+    from backend.libs.auth.jwt_utils import get_jwt_payload
+
+    # Create endpoint
+    @app.get("/no-responses")
+    def endpoint_without_responses(jwt: dict = Security(get_jwt_payload)):
+        return {"data": "test"}
+
+    # Mock get_openapi to remove responses from the endpoint
+    def mock_get_openapi(*args, **kwargs):
+        schema = original_get_openapi(*args, **kwargs)
+        # Remove responses from our endpoint to trigger line 40
+        if "/no-responses" in schema.get("paths", {}):
+            if "get" in schema["paths"]["/no-responses"]:
+                # Delete responses to force the code to create it
+                if "responses" in schema["paths"]["/no-responses"]["get"]:
+                    del schema["paths"]["/no-responses"]["get"]["responses"]
+        return schema
+
+    with mock.patch("backend.libs.auth.helpers.get_openapi", mock_get_openapi):
+        # Apply customization
+        add_auth_responses_to_openapi(app)
+
+        # Get schema and verify 401 was added
+        schema = app.openapi()
+
+        # The endpoint should now have 401 response
+        if "/no-responses" in schema["paths"]:
+            if "get" in schema["paths"]["/no-responses"]:
+                responses = schema["paths"]["/no-responses"]["get"].get("responses", {})
+                assert "401" in responses
+                assert (
+                    responses["401"]["$ref"]
+                    == "#/components/responses/HTTP401NotAuthenticatedError"
+                )
+
+
+def test_components_with_existing_responses():
+    """Test when components already has a responses section."""
+    app = FastAPI()
+
+    # Mock get_openapi to return schema with existing components/responses
+    from fastapi.openapi.utils import get_openapi as original_get_openapi
+
+    def mock_get_openapi(*args, **kwargs):
+        schema = original_get_openapi(*args, **kwargs)
+        # Add existing components/responses
+        if "components" not in schema:
+            schema["components"] = {}
+        schema["components"]["responses"] = {
+            "ExistingResponse": {"description": "An existing response"}
+        }
+        return schema
+
+    with mock.patch("backend.libs.auth.helpers.get_openapi", mock_get_openapi):
+        # Apply customization
+        add_auth_responses_to_openapi(app)
+
+        schema = app.openapi()
+
+        # Both responses should exist
+        assert "ExistingResponse" in schema["components"]["responses"]
+        assert "HTTP401NotAuthenticatedError" in schema["components"]["responses"]
+
+        # Verify our 401 response structure
+        error_response = schema["components"]["responses"][
+            "HTTP401NotAuthenticatedError"
+        ]
+        assert error_response["description"] == "Authentication required"
+
+
+def test_openapi_schema_persistence():
+    """Test that modifications to OpenAPI schema persist correctly."""
+    app = FastAPI()
+
+    from fastapi import Security
+
+    from backend.libs.auth.jwt_utils import get_jwt_payload
+
+    @app.get("/test")
+    def test_endpoint(jwt: dict = Security(get_jwt_payload)):
+        return {"test": True}
+
+    # Apply customization
+    add_auth_responses_to_openapi(app)
+
+    # Get schema multiple times
+    schema1 = app.openapi()
+
+    # Modify the cached schema (shouldn't affect future calls)
+    schema1["info"]["title"] = "Modified Title"
+
+    # Clear cache and get again
+    app.openapi_schema = None
+    schema2 = app.openapi()
+
+    # Should regenerate with original title
+    assert schema2["info"]["title"] == app.title
+    assert schema2["info"]["title"] != "Modified Title"

--- a/autogpt_platform/backend/backend/libs/auth/jwt_utils.py
+++ b/autogpt_platform/backend/backend/libs/auth/jwt_utils.py
@@ -1,0 +1,80 @@
+import logging
+from typing import Any
+
+import jwt
+from fastapi import HTTPException, Security
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+from .config import get_settings
+from .models import User
+
+logger = logging.getLogger(__name__)
+
+# Bearer token authentication scheme
+bearer_jwt_auth = HTTPBearer(
+    bearerFormat="jwt", scheme_name="HTTPBearerJWT", auto_error=False
+)
+
+
+async def get_jwt_payload(
+    credentials: HTTPAuthorizationCredentials | None = Security(bearer_jwt_auth),
+) -> dict[str, Any]:
+    """
+    Extract and validate JWT payload from HTTP Authorization header.
+
+    This is the core authentication function that handles:
+    - Reading the `Authorization` header to obtain the JWT token
+    - Verifying the JWT token's signature
+    - Decoding the JWT token's payload
+
+    :param credentials: HTTP Authorization credentials from bearer token
+    :return: JWT payload dictionary
+    :raises HTTPException: 401 if authentication fails
+    """
+    if not credentials:
+        raise HTTPException(status_code=401, detail="Authorization header is missing")
+
+    try:
+        payload = parse_jwt_token(credentials.credentials)
+        logger.debug("Token decoded successfully")
+        return payload
+    except ValueError as e:
+        raise HTTPException(status_code=401, detail=str(e))
+
+
+def parse_jwt_token(token: str) -> dict[str, Any]:
+    """
+    Parse and validate a JWT token.
+
+    :param token: The token to parse
+    :return: The decoded payload
+    :raises ValueError: If the token is invalid or expired
+    """
+    settings = get_settings()
+    try:
+        payload = jwt.decode(
+            token,
+            settings.JWT_VERIFY_KEY,
+            algorithms=[settings.JWT_ALGORITHM],
+            audience="authenticated",
+        )
+        return payload
+    except jwt.ExpiredSignatureError:
+        raise ValueError("Token has expired")
+    except jwt.InvalidTokenError as e:
+        raise ValueError(f"Invalid token: {str(e)}")
+
+
+def verify_user(jwt_payload: dict | None, admin_only: bool) -> User:
+    if jwt_payload is None:
+        raise HTTPException(status_code=401, detail="Authorization header is missing")
+
+    user_id = jwt_payload.get("sub")
+
+    if not user_id:
+        raise HTTPException(status_code=401, detail="User ID not found in token")
+
+    if admin_only and jwt_payload["role"] != "admin":
+        raise HTTPException(status_code=403, detail="Admin access required")
+
+    return User.from_payload(jwt_payload)

--- a/autogpt_platform/backend/backend/libs/auth/jwt_utils_test.py
+++ b/autogpt_platform/backend/backend/libs/auth/jwt_utils_test.py
@@ -1,0 +1,308 @@
+"""
+Comprehensive tests for JWT token parsing and validation.
+Ensures 100% line and branch coverage for JWT security functions.
+"""
+
+import os
+from datetime import datetime, timedelta, timezone
+
+import jwt
+import pytest
+from fastapi import HTTPException
+from fastapi.security import HTTPAuthorizationCredentials
+from pytest_mock import MockerFixture
+
+from backend.libs.auth import config, jwt_utils
+from backend.libs.auth.config import Settings
+from backend.libs.auth.models import User
+
+MOCK_JWT_SECRET = "test-secret-key-with-at-least-32-characters"
+TEST_USER_PAYLOAD = {
+    "sub": "test-user-id",
+    "role": "user",
+    "aud": "authenticated",
+    "email": "test@example.com",
+}
+TEST_ADMIN_PAYLOAD = {
+    "sub": "admin-user-id",
+    "role": "admin",
+    "aud": "authenticated",
+    "email": "admin@example.com",
+}
+
+
+@pytest.fixture(autouse=True)
+def mock_config(mocker: MockerFixture):
+    mocker.patch.dict(os.environ, {"JWT_VERIFY_KEY": MOCK_JWT_SECRET}, clear=True)
+    mocker.patch.object(config, "_settings", Settings())
+    yield
+
+
+def create_token(payload, secret=None, algorithm="HS256"):
+    """Helper to create JWT tokens."""
+    if secret is None:
+        secret = MOCK_JWT_SECRET
+    return jwt.encode(payload, secret, algorithm=algorithm)
+
+
+def test_parse_jwt_token_valid():
+    """Test parsing a valid JWT token."""
+    token = create_token(TEST_USER_PAYLOAD)
+    result = jwt_utils.parse_jwt_token(token)
+
+    assert result["sub"] == "test-user-id"
+    assert result["role"] == "user"
+    assert result["aud"] == "authenticated"
+
+
+def test_parse_jwt_token_expired():
+    """Test parsing an expired JWT token."""
+    expired_payload = {
+        **TEST_USER_PAYLOAD,
+        "exp": datetime.now(timezone.utc) - timedelta(hours=1),
+    }
+    token = create_token(expired_payload)
+
+    with pytest.raises(ValueError) as exc_info:
+        jwt_utils.parse_jwt_token(token)
+    assert "Token has expired" in str(exc_info.value)
+
+
+def test_parse_jwt_token_invalid_signature():
+    """Test parsing a token with invalid signature."""
+    # Create token with different secret
+    token = create_token(TEST_USER_PAYLOAD, secret="wrong-secret")
+
+    with pytest.raises(ValueError) as exc_info:
+        jwt_utils.parse_jwt_token(token)
+    assert "Invalid token" in str(exc_info.value)
+
+
+def test_parse_jwt_token_malformed():
+    """Test parsing a malformed token."""
+    malformed_tokens = [
+        "not.a.token",
+        "invalid",
+        "",
+        # Header only
+        "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9",
+        # No signature
+        "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0In0",
+    ]
+
+    for token in malformed_tokens:
+        with pytest.raises(ValueError) as exc_info:
+            jwt_utils.parse_jwt_token(token)
+        assert "Invalid token" in str(exc_info.value)
+
+
+def test_parse_jwt_token_wrong_audience():
+    """Test parsing a token with wrong audience."""
+    wrong_aud_payload = {**TEST_USER_PAYLOAD, "aud": "wrong-audience"}
+    token = create_token(wrong_aud_payload)
+
+    with pytest.raises(ValueError) as exc_info:
+        jwt_utils.parse_jwt_token(token)
+    assert "Invalid token" in str(exc_info.value)
+
+
+def test_parse_jwt_token_missing_audience():
+    """Test parsing a token without audience claim."""
+    no_aud_payload = {k: v for k, v in TEST_USER_PAYLOAD.items() if k != "aud"}
+    token = create_token(no_aud_payload)
+
+    with pytest.raises(ValueError) as exc_info:
+        jwt_utils.parse_jwt_token(token)
+    assert "Invalid token" in str(exc_info.value)
+
+
+async def test_get_jwt_payload_with_valid_token():
+    """Test extracting JWT payload with valid bearer token."""
+    token = create_token(TEST_USER_PAYLOAD)
+    credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+
+    result = await jwt_utils.get_jwt_payload(credentials)
+    assert result["sub"] == "test-user-id"
+    assert result["role"] == "user"
+
+
+async def test_get_jwt_payload_no_credentials():
+    """Test JWT payload when no credentials provided."""
+    with pytest.raises(HTTPException) as exc_info:
+        await jwt_utils.get_jwt_payload(None)
+    assert exc_info.value.status_code == 401
+    assert "Authorization header is missing" in exc_info.value.detail
+
+
+async def test_get_jwt_payload_invalid_token():
+    """Test JWT payload extraction with invalid token."""
+    credentials = HTTPAuthorizationCredentials(
+        scheme="Bearer", credentials="invalid.token.here"
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await jwt_utils.get_jwt_payload(credentials)
+    assert exc_info.value.status_code == 401
+    assert "Invalid token" in exc_info.value.detail
+
+
+def test_verify_user_with_valid_user():
+    """Test verifying a valid user."""
+    user = jwt_utils.verify_user(TEST_USER_PAYLOAD, admin_only=False)
+    assert isinstance(user, User)
+    assert user.user_id == "test-user-id"
+    assert user.role == "user"
+    assert user.email == "test@example.com"
+
+
+def test_verify_user_with_admin():
+    """Test verifying an admin user."""
+    user = jwt_utils.verify_user(TEST_ADMIN_PAYLOAD, admin_only=True)
+    assert isinstance(user, User)
+    assert user.user_id == "admin-user-id"
+    assert user.role == "admin"
+
+
+def test_verify_user_admin_only_with_regular_user():
+    """Test verifying regular user when admin is required."""
+    with pytest.raises(HTTPException) as exc_info:
+        jwt_utils.verify_user(TEST_USER_PAYLOAD, admin_only=True)
+    assert exc_info.value.status_code == 403
+    assert "Admin access required" in exc_info.value.detail
+
+
+def test_verify_user_no_payload():
+    """Test verifying user with no payload."""
+    with pytest.raises(HTTPException) as exc_info:
+        jwt_utils.verify_user(None, admin_only=False)
+    assert exc_info.value.status_code == 401
+    assert "Authorization header is missing" in exc_info.value.detail
+
+
+def test_verify_user_missing_sub():
+    """Test verifying user with payload missing 'sub' field."""
+    invalid_payload = {"role": "user", "email": "test@example.com"}
+    with pytest.raises(HTTPException) as exc_info:
+        jwt_utils.verify_user(invalid_payload, admin_only=False)
+    assert exc_info.value.status_code == 401
+    assert "User ID not found in token" in exc_info.value.detail
+
+
+def test_verify_user_empty_sub():
+    """Test verifying user with empty 'sub' field."""
+    invalid_payload = {"sub": "", "role": "user"}
+    with pytest.raises(HTTPException) as exc_info:
+        jwt_utils.verify_user(invalid_payload, admin_only=False)
+    assert exc_info.value.status_code == 401
+    assert "User ID not found in token" in exc_info.value.detail
+
+
+def test_verify_user_none_sub():
+    """Test verifying user with None 'sub' field."""
+    invalid_payload = {"sub": None, "role": "user"}
+    with pytest.raises(HTTPException) as exc_info:
+        jwt_utils.verify_user(invalid_payload, admin_only=False)
+    assert exc_info.value.status_code == 401
+    assert "User ID not found in token" in exc_info.value.detail
+
+
+def test_verify_user_missing_role_admin_check():
+    """Test verifying admin when role field is missing."""
+    no_role_payload = {"sub": "user-id"}
+    with pytest.raises(KeyError):
+        # This will raise KeyError when checking payload["role"]
+        jwt_utils.verify_user(no_role_payload, admin_only=True)
+
+
+# ======================== EDGE CASES ======================== #
+
+
+def test_jwt_with_additional_claims():
+    """Test JWT token with additional custom claims."""
+    extra_claims_payload = {
+        "sub": "user-id",
+        "role": "user",
+        "aud": "authenticated",
+        "custom_claim": "custom_value",
+        "permissions": ["read", "write"],
+        "metadata": {"key": "value"},
+    }
+    token = create_token(extra_claims_payload)
+
+    result = jwt_utils.parse_jwt_token(token)
+    assert result["sub"] == "user-id"
+    assert result["custom_claim"] == "custom_value"
+    assert result["permissions"] == ["read", "write"]
+
+
+def test_jwt_with_numeric_sub():
+    """Test JWT token with numeric user ID."""
+    payload = {
+        "sub": 12345,  # Numeric ID
+        "role": "user",
+        "aud": "authenticated",
+    }
+    # Should convert to string internally
+    user = jwt_utils.verify_user(payload, admin_only=False)
+    assert user.user_id == 12345
+
+
+def test_jwt_with_very_long_sub():
+    """Test JWT token with very long user ID."""
+    long_id = "a" * 1000
+    payload = {
+        "sub": long_id,
+        "role": "user",
+        "aud": "authenticated",
+    }
+    user = jwt_utils.verify_user(payload, admin_only=False)
+    assert user.user_id == long_id
+
+
+def test_jwt_with_special_characters_in_claims():
+    """Test JWT token with special characters in claims."""
+    payload = {
+        "sub": "user@example.com/special-chars!@#$%",
+        "role": "admin",
+        "aud": "authenticated",
+        "email": "test+special@example.com",
+    }
+    user = jwt_utils.verify_user(payload, admin_only=True)
+    assert "special-chars!@#$%" in user.user_id
+
+
+def test_jwt_with_future_iat():
+    """Test JWT token with issued-at time in future."""
+    future_payload = {
+        "sub": "user-id",
+        "role": "user",
+        "aud": "authenticated",
+        "iat": datetime.now(timezone.utc) + timedelta(hours=1),
+    }
+    token = create_token(future_payload)
+
+    # PyJWT validates iat claim and should reject future tokens
+    with pytest.raises(ValueError, match="not yet valid"):
+        jwt_utils.parse_jwt_token(token)
+
+
+def test_jwt_with_different_algorithms():
+    """Test that only HS256 algorithm is accepted."""
+    payload = {
+        "sub": "user-id",
+        "role": "user",
+        "aud": "authenticated",
+    }
+
+    # Try different algorithms
+    algorithms = ["HS384", "HS512", "none"]
+    for algo in algorithms:
+        if algo == "none":
+            # Special case for 'none' algorithm (security vulnerability if accepted)
+            token = create_token(payload, "", algorithm="none")
+        else:
+            token = create_token(payload, algorithm=algo)
+
+        with pytest.raises(ValueError) as exc_info:
+            jwt_utils.parse_jwt_token(token)
+        assert "Invalid token" in str(exc_info.value)

--- a/autogpt_platform/backend/backend/libs/auth/models.py
+++ b/autogpt_platform/backend/backend/libs/auth/models.py
@@ -1,0 +1,22 @@
+from dataclasses import dataclass
+
+DEFAULT_USER_ID = "3e53486c-cf57-477e-ba2a-cb02dc828e1a"
+DEFAULT_EMAIL = "default@example.com"
+
+
+# Using dataclass here to avoid adding dependency on pydantic
+@dataclass(frozen=True)
+class User:
+    user_id: str
+    email: str
+    phone_number: str
+    role: str
+
+    @classmethod
+    def from_payload(cls, payload):
+        return cls(
+            user_id=payload["sub"],
+            email=payload.get("email", ""),
+            phone_number=payload.get("phone", ""),
+            role=payload["role"],
+        )

--- a/autogpt_platform/backend/backend/libs/logging/__init__.py
+++ b/autogpt_platform/backend/backend/libs/logging/__init__.py
@@ -1,0 +1,9 @@
+from .config import configure_logging
+from .filters import BelowLevelFilter
+from .formatters import FancyConsoleFormatter
+
+__all__ = [
+    "configure_logging",
+    "BelowLevelFilter",
+    "FancyConsoleFormatter",
+]

--- a/autogpt_platform/backend/backend/libs/logging/config.py
+++ b/autogpt_platform/backend/backend/libs/logging/config.py
@@ -1,0 +1,191 @@
+"""Logging module for Auto-GPT."""
+
+import logging
+import os
+import socket
+import sys
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+
+from pydantic import Field, field_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+from .filters import BelowLevelFilter
+from .formatters import AGPTFormatter
+
+# Configure global socket timeout and gRPC keepalive to prevent deadlocks
+# This must be done at import time before any gRPC connections are established
+socket.setdefaulttimeout(30)  # 30-second socket timeout
+
+# Enable gRPC keepalive to detect dead connections faster
+os.environ.setdefault("GRPC_KEEPALIVE_TIME_MS", "30000")  # 30 seconds
+os.environ.setdefault("GRPC_KEEPALIVE_TIMEOUT_MS", "5000")  # 5 seconds
+os.environ.setdefault("GRPC_KEEPALIVE_PERMIT_WITHOUT_CALLS", "true")
+
+LOG_DIR = Path(__file__).parent.parent.parent.parent / "logs"
+LOG_FILE = "activity.log"
+DEBUG_LOG_FILE = "debug.log"
+ERROR_LOG_FILE = "error.log"
+
+SIMPLE_LOG_FORMAT = "%(asctime)s %(levelname)s  %(title)s%(message)s"
+
+DEBUG_LOG_FORMAT = (
+    "%(asctime)s %(levelname)s %(filename)s:%(lineno)d  %(title)s%(message)s"
+)
+
+
+class LoggingConfig(BaseSettings):
+    level: str = Field(
+        default="INFO",
+        description="Logging level",
+        validation_alias="LOG_LEVEL",
+    )
+
+    enable_cloud_logging: bool = Field(
+        default=False,
+        description="Enable logging to Google Cloud Logging",
+    )
+
+    enable_file_logging: bool = Field(
+        default=False,
+        description="Enable logging to file",
+    )
+    # File output
+    log_dir: Path = Field(
+        default=LOG_DIR,
+        description="Log directory",
+    )
+
+    model_config = SettingsConfigDict(
+        env_prefix="",
+        env_file=".env",
+        env_file_encoding="utf-8",
+        extra="ignore",
+    )
+
+    @field_validator("level", mode="before")
+    @classmethod
+    def parse_log_level(cls, v):
+        if isinstance(v, str):
+            v = v.upper()
+            if v not in ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]:
+                raise ValueError(f"Invalid log level: {v}")
+            return v
+        return v
+
+
+def configure_logging(force_cloud_logging: bool = False) -> None:
+    """Configure the native logging module based on the LoggingConfig settings.
+
+    This function sets up logging handlers and formatters according to the
+    configuration specified in the LoggingConfig object. It supports various
+    logging outputs including console, file, cloud, and JSON logging.
+
+    The function uses the LoggingConfig object to determine which logging
+    features to enable and how to configure them. This includes setting
+    log levels, log formats, and output destinations.
+
+    No arguments are required as the function creates its own LoggingConfig
+    instance internally.
+
+    Note: This function is typically called at the start of the application
+    to set up the logging infrastructure.
+    """
+    config = LoggingConfig()
+    log_handlers: list[logging.Handler] = []
+
+    structured_logging = config.enable_cloud_logging or force_cloud_logging
+
+    # Console output handlers
+    if not structured_logging:
+        stdout = logging.StreamHandler(stream=sys.stdout)
+        stdout.setLevel(config.level)
+        stdout.addFilter(BelowLevelFilter(logging.WARNING))
+        if config.level == logging.DEBUG:
+            stdout.setFormatter(AGPTFormatter(DEBUG_LOG_FORMAT))
+        else:
+            stdout.setFormatter(AGPTFormatter(SIMPLE_LOG_FORMAT))
+
+        stderr = logging.StreamHandler()
+        stderr.setLevel(logging.WARNING)
+        if config.level == logging.DEBUG:
+            stderr.setFormatter(AGPTFormatter(DEBUG_LOG_FORMAT))
+        else:
+            stderr.setFormatter(AGPTFormatter(SIMPLE_LOG_FORMAT))
+
+        log_handlers += [stdout, stderr]
+
+    # Cloud logging setup
+    else:
+        # Use Google Cloud Structured Log Handler. Log entries are printed to stdout
+        # in a JSON format which is automatically picked up by Google Cloud Logging.
+        from google.cloud.logging.handlers import StructuredLogHandler
+
+        structured_log_handler = StructuredLogHandler(stream=sys.stdout)
+        structured_log_handler.setLevel(config.level)
+        log_handlers.append(structured_log_handler)
+
+    # File logging setup
+    if config.enable_file_logging:
+        # create log directory if it doesn't exist
+        if not config.log_dir.exists():
+            config.log_dir.mkdir(parents=True, exist_ok=True)
+
+        print(f"Log directory: {config.log_dir}")
+
+        # Activity log handler (INFO and above)
+        # Security fix: Use RotatingFileHandler with size limits to prevent disk exhaustion
+        activity_log_handler = RotatingFileHandler(
+            config.log_dir / LOG_FILE,
+            mode="a",
+            encoding="utf-8",
+            maxBytes=10 * 1024 * 1024,  # 10MB per file
+            backupCount=3,  # Keep 3 backup files (40MB total)
+        )
+        activity_log_handler.setLevel(config.level)
+        activity_log_handler.setFormatter(
+            AGPTFormatter(SIMPLE_LOG_FORMAT, no_color=True)
+        )
+        log_handlers.append(activity_log_handler)
+
+        if config.level == logging.DEBUG:
+            # Debug log handler (all levels)
+            # Security fix: Use RotatingFileHandler with size limits
+            debug_log_handler = RotatingFileHandler(
+                config.log_dir / DEBUG_LOG_FILE,
+                mode="a",
+                encoding="utf-8",
+                maxBytes=10 * 1024 * 1024,  # 10MB per file
+                backupCount=3,  # Keep 3 backup files (40MB total)
+            )
+            debug_log_handler.setLevel(logging.DEBUG)
+            debug_log_handler.setFormatter(
+                AGPTFormatter(DEBUG_LOG_FORMAT, no_color=True)
+            )
+            log_handlers.append(debug_log_handler)
+
+        # Error log handler (ERROR and above)
+        # Security fix: Use RotatingFileHandler with size limits
+        error_log_handler = RotatingFileHandler(
+            config.log_dir / ERROR_LOG_FILE,
+            mode="a",
+            encoding="utf-8",
+            maxBytes=10 * 1024 * 1024,  # 10MB per file
+            backupCount=3,  # Keep 3 backup files (40MB total)
+        )
+        error_log_handler.setLevel(logging.ERROR)
+        error_log_handler.setFormatter(AGPTFormatter(DEBUG_LOG_FORMAT, no_color=True))
+        log_handlers.append(error_log_handler)
+
+    # Configure the root logger
+    logging.basicConfig(
+        format=(
+            "%(levelname)s  %(message)s"
+            if structured_logging
+            else (
+                DEBUG_LOG_FORMAT if config.level == logging.DEBUG else SIMPLE_LOG_FORMAT
+            )
+        ),
+        level=config.level,
+        handlers=log_handlers,
+    )

--- a/autogpt_platform/backend/backend/libs/logging/filters.py
+++ b/autogpt_platform/backend/backend/libs/logging/filters.py
@@ -1,0 +1,12 @@
+import logging
+
+
+class BelowLevelFilter(logging.Filter):
+    """Filter for logging levels below a certain threshold."""
+
+    def __init__(self, below_level: int):
+        super().__init__()
+        self.below_level = below_level
+
+    def filter(self, record: logging.LogRecord):
+        return record.levelno < self.below_level

--- a/autogpt_platform/backend/backend/libs/logging/formatters.py
+++ b/autogpt_platform/backend/backend/libs/logging/formatters.py
@@ -1,0 +1,81 @@
+import logging
+
+from colorama import Fore, Style
+
+from .utils import remove_color_codes
+
+
+class FancyConsoleFormatter(logging.Formatter):
+    """
+    A custom logging formatter designed for console output.
+
+    This formatter enhances the standard logging output with color coding. The color
+    coding is based on the level of the log message, making it easier to distinguish
+    between different types of messages in the console output.
+
+    The color for each level is defined in the LEVEL_COLOR_MAP class attribute.
+    """
+
+    # level -> (level & text color, title color)
+    LEVEL_COLOR_MAP = {
+        logging.DEBUG: Fore.LIGHTBLACK_EX,
+        logging.INFO: Fore.BLUE,
+        logging.WARNING: Fore.YELLOW,
+        logging.ERROR: Fore.RED,
+        logging.CRITICAL: Fore.RED + Style.BRIGHT,
+    }
+
+    def format(self, record: logging.LogRecord) -> str:
+        # Make sure `msg` is a string
+        if not hasattr(record, "msg"):
+            record.msg = ""
+        elif type(record.msg) is not str:
+            record.msg = str(record.msg)
+
+        # Determine default color based on error level
+        level_color = ""
+        if record.levelno in self.LEVEL_COLOR_MAP:
+            level_color = self.LEVEL_COLOR_MAP[record.levelno]
+            record.levelname = f"{level_color}{record.levelname}{Style.RESET_ALL}"
+
+        # Determine color for message
+        color = getattr(record, "color", level_color)
+        color_is_specified = hasattr(record, "color")
+
+        # Don't color INFO messages unless the color is explicitly specified.
+        if color and (record.levelno != logging.INFO or color_is_specified):
+            record.msg = f"{color}{record.msg}{Style.RESET_ALL}"
+
+        return super().format(record)
+
+
+class AGPTFormatter(FancyConsoleFormatter):
+    def __init__(self, *args, no_color: bool = False, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.no_color = no_color
+
+    def format(self, record: logging.LogRecord) -> str:
+        # Make sure `msg` is a string
+        if not hasattr(record, "msg"):
+            record.msg = ""
+        elif type(record.msg) is not str:
+            record.msg = str(record.msg)
+
+        # Strip color from the message to prevent color spoofing
+        if record.msg and not getattr(record, "preserve_color", False):
+            record.msg = remove_color_codes(record.msg)
+
+        # Determine color for title
+        title = getattr(record, "title", "")
+        title_color = getattr(record, "title_color", "") or self.LEVEL_COLOR_MAP.get(
+            record.levelno, ""
+        )
+        if title and title_color:
+            title = f"{title_color + Style.BRIGHT}{title}{Style.RESET_ALL}"
+        # Make sure record.title is set, and padded with a space if not empty
+        record.title = f"{title} " if title else ""
+
+        if self.no_color:
+            return remove_color_codes(super().format(record))
+        else:
+            return super().format(record)

--- a/autogpt_platform/backend/backend/libs/logging/handlers.py
+++ b/autogpt_platform/backend/backend/libs/logging/handlers.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import json
+import logging
+
+
+class JsonFileHandler(logging.FileHandler):
+    def format(self, record: logging.LogRecord) -> str:
+        record.json_data = json.loads(record.getMessage())
+        return json.dumps(getattr(record, "json_data"), ensure_ascii=False, indent=4)
+
+    def emit(self, record: logging.LogRecord) -> None:
+        with open(self.baseFilename, "w", encoding="utf-8") as f:
+            f.write(self.format(record))

--- a/autogpt_platform/backend/backend/libs/logging/test_utils.py
+++ b/autogpt_platform/backend/backend/libs/logging/test_utils.py
@@ -1,0 +1,36 @@
+import pytest
+
+from .utils import remove_color_codes
+
+
+@pytest.mark.parametrize(
+    "raw_text, clean_text",
+    [
+        (
+            "COMMAND = \x1b[36mbrowse_website\x1b[0m  "
+            "ARGUMENTS = \x1b[36m{'url': 'https://www.google.com',"
+            " 'question': 'What is the capital of France?'}\x1b[0m",
+            "COMMAND = browse_website  "
+            "ARGUMENTS = {'url': 'https://www.google.com',"
+            " 'question': 'What is the capital of France?'}",
+        ),
+        (
+            "{'Schaue dir meine Projekte auf github () an, als auch meine Webseiten': "
+            "'https://github.com/Significant-Gravitas/AutoGPT,"
+            " https://discord.gg/autogpt und https://twitter.com/Auto_GPT'}",
+            "{'Schaue dir meine Projekte auf github () an, als auch meine Webseiten': "
+            "'https://github.com/Significant-Gravitas/AutoGPT,"
+            " https://discord.gg/autogpt und https://twitter.com/Auto_GPT'}",
+        ),
+        ("", ""),
+        ("hello", "hello"),
+        ("hello\x1b[31m world", "hello world"),
+        ("\x1b[36mHello,\x1b[32m World!", "Hello, World!"),
+        (
+            "\x1b[1m\x1b[31mError:\x1b[0m\x1b[31m file not found",
+            "Error: file not found",
+        ),
+    ],
+)
+def test_remove_color_codes(raw_text, clean_text):
+    assert remove_color_codes(raw_text) == clean_text

--- a/autogpt_platform/backend/backend/libs/logging/utils.py
+++ b/autogpt_platform/backend/backend/libs/logging/utils.py
@@ -1,0 +1,5 @@
+import re
+
+
+def remove_color_codes(s: str) -> str:
+    return re.sub(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])", "", s)

--- a/autogpt_platform/backend/backend/libs/rate_limit/config.py
+++ b/autogpt_platform/backend/backend/libs/rate_limit/config.py
@@ -1,0 +1,33 @@
+from typing import Optional
+
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class RateLimitSettings(BaseSettings):
+    redis_host: str = Field(
+        default="redis://localhost:6379",
+        description="Redis host",
+        validation_alias="REDIS_HOST",
+    )
+
+    redis_port: str = Field(
+        default="6379", description="Redis port", validation_alias="REDIS_PORT"
+    )
+
+    redis_password: Optional[str] = Field(
+        default=None,
+        description="Redis password",
+        validation_alias="REDIS_PASSWORD",
+    )
+
+    requests_per_minute: int = Field(
+        default=60,
+        description="Maximum number of requests allowed per minute per API key",
+        validation_alias="RATE_LIMIT_REQUESTS_PER_MINUTE",
+    )
+
+    model_config = SettingsConfigDict(case_sensitive=True, extra="ignore")
+
+
+RATE_LIMIT_SETTINGS = RateLimitSettings()

--- a/autogpt_platform/backend/backend/libs/rate_limit/limiter.py
+++ b/autogpt_platform/backend/backend/libs/rate_limit/limiter.py
@@ -1,0 +1,51 @@
+import time
+from typing import Tuple
+
+from redis import Redis
+
+from .config import RATE_LIMIT_SETTINGS
+
+
+class RateLimiter:
+    def __init__(
+        self,
+        redis_host: str = RATE_LIMIT_SETTINGS.redis_host,
+        redis_port: str = RATE_LIMIT_SETTINGS.redis_port,
+        redis_password: str | None = RATE_LIMIT_SETTINGS.redis_password,
+        requests_per_minute: int = RATE_LIMIT_SETTINGS.requests_per_minute,
+    ):
+        self.redis = Redis(
+            host=redis_host,
+            port=int(redis_port),
+            password=redis_password,
+            decode_responses=True,
+        )
+        self.window = 60
+        self.max_requests = requests_per_minute
+
+    async def check_rate_limit(self, api_key_id: str) -> Tuple[bool, int, int]:
+        """
+        Check if request is within rate limits.
+
+        Args:
+            api_key_id: The API key identifier to check
+
+        Returns:
+            Tuple of (is_allowed, remaining_requests, reset_time)
+        """
+        now = time.time()
+        window_start = now - self.window
+        key = f"ratelimit:{api_key_id}:1min"
+
+        pipe = self.redis.pipeline()
+        pipe.zremrangebyscore(key, 0, window_start)
+        pipe.zadd(key, {str(now): now})
+        pipe.zcount(key, window_start, now)
+        pipe.expire(key, self.window)
+
+        _, _, request_count, _ = pipe.execute()
+
+        remaining = max(0, self.max_requests - request_count)
+        reset_time = int(now + self.window)
+
+        return request_count <= self.max_requests, remaining, reset_time

--- a/autogpt_platform/backend/backend/libs/rate_limit/middleware.py
+++ b/autogpt_platform/backend/backend/libs/rate_limit/middleware.py
@@ -1,0 +1,32 @@
+from fastapi import HTTPException, Request
+from starlette.middleware.base import RequestResponseEndpoint
+
+from .limiter import RateLimiter
+
+
+async def rate_limit_middleware(request: Request, call_next: RequestResponseEndpoint):
+    """FastAPI middleware for rate limiting API requests."""
+    limiter = RateLimiter()
+
+    if not request.url.path.startswith("/api"):
+        return await call_next(request)
+
+    api_key = request.headers.get("Authorization")
+    if not api_key:
+        return await call_next(request)
+
+    api_key = api_key.replace("Bearer ", "")
+
+    is_allowed, remaining, reset_time = await limiter.check_rate_limit(api_key)
+
+    if not is_allowed:
+        raise HTTPException(
+            status_code=429, detail="Rate limit exceeded. Please try again later."
+        )
+
+    response = await call_next(request)
+    response.headers["X-RateLimit-Limit"] = str(limiter.max_requests)
+    response.headers["X-RateLimit-Remaining"] = str(remaining)
+    response.headers["X-RateLimit-Reset"] = str(reset_time)
+
+    return response

--- a/autogpt_platform/backend/backend/libs/supabase_integration_credentials_store/types.py
+++ b/autogpt_platform/backend/backend/libs/supabase_integration_credentials_store/types.py
@@ -1,0 +1,76 @@
+from typing import Annotated, Any, Literal, Optional, TypedDict
+from uuid import uuid4
+
+from pydantic import BaseModel, Field, SecretStr, field_serializer
+
+
+class _BaseCredentials(BaseModel):
+    id: str = Field(default_factory=lambda: str(uuid4()))
+    provider: str
+    title: Optional[str]
+
+    @field_serializer("*")
+    def dump_secret_strings(value: Any, _info):
+        if isinstance(value, SecretStr):
+            return value.get_secret_value()
+        return value
+
+
+class OAuth2Credentials(_BaseCredentials):
+    type: Literal["oauth2"] = "oauth2"
+    username: Optional[str]
+    """Username of the third-party service user that these credentials belong to"""
+    access_token: SecretStr
+    access_token_expires_at: Optional[int]
+    """Unix timestamp (seconds) indicating when the access token expires (if at all)"""
+    refresh_token: Optional[SecretStr]
+    refresh_token_expires_at: Optional[int]
+    """Unix timestamp (seconds) indicating when the refresh token expires (if at all)"""
+    scopes: list[str]
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    def bearer(self) -> str:
+        return f"Bearer {self.access_token.get_secret_value()}"
+
+
+class APIKeyCredentials(_BaseCredentials):
+    type: Literal["api_key"] = "api_key"
+    api_key: SecretStr
+    expires_at: Optional[int]
+    """Unix timestamp (seconds) indicating when the API key expires (if at all)"""
+
+    def bearer(self) -> str:
+        return f"Bearer {self.api_key.get_secret_value()}"
+
+
+Credentials = Annotated[
+    OAuth2Credentials | APIKeyCredentials,
+    Field(discriminator="type"),
+]
+
+
+CredentialsType = Literal["api_key", "oauth2"]
+
+
+class OAuthState(BaseModel):
+    token: str
+    provider: str
+    expires_at: int
+    code_verifier: Optional[str] = None
+    scopes: list[str]
+    """Unix timestamp (seconds) indicating when this OAuth state expires"""
+
+
+class UserMetadata(BaseModel):
+    integration_credentials: list[Credentials] = Field(default_factory=list)
+    integration_oauth_states: list[OAuthState] = Field(default_factory=list)
+
+
+class UserMetadataRaw(TypedDict, total=False):
+    integration_credentials: list[dict]
+    integration_oauth_states: list[dict]
+
+
+class UserIntegrations(BaseModel):
+    credentials: list[Credentials] = Field(default_factory=list)
+    oauth_states: list[OAuthState] = Field(default_factory=list)

--- a/autogpt_platform/backend/backend/libs/utils/synchronize.py
+++ b/autogpt_platform/backend/backend/libs/utils/synchronize.py
@@ -1,0 +1,61 @@
+import asyncio
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING, Any
+
+from expiringdict import ExpiringDict
+
+if TYPE_CHECKING:
+    from redis.asyncio import Redis as AsyncRedis
+    from redis.asyncio.lock import Lock as AsyncRedisLock
+
+
+class AsyncRedisKeyedMutex:
+    """
+    This class provides a mutex that can be locked and unlocked by a specific key,
+    using Redis as a distributed locking provider.
+    It uses an ExpiringDict to automatically clear the mutex after a specified timeout,
+    in case the key is not unlocked for a specified duration, to prevent memory leaks.
+    """
+
+    def __init__(self, redis: "AsyncRedis", timeout: int | None = 60):
+        self.redis = redis
+        self.timeout = timeout
+        self.locks: dict[Any, "AsyncRedisLock"] = ExpiringDict(
+            max_len=6000, max_age_seconds=self.timeout
+        )
+        self.locks_lock = asyncio.Lock()
+
+    @asynccontextmanager
+    async def locked(self, key: Any):
+        lock = await self.acquire(key)
+        try:
+            yield
+        finally:
+            if (await lock.locked()) and (await lock.owned()):
+                await lock.release()
+
+    async def acquire(self, key: Any) -> "AsyncRedisLock":
+        """Acquires and returns a lock with the given key"""
+        async with self.locks_lock:
+            if key not in self.locks:
+                self.locks[key] = self.redis.lock(
+                    str(key), self.timeout, thread_local=False
+                )
+            lock = self.locks[key]
+        await lock.acquire()
+        return lock
+
+    async def release(self, key: Any):
+        if (
+            (lock := self.locks.get(key))
+            and (await lock.locked())
+            and (await lock.owned())
+        ):
+            await lock.release()
+
+    async def release_all_locks(self):
+        """Call this on process termination to ensure all locks are released"""
+        async with self.locks_lock:
+            for lock in self.locks.values():
+                if (await lock.locked()) and (await lock.owned()):
+                    await lock.release()

--- a/autogpt_platform/backend/backend/util/feature_flag.py
+++ b/autogpt_platform/backend/backend/util/feature_flag.py
@@ -5,7 +5,7 @@ from functools import wraps
 from typing import Any, Awaitable, Callable, TypeVar
 
 import ldclient
-from autogpt_libs.auth.dependencies import get_optional_user_id
+from backend.libs.auth.dependencies import get_optional_user_id
 from fastapi import HTTPException, Security
 from ldclient import Context, LDClient
 from ldclient.config import Config

--- a/autogpt_platform/backend/backend/util/feature_flag.py
+++ b/autogpt_platform/backend/backend/util/feature_flag.py
@@ -5,12 +5,12 @@ from functools import wraps
 from typing import Any, Awaitable, Callable, TypeVar
 
 import ldclient
-from backend.libs.auth.dependencies import get_optional_user_id
 from fastapi import HTTPException, Security
 from ldclient import Context, LDClient
 from ldclient.config import Config
 from typing_extensions import ParamSpec
 
+from backend.libs.auth.dependencies import get_optional_user_id
 from backend.util.cache import cached
 from backend.util.settings import Settings
 

--- a/autogpt_platform/backend/backend/util/logging.py
+++ b/autogpt_platform/backend/backend/util/logging.py
@@ -6,12 +6,12 @@ settings = Settings()
 
 
 def configure_logging():
-    import autogpt_libs.logging.config
+    import backend.libs.logging.config
 
     if not is_structured_logging_enabled():
-        autogpt_libs.logging.config.configure_logging(force_cloud_logging=False)
+        backend.libs.logging.config.configure_logging(force_cloud_logging=False)
     else:
-        autogpt_libs.logging.config.configure_logging(force_cloud_logging=True)
+        backend.libs.logging.config.configure_logging(force_cloud_logging=True)
 
     # Silence httpx logger
     logging.getLogger("httpx").setLevel(logging.WARNING)

--- a/autogpt_platform/backend/backend/util/test.py
+++ b/autogpt_platform/backend/backend/util/test.py
@@ -5,7 +5,7 @@ import time
 import uuid
 from typing import Sequence, cast
 
-from autogpt_libs.auth import get_user_id
+from backend.libs.auth import get_user_id
 
 from backend.api.rest_api import AgentServer
 from backend.blocks._base import Block, BlockSchema

--- a/autogpt_platform/backend/backend/util/test.py
+++ b/autogpt_platform/backend/backend/util/test.py
@@ -5,8 +5,6 @@ import time
 import uuid
 from typing import Sequence, cast
 
-from backend.libs.auth import get_user_id
-
 from backend.api.rest_api import AgentServer
 from backend.blocks._base import Block, BlockSchema
 from backend.data import db
@@ -21,6 +19,7 @@ from backend.data.execution import (
 from backend.data.model import _BaseCredentials
 from backend.data.user import create_default_user
 from backend.executor import ExecutionManager, Scheduler
+from backend.libs.auth import get_user_id
 from backend.notifications.notifications import NotificationManager
 
 log = logging.getLogger(__name__)

--- a/autogpt_platform/backend/poetry.lock
+++ b/autogpt_platform/backend/poetry.lock
@@ -447,34 +447,6 @@ files = [
 ]
 
 [[package]]
-name = "autogpt-libs"
-version = "0.2.0"
-description = "Shared libraries across AutoGPT Platform"
-optional = false
-python-versions = ">=3.10,<4.0"
-groups = ["main"]
-files = []
-develop = true
-
-[package.dependencies]
-colorama = "^0.4.6"
-cryptography = "^46.0"
-expiringdict = "^1.2.2"
-fastapi = "^0.128.7"
-google-cloud-logging = "^3.13.0"
-launchdarkly-server-sdk = "^9.15.0"
-pydantic = "^2.12.5"
-pydantic-settings = "^2.12.0"
-pyjwt = {version = "^2.11.0", extras = ["crypto"]}
-redis = "^6.2.0"
-supabase = "^2.28.0"
-uvicorn = "^0.40.0"
-
-[package.source]
-type = "directory"
-url = "../autogpt_libs"
-
-[[package]]
 name = "backoff"
 version = "2.2.1"
 description = "Function decoration for backoff and retry"

--- a/autogpt_platform/backend/poetry.lock
+++ b/autogpt_platform/backend/poetry.lock
@@ -944,7 +944,6 @@ files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
-markers = {dev = "platform_system == \"Windows\" or sys_platform == \"win32\""}
 
 [[package]]
 name = "crashtest"
@@ -8602,4 +8601,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.14"
-content-hash = "1dd10577184ebff0d10997f4c6ba49484de79b7fa090946e8e5ce5c5bac3cdeb"
+content-hash = "d2f2c0aeb95932cfd07d7fb1199d79e2667484468103d6b80a2112cdd645cfc8"

--- a/autogpt_platform/backend/pyproject.toml
+++ b/autogpt_platform/backend/pyproject.toml
@@ -15,20 +15,22 @@ aiodns = "^3.5.0"
 agentmail = "^0.4.5"
 anthropic = "^0.79.0"
 apscheduler = "^3.11.1"
-autogpt-libs = { path = "../autogpt_libs", develop = true }
 bleach = { extras = ["css"], version = "^6.2.0" }
 claude-agent-sdk = "0.1.45"  # see copilot/sdk/sdk_compat_test.py for capability checks
 click = "^8.2.0"
+colorama = "^0.4.6"
 cryptography = "^46.0"
 discord-py = "^2.5.2"
 e2b = "^2.15.2"
 e2b-code-interpreter = "^2.0"
 elevenlabs = "^1.50.0"
+expiringdict = "^1.2.2"
 fastapi = "^0.128.6"
 feedparser = "^6.0.11"
 flake8 = "^7.3.0"
 google-api-python-client = "^2.177.0"
 google-auth-oauthlib = "^1.2.2"
+google-cloud-logging = "^3.13.0"
 google-cloud-storage = "^3.2.0"
 googlemaps = "^4.10.0"
 gravitasml = "^0.1.4"
@@ -57,6 +59,7 @@ psutil = "^7.0.0"
 psycopg2-binary = "^2.9.10"
 pydantic = { extras = ["email"], version = "^2.12.5" }
 pydantic-settings = "^2.12.0"
+pyjwt = { version = "^2.11.0", extras = ["crypto"] }
 pytest = "^8.4.1"
 pytest-asyncio = "^1.1.0"
 python-dotenv = "^1.1.1"
@@ -163,4 +166,3 @@ filterwarnings = [
 
 [tool.ruff]
 target-version = "py310"
-

--- a/autogpt_platform/backend/scripts/linter.py
+++ b/autogpt_platform/backend/scripts/linter.py
@@ -5,8 +5,7 @@ import sys
 backend_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 
 BACKEND_DIR = "."
-LIBS_DIR = "../autogpt_libs"
-TARGET_DIRS = [BACKEND_DIR, LIBS_DIR]
+TARGET_DIRS = [BACKEND_DIR]
 
 
 def run(*command: str) -> None:
@@ -33,9 +32,9 @@ def lint():
 
     lint_step_args: list[list[str]] = [
         ["ruff", "check", *TARGET_DIRS, "--exit-zero"],
-        ["ruff", "format", "--diff", "--check", LIBS_DIR],
-        ["isort", "--diff", "--check", "--profile", "black", BACKEND_DIR],
-        ["black", "--diff", "--check", BACKEND_DIR],
+        ["ruff", "format", "--diff", "--check", *TARGET_DIRS],
+        ["isort", "--diff", "--check", "--profile", "black", *TARGET_DIRS],
+        ["black", "--diff", "--check", *TARGET_DIRS],
     ]
     if not skip_pyright:
         lint_step_args.append(["pyright", *TARGET_DIRS])
@@ -53,9 +52,9 @@ def lint():
 
 def format():
     run("ruff", "check", "--fix", *TARGET_DIRS)
-    run("ruff", "format", LIBS_DIR)
-    run("isort", "--profile", "black", BACKEND_DIR)
-    run("black", BACKEND_DIR)
+    run("ruff", "format", *TARGET_DIRS)
+    run("isort", "--profile", "black", *TARGET_DIRS)
+    run("black", *TARGET_DIRS)
     # Generate Prisma types stub before running pyright to prevent type budget exhaustion
     run("gen-prisma-stub")
     run("pyright", *TARGET_DIRS)

--- a/autogpt_platform/backend/test/test_data_creator.py
+++ b/autogpt_platform/backend/test/test_data_creator.py
@@ -22,7 +22,7 @@ from datetime import datetime
 
 import prisma.enums
 import pytest
-from autogpt_libs.api_key.keysmith import APIKeySmith
+from backend.libs.api_key.keysmith import APIKeySmith
 from faker import Faker
 from prisma import Json, Prisma
 from prisma.types import (

--- a/autogpt_platform/backend/test/test_data_creator.py
+++ b/autogpt_platform/backend/test/test_data_creator.py
@@ -22,7 +22,6 @@ from datetime import datetime
 
 import prisma.enums
 import pytest
-from backend.libs.api_key.keysmith import APIKeySmith
 from faker import Faker
 from prisma import Json, Prisma
 from prisma.types import (
@@ -38,6 +37,8 @@ from prisma.types import (
     StoreListingReviewCreateInput,
     UserCreateInput,
 )
+
+from backend.libs.api_key.keysmith import APIKeySmith
 
 faker = Faker()
 

--- a/autogpt_platform/frontend/Dockerfile
+++ b/autogpt_platform/frontend/Dockerfile
@@ -1,5 +1,5 @@
 # Base stage for both dev and prod
-FROM node:21-alpine AS base
+FROM node:22.22-alpine3.23 AS base
 WORKDIR /app
 RUN corepack enable
 COPY autogpt_platform/frontend/package.json autogpt_platform/frontend/pnpm-lock.yaml ./
@@ -33,7 +33,7 @@ ENV NEXT_PUBLIC_SOURCEMAPS="false"
 RUN if [ "$NEXT_PUBLIC_PW_TEST" = "true" ]; then NEXT_PUBLIC_PW_TEST=true NODE_OPTIONS="--max-old-space-size=8192" pnpm build; else NODE_OPTIONS="--max-old-space-size=8192" pnpm build; fi
 
 # Prod stage - based on NextJS reference Dockerfile https://github.com/vercel/next.js/blob/64271354533ed16da51be5dce85f0dbd15f17517/examples/with-docker/Dockerfile
-FROM node:21-alpine AS prod
+FROM node:22.22-alpine3.23 AS prod
 ENV NODE_ENV=production
 ENV HOSTNAME=0.0.0.0
 WORKDIR /app

--- a/docs/platform/new_blocks.md
+++ b/docs/platform/new_blocks.md
@@ -315,7 +315,7 @@ class BlockWithAPIKeyAndOAuth(Block):
 
 The credentials will be automagically injected by the executor in the back end.
 
-The `APIKeyCredentials` and `OAuth2Credentials` models are defined [here](https://github.com/Significant-Gravitas/AutoGPT/blob/master/autogpt_platform/autogpt_libs/autogpt_libs/supabase_integration_credentials_store/types.py).
+The `APIKeyCredentials` and `OAuth2Credentials` models are defined [here](https://github.com/Significant-Gravitas/AutoGPT/blob/master/autogpt_platform/backend/backend/libs/supabase_integration_credentials_store/types.py).
 To use them in e.g. an API request, you can either access the token directly:
 
 ```python


### PR DESCRIPTION
**Why**                                                                                                                              
                                                                                                                                        
   `autogpt_libs` is only used by the platform backend, but it is currently maintained as a separate Poetry package with a path         
 dependency. That adds extra dependency-management overhead, creates duplicate Dependabot churn, and makes backend tooling/CI more      
 complex than necessary.                                                                                                                
                                                                                                                                        
   This PR consolidates that code into the backend package so backend code, dependencies, and tooling can be managed in one place.      
                                                                                                                                        
   **What**                                                                                                                             
                                                                                                                                        
   This PR:                                                                                                                             
   - moves the shared library code into `autogpt_platform/backend/backend/libs/`                                                        
   - updates backend imports from `autogpt_libs.*` to `backend.libs.*`                                                                  
   - removes the backend path dependency on `autogpt-libs`                                                                              
   - folds the former libs-only dependencies into `autogpt_platform/backend/pyproject.toml`                                             
   - updates backend CI, Dependabot, pre-commit, Docker, and related docs/tooling to reflect the new structure                          
                                                                                                                                        
   **How**                                                                                                                              
                                                                                                                                        
   I copied the existing library modules into `backend/backend/libs/`, then rewired backend code and tests to import from               
 `backend.libs`.                                                                                                                        
                                                                                                                                        
   I also removed repo/tooling references that still treated `autogpt_libs` as a separate backend package, including CI triggers,       
 dependency automation, local tooling, and contributor setup docs.                                                                      
                                                                                                                                        
   For review safety, I left the legacy `autogpt_platform/autogpt_libs/` directory in place for now rather than deleting it as part of  
 the same change.                                                                                                                       
                                                                                                                                        
   ### Changes 🏗️                                                                                                                       
                                                                                                                                        
   - Added `autogpt_platform/backend/backend/libs/` with the former `autogpt_libs` modules                                              
   - Updated backend and backend-test imports to use `backend.libs.*`                                                                   
   - Removed `autogpt-libs` as a backend path dependency                                                                                
   - Added direct backend dependencies previously supplied by `autogpt-libs`                                                            
   - Updated backend Docker and lint/typecheck tooling for the consolidated package layout                                              
   - Removed separate backend-related Dependabot / CI / pre-commit references to `autogpt_libs`                                         
   - Updated docs and contributor tooling references to the new path                                                                    
                                                                                                                                        
   ### Checklist 📋                                                                                                                     
                                                                                                                                        
   #### For code changes:                                                                                                               
   - [x] I have clearly listed my changes in the PR description                                                                         
   - [x] I have made a test plan                                                                                                        
   - [ ] I have tested my changes according to the test plan:                                                                           
    <!-- Put your test plan here: -->                                                                                                   
    - [x] `python3 -m compileall autogpt_platform/backend/backend autogpt_platform/backend/scripts autogpt_platform/backend/test`       
    - [x] `git diff --check`                                                                                                            
    - [x] Verified there are no remaining backend/tooling references to `autogpt_libs` or `autogpt-libs` outside the legacy directory   
    - [ ] `poetry -C autogpt_platform/backend install`                                                                                  
    - [ ] `poetry -C autogpt_platform/backend run pyright`                                                                              
    - [ ] `poetry -C autogpt_platform/backend run pytest`                                                                               
    - [ ] `docker build -f autogpt_platform/backend/Dockerfile .`    