### PR TITLE
dx(platform): align feature flag infrastructure — env overrides + LD context parity

### DIFF
--- a/autogpt_platform/backend/backend/util/feature_flag.py
+++ b/autogpt_platform/backend/backend/util/feature_flag.py
@@ -1,5 +1,6 @@
 import contextlib
 import logging
+import os
 from enum import Enum
 from functools import wraps
 from typing import Any, Awaitable, Callable, TypeVar
@@ -165,6 +166,30 @@ async def get_feature_flag_value(
         return default
 
 
+def _env_flag_override(flag_key: Flag) -> bool | None:
+    """Return a local override for ``flag_key`` from the environment.
+
+    Set ``FORCE_FLAG_<NAME>=true|false`` (``NAME`` = flag value with
+    ``-`` → ``_``, upper-cased) to bypass LaunchDarkly for a single
+    flag in local dev or tests.  Returns ``None`` when no override
+    is configured so the caller falls through to LaunchDarkly.
+
+    The ``NEXT_PUBLIC_FORCE_FLAG_<NAME>`` prefix is also accepted so a
+    single shared env var can toggle a flag across backend and
+    frontend (the frontend requires the ``NEXT_PUBLIC_`` prefix to
+    expose the value to the browser bundle).
+
+    Example: ``FORCE_FLAG_CHAT_MODE_OPTION=true`` forces
+    ``Flag.CHAT_MODE_OPTION`` on regardless of LaunchDarkly.
+    """
+    suffix = flag_key.value.upper().replace("-", "_")
+    for prefix in ("FORCE_FLAG_", "NEXT_PUBLIC_FORCE_FLAG_"):
+        raw = os.environ.get(prefix + suffix)
+        if raw is not None:
+            return raw.strip().lower() in ("1", "true", "yes", "on")
+    return None
+
+
 async def is_feature_enabled(
     flag_key: Flag,
     user_id: str,
@@ -181,6 +206,11 @@ async def is_feature_enabled(
     Returns:
         True if feature is enabled, False otherwise
     """
+    override = _env_flag_override(flag_key)
+    if override is not None:
+        logger.debug(f"Feature flag {flag_key} overridden by env: {override}")
+        return override
+
     result = await get_feature_flag_value(flag_key.value, user_id, default)
 
     # If the result is already a boolean, return it

--- a/autogpt_platform/frontend/src/services/feature-flags/feature-flag-provider.tsx
+++ b/autogpt_platform/frontend/src/services/feature-flags/feature-flag-provider.tsx
@@ -26,11 +26,18 @@ export function LaunchDarklyProvider({ children }: { children: ReactNode }) {
       };
     }
 
+    // Mirror the context built by the backend
+    // (feature_flag.py:_fetch_user_context_data) so LaunchDarkly targeting
+    // rules evaluate identically on both sides.
     return {
       kind: "user" as const,
       key: user.id,
-      ...(user.email && { email: user.email }),
       anonymous: false,
+      ...(user.email && {
+        email: user.email,
+        email_domain: user.email.split("@").at(-1),
+      }),
+      ...(user.role && { role: user.role }),
       custom: {
         ...(user.role && { role: user.role }),
       },

--- a/autogpt_platform/frontend/src/services/feature-flags/use-get-flag.ts
+++ b/autogpt_platform/frontend/src/services/feature-flags/use-get-flag.ts
@@ -30,10 +30,41 @@ const defaultFlags = {
 
 type FlagValues = typeof defaultFlags;
 
+/**
+ * Read a per-flag override from the build-time env.
+ *
+ * Set ``NEXT_PUBLIC_FORCE_FLAG_<NAME>=true|false`` (``NAME`` = flag value
+ * with ``-`` → ``_``, upper-cased) to bypass LaunchDarkly for that flag
+ * in local dev.  Returns ``undefined`` when no override is configured so
+ * the caller falls through to LaunchDarkly / ``defaultFlags``.
+ *
+ * Note: ``NEXT_PUBLIC_*`` env vars are baked into the bundle at build
+ * time, so the frontend image must be rebuilt after changing them.
+ */
+function envFlagOverride<T extends Flag>(flag: T): FlagValues[T] | undefined {
+  const envName =
+    "NEXT_PUBLIC_FORCE_FLAG_" + flag.toUpperCase().replace(/-/g, "_");
+  const raw = process.env[envName];
+  if (raw === undefined) return undefined;
+  const normalized = raw.trim().toLowerCase();
+  if (["1", "true", "yes", "on"].includes(normalized)) {
+    return true as FlagValues[T];
+  }
+  if (["0", "false", "no", "off"].includes(normalized)) {
+    return false as FlagValues[T];
+  }
+  return undefined;
+}
+
 export function useGetFlag<T extends Flag>(flag: T): FlagValues[T] {
   const currentFlags = useFlags<FlagValues>();
   const flagValue = currentFlags[flag];
   const areFlagsEnabled = environment.areFeatureFlagsEnabled();
+
+  const override = envFlagOverride(flag);
+  if (override !== undefined) {
+    return override;
+  }
 
   if (!areFlagsEnabled || isPwMockEnabled) {
     return defaultFlags[flag];


### PR DESCRIPTION
## Summary

Two related feature-flag infrastructure fixes.

### 1. FORCE_FLAG env-var overrides for LaunchDarkly flags

Both [backend/backend/util/feature_flag.py](autogpt_platform/backend/backend/util/feature_flag.py) and [services/feature-flags/use-get-flag.ts](autogpt_platform/frontend/src/services/feature-flags/use-get-flag.ts) now check an env-var override **before** consulting LaunchDarkly:

- Backend: `FORCE_FLAG_<NAME>=true|false` (also accepts `NEXT_PUBLIC_FORCE_FLAG_<NAME>` as an alias)
- Frontend: `NEXT_PUBLIC_FORCE_FLAG_<NAME>=true|false` (must be `NEXT_PUBLIC_` prefixed so Next.js exposes it to the browser bundle)

`<NAME>` is the flag value upper-cased with `-` → `_`. Example: `chat-mode-option` → `CHAT_MODE_OPTION`.

**Why:** previously, testing a flag-gated feature locally required patching `default=` at each call site (tracked code change) or unsetting `NEXT_PUBLIC_LAUNCHDARKLY_CLIENT_ID` and rebuilding. Both had to be reverted manually. `.env` overrides are gitignored.

### 2. Align LaunchDarkly user context (frontend ↔ backend)

Frontend was sending a smaller context than backend, so targeting rules using `email_domain` or top-level `role` could evaluate differently on each side and silently diverge (e.g. frontend shows a feature, backend denies it — observed during PR #12623 testing).

**Before:**
```typescript
// Frontend
{ key, email, anonymous, custom: { role } }
```
```python
# Backend
{ key, anonymous, role, custom: {"role"}, email, email_domain }
```

**After:** frontend now builds the same shape as backend.

## Test plan

- [x] Backend: `FORCE_FLAG_CHAT_MODE_OPTION=true` exposes `mode=fast/extended_thinking` routing (verified on PR #12623 E2E run)
- [x] Frontend: `NEXT_PUBLIC_FORCE_FLAG_CHAT_MODE_OPTION=true` renders the ChatInput mode toggle (verified on PR #12623 E2E run)
- [x] Backend accepts the `NEXT_PUBLIC_FORCE_FLAG_` alias
- [x] Falls through to LaunchDarkly when env var is unset
- [x] Pre-commit: ruff, prettier, tsc, black, isort all pass