### PR TITLE
feat(e2b): set default git committer identity to autopilot@agpt.co

### DIFF
--- a/autogpt_platform/backend/backend/blocks/claude_code.py
+++ b/autogpt_platform/backend/backend/blocks/claude_code.py
@@ -331,7 +331,13 @@ class ClaudeCodeBlock(Block):
                     template=self.DEFAULT_TEMPLATE,
                     api_key=e2b_api_key,
                     timeout=timeout,
-                    envs={"ANTHROPIC_API_KEY": anthropic_api_key},
+                    envs={
+                        "ANTHROPIC_API_KEY": anthropic_api_key,
+                        "GIT_AUTHOR_NAME": "AutoGPT",
+                        "GIT_AUTHOR_EMAIL": "autopilot@agpt.co",
+                        "GIT_COMMITTER_NAME": "AutoGPT",
+                        "GIT_COMMITTER_EMAIL": "autopilot@agpt.co",
+                    },
                 )
 
                 # Install Claude Code from npm (ensures we get the latest version)

--- a/autogpt_platform/backend/backend/copilot/tools/bash_exec.py
+++ b/autogpt_platform/backend/backend/copilot/tools/bash_exec.py
@@ -149,6 +149,10 @@ class BashExecTool(BaseTool):
         """
         envs: dict[str, str] = {
             "PATH": "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
+            "GIT_AUTHOR_NAME": "AutoGPT",
+            "GIT_AUTHOR_EMAIL": "autopilot@agpt.co",
+            "GIT_COMMITTER_NAME": "AutoGPT",
+            "GIT_COMMITTER_EMAIL": "autopilot@agpt.co",
         }
         # Collect injected secret values so we can scrub them from output.
         secret_values: list[str] = []

--- a/autogpt_platform/backend/backend/copilot/tools/bash_exec_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/bash_exec_test.py
@@ -54,6 +54,31 @@ class TestBashExecE2BTokenInjection:
         assert isinstance(result, BashExecResponse)
 
     @pytest.mark.asyncio(loop_scope="session")
+    async def test_git_identity_env_vars_always_set(self):
+        """Git author/committer env vars are always present in sandbox envs."""
+        tool = _make_tool()
+        session = make_session(user_id=_USER)
+        sandbox = _make_sandbox(stdout="ok")
+
+        with patch(
+            "backend.copilot.tools.bash_exec.get_integration_env_vars",
+            new=AsyncMock(return_value={}),
+        ):
+            await tool._execute_on_e2b(
+                sandbox=sandbox,
+                command="git commit -m test",
+                timeout=10,
+                session_id=session.session_id,
+                user_id=_USER,
+            )
+
+        call_kwargs = sandbox.commands.run.call_args[1]
+        assert call_kwargs["envs"]["GIT_AUTHOR_NAME"] == "AutoGPT"
+        assert call_kwargs["envs"]["GIT_AUTHOR_EMAIL"] == "autopilot@agpt.co"
+        assert call_kwargs["envs"]["GIT_COMMITTER_NAME"] == "AutoGPT"
+        assert call_kwargs["envs"]["GIT_COMMITTER_EMAIL"] == "autopilot@agpt.co"
+
+    @pytest.mark.asyncio(loop_scope="session")
     async def test_no_token_injection_when_user_id_is_none(self):
         """When user_id is None, get_integration_env_vars must NOT be called."""
         tool = _make_tool()
@@ -75,4 +100,7 @@ class TestBashExecE2BTokenInjection:
         mock_get_env.assert_not_called()
         call_kwargs = sandbox.commands.run.call_args[1]
         assert "GH_TOKEN" not in call_kwargs["envs"]
+        # Git identity env vars should still be present even without user_id
+        assert call_kwargs["envs"]["GIT_AUTHOR_EMAIL"] == "autopilot@agpt.co"
+        assert call_kwargs["envs"]["GIT_COMMITTER_EMAIL"] == "autopilot@agpt.co"
         assert isinstance(result, BashExecResponse)

--- a/autogpt_platform/frontend/Dockerfile
+++ b/autogpt_platform/frontend/Dockerfile
@@ -1,5 +1,5 @@
 # Base stage for both dev and prod
-FROM node:21-alpine AS base
+FROM node:22.22-alpine3.23 AS base
 WORKDIR /app
 RUN corepack enable
 COPY autogpt_platform/frontend/package.json autogpt_platform/frontend/pnpm-lock.yaml ./
@@ -33,7 +33,7 @@ ENV NEXT_PUBLIC_SOURCEMAPS="false"
 RUN if [ "$NEXT_PUBLIC_PW_TEST" = "true" ]; then NEXT_PUBLIC_PW_TEST=true NODE_OPTIONS="--max-old-space-size=8192" pnpm build; else NODE_OPTIONS="--max-old-space-size=8192" pnpm build; fi
 
 # Prod stage - based on NextJS reference Dockerfile https://github.com/vercel/next.js/blob/64271354533ed16da51be5dce85f0dbd15f17517/examples/with-docker/Dockerfile
-FROM node:21-alpine AS prod
+FROM node:22.22-alpine3.23 AS prod
 ENV NODE_ENV=production
 ENV HOSTNAME=0.0.0.0
 WORKDIR /app


### PR DESCRIPTION
## Why
E2B sandbox git commits currently have no default author/committer identity, which can cause `git commit` to fail or produce commits with unhelpful metadata.

## What
Add `GIT_AUTHOR_NAME`, `GIT_AUTHOR_EMAIL`, `GIT_COMMITTER_NAME`, and `GIT_COMMITTER_EMAIL` environment variables to E2B sandbox execution so git commits default to `AutoGPT <autopilot@agpt.co>` without requiring manual `git config`.

### Changes
- **`copilot/tools/bash_exec.py`** — Added 4 git identity env vars to the default `envs` dict in `_execute_on_e2b()`, injected on every sandbox command
- **`blocks/claude_code.py`** — Added same env vars to E2B sandbox creation `envs` dict
- **`copilot/tools/bash_exec_test.py`** — Added `test_git_identity_env_vars_always_set` test + assertions in existing test

## How
Git respects `GIT_AUTHOR_*` and `GIT_COMMITTER_*` environment variables over `git config`. By setting these in the sandbox env dict, every `git commit` in E2B automatically uses the `autopilot@agpt.co` identity.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adds fixed `GIT_AUTHOR_*`/`GIT_COMMITTER_*` env vars to sandbox execution/creation and extends tests; no auth, data, or control-flow changes.
> 
> **Overview**
> Ensures `git commit` in E2B sandboxes uses a consistent default identity by injecting **Git author/committer env vars** (`GIT_AUTHOR_*`, `GIT_COMMITTER_*`) alongside existing sandbox env configuration.
> 
> Applies this both when creating the Claude Code E2B sandbox (`blocks/claude_code.py`) and for every E2B command execution via `bash_exec` (`copilot/tools/bash_exec.py`), and adds/updates tests to assert these env vars are always present (`bash_exec_test.py`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 16b5a67a523aa2a2ec74ef322c7d346193a9194f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->