### PR TITLE
fix(backend/copilot): CLI ResultMessage "Prompt is too long" bypasses compaction

### DIFF
--- a/autogpt_platform/backend/backend/copilot/sdk/retry_scenarios_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/retry_scenarios_test.py
@@ -1414,3 +1414,76 @@ class TestStreamChatCompletionRetryIntegration:
         # Verify user-friendly message (not raw SDK text)
         assert "Authentication" in errors[0].errorText
         assert any(isinstance(e, StreamStart) for e in events)
+
+    @pytest.mark.asyncio
+    async def test_result_message_prompt_too_long_triggers_compaction(self):
+        """CLI returns ResultMessage(subtype="error") with "Prompt is too long".
+
+        When the Claude CLI rejects the prompt pre-API (model=<synthetic>,
+        duration_api_ms=0), it sends a ResultMessage with is_error=True
+        instead of raising a Python exception.  The retry loop must still
+        detect this as a context-length error and trigger compaction.
+        """
+        import contextlib
+
+        from claude_agent_sdk import ResultMessage
+
+        from backend.copilot.response_model import StreamError, StreamStart
+        from backend.copilot.sdk.service import stream_chat_completion_sdk
+
+        session = self._make_session()
+        success_result = self._make_result_message()
+        attempt_count = [0]
+
+        error_result = ResultMessage(
+            subtype="error",
+            result="Prompt is too long",
+            duration_ms=100,
+            duration_api_ms=0,
+            is_error=True,
+            num_turns=0,
+            session_id="test-session-id",
+        )
+
+        def _client_factory(*args, **kwargs):
+            attempt_count[0] += 1
+            if attempt_count[0] == 1:
+                # First attempt: CLI returns error ResultMessage
+                return self._make_client_mock(result_message=error_result)
+            # Second attempt (after compaction): succeeds
+            return self._make_client_mock(result_message=success_result)
+
+        original_transcript = _build_transcript(
+            [("user", "prior question"), ("assistant", "prior answer")]
+        )
+        compacted_transcript = _build_transcript(
+            [("user", "[summary]"), ("assistant", "summary reply")]
+        )
+
+        patches = _make_sdk_patches(
+            session,
+            original_transcript=original_transcript,
+            compacted_transcript=compacted_transcript,
+            client_side_effect=_client_factory,
+        )
+
+        events = []
+        with contextlib.ExitStack() as stack:
+            for target, kwargs in patches:
+                stack.enter_context(patch(target, **kwargs))
+            async for event in stream_chat_completion_sdk(
+                session_id="test-session-id",
+                message="hello",
+                is_user_message=True,
+                user_id="test-user",
+                session=session,
+            ):
+                events.append(event)
+
+        assert attempt_count[0] == 2, (
+            f"Expected 2 SDK attempts (CLI error ResultMessage "
+            f"should trigger compaction retry), got {attempt_count[0]}"
+        )
+        errors = [e for e in events if isinstance(e, StreamError)]
+        assert not errors, f"Unexpected StreamError: {errors}"
+        assert any(isinstance(e, StreamStart) for e in events)

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -1404,6 +1404,14 @@ async def _run_stream_attempt(
                         ctx.log_prefix,
                         sdk_msg.result or "(no error message provided)",
                     )
+                    # If the CLI itself rejected the prompt as too long
+                    # (pre-API check, duration_api_ms=0), re-raise as an
+                    # exception so the retry loop can trigger compaction.
+                    # Without this, the ResultMessage is silently consumed
+                    # and the retry/compaction mechanism is never invoked.
+                    error_text = (sdk_msg.result or "").lower()
+                    if any(p in error_text for p in _PROMPT_TOO_LONG_PATTERNS):
+                        raise Exception(sdk_msg.result or "prompt is too long")
 
                 # Capture token usage from ResultMessage.
                 # Anthropic reports cached tokens separately:

--- a/autogpt_platform/backend/backend/copilot/sdk/transcript.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/transcript.py
@@ -43,6 +43,10 @@ STRIPPABLE_TYPES = frozenset(
     {"progress", "file-history-snapshot", "queue-operation", "summary", "pr-link"}
 )
 
+# Thinking block types that can be stripped from non-last assistant entries.
+# The Anthropic API only requires these in the *last* assistant message.
+_THINKING_BLOCK_TYPES = frozenset({"thinking", "redacted_thinking"})
+
 
 @dataclass
 class TranscriptDownload:
@@ -450,6 +454,75 @@ def _build_meta_storage_path(user_id: str, session_id: str, backend: object) -> 
     )
 
 
+def strip_stale_thinking_blocks(content: str) -> str:
+    """Remove thinking/redacted_thinking blocks from non-last assistant entries.
+
+    The Anthropic API only requires thinking blocks in the **last** assistant
+    message to be value-identical to the original response.  Older assistant
+    entries carry stale thinking blocks that consume significant tokens
+    (often 10-50K each) without providing useful context for ``--resume``.
+
+    Stripping them before upload prevents the CLI from triggering compaction
+    every turn just to compress away the stale thinking bloat.
+    """
+    lines = content.strip().split("\n")
+    if not lines:
+        return content
+
+    parsed: list[tuple[str, dict | None]] = []
+    for line in lines:
+        parsed.append((line, json.loads(line, fallback=None)))
+
+    # Reverse scan to find the last assistant message ID.
+    last_asst_msg_id: str | None = None
+    for _line, entry in reversed(parsed):
+        if not isinstance(entry, dict):
+            continue
+        msg = entry.get("message", {})
+        if msg.get("role") == "assistant":
+            last_asst_msg_id = msg.get("id")
+            break
+
+    if last_asst_msg_id is None:
+        return content
+
+    result_lines: list[str] = []
+    stripped_count = 0
+    for line, entry in parsed:
+        if not isinstance(entry, dict):
+            result_lines.append(line)
+            continue
+
+        msg = entry.get("message", {})
+        # Only strip from assistant entries that are NOT the last turn.
+        if (
+            msg.get("role") == "assistant"
+            and msg.get("id") != last_asst_msg_id
+            and isinstance(msg.get("content"), list)
+        ):
+            content_blocks = msg["content"]
+            filtered = [
+                b
+                for b in content_blocks
+                if not (isinstance(b, dict) and b.get("type") in _THINKING_BLOCK_TYPES)
+            ]
+            if len(filtered) < len(content_blocks):
+                stripped_count += len(content_blocks) - len(filtered)
+                entry = {**entry, "message": {**msg, "content": filtered}}
+                result_lines.append(json.dumps(entry, separators=(",", ":")))
+                continue
+
+        result_lines.append(line)
+
+    if stripped_count:
+        logger.info(
+            "[Transcript] Stripped %d stale thinking block(s) from non-last entries",
+            stripped_count,
+        )
+
+    return "\n".join(result_lines) + "\n"
+
+
 async def upload_transcript(
     user_id: str,
     session_id: str,
@@ -472,6 +545,9 @@ async def upload_transcript(
     # Strip metadata entries (progress, file-history-snapshot, etc.)
     # Note: SDK-built transcripts shouldn't have these, but strip for safety
     stripped = strip_progress_entries(content)
+    # Strip stale thinking blocks from older assistant entries — these consume
+    # significant tokens and trigger unnecessary CLI compaction every turn.
+    stripped = strip_stale_thinking_blocks(stripped)
     if not validate_transcript(stripped):
         # Log entry types for debugging — helps identify why validation failed
         entry_types = [


### PR DESCRIPTION
## Why

Long-running CoPilot sessions hit "Prompt is too long" and get permanently stuck — compaction never triggers, so users can't continue the conversation. This was reported on session `08b807d4-114f-46b7-9b9e-7fb6b35481a9` (Langfuse).

## Root Cause Investigation

Traced via Langfuse OTEL data for the affected session:

1. **Turn 9** was massive — 100+ tool calls (file writes, reads, bash exec, run_block) spanning hours on March 13
2. **Turn 13** (today, user typed "hi") resumed the session. The Claude CLI did a **pre-API check** and detected the prompt exceeded the context limit
3. The CLI returned `ResultMessage(subtype="error", result="Prompt is too long")` with `duration_api_ms=0` and model `<synthetic>` — meaning no API call was ever made
4. Our code in `_run_stream_attempt` received this as a **normal message**, logged the error, and the adapter converted it to `StreamError` + `StreamFinish`
5. The retry loop saw a "successful" stream completion and `break`ed — **compaction was never triggered**

The retry/compaction mechanism at `service.py:2117-2153` only catches **Python exceptions**. When the CLI returns the error as a structured `ResultMessage` instead of raising, the entire compaction path is bypassed.

## What

### Fix 1: Re-raise CLI prompt-too-long as exception (`service.py`)

When a `ResultMessage` with `subtype="error"` has result text matching `_PROMPT_TOO_LONG_PATTERNS` (e.g. "prompt is too long"), we now `raise Exception(...)` **before** the adapter converts it to stream events. This ensures:
- The exception propagates to the retry loop
- `_is_prompt_too_long(e)` matches → `is_context_error=True`
- `events_yielded == 0` (CLI returned immediately) → retry is allowed
- `_reduce_context()` runs compaction on the next attempt

### Fix 2: Strip stale thinking blocks from transcript (`transcript.py`)

Adds `strip_stale_thinking_blocks()` — removes thinking/redacted_thinking blocks from **non-last** assistant entries before transcript upload. These blocks consume 10-50K tokens each but carry no context value for `--resume`. Stripping them prevents the CLI from triggering compaction every turn just to compress away stale thinking bloat.

The Anthropic API only requires thinking blocks in the **last** assistant message to be byte-identical — older entries can safely have them removed.

## How

- **`service.py`**: Added check after `ResultMessage` error logging (line ~1406) — if the error text matches any `_PROMPT_TOO_LONG_PATTERNS`, raise before the adapter processes it
- **`transcript.py`**: New `strip_stale_thinking_blocks()` function + call in `upload_transcript()` after `strip_progress_entries()`
- **`retry_scenarios_test.py`**: New integration test `test_result_message_prompt_too_long_triggers_compaction` — simulates CLI returning error ResultMessage, asserts compaction retry happens (attempt_count==2) with no StreamError

## Test plan

- [ ] New test: `test_result_message_prompt_too_long_triggers_compaction` — CLI error ResultMessage triggers compaction retry
- [ ] Existing test: `test_prompt_too_long_retries_with_compaction` — exception path still works
- [ ] Existing test: `test_all_attempts_exhausted_yields_stream_error` — exhaustion path still works
- [ ] Existing test: `test_events_yielded_prevents_retry` — mid-stream errors still break
- [ ] Existing test: `test_non_context_error_breaks_immediately` — non-context errors still break
- [ ] CI green
