### PR TITLE
docs: list model developers (not providers) in Available Language Models

### DIFF
--- a/docs/platform/what-is-autogpt-platform.md
+++ b/docs/platform/what-is-autogpt-platform.md
@@ -58,14 +58,21 @@ You can learn more under: [Build your own Blocks](new_blocks.md)
 
 ## Available Language Models
 
-The platform comes pre-integrated with cutting-edge LLM providers:
+The platform provides access to models from leading AI model developers:
 
-* OpenAI - <https://openai.com/>
-* Anthropic - <https://www.anthropic.com/>
-* Groq - <https://groq.com/>
-* Llama - <https://llamaindex.ai/>
-* AI/ML API - <https://aimlapi.com/>
-  * AI/ML API provides 300+ AI models including Deepseek, Gemini, ChatGPT. The models run at enterprise-grade rate limits and uptimes.
+* [OpenAI](https://openai.com/) — GPT-5, GPT-4.1, O3, and more
+* [Anthropic](https://www.anthropic.com/) — Claude Opus, Sonnet, and Haiku
+* [Google DeepMind](https://deepmind.google/) — Gemini 3, 2.5, and 2.0
+* [Meta](https://ai.meta.com/) — Llama 4 and Llama 3
+* [Mistral AI](https://mistral.ai/) — Mistral Large, Medium, Small, and Codestral
+* [xAI](https://x.ai/) — Grok 4 and Grok 3
+* [DeepSeek](https://www.deepseek.com/) — DeepSeek R1 and V3
+* [Cohere](https://cohere.com/) — Command A and Command R
+* [Perplexity](https://www.perplexity.ai/) — Sonar, Sonar Pro, and Sonar Deep Research
+* [Qwen (Alibaba)](https://www.alibabacloud.com/en/solutions/generative-ai/qwen) — Qwen 3
+* [Amazon](https://aws.amazon.com/ai/) — Nova Pro, Lite, and Micro
+* [Microsoft](https://www.microsoft.com/en-us/research/ai/) — Phi-4 and WizardLM 2
+* [Nvidia](https://www.nvidia.com/en-us/ai/) — Nemotron
 
 ## License Overview
 

--- a/docs/platform/what-is-autogpt-platform.md
+++ b/docs/platform/what-is-autogpt-platform.md
@@ -58,21 +58,25 @@ You can learn more under: [Build your own Blocks](new_blocks.md)
 
 ## Available Language Models
 
-The platform provides access to models from leading AI model developers:
+The platform provides access to models from a wide range of model developers, ranked roughly by industry adoption:
 
-* [OpenAI](https://openai.com/) — GPT-5, GPT-4.1, O3, and more
-* [Anthropic](https://www.anthropic.com/) — Claude Opus, Sonnet, and Haiku
 * [Google DeepMind](https://deepmind.google/) — Gemini 3, 2.5, and 2.0
+* [Anthropic](https://www.anthropic.com/) — Claude Opus, Sonnet, and Haiku
+* [DeepSeek](https://www.deepseek.com/) — DeepSeek R1 and V3
+* [Qwen (Alibaba)](https://qwen.readthedocs.io/) — Qwen 3
+* [OpenAI](https://openai.com/) — GPT-5, GPT-4.1, O3, and more
 * [Meta](https://ai.meta.com/) — Llama 4 and Llama 3
 * [Mistral AI](https://mistral.ai/) — Mistral Large, Medium, Small, and Codestral
 * [xAI](https://x.ai/) — Grok 4 and Grok 3
-* [DeepSeek](https://www.deepseek.com/) — DeepSeek R1 and V3
-* [Cohere](https://cohere.com/) — Command A and Command R
+* [Moonshot AI](https://www.moonshot.cn/) — Kimi K2
 * [Perplexity](https://www.perplexity.ai/) — Sonar, Sonar Pro, and Sonar Deep Research
-* [Qwen (Alibaba)](https://www.alibabacloud.com/en/solutions/generative-ai/qwen) — Qwen 3
 * [Amazon](https://aws.amazon.com/ai/) — Nova Pro, Lite, and Micro
 * [Microsoft](https://www.microsoft.com/en-us/research/ai/) — Phi-4 and WizardLM 2
+* [Cohere](https://cohere.com/) — Command A and Command R
 * [Nvidia](https://www.nvidia.com/en-us/ai/) — Nemotron
+* [Nous Research](https://nousresearch.com/) — Hermes
+* [Vercel](https://v0.dev/) — v0
+* [Gryphe](https://gryphe.github.io/) — MythoMax
 
 ## License Overview
 


### PR DESCRIPTION
## What changed

Replaces the **Available Language Models** section in `what-is-autogpt-platform.md`.

### Before
The list mixed model creators (OpenAI, Anthropic) with inference providers and aggregators (Groq, AI/ML API) and linked 'Llama' to LlamaIndex — which isn't a model developer at all.

### After
- Uses the industry-standard term **model developers** instead of 'LLM providers'
- Lists **every** model developer whose models are in the platform's `LlmModel` enum (`dev` branch) — 17 total
- Removes entries that are inference providers/aggregators, not model developers: **Groq, AI/ML API, Llama (LlamaIndex)**
- Ranked by approximate industry adoption based on [OpenRouter market-share data](https://openrouter.ai/rankings#market-share), not alphabetically
- Each entry links to the developer's site and highlights their key model families

### Full list (ranked by adoption)
1. Google DeepMind — Gemini 3, 2.5, and 2.0
2. Anthropic — Claude Opus, Sonnet, and Haiku
3. DeepSeek — DeepSeek R1 and V3
4. Qwen (Alibaba) — Qwen 3
5. OpenAI — GPT-5, GPT-4.1, O3, and more
6. Meta — Llama 4 and Llama 3
7. Mistral AI — Mistral Large, Medium, Small, and Codestral
8. xAI — Grok 4 and Grok 3
9. Moonshot AI — Kimi K2
10. Perplexity — Sonar, Sonar Pro, and Sonar Deep Research
11. Amazon — Nova Pro, Lite, and Micro
12. Microsoft — Phi-4 and WizardLM 2
13. Cohere — Command A and Command R
14. Nvidia — Nemotron
15. Nous Research — Hermes
16. Vercel — v0
17. Gryphe — MythoMax