### PR TITLE
feat(blocks): add Google Gemma 4 31B model (google/gemma-4-31b-it) via OpenRouter

### DIFF
--- a/autogpt_platform/backend/backend/blocks/llm.py
+++ b/autogpt_platform/backend/backend/blocks/llm.py
@@ -170,6 +170,7 @@ class LlmModel(str, Enum, metaclass=LlmModelMeta):
     GEMINI_3_1_FLASH_LITE_PREVIEW = "google/gemini-3.1-flash-lite-preview"
     GEMINI_2_5_FLASH_LITE_PREVIEW = "google/gemini-2.5-flash-lite-preview-06-17"
     GEMINI_2_0_FLASH_LITE = "google/gemini-2.0-flash-lite-001"
+    GEMMA_4_31B_IT = "google/gemma-4-31b-it"
     MISTRAL_NEMO = "mistralai/mistral-nemo"
     MISTRAL_LARGE_3 = "mistralai/mistral-large-2512"
     MISTRAL_MEDIUM_3_1 = "mistralai/mistral-medium-3.1"
@@ -437,6 +438,15 @@ MODEL_METADATA = {
         1048576,
         8192,
         "Gemini 2.0 Flash Lite 001",
+        "OpenRouter",
+        "Google",
+        1,
+    ),
+    LlmModel.GEMMA_4_31B_IT: ModelMetadata(
+        "open_router",
+        262144,
+        131072,
+        "Gemma 4 31B",
         "OpenRouter",
         "Google",
         1,

--- a/autogpt_platform/backend/backend/data/block_cost_config.py
+++ b/autogpt_platform/backend/backend/data/block_cost_config.py
@@ -108,6 +108,7 @@ MODEL_COST: dict[LlmModel, int] = {
     LlmModel.GEMINI_3_1_FLASH_LITE_PREVIEW: 1,
     LlmModel.GEMINI_2_5_FLASH_LITE_PREVIEW: 1,
     LlmModel.GEMINI_2_0_FLASH_LITE: 1,
+    LlmModel.GEMMA_4_31B_IT: 1,
     LlmModel.MISTRAL_NEMO: 1,
     LlmModel.MISTRAL_LARGE_3: 2,
     LlmModel.MISTRAL_MEDIUM_3_1: 2,


### PR DESCRIPTION
### Why / What / How

**Why:** The Google Gemma 4 31B model (`google/gemma-4-31b-it`) is currently available on OpenRouter's API but is not offered as an option in the AutoGPT Platform's LLM blocks. This limits users who want to leverage Gemma 4's multimodal capabilities (text+image+video→text) with a 262K context window.

**What:** This PR adds the Google Gemma 4 31B Instruct model to all LLM-based blocks (AITextGeneratorBlock, AIListGeneratorBlock, AITextSummarizerBlock, etc.) by adding it to the shared `LlmModel` enum, `MODEL_METADATA`, and `MODEL_COST` configuration.

**How:** 
- Added `GEMMA_4_31B_IT = "google/gemma-4-31b-it"` to the `LlmModel` enum
- Added corresponding `ModelMetadata` entry with OpenRouter provider, 262,144 context window, and 131,072 max output tokens
- Added cost configuration entry (tier 1) in `block_cost_config.py`

### Changes 🏗️

- **`autogpt_platform/backend/backend/blocks/llm.py`**: Added `GEMMA_4_31B_IT` enum member and its `ModelMetadata` entry (OpenRouter provider, 262K context, 131K max output, price tier 1)
- **`autogpt_platform/backend/backend/data/block_cost_config.py`**: Added cost entry for `GEMMA_4_31B_IT` (1 credit)

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Verified `poetry run format` passes with no formatting changes
  - [x] Verified the new enum member follows existing naming conventions (alphabetical placement among Google models)
  - [x] Confirmed `MODEL_METADATA` validation loop at startup will cover the new entry
  - [x] Confirmed the model string `google/gemma-4-31b-it` matches the OpenRouter API exactly
