### PR TITLE
ci(frontend): make frontend coverage checks informational (non-blocking)

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -43,6 +43,13 @@ component_management:
       name: "Platform Frontend"
       paths:
         - autogpt_platform/frontend/src/**
+      statuses:
+        - type: project
+          target: auto
+          informational: true
+        - type: patch
+          target: 80%
+          informational: true
     - component_id: autogpt-libs
       name: "AutoGPT Libs"
       paths:


### PR DESCRIPTION
### Why / What / How

**Why:** Frontend test coverage is still ramping up. The default component status checks (project + patch at 80%) would block merges for insufficient coverage on frontend changes, which isn't practical yet.

**What:** Override the platform-frontend component's coverage statuses to be `informational: true`, so they report but don't block merges.

**How:** Added explicit `statuses` to the `platform-frontend` component in `codecov.yml` with `informational: true` on both project and patch checks, overriding the `default_rules`.

### Changes 🏗️

- **`codecov.yml`**: Added `informational: true` to platform-frontend component's project and patch status checks

### Checklist 📋

#### For code changes:
- [ ] I have clearly listed my changes in the PR description
- [ ] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [ ] Verify Codecov frontend status checks show as informational (non-blocking) on PRs touching frontend code

#### For configuration changes:

- [x] `.env.default` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes
- [x] I have included a list of my configuration changes in the PR description (under **Changes**)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: Codecov configuration-only change that affects merge gating for frontend coverage statuses but does not alter runtime code.
> 
> **Overview**
> Updates `codecov.yml` to override the `platform-frontend` component’s coverage `statuses` so both **project** and **patch** checks are marked `informational: true` (non-blocking), while leaving the default component coverage rules unchanged for other components.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f8e8426a31e8fa28817c9d3f10f6e5faa2c00c46. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->