### PR TITLE
fix(backend/copilot): close open text block before compaction events to prevent text-end errors

### DIFF
--- a/autogpt_platform/backend/backend/copilot/sdk/response_adapter_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/response_adapter_test.py
@@ -29,6 +29,7 @@ from backend.copilot.response_model import (
     StreamToolOutputAvailable,
 )
 
+from .compaction import compaction_events
 from .response_adapter import SDKResponseAdapter
 from .tool_adapter import MCP_TOOL_PREFIX
 from .tool_adapter import _pending_tool_outputs as _pto
@@ -689,3 +690,67 @@ def test_already_resolved_tool_skipped_in_user_message():
     assert (
         len(output_events) == 0
     ), "Already-resolved tool should not emit duplicate output"
+
+
+# -- _end_text_if_open before compaction -------------------------------------
+
+
+def test_end_text_if_open_emits_text_end_before_finish_step():
+    """StreamTextEnd must be emitted before StreamFinishStep during compaction.
+
+    When ``emit_end_if_ready`` fires compaction events while a text block is
+    still open, ``_end_text_if_open`` must close it first.  If StreamFinishStep
+    arrives before StreamTextEnd, the Vercel AI SDK clears ``activeTextParts``
+    and raises "Received text-end for missing text part".
+    """
+    adapter = _adapter()
+
+    # Open a text block by processing an AssistantMessage with text
+    msg = AssistantMessage(content=[TextBlock(text="partial response")], model="test")
+    adapter.convert_message(msg)
+    assert adapter.has_started_text
+    assert not adapter.has_ended_text
+
+    # Simulate what service.py does before yielding compaction events
+    pre_close: list[StreamBaseResponse] = []
+    adapter._end_text_if_open(pre_close)
+    combined = pre_close + list(compaction_events("Compacted transcript"))
+
+    text_end_idx = next(
+        (i for i, e in enumerate(combined) if isinstance(e, StreamTextEnd)), None
+    )
+    finish_step_idx = next(
+        (i for i, e in enumerate(combined) if isinstance(e, StreamFinishStep)), None
+    )
+
+    assert text_end_idx is not None, "StreamTextEnd must be present"
+    assert finish_step_idx is not None, "StreamFinishStep must be present"
+    assert text_end_idx < finish_step_idx, (
+        f"StreamTextEnd (idx={text_end_idx}) must precede "
+        f"StreamFinishStep (idx={finish_step_idx}) — otherwise the Vercel AI SDK "
+        "clears activeTextParts before text-end arrives"
+    )
+
+
+def test_end_text_if_open_no_op_when_no_text_open():
+    """_end_text_if_open emits nothing when no text block is open."""
+    adapter = _adapter()
+    results: list[StreamBaseResponse] = []
+    adapter._end_text_if_open(results)
+    assert results == []
+
+
+def test_end_text_if_open_no_op_after_text_already_ended():
+    """_end_text_if_open emits nothing when the text block is already closed."""
+    adapter = _adapter()
+    msg = AssistantMessage(content=[TextBlock(text="hello")], model="test")
+    adapter.convert_message(msg)
+    # Close it once
+    first: list[StreamBaseResponse] = []
+    adapter._end_text_if_open(first)
+    assert len(first) == 1
+    assert isinstance(first[0], StreamTextEnd)
+    # Second call must be a no-op
+    second: list[StreamBaseResponse] = []
+    adapter._end_text_if_open(second)
+    assert second == []

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -1453,6 +1453,16 @@ async def _run_stream_attempt(
             # Emit compaction end if SDK finished compacting.
             # Sync TranscriptBuilder with the CLI's active context.
             compact_result = await ctx.compaction.emit_end_if_ready(ctx.session)
+            if compact_result.events:
+                # Compaction events end with StreamFinishStep, which maps to
+                # Vercel AI SDK's "finish-step" — that clears activeTextParts.
+                # Close any open text block BEFORE the compaction events so
+                # the text-end arrives before finish-step, preventing
+                # "text-end for missing text part" errors on the frontend.
+                pre_close: list[StreamBaseResponse] = []
+                state.adapter._end_text_if_open(pre_close)
+                for r in pre_close:
+                    yield r
             for ev in compact_result.events:
                 yield ev
             entries_replaced = False


### PR DESCRIPTION
## Why

When the Claude SDK triggers auto-compaction during active text streaming, `emit_end_if_ready` yields compaction events that end with `StreamFinishStep`. The Vercel AI SDK's `finish-step` chunk handler clears `state.activeTextParts = {}`. If a `StreamTextEnd` event arrives after this (e.g. when the next `AssistantMessage` closes the previous text block), the SDK throws:

> "Received text-end for missing text part with ID '...'"

This was seen in session `bc12e570-abc3-4941-b011-40199dd831e8` at 16:59:38 UTC after the SDK auto-compacted while text was streaming.

## What

Before yielding compaction events, call `_end_text_if_open` to flush any in-progress text block. This ensures `StreamTextEnd` always arrives before `StreamFinishStep`, matching the order the Vercel AI SDK expects.

## How

In `_run_stream_attempt`, when `compact_result.events` is non-empty, collect pre-close events via `_end_text_if_open` and yield them first:

```python
if compact_result.events:
    pre_close: list[StreamBaseResponse] = []
    state.adapter._end_text_if_open(pre_close)
    for r in pre_close:
        yield r
for ev in compact_result.events:
    yield ev
```

Three unit tests added to `response_adapter_test.py`:
- `test_end_text_if_open_emits_text_end_before_finish_step` — asserts `StreamTextEnd` index < `StreamFinishStep` index in combined stream
- `test_end_text_if_open_no_op_when_no_text_open` — no events emitted when no text is open
- `test_end_text_if_open_no_op_after_text_already_ended` — idempotent; second call is a no-op

## Checklist

- [x] I've considered the impact this change will have on existing users
- [x] I've tested my changes
- [x] I've written new tests where applicable
