### PR TITLE
dx: add /orchestrate skill — Claude Code agent fleet supervisor with spare worktree lifecycle

### DIFF
--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -144,12 +144,12 @@ Tell the user:
 ## Subcommand: stop
 
 ```bash
+# Show current agent state before marking inactive
+jq '.agents[] | {window, state, worktree}' ~/.claude/orchestrator-state.json
+
 # Mark inactive
 jq '.active = false' ~/.claude/orchestrator-state.json > /tmp/orch.tmp \
   && mv /tmp/orch.tmp ~/.claude/orchestrator-state.json
-
-# Show current state before stopping
-jq '.agents[] | {window, state, worktree}' ~/.claude/orchestrator-state.json
 ```
 
 Then use CronDelete with the stored job ID to cancel the loop:

--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -1,34 +1,47 @@
 ---
 name: orchestrate
-description: "Meta-agent supervisor that manages a fleet of Claude Code agents running in tmux windows. Auto-discovers spare worktrees (spare/N branches), spawns agents into new windows, monitors state, kicks idle agents, auto-approves safe confirmations, and recycles worktrees when done. TRIGGER when user asks to supervise agents, manage a fleet, monitor tmux agents, or orchestrate parallel worktrees."
+description: "Meta-agent supervisor that manages a fleet of Claude Code agents running in tmux windows. Auto-discovers spare worktrees, spawns agents, monitors state, kicks idle agents, approves safe confirmations, and recycles worktrees when done. TRIGGER when user asks to supervise agents, run parallel tasks, manage worktrees, check agent status, or orchestrate parallel work."
 user-invocable: true
-argument-hint: "[start|stop|status|add|poll|capacity] — start spawns agents into spare worktrees, add assigns one more task, capacity shows available worktrees, poll runs one check cycle"
+argument-hint: "any free text — e.g. 'start 3 agents on X Y Z', 'show status', 'add task: implement feature A', 'stop', 'how many are free?'"
 metadata:
   author: autogpt-team
-  version: "2.0.0"
+  version: "3.0.0"
 ---
 
 # Orchestrate — Agent Fleet Supervisor
 
-One tmux session, N windows — each window is one agent in one worktree. The orchestrator auto-discovers spare worktrees, spawns agents, monitors them, and recycles worktrees when work is done. No manual window setup required.
+One tmux session, N windows — each window is one agent working in its own worktree. Speak naturally; Claude maps your intent to the right scripts.
+
+## Scripts
+
+```bash
+SKILLS_DIR=$(git rev-parse --show-toplevel)/.claude/skills/orchestrate/scripts
+STATE_FILE=~/.claude/orchestrator-state.json
+```
+
+| Script | Purpose | Key args |
+|---|---|---|
+| `find-spare.sh [REPO_ROOT]` | List free worktrees — one `PATH BRANCH` per line | |
+| `spawn-agent.sh SESSION PATH SPARE NEW_BRANCH OBJECTIVE` | Create window + checkout branch + launch claude + send task. **Stdout: `SESSION:WIN` only** | |
+| `recycle-agent.sh WINDOW PATH SPARE_BRANCH` | Kill window + restore spare branch | |
+| `capacity.sh [REPO_ROOT]` | Print available + in-use worktrees | |
+| `status.sh` | Print fleet status + live pane commands | |
+| `poll-cycle.sh` | One monitoring cycle — returns JSON action array | |
+| `classify-pane.sh WINDOW` | Classify one pane state | |
 
 ## Worktree lifecycle
 
 ```text
-spare/N branch   →   orchestrate add   →   new window + feat/branch + claude running
-                                                        ↓
-                                               ORCHESTRATOR:DONE
-                                                        ↓
-                                        kill window + git checkout spare/N
-                                                        ↓
-                                               spare/N (free again)
+spare/N branch  →  spawn-agent.sh  →  window + feat/branch + claude running
+                                                ↓
+                                         ORCHESTRATOR:DONE
+                                                ↓
+                               recycle-agent.sh → spare/N (free again)
 ```
 
-Windows are always capped by worktree count — no creep. Auto-close on completion is how the orchestrator signals a worktree is free for the next task.
+## State file (`~/.claude/orchestrator-state.json`)
 
-## State file
-
-Lives at `~/.claude/orchestrator-state.json` (outside repo, never committed):
+Never committed to git. Claude maintains this file directly using `jq` + atomic writes (`.tmp` → `mv`).
 
 ```json
 {
@@ -36,12 +49,12 @@ Lives at `~/.claude/orchestrator-state.json` (outside repo, never committed):
   "tmux_session": "autogpt1",
   "idle_threshold_seconds": 300,
   "cron_job_id": "...",
-  "last_poll_at": 1712345678,
+  "last_poll_at": 0,
   "agents": [
     {
       "window": "autogpt1:3",
       "worktree": "AutoGPT6",
-      "worktree_path": "/path/to/worktrees/AutoGPT6",
+      "worktree_path": "/path/to/AutoGPT6",
       "spare_branch": "spare/6",
       "branch": "feat/my-feature",
       "objective": "Implement X and open a PR",
@@ -57,357 +70,150 @@ Lives at `~/.claude/orchestrator-state.json` (outside repo, never committed):
 
 Agent states: `running` | `idle` | `stuck` | `waiting_approval` | `complete` | `done` | `escalated`
 
-> **State transitions:** `complete` = set by poll-cycle.sh when ORCHESTRATOR:DONE is detected on screen; `done` = set by Claude after recycling the worktree.
+## Intent → action mapping
 
-## Scripts
+Match the user's message to one of these intents:
 
-```bash
-SKILLS_DIR=$(git rev-parse --show-toplevel)/.claude/skills/orchestrate
-POLL_SCRIPT=$SKILLS_DIR/scripts/poll-cycle.sh
-CLASSIFY_SCRIPT=$SKILLS_DIR/scripts/classify-pane.sh
-STATE_FILE=~/.claude/orchestrator-state.json
-```
+| The user says something like… | What to do |
+|---|---|
+| "status", "what's running", "show agents" | Run `status.sh` + `capacity.sh`, show output |
+| "how many free", "capacity", "available worktrees" | Run `capacity.sh`, show output |
+| "start N agents on X, Y, Z" or "run these tasks: …" | See **Spawning agents** below |
+| "add task: …", "add one more agent for …" | See **Adding an agent** below |
+| "stop", "shut down", "pause the fleet" | See **Stopping** below |
+| "poll", "check now", "run a cycle" | Run `poll-cycle.sh`, process actions |
+| "recycle window X", "free up autogpt3" | Run `recycle-agent.sh` directly |
 
-## find_spare_worktrees — discover available capacity
+When the intent is ambiguous, show capacity first and ask what tasks to run.
 
-```bash
-# List all worktrees on spare/N branches (these are free to use)
-# Output: one line per available worktree: "PATH SPARE_BRANCH"
-git worktree list --porcelain | awk '
-  /^worktree / { path = substr($0, 10) }
-  /^branch /   { branch = substr($0, 8); print path " " branch }
-' | grep -E " refs/heads/spare/[0-9]+$" | sed 's|refs/heads/||'
-```
+## Spawning agents
 
-Example output:
-```text
-/path/to/worktrees/AutoGPT3 spare/3
-/path/to/worktrees/AutoGPT7 spare/7
-```
-
-## spawn_agent — create window, launch agent, send task
-
-```bash
-# Usage: spawn_agent SESSION WORKTREE_PATH SPARE_BRANCH NEW_BRANCH OBJECTIVE
-# Returns: "SESSION:WINDOW_IDX" on stdout
-
-SESSION="$1"
-WORKTREE_PATH="$2"
-SPARE_BRANCH="$3"       # e.g. spare/6  — to restore on completion
-NEW_BRANCH="$4"         # e.g. feat/my-feature  — branch to create for this task
-OBJECTIVE="$5"
-WORKTREE_NAME=$(basename "$WORKTREE_PATH")
-
-# Create the task branch
-git -C "$WORKTREE_PATH" checkout -b "$NEW_BRANCH" 2>/dev/null \
-  || git -C "$WORKTREE_PATH" checkout "$NEW_BRANCH"
-
-# Create a new named window, capture its numeric index
-WIN_IDX=$(tmux new-window -t "$SESSION" -n "$WORKTREE_NAME" -P -F '#{window_index}')
-WINDOW="${SESSION}:${WIN_IDX}"
-
-# Launch claude with bypass permissions
-# Single-quote WORKTREE_PATH so the pane shell handles spaces and special chars correctly
-tmux send-keys -t "$WINDOW" "cd '${WORKTREE_PATH}' && claude --permission-mode bypassPermissions" Enter
-
-# Wait up to 30s for claude to start (foreground becomes 'node')
-for i in $(seq 1 30); do
-  CMD=$(tmux display-message -t "$WINDOW" -p '#{pane_current_command}' 2>/dev/null || echo "")
-  [[ "$CMD" == "node" ]] && break
-  sleep 1
-done
-
-# Auto-dismiss Claude settings error dialog if present
-CMD=$(tmux display-message -t "$WINDOW" -p '#{pane_current_command}' 2>/dev/null || echo "")
-if [[ "$CMD" != "node" ]]; then
-  PANE=$(tmux capture-pane -t "$WINDOW" -p 2>/dev/null | tail -5)
-  if echo "$PANE" | grep -q "Enter to confirm"; then
-    tmux send-keys -t "$WINDOW" Down Enter
-    sleep 2
-  fi
-fi
-
-# Send the task
-tmux send-keys -t "$WINDOW" "${OBJECTIVE}. When all work is done, output the exact string: ORCHESTRATOR:DONE" Enter
-
-echo "$WINDOW"
-```
-
-## recycle_worktree — restore worktree to spare after completion
-
-```bash
-# Usage: recycle_worktree WINDOW WORKTREE_PATH SPARE_BRANCH
-WINDOW="$1"
-WORKTREE_PATH="$2"
-SPARE_BRANCH="$3"
-
-# Kill the tmux window
-tmux kill-window -t "$WINDOW" 2>/dev/null
-
-# Restore to spare branch (clean tracked files and remove untracked files/dirs)
-git -C "$WORKTREE_PATH" reset --hard HEAD 2>/dev/null
-git -C "$WORKTREE_PATH" clean -fd 2>/dev/null
-git -C "$WORKTREE_PATH" checkout "$SPARE_BRANCH"
-
-echo "Recycled: $WORKTREE_PATH → $SPARE_BRANCH (window $WINDOW closed)"
-```
-
-## Subcommand: capacity
-
-Show available worktrees before starting. Run this to understand the fleet size.
-
-```bash
-echo "=== Available (spare) worktrees ==="
-git worktree list --porcelain | awk '
-  /^worktree / { path = substr($0, 10) }
-  /^branch /   { branch = substr($0, 8); print path " " branch }
-' | grep -E " refs/heads/spare/[0-9]+$" | sed 's|refs/heads/||' \
-  | while read path branch; do
-      echo "  ✓ $path ($branch)"
-    done
-
-echo ""
-echo "=== In-use worktrees ==="
-jq -r '.agents[] | select(.state != "done") | "  [\(.state)] \(.worktree_path) → \(.branch)"' \
-  ~/.claude/orchestrator-state.json 2>/dev/null || echo "  (no active state file)"
-```
-
-## Subcommand: start
-
-Gather task list, auto-assign spare worktrees, spawn agents, start polling.
-
-### Step 1 — Resolve tmux session
-
-If `$ARGUMENTS` provides a session name, use it. Otherwise:
+### 1. Resolve tmux session
 
 ```bash
 tmux list-sessions -F "#{session_name}: #{session_windows} windows" 2>/dev/null
 ```
 
-If no sessions exist, create one:
+Use the existing session. If none exist, create one:
 ```bash
 tmux new-session -d -s autogpt1
+SESSION="autogpt1"
 ```
 
-### Step 2 — Show available capacity
+### 2. Show available capacity
 
 ```bash
-git worktree list --porcelain | awk '
-  /^worktree / { path = substr($0, 10) }
-  /^branch /   { branch = substr($0, 8); print path " " branch }
-' | grep -E " refs/heads/spare/[0-9]+$" | sed 's|refs/heads/||'
+bash $SKILLS_DIR/capacity.sh $(git rev-parse --show-toplevel)
 ```
 
-Show the user how many spare worktrees are available.
+### 3. Collect tasks from the user
 
-### Step 3 — Gather tasks
+For each task, gather:
+- **objective** — what to do (e.g. "implement feature X and open a PR")
+- **branch name** — e.g. `feat/my-feature` (derive from objective if not given)
 
-For each task the user wants to run, collect:
-- **objective**: what the agent should do
-- **branch name**: e.g. `feat/my-feature` (derived from objective if not given)
+Ask for `idle_threshold_seconds` only if the user mentions it (default: 300).
 
-The worktree is auto-assigned from the spare list — the user does not need to specify it.
+Never ask the user to specify a worktree — auto-assign from `find-spare.sh`.
 
-Also ask: **idle_threshold_seconds** (default: 300).
-
-### Step 4 — Spawn agents
-
-For each task, pick the next available spare worktree and spawn:
+### 4. Spawn one agent per task
 
 ```bash
-SPARE_LIST=$(git worktree list --porcelain | awk '
-  /^worktree / { path = substr($0, 10) }
-  /^branch /   { branch = substr($0, 8); print path " " branch }
-' | grep -E " refs/heads/spare/[0-9]+$" | sed 's|refs/heads/||')
+# Get ordered list of spare worktrees
+SPARE_LIST=$(bash $SKILLS_DIR/find-spare.sh $(git rev-parse --show-toplevel))
 
-AGENTS_JSON="[]"
-# TASKS is an array of "NEW_BRANCH|OBJECTIVE" strings populated in Step 3
-# TASK_IDX tracks which task to assign to each spare worktree
-TASK_IDX=0
-while IFS= read -r spare_line; do
-  [ -z "$spare_line" ] && continue
-  [ "$TASK_IDX" -ge "${#TASKS[@]}" ] && break
+# For each task, take the next spare line:
+WORKTREE_PATH=$(echo "$SPARE_LINE" | awk '{print $1}')
+SPARE_BRANCH=$(echo "$SPARE_LINE" | awk '{print $2}')
 
-  WORKTREE_PATH=$(echo "$spare_line" | awk '{print $1}')
-  SPARE_BRANCH=$(echo "$spare_line" | awk '{print $2}')
-  WORKTREE_NAME=$(basename "$WORKTREE_PATH")
-  NEW_BRANCH=$(echo "${TASKS[$TASK_IDX]}" | cut -d'|' -f1)
-  OBJECTIVE=$(echo "${TASKS[$TASK_IDX]}" | cut -d'|' -f2-)
-
-  WINDOW=$(spawn_agent "$SESSION" "$WORKTREE_PATH" "$SPARE_BRANCH" "$NEW_BRANCH" "$OBJECTIVE")
-
-  AGENT=$(jq -n \
-    --arg window "$WINDOW" \
-    --arg worktree "$WORKTREE_NAME" \
-    --arg path "$WORKTREE_PATH" \
-    --arg spare "$SPARE_BRANCH" \
-    --arg branch "$NEW_BRANCH" \
-    --arg obj "$OBJECTIVE" \
-    '{window:$window, worktree:$worktree, worktree_path:$path, spare_branch:$spare,
-      branch:$branch, objective:$obj, state:"running", last_output_hash:"",
-      last_seen_at:0, idle_since:0, revision_count:0}')
-
-  AGENTS_JSON=$(echo "$AGENTS_JSON" | jq --argjson a "$AGENT" '. + [$a]')
-  echo "Spawned: $WINDOW ($WORKTREE_NAME on $NEW_BRANCH)"
-  TASK_IDX=$(( TASK_IDX + 1 ))
-done <<< "$SPARE_LIST"
+WINDOW=$(bash $SKILLS_DIR/spawn-agent.sh "$SESSION" "$WORKTREE_PATH" "$SPARE_BRANCH" "$NEW_BRANCH" "$OBJECTIVE")
 ```
 
-### Step 5 — Write state file
+Build an agent record and append it to the state file. If the state file doesn't exist yet, initialize it:
 
 ```bash
 jq -n \
   --arg session "$SESSION" \
-  --argjson threshold "$THRESHOLD" \
-  --argjson agents "$AGENTS_JSON" \
+  --argjson threshold 300 \
   '{active:true, tmux_session:$session, idle_threshold_seconds:$threshold,
-    cron_job_id:null, last_poll_at:0, agents:$agents}' \
+    cron_job_id:null, last_poll_at:0, agents:[]}' \
   > ~/.claude/orchestrator-state.json
 ```
 
-### Step 6 — Run first poll, then start CronCreate
-
+Append each new agent:
 ```bash
-SKILLS_DIR=$(git rev-parse --show-toplevel)/.claude/skills/orchestrate
-bash $SKILLS_DIR/scripts/poll-cycle.sh | jq .
+jq --argjson a "$NEW_AGENT" '.agents += [$a]' ~/.claude/orchestrator-state.json \
+  > /tmp/orch.tmp && mv /tmp/orch.tmp ~/.claude/orchestrator-state.json
 ```
 
-CronCreate prompt (fill in SKILLS_DIR with absolute path):
+### 5. Run first poll, then start the cron
+
+```bash
+bash $SKILLS_DIR/poll-cycle.sh | jq .
+```
+
+Then start CronCreate with this prompt (substitute the real absolute path for `SKILLS_DIR`):
+
 ```text
 Orchestrator poll cycle.
 
-Run: bash SKILLS_DIR/scripts/poll-cycle.sh
+Run: bash SKILLS_DIR/poll-cycle.sh
 
-Read the JSON output. For each action:
+Read the JSON output array. For each action object:
 
-- "kick" (idle — shell foreground): get worktree_path + spare_branch from state file.
-  Run: tmux send-keys -t <window> "cd <worktree_path> && claude --permission-mode bypassPermissions" Enter
-  Wait 3s. If pane shows "Enter to confirm", send Down+Enter first.
-  Then send: "<objective>. When done output ORCHESTRATOR:DONE" Enter
+- action=="kick" AND state=="idle" (agent exited — shell is foreground):
+  Restart the agent:
+    tmux send-keys -t <window> "cd '<worktree_path>' && claude --permission-mode bypassPermissions" Enter
+  Wait 3s. Capture pane: if "Enter to confirm" visible, send Down+Enter first.
+  Then send: "<objective>. When all work is done, output the exact string: ORCHESTRATOR:DONE" Enter
 
-- "kick" (stuck — claude still running): send nudge only, do NOT restart:
-  tmux send-keys -t <window> "Continue with your task. Review errors. When done output ORCHESTRATOR:DONE" Enter
+- action=="kick" AND state=="stuck" (claude still running but frozen):
+  Nudge only — do NOT restart:
+    tmux send-keys -t <window> "Continue with your task. Review any errors and proceed. When done output ORCHESTRATOR:DONE" Enter
 
-- "approve": inspect pane tail. Send "y" Enter if safe (git/install/test/docker/localhost curl).
-  Escalate (mark state=escalated) for: rm -rf outside worktree, force push, sudo, secrets.
+- action=="approve":
+  Capture pane: tmux capture-pane -t <window> -p | tail -5
+  SAFE to approve: git operations, install/build, tests, docker, curl to localhost
+  ESCALATE (set state=escalated, do not send keys) for: rm -rf outside worktree, force push to main/master, sudo, writing secrets to files
   Settings dialog "Enter to confirm": send Down+Enter
 
-- "complete": mark done, then recycle — kill the window and restore spare branch:
-  tmux kill-window -t <window>
-  git -C <worktree_path> reset --hard HEAD
-  git -C <worktree_path> clean -fd
-  git -C <worktree_path> checkout <spare_branch>
-  Update state: .state = "done"
-  Output: "AGENT DONE + RECYCLED: <window> (<worktree>) → <spare_branch>"
+- action=="complete":
+  Recycle the worktree:
+    bash SKILLS_DIR/recycle-agent.sh <window> <worktree_path> <spare_branch>
+  Update state file: set agent .state = "done"
+    jq --arg w "<window>" '.agents |= map(if .window == $w then .state = "done" else . end)' \
+      ~/.claude/orchestrator-state.json > /tmp/orch.tmp && mv /tmp/orch.tmp ~/.claude/orchestrator-state.json
+  Print: "AGENT DONE + RECYCLED: <window> (<worktree>) → <spare_branch>"
 
-After all actions: "Poll [HH:MM] — N agents: X running, Y kicked, Z done+recycled, V escalated"
+After processing all actions, print one summary line:
+"Poll [HH:MM] — N agents: X running, Y kicked, Z done+recycled, V escalated"
 ```
 
-Store cron job ID in state file after CronCreate returns.
+Store the returned cron job ID: update `.cron_job_id` in the state file.
 
-## Subcommand: add
+## Adding an agent
 
-Assign one new task to the next available spare worktree.
+Find the next spare worktree, then spawn and append to state — same as steps 2–4 above but for a single task. If no spare worktrees are available, tell the user.
 
-First, gather from the user:
-- **objective**: what the agent should do
-- **branch name**: e.g. `feat/my-feature` (derived from objective if not given)
-
-Then run:
+## Stopping
 
 ```bash
-# NEW_BRANCH and OBJECTIVE must be set before this block (gathered from user above)
-SESSION=$(jq -r '.tmux_session' ~/.claude/orchestrator-state.json)
-
-# Find first spare worktree
-SPARE_LINE=$(git worktree list --porcelain | awk '
-  /^worktree / { path = substr($0, 10) }
-  /^branch /   { branch = substr($0, 8); print path " " branch }
-' | grep -E " refs/heads/spare/[0-9]+$" | sed 's|refs/heads/||' | head -1)
-
-if [ -z "$SPARE_LINE" ]; then
-  echo "No spare worktrees available. All worktrees are in use."
-  echo "Wait for a task to complete, or check /orchestrate capacity."
-  exit 1
-fi
-
-WORKTREE_PATH=$(echo "$SPARE_LINE" | awk '{print $1}')
-SPARE_BRANCH=$(echo "$SPARE_LINE" | awk '{print $2}')
-WORKTREE_NAME=$(basename "$WORKTREE_PATH")
-
-WINDOW=$(spawn_agent "$SESSION" "$WORKTREE_PATH" "$SPARE_BRANCH" "$NEW_BRANCH" "$OBJECTIVE")
-
-NEW_AGENT=$(jq -n \
-  --arg window "$WINDOW" \
-  --arg worktree "$WORKTREE_NAME" \
-  --arg path "$WORKTREE_PATH" \
-  --arg spare "$SPARE_BRANCH" \
-  --arg branch "$NEW_BRANCH" \
-  --arg obj "$OBJECTIVE" \
-  '{window:$window, worktree:$worktree, worktree_path:$path, spare_branch:$spare,
-    branch:$branch, objective:$obj, state:"running", last_output_hash:"",
-    last_seen_at:0, idle_since:0, revision_count:0}')
-
-jq --argjson a "$NEW_AGENT" '.agents += [$a]' ~/.claude/orchestrator-state.json > /tmp/orch.tmp \
-  && mv /tmp/orch.tmp ~/.claude/orchestrator-state.json
-
-echo "Added: $WINDOW ($WORKTREE_NAME on $NEW_BRANCH)"
-```
-
-## Subcommand: stop
-
-```bash
-# Mark inactive first (so cron stops acting on new polls)
+# Mark inactive so poll-cycle.sh exits early (active==false)
 jq '.active = false' ~/.claude/orchestrator-state.json > /tmp/orch.tmp \
   && mv /tmp/orch.tmp ~/.claude/orchestrator-state.json
-
-# Show state (after marking inactive)
-jq '.agents[] | {window, state, worktree, branch}' ~/.claude/orchestrator-state.json
-
-# Cancel cron
-CRON_ID=$(jq -r '.cron_job_id // ""' ~/.claude/orchestrator-state.json)
-# Use CronDelete with CRON_ID (skip if empty)
 ```
 
-Does NOT recycle worktrees — agents may still be mid-task. Use `/orchestrate capacity` to see what's still running.
+Cancel the cron job using CronDelete with `.cron_job_id` from the state file.
 
-## Subcommand: status
-
-```bash
-jq -r '
-  "=== Orchestrator [\(if .active then "RUNNING" else "STOPPED" end)] ===",
-  "Session: \(.tmux_session)  |  Idle threshold: \(.idle_threshold_seconds)s",
-  "Last poll: \(if .last_poll_at == 0 then "never" else (.last_poll_at | strftime("%H:%M:%S")) end)",
-  "",
-  (.agents[] | "  [\(.state | ascii_upcase)] \(.window)  \(.worktree)/\(.branch)\n    \(.objective | .[0:70])")
-' ~/.claude/orchestrator-state.json
-
-for WINDOW in $(jq -r '.agents[] | select(.state != "done") | .window' ~/.claude/orchestrator-state.json); do
-  CMD=$(tmux display-message -t "$WINDOW" -p '#{pane_current_command}' 2>/dev/null || echo "unreachable")
-  echo "  $WINDOW live: $CMD"
-done
-```
-
-## Subcommand: poll
-
-Manual poll cycle (same logic as the CronCreate loop).
-
-```bash
-SKILLS_DIR=$(git rev-parse --show-toplevel)/.claude/skills/orchestrate
-ACTIONS=$(bash $SKILLS_DIR/scripts/poll-cycle.sh)
-echo "$ACTIONS" | jq .
-```
-
-Process each action per the rules in the CronCreate prompt above.
+Does **not** recycle running worktrees — agents may still be mid-task. Run `capacity.sh` to see what's still in progress.
 
 ## Key rules
 
-1. **Auto-assign spare worktrees** — never ask the user to pick a worktree path manually
-2. **Auto-close + recycle on done** — kill window, restore `spare/N` branch; this is how capacity frees up
-3. **Never restart a running agent** — only restart when foreground process is a shell
-4. **Handle settings errors automatically** — if "Enter to confirm" appears, send Down+Enter
-5. **Always use `--permission-mode bypassPermissions`** on every spawn
-6. **Escalate after 3 kicks** — mark as `escalated`, alert user
-7. **Atomic state writes** — `.tmp` + `mv` always
-8. **Never approve destructive commands** — when in doubt, escalate
-9. **Loop is session-scoped** — stops when this Claude session closes
+1. **Scripts do all the heavy lifting** — don't reimplement their logic inline in this file
+2. **Never ask the user to pick a worktree** — auto-assign from `find-spare.sh` output
+3. **Never restart a running agent** — only restart on `idle` kicks (foreground is a shell)
+4. **Auto-dismiss settings dialogs** — if "Enter to confirm" appears, send Down+Enter
+5. **Always `--permission-mode bypassPermissions`** on every spawn
+6. **Escalate after 3 kicks** — mark `escalated`, surface to user
+7. **Atomic state writes** — always write to `.tmp` then `mv`
+8. **Never approve destructive commands** outside the worktree scope — when in doubt, escalate

--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -24,6 +24,7 @@ STATE_FILE=~/.claude/orchestrator-state.json
 | `find-spare.sh [REPO_ROOT]` | List free worktrees — one `PATH BRANCH` per line | |
 | `spawn-agent.sh SESSION PATH SPARE NEW_BRANCH OBJECTIVE` | Create window + checkout branch + launch claude + send task. **Stdout: `SESSION:WIN` only** | |
 | `recycle-agent.sh WINDOW PATH SPARE_BRANCH` | Kill window + restore spare branch | |
+| `run-loop.sh` | Polling loop — runs in its own tmux window, zero token cost | |
 | `capacity.sh [REPO_ROOT]` | Print available + in-use worktrees | |
 | `status.sh` | Print fleet status + live pane commands | |
 | `poll-cycle.sh` | One monitoring cycle — returns JSON action array | |
@@ -48,7 +49,7 @@ Never committed to git. Claude maintains this file directly using `jq` + atomic 
   "active": true,
   "tmux_session": "autogpt1",
   "idle_threshold_seconds": 300,
-  "cron_job_id": "...",
+  "loop_window": "autogpt1:0",
   "last_poll_at": 0,
   "agents": [
     {
@@ -136,7 +137,7 @@ jq -n \
   --arg session "$SESSION" \
   --argjson threshold 300 \
   '{active:true, tmux_session:$session, idle_threshold_seconds:$threshold,
-    cron_job_id:null, last_poll_at:0, agents:[]}' \
+    loop_window:null, last_poll_at:0, agents:[]}' \
   > ~/.claude/orchestrator-state.json
 ```
 
@@ -146,50 +147,21 @@ jq --argjson a "$NEW_AGENT" '.agents += [$a]' ~/.claude/orchestrator-state.json 
   > /tmp/orch.tmp && mv /tmp/orch.tmp ~/.claude/orchestrator-state.json
 ```
 
-### 5. Run first poll, then start the cron
+### 5. Start the polling loop
+
+Open a dedicated `orchestrator` window in the same tmux session and run `run-loop.sh` there. It polls every 30s, handles all actions in bash, and costs zero Claude tokens.
 
 ```bash
-bash $SKILLS_DIR/poll-cycle.sh | jq .
+LOOP_WIN=$(tmux new-window -t "$SESSION" -n "orchestrator" -P -F '#{window_index}')
+LOOP_WINDOW="${SESSION}:${LOOP_WIN}"
+tmux send-keys -t "$LOOP_WINDOW" "bash $SKILLS_DIR/run-loop.sh" Enter
+
+# Store loop_window so we know how to stop it later
+jq --arg w "$LOOP_WINDOW" '.loop_window = $w' ~/.claude/orchestrator-state.json \
+  > /tmp/orch.tmp && mv /tmp/orch.tmp ~/.claude/orchestrator-state.json
 ```
 
-Then start CronCreate with this prompt (substitute the real absolute path for `SKILLS_DIR`):
-
-```text
-Orchestrator poll cycle.
-
-Run: bash SKILLS_DIR/poll-cycle.sh
-
-Read the JSON output array. For each action object:
-
-- action=="kick" AND state=="idle" (agent exited — shell is foreground):
-  Restart the agent:
-    tmux send-keys -t <window> "cd '<worktree_path>' && claude --permission-mode bypassPermissions" Enter
-  Wait 3s. Capture pane: if "Enter to confirm" visible, send Down+Enter first.
-  Then send: "<objective>. When all work is done, output the exact string: ORCHESTRATOR:DONE" Enter
-
-- action=="kick" AND state=="stuck" (claude still running but frozen):
-  Nudge only — do NOT restart:
-    tmux send-keys -t <window> "Continue with your task. Review any errors and proceed. When done output ORCHESTRATOR:DONE" Enter
-
-- action=="approve":
-  Capture pane: tmux capture-pane -t <window> -p | tail -5
-  SAFE to approve: git operations, install/build, tests, docker, curl to localhost
-  ESCALATE (set state=escalated, do not send keys) for: rm -rf outside worktree, force push to main/master, sudo, writing secrets to files
-  Settings dialog "Enter to confirm": send Down+Enter
-
-- action=="complete":
-  Recycle the worktree:
-    bash SKILLS_DIR/recycle-agent.sh <window> <worktree_path> <spare_branch>
-  Update state file: set agent .state = "done"
-    jq --arg w "<window>" '.agents |= map(if .window == $w then .state = "done" else . end)' \
-      ~/.claude/orchestrator-state.json > /tmp/orch.tmp && mv /tmp/orch.tmp ~/.claude/orchestrator-state.json
-  Print: "AGENT DONE + RECYCLED: <window> (<worktree>) → <spare_branch>"
-
-After processing all actions, print one summary line:
-"Poll [HH:MM] — N agents: X running, Y kicked, Z done+recycled, V escalated"
-```
-
-Store the returned cron job ID: update `.cron_job_id` in the state file.
+The loop window prints a timestamped summary line after every poll. Attach with `tmux attach -t "$SESSION"` and switch to the `orchestrator` window to watch it live.
 
 ## Adding an agent
 
@@ -198,12 +170,14 @@ Find the next spare worktree, then spawn and append to state — same as steps 2
 ## Stopping
 
 ```bash
-# Mark inactive so poll-cycle.sh exits early (active==false)
+# Mark inactive — run-loop.sh checks this and exits cleanly
 jq '.active = false' ~/.claude/orchestrator-state.json > /tmp/orch.tmp \
   && mv /tmp/orch.tmp ~/.claude/orchestrator-state.json
-```
 
-Cancel the cron job using CronDelete with `.cron_job_id` from the state file.
+# Kill the orchestrator window
+LOOP_WINDOW=$(jq -r '.loop_window // ""' ~/.claude/orchestrator-state.json)
+[ -n "$LOOP_WINDOW" ] && tmux kill-window -t "$LOOP_WINDOW" 2>/dev/null || true
+```
 
 Does **not** recycle running worktrees — agents may still be mid-task. Run `capacity.sh` to see what's still in progress.
 

--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -5,7 +5,7 @@ user-invocable: true
 argument-hint: "any free text — e.g. 'start 3 agents on X Y Z', 'show status', 'add task: implement feature A', 'stop', 'how many are free?'"
 metadata:
   author: autogpt-team
-  version: "5.0.0"
+  version: "6.0.0"
 ---
 
 # Orchestrate — Agent Fleet Supervisor
@@ -97,6 +97,7 @@ Never committed to git. You maintain this file directly using `jq` + atomic writ
       "state": "running",
       "last_output_hash": "",
       "last_seen_at": 0,
+      "spawned_at": 0,
       "idle_since": 0,
       "revision_count": 0,
       "last_rebriefed_at": 0
@@ -298,19 +299,88 @@ spawn-agent.sh automatically includes this instruction in every objective:
 > and `gh pr view PR_NUMBER --json title,body,headRefName` to reorient.
 > Output each completed step as `CHECKPOINT:<step-name>` on its own line.
 
-## Stopping
+## Passing images and screenshots to agents
+
+`tmux send-keys` is text-only — you cannot paste a raw image into a pane. To give an agent visual context (screenshots, diagrams, mockups):
+
+1. **Save the image to a temp file** with a stable path:
+   ```bash
+   # If the user drags in a screenshot or you receive a file path:
+   IMAGE_PATH="/tmp/orchestrator-context-$(date +%s).png"
+   cp "$USER_PROVIDED_PATH" "$IMAGE_PATH"
+   ```
+
+2. **Reference the path in the objective string**:
+   ```bash
+   OBJECTIVE="Implement the layout shown in /tmp/orchestrator-context-1234567890.png. Read that image first with the Read tool to understand the design."
+   ```
+
+3. The agent uses its `Read` tool to view the image at startup — Claude Code agents are multimodal and can read image files directly.
+
+**Rule**: always use `/tmp/orchestrator-context-<timestamp>.png` as the naming convention so the supervisor knows what to look for if it needs to re-brief an agent with the same image.
+
+---
+
+## When to stop the fleet
+
+Stop the fleet (`active = false`) when **all** of the following are true:
+
+| Check | How to verify |
+|---|---|
+| All agents are `done` or `escalated` | `jq '[.agents[] | select(.state | test("running\|stuck\|idle\|waiting_approval"))] | length' ~/.claude/orchestrator-state.json` == 0 |
+| All PRs have 0 unresolved review threads | GraphQL `isResolved` check per PR |
+| All PRs have green CI **on a run triggered after the agent's last push** | `gh run list --branch BRANCH --limit 1` timestamp > `spawned_at` in state |
+| No agents are `escalated` without human review | If any are escalated, surface to user first |
+
+**Do NOT stop just because agents output `ORCHESTRATOR:DONE`.** That is a signal to verify, not a signal to stop.
+
+**Do stop** if the user explicitly says "stop", "shut down", or "kill everything", even with agents still running.
 
 ```bash
-# Mark inactive — run-loop.sh checks this and exits cleanly
+# Graceful stop
 jq '.active = false' ~/.claude/orchestrator-state.json > /tmp/orch.tmp \
   && mv /tmp/orch.tmp ~/.claude/orchestrator-state.json
 
-# Kill the orchestrator window
 LOOP_WINDOW=$(jq -r '.loop_window // ""' ~/.claude/orchestrator-state.json)
 [ -n "$LOOP_WINDOW" ] && tmux kill-window -t "$LOOP_WINDOW" 2>/dev/null || true
+
+SUP_WINDOW=$(jq -r '.supervisor_window // ""' ~/.claude/orchestrator-state.json)
+[ -n "$SUP_WINDOW" ] && tmux kill-window -t "$SUP_WINDOW" 2>/dev/null || true
 ```
 
 Does **not** recycle running worktrees — agents may still be mid-task. Run `capacity.sh` to see what's still in progress.
+
+## tmux send-keys pattern
+
+**Always split long messages into text + Enter as two separate calls with a sleep between them.** If sent as one call (`"text" Enter`), Enter can fire before the full string is buffered into Claude's input — leaving the message stuck as `[Pasted text +N lines]` unsent.
+
+```bash
+# CORRECT — text then Enter separately
+tmux send-keys -t "$WINDOW" "your long message here"
+sleep 0.3
+tmux send-keys -t "$WINDOW" Enter
+
+# WRONG — Enter may fire before text is buffered
+tmux send-keys -t "$WINDOW" "your long message here" Enter
+```
+
+Short single-character sends (`y`, `Down`, empty Enter for dialog approval) are safe to combine since they have no buffering lag.
+
+---
+
+## Protected worktrees
+
+Some worktrees must **never** be used as spare worktrees for agent tasks because they host files critical to the orchestrator itself:
+
+| Worktree | Protected branch | Why |
+|---|---|---|
+| `AutoGPT1` | `dx/orchestrate-skill` | Hosts the orchestrate skill scripts. `recycle-agent.sh` would check out `spare/1`, wiping `.claude/skills/` and breaking all subsequent `spawn-agent.sh` calls. |
+
+**Rule**: when selecting spare worktrees via `find-spare.sh`, skip any worktree whose CURRENT branch matches a protected branch. If you accidentally spawn an agent in a protected worktree, do not let `recycle-agent.sh` run on it — manually restore the branch after the agent finishes.
+
+When `dx/orchestrate-skill` is merged into `dev`, `AutoGPT1` becomes a normal spare again.
+
+---
 
 ## Key rules
 
@@ -325,3 +395,7 @@ Does **not** recycle running worktrees — agents may still be mid-task. Run `ca
 9. **Never recycle without verification** — `verify-complete.sh` must pass before recycling
 10. **No TASK.md files** — commit risk; use state file + `gh pr view` for agent context persistence
 11. **Re-brief stalled agents** — read objective from state file + `gh pr view`, send via tmux
+12. **ORCHESTRATOR:DONE is a signal to verify, not to accept** — always run `verify-complete.sh` and check CI run timestamp before recycling
+13. **Protected worktrees** — never use the worktree hosting the skill scripts as a spare
+14. **Images via file path** — save screenshots to `/tmp/orchestrator-context-<ts>.png`, pass path in objective; agents read with the `Read` tool
+15. **Split send-keys** — always separate text and Enter with `sleep 0.3` between calls for long strings

--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -14,7 +14,7 @@ One tmux session, N windows — each window is one agent in one worktree. The or
 
 ## Worktree lifecycle
 
-```
+```text
 spare/N branch   →   orchestrate add   →   new window + feat/branch + claude running
                                                         ↓
                                                ORCHESTRATOR:DONE
@@ -80,7 +80,7 @@ git worktree list --porcelain | awk '
 ```
 
 Example output:
-```
+```text
 /path/to/worktrees/AutoGPT3 spare/3
 /path/to/worktrees/AutoGPT7 spare/7
 ```
@@ -273,7 +273,7 @@ bash $SKILLS_DIR/scripts/poll-cycle.sh | jq .
 ```
 
 CronCreate prompt (fill in SKILLS_DIR with absolute path):
-```
+```text
 Orchestrator poll cycle.
 
 Run: bash SKILLS_DIR/scripts/poll-cycle.sh

--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -32,16 +32,16 @@ STATE_FILE=~/.claude/orchestrator-state.json
 | `poll-cycle.sh` | One monitoring cycle — classifies panes, tracks checkpoints, returns JSON action array |
 | `classify-pane.sh WINDOW` | Classify one pane state |
 
-## Two-layer supervision model
+## Supervision model
 
 ```
-Supervisor window (dedicated Claude Code in tmux, runs continuously)
+Orchestrating Claude (this Claude session — IS the supervisor)
   └── Reads pane output, checks CI, intervenes with targeted guidance
         run-loop.sh (separate tmux window, every 30s)
           └── Mechanical only: idle restart, dialog approval, recycle on ORCHESTRATOR:DONE
 ```
 
-**Supervisor window** is the intelligence layer — a dedicated Claude Code instance running in its own tmux window. It reads each agent's pane, checks PR CI/threads, and sends specific guidance when agents stall, deviate, or claim completion without meeting all criteria. Running in its own window means it doesn't pollute the user's main Claude session context, and survives context compression.
+**You (the orchestrating Claude)** are the supervisor. After spawning agents, stay in this conversation and actively monitor: poll each agent's pane every 2-3 minutes, check CI, nudge stalled agents, and verify completions. Do not spawn a separate supervisor Claude window — it loses context, is hard to observe, and compounds context compression problems.
 
 **run-loop.sh** is the mechanical layer — zero tokens, handles things that need no judgment: restart crashed agents, press Enter on dialogs, recycle completed worktrees (only after `verify-complete.sh` passes).
 
@@ -79,7 +79,6 @@ Never committed to git. You maintain this file directly using `jq` + atomic writ
   "tmux_session": "autogpt1",
   "idle_threshold_seconds": 300,
   "loop_window": "autogpt1:5",
-  "supervisor_window": "autogpt1:6",
   "repo": "Significant-Gravitas/AutoGPT",
   "discord_webhook": "https://discord.com/api/webhooks/...",
   "last_poll_at": 0,
@@ -109,7 +108,6 @@ Never committed to git. You maintain this file directly using `jq` + atomic writ
 Top-level optional fields:
 - `repo` — GitHub `owner/repo` for CI/thread checks. Auto-derived from git remote if omitted.
 - `discord_webhook` — Discord webhook URL for completion notifications. Also reads `DISCORD_WEBHOOK_URL` env var.
-- `supervisor_window` — tmux window running the supervisor Claude; `run-loop.sh` restarts it if it exits.
 
 Per-agent optional fields:
 - `last_rebriefed_at` — Unix timestamp of last re-brief; enforces 5-min cooldown to prevent spam.
@@ -200,9 +198,8 @@ jq --arg hook "$DISCORD_WEBHOOK_URL" '.discord_webhook = $hook' ~/.claude/orches
 
 `spawn-agent.sh` writes the initial agent record (window, worktree_path, branch, objective, state, etc.) to the state file automatically — **do not append the record again after calling it.** The record already exists and `pr_number`/`steps` are patched in by the script itself.
 
-### 5. Start both supervision layers
+### 5. Start the mechanical babysitter
 
-**Layer 1 — mechanical babysitter** (tmux window, zero tokens):
 ```bash
 LOOP_WIN=$(tmux new-window -t "$SESSION" -n "orchestrator" -P -F '#{window_index}')
 LOOP_WINDOW="${SESSION}:${LOOP_WIN}"
@@ -212,98 +209,63 @@ jq --arg w "$LOOP_WINDOW" '.loop_window = $w' ~/.claude/orchestrator-state.json 
   > /tmp/orch.tmp && mv /tmp/orch.tmp ~/.claude/orchestrator-state.json
 ```
 
-**Layer 2 — intelligent supervisor** (dedicated Claude Code window):
+### 6. Begin supervising directly in this conversation
 
-Open a new tmux window in the SAME session and launch Claude there:
-
-```bash
-SUP_WIN=$(tmux new-window -t "$SESSION" -n "supervisor" -P -F '#{window_index}')
-SUP_WINDOW="${SESSION}:${SUP_WIN}"
-SKILLS_DIR_ABS="$(git -C "$(git rev-parse --show-toplevel)" rev-parse --show-toplevel)/.claude/skills/orchestrate/scripts"
-
-tmux send-keys -t "$SUP_WINDOW" "cd '$(git rev-parse --show-toplevel)' && claude --permission-mode bypassPermissions" Enter
-# Wait for claude to be ready (same pattern as spawn-agent.sh)
-# Then send the supervisor prompt:
-```
-
-Send this prompt to the supervisor window (fill in real session, window IDs, and skills dir):
-
-```text
-You are the intelligent supervisor for a Claude agent fleet.
-
-Your job: every 2-3 minutes, check all running agents and intervene when needed.
-
-SELF-RECOVERY: If your own context compacts and you lose track of what you were doing,
-re-read the state file: cat ~/.claude/orchestrator-state.json | jq
-That gives you the full picture. Resume supervision immediately.
-
-State file: cat ~/.claude/orchestrator-state.json | jq
-
-SKILLS_DIR: <SKILLS_DIR_ABS>
-
-For each running agent, read their pane:
-  tmux capture-pane -t SESSION:WIN -p -S -200 | tail -80
-
-For each agent decide:
-- Actively working (spinner/tools running) → do nothing
-- Idle at ❯ prompt without ORCHESTRATOR:DONE → stalled; send specific nudge:
-    tmux send-keys -t SESSION:WIN "Your objective: <restate from state file>. Continue from where you left off." Enter
-- Stuck in loop / repeating error → send targeted fix guidance
-- Waiting for input / asking a question → answer and unblock
-- CI red → run: gh pr checks PR_NUMBER --repo $(jq -r '.repo // "Significant-Gravitas/AutoGPT"' ~/.claude/orchestrator-state.json)
-    then tell the agent exactly what's failing and how to fix it
-- Context compacted, agent appears lost → send recovery command:
-    tmux send-keys -t SESSION:WIN "Run: cat ~/.claude/orchestrator-state.json | jq '.agents[] | select(.window==\"SESSION:WIN\")' and gh pr view PR_NUMBER --json title,body,headRefName to reorient, then continue your task." Enter
-- Claims ORCHESTRATOR:DONE → run verify-complete.sh:
-    bash SKILLS_DIR/verify-complete.sh SESSION:WIN
-    If it fails, re-brief the agent with the specific failure reason.
-
-Only surface to the user if a strategic decision is needed.
-When all agents reach state "done" or "escalated", your job is complete.
-
-Begin your first check now, then loop every 2-3 minutes.
-```
-
-Store the supervisor window in the state file:
-
-```bash
-jq --arg w "$SUP_WINDOW" '.supervisor_window = $w' ~/.claude/orchestrator-state.json \
-  > /tmp/orch.tmp && mv /tmp/orch.tmp ~/.claude/orchestrator-state.json
-```
+You are the supervisor. After spawning, immediately start your first poll loop (see **Supervisor duties** below) and continue every 2-3 minutes. Do NOT spawn a separate supervisor Claude window.
 
 ## Adding an agent
 
 Find the next spare worktree, then spawn and append to state — same as steps 2–4 above but for a single task. If no spare worktrees are available, tell the user.
 
-## Supervisor duties (what the supervisor window does every 2-3 min)
+## Supervisor duties (YOUR job, every 2-3 min in this conversation)
 
-1. Read `~/.claude/orchestrator-state.json` to get agent windows and objectives
-2. For each agent in `running`/`idle`/`stuck` state, capture pane output
-3. **Check for stalling**: no new output in last 5+ min → send specific re-orientation message referencing the objective from state
-4. **Check for deviation**: agent doing something unrelated to its objective → correct immediately with a specific redirect
-5. **Check for PR issues**: unresolved threads, CI failures → tell the agent exactly what's failing and how to fix it
-6. **Strict ORCHESTRATOR:DONE gate** — when agent outputs ORCHESTRATOR:DONE, run ALL three checks before allowing recycling:
-   ```bash
-   # 1. Checkpoints + 0 threads + CI green
-   bash SKILLS_DIR/verify-complete.sh SESSION:WIN
+You are the supervisor. Run this poll loop directly in your Claude session — not in a separate window.
 
-   # 2. CI ran AFTER agent spawned (proves agent actually pushed something new)
-   SPAWNED_AT=$(jq -r --arg w SESSION:WIN '.agents[] | select(.window==$w) | .spawned_at // 0' ~/.claude/orchestrator-state.json)
-   LATEST_RUN=$(gh run list --repo REPO --branch BRANCH --limit 1 --json createdAt --jq '.[0].createdAt')
-   # LATEST_RUN must be after SPAWNED_AT
+### Poll loop (repeat every 2-3 min until all agents done)
 
-   # 3. No CHANGES_REQUESTED review decision
-   gh pr view PR_NUMBER --json reviewDecision --jq '.reviewDecision'
-   ```
-   If any check fails, tell the agent specifically what's missing and mark state back to `running`. Do not allow recycling until all three pass.
-7. **Re-brief after context compaction**: if agent asks "what should I do?" or appears lost:
-   ```bash
-   cat ~/.claude/orchestrator-state.json | jq '.agents[] | select(.window=="SESSION:WIN")'
-   gh pr view PR_NUMBER --json title,body,headRefName
-   ```
-   Send objective + PR context via tmux (remember: split send-keys, sleep 0.3 between text and Enter).
-   If `image_path` is set on the agent, include: "Re-read context at IMAGE_PATH with the Read tool."
-8. **send-keys rule**: never combine long text and Enter in one call — always `send-keys "text"` then `sleep 0.3` then `send-keys Enter`
+```bash
+# 1. Read state
+cat ~/.claude/orchestrator-state.json | jq '.agents[] | {window, worktree, branch, state, pr_number, checkpoints}'
+
+# 2. For each running/stuck/idle agent, capture pane
+tmux capture-pane -t SESSION:WIN -p -S -200 | tail -60
+```
+
+For each agent, decide:
+
+| What you see | Action |
+|---|---|
+| Spinner / tools running | Do nothing — agent is working |
+| Idle `❯` prompt, no `ORCHESTRATOR:DONE` | Stalled — send specific nudge with objective from state |
+| Stuck in error loop | Send targeted fix with exact error + solution |
+| Waiting for input / question | Answer and unblock via `tmux send-keys` |
+| CI red | `gh pr checks PR_NUMBER --repo REPO` → tell agent exactly what's failing |
+| Context compacted / agent lost | Send recovery: `cat ~/.claude/orchestrator-state.json | jq '.agents[] | select(.window=="WIN")'` + `gh pr view PR_NUMBER --json title,body` |
+| `ORCHESTRATOR:DONE` in output | Run `verify-complete.sh` — if it fails, re-brief with specific reason |
+
+### Strict ORCHESTRATOR:DONE gate
+
+`verify-complete.sh` handles the main checks automatically (checkpoints, threads, CHANGES_REQUESTED, CI green, spawned_at). Run it:
+
+```bash
+SKILLS_DIR=~/.claude/orchestrator/scripts
+bash $SKILLS_DIR/verify-complete.sh SESSION:WIN
+```
+
+If it passes → run-loop.sh will recycle the window automatically. No manual action needed.
+If it fails → re-brief the agent with the failure reason. Never manually mark state `done` to bypass this.
+
+### Re-brief a stalled agent
+
+```bash
+OBJ=$(jq -r --arg w SESSION:WIN '.agents[] | select(.window==$w) | .objective' ~/.claude/orchestrator-state.json)
+PR=$(jq -r --arg w SESSION:WIN '.agents[] | select(.window==$w) | .pr_number' ~/.claude/orchestrator-state.json)
+tmux send-keys -t SESSION:WIN "You appear stalled. Your objective: $OBJ. Check: gh pr view $PR --json title,body,headRefName to reorient."
+sleep 0.3
+tmux send-keys -t SESSION:WIN Enter
+```
+
+If `image_path` is set on the agent record, include: "Re-read context at IMAGE_PATH with the Read tool."
 
 ## Self-recovery protocol (agents)
 
@@ -358,9 +320,6 @@ jq '.active = false' ~/.claude/orchestrator-state.json > /tmp/orch.tmp \
 
 LOOP_WINDOW=$(jq -r '.loop_window // ""' ~/.claude/orchestrator-state.json)
 [ -n "$LOOP_WINDOW" ] && tmux kill-window -t "$LOOP_WINDOW" 2>/dev/null || true
-
-SUP_WINDOW=$(jq -r '.supervisor_window // ""' ~/.claude/orchestrator-state.json)
-[ -n "$SUP_WINDOW" ] && tmux kill-window -t "$SUP_WINDOW" 2>/dev/null || true
 ```
 
 Does **not** recycle running worktrees — agents may still be mid-task. Run `capacity.sh` to see what's still in progress.

--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -381,6 +381,57 @@ spawn-agent.sh automatically includes this instruction in every objective:
 
 ---
 
+## Orchestrator final evaluation (YOU decide, not the script)
+
+`verify-complete.sh` is a gate — it blocks premature marking. But it cannot tell you if the work is actually good. That is YOUR job.
+
+When run-loop marks an agent `pending_evaluation` and you're notified, do all of these before marking done:
+
+### 1. Run /pr-test (required, serialized, use TodoWrite to queue)
+
+`/pr-test` is the only reliable confirmation that the objective is actually met. Run it yourself, not the agent.
+
+**When multiple PRs reach `pending_evaluation` at the same time, use TodoWrite to queue them:**
+```
+- [ ] /pr-test PR #12636 — fix copilot retry logic
+- [ ] /pr-test PR #12699 — builder chat panel
+```
+Run one at a time. Check off as you go.
+
+```
+/pr-test https://github.com/Significant-Gravitas/AutoGPT/pull/PR_NUMBER
+```
+
+**/pr-test can be lazy** — if it gives vague output, re-run with full context:
+
+```
+/pr-test https://github.com/OWNER/REPO/pull/PR_NUMBER
+Context: This PR implements <objective from state file>. Key files: <list>.
+Please verify: <specific behaviors to check>.
+```
+
+Only one `/pr-test` at a time — they share ports and DB.
+
+### 2. Do your own evaluation
+
+1. **Read the PR diff and objective** — does the code actually implement what was asked? Is anything obviously missing or half-done?
+2. **Read the resolved threads** — were comments addressed with real fixes, or just dismissed/resolved without changes?
+3. **Check CI run names** — any suspicious retries that shouldn't have passed?
+4. **Check the PR description** — title, summary, test plan complete?
+
+### 3. Decide
+
+- `/pr-test` passes + evaluation looks good → mark `done` in state, tell the user the PR is ready, ask if window should be closed
+- `/pr-test` fails or evaluation finds gaps → re-brief the agent with specific failures, set state back to `running`
+
+**Never mark done based purely on script output.** You hold the full objective context; the script does not.
+
+```bash
+# Mark done after your positive evaluation:
+jq --arg w "SESSION:WIN" '(.agents[] | select(.window == $w)).state = "done"' \
+  ~/.claude/orchestrator-state.json > /tmp/orch.tmp && mv /tmp/orch.tmp ~/.claude/orchestrator-state.json
+```
+
 ## When to stop the fleet
 
 Stop the fleet (`active = false`) when **all** of the following are true:

--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -221,7 +221,22 @@ Find the next spare worktree, then spawn and append to state — same as steps 2
 
 You are the supervisor. Run this poll loop directly in your Claude session — not in a separate window.
 
-### Poll loop (repeat every 2-3 min until all agents done)
+### Poll loop mechanism
+
+You are reactive — you only act when a tool completes or the user sends a message. To create a self-sustaining poll loop without user involvement:
+
+1. Start each poll with `run_in_background: true` + a sleep before the work:
+   ```bash
+   sleep 120 && tmux capture-pane -t autogpt1:0 -p -S -200 | tail -40
+   # + similar for each active window
+   ```
+2. When the background job notifies you, read the pane output and take action.
+3. Immediately schedule the next background poll — this keeps the loop alive.
+4. Stop scheduling when all agents are done/escalated.
+
+**Never tell the user "I'll poll every 2-3 minutes"** — that does nothing without a trigger. Start the background job instead.
+
+### Each poll: what to check
 
 ```bash
 # 1. Read state

--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -95,11 +95,7 @@ When the intent is ambiguous, show capacity first and ask what tasks to run.
 tmux list-sessions -F "#{session_name}: #{session_windows} windows" 2>/dev/null
 ```
 
-Use the existing session. If none exist, create one:
-```bash
-tmux new-session -d -s autogpt1
-SESSION="autogpt1"
-```
+Use an existing session. **Never create a tmux session from within Claude** — it becomes a child of Claude's process and dies when the session ends. If no session exists, tell the user to run `tmux new-session -d -s autogpt1` in their terminal first, then re-invoke `/orchestrate`.
 
 ### 2. Show available capacity
 

--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -58,15 +58,38 @@ Required steps are passed as args to `spawn-agent.sh` (e.g. `pr-address pr-test`
 ## Worktree lifecycle
 
 ```text
-spare/N branch  →  spawn-agent.sh  →  window + feat/branch + claude running
-                                                ↓
-                                  CHECKPOINT:<step> (as steps complete)
-                                                ↓
-                                         ORCHESTRATOR:DONE
-                                                ↓
-                          verify-complete.sh: checkpoints ✓ + 0 threads + CI green
-                                                ↓
-                               recycle-agent.sh → spare/N (free again)
+spare/N branch  →  spawn-agent.sh (--session-id UUID)  →  window + feat/branch + claude running
+                                                                 ↓
+                                               CHECKPOINT:<step> (as steps complete)
+                                                                 ↓
+                                                        ORCHESTRATOR:DONE
+                                                                 ↓
+                                    verify-complete.sh: checkpoints ✓ + 0 threads + CI green
+                                                                 ↓
+                                              state → "done", notify, window KEPT OPEN
+                                                                 ↓
+                              user/orchestrator explicitly requests recycle
+                                                                 ↓
+                                         recycle-agent.sh → spare/N (free again)
+```
+
+**Windows are never auto-killed.** The worktree stays on its branch, the session stays alive. The agent is done working but the window, git state, and Claude session are all preserved until you choose to recycle.
+
+**To resume a done or crashed session:**
+```bash
+# Resume by stored session ID (preferred — exact session, full context)
+claude --resume SESSION_ID --permission-mode bypassPermissions
+
+# Or resume most recent session in that worktree directory
+cd /path/to/worktree && claude --continue --permission-mode bypassPermissions
+```
+
+**To manually recycle when ready:**
+```bash
+bash ~/.claude/orchestrator/scripts/recycle-agent.sh SESSION:WIN WORKTREE_PATH spare/N
+# Then update state:
+jq --arg w "SESSION:WIN" '.agents |= map(if .window == $w then .state = "recycled" else . end)' \
+  ~/.claude/orchestrator-state.json > /tmp/orch.tmp && mv /tmp/orch.tmp ~/.claude/orchestrator-state.json
 ```
 
 ## State file (`~/.claude/orchestrator-state.json`)
@@ -91,6 +114,7 @@ Never committed to git. You maintain this file directly using `jq` + atomic writ
       "branch": "feat/my-feature",
       "objective": "Implement X and open a PR",
       "pr_number": "12345",
+      "session_id": "550e8400-e29b-41d4-a716-446655440000",
       "steps": ["pr-address", "pr-test"],
       "checkpoints": ["pr-address"],
       "state": "running",
@@ -109,10 +133,13 @@ Top-level optional fields:
 - `repo` — GitHub `owner/repo` for CI/thread checks. Auto-derived from git remote if omitted.
 - `discord_webhook` — Discord webhook URL for completion notifications. Also reads `DISCORD_WEBHOOK_URL` env var.
 
-Per-agent optional fields:
+Per-agent fields:
+- `session_id` — UUID passed to `claude --session-id` at spawn; use with `claude --resume UUID` to restore exact session context after a crash or window close.
 - `last_rebriefed_at` — Unix timestamp of last re-brief; enforces 5-min cooldown to prevent spam.
 
 Agent states: `running` | `idle` | `stuck` | `waiting_approval` | `complete` | `done` | `escalated`
+
+`done` means verified complete — window is still open, session still alive, worktree still on task branch. Not recycled yet.
 
 ## Intent → action mapping
 

--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -5,7 +5,7 @@ user-invocable: true
 argument-hint: "any free text — e.g. 'start 3 agents on X Y Z', 'show status', 'add task: implement feature A', 'stop', 'how many are free?'"
 metadata:
   author: autogpt-team
-  version: "3.0.0"
+  version: "4.0.0"
 ---
 
 # Orchestrate — Agent Fleet Supervisor
@@ -22,9 +22,10 @@ STATE_FILE=~/.claude/orchestrator-state.json
 | Script | Purpose |
 |---|---|
 | `find-spare.sh [REPO_ROOT]` | List free worktrees — one `PATH BRANCH` per line |
-| `spawn-agent.sh SESSION PATH SPARE NEW_BRANCH OBJECTIVE` | Create window + checkout branch + launch claude + send task. **Stdout: `SESSION:WIN` only** |
+| `spawn-agent.sh SESSION PATH SPARE NEW_BRANCH OBJECTIVE [PR_NUMBER] [STEPS...]` | Create window + checkout branch + launch claude + send task. **Stdout: `SESSION:WIN` only** |
 | `recycle-agent.sh WINDOW PATH SPARE_BRANCH` | Kill window + restore spare branch |
-| `run-loop.sh` | **Mechanical babysitter** — idle restart + dialog approval + recycle. No intelligence. |
+| `run-loop.sh` | **Mechanical babysitter** — idle restart + dialog approval + recycle on ORCHESTRATOR:DONE |
+| `verify-complete.sh WINDOW` | Verify PR is done: checkpoints ✓ + 0 unresolved threads + CI green |
 | `capacity.sh [REPO_ROOT]` | Print available + in-use worktrees |
 | `status.sh` | Print fleet status + live pane commands |
 | `poll-cycle.sh` | One monitoring cycle — returns JSON action array |
@@ -33,36 +34,50 @@ STATE_FILE=~/.claude/orchestrator-state.json
 ## Two-layer supervision model
 
 ```
-CronCreate (this session, every 3 min)
+Supervisor window (dedicated Claude Code in tmux, runs continuously)
   └── Reads pane output, checks CI, intervenes with targeted guidance
-        run-loop.sh (tmux window, every 30s)
+        run-loop.sh (separate tmux window, every 30s)
           └── Mechanical only: idle restart, dialog approval, recycle on ORCHESTRATOR:DONE
 ```
 
-**CronCreate** is the intelligence layer — it runs in the main Claude session so it has full context and can make real decisions. It reads each agent's pane, checks PR CI status, and sends specific guidance when agents stall or deviate.
+**Supervisor window** is the intelligence layer — a dedicated Claude Code instance running in its own tmux window. It reads each agent's pane, checks PR CI/threads, and sends specific guidance when agents stall, deviate, or claim completion without meeting all criteria. Running in its own window means it doesn't pollute the user's main Claude session context, and survives context compression.
 
-**run-loop.sh** is the mechanical layer — zero tokens, handles things that need no judgment: restart crashed agents, press Enter on dialogs, recycle completed worktrees.
+**run-loop.sh** is the mechanical layer — zero tokens, handles things that need no judgment: restart crashed agents, press Enter on dialogs, recycle completed worktrees (only after `verify-complete.sh` passes).
+
+## Checkpoint protocol
+
+Agents output checkpoints as they complete each required step:
+
+```
+CHECKPOINT:<step-name>
+```
+
+Required steps are passed as args to `spawn-agent.sh` (e.g. `pr-address pr-test`). `run-loop.sh` will not recycle a window until all required checkpoints are found in the pane output. If `verify-complete.sh` fails, the agent is re-briefed automatically.
 
 ## Worktree lifecycle
 
 ```text
 spare/N branch  →  spawn-agent.sh  →  window + feat/branch + claude running
                                                 ↓
+                                  CHECKPOINT:<step> (as steps complete)
+                                                ↓
                                          ORCHESTRATOR:DONE
+                                                ↓
+                          verify-complete.sh: checkpoints ✓ + 0 threads + CI green
                                                 ↓
                                recycle-agent.sh → spare/N (free again)
 ```
 
 ## State file (`~/.claude/orchestrator-state.json`)
 
-Never committed to git. Claude maintains this file directly using `jq` + atomic writes (`.tmp` → `mv`).
+Never committed to git. You maintain this file directly using `jq` + atomic writes (`.tmp` → `mv`).
 
 ```json
 {
   "active": true,
   "tmux_session": "autogpt1",
   "idle_threshold_seconds": 300,
-  "loop_window": "autogpt1:0",
+  "loop_window": "autogpt1:5",
   "last_poll_at": 0,
   "agents": [
     {
@@ -72,6 +87,9 @@ Never committed to git. Claude maintains this file directly using `jq` + atomic 
       "spare_branch": "spare/6",
       "branch": "feat/my-feature",
       "objective": "Implement X and open a PR",
+      "pr_number": "12345",
+      "steps": ["pr-address", "pr-test"],
+      "checkpoints": ["pr-address"],
       "state": "running",
       "last_output_hash": "",
       "last_seen_at": 0,
@@ -121,6 +139,8 @@ bash $SKILLS_DIR/capacity.sh $(git rev-parse --show-toplevel)
 For each task, gather:
 - **objective** — what to do (e.g. "implement feature X and open a PR")
 - **branch name** — e.g. `feat/my-feature` (derive from objective if not given)
+- **pr_number** — GitHub PR number if working on an existing PR (for verification)
+- **steps** — required checkpoint names in order (e.g. `pr-address pr-test`) — derive from objective
 
 Ask for `idle_threshold_seconds` only if the user mentions it (default: 300).
 
@@ -136,6 +156,10 @@ SPARE_LIST=$(bash $SKILLS_DIR/find-spare.sh $(git rev-parse --show-toplevel))
 WORKTREE_PATH=$(echo "$SPARE_LINE" | awk '{print $1}')
 SPARE_BRANCH=$(echo "$SPARE_LINE" | awk '{print $2}')
 
+# With PR number and required steps:
+WINDOW=$(bash $SKILLS_DIR/spawn-agent.sh "$SESSION" "$WORKTREE_PATH" "$SPARE_BRANCH" "$NEW_BRANCH" "$OBJECTIVE" "$PR_NUMBER" "pr-address" "pr-test")
+
+# Without PR (new work):
 WINDOW=$(bash $SKILLS_DIR/spawn-agent.sh "$SESSION" "$WORKTREE_PATH" "$SPARE_BRANCH" "$NEW_BRANCH" "$OBJECTIVE")
 ```
 
@@ -168,32 +192,88 @@ jq --arg w "$LOOP_WINDOW" '.loop_window = $w' ~/.claude/orchestrator-state.json 
   > /tmp/orch.tmp && mv /tmp/orch.tmp ~/.claude/orchestrator-state.json
 ```
 
-**Layer 2 — intelligent supervisor** (CronCreate in this session, every 3 min):
+**Layer 2 — intelligent supervisor** (dedicated Claude Code window):
 
-Use CronCreate with this prompt (fill in the real window IDs and agent context):
+Open a new tmux window in the SAME session and launch Claude there:
+
+```bash
+SUP_WIN=$(tmux new-window -t "$SESSION" -n "supervisor" -P -F '#{window_index}')
+SUP_WINDOW="${SESSION}:${SUP_WIN}"
+SKILLS_DIR_ABS="$(git -C "$(git rev-parse --show-toplevel)" rev-parse --show-toplevel)/.claude/skills/orchestrate/scripts"
+
+tmux send-keys -t "$SUP_WINDOW" "cd '$(git rev-parse --show-toplevel)' && claude --permission-mode bypassPermissions" Enter
+# Wait for claude to be ready (same pattern as spawn-agent.sh)
+# Then send the supervisor prompt:
+```
+
+Send this prompt to the supervisor window (fill in real session, window IDs, and skills dir):
 
 ```text
-You are supervising Claude agents working on PRs. Check each agent now.
+You are the intelligent supervisor for a Claude agent fleet.
 
-Read their pane output:
-  tmux capture-pane -t SESSION:WIN -p -S -40 | tail -40
-  (repeat for each agent window)
+Your job: every 2-3 minutes, check all running agents and intervene when needed.
+
+State file: cat ~/.claude/orchestrator-state.json | jq
+
+SKILLS_DIR: <SKILLS_DIR_ABS>
+
+For each running agent, read their pane:
+  tmux capture-pane -t SESSION:WIN -p -S -200 | tail -80
 
 For each agent decide:
 - Actively working (spinner/tools running) → do nothing
-- Idle at ❯ prompt without ORCHESTRATOR:DONE → stalled, send specific nudge based on last seen action
-- Stuck in loop / repeating error → intervene with targeted fix guidance
+- Idle at ❯ prompt without ORCHESTRATOR:DONE → stalled; send specific nudge:
+    tmux send-keys -t SESSION:WIN "Your objective: <restate from state file>. Continue from where you left off." Enter
+- Stuck in loop / repeating error → send targeted fix guidance
 - Waiting for input / asking a question → answer and unblock
-- CI red → check gh pr checks N, tell the agent what's failing and how to fix
+- CI red → run: gh pr checks PR_NUMBER --repo Significant-Gravitas/AutoGPT
+    then tell the agent exactly what's failing and how to fix it
+- Context compacted, agent appears lost → send recovery command:
+    tmux send-keys -t SESSION:WIN "Run: cat ~/.claude/orchestrator-state.json | jq '.agents[] | select(.window==\"SESSION:WIN\")' and gh pr view PR_NUMBER --json title,body,headRefName to reorient, then continue your task." Enter
+- Claims ORCHESTRATOR:DONE → run verify-complete.sh:
+    bash SKILLS_DIR/verify-complete.sh SESSION:WIN
+    If it fails, re-brief the agent with the specific failure reason.
 
 Only surface to the user if a strategic decision is needed.
+When all agents reach state "done" or "escalated", your job is complete.
+
+Begin your first check now, then loop every 2-3 minutes.
 ```
 
-Store the cron job ID in the state file: `.supervisor_cron_id`.
+Store the supervisor window in the state file:
+
+```bash
+jq --arg w "$SUP_WINDOW" '.supervisor_window = $w' ~/.claude/orchestrator-state.json \
+  > /tmp/orch.tmp && mv /tmp/orch.tmp ~/.claude/orchestrator-state.json
+```
 
 ## Adding an agent
 
 Find the next spare worktree, then spawn and append to state — same as steps 2–4 above but for a single task. If no spare worktrees are available, tell the user.
+
+## Supervisor duties (what the supervisor window does every 2-3 min)
+
+1. Read `~/.claude/orchestrator-state.json` to get agent windows and objectives
+2. For each agent in `running`/`idle`/`stuck` state, capture pane output
+3. **Check for stalling**: no new output in last 5+ min → send specific re-orientation message
+4. **Check for deviation**: agent doing something unrelated → correct it
+5. **Check for PR issues**: unresolved threads, CI failures → inform agent with specifics
+6. **Verify claims of completion**: run `verify-complete.sh` when agent says ORCHESTRATOR:DONE (run-loop.sh also does this, but you catch it faster)
+7. **Re-brief after context compaction**: if agent asks "what should I do?" or appears lost, run:
+   ```bash
+   cat ~/.claude/orchestrator-state.json | jq '.agents[] | select(.window=="SESSION:WIN")'
+   gh pr view PR_NUMBER --json title,body,headRefName
+   ```
+   Then send the agent its objective + PR context via tmux
+
+## Self-recovery protocol (agents)
+
+spawn-agent.sh automatically includes this instruction in every objective:
+
+> If your context compacts and you lose track of what to do, run:
+> `cat ~/.claude/orchestrator-state.json | jq '.agents[] | select(.window=="SESSION:WIN")'`
+> and `gh pr view PR_NUMBER --json title,body,headRefName` to reorient.
+> Output each completed step as `CHECKPOINT:<step-name>` on its own line.
 
 ## Stopping
 
@@ -219,3 +299,6 @@ Does **not** recycle running worktrees — agents may still be mid-task. Run `ca
 6. **Escalate after 3 kicks** — mark `escalated`, surface to user
 7. **Atomic state writes** — always write to `.tmp` then `mv`
 8. **Never approve destructive commands** outside the worktree scope — when in doubt, escalate
+9. **Never recycle without verification** — `verify-complete.sh` must pass before recycling
+10. **No TASK.md files** — commit risk; use state file + `gh pr view` for agent context persistence
+11. **Re-brief stalled agents** — read objective from state file + `gh pr view`, send via tmux

--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -279,16 +279,31 @@ Find the next spare worktree, then spawn and append to state — same as steps 2
 
 1. Read `~/.claude/orchestrator-state.json` to get agent windows and objectives
 2. For each agent in `running`/`idle`/`stuck` state, capture pane output
-3. **Check for stalling**: no new output in last 5+ min → send specific re-orientation message
-4. **Check for deviation**: agent doing something unrelated → correct it
-5. **Check for PR issues**: unresolved threads, CI failures → inform agent with specifics
-6. **Verify claims of completion**: run `verify-complete.sh` when agent says ORCHESTRATOR:DONE (run-loop.sh also does this, but you catch it faster)
-7. **Re-brief after context compaction**: if agent asks "what should I do?" or appears lost, run:
+3. **Check for stalling**: no new output in last 5+ min → send specific re-orientation message referencing the objective from state
+4. **Check for deviation**: agent doing something unrelated to its objective → correct immediately with a specific redirect
+5. **Check for PR issues**: unresolved threads, CI failures → tell the agent exactly what's failing and how to fix it
+6. **Strict ORCHESTRATOR:DONE gate** — when agent outputs ORCHESTRATOR:DONE, run ALL three checks before allowing recycling:
+   ```bash
+   # 1. Checkpoints + 0 threads + CI green
+   bash SKILLS_DIR/verify-complete.sh SESSION:WIN
+
+   # 2. CI ran AFTER agent spawned (proves agent actually pushed something new)
+   SPAWNED_AT=$(jq -r --arg w SESSION:WIN '.agents[] | select(.window==$w) | .spawned_at // 0' ~/.claude/orchestrator-state.json)
+   LATEST_RUN=$(gh run list --repo REPO --branch BRANCH --limit 1 --json createdAt --jq '.[0].createdAt')
+   # LATEST_RUN must be after SPAWNED_AT
+
+   # 3. No CHANGES_REQUESTED review decision
+   gh pr view PR_NUMBER --json reviewDecision --jq '.reviewDecision'
+   ```
+   If any check fails, tell the agent specifically what's missing and mark state back to `running`. Do not allow recycling until all three pass.
+7. **Re-brief after context compaction**: if agent asks "what should I do?" or appears lost:
    ```bash
    cat ~/.claude/orchestrator-state.json | jq '.agents[] | select(.window=="SESSION:WIN")'
    gh pr view PR_NUMBER --json title,body,headRefName
    ```
-   Then send the agent its objective + PR context via tmux
+   Send objective + PR context via tmux (remember: split send-keys, sleep 0.3 between text and Enter).
+   If `image_path` is set on the agent, include: "Re-read context at IMAGE_PATH with the Read tool."
+8. **send-keys rule**: never combine long text and Enter in one call — always `send-keys "text"` then `sleep 0.3` then `send-keys Enter`
 
 ## Self-recovery protocol (agents)
 

--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -197,11 +197,7 @@ jq --arg hook "$DISCORD_WEBHOOK_URL" '.discord_webhook = $hook' ~/.claude/orches
   > /tmp/orch.tmp && mv /tmp/orch.tmp ~/.claude/orchestrator-state.json
 ```
 
-Append each new agent:
-```bash
-jq --argjson a "$NEW_AGENT" '.agents += [$a]' ~/.claude/orchestrator-state.json \
-  > /tmp/orch.tmp && mv /tmp/orch.tmp ~/.claude/orchestrator-state.json
-```
+`spawn-agent.sh` writes the initial agent record (window, worktree_path, branch, objective, state, etc.) to the state file automatically — **do not append the record again after calling it.** The record already exists and `pr_number`/`steps` are patched in by the script itself.
 
 ### 5. Start both supervision layers
 

--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -5,7 +5,7 @@ user-invocable: true
 argument-hint: "any free text — e.g. 'start 3 agents on X Y Z', 'show status', 'add task: implement feature A', 'stop', 'how many are free?'"
 metadata:
   author: autogpt-team
-  version: "4.0.0"
+  version: "5.0.0"
 ---
 
 # Orchestrate — Agent Fleet Supervisor
@@ -24,11 +24,12 @@ STATE_FILE=~/.claude/orchestrator-state.json
 | `find-spare.sh [REPO_ROOT]` | List free worktrees — one `PATH BRANCH` per line |
 | `spawn-agent.sh SESSION PATH SPARE NEW_BRANCH OBJECTIVE [PR_NUMBER] [STEPS...]` | Create window + checkout branch + launch claude + send task. **Stdout: `SESSION:WIN` only** |
 | `recycle-agent.sh WINDOW PATH SPARE_BRANCH` | Kill window + restore spare branch |
-| `run-loop.sh` | **Mechanical babysitter** — idle restart + dialog approval + recycle on ORCHESTRATOR:DONE |
-| `verify-complete.sh WINDOW` | Verify PR is done: checkpoints ✓ + 0 unresolved threads + CI green |
+| `run-loop.sh` | **Mechanical babysitter** — idle restart + dialog approval + recycle on ORCHESTRATOR:DONE + supervisor health check + all-done notification |
+| `verify-complete.sh WINDOW` | Verify PR is done: checkpoints ✓ + 0 unresolved threads + CI green. Repo auto-derived from state file `.repo` or git remote. |
+| `notify.sh MESSAGE` | Send notification via Discord webhook (env `DISCORD_WEBHOOK_URL` or state `.discord_webhook`), macOS notification center, and stdout |
 | `capacity.sh [REPO_ROOT]` | Print available + in-use worktrees |
 | `status.sh` | Print fleet status + live pane commands |
-| `poll-cycle.sh` | One monitoring cycle — returns JSON action array |
+| `poll-cycle.sh` | One monitoring cycle — classifies panes, tracks checkpoints, returns JSON action array |
 | `classify-pane.sh WINDOW` | Classify one pane state |
 
 ## Two-layer supervision model
@@ -78,6 +79,9 @@ Never committed to git. You maintain this file directly using `jq` + atomic writ
   "tmux_session": "autogpt1",
   "idle_threshold_seconds": 300,
   "loop_window": "autogpt1:5",
+  "supervisor_window": "autogpt1:6",
+  "repo": "Significant-Gravitas/AutoGPT",
+  "discord_webhook": "https://discord.com/api/webhooks/...",
   "last_poll_at": 0,
   "agents": [
     {
@@ -94,11 +98,20 @@ Never committed to git. You maintain this file directly using `jq` + atomic writ
       "last_output_hash": "",
       "last_seen_at": 0,
       "idle_since": 0,
-      "revision_count": 0
+      "revision_count": 0,
+      "last_rebriefed_at": 0
     }
   ]
 }
 ```
+
+Top-level optional fields:
+- `repo` — GitHub `owner/repo` for CI/thread checks. Auto-derived from git remote if omitted.
+- `discord_webhook` — Discord webhook URL for completion notifications. Also reads `DISCORD_WEBHOOK_URL` env var.
+- `supervisor_window` — tmux window running the supervisor Claude; `run-loop.sh` restarts it if it exits.
+
+Per-agent optional fields:
+- `last_rebriefed_at` — Unix timestamp of last re-brief; enforces 5-min cooldown to prevent spam.
 
 Agent states: `running` | `idle` | `stuck` | `waiting_approval` | `complete` | `done` | `escalated`
 
@@ -166,12 +179,22 @@ WINDOW=$(bash $SKILLS_DIR/spawn-agent.sh "$SESSION" "$WORKTREE_PATH" "$SPARE_BRA
 Build an agent record and append it to the state file. If the state file doesn't exist yet, initialize it:
 
 ```bash
+# Derive repo from git remote (used by verify-complete.sh + supervisor)
+REPO=$(git remote get-url origin 2>/dev/null | sed 's|.*github\.com[:/]||; s|\.git$||' || echo "")
+
 jq -n \
   --arg session "$SESSION" \
+  --arg repo "$REPO" \
   --argjson threshold 300 \
   '{active:true, tmux_session:$session, idle_threshold_seconds:$threshold,
-    loop_window:null, last_poll_at:0, agents:[]}' \
+    repo:$repo, loop_window:null, supervisor_window:null, last_poll_at:0, agents:[]}' \
   > ~/.claude/orchestrator-state.json
+```
+
+Optionally add a Discord webhook for completion notifications:
+```bash
+jq --arg hook "$DISCORD_WEBHOOK_URL" '.discord_webhook = $hook' ~/.claude/orchestrator-state.json \
+  > /tmp/orch.tmp && mv /tmp/orch.tmp ~/.claude/orchestrator-state.json
 ```
 
 Append each new agent:
@@ -213,6 +236,10 @@ You are the intelligent supervisor for a Claude agent fleet.
 
 Your job: every 2-3 minutes, check all running agents and intervene when needed.
 
+SELF-RECOVERY: If your own context compacts and you lose track of what you were doing,
+re-read the state file: cat ~/.claude/orchestrator-state.json | jq
+That gives you the full picture. Resume supervision immediately.
+
 State file: cat ~/.claude/orchestrator-state.json | jq
 
 SKILLS_DIR: <SKILLS_DIR_ABS>
@@ -226,7 +253,7 @@ For each agent decide:
     tmux send-keys -t SESSION:WIN "Your objective: <restate from state file>. Continue from where you left off." Enter
 - Stuck in loop / repeating error → send targeted fix guidance
 - Waiting for input / asking a question → answer and unblock
-- CI red → run: gh pr checks PR_NUMBER --repo Significant-Gravitas/AutoGPT
+- CI red → run: gh pr checks PR_NUMBER --repo $(jq -r '.repo // "Significant-Gravitas/AutoGPT"' ~/.claude/orchestrator-state.json)
     then tell the agent exactly what's failing and how to fix it
 - Context compacted, agent appears lost → send recovery command:
     tmux send-keys -t SESSION:WIN "Run: cat ~/.claude/orchestrator-state.json | jq '.agents[] | select(.window==\"SESSION:WIN\")' and gh pr view PR_NUMBER --json title,body,headRefName to reorient, then continue your task." Enter

--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -19,16 +19,29 @@ SKILLS_DIR=$(git rev-parse --show-toplevel)/.claude/skills/orchestrate/scripts
 STATE_FILE=~/.claude/orchestrator-state.json
 ```
 
-| Script | Purpose | Key args |
-|---|---|---|
-| `find-spare.sh [REPO_ROOT]` | List free worktrees — one `PATH BRANCH` per line | |
-| `spawn-agent.sh SESSION PATH SPARE NEW_BRANCH OBJECTIVE` | Create window + checkout branch + launch claude + send task. **Stdout: `SESSION:WIN` only** | |
-| `recycle-agent.sh WINDOW PATH SPARE_BRANCH` | Kill window + restore spare branch | |
-| `run-loop.sh` | Polling loop — runs in its own tmux window, zero token cost | |
-| `capacity.sh [REPO_ROOT]` | Print available + in-use worktrees | |
-| `status.sh` | Print fleet status + live pane commands | |
-| `poll-cycle.sh` | One monitoring cycle — returns JSON action array | |
-| `classify-pane.sh WINDOW` | Classify one pane state | |
+| Script | Purpose |
+|---|---|
+| `find-spare.sh [REPO_ROOT]` | List free worktrees — one `PATH BRANCH` per line |
+| `spawn-agent.sh SESSION PATH SPARE NEW_BRANCH OBJECTIVE` | Create window + checkout branch + launch claude + send task. **Stdout: `SESSION:WIN` only** |
+| `recycle-agent.sh WINDOW PATH SPARE_BRANCH` | Kill window + restore spare branch |
+| `run-loop.sh` | **Mechanical babysitter** — idle restart + dialog approval + recycle. No intelligence. |
+| `capacity.sh [REPO_ROOT]` | Print available + in-use worktrees |
+| `status.sh` | Print fleet status + live pane commands |
+| `poll-cycle.sh` | One monitoring cycle — returns JSON action array |
+| `classify-pane.sh WINDOW` | Classify one pane state |
+
+## Two-layer supervision model
+
+```
+CronCreate (this session, every 3 min)
+  └── Reads pane output, checks CI, intervenes with targeted guidance
+        run-loop.sh (tmux window, every 30s)
+          └── Mechanical only: idle restart, dialog approval, recycle on ORCHESTRATOR:DONE
+```
+
+**CronCreate** is the intelligence layer — it runs in the main Claude session so it has full context and can make real decisions. It reads each agent's pane, checks PR CI status, and sends specific guidance when agents stall or deviate.
+
+**run-loop.sh** is the mechanical layer — zero tokens, handles things that need no judgment: restart crashed agents, press Enter on dialogs, recycle completed worktrees.
 
 ## Worktree lifecycle
 
@@ -143,21 +156,40 @@ jq --argjson a "$NEW_AGENT" '.agents += [$a]' ~/.claude/orchestrator-state.json 
   > /tmp/orch.tmp && mv /tmp/orch.tmp ~/.claude/orchestrator-state.json
 ```
 
-### 5. Start the polling loop
+### 5. Start both supervision layers
 
-Open a dedicated `orchestrator` window in the same tmux session and run `run-loop.sh` there. It polls every 30s, handles all actions in bash, and costs zero Claude tokens.
-
+**Layer 1 — mechanical babysitter** (tmux window, zero tokens):
 ```bash
 LOOP_WIN=$(tmux new-window -t "$SESSION" -n "orchestrator" -P -F '#{window_index}')
 LOOP_WINDOW="${SESSION}:${LOOP_WIN}"
 tmux send-keys -t "$LOOP_WINDOW" "bash $SKILLS_DIR/run-loop.sh" Enter
 
-# Store loop_window so we know how to stop it later
 jq --arg w "$LOOP_WINDOW" '.loop_window = $w' ~/.claude/orchestrator-state.json \
   > /tmp/orch.tmp && mv /tmp/orch.tmp ~/.claude/orchestrator-state.json
 ```
 
-The loop window prints a timestamped summary line after every poll. Attach with `tmux attach -t "$SESSION"` and switch to the `orchestrator` window to watch it live.
+**Layer 2 — intelligent supervisor** (CronCreate in this session, every 3 min):
+
+Use CronCreate with this prompt (fill in the real window IDs and agent context):
+
+```text
+You are supervising Claude agents working on PRs. Check each agent now.
+
+Read their pane output:
+  tmux capture-pane -t SESSION:WIN -p -S -40 | tail -40
+  (repeat for each agent window)
+
+For each agent decide:
+- Actively working (spinner/tools running) → do nothing
+- Idle at ❯ prompt without ORCHESTRATOR:DONE → stalled, send specific nudge based on last seen action
+- Stuck in loop / repeating error → intervene with targeted fix guidance
+- Waiting for input / asking a question → answer and unblock
+- CI red → check gh pr checks N, tell the agent what's failing and how to fix
+
+Only surface to the user if a strategic decision is needed.
+```
+
+Store the cron job ID in the state file: `.supervisor_cron_id`.
 
 ## Adding an agent
 

--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -309,7 +309,14 @@ Store cron job ID in state file after CronCreate returns.
 
 Assign one new task to the next available spare worktree.
 
+First, gather from the user:
+- **objective**: what the agent should do
+- **branch name**: e.g. `feat/my-feature` (derived from objective if not given)
+
+Then run:
+
 ```bash
+# NEW_BRANCH and OBJECTIVE must be set before this block (gathered from user above)
 SESSION=$(jq -r '.tmux_session' ~/.claude/orchestrator-state.json)
 
 # Find first spare worktree

--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -1,0 +1,316 @@
+---
+name: orchestrate
+description: "Meta-agent supervisor that manages a fleet of Claude Code agents running in tmux windows. Monitors agent states, auto-approves safe tool calls, kicks idle/exited agents back to work, and reports completions. TRIGGER when user asks to supervise agents, manage a fleet, monitor tmux agents, or orchestrate parallel worktrees."
+user-invocable: true
+argument-hint: "[start|stop|status|add|poll] — start begins monitoring, stop halts it, status shows fleet, add registers a new agent, poll runs one check cycle manually"
+metadata:
+  author: autogpt-team
+  version: "1.0.0"
+---
+
+# Orchestrate — Agent Fleet Supervisor
+
+Manages multiple Claude Code agents running in tmux windows. Monitors their state, kicks them when idle, and auto-approves safe confirmations so they never block on human input.
+
+## Setup agents for orchestration
+
+Before registering an agent with the orchestrator, launch it in a tmux window with bypass permissions:
+
+```bash
+# In your tmux session (e.g., session named "work"):
+# window 0: cd /Users/majdyz/Code/AutoGPT6 && claude --permission-mode bypassPermissions
+# window 1: cd /Users/majdyz/Code/AutoGPT9 && claude --permission-mode bypassPermissions
+```
+
+Also add this to the end of each agent's initial prompt so the orchestrator knows when it's done:
+> "When you have finished all work, output the exact string: ORCHESTRATOR:DONE"
+
+## State file
+
+All state lives at `~/.claude/orchestrator-state.json`. It is NOT in the repo. Schema:
+
+```json
+{
+  "active": true,
+  "tmux_session": "work",
+  "idle_threshold_seconds": 300,
+  "cron_job_id": "...",
+  "last_poll_at": 1712345678,
+  "agents": [
+    {
+      "window": "work:0",
+      "worktree": "AutoGPT6",
+      "worktree_path": "/Users/majdyz/Code/AutoGPT6",
+      "branch": "feat/my-feature",
+      "objective": "Implement X and open a PR",
+      "state": "running",
+      "last_output_hash": "abc123",
+      "last_seen_at": 1712345678,
+      "idle_since": 0,
+      "revision_count": 0
+    }
+  ]
+}
+```
+
+Agent states: `running` | `idle` | `stuck` | `waiting_approval` | `complete` | `done` | `escalated`
+
+## Scripts
+
+```
+SKILLS_DIR=$(git rev-parse --show-toplevel)/.claude/skills/orchestrate
+POLL_SCRIPT=$SKILLS_DIR/scripts/poll-cycle.sh
+CLASSIFY_SCRIPT=$SKILLS_DIR/scripts/classify-pane.sh
+STATE_FILE=~/.claude/orchestrator-state.json
+```
+
+## Subcommand: start
+
+Collect fleet info from the user, write the state file, and start the CronCreate polling loop.
+
+### Step 1 — Gather fleet info
+
+Ask the user:
+1. tmux session name (default: `work`)
+2. For each agent window: `window` (e.g. `work:0`), `worktree` name (e.g. `AutoGPT6`), `objective` (what it's supposed to do)
+3. Optional: `idle_threshold_seconds` (default: 300)
+
+### Step 2 — Write state file
+
+```bash
+cat > ~/.claude/orchestrator-state.json << 'EOF'
+{
+  "active": true,
+  "tmux_session": "TMUX_SESSION",
+  "idle_threshold_seconds": THRESHOLD,
+  "cron_job_id": null,
+  "last_poll_at": 0,
+  "agents": [AGENTS_ARRAY]
+}
+EOF
+```
+
+### Step 3 — Verify tmux connectivity
+
+For each registered agent, verify the window exists and capture its current state:
+
+```bash
+for WINDOW in WINDOW_LIST; do
+  tmux list-windows -t "${WINDOW%%:*}" 2>/dev/null && echo "$WINDOW: OK" || echo "$WINDOW: NOT FOUND"
+  tmux display-message -t "$WINDOW" -p '#{pane_current_command}' 2>/dev/null
+done
+```
+
+### Step 4 — Run first poll manually
+
+```bash
+SKILLS_DIR=$(git rev-parse --show-toplevel)/.claude/skills/orchestrate
+bash $SKILLS_DIR/scripts/poll-cycle.sh
+```
+
+Read the output and process any immediate actions (see **Subcommand: poll** below).
+
+### Step 5 — Start CronCreate loop
+
+Use CronCreate to fire the poll cycle every 2 minutes. The poll prompt must be self-contained:
+
+The cron prompt to use (fill in SKILLS_DIR with the actual path):
+```
+Orchestrator poll cycle — run: bash SKILLS_DIR/scripts/poll-cycle.sh
+
+Read its JSON output array. For each element:
+- action "kick": run tmux send-keys -t <window> "Continue with your current task. If all work is done output ORCHESTRATOR:DONE" Enter
+- action "approve": run tmux send-keys -t <window> "y" Enter  
+- action "complete": output "AGENT COMPLETE: <window> (<worktree>)" so the user sees it
+
+Then output a 1-line summary: "Poll done — N agents: X running, Y idle/kicked, Z complete"
+```
+
+After CronCreate returns a job ID, store it in the state file:
+
+```bash
+jq --arg id "CRON_JOB_ID" '.cron_job_id = $id' ~/.claude/orchestrator-state.json > /tmp/orch.tmp \
+  && mv /tmp/orch.tmp ~/.claude/orchestrator-state.json
+```
+
+Tell the user:
+- The loop is running — it fires every ~2 minutes while this Claude session is open
+- **CronCreate is session-scoped**: the loop stops when this Claude session closes
+- To stop monitoring: run `/orchestrate stop`
+- The loop auto-expires after 7 days per CronCreate limits
+
+## Subcommand: stop
+
+```bash
+# Mark inactive
+jq '.active = false' ~/.claude/orchestrator-state.json > /tmp/orch.tmp \
+  && mv /tmp/orch.tmp ~/.claude/orchestrator-state.json
+
+# Show current state before stopping
+jq '.agents[] | {window, state, worktree}' ~/.claude/orchestrator-state.json
+```
+
+Then use CronDelete with the stored job ID to cancel the loop:
+```bash
+CRON_ID=$(jq -r '.cron_job_id // ""' ~/.claude/orchestrator-state.json)
+```
+
+If `CRON_ID` is empty or null, the job was already gone (session ended). Tell the user.
+
+## Subcommand: status
+
+Display a readable summary of the fleet:
+
+```bash
+cat ~/.claude/orchestrator-state.json | jq -r '
+  "=== Orchestrator Status ===",
+  "Active: \(.active)",
+  "Session: \(.tmux_session)",
+  "Last poll: \(if .last_poll_at == 0 then "never" else (.last_poll_at | strftime("%H:%M:%S")) end)",
+  "Idle threshold: \(.idle_threshold_seconds)s",
+  "",
+  "Agents:",
+  (.agents[] | "  [\(.state | ascii_upcase)] \(.window) → \(.worktree): \(.objective | .[0:60])")
+'
+```
+
+Also show pane command for each agent:
+
+```bash
+for WINDOW in $(jq -r '.agents[].window' ~/.claude/orchestrator-state.json); do
+  CMD=$(tmux display-message -t "$WINDOW" -p '#{pane_current_command}' 2>/dev/null || echo "unreachable")
+  echo "  $WINDOW foreground: $CMD"
+done
+```
+
+## Subcommand: add
+
+Add a new agent to an already-running orchestrator without restarting.
+
+Ask the user for: `window`, `worktree`, `worktree_path`, `branch`, `objective`.
+
+```bash
+NEW_AGENT=$(jq -n \
+  --arg window "WINDOW" \
+  --arg worktree "WORKTREE" \
+  --arg path "WORKTREE_PATH" \
+  --arg branch "BRANCH" \
+  --arg obj "OBJECTIVE" \
+  '{window:$window, worktree:$worktree, worktree_path:$path, branch:$branch,
+    objective:$obj, state:"running", last_output_hash:"", last_seen_at:0,
+    idle_since:0, revision_count:0}')
+
+jq --argjson a "$NEW_AGENT" '.agents += [$a]' ~/.claude/orchestrator-state.json > /tmp/orch.tmp \
+  && mv /tmp/orch.tmp ~/.claude/orchestrator-state.json
+```
+
+Immediately run a classify on the new window to get its current state:
+
+```bash
+SKILLS_DIR=$(git rev-parse --show-toplevel)/.claude/skills/orchestrate
+bash $SKILLS_DIR/scripts/classify-pane.sh WINDOW
+```
+
+## Subcommand: poll
+
+Run one poll cycle manually (also called by the CronCreate loop).
+
+```bash
+SKILLS_DIR=$(git rev-parse --show-toplevel)/.claude/skills/orchestrate
+ACTIONS=$(bash $SKILLS_DIR/scripts/poll-cycle.sh)
+echo "Actions: $ACTIONS"
+```
+
+Read the JSON array output. For each action object, take the appropriate action:
+
+### action: "kick" (idle or stuck agent)
+
+The agent process has exited (shell is foreground) or its output has been frozen for too long.
+
+```bash
+# Re-enter the agent's worktree and restart claude
+tmux send-keys -t WINDOW "cd WORKTREE_PATH && claude --permission-mode bypassPermissions" Enter
+```
+
+Wait 3 seconds for the shell to process, then send the continuation message:
+```bash
+sleep 3
+tmux send-keys -t WINDOW "Continue with your current task: OBJECTIVE. When done, output ORCHESTRATOR:DONE" Enter
+```
+
+For **stuck** agents (claude is still running but output frozen):
+```bash
+# Send a nudge — do NOT restart, just prompt
+tmux send-keys -t WINDOW "Continue with your current task. Review any errors and proceed. When done output ORCHESTRATOR:DONE" Enter
+```
+
+Increment the agent's `revision_count` in the state file. If `revision_count >= 3`, mark as `escalated` instead and notify the user that this agent needs human attention.
+
+### action: "approve" (waiting for approval)
+
+The agent has a confirmation prompt. Classify the pending command first:
+
+```bash
+tmux capture-pane -t WINDOW -p | tail -20
+```
+
+**Always send `y` for:**
+- `git add`, `git commit`, `git push` (to non-main/master branches)
+- `git checkout`, `git branch`, `git merge`
+- `mkdir`, `cp`, `mv` within worktree path
+- `npm install`, `pnpm install`, `poetry install`, `pip install`
+- `docker compose up/down/build/stop`
+- `pytest`, `pnpm test`, `cargo test`, `go test`
+- `curl` to `localhost` only
+
+**Escalate (mark as `escalated`, alert user) for:**
+- `rm -rf` with paths outside the worktree
+- `git push --force` or `git push -f`
+- `git reset --hard`
+- `sudo` any command
+- Any command touching `/etc/`, `/usr/`, `/sys/`
+- Writing API keys or secrets to files
+- `DROP TABLE`, `DELETE FROM` without `WHERE`
+
+```bash
+# Safe: approve
+tmux send-keys -t WINDOW "y" Enter
+
+# Unsafe: DO NOT approve — escalate
+jq --arg w "WINDOW" '
+  .agents[] |= if .window == $w then .state = "escalated" else . end
+' ~/.claude/orchestrator-state.json > /tmp/orch.tmp && mv /tmp/orch.tmp ~/.claude/orchestrator-state.json
+```
+
+Output a clear warning to the user about the escalated approval.
+
+### action: "complete"
+
+The agent output `ORCHESTRATOR:DONE`. Mark it done in the state file:
+
+```bash
+jq --arg w "WINDOW" '
+  .agents[] |= if .window == $w then .state = "done" else . end
+' ~/.claude/orchestrator-state.json > /tmp/orch.tmp && mv /tmp/orch.tmp ~/.claude/orchestrator-state.json
+```
+
+Output to the user: `AGENT DONE: WINDOW (WORKTREE) — OBJECTIVE`
+
+Optionally, ask the user if they want to run `/pr-test WORKTREE_PATH` on the completed agent.
+
+## Poll cycle summary
+
+After processing all actions, output a one-line summary:
+
+```
+Poll [HH:MM:SS] — N agents | X running | Y kicked | Z approved | W complete | V escalated
+```
+
+## Key rules
+
+1. **Never restart an agent that is still running** — only restart when the foreground process is a shell
+2. **bypassPermissions is the default** — agents launched with it should rarely need approval. If you see frequent approval prompts, something is wrong — escalate rather than blindly approving
+3. **Increment revision_count on every kick** — after 3 kicks to the same agent, escalate to user
+4. **Atomic state writes** — always write to `.tmp` then `mv` to avoid corruption
+5. **Never approve destructive commands** — when in doubt, escalate
+6. **The loop is session-scoped** — remind the user of this when they run `start`

--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -18,8 +18,8 @@ Before registering an agent with the orchestrator, launch it in a tmux window wi
 
 ```bash
 # In your tmux session (e.g., session named "work"):
-# window 0: cd /Users/majdyz/Code/AutoGPT6 && claude --permission-mode bypassPermissions
-# window 1: cd /Users/majdyz/Code/AutoGPT9 && claude --permission-mode bypassPermissions
+# window 0: cd /path/to/worktree-1 && claude --permission-mode bypassPermissions
+# window 1: cd /path/to/worktree-2 && claude --permission-mode bypassPermissions
 ```
 
 Also add this to the end of each agent's initial prompt so the orchestrator knows when it's done:

--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -41,7 +41,7 @@ Lives at `~/.claude/orchestrator-state.json` (outside repo, never committed):
     {
       "window": "autogpt1:3",
       "worktree": "AutoGPT6",
-      "worktree_path": "/Users/majdyz/Code/AutoGPT6",
+      "worktree_path": "/path/to/worktrees/AutoGPT6",
       "spare_branch": "spare/6",
       "branch": "feat/my-feature",
       "objective": "Implement X and open a PR",
@@ -79,8 +79,8 @@ git worktree list --porcelain | awk '
 
 Example output:
 ```
-/Users/majdyz/Code/AutoGPT3 spare/3
-/Users/majdyz/Code/AutoGPT7 spare/7
+/path/to/worktrees/AutoGPT3 spare/3
+/path/to/worktrees/AutoGPT7 spare/7
 ```
 
 ## spawn_agent — create window, launch agent, send task
@@ -105,7 +105,8 @@ WIN_IDX=$(tmux new-window -t "$SESSION" -n "$WORKTREE_NAME" -P -F '#{window_inde
 WINDOW="${SESSION}:${WIN_IDX}"
 
 # Launch claude with bypass permissions
-tmux send-keys -t "$WINDOW" "cd $WORKTREE_PATH && claude --permission-mode bypassPermissions" Enter
+# Single-quote WORKTREE_PATH so the pane shell handles spaces and special chars correctly
+tmux send-keys -t "$WINDOW" "cd '${WORKTREE_PATH}' && claude --permission-mode bypassPermissions" Enter
 
 # Wait up to 30s for claude to start (foreground becomes 'node')
 for i in $(seq 1 30); do
@@ -141,8 +142,9 @@ SPARE_BRANCH="$3"
 # Kill the tmux window
 tmux kill-window -t "$WINDOW" 2>/dev/null
 
-# Restore to spare branch (clean working tree first)
+# Restore to spare branch (clean tracked files and remove untracked files/dirs)
 git -C "$WORKTREE_PATH" reset --hard HEAD 2>/dev/null
+git -C "$WORKTREE_PATH" clean -fd 2>/dev/null
 git -C "$WORKTREE_PATH" checkout "$SPARE_BRANCH"
 
 echo "Recycled: $WORKTREE_PATH → $SPARE_BRANCH (window $WINDOW closed)"
@@ -217,10 +219,18 @@ SPARE_LIST=$(git worktree list --porcelain | awk '
 ' | grep -E " refs/heads/spare/[0-9]+$" | sed 's|refs/heads/||')
 
 AGENTS_JSON="[]"
-while IFS= read -r spare_line && [[ -n "$TASK" ]]; do
+# TASKS is an array of "NEW_BRANCH|OBJECTIVE" strings populated in Step 3
+# TASK_IDX tracks which task to assign to each spare worktree
+TASK_IDX=0
+while IFS= read -r spare_line; do
+  [ -z "$spare_line" ] && continue
+  [ "$TASK_IDX" -ge "${#TASKS[@]}" ] && break
+
   WORKTREE_PATH=$(echo "$spare_line" | awk '{print $1}')
   SPARE_BRANCH=$(echo "$spare_line" | awk '{print $2}')
   WORKTREE_NAME=$(basename "$WORKTREE_PATH")
+  NEW_BRANCH=$(echo "${TASKS[$TASK_IDX]}" | cut -d'|' -f1)
+  OBJECTIVE=$(echo "${TASKS[$TASK_IDX]}" | cut -d'|' -f2-)
 
   WINDOW=$(spawn_agent "$SESSION" "$WORKTREE_PATH" "$SPARE_BRANCH" "$NEW_BRANCH" "$OBJECTIVE")
 
@@ -237,6 +247,7 @@ while IFS= read -r spare_line && [[ -n "$TASK" ]]; do
 
   AGENTS_JSON=$(echo "$AGENTS_JSON" | jq --argjson a "$AGENT" '. + [$a]')
   echo "Spawned: $WINDOW ($WORKTREE_NAME on $NEW_BRANCH)"
+  TASK_IDX=$(( TASK_IDX + 1 ))
 done <<< "$SPARE_LIST"
 ```
 
@@ -282,6 +293,7 @@ Read the JSON output. For each action:
 - "complete": mark done, then recycle — kill the window and restore spare branch:
   tmux kill-window -t <window>
   git -C <worktree_path> reset --hard HEAD
+  git -C <worktree_path> clean -fd
   git -C <worktree_path> checkout <spare_branch>
   Update state: .state = "done"
   Output: "AGENT DONE + RECYCLED: <window> (<worktree>) → <spare_branch>"
@@ -336,12 +348,12 @@ echo "Added: $WINDOW ($WORKTREE_NAME on $NEW_BRANCH)"
 ## Subcommand: stop
 
 ```bash
-# Show state
-jq '.agents[] | {window, state, worktree, branch}' ~/.claude/orchestrator-state.json
-
-# Mark inactive
+# Mark inactive first (so cron stops acting on new polls)
 jq '.active = false' ~/.claude/orchestrator-state.json > /tmp/orch.tmp \
   && mv /tmp/orch.tmp ~/.claude/orchestrator-state.json
+
+# Show current state
+jq '.agents[] | {window, state, worktree, branch}' ~/.claude/orchestrator-state.json
 
 # Cancel cron
 CRON_ID=$(jq -r '.cron_job_id // ""' ~/.claude/orchestrator-state.json)

--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -141,6 +141,47 @@ Agent states: `running` | `idle` | `stuck` | `waiting_approval` | `complete` | `
 
 `done` means verified complete — window is still open, session still alive, worktree still on task branch. Not recycled yet.
 
+## Serial /pr-test rule
+
+`/pr-test` and `/pr-test --fix` run local Docker + integration tests that use shared ports, a shared database, and shared build caches. **Running two `/pr-test` jobs simultaneously will cause port conflicts and database corruption.**
+
+**Rule: only one `/pr-test` runs at a time. The orchestrator serializes them.**
+
+You (the orchestrating Claude) own the test queue:
+1. Agents do `pr-review` and `pr-address` in parallel — that's safe (they only push code and reply to GitHub).
+2. When a PR needs local testing, add it to your mental queue — don't give agents a `pr-test` step.
+3. Run `/pr-test https://github.com/OWNER/REPO/pull/PR_NUMBER --fix` yourself, sequentially.
+4. Feed results back to the relevant agent via `tmux send-keys`:
+   ```bash
+   tmux send-keys -t SESSION:WIN "Local tests for PR #N: <paste failure output or 'all passed'>. Fix any failures and push, then output ORCHESTRATOR:DONE."
+   sleep 0.3
+   tmux send-keys -t SESSION:WIN Enter
+   ```
+5. Wait for CI to confirm green before marking the agent done.
+
+If multiple PRs need testing at the same time, pick the one furthest along (fewest pending CI checks) and test it first. Only start the next test after the previous one completes.
+
+## Session restore (tested and confirmed)
+
+Agent sessions are saved to disk. To restore a closed or crashed session:
+
+```bash
+# If session_id is in state (preferred):
+NEW_WIN=$(tmux new-window -t SESSION -n WORKTREE_NAME -P -F '#{window_index}')
+tmux send-keys -t "SESSION:${NEW_WIN}" "cd /path/to/worktree && claude --resume SESSION_ID --permission-mode bypassPermissions" Enter
+
+# If no session_id (use --continue for most recent session in that directory):
+tmux send-keys -t "SESSION:${NEW_WIN}" "cd /path/to/worktree && claude --continue --permission-mode bypassPermissions" Enter
+```
+
+`--continue` restores the full conversation history including all tool calls, file edits, and context. The agent resumes exactly where it left off. After restoring, update the window address in the state file:
+
+```bash
+jq --arg old "SESSION:OLD_WIN" --arg new "SESSION:NEW_WIN" \
+  '(.agents[] | select(.window == $old)).window = $new' \
+  ~/.claude/orchestrator-state.json > /tmp/orch.tmp && mv /tmp/orch.tmp ~/.claude/orchestrator-state.json
+```
+
 ## Intent → action mapping
 
 Match the user's message to one of these intents:

--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -39,9 +39,9 @@ All state lives at `~/.claude/orchestrator-state.json`. It is NOT in the repo. S
   "agents": [
     {
       "window": "work:0",
-      "worktree": "AutoGPT6",
-      "worktree_path": "/Users/majdyz/Code/AutoGPT6",
-      "branch": "feat/my-feature",
+      "worktree": "my-worktree",
+      "worktree_path": "/path/to/worktree",
+      "branch": "feat/your-feature",
       "objective": "Implement X and open a PR",
       "state": "running",
       "last_output_hash": "abc123",
@@ -54,6 +54,8 @@ All state lives at `~/.claude/orchestrator-state.json`. It is NOT in the repo. S
 ```
 
 Agent states: `running` | `idle` | `stuck` | `waiting_approval` | `complete` | `done` | `escalated`
+
+*State transitions: `complete` = script detected ORCHESTRATOR:DONE (pending Claude acknowledgment); `done` = Claude confirmed and marked finished*
 
 ## Scripts
 

--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -1,51 +1,53 @@
 ---
 name: orchestrate
-description: "Meta-agent supervisor that manages a fleet of Claude Code agents running in tmux windows. Monitors agent states, auto-approves safe tool calls, kicks idle/exited agents back to work, and reports completions. TRIGGER when user asks to supervise agents, manage a fleet, monitor tmux agents, or orchestrate parallel worktrees."
+description: "Meta-agent supervisor that manages a fleet of Claude Code agents running in tmux windows. Auto-discovers spare worktrees (spare/N branches), spawns agents into new windows, monitors state, kicks idle agents, auto-approves safe confirmations, and recycles worktrees when done. TRIGGER when user asks to supervise agents, manage a fleet, monitor tmux agents, or orchestrate parallel worktrees."
 user-invocable: true
-argument-hint: "[start|stop|status|add|poll] — start begins monitoring, stop halts it, status shows fleet, add registers a new agent, poll runs one check cycle manually"
+argument-hint: "[start|stop|status|add|poll|capacity] — start spawns agents into spare worktrees, add assigns one more task, capacity shows available worktrees, poll runs one check cycle"
 metadata:
   author: autogpt-team
-  version: "1.0.0"
+  version: "2.0.0"
 ---
 
 # Orchestrate — Agent Fleet Supervisor
 
-Manages multiple Claude Code agents running in tmux windows. Monitors their state, kicks them when idle, and auto-approves safe confirmations so they never block on human input.
+One tmux session, N windows — each window is one agent in one worktree. The orchestrator auto-discovers spare worktrees, spawns agents, monitors them, and recycles worktrees when work is done. No manual window setup required.
 
-## Setup agents for orchestration
+## Worktree lifecycle
 
-Before registering an agent with the orchestrator, launch it in a tmux window with bypass permissions:
-
-```bash
-# In your tmux session (e.g., session named "work"):
-# window 0: cd /path/to/worktree-1 && claude --permission-mode bypassPermissions
-# window 1: cd /path/to/worktree-2 && claude --permission-mode bypassPermissions
+```
+spare/N branch   →   orchestrate add   →   new window + feat/branch + claude running
+                                                        ↓
+                                               ORCHESTRATOR:DONE
+                                                        ↓
+                                        kill window + git checkout spare/N
+                                                        ↓
+                                               spare/N (free again)
 ```
 
-Also add this to the end of each agent's initial prompt so the orchestrator knows when it's done:
-> "When you have finished all work, output the exact string: ORCHESTRATOR:DONE"
+Windows are always capped by worktree count — no creep. Auto-close on completion is how the orchestrator signals a worktree is free for the next task.
 
 ## State file
 
-All state lives at `~/.claude/orchestrator-state.json`. It is NOT in the repo. Schema:
+Lives at `~/.claude/orchestrator-state.json` (outside repo, never committed):
 
 ```json
 {
   "active": true,
-  "tmux_session": "work",
+  "tmux_session": "autogpt1",
   "idle_threshold_seconds": 300,
   "cron_job_id": "...",
   "last_poll_at": 1712345678,
   "agents": [
     {
-      "window": "work:0",
-      "worktree": "my-worktree",
-      "worktree_path": "/path/to/worktree",
-      "branch": "feat/your-feature",
+      "window": "autogpt1:3",
+      "worktree": "AutoGPT6",
+      "worktree_path": "/Users/majdyz/Code/AutoGPT6",
+      "spare_branch": "spare/6",
+      "branch": "feat/my-feature",
       "objective": "Implement X and open a PR",
       "state": "running",
-      "last_output_hash": "abc123",
-      "last_seen_at": 1712345678,
+      "last_output_hash": "",
+      "last_seen_at": 0,
       "idle_since": 0,
       "revision_count": 0
     }
@@ -55,264 +57,336 @@ All state lives at `~/.claude/orchestrator-state.json`. It is NOT in the repo. S
 
 Agent states: `running` | `idle` | `stuck` | `waiting_approval` | `complete` | `done` | `escalated`
 
-*State transitions: `complete` = script detected ORCHESTRATOR:DONE (pending Claude acknowledgment); `done` = Claude confirmed and marked finished*
-
 ## Scripts
 
-```
+```bash
 SKILLS_DIR=$(git rev-parse --show-toplevel)/.claude/skills/orchestrate
 POLL_SCRIPT=$SKILLS_DIR/scripts/poll-cycle.sh
 CLASSIFY_SCRIPT=$SKILLS_DIR/scripts/classify-pane.sh
 STATE_FILE=~/.claude/orchestrator-state.json
 ```
 
+## find_spare_worktrees — discover available capacity
+
+```bash
+# List all worktrees on spare/N branches (these are free to use)
+# Output: one line per available worktree: "PATH SPARE_BRANCH"
+git worktree list --porcelain | awk '
+  /^worktree / { path = substr($0, 10) }
+  /^branch /   { branch = substr($0, 8); print path " " branch }
+' | grep -E " refs/heads/spare/[0-9]+$" | sed 's|refs/heads/||'
+```
+
+Example output:
+```
+/Users/majdyz/Code/AutoGPT3 spare/3
+/Users/majdyz/Code/AutoGPT7 spare/7
+```
+
+## spawn_agent — create window, launch agent, send task
+
+```bash
+# Usage: spawn_agent SESSION WORKTREE_PATH SPARE_BRANCH NEW_BRANCH OBJECTIVE
+# Returns: "SESSION:WINDOW_IDX" on stdout
+
+SESSION="$1"
+WORKTREE_PATH="$2"
+SPARE_BRANCH="$3"       # e.g. spare/6  — to restore on completion
+NEW_BRANCH="$4"         # e.g. feat/my-feature  — branch to create for this task
+OBJECTIVE="$5"
+WORKTREE_NAME=$(basename "$WORKTREE_PATH")
+
+# Create the task branch
+git -C "$WORKTREE_PATH" checkout -b "$NEW_BRANCH" 2>/dev/null \
+  || git -C "$WORKTREE_PATH" checkout "$NEW_BRANCH"
+
+# Create a new named window, capture its numeric index
+WIN_IDX=$(tmux new-window -t "$SESSION" -n "$WORKTREE_NAME" -P -F '#{window_index}')
+WINDOW="${SESSION}:${WIN_IDX}"
+
+# Launch claude with bypass permissions
+tmux send-keys -t "$WINDOW" "cd $WORKTREE_PATH && claude --permission-mode bypassPermissions" Enter
+
+# Wait up to 30s for claude to start (foreground becomes 'node')
+for i in $(seq 1 30); do
+  CMD=$(tmux display-message -t "$WINDOW" -p '#{pane_current_command}' 2>/dev/null || echo "")
+  [[ "$CMD" == "node" ]] && break
+  sleep 1
+done
+
+# Auto-dismiss Claude settings error dialog if present
+CMD=$(tmux display-message -t "$WINDOW" -p '#{pane_current_command}' 2>/dev/null || echo "")
+if [[ "$CMD" != "node" ]]; then
+  PANE=$(tmux capture-pane -t "$WINDOW" -p 2>/dev/null | tail -5)
+  if echo "$PANE" | grep -q "Enter to confirm"; then
+    tmux send-keys -t "$WINDOW" Down Enter
+    sleep 2
+  fi
+fi
+
+# Send the task
+tmux send-keys -t "$WINDOW" "${OBJECTIVE}. When all work is done, output the exact string: ORCHESTRATOR:DONE" Enter
+
+echo "$WINDOW"
+```
+
+## recycle_worktree — restore worktree to spare after completion
+
+```bash
+# Usage: recycle_worktree WINDOW WORKTREE_PATH SPARE_BRANCH
+WINDOW="$1"
+WORKTREE_PATH="$2"
+SPARE_BRANCH="$3"
+
+# Kill the tmux window
+tmux kill-window -t "$WINDOW" 2>/dev/null
+
+# Restore to spare branch (clean working tree first)
+git -C "$WORKTREE_PATH" reset --hard HEAD 2>/dev/null
+git -C "$WORKTREE_PATH" checkout "$SPARE_BRANCH"
+
+echo "Recycled: $WORKTREE_PATH → $SPARE_BRANCH (window $WINDOW closed)"
+```
+
+## Subcommand: capacity
+
+Show available worktrees before starting. Run this to understand the fleet size.
+
+```bash
+echo "=== Available (spare) worktrees ==="
+git worktree list --porcelain | awk '
+  /^worktree / { path = substr($0, 10) }
+  /^branch /   { branch = substr($0, 8); print path " " branch }
+' | grep -E " refs/heads/spare/[0-9]+$" | sed 's|refs/heads/||' \
+  | while read path branch; do
+      echo "  ✓ $path ($branch)"
+    done
+
+echo ""
+echo "=== In-use worktrees ==="
+jq -r '.agents[] | select(.state != "done") | "  [\(.state)] \(.worktree_path) → \(.branch)"' \
+  ~/.claude/orchestrator-state.json 2>/dev/null || echo "  (no active state file)"
+```
+
 ## Subcommand: start
 
-Collect fleet info from the user, write the state file, and start the CronCreate polling loop.
+Gather task list, auto-assign spare worktrees, spawn agents, start polling.
 
-### Step 1 — Gather fleet info
+### Step 1 — Resolve tmux session
 
-Ask the user:
-1. tmux session name (default: `work`)
-2. For each agent window: `window` (e.g. `work:0`), `worktree` name (e.g. `AutoGPT6`), `objective` (what it's supposed to do)
-3. Optional: `idle_threshold_seconds` (default: 300)
-
-### Step 2 — Write state file
+If `$ARGUMENTS` provides a session name, use it. Otherwise:
 
 ```bash
-cat > ~/.claude/orchestrator-state.json << 'EOF'
-{
-  "active": true,
-  "tmux_session": "TMUX_SESSION",
-  "idle_threshold_seconds": THRESHOLD,
-  "cron_job_id": null,
-  "last_poll_at": 0,
-  "agents": [AGENTS_ARRAY]
-}
-EOF
+tmux list-sessions -F "#{session_name}: #{session_windows} windows" 2>/dev/null
 ```
 
-### Step 3 — Verify tmux connectivity
+If no sessions exist, create one:
+```bash
+tmux new-session -d -s autogpt1
+```
 
-For each registered agent, verify the window exists and capture its current state:
+### Step 2 — Show available capacity
 
 ```bash
-for WINDOW in WINDOW_LIST; do
-  tmux list-windows -t "${WINDOW%%:*}" 2>/dev/null && echo "$WINDOW: OK" || echo "$WINDOW: NOT FOUND"
-  tmux display-message -t "$WINDOW" -p '#{pane_current_command}' 2>/dev/null
-done
+git worktree list --porcelain | awk '
+  /^worktree / { path = substr($0, 10) }
+  /^branch /   { branch = substr($0, 8); print path " " branch }
+' | grep -E " refs/heads/spare/[0-9]+$" | sed 's|refs/heads/||'
 ```
 
-### Step 4 — Run first poll manually
+Show the user how many spare worktrees are available.
+
+### Step 3 — Gather tasks
+
+For each task the user wants to run, collect:
+- **objective**: what the agent should do
+- **branch name**: e.g. `feat/my-feature` (derived from objective if not given)
+
+The worktree is auto-assigned from the spare list — the user does not need to specify it.
+
+Also ask: **idle_threshold_seconds** (default: 300).
+
+### Step 4 — Spawn agents
+
+For each task, pick the next available spare worktree and spawn:
+
+```bash
+SPARE_LIST=$(git worktree list --porcelain | awk '
+  /^worktree / { path = substr($0, 10) }
+  /^branch /   { branch = substr($0, 8); print path " " branch }
+' | grep -E " refs/heads/spare/[0-9]+$" | sed 's|refs/heads/||')
+
+AGENTS_JSON="[]"
+while IFS= read -r spare_line && [[ -n "$TASK" ]]; do
+  WORKTREE_PATH=$(echo "$spare_line" | awk '{print $1}')
+  SPARE_BRANCH=$(echo "$spare_line" | awk '{print $2}')
+  WORKTREE_NAME=$(basename "$WORKTREE_PATH")
+
+  WINDOW=$(spawn_agent "$SESSION" "$WORKTREE_PATH" "$SPARE_BRANCH" "$NEW_BRANCH" "$OBJECTIVE")
+
+  AGENT=$(jq -n \
+    --arg window "$WINDOW" \
+    --arg worktree "$WORKTREE_NAME" \
+    --arg path "$WORKTREE_PATH" \
+    --arg spare "$SPARE_BRANCH" \
+    --arg branch "$NEW_BRANCH" \
+    --arg obj "$OBJECTIVE" \
+    '{window:$window, worktree:$worktree, worktree_path:$path, spare_branch:$spare,
+      branch:$branch, objective:$obj, state:"running", last_output_hash:"",
+      last_seen_at:0, idle_since:0, revision_count:0}')
+
+  AGENTS_JSON=$(echo "$AGENTS_JSON" | jq --argjson a "$AGENT" '. + [$a]')
+  echo "Spawned: $WINDOW ($WORKTREE_NAME on $NEW_BRANCH)"
+done <<< "$SPARE_LIST"
+```
+
+### Step 5 — Write state file
+
+```bash
+jq -n \
+  --arg session "$SESSION" \
+  --argjson threshold "$THRESHOLD" \
+  --argjson agents "$AGENTS_JSON" \
+  '{active:true, tmux_session:$session, idle_threshold_seconds:$threshold,
+    cron_job_id:null, last_poll_at:0, agents:$agents}' \
+  > ~/.claude/orchestrator-state.json
+```
+
+### Step 6 — Run first poll, then start CronCreate
 
 ```bash
 SKILLS_DIR=$(git rev-parse --show-toplevel)/.claude/skills/orchestrate
-bash $SKILLS_DIR/scripts/poll-cycle.sh
+bash $SKILLS_DIR/scripts/poll-cycle.sh | jq .
 ```
 
-Read the output and process any immediate actions (see **Subcommand: poll** below).
-
-### Step 5 — Start CronCreate loop
-
-Use CronCreate to fire the poll cycle every 2 minutes. The poll prompt must be self-contained:
-
-The cron prompt to use (fill in SKILLS_DIR with the actual path):
+CronCreate prompt (fill in SKILLS_DIR with absolute path):
 ```
-Orchestrator poll cycle — run: bash SKILLS_DIR/scripts/poll-cycle.sh
+Orchestrator poll cycle.
 
-Read its JSON output array. For each element:
-- action "kick": run tmux send-keys -t <window> "Continue with your current task. If all work is done output ORCHESTRATOR:DONE" Enter
-- action "approve": run tmux send-keys -t <window> "y" Enter  
-- action "complete": output "AGENT COMPLETE: <window> (<worktree>)" so the user sees it
+Run: bash SKILLS_DIR/scripts/poll-cycle.sh
 
-Then output a 1-line summary: "Poll done — N agents: X running, Y idle/kicked, Z complete"
+Read the JSON output. For each action:
+
+- "kick" (idle — shell foreground): get worktree_path + spare_branch from state file.
+  Run: tmux send-keys -t <window> "cd <worktree_path> && claude --permission-mode bypassPermissions" Enter
+  Wait 3s. If pane shows "Enter to confirm", send Down+Enter first.
+  Then send: "<objective>. When done output ORCHESTRATOR:DONE" Enter
+
+- "kick" (stuck — claude still running): send nudge only, do NOT restart:
+  tmux send-keys -t <window> "Continue with your task. Review errors. When done output ORCHESTRATOR:DONE" Enter
+
+- "approve": inspect pane tail. Send "y" Enter if safe (git/install/test/docker/localhost curl).
+  Escalate (mark state=escalated) for: rm -rf outside worktree, force push, sudo, secrets.
+  Settings dialog "Enter to confirm": send Down+Enter
+
+- "complete": mark done, then recycle — kill the window and restore spare branch:
+  tmux kill-window -t <window>
+  git -C <worktree_path> reset --hard HEAD
+  git -C <worktree_path> checkout <spare_branch>
+  Update state: .state = "done"
+  Output: "AGENT DONE + RECYCLED: <window> (<worktree>) → <spare_branch>"
+
+After all actions: "Poll [HH:MM] — N agents: X running, Y kicked, Z done+recycled, V escalated"
 ```
 
-After CronCreate returns a job ID, store it in the state file:
+Store cron job ID in state file after CronCreate returns.
+
+## Subcommand: add
+
+Assign one new task to the next available spare worktree.
 
 ```bash
-jq --arg id "CRON_JOB_ID" '.cron_job_id = $id' ~/.claude/orchestrator-state.json > /tmp/orch.tmp \
-  && mv /tmp/orch.tmp ~/.claude/orchestrator-state.json
-```
+SESSION=$(jq -r '.tmux_session' ~/.claude/orchestrator-state.json)
 
-Tell the user:
-- The loop is running — it fires every ~2 minutes while this Claude session is open
-- **CronCreate is session-scoped**: the loop stops when this Claude session closes
-- To stop monitoring: run `/orchestrate stop`
-- The loop auto-expires after 7 days per CronCreate limits
+# Find first spare worktree
+SPARE_LINE=$(git worktree list --porcelain | awk '
+  /^worktree / { path = substr($0, 10) }
+  /^branch /   { branch = substr($0, 8); print path " " branch }
+' | grep -E " refs/heads/spare/[0-9]+$" | sed 's|refs/heads/||' | head -1)
+
+if [ -z "$SPARE_LINE" ]; then
+  echo "No spare worktrees available. All worktrees are in use."
+  echo "Wait for a task to complete, or check /orchestrate capacity."
+  exit 1
+fi
+
+WORKTREE_PATH=$(echo "$SPARE_LINE" | awk '{print $1}')
+SPARE_BRANCH=$(echo "$SPARE_LINE" | awk '{print $2}')
+WORKTREE_NAME=$(basename "$WORKTREE_PATH")
+
+WINDOW=$(spawn_agent "$SESSION" "$WORKTREE_PATH" "$SPARE_BRANCH" "$NEW_BRANCH" "$OBJECTIVE")
+
+NEW_AGENT=$(jq -n \
+  --arg window "$WINDOW" \
+  --arg worktree "$WORKTREE_NAME" \
+  --arg path "$WORKTREE_PATH" \
+  --arg spare "$SPARE_BRANCH" \
+  --arg branch "$NEW_BRANCH" \
+  --arg obj "$OBJECTIVE" \
+  '{window:$window, worktree:$worktree, worktree_path:$path, spare_branch:$spare,
+    branch:$branch, objective:$obj, state:"running", last_output_hash:"",
+    last_seen_at:0, idle_since:0, revision_count:0}')
+
+jq --argjson a "$NEW_AGENT" '.agents += [$a]' ~/.claude/orchestrator-state.json > /tmp/orch.tmp \
+  && mv /tmp/orch.tmp ~/.claude/orchestrator-state.json
+
+echo "Added: $WINDOW ($WORKTREE_NAME on $NEW_BRANCH)"
+```
 
 ## Subcommand: stop
 
 ```bash
-# Show current agent state before marking inactive
-jq '.agents[] | {window, state, worktree}' ~/.claude/orchestrator-state.json
+# Show state
+jq '.agents[] | {window, state, worktree, branch}' ~/.claude/orchestrator-state.json
 
 # Mark inactive
 jq '.active = false' ~/.claude/orchestrator-state.json > /tmp/orch.tmp \
   && mv /tmp/orch.tmp ~/.claude/orchestrator-state.json
-```
 
-Then use CronDelete with the stored job ID to cancel the loop:
-```bash
+# Cancel cron
 CRON_ID=$(jq -r '.cron_job_id // ""' ~/.claude/orchestrator-state.json)
+# Use CronDelete with CRON_ID (skip if empty)
 ```
 
-If `CRON_ID` is empty or null, the job was already gone (session ended). Tell the user.
+Does NOT recycle worktrees — agents may still be mid-task. Use `/orchestrate capacity` to see what's still running.
 
 ## Subcommand: status
 
-Display a readable summary of the fleet:
-
 ```bash
-cat ~/.claude/orchestrator-state.json | jq -r '
-  "=== Orchestrator Status ===",
-  "Active: \(.active)",
-  "Session: \(.tmux_session)",
+jq -r '
+  "=== Orchestrator [\(if .active then "RUNNING" else "STOPPED" end)] ===",
+  "Session: \(.tmux_session)  |  Idle threshold: \(.idle_threshold_seconds)s",
   "Last poll: \(if .last_poll_at == 0 then "never" else (.last_poll_at | strftime("%H:%M:%S")) end)",
-  "Idle threshold: \(.idle_threshold_seconds)s",
   "",
-  "Agents:",
-  (.agents[] | "  [\(.state | ascii_upcase)] \(.window) → \(.worktree): \(.objective | .[0:60])")
-'
-```
+  (.agents[] | "  [\(.state | ascii_upcase)] \(.window)  \(.worktree)/\(.branch)\n    \(.objective | .[0:70])")
+' ~/.claude/orchestrator-state.json
 
-Also show pane command for each agent:
-
-```bash
-for WINDOW in $(jq -r '.agents[].window' ~/.claude/orchestrator-state.json); do
+for WINDOW in $(jq -r '.agents[] | select(.state != "done") | .window' ~/.claude/orchestrator-state.json); do
   CMD=$(tmux display-message -t "$WINDOW" -p '#{pane_current_command}' 2>/dev/null || echo "unreachable")
-  echo "  $WINDOW foreground: $CMD"
+  echo "  $WINDOW live: $CMD"
 done
-```
-
-## Subcommand: add
-
-Add a new agent to an already-running orchestrator without restarting.
-
-Ask the user for: `window`, `worktree`, `worktree_path`, `branch`, `objective`.
-
-```bash
-NEW_AGENT=$(jq -n \
-  --arg window "WINDOW" \
-  --arg worktree "WORKTREE" \
-  --arg path "WORKTREE_PATH" \
-  --arg branch "BRANCH" \
-  --arg obj "OBJECTIVE" \
-  '{window:$window, worktree:$worktree, worktree_path:$path, branch:$branch,
-    objective:$obj, state:"running", last_output_hash:"", last_seen_at:0,
-    idle_since:0, revision_count:0}')
-
-jq --argjson a "$NEW_AGENT" '.agents += [$a]' ~/.claude/orchestrator-state.json > /tmp/orch.tmp \
-  && mv /tmp/orch.tmp ~/.claude/orchestrator-state.json
-```
-
-Immediately run a classify on the new window to get its current state:
-
-```bash
-SKILLS_DIR=$(git rev-parse --show-toplevel)/.claude/skills/orchestrate
-bash $SKILLS_DIR/scripts/classify-pane.sh WINDOW
 ```
 
 ## Subcommand: poll
 
-Run one poll cycle manually (also called by the CronCreate loop).
+Manual poll cycle (same logic as the CronCreate loop).
 
 ```bash
 SKILLS_DIR=$(git rev-parse --show-toplevel)/.claude/skills/orchestrate
 ACTIONS=$(bash $SKILLS_DIR/scripts/poll-cycle.sh)
-echo "Actions: $ACTIONS"
+echo "$ACTIONS" | jq .
 ```
 
-Read the JSON array output. For each action object, take the appropriate action:
-
-### action: "kick" (idle or stuck agent)
-
-The agent process has exited (shell is foreground) or its output has been frozen for too long.
-
-```bash
-# Re-enter the agent's worktree and restart claude
-tmux send-keys -t WINDOW "cd WORKTREE_PATH && claude --permission-mode bypassPermissions" Enter
-```
-
-Wait 3 seconds for the shell to process, then send the continuation message:
-```bash
-sleep 3
-tmux send-keys -t WINDOW "Continue with your current task: OBJECTIVE. When done, output ORCHESTRATOR:DONE" Enter
-```
-
-For **stuck** agents (claude is still running but output frozen):
-```bash
-# Send a nudge — do NOT restart, just prompt
-tmux send-keys -t WINDOW "Continue with your current task. Review any errors and proceed. When done output ORCHESTRATOR:DONE" Enter
-```
-
-Increment the agent's `revision_count` in the state file. If `revision_count >= 3`, mark as `escalated` instead and notify the user that this agent needs human attention.
-
-### action: "approve" (waiting for approval)
-
-The agent has a confirmation prompt. Classify the pending command first:
-
-```bash
-tmux capture-pane -t WINDOW -p | tail -20
-```
-
-**Always send `y` for:**
-- `git add`, `git commit`, `git push` (to non-main/master branches)
-- `git checkout`, `git branch`, `git merge`
-- `mkdir`, `cp`, `mv` within worktree path
-- `npm install`, `pnpm install`, `poetry install`, `pip install`
-- `docker compose up/down/build/stop`
-- `pytest`, `pnpm test`, `cargo test`, `go test`
-- `curl` to `localhost` only
-
-**Escalate (mark as `escalated`, alert user) for:**
-- `rm -rf` with paths outside the worktree
-- `git push --force` or `git push -f`
-- `git reset --hard`
-- `sudo` any command
-- Any command touching `/etc/`, `/usr/`, `/sys/`
-- Writing API keys or secrets to files
-- `DROP TABLE`, `DELETE FROM` without `WHERE`
-
-```bash
-# Safe: approve
-tmux send-keys -t WINDOW "y" Enter
-
-# Unsafe: DO NOT approve — escalate
-jq --arg w "WINDOW" '
-  .agents[] |= if .window == $w then .state = "escalated" else . end
-' ~/.claude/orchestrator-state.json > /tmp/orch.tmp && mv /tmp/orch.tmp ~/.claude/orchestrator-state.json
-```
-
-Output a clear warning to the user about the escalated approval.
-
-### action: "complete"
-
-The agent output `ORCHESTRATOR:DONE`. Mark it done in the state file:
-
-```bash
-jq --arg w "WINDOW" '
-  .agents[] |= if .window == $w then .state = "done" else . end
-' ~/.claude/orchestrator-state.json > /tmp/orch.tmp && mv /tmp/orch.tmp ~/.claude/orchestrator-state.json
-```
-
-Output to the user: `AGENT DONE: WINDOW (WORKTREE) — OBJECTIVE`
-
-Optionally, ask the user if they want to run `/pr-test WORKTREE_PATH` on the completed agent.
-
-## Poll cycle summary
-
-After processing all actions, output a one-line summary:
-
-```
-Poll [HH:MM:SS] — N agents | X running | Y kicked | Z approved | W complete | V escalated
-```
+Process each action per the rules in the CronCreate prompt above.
 
 ## Key rules
 
-1. **Never restart an agent that is still running** — only restart when the foreground process is a shell
-2. **bypassPermissions is the default** — agents launched with it should rarely need approval. If you see frequent approval prompts, something is wrong — escalate rather than blindly approving
-3. **Increment revision_count on every kick** — after 3 kicks to the same agent, escalate to user
-4. **Atomic state writes** — always write to `.tmp` then `mv` to avoid corruption
-5. **Never approve destructive commands** — when in doubt, escalate
-6. **The loop is session-scoped** — remind the user of this when they run `start`
+1. **Auto-assign spare worktrees** — never ask the user to pick a worktree path manually
+2. **Auto-close + recycle on done** — kill window, restore `spare/N` branch; this is how capacity frees up
+3. **Never restart a running agent** — only restart when foreground process is a shell
+4. **Handle settings errors automatically** — if "Enter to confirm" appears, send Down+Enter
+5. **Always use `--permission-mode bypassPermissions`** on every spawn
+6. **Escalate after 3 kicks** — mark as `escalated`, alert user
+7. **Atomic state writes** — `.tmp` + `mv` always
+8. **Never approve destructive commands** — when in doubt, escalate
+9. **Loop is session-scoped** — stops when this Claude session closes

--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -57,6 +57,8 @@ Lives at `~/.claude/orchestrator-state.json` (outside repo, never committed):
 
 Agent states: `running` | `idle` | `stuck` | `waiting_approval` | `complete` | `done` | `escalated`
 
+> **State transitions:** `complete` = set by poll-cycle.sh when ORCHESTRATOR:DONE is detected on screen; `done` = set by Claude after recycling the worktree.
+
 ## Scripts
 
 ```bash
@@ -352,7 +354,7 @@ echo "Added: $WINDOW ($WORKTREE_NAME on $NEW_BRANCH)"
 jq '.active = false' ~/.claude/orchestrator-state.json > /tmp/orch.tmp \
   && mv /tmp/orch.tmp ~/.claude/orchestrator-state.json
 
-# Show current state
+# Show state (after marking inactive)
 jq '.agents[] | {window, state, worktree, branch}' ~/.claude/orchestrator-state.json
 
 # Cancel cron

--- a/.claude/skills/orchestrate/scripts/capacity.sh
+++ b/.claude/skills/orchestrate/scripts/capacity.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# capacity.sh — show fleet capacity: available spare worktrees + in-use agents
+#
+# Usage: capacity.sh [REPO_ROOT]
+#   REPO_ROOT defaults to the root worktree of the current git repo.
+#
+# Reads: ~/.claude/orchestrator-state.json (skipped if missing or corrupt)
+
+set -euo pipefail
+
+SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STATE_FILE="${ORCHESTRATOR_STATE_FILE:-$HOME/.claude/orchestrator-state.json}"
+REPO_ROOT="${1:-$(git rev-parse --show-toplevel 2>/dev/null || echo "")}"
+
+echo "=== Available (spare) worktrees ==="
+if [ -n "$REPO_ROOT" ]; then
+  SPARE=$("$SCRIPTS_DIR/find-spare.sh" "$REPO_ROOT" 2>/dev/null || echo "")
+else
+  SPARE=$("$SCRIPTS_DIR/find-spare.sh" 2>/dev/null || echo "")
+fi
+
+if [ -z "$SPARE" ]; then
+  echo "  (none)"
+else
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    echo "  ✓ $line"
+  done <<< "$SPARE"
+fi
+
+echo ""
+echo "=== In-use worktrees ==="
+if [ -f "$STATE_FILE" ] && jq -e '.' "$STATE_FILE" >/dev/null 2>&1; then
+  IN_USE=$(jq -r '.agents[] | select(.state != "done") | "  [\(.state)] \(.worktree_path) → \(.branch)"' \
+    "$STATE_FILE" 2>/dev/null || echo "")
+  if [ -n "$IN_USE" ]; then
+    echo "$IN_USE"
+  else
+    echo "  (none)"
+  fi
+else
+  echo "  (no active state file)"
+fi

--- a/.claude/skills/orchestrate/scripts/classify-pane.sh
+++ b/.claude/skills/orchestrate/scripts/classify-pane.sh
@@ -19,7 +19,7 @@ if [ -z "$TARGET" ]; then
 fi
 
 # Validate tmux target format: session:window or session:window.pane
-if ! [[ "$TARGET" =~ ^[a-zA-Z0-9_.-]+:[0-9]+(\.[0-9]+)?$ ]]; then
+if ! [[ "$TARGET" =~ ^[a-zA-Z0-9_.-]+:[a-zA-Z0-9_.-]+(\.[0-9]+)?$ ]]; then
   echo '{"state":"error","reason":"invalid tmux target format","pane_cmd":""}'
   exit 1
 fi

--- a/.claude/skills/orchestrate/scripts/classify-pane.sh
+++ b/.claude/skills/orchestrate/scripts/classify-pane.sh
@@ -34,7 +34,7 @@ fi
 PANE_CMD=$(tmux display-message -t "$TARGET" -p '#{pane_current_command}' 2>/dev/null || echo "unknown")
 
 # Capture and strip ANSI codes (use perl for cross-platform compatibility — BSD sed lacks \x1b support)
-RAW=$(tmux capture-pane -t "$TARGET" -p 2>/dev/null || echo "")
+RAW=$(tmux capture-pane -t "$TARGET" -p -S -50 2>/dev/null || echo "")
 CLEAN=$(echo "$RAW" | perl -pe 's/\x1b\[[0-9;]*[a-zA-Z]//g; s/\x1b\(B//g; s/\x1b\[\?[0-9]*[hl]//g; s/\r//g' \
   | grep -v '^[[:space:]]*$' || true)
 

--- a/.claude/skills/orchestrate/scripts/classify-pane.sh
+++ b/.claude/skills/orchestrate/scripts/classify-pane.sh
@@ -1,27 +1,31 @@
 #!/usr/bin/env bash
 # classify-pane.sh — Classify the current state of a tmux pane
 #
-# Usage: classify-pane.sh <tmux-target> [idle-threshold-seconds]
+# Usage: classify-pane.sh <tmux-target>
 #   tmux-target: e.g. "work:0", "work:1.0"
-#   idle-threshold-seconds: seconds before hash-stable output is declared idle (default: 300)
 #
 # Output (stdout): JSON object:
 #   { "state": "running|idle|waiting_approval|complete", "reason": "...", "pane_cmd": "..." }
 #
-# Exit codes: 0=ok, 1=tmux window not found
+# Exit codes: 0=ok, 1=error (invalid target or tmux window not found)
 
 set -euo pipefail
 
 TARGET="${1:-}"
-IDLE_THRESHOLD="${2:-300}"
 
 if [ -z "$TARGET" ]; then
-  echo '{"state":"error","reason":"no target provided","pane_cmd":""}' >&2
+  echo '{"state":"error","reason":"no target provided","pane_cmd":""}'
   exit 1
 fi
 
-# Check window exists
-if ! tmux list-windows -t "${TARGET%%.*}" &>/dev/null 2>&1; then
+# Validate tmux target format: session:window or session:window.pane
+if ! [[ "$TARGET" =~ ^[a-zA-Z0-9_.-]+:[0-9]+(\.[0-9]+)?$ ]]; then
+  echo '{"state":"error","reason":"invalid tmux target format","pane_cmd":""}'
+  exit 1
+fi
+
+# Check session exists (use %%:* to extract session name from session:window)
+if ! tmux list-windows -t "${TARGET%%:*}" &>/dev/null 2>&1; then
   echo '{"state":"error","reason":"tmux target not found","pane_cmd":""}'
   exit 1
 fi
@@ -29,18 +33,14 @@ fi
 # Get the current foreground command in the pane
 PANE_CMD=$(tmux display-message -t "$TARGET" -p '#{pane_current_command}' 2>/dev/null || echo "unknown")
 
-# Capture and strip ANSI codes
+# Capture and strip ANSI codes (use perl for cross-platform compatibility — BSD sed lacks \x1b support)
 RAW=$(tmux capture-pane -t "$TARGET" -p 2>/dev/null || echo "")
-CLEAN=$(echo "$RAW" | sed \
-  -e 's/\x1b\[[0-9;]*[a-zA-Z]//g' \
-  -e 's/\x1b(B//g' \
-  -e 's/\x1b\[[?][0-9]*[hl]//g' \
-  -e 's/\r//g' \
+CLEAN=$(echo "$RAW" | perl -pe 's/\x1b\[[0-9;]*[a-zA-Z]//g; s/\x1b\(B//g; s/\x1b\[\?[0-9]*[hl]//g; s/\r//g' \
   | grep -v '^[[:space:]]*$' || true)
 
 # --- Check: explicit completion marker ---
 if echo "$CLEAN" | grep -q "ORCHESTRATOR:DONE"; then
-  printf '{"state":"complete","reason":"ORCHESTRATOR:DONE marker found","pane_cmd":"%s"}' "$PANE_CMD"
+  jq -n --arg cmd "$PANE_CMD" '{"state":"complete","reason":"ORCHESTRATOR:DONE marker found","pane_cmd":$cmd}'
   exit 0
 fi
 
@@ -60,8 +60,8 @@ APPROVAL_PATTERNS=(
 )
 for pattern in "${APPROVAL_PATTERNS[@]}"; do
   if echo "$LAST_40" | grep -qiE "$pattern"; then
-    printf '{"state":"waiting_approval","reason":"approval pattern: %s","pane_cmd":"%s"}' \
-      "$(echo "$pattern" | sed 's/"/\\"/g')" "$PANE_CMD"
+    jq -n --arg pattern "$pattern" --arg cmd "$PANE_CMD" \
+      '{"state":"waiting_approval","reason":"approval pattern: \($pattern)","pane_cmd":$cmd}'
     exit 0
   fi
 done
@@ -70,13 +70,13 @@ done
 # If the foreground process is a shell (not claude/node), the agent has exited
 case "$PANE_CMD" in
   zsh|bash|fish|sh|dash|tcsh|ksh)
-    printf '{"state":"idle","reason":"agent exited — shell prompt active (cmd: %s)","pane_cmd":"%s"}' \
-      "$PANE_CMD" "$PANE_CMD"
+    jq -n --arg cmd "$PANE_CMD" \
+      '{"state":"idle","reason":"agent exited — shell prompt active","pane_cmd":$cmd}'
     exit 0
     ;;
 esac
 
 # Agent is still running (claude/node/python is the foreground process)
-printf '{"state":"running","reason":"foreground process: %s","pane_cmd":"%s"}' \
-  "$PANE_CMD" "$PANE_CMD"
+jq -n --arg cmd "$PANE_CMD" \
+  '{"state":"running","reason":"foreground process: \($cmd)","pane_cmd":$cmd}'
 exit 0

--- a/.claude/skills/orchestrate/scripts/classify-pane.sh
+++ b/.claude/skills/orchestrate/scripts/classify-pane.sh
@@ -48,6 +48,7 @@ fi
 LAST_40=$(echo "$CLEAN" | tail -40)
 APPROVAL_PATTERNS=(
   "Do you want to proceed"
+  "Do you want to make this"
   "\\[y/n\\]"
   "\\[Y/n\\]"
   "\\[n/Y\\]"
@@ -57,6 +58,7 @@ APPROVAL_PATTERNS=(
   "Allow bash"
   "Would you like"
   "Press enter to continue"
+  "Esc to cancel"
 )
 for pattern in "${APPROVAL_PATTERNS[@]}"; do
   if echo "$LAST_40" | grep -qiE "$pattern"; then

--- a/.claude/skills/orchestrate/scripts/classify-pane.sh
+++ b/.claude/skills/orchestrate/scripts/classify-pane.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# classify-pane.sh — Classify the current state of a tmux pane
+#
+# Usage: classify-pane.sh <tmux-target> [idle-threshold-seconds]
+#   tmux-target: e.g. "work:0", "work:1.0"
+#   idle-threshold-seconds: seconds before hash-stable output is declared idle (default: 300)
+#
+# Output (stdout): JSON object:
+#   { "state": "running|idle|waiting_approval|complete", "reason": "...", "pane_cmd": "..." }
+#
+# Exit codes: 0=ok, 1=tmux window not found
+
+set -euo pipefail
+
+TARGET="${1:-}"
+IDLE_THRESHOLD="${2:-300}"
+
+if [ -z "$TARGET" ]; then
+  echo '{"state":"error","reason":"no target provided","pane_cmd":""}' >&2
+  exit 1
+fi
+
+# Check window exists
+if ! tmux list-windows -t "${TARGET%%.*}" &>/dev/null 2>&1; then
+  echo '{"state":"error","reason":"tmux target not found","pane_cmd":""}'
+  exit 1
+fi
+
+# Get the current foreground command in the pane
+PANE_CMD=$(tmux display-message -t "$TARGET" -p '#{pane_current_command}' 2>/dev/null || echo "unknown")
+
+# Capture and strip ANSI codes
+RAW=$(tmux capture-pane -t "$TARGET" -p 2>/dev/null || echo "")
+CLEAN=$(echo "$RAW" | sed \
+  -e 's/\x1b\[[0-9;]*[a-zA-Z]//g' \
+  -e 's/\x1b(B//g' \
+  -e 's/\x1b\[[?][0-9]*[hl]//g' \
+  -e 's/\r//g' \
+  | grep -v '^[[:space:]]*$' || true)
+
+# --- Check: explicit completion marker ---
+if echo "$CLEAN" | grep -q "ORCHESTRATOR:DONE"; then
+  printf '{"state":"complete","reason":"ORCHESTRATOR:DONE marker found","pane_cmd":"%s"}' "$PANE_CMD"
+  exit 0
+fi
+
+# --- Check: Claude Code approval prompt patterns ---
+LAST_40=$(echo "$CLEAN" | tail -40)
+APPROVAL_PATTERNS=(
+  "Do you want to proceed"
+  "\\[y/n\\]"
+  "\\[Y/n\\]"
+  "\\[n/Y\\]"
+  "Proceed\\?"
+  "Allow this command"
+  "Run bash command"
+  "Allow bash"
+  "Would you like"
+  "Press enter to continue"
+)
+for pattern in "${APPROVAL_PATTERNS[@]}"; do
+  if echo "$LAST_40" | grep -qiE "$pattern"; then
+    printf '{"state":"waiting_approval","reason":"approval pattern: %s","pane_cmd":"%s"}' \
+      "$(echo "$pattern" | sed 's/"/\\"/g')" "$PANE_CMD"
+    exit 0
+  fi
+done
+
+# --- Check: shell prompt (claude has exited) ---
+# If the foreground process is a shell (not claude/node), the agent has exited
+case "$PANE_CMD" in
+  zsh|bash|fish|sh|dash|tcsh|ksh)
+    printf '{"state":"idle","reason":"agent exited — shell prompt active (cmd: %s)","pane_cmd":"%s"}' \
+      "$PANE_CMD" "$PANE_CMD"
+    exit 0
+    ;;
+esac
+
+# Agent is still running (claude/node/python is the foreground process)
+printf '{"state":"running","reason":"foreground process: %s","pane_cmd":"%s"}' \
+  "$PANE_CMD" "$PANE_CMD"
+exit 0

--- a/.claude/skills/orchestrate/scripts/classify-pane.sh
+++ b/.claude/skills/orchestrate/scripts/classify-pane.sh
@@ -40,7 +40,7 @@ CLEAN=$(echo "$RAW" | perl -pe 's/\x1b\[[0-9;]*[a-zA-Z]//g; s/\x1b\(B//g; s/\x1b
 
 # --- Check: explicit completion marker ---
 # Must be on its own line (not buried in the objective text sent at spawn time).
-if echo "$CLEAN" | grep -qE "^ORCHESTRATOR:DONE$"; then
+if echo "$CLEAN" | grep -qE "^[[:space:]]*ORCHESTRATOR:DONE[[:space:]]*$"; then
   jq -n --arg cmd "$PANE_CMD" '{"state":"complete","reason":"ORCHESTRATOR:DONE marker found","pane_cmd":$cmd}'
   exit 0
 fi

--- a/.claude/skills/orchestrate/scripts/classify-pane.sh
+++ b/.claude/skills/orchestrate/scripts/classify-pane.sh
@@ -39,7 +39,8 @@ CLEAN=$(echo "$RAW" | perl -pe 's/\x1b\[[0-9;]*[a-zA-Z]//g; s/\x1b\(B//g; s/\x1b
   | grep -v '^[[:space:]]*$' || true)
 
 # --- Check: explicit completion marker ---
-if echo "$CLEAN" | grep -q "ORCHESTRATOR:DONE"; then
+# Must be on its own line (not buried in the objective text sent at spawn time).
+if echo "$CLEAN" | grep -qE "^ORCHESTRATOR:DONE$"; then
   jq -n --arg cmd "$PANE_CMD" '{"state":"complete","reason":"ORCHESTRATOR:DONE marker found","pane_cmd":$cmd}'
   exit 0
 fi

--- a/.claude/skills/orchestrate/scripts/find-spare.sh
+++ b/.claude/skills/orchestrate/scripts/find-spare.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# find-spare.sh — list worktrees on spare/N branches (free to use)
+#
+# Usage: find-spare.sh [REPO_ROOT]
+#   REPO_ROOT defaults to the root worktree containing the current git repo.
+#
+# Output (stdout): one line per available worktree: "PATH BRANCH"
+#   e.g.: /Users/me/Code/AutoGPT3 spare/3
+
+set -euo pipefail
+
+REPO_ROOT="${1:-$(git rev-parse --show-toplevel 2>/dev/null || echo "")}"
+if [ -z "$REPO_ROOT" ]; then
+  echo "Error: not inside a git repo and no REPO_ROOT provided" >&2
+  exit 1
+fi
+
+git -C "$REPO_ROOT" worktree list --porcelain \
+  | awk '
+      /^worktree / { path = substr($0, 10) }
+      /^branch /   { branch = substr($0, 8); print path " " branch }
+    ' \
+  | grep -E " refs/heads/spare/[0-9]+$" \
+  | sed 's|refs/heads/||'

--- a/.claude/skills/orchestrate/scripts/find-spare.sh
+++ b/.claude/skills/orchestrate/scripts/find-spare.sh
@@ -20,5 +20,5 @@ git -C "$REPO_ROOT" worktree list --porcelain \
       /^worktree / { path = substr($0, 10) }
       /^branch /   { branch = substr($0, 8); print path " " branch }
     ' \
-  | grep -E " refs/heads/spare/[0-9]+$" \
+  | { grep -E " refs/heads/spare/[0-9]+$" || true; } \
   | sed 's|refs/heads/||'

--- a/.claude/skills/orchestrate/scripts/notify.sh
+++ b/.claude/skills/orchestrate/scripts/notify.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# notify.sh — send a fleet notification message
+#
+# Delivery order (first available wins):
+#   1. Discord webhook — DISCORD_WEBHOOK_URL env var OR state file .discord_webhook
+#   2. macOS notification center — osascript (silent fail if unavailable)
+#   3. Stdout only
+#
+# Usage: notify.sh MESSAGE
+# Exit: always 0 (notification failure must not abort the caller)
+
+MESSAGE="${1:-}"
+[ -z "$MESSAGE" ] && exit 0
+
+STATE_FILE="${ORCHESTRATOR_STATE_FILE:-$HOME/.claude/orchestrator-state.json}"
+
+# --- Resolve Discord webhook ---
+WEBHOOK="${DISCORD_WEBHOOK_URL:-}"
+if [ -z "$WEBHOOK" ] && [ -f "$STATE_FILE" ]; then
+  WEBHOOK=$(jq -r '.discord_webhook // ""' "$STATE_FILE" 2>/dev/null || echo "")
+fi
+
+# --- Discord delivery ---
+if [ -n "$WEBHOOK" ]; then
+  PAYLOAD=$(jq -n --arg msg "$MESSAGE" '{"content": $msg}')
+  curl -s -X POST "$WEBHOOK" \
+    -H "Content-Type: application/json" \
+    -d "$PAYLOAD" > /dev/null 2>&1 || true
+fi
+
+# --- macOS notification center (silent if not macOS or osascript missing) ---
+if command -v osascript &>/dev/null 2>&1; then
+  # Escape single quotes for AppleScript
+  SAFE_MSG=$(echo "$MESSAGE" | sed "s/'/\\\\'/g")
+  osascript -e "display notification \"${SAFE_MSG}\" with title \"Orchestrator\"" 2>/dev/null || true
+fi
+
+# Always print to stdout so run-loop.sh logs it
+echo "$MESSAGE"
+exit 0

--- a/.claude/skills/orchestrate/scripts/poll-cycle.sh
+++ b/.claude/skills/orchestrate/scripts/poll-cycle.sh
@@ -34,6 +34,15 @@ if [ ! -f "$STATE_FILE" ]; then
   echo '{"active":false,"agents":[]}' > "$STATE_FILE"
 fi
 
+# Validate JSON upfront before any jq reads that run under set -e.
+# A truncated/corrupt file (e.g. from a SIGKILL mid-write) would otherwise
+# abort the script at the ACTIVE read below without emitting any JSON output.
+if ! jq -e '.' "$STATE_FILE" >/dev/null 2>&1; then
+  echo "State file parse error — check $STATE_FILE" >&2
+  echo "[]"
+  exit 0
+fi
+
 ACTIVE=$(jq -r '.active // false' "$STATE_FILE")
 if [ "$ACTIVE" != "true" ]; then
   echo "[]"

--- a/.claude/skills/orchestrate/scripts/poll-cycle.sh
+++ b/.claude/skills/orchestrate/scripts/poll-cycle.sh
@@ -97,9 +97,12 @@ while IFS= read -r agent; do
     continue
   fi
 
-  # Classify pane
-  CLASSIFICATION=$("$CLASSIFY" "$WINDOW" 2>/dev/null || \
-    echo '{"state":"error","reason":"classify failed","pane_cmd":"unknown"}')
+  # Classify pane.
+  # classify-pane.sh always emits JSON before exit (even on error), so using
+  # "|| echo '...'" would concatenate two JSON objects when it exits non-zero.
+  # Capture output directly; fall back only if output is unexpectedly empty.
+  CLASSIFICATION=$("$CLASSIFY" "$WINDOW" 2>/dev/null)
+  [ -z "$CLASSIFICATION" ] && CLASSIFICATION='{"state":"error","reason":"classify failed","pane_cmd":"unknown"}'
 
   PANE_STATE=$(echo "$CLASSIFICATION" | jq -r '.state')
   PANE_REASON=$(echo "$CLASSIFICATION" | jq -r '.reason')
@@ -142,9 +145,10 @@ while IFS= read -r agent; do
       fi
       ;;
     running)
-      # Clear idle_since carried over from a previous idle/stuck state so the
-      # stuck-detection timer starts fresh after a kick-and-restart cycle.
-      if [[ "$STATE" == "idle" || "$STATE" == "stuck" ]]; then
+      # Clear idle_since only when transitioning from idle (agent was kicked and
+      # restarted). Do NOT reset for stuck — idle_since must persist across polls
+      # so STUCK_DURATION can accumulate and trigger escalation.
+      if [[ "$STATE" == "idle" ]]; then
         NEW_IDLE_SINCE=0
       fi
       # Check if hash has been stable (agent may be stuck mid-task)

--- a/.claude/skills/orchestrate/scripts/poll-cycle.sh
+++ b/.claude/skills/orchestrate/scripts/poll-cycle.sh
@@ -100,8 +100,9 @@ while IFS= read -r agent; do
   # Classify pane.
   # classify-pane.sh always emits JSON before exit (even on error), so using
   # "|| echo '...'" would concatenate two JSON objects when it exits non-zero.
-  # Capture output directly; fall back only if output is unexpectedly empty.
-  CLASSIFICATION=$("$CLASSIFY" "$WINDOW" 2>/dev/null)
+  # Use "|| true" inside the substitution so set -euo pipefail does not abort
+  # the poll cycle when classify exits with a non-zero status code.
+  CLASSIFICATION=$("$CLASSIFY" "$WINDOW" 2>/dev/null || true)
   [ -z "$CLASSIFICATION" ] && CLASSIFICATION='{"state":"error","reason":"classify failed","pane_cmd":"unknown"}'
 
   PANE_STATE=$(echo "$CLASSIFICATION" | jq -r '.state')
@@ -172,9 +173,13 @@ while IFS= read -r agent; do
           fi
         fi
       else
-        # Output changed — reset idle timer
-        NEW_STATE="running"
-        NEW_IDLE_SINCE=0
+        # Only reset the idle timer when we have a valid hash comparison (pane
+        # capture succeeded). If CURRENT_HASH is empty (tmux capture-pane failed),
+        # preserve existing timers so stuck detection is not inadvertently reset.
+        if [ -n "$CURRENT_HASH" ]; then
+          NEW_STATE="running"
+          NEW_IDLE_SINCE=0
+        fi
       fi
       ;;
     error)

--- a/.claude/skills/orchestrate/scripts/poll-cycle.sh
+++ b/.claude/skills/orchestrate/scripts/poll-cycle.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# poll-cycle.sh — Single orchestrator poll cycle
+#
+# Reads ~/.claude/orchestrator-state.json, classifies each agent, updates state,
+# and outputs a JSON array of actions for Claude to take.
+#
+# Usage: poll-cycle.sh
+# Output (stdout): JSON array of action objects
+#   [{ "window": "work:0", "action": "kick|approve|none", "state": "...",
+#      "worktree": "...", "objective": "...", "reason": "..." }]
+#
+# The state file is updated in-place (atomic write via .tmp).
+
+set -uo pipefail
+
+STATE_FILE="${ORCHESTRATOR_STATE_FILE:-$HOME/.claude/orchestrator-state.json}"
+SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLASSIFY="$SCRIPTS_DIR/classify-pane.sh"
+
+# Cross-platform md5
+md5_hash() {
+  if command -v md5sum &>/dev/null; then
+    md5sum | awk '{print $1}'
+  else
+    md5
+  fi
+}
+
+# Ensure state file exists
+if [ ! -f "$STATE_FILE" ]; then
+  echo '{"active":false,"agents":[]}' > "$STATE_FILE"
+fi
+
+ACTIVE=$(jq -r '.active // false' "$STATE_FILE")
+if [ "$ACTIVE" != "true" ]; then
+  echo "[]"
+  exit 0
+fi
+
+NOW=$(date +%s)
+IDLE_THRESHOLD=$(jq -r '.idle_threshold_seconds // 300' "$STATE_FILE")
+
+ACTIONS="[]"
+UPDATED_AGENTS="[]"
+
+# Read agents as newline-delimited JSON objects
+AGENTS_JSON=$(jq -c '.agents[]' "$STATE_FILE" 2>/dev/null || echo "")
+
+if [ -z "$AGENTS_JSON" ]; then
+  echo "[]"
+  exit 0
+fi
+
+while IFS= read -r agent; do
+  [ -z "$agent" ] && continue
+
+  WINDOW=$(echo "$agent"   | jq -r '.window')
+  WORKTREE=$(echo "$agent" | jq -r '.worktree')
+  OBJECTIVE=$(echo "$agent"| jq -r '.objective')
+  STATE=$(echo "$agent"    | jq -r '.state // "running"')
+  LAST_HASH=$(echo "$agent"| jq -r '.last_output_hash // ""')
+  IDLE_SINCE=$(echo "$agent"| jq -r '.idle_since // 0')
+
+  # Pass-through done/escalated agents
+  if [[ "$STATE" == "done" || "$STATE" == "escalated" ]]; then
+    UPDATED_AGENTS=$(echo "$UPDATED_AGENTS" | jq --argjson a "$agent" '. + [$a]')
+    continue
+  fi
+
+  # Classify pane
+  CLASSIFICATION=$("$CLASSIFY" "$WINDOW" "$IDLE_THRESHOLD" 2>/dev/null || \
+    echo '{"state":"error","reason":"classify failed","pane_cmd":"unknown"}')
+
+  PANE_STATE=$(echo "$CLASSIFICATION" | jq -r '.state')
+  PANE_REASON=$(echo "$CLASSIFICATION" | jq -r '.reason')
+
+  # Compute content hash for stuck-detection (only for running agents)
+  CURRENT_HASH=""
+  if [[ "$PANE_STATE" == "running" ]]; then
+    RAW=$(tmux capture-pane -t "$WINDOW" -p 2>/dev/null || echo "")
+    CURRENT_HASH=$(echo "$RAW" | tail -20 | md5_hash)
+  fi
+
+  NEW_STATE="$STATE"
+  NEW_IDLE_SINCE="$IDLE_SINCE"
+  ACTION="none"
+  REASON="$PANE_REASON"
+
+  case "$PANE_STATE" in
+    complete)
+      NEW_STATE="complete"
+      ACTION="complete"
+      ;;
+    waiting_approval)
+      NEW_STATE="waiting_approval"
+      ACTION="approve"
+      ;;
+    idle)
+      # Agent process has exited — needs restart
+      NEW_STATE="idle"
+      ACTION="kick"
+      REASON="agent exited (shell is foreground)"
+      ;;
+    running)
+      # Check if hash has been stable (agent may be stuck mid-task)
+      if [ -n "$CURRENT_HASH" ] && [ "$CURRENT_HASH" = "$LAST_HASH" ] && [ "$LAST_HASH" != "" ]; then
+        if [ "$IDLE_SINCE" = "0" ] || [ "$IDLE_SINCE" = "null" ]; then
+          NEW_IDLE_SINCE=$NOW
+        else
+          STUCK_DURATION=$(( NOW - IDLE_SINCE ))
+          if [ "$STUCK_DURATION" -gt "$IDLE_THRESHOLD" ]; then
+            NEW_STATE="stuck"
+            ACTION="kick"
+            REASON="output unchanged for ${STUCK_DURATION}s (threshold: ${IDLE_THRESHOLD}s)"
+          fi
+        fi
+      else
+        # Output changed — reset idle timer
+        NEW_STATE="running"
+        NEW_IDLE_SINCE=0
+      fi
+      ;;
+    error)
+      REASON="classify error: $PANE_REASON"
+      ;;
+  esac
+
+  # Build updated agent record
+  UPDATED_AGENT=$(echo "$agent" | jq \
+    --arg state "$NEW_STATE" \
+    --arg hash "$CURRENT_HASH" \
+    --argjson now "$NOW" \
+    --argjson idle_since "$NEW_IDLE_SINCE" \
+    '.state = $state
+     | .last_output_hash = (if $hash == "" then .last_output_hash else $hash end)
+     | .last_seen_at = $now
+     | .idle_since = $idle_since')
+
+  UPDATED_AGENTS=$(echo "$UPDATED_AGENTS" | jq --argjson a "$UPDATED_AGENT" '. + [$a]')
+
+  # Add action if needed
+  if [ "$ACTION" != "none" ]; then
+    ACTION_OBJ=$(jq -n \
+      --arg window "$WINDOW" \
+      --arg action "$ACTION" \
+      --arg state "$NEW_STATE" \
+      --arg worktree "$WORKTREE" \
+      --arg objective "$OBJECTIVE" \
+      --arg reason "$REASON" \
+      '{window:$window, action:$action, state:$state, worktree:$worktree, objective:$objective, reason:$reason}')
+    ACTIONS=$(echo "$ACTIONS" | jq --argjson a "$ACTION_OBJ" '. + [$a]')
+  fi
+
+done <<< "$AGENTS_JSON"
+
+# Atomic state file update
+jq --argjson agents "$UPDATED_AGENTS" \
+   --argjson now "$NOW" \
+   '.agents = $agents | .last_poll_at = $now' \
+   "$STATE_FILE" > "${STATE_FILE}.tmp" && mv "${STATE_FILE}.tmp" "$STATE_FILE"
+
+echo "$ACTIONS"

--- a/.claude/skills/orchestrate/scripts/poll-cycle.sh
+++ b/.claude/skills/orchestrate/scripts/poll-cycle.sh
@@ -142,6 +142,11 @@ while IFS= read -r agent; do
       fi
       ;;
     running)
+      # Clear idle_since carried over from a previous idle/stuck state so the
+      # stuck-detection timer starts fresh after a kick-and-restart cycle.
+      if [[ "$STATE" == "idle" || "$STATE" == "stuck" ]]; then
+        NEW_IDLE_SINCE=0
+      fi
       # Check if hash has been stable (agent may be stuck mid-task)
       if [ -n "$CURRENT_HASH" ] && [ "$CURRENT_HASH" = "$LAST_HASH" ] && [ "$LAST_HASH" != "" ]; then
         if [ "$IDLE_SINCE" = "0" ] || [ "$IDLE_SINCE" = "null" ]; then

--- a/.claude/skills/orchestrate/scripts/poll-cycle.sh
+++ b/.claude/skills/orchestrate/scripts/poll-cycle.sh
@@ -43,9 +43,15 @@ IDLE_THRESHOLD=$(jq -r '.idle_threshold_seconds // 300' "$STATE_FILE")
 ACTIONS="[]"
 UPDATED_AGENTS="[]"
 
-# Read agents as newline-delimited JSON objects
-if ! AGENTS_JSON=$(jq -c '.agents[]' "$STATE_FILE" 2>/dev/null); then
-  echo "State file parse error — check $STATE_FILE" >&2
+# Read agents as newline-delimited JSON objects.
+# jq exits non-zero (5) when .agents[] has no matches on an empty array, which is valid.
+# Pipe stderr separately and only treat real parse errors as failures.
+if ! AGENTS_JSON=$(jq -e -c '.agents // empty | .[]' "$STATE_FILE" 2>/dev/null); then
+  # jq -e exits 1 when result is false/null; exits other codes for real errors
+  # If we reach here, either agents is missing/null (treat as empty) or file is unparseable.
+  if ! jq -e '.' "$STATE_FILE" > /dev/null 2>&1; then
+    echo "State file parse error — check $STATE_FILE" >&2
+  fi
   echo "[]"
   exit 0
 fi
@@ -66,15 +72,16 @@ while IFS= read -r agent; do
   IDLE_SINCE=$(echo "$agent"| jq -r '.idle_since // 0')
   REVISION_COUNT=$(echo "$agent"| jq -r '.revision_count // 0')
 
-  # Validate window format to prevent tmux target injection
-  if ! [[ "$WINDOW" =~ ^[a-zA-Z0-9_.-]+:[0-9]+(\.[0-9]+)?$ ]]; then
+  # Validate window format to prevent tmux target injection.
+  # Allow session:window (numeric or named) and session:window.pane
+  if ! [[ "$WINDOW" =~ ^[a-zA-Z0-9_.-]+:[a-zA-Z0-9_.-]+(\.[0-9]+)?$ ]]; then
     echo "Skipping agent with invalid window value: $WINDOW" >&2
     UPDATED_AGENTS=$(echo "$UPDATED_AGENTS" | jq --argjson a "$agent" '. + [$a]')
     continue
   fi
 
-  # Pass-through done/escalated agents
-  if [[ "$STATE" == "done" || "$STATE" == "escalated" ]]; then
+  # Pass-through terminal-state agents
+  if [[ "$STATE" == "done" || "$STATE" == "escalated" || "$STATE" == "complete" ]]; then
     UPDATED_AGENTS=$(echo "$UPDATED_AGENTS" | jq --argjson a "$agent" '. + [$a]')
     continue
   fi

--- a/.claude/skills/orchestrate/scripts/poll-cycle.sh
+++ b/.claude/skills/orchestrate/scripts/poll-cycle.sh
@@ -26,6 +26,9 @@ md5_hash() {
   fi
 }
 
+# Clean up temp file on any exit (avoids stale .tmp if jq write fails)
+trap 'rm -f "${STATE_FILE}.tmp"' EXIT
+
 # Ensure state file exists
 if [ ! -f "$STATE_FILE" ]; then
   echo '{"active":false,"agents":[]}' > "$STATE_FILE"
@@ -44,11 +47,9 @@ ACTIONS="[]"
 UPDATED_AGENTS="[]"
 
 # Read agents as newline-delimited JSON objects.
-# jq exits non-zero (5) when .agents[] has no matches on an empty array, which is valid.
-# Pipe stderr separately and only treat real parse errors as failures.
+# jq exits non-zero when .agents[] has no matches on an empty array, which is valid —
+# so we suppress that exit code and separately validate the file is well-formed JSON.
 if ! AGENTS_JSON=$(jq -e -c '.agents // empty | .[]' "$STATE_FILE" 2>/dev/null); then
-  # jq -e exits 1 when result is false/null; exits other codes for real errors
-  # If we reach here, either agents is missing/null (treat as empty) or file is unparseable.
   if ! jq -e '.' "$STATE_FILE" > /dev/null 2>&1; then
     echo "State file parse error — check $STATE_FILE" >&2
   fi
@@ -64,9 +65,10 @@ fi
 while IFS= read -r agent; do
   [ -z "$agent" ] && continue
 
-  WINDOW=$(echo "$agent"   | jq -r '.window')
-  WORKTREE=$(echo "$agent" | jq -r '.worktree')
-  OBJECTIVE=$(echo "$agent"| jq -r '.objective')
+  # Use // "" defaults so a single malformed field doesn't abort the whole cycle
+  WINDOW=$(echo "$agent"   | jq -r '.window // ""')
+  WORKTREE=$(echo "$agent" | jq -r '.worktree // ""')
+  OBJECTIVE=$(echo "$agent"| jq -r '.objective // ""')
   STATE=$(echo "$agent"    | jq -r '.state // "running"')
   LAST_HASH=$(echo "$agent"| jq -r '.last_output_hash // ""')
   IDLE_SINCE=$(echo "$agent"| jq -r '.idle_since // 0')

--- a/.claude/skills/orchestrate/scripts/poll-cycle.sh
+++ b/.claude/skills/orchestrate/scripts/poll-cycle.sh
@@ -11,18 +11,18 @@
 #
 # The state file is updated in-place (atomic write via .tmp).
 
-set -uo pipefail
+set -euo pipefail
 
 STATE_FILE="${ORCHESTRATOR_STATE_FILE:-$HOME/.claude/orchestrator-state.json}"
 SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CLASSIFY="$SCRIPTS_DIR/classify-pane.sh"
 
-# Cross-platform md5
+# Cross-platform md5: always outputs just the hex digest
 md5_hash() {
   if command -v md5sum &>/dev/null; then
     md5sum | awk '{print $1}'
   else
-    md5
+    md5 | awk '{print $NF}'
   fi
 }
 
@@ -44,7 +44,11 @@ ACTIONS="[]"
 UPDATED_AGENTS="[]"
 
 # Read agents as newline-delimited JSON objects
-AGENTS_JSON=$(jq -c '.agents[]' "$STATE_FILE" 2>/dev/null || echo "")
+if ! AGENTS_JSON=$(jq -c '.agents[]' "$STATE_FILE" 2>/dev/null); then
+  echo "State file parse error — check $STATE_FILE" >&2
+  echo "[]"
+  exit 0
+fi
 
 if [ -z "$AGENTS_JSON" ]; then
   echo "[]"
@@ -60,6 +64,14 @@ while IFS= read -r agent; do
   STATE=$(echo "$agent"    | jq -r '.state // "running"')
   LAST_HASH=$(echo "$agent"| jq -r '.last_output_hash // ""')
   IDLE_SINCE=$(echo "$agent"| jq -r '.idle_since // 0')
+  REVISION_COUNT=$(echo "$agent"| jq -r '.revision_count // 0')
+
+  # Validate window format to prevent tmux target injection
+  if ! [[ "$WINDOW" =~ ^[a-zA-Z0-9_.-]+:[0-9]+(\.[0-9]+)?$ ]]; then
+    echo "Skipping agent with invalid window value: $WINDOW" >&2
+    UPDATED_AGENTS=$(echo "$UPDATED_AGENTS" | jq --argjson a "$agent" '. + [$a]')
+    continue
+  fi
 
   # Pass-through done/escalated agents
   if [[ "$STATE" == "done" || "$STATE" == "escalated" ]]; then
@@ -68,7 +80,7 @@ while IFS= read -r agent; do
   fi
 
   # Classify pane
-  CLASSIFICATION=$("$CLASSIFY" "$WINDOW" "$IDLE_THRESHOLD" 2>/dev/null || \
+  CLASSIFICATION=$("$CLASSIFY" "$WINDOW" 2>/dev/null || \
     echo '{"state":"error","reason":"classify failed","pane_cmd":"unknown"}')
 
   PANE_STATE=$(echo "$CLASSIFICATION" | jq -r '.state')
@@ -78,11 +90,14 @@ while IFS= read -r agent; do
   CURRENT_HASH=""
   if [[ "$PANE_STATE" == "running" ]]; then
     RAW=$(tmux capture-pane -t "$WINDOW" -p 2>/dev/null || echo "")
-    CURRENT_HASH=$(echo "$RAW" | tail -20 | md5_hash)
+    if [ -n "$RAW" ]; then
+      CURRENT_HASH=$(echo "$RAW" | tail -20 | md5_hash)
+    fi
   fi
 
   NEW_STATE="$STATE"
   NEW_IDLE_SINCE="$IDLE_SINCE"
+  NEW_REVISION_COUNT="$REVISION_COUNT"
   ACTION="none"
   REASON="$PANE_REASON"
 
@@ -100,6 +115,13 @@ while IFS= read -r agent; do
       NEW_STATE="idle"
       ACTION="kick"
       REASON="agent exited (shell is foreground)"
+      NEW_REVISION_COUNT=$(( REVISION_COUNT + 1 ))
+      NEW_IDLE_SINCE=$NOW
+      if [ "$NEW_REVISION_COUNT" -ge 3 ]; then
+        NEW_STATE="escalated"
+        ACTION="none"
+        REASON="escalated after ${NEW_REVISION_COUNT} kicks — needs human attention"
+      fi
       ;;
     running)
       # Check if hash has been stable (agent may be stuck mid-task)
@@ -109,9 +131,17 @@ while IFS= read -r agent; do
         else
           STUCK_DURATION=$(( NOW - IDLE_SINCE ))
           if [ "$STUCK_DURATION" -gt "$IDLE_THRESHOLD" ]; then
-            NEW_STATE="stuck"
-            ACTION="kick"
-            REASON="output unchanged for ${STUCK_DURATION}s (threshold: ${IDLE_THRESHOLD}s)"
+            NEW_REVISION_COUNT=$(( REVISION_COUNT + 1 ))
+            NEW_IDLE_SINCE=$NOW
+            if [ "$NEW_REVISION_COUNT" -ge 3 ]; then
+              NEW_STATE="escalated"
+              ACTION="none"
+              REASON="escalated after ${NEW_REVISION_COUNT} kicks — needs human attention"
+            else
+              NEW_STATE="stuck"
+              ACTION="kick"
+              REASON="output unchanged for ${STUCK_DURATION}s (threshold: ${IDLE_THRESHOLD}s)"
+            fi
           fi
         fi
       else
@@ -125,16 +155,18 @@ while IFS= read -r agent; do
       ;;
   esac
 
-  # Build updated agent record
+  # Build updated agent record (ensure idle_since and revision_count are numeric)
   UPDATED_AGENT=$(echo "$agent" | jq \
     --arg state "$NEW_STATE" \
     --arg hash "$CURRENT_HASH" \
     --argjson now "$NOW" \
-    --argjson idle_since "$NEW_IDLE_SINCE" \
+    --arg idle_since "$NEW_IDLE_SINCE" \
+    --arg revision_count "$NEW_REVISION_COUNT" \
     '.state = $state
      | .last_output_hash = (if $hash == "" then .last_output_hash else $hash end)
      | .last_seen_at = $now
-     | .idle_since = $idle_since')
+     | .idle_since = ($idle_since | tonumber)
+     | .revision_count = ($revision_count | tonumber)')
 
   UPDATED_AGENTS=$(echo "$UPDATED_AGENTS" | jq --argjson a "$UPDATED_AGENT" '. + [$a]')
 

--- a/.claude/skills/orchestrate/scripts/poll-cycle.sh
+++ b/.claude/skills/orchestrate/scripts/poll-cycle.sh
@@ -108,13 +108,31 @@ while IFS= read -r agent; do
   PANE_STATE=$(echo "$CLASSIFICATION" | jq -r '.state')
   PANE_REASON=$(echo "$CLASSIFICATION" | jq -r '.reason')
 
+  # Capture full pane output once — used for hash (stuck detection) and checkpoint parsing.
+  # Use -S -500 to get the last ~500 lines of scrollback so checkpoints aren't missed.
+  RAW=$(tmux capture-pane -t "$WINDOW" -p -S -500 2>/dev/null || echo "")
+
+  # --- Checkpoint tracking ---
+  # Parse any "CHECKPOINT:<step>" lines the agent has output and merge into state file.
+  # The agent writes these as it completes each required step so verify-complete.sh can gate recycling.
+  EXISTING_CPS=$(echo "$agent" | jq -c '.checkpoints // []')
+  NEW_CHECKPOINTS_JSON="$EXISTING_CPS"
+  if [ -n "$RAW" ]; then
+    FOUND_CPS=$(echo "$RAW" \
+      | grep -oE "CHECKPOINT:[a-zA-Z0-9_-]+" \
+      | sed 's/CHECKPOINT://' \
+      | sort -u \
+      | jq -R . | jq -s . 2>/dev/null || echo "[]")
+    NEW_CHECKPOINTS_JSON=$(jq -n \
+      --argjson existing "$EXISTING_CPS" \
+      --argjson found "$FOUND_CPS" \
+      '($existing + $found) | unique' 2>/dev/null || echo "$EXISTING_CPS")
+  fi
+
   # Compute content hash for stuck-detection (only for running agents)
   CURRENT_HASH=""
-  if [[ "$PANE_STATE" == "running" ]]; then
-    RAW=$(tmux capture-pane -t "$WINDOW" -p 2>/dev/null || echo "")
-    if [ -n "$RAW" ]; then
-      CURRENT_HASH=$(echo "$RAW" | tail -20 | md5_hash)
-    fi
+  if [[ "$PANE_STATE" == "running" ]] && [ -n "$RAW" ]; then
+    CURRENT_HASH=$(echo "$RAW" | tail -20 | md5_hash)
   fi
 
   NEW_STATE="$STATE"
@@ -199,11 +217,13 @@ while IFS= read -r agent; do
     --argjson now "$NOW" \
     --arg idle_since "$NEW_IDLE_SINCE" \
     --arg revision_count "$NEW_REVISION_COUNT" \
+    --argjson checkpoints "$NEW_CHECKPOINTS_JSON" \
     '.state = $state
      | .last_output_hash = (if $hash == "" then .last_output_hash else $hash end)
      | .last_seen_at = $now
      | .idle_since = ($idle_since | tonumber)
-     | .revision_count = ($revision_count | tonumber)' 2>/dev/null) || {
+     | .revision_count = ($revision_count | tonumber)
+     | .checkpoints = $checkpoints' 2>/dev/null) || {
     echo "Warning: failed to build updated agent for window $WINDOW — keeping original" >&2
     UPDATED_AGENTS=$(echo "$UPDATED_AGENTS" | jq --argjson a "$agent" '. + [$a]')
     continue

--- a/.claude/skills/orchestrate/scripts/poll-cycle.sh
+++ b/.claude/skills/orchestrate/scripts/poll-cycle.sh
@@ -92,7 +92,7 @@ while IFS= read -r agent; do
   fi
 
   # Pass-through terminal-state agents
-  if [[ "$STATE" == "done" || "$STATE" == "escalated" || "$STATE" == "complete" ]]; then
+  if [[ "$STATE" == "done" || "$STATE" == "escalated" || "$STATE" == "complete" || "$STATE" == "pending_evaluation" ]]; then
     UPDATED_AGENTS=$(echo "$UPDATED_AGENTS" | jq --argjson a "$agent" '. + [$a]')
     continue
   fi
@@ -143,8 +143,10 @@ while IFS= read -r agent; do
 
   case "$PANE_STATE" in
     complete)
-      NEW_STATE="complete"
-      ACTION="complete"
+      # Agent output ORCHESTRATOR:DONE — mark pending_evaluation so orchestrator handles it.
+      # run-loop does NOT verify or notify; orchestrator's background poll picks this up.
+      NEW_STATE="pending_evaluation"
+      ACTION="complete"  # run-loop logs it but takes no action
       ;;
     waiting_approval)
       NEW_STATE="waiting_approval"

--- a/.claude/skills/orchestrate/scripts/poll-cycle.sh
+++ b/.claude/skills/orchestrate/scripts/poll-cycle.sh
@@ -165,6 +165,8 @@ while IFS= read -r agent; do
   esac
 
   # Build updated agent record (ensure idle_since and revision_count are numeric)
+  # Use || true on each jq call so a malformed field skips this agent rather than
+  # aborting the entire poll cycle under set -e.
   UPDATED_AGENT=$(echo "$agent" | jq \
     --arg state "$NEW_STATE" \
     --arg hash "$CURRENT_HASH" \
@@ -175,7 +177,11 @@ while IFS= read -r agent; do
      | .last_output_hash = (if $hash == "" then .last_output_hash else $hash end)
      | .last_seen_at = $now
      | .idle_since = ($idle_since | tonumber)
-     | .revision_count = ($revision_count | tonumber)')
+     | .revision_count = ($revision_count | tonumber)' 2>/dev/null) || {
+    echo "Warning: failed to build updated agent for window $WINDOW — keeping original" >&2
+    UPDATED_AGENTS=$(echo "$UPDATED_AGENTS" | jq --argjson a "$agent" '. + [$a]')
+    continue
+  }
 
   UPDATED_AGENTS=$(echo "$UPDATED_AGENTS" | jq --argjson a "$UPDATED_AGENT" '. + [$a]')
 

--- a/.claude/skills/orchestrate/scripts/poll-cycle.sh
+++ b/.claude/skills/orchestrate/scripts/poll-cycle.sh
@@ -149,8 +149,11 @@ while IFS= read -r agent; do
       # Clear idle_since only when transitioning from idle (agent was kicked and
       # restarted). Do NOT reset for stuck — idle_since must persist across polls
       # so STUCK_DURATION can accumulate and trigger escalation.
+      # Also update the local IDLE_SINCE so the hash-stability check below uses
+      # the reset value on this same poll, not the stale kick timestamp.
       if [[ "$STATE" == "idle" ]]; then
         NEW_IDLE_SINCE=0
+        IDLE_SINCE=0
       fi
       # Check if hash has been stable (agent may be stuck mid-task)
       if [ -n "$CURRENT_HASH" ] && [ "$CURRENT_HASH" = "$LAST_HASH" ] && [ "$LAST_HASH" != "" ]; then

--- a/.claude/skills/orchestrate/scripts/recycle-agent.sh
+++ b/.claude/skills/orchestrate/scripts/recycle-agent.sh
@@ -22,7 +22,9 @@ SPARE_BRANCH="$3"
 # Kill the tmux window (ignore error — may already be gone)
 tmux kill-window -t "$WINDOW" 2>/dev/null || true
 
-# Restore to spare branch: clean tracked then untracked files
+# Restore to spare branch: abort any in-progress operation, then clean
+git -C "$WORKTREE_PATH" rebase --abort 2>/dev/null || true
+git -C "$WORKTREE_PATH" merge --abort 2>/dev/null || true
 git -C "$WORKTREE_PATH" reset --hard HEAD 2>/dev/null
 git -C "$WORKTREE_PATH" clean -fd 2>/dev/null
 git -C "$WORKTREE_PATH" checkout "$SPARE_BRANCH"

--- a/.claude/skills/orchestrate/scripts/recycle-agent.sh
+++ b/.claude/skills/orchestrate/scripts/recycle-agent.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# recycle-agent.sh — kill a tmux window and restore the worktree to its spare branch
+#
+# Usage: recycle-agent.sh WINDOW WORKTREE_PATH SPARE_BRANCH
+#   WINDOW        — tmux target, e.g. autogpt1:3
+#   WORKTREE_PATH — absolute path to the git worktree
+#   SPARE_BRANCH  — branch to restore, e.g. spare/6
+#
+# Stdout: one status line
+
+set -euo pipefail
+
+if [ $# -lt 3 ]; then
+  echo "Usage: recycle-agent.sh WINDOW WORKTREE_PATH SPARE_BRANCH" >&2
+  exit 1
+fi
+
+WINDOW="$1"
+WORKTREE_PATH="$2"
+SPARE_BRANCH="$3"
+
+# Kill the tmux window (ignore error — may already be gone)
+tmux kill-window -t "$WINDOW" 2>/dev/null || true
+
+# Restore to spare branch: clean tracked then untracked files
+git -C "$WORKTREE_PATH" reset --hard HEAD 2>/dev/null
+git -C "$WORKTREE_PATH" clean -fd 2>/dev/null
+git -C "$WORKTREE_PATH" checkout "$SPARE_BRANCH"
+
+echo "Recycled: $(basename "$WORKTREE_PATH") → $SPARE_BRANCH (window $WINDOW closed)"

--- a/.claude/skills/orchestrate/scripts/run-loop.sh
+++ b/.claude/skills/orchestrate/scripts/run-loop.sh
@@ -4,14 +4,11 @@
 # Handles ONLY things that need no intelligence:
 #   idle    → restart claude (agent process crashed/exited)
 #   approve → auto-approve safe dialogs, press Enter on numbered-option dialogs
-#   complete → recycle worktree via recycle-agent.sh (after verify-complete.sh passes)
+#   complete → verify + mark done + notify (NO auto-recycle — user must explicitly recycle)
 #
-# Also monitors:
-#   supervisor → restart supervisor Claude window if it exits
-#   all-done   → call notify.sh when every agent reaches done/escalated
-#
-# Stuck agents and task deviation are handled by the supervisor (dedicated Claude
-# window) which has real context and can give targeted guidance.
+# Worktrees are NEVER recycled automatically. Recycling requires explicit user consent.
+# To recycle a completed window: bash recycle-agent.sh WINDOW WORKTREE_PATH SPARE_BRANCH
+# Sessions can be resumed at any time: claude --resume SESSION_ID --permission-mode bypassPermissions
 #
 # Usage: run-loop.sh
 # Env:   POLL_INTERVAL (default: 30), ORCHESTRATOR_STATE_FILE
@@ -57,44 +54,44 @@ agent_field() {
 }
 
 # ---------------------------------------------------------------------------
+# wait_for_prompt WINDOW — wait up to 60s for Claude's ❯ prompt
+# ---------------------------------------------------------------------------
+wait_for_prompt() {
+  local window="$1"
+  for i in $(seq 1 60); do
+    local cmd pane
+    cmd=$(tmux display-message -t "$window" -p '#{pane_current_command}' 2>/dev/null || echo "")
+    pane=$(tmux capture-pane -t "$window" -p 2>/dev/null || echo "")
+    if echo "$pane" | grep -q "Enter to confirm"; then
+      tmux send-keys -t "$window" Down Enter; sleep 2; continue
+    fi
+    [[ "$cmd" == "node" ]] && echo "$pane" | grep -q "❯" && return 0
+    sleep 1
+  done
+  return 1  # timed out
+}
+
+# ---------------------------------------------------------------------------
 # handle_kick WINDOW STATE — only for idle (crashed) agents, not stuck
 # ---------------------------------------------------------------------------
 handle_kick() {
   local window="$1" state="$2"
   [[ "$state" != "idle" ]] && return  # stuck agents handled by supervisor
 
-  local worktree_path objective
+  local worktree_path session_id
   worktree_path=$(agent_field "$window" "worktree_path")
-  objective=$(agent_field "$window" "objective")
+  session_id=$(agent_field "$window" "session_id")
 
-  echo "[$(date +%H:%M:%S)] KICK restart  $window — agent exited, restarting"
-  tmux send-keys -t "$window" "cd '${worktree_path}' && claude --permission-mode bypassPermissions" Enter
+  echo "[$(date +%H:%M:%S)] KICK restart  $window — agent exited, resuming session"
 
-  # Wait up to 60s for claude to be fully interactive: node + ❯ prompt visible
-  local kick_prompt_found=false
-  for i in $(seq 1 60); do
-    local kick_cmd kick_pane
-    kick_cmd=$(tmux display-message -t "$window" -p '#{pane_current_command}' 2>/dev/null || echo "")
-    kick_pane=$(tmux capture-pane -t "$window" -p 2>/dev/null || echo "")
-    if echo "$kick_pane" | grep -q "Enter to confirm"; then
-      tmux send-keys -t "$window" Down Enter
-      sleep 2
-      continue
-    fi
-    if [[ "$kick_cmd" == "node" ]] && echo "$kick_pane" | grep -q "❯"; then
-      kick_prompt_found=true
-      break
-    fi
-    sleep 1
-  done
-
-  if ! $kick_prompt_found; then
-    echo "[$(date +%H:%M:%S)] KICK WARNING  $window — timed out waiting for ❯, sending objective anyway"
+  # Resume the exact session so the agent retains full context — no need to re-send objective
+  if [ -n "$session_id" ]; then
+    tmux send-keys -t "$window" "cd '${worktree_path}' && claude --resume '${session_id}' --permission-mode bypassPermissions" Enter
+  else
+    tmux send-keys -t "$window" "cd '${worktree_path}' && claude --continue --permission-mode bypassPermissions" Enter
   fi
 
-  tmux send-keys -t "$window" "${objective}. When all work is done, output the exact string: ORCHESTRATOR:DONE"
-  sleep 0.3
-  tmux send-keys -t "$window" Enter
+  wait_for_prompt "$window" || echo "[$(date +%H:%M:%S)] KICK WARNING  $window — timed out waiting for ❯"
 }
 
 # ---------------------------------------------------------------------------
@@ -132,16 +129,14 @@ handle_approve() {
 }
 
 # ---------------------------------------------------------------------------
-# handle_complete WINDOW — verify before recycling; re-brief with cooldown if not done
+# handle_complete WINDOW — verify; re-brief if not done; mark done+notify (NO recycle)
 # ---------------------------------------------------------------------------
 handle_complete() {
   local window="$1"
-  local worktree_path spare_branch objective
-  worktree_path=$(agent_field "$window" "worktree_path")
-  spare_branch=$(agent_field "$window" "spare_branch")
+  local objective
   objective=$(agent_field "$window" "objective")
 
-  # Verify completion: check checkpoints, CI, unresolved threads
+  # Verify completion: checkpoints, CI, unresolved threads, CHANGES_REQUESTED
   local verify_msg
   if ! verify_msg=$(bash "$SCRIPTS_DIR/verify-complete.sh" "$window" 2>&1); then
     # Enforce re-brief cooldown — don't spam the agent every 30s
@@ -170,13 +165,22 @@ handle_complete() {
     return
   fi
 
+  # Verified complete — mark done and notify. DO NOT recycle the window.
+  # The worktree stays on its branch, the session stays alive, the window stays open.
+  # Recycling requires explicit user/orchestrator consent.
   echo "[$(date +%H:%M:%S)] COMPLETE ✓     $window — $verify_msg"
-  echo "[$(date +%H:%M:%S)] RECYCLING      $window → $spare_branch"
-  bash "$SCRIPTS_DIR/recycle-agent.sh" "$window" "$worktree_path" "$spare_branch"
+  echo "[$(date +%H:%M:%S)] MARKED DONE    $window — window kept open; recycle when ready"
   update_state "$window" "state" "done"
 
-  # Notify on every completion; all-done check runs in the main loop
-  bash "$SCRIPTS_DIR/notify.sh" "✓ Agent $window complete — recycled to $spare_branch" || true
+  local worktree spare_branch session_id
+  worktree=$(agent_field "$window" "worktree")
+  spare_branch=$(agent_field "$window" "spare_branch")
+  session_id=$(agent_field "$window" "session_id")
+
+  local resume_hint=""
+  [ -n "$session_id" ] && resume_hint=" Resume: claude --resume $session_id --permission-mode bypassPermissions"
+
+  bash "$SCRIPTS_DIR/notify.sh" "✓ $window ($worktree) done — window kept open.${resume_hint} To recycle: recycle-agent.sh $window WORKTREE_PATH $spare_branch" || true
 }
 
 # ---------------------------------------------------------------------------

--- a/.claude/skills/orchestrate/scripts/run-loop.sh
+++ b/.claude/skills/orchestrate/scripts/run-loop.sh
@@ -188,14 +188,27 @@ check_supervisor() {
       [[ -z "$work_dir" ]] && work_dir="$HOME"
 
       tmux send-keys -t "$sup_win" "cd '${work_dir}' && claude --permission-mode bypassPermissions" Enter
-      sleep 5
 
-      # Auto-dismiss settings dialog if it appears
-      local pane
-      pane=$(tmux capture-pane -t "$sup_win" -p 2>/dev/null || echo "")
-      if echo "$pane" | grep -q "Enter to confirm"; then
-        tmux send-keys -t "$sup_win" Down Enter
-        sleep 2
+      # Wait up to 60s for claude to be fully interactive: node + ❯ prompt visible
+      local sup_prompt_found=false
+      for i in $(seq 1 60); do
+        local sup_cmd sup_pane
+        sup_cmd=$(tmux display-message -t "$sup_win" -p '#{pane_current_command}' 2>/dev/null || echo "")
+        sup_pane=$(tmux capture-pane -t "$sup_win" -p 2>/dev/null || echo "")
+        if echo "$sup_pane" | grep -q "Enter to confirm"; then
+          tmux send-keys -t "$sup_win" Down Enter
+          sleep 2
+          continue
+        fi
+        if [[ "$sup_cmd" == "node" ]] && echo "$sup_pane" | grep -q "❯"; then
+          sup_prompt_found=true
+          break
+        fi
+        sleep 1
+      done
+
+      if ! $sup_prompt_found; then
+        echo "[$(date +%H:%M:%S)] SUPERVISOR WARNING — timed out waiting for ❯, sending recovery prompt anyway"
       fi
 
       # Send recovery prompt — reads full state from file so no hardcoded context needed

--- a/.claude/skills/orchestrate/scripts/run-loop.sh
+++ b/.claude/skills/orchestrate/scripts/run-loop.sh
@@ -4,10 +4,14 @@
 # Handles ONLY things that need no intelligence:
 #   idle    → restart claude (agent process crashed/exited)
 #   approve → auto-approve safe dialogs, press Enter on numbered-option dialogs
-#   complete → recycle worktree via recycle-agent.sh
+#   complete → recycle worktree via recycle-agent.sh (after verify-complete.sh passes)
 #
-# Stuck agents and task deviation are handled by the supervisor (CronCreate in
-# the main Claude session) which has real context and can give targeted guidance.
+# Also monitors:
+#   supervisor → restart supervisor Claude window if it exits
+#   all-done   → call notify.sh when every agent reaches done/escalated
+#
+# Stuck agents and task deviation are handled by the supervisor (dedicated Claude
+# window) which has real context and can give targeted guidance.
 #
 # Usage: run-loop.sh
 # Env:   POLL_INTERVAL (default: 30), ORCHESTRATOR_STATE_FILE
@@ -17,6 +21,7 @@ set -euo pipefail
 SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 STATE_FILE="${ORCHESTRATOR_STATE_FILE:-$HOME/.claude/orchestrator-state.json}"
 POLL_INTERVAL="${POLL_INTERVAL:-30}"
+REBRIEFED_COOLDOWN=300  # 5 minutes between re-briefs for the same agent
 
 # ---------------------------------------------------------------------------
 # update_state WINDOW FIELD VALUE
@@ -28,6 +33,13 @@ update_state() {
     "$STATE_FILE" > "${STATE_FILE}.tmp" && mv "${STATE_FILE}.tmp" "$STATE_FILE"
 }
 
+update_state_int() {
+  local window="$1" field="$2" value="$3"
+  jq --arg w "$window" --arg f "$field" --argjson v "$value" \
+    '.agents |= map(if .window == $w then .[$f] = $v else . end)' \
+    "$STATE_FILE" > "${STATE_FILE}.tmp" && mv "${STATE_FILE}.tmp" "$STATE_FILE"
+}
+
 agent_field() {
   jq -r --arg w "$1" --arg f "$2" \
     '.agents[] | select(.window == $w) | .[$f] // ""' \
@@ -35,7 +47,7 @@ agent_field() {
 }
 
 # ---------------------------------------------------------------------------
-# handle_kick WINDOW — only for idle (crashed) agents, not stuck
+# handle_kick WINDOW STATE — only for idle (crashed) agents, not stuck
 # ---------------------------------------------------------------------------
 handle_kick() {
   local window="$1" state="$2"
@@ -95,7 +107,7 @@ handle_approve() {
 }
 
 # ---------------------------------------------------------------------------
-# handle_complete WINDOW — verify before recycling
+# handle_complete WINDOW — verify before recycling; re-brief with cooldown if not done
 # ---------------------------------------------------------------------------
 handle_complete() {
   local window="$1"
@@ -104,15 +116,30 @@ handle_complete() {
   spare_branch=$(agent_field "$window" "spare_branch")
   objective=$(agent_field "$window" "objective")
 
-  # Verify completion: check unresolved threads, CI, checkpoints
+  # Verify completion: check checkpoints, CI, unresolved threads
   local verify_msg
   if ! verify_msg=$(bash "$SCRIPTS_DIR/verify-complete.sh" "$window" 2>&1); then
+    # Enforce re-brief cooldown — don't spam the agent every 30s
+    local now last_rebriefed elapsed
+    now=$(date +%s)
+    last_rebriefed=$(agent_field "$window" "last_rebriefed_at")
+    last_rebriefed=${last_rebriefed:-0}
+    [[ "$last_rebriefed" == "null" || -z "$last_rebriefed" ]] && last_rebriefed=0
+    elapsed=$(( now - last_rebriefed ))
+
+    if [ "$elapsed" -lt "$REBRIEFED_COOLDOWN" ]; then
+      local wait_secs=$(( REBRIEFED_COOLDOWN - elapsed ))
+      echo "[$(date +%H:%M:%S)] RE-BRIEF COOLDOWN $window — next in ${wait_secs}s ($verify_msg)"
+      return
+    fi
+
     echo "[$(date +%H:%M:%S)] NOT DONE       $window — $verify_msg"
     echo "[$(date +%H:%M:%S)] RE-BRIEFING    $window — sending task context from state file"
     local pr_number
     pr_number=$(agent_field "$window" "pr_number")
     tmux send-keys -t "$window" "You output ORCHESTRATOR:DONE but work is not complete: $verify_msg. Re-read your task: cat ~/.claude/orchestrator-state.json | jq '.agents[] | select(.window==\"$window\")' and gh pr view $pr_number --json title,body to reorient. Fix what is missing, then output ORCHESTRATOR:DONE again." Enter
     update_state "$window" "state" "running"
+    update_state_int "$window" "last_rebriefed_at" "$(date +%s)"
     return
   fi
 
@@ -120,13 +147,77 @@ handle_complete() {
   echo "[$(date +%H:%M:%S)] RECYCLING      $window → $spare_branch"
   bash "$SCRIPTS_DIR/recycle-agent.sh" "$window" "$worktree_path" "$spare_branch"
   update_state "$window" "state" "done"
+
+  # Notify on every completion; all-done check runs in the main loop
+  bash "$SCRIPTS_DIR/notify.sh" "✓ Agent $window complete — recycled to $spare_branch" || true
+}
+
+# ---------------------------------------------------------------------------
+# check_supervisor — restart supervisor Claude window if its process has exited
+# ---------------------------------------------------------------------------
+check_supervisor() {
+  local sup_win
+  sup_win=$(jq -r '.supervisor_window // ""' "$STATE_FILE" 2>/dev/null || echo "")
+  [[ -z "$sup_win" || "$sup_win" == "null" ]] && return
+
+  local cmd
+  cmd=$(tmux display-message -t "$sup_win" -p '#{pane_current_command}' 2>/dev/null || echo "unknown")
+  case "$cmd" in
+    zsh|bash|fish|sh|dash|tcsh|ksh)
+      echo "[$(date +%H:%M:%S)] SUPERVISOR DEAD — restarting $sup_win"
+      # Use first agent's worktree_path as working directory (any valid git root works)
+      local work_dir
+      work_dir=$(jq -r '(.agents // []) | map(select(.worktree_path != "")) | .[0].worktree_path // ""' "$STATE_FILE" 2>/dev/null || echo "")
+      [[ -z "$work_dir" ]] && work_dir="$HOME"
+
+      tmux send-keys -t "$sup_win" "cd '${work_dir}' && claude --permission-mode bypassPermissions" Enter
+      sleep 5
+
+      # Auto-dismiss settings dialog if it appears
+      local pane
+      pane=$(tmux capture-pane -t "$sup_win" -p 2>/dev/null || echo "")
+      if echo "$pane" | grep -q "Enter to confirm"; then
+        tmux send-keys -t "$sup_win" Down Enter
+        sleep 2
+      fi
+
+      # Send recovery prompt — reads full state from file so no hardcoded context needed
+      local state_file_path="$STATE_FILE"
+      tmux send-keys -t "$sup_win" "You are the fleet supervisor. Your prior context was lost. Start by reading: cat ${state_file_path} | jq — then capture each running agent's pane (tmux capture-pane -t WINDOW -p -S -200 | tail -80) and resume active supervision: nudge stalled agents, fix CI failures, answer questions. Loop every 2-3 minutes until all agents are done." Enter
+      ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# check_all_done — notify and optionally stop when every agent is terminal
+# ---------------------------------------------------------------------------
+NOTIFIED_DONE=false
+
+check_all_done() {
+  $NOTIFIED_DONE && return  # already notified this run
+
+  local total running
+  total=$(jq '.agents | length' "$STATE_FILE" 2>/dev/null || echo 0)
+  [ "$total" -eq 0 ] && return
+
+  running=$(jq '[.agents[] | select(.state | test("running|stuck|waiting_approval|idle"))] | length' \
+    "$STATE_FILE" 2>/dev/null || echo 1)
+
+  if [ "$running" -eq 0 ]; then
+    local done_count escalated_count
+    done_count=$(jq '[.agents[] | select(.state == "done")] | length' "$STATE_FILE" 2>/dev/null || echo 0)
+    escalated_count=$(jq '[.agents[] | select(.state == "escalated")] | length' "$STATE_FILE" 2>/dev/null || echo 0)
+    echo "[$(date +%H:%M:%S)] ALL DONE ✓     ${done_count} done, ${escalated_count} escalated"
+    bash "$SCRIPTS_DIR/notify.sh" "🏁 Fleet complete — ${done_count}/${total} done, ${escalated_count} escalated. Run capacity.sh to see free worktrees." || true
+    NOTIFIED_DONE=true
+  fi
 }
 
 # ---------------------------------------------------------------------------
 # Main loop
 # ---------------------------------------------------------------------------
 echo "[$(date +%H:%M:%S)] run-loop started (mechanical only, poll every ${POLL_INTERVAL}s)"
-echo "[$(date +%H:%M:%S)] Supervisor: CronCreate in main Claude session"
+echo "[$(date +%H:%M:%S)] Supervisor: dedicated window (see .supervisor_window in state file)"
 echo "---"
 
 while true; do
@@ -150,6 +241,12 @@ while true; do
       complete) handle_complete "$WINDOW" || true; DONE=$(( DONE + 1 )) ;;
     esac
   done < <(echo "$ACTIONS" | jq -c '.[]' 2>/dev/null || true)
+
+  # Monitor supervisor health — restart if Claude has exited
+  check_supervisor || true
+
+  # Check if fleet is fully complete
+  check_all_done || true
 
   RUNNING=$(jq '[.agents[] | select(.state | test("running|stuck|waiting_approval|idle"))] | length' \
     "$STATE_FILE" 2>/dev/null || echo 0)

--- a/.claude/skills/orchestrate/scripts/run-loop.sh
+++ b/.claude/skills/orchestrate/scripts/run-loop.sh
@@ -86,11 +86,11 @@ handle_approve() {
   fi
 
   # Numbered-option dialog (e.g. "Do you want to make this edit?" / "1. Yes / 2. Yes, and... / 3. No")
-  # These appear when claude edits files in .claude/ or needs session-level permission.
-  # Always pick option 1 (Yes) for safe operations.
-  if echo "$pane_tail" | grep -qE "^\s*[❯>]\s*1\." || echo "$pane_tail" | grep -q "Esc to cancel"; then
-    echo "[$(date +%H:%M:%S)] APPROVE numbered $window — sending 1 (Yes)"
-    tmux send-keys -t "$window" "1" Enter
+  # The ❯ cursor is already on option 1 (Yes) — pressing Enter alone confirms it.
+  # Sending "1" or "2" types the digit into the input rather than selecting the option.
+  if echo "$pane_tail" | grep -qE "❯\s*1\." || echo "$pane_tail" | grep -q "Esc to cancel"; then
+    echo "[$(date +%H:%M:%S)] APPROVE numbered $window — pressing Enter (Yes)"
+    tmux send-keys -t "$window" "" Enter
     return
   fi
 

--- a/.claude/skills/orchestrate/scripts/run-loop.sh
+++ b/.claude/skills/orchestrate/scripts/run-loop.sh
@@ -82,7 +82,9 @@ handle_kick() {
     echo "[$(date +%H:%M:%S)] KICK WARNING  $window — timed out waiting for ❯, sending objective anyway"
   fi
 
-  tmux send-keys -t "$window" "${objective}. When all work is done, output the exact string: ORCHESTRATOR:DONE" Enter
+  tmux send-keys -t "$window" "${objective}. When all work is done, output the exact string: ORCHESTRATOR:DONE"
+  sleep 0.3
+  tmux send-keys -t "$window" Enter
 }
 
 # ---------------------------------------------------------------------------
@@ -150,7 +152,9 @@ handle_complete() {
     echo "[$(date +%H:%M:%S)] RE-BRIEFING    $window — sending task context from state file"
     local pr_number
     pr_number=$(agent_field "$window" "pr_number")
-    tmux send-keys -t "$window" "You output ORCHESTRATOR:DONE but work is not complete: $verify_msg. Re-read your task: cat ~/.claude/orchestrator-state.json | jq '.agents[] | select(.window==\"$window\")' and gh pr view $pr_number --json title,body to reorient. Fix what is missing, then output ORCHESTRATOR:DONE again." Enter
+    tmux send-keys -t "$window" "You output ORCHESTRATOR:DONE but work is not complete: $verify_msg. Re-read your task: cat ~/.claude/orchestrator-state.json | jq '.agents[] | select(.window==\"$window\")' and gh pr view $pr_number --json title,body to reorient. Fix what is missing, then output ORCHESTRATOR:DONE again."
+    sleep 0.3
+    tmux send-keys -t "$window" Enter
     update_state "$window" "state" "running"
     update_state_int "$window" "last_rebriefed_at" "$(date +%s)"
     return
@@ -196,7 +200,9 @@ check_supervisor() {
 
       # Send recovery prompt — reads full state from file so no hardcoded context needed
       local state_file_path="$STATE_FILE"
-      tmux send-keys -t "$sup_win" "You are the fleet supervisor. Your prior context was lost. Start by reading: cat ${state_file_path} | jq — then capture each running agent's pane (tmux capture-pane -t WINDOW -p -S -200 | tail -80) and resume active supervision: nudge stalled agents, fix CI failures, answer questions. Loop every 2-3 minutes until all agents are done." Enter
+      tmux send-keys -t "$sup_win" "You are the fleet supervisor. Your prior context was lost. Start by reading: cat ${state_file_path} | jq — then capture each running agent's pane (tmux capture-pane -t WINDOW -p -S -200 | tail -80) and resume active supervision: nudge stalled agents, fix CI failures, answer questions. Loop every 2-3 minutes until all agents are done."
+      sleep 0.3
+      tmux send-keys -t "$sup_win" Enter
       ;;
   esac
 }

--- a/.claude/skills/orchestrate/scripts/run-loop.sh
+++ b/.claude/skills/orchestrate/scripts/run-loop.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
-# run-loop.sh — Orchestrator polling loop (runs in its own dedicated tmux window)
+# run-loop.sh — Mechanical babysitter for the agent fleet (runs in its own tmux window)
 #
-# Calls poll-cycle.sh every POLL_INTERVAL seconds and handles all actions in bash:
-#   kick (idle)  → restart agent (spawn claude + send objective)
-#   kick (stuck) → nudge running agent
-#   approve      → auto-approve safe ops; escalate destructive ones
-#   complete     → recycle via recycle-agent.sh + mark done in state file
+# Handles ONLY things that need no intelligence:
+#   idle    → restart claude (agent process crashed/exited)
+#   approve → auto-approve safe dialogs, press Enter on numbered-option dialogs
+#   complete → recycle worktree via recycle-agent.sh
+#
+# Stuck agents and task deviation are handled by the supervisor (CronCreate in
+# the main Claude session) which has real context and can give targeted guidance.
 #
 # Usage: run-loop.sh
 # Env:   POLL_INTERVAL (default: 30), ORCHESTRATOR_STATE_FILE
@@ -16,14 +18,8 @@ SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 STATE_FILE="${ORCHESTRATOR_STATE_FILE:-$HOME/.claude/orchestrator-state.json}"
 POLL_INTERVAL="${POLL_INTERVAL:-30}"
 
-# Auto-approve: command matches one of these patterns (case-insensitive, extended regex)
-SAFE_PATTERNS="(^git |^npm |^pnpm |^poetry |^pytest|^docker |^make |^cargo |^pip |^yarn |^npx |curl .*(localhost|127\.0\.0\.1))"
-
-# Escalate immediately: never auto-approve these
-ESCALATE_PATTERNS="(rm -rf [^.~/]|--force.*(main|master)|sudo |GITHUB_TOKEN|API_KEY|SECRET)"
-
 # ---------------------------------------------------------------------------
-# update_state WINDOW FIELD VALUE — atomically update one agent field
+# update_state WINDOW FIELD VALUE
 # ---------------------------------------------------------------------------
 update_state() {
   local window="$1" field="$2" value="$3"
@@ -32,9 +28,6 @@ update_state() {
     "$STATE_FILE" > "${STATE_FILE}.tmp" && mv "${STATE_FILE}.tmp" "$STATE_FILE"
 }
 
-# ---------------------------------------------------------------------------
-# agent_field WINDOW FIELD — read a field from state file for one agent
-# ---------------------------------------------------------------------------
 agent_field() {
   jq -r --arg w "$1" --arg f "$2" \
     '.agents[] | select(.window == $w) | .[$f] // ""' \
@@ -42,79 +35,63 @@ agent_field() {
 }
 
 # ---------------------------------------------------------------------------
-# handle_kick WINDOW STATE
+# handle_kick WINDOW — only for idle (crashed) agents, not stuck
 # ---------------------------------------------------------------------------
 handle_kick() {
   local window="$1" state="$2"
-  local worktree_path objective
+  [[ "$state" != "idle" ]] && return  # stuck agents handled by supervisor
 
+  local worktree_path objective
   worktree_path=$(agent_field "$window" "worktree_path")
   objective=$(agent_field "$window" "objective")
 
-  if [[ "$state" == "idle" ]]; then
-    echo "[$(date +%H:%M:%S)] KICK restart  $window"
-    tmux send-keys -t "$window" "cd '${worktree_path}' && claude --permission-mode bypassPermissions" Enter
-    sleep 3
-    # Auto-dismiss settings error dialog if present
-    local pane
-    pane=$(tmux capture-pane -t "$window" -p 2>/dev/null || echo "")
-    if echo "$pane" | grep -q "Enter to confirm"; then
-      tmux send-keys -t "$window" Down Enter
-      sleep 2
-    fi
-    tmux send-keys -t "$window" "${objective}. When all work is done, output the exact string: ORCHESTRATOR:DONE" Enter
-  else
-    # stuck — claude is running but output is frozen, nudge it
-    echo "[$(date +%H:%M:%S)] KICK nudge    $window (stuck)"
-    tmux send-keys -t "$window" "Continue with your task. Review any errors and proceed. When done output ORCHESTRATOR:DONE" Enter
+  echo "[$(date +%H:%M:%S)] KICK restart  $window — agent exited, restarting"
+  tmux send-keys -t "$window" "cd '${worktree_path}' && claude --permission-mode bypassPermissions" Enter
+  sleep 3
+
+  # Auto-dismiss settings error dialog
+  local pane
+  pane=$(tmux capture-pane -t "$window" -p 2>/dev/null || echo "")
+  if echo "$pane" | grep -q "Enter to confirm"; then
+    tmux send-keys -t "$window" Down Enter
+    sleep 2
   fi
+
+  tmux send-keys -t "$window" "${objective}. When all work is done, output the exact string: ORCHESTRATOR:DONE" Enter
 }
 
 # ---------------------------------------------------------------------------
-# handle_approve WINDOW
+# handle_approve WINDOW — auto-approve dialogs that need no judgment
 # ---------------------------------------------------------------------------
 handle_approve() {
   local window="$1"
   local pane_tail
   pane_tail=$(tmux capture-pane -t "$window" -p 2>/dev/null | tail -10 || echo "")
 
-  # Settings error dialog (startup)
+  # Settings error dialog at startup
   if echo "$pane_tail" | grep -q "Enter to confirm"; then
-    echo "[$(date +%H:%M:%S)] APPROVE dialog $window — dismissing settings error"
+    echo "[$(date +%H:%M:%S)] APPROVE dialog $window — settings error"
     tmux send-keys -t "$window" Down Enter
     return
   fi
 
-  # Numbered-option dialog (e.g. "Do you want to make this edit?" / "1. Yes / 2. Yes, and... / 3. No")
-  # The ❯ cursor is already on option 1 (Yes) — pressing Enter alone confirms it.
-  # Sending "1" or "2" types the digit into the input rather than selecting the option.
+  # Numbered-option dialog (e.g. "Do you want to make this edit?")
+  # ❯ is already on option 1 (Yes) — Enter confirms it
   if echo "$pane_tail" | grep -qE "❯\s*1\." || echo "$pane_tail" | grep -q "Esc to cancel"; then
-    echo "[$(date +%H:%M:%S)] APPROVE numbered $window — pressing Enter (Yes)"
+    echo "[$(date +%H:%M:%S)] APPROVE edit   $window"
     tmux send-keys -t "$window" "" Enter
     return
   fi
 
-  # Escalation patterns — never auto-approve
-  if echo "$pane_tail" | grep -qiE "$ESCALATE_PATTERNS"; then
-    echo "[$(date +%H:%M:%S)] ESCALATE       $window — destructive pattern, needs human review:"
-    echo "$pane_tail" | tail -5 | sed 's/^/    /'
-    update_state "$window" "state" "escalated"
-    printf '\a'  # terminal bell
-    return
-  fi
-
-  # Safe patterns — auto-approve with y
-  if echo "$pane_tail" | grep -qiE "$SAFE_PATTERNS"; then
-    echo "[$(date +%H:%M:%S)] APPROVE auto   $window"
+  # y/n prompt for safe operations
+  if echo "$pane_tail" | grep -qiE "(^git |^npm |^pnpm |^poetry |^pytest|^docker |^make |^cargo |^pip |^yarn |curl .*(localhost|127\.0\.0\.1))"; then
+    echo "[$(date +%H:%M:%S)] APPROVE safe   $window"
     tmux send-keys -t "$window" "y" Enter
     return
   fi
 
-  # Unknown — escalate to be safe
-  echo "[$(date +%H:%M:%S)] ESCALATE       $window — unknown approval request:"
-  echo "$pane_tail" | tail -5 | sed 's/^/    /'
-  update_state "$window" "state" "escalated"
-  printf '\a'
+  # Anything else — supervisor handles it, just log
+  echo "[$(date +%H:%M:%S)] APPROVE skip   $window — unknown dialog, supervisor will handle"
 }
 
 # ---------------------------------------------------------------------------
@@ -134,14 +111,13 @@ handle_complete() {
 # ---------------------------------------------------------------------------
 # Main loop
 # ---------------------------------------------------------------------------
-echo "[$(date +%H:%M:%S)] Orchestrator loop started (poll every ${POLL_INTERVAL}s)"
-echo "[$(date +%H:%M:%S)] State: $STATE_FILE"
+echo "[$(date +%H:%M:%S)] run-loop started (mechanical only, poll every ${POLL_INTERVAL}s)"
+echo "[$(date +%H:%M:%S)] Supervisor: CronCreate in main Claude session"
 echo "---"
 
 while true; do
-  # Stop if orchestrator was deactivated
   if ! jq -e '.active == true' "$STATE_FILE" >/dev/null 2>&1; then
-    echo "[$(date +%H:%M:%S)] active=false — loop exiting."
+    echo "[$(date +%H:%M:%S)] active=false — exiting."
     exit 0
   fi
 
@@ -150,32 +126,20 @@ while true; do
 
   while IFS= read -r action; do
     [ -z "$action" ] && continue
-
     WINDOW=$(echo "$action" | jq -r '.window // ""')
     ACTION=$(echo "$action" | jq -r '.action // ""')
     STATE=$(echo "$action"  | jq -r '.state // ""')
 
     case "$ACTION" in
-      kick)
-        handle_kick "$WINDOW" "$STATE" || true
-        KICKED=$(( KICKED + 1 ))
-        ;;
-      approve)
-        handle_approve "$WINDOW" || true
-        ;;
-      complete)
-        handle_complete "$WINDOW" || true
-        DONE=$(( DONE + 1 ))
-        ;;
+      kick)     handle_kick "$WINDOW" "$STATE" || true; KICKED=$(( KICKED + 1 )) ;;
+      approve)  handle_approve "$WINDOW" || true ;;
+      complete) handle_complete "$WINDOW" || true; DONE=$(( DONE + 1 )) ;;
     esac
   done < <(echo "$ACTIONS" | jq -c '.[]' 2>/dev/null || true)
 
   RUNNING=$(jq '[.agents[] | select(.state | test("running|stuck|waiting_approval|idle"))] | length' \
     "$STATE_FILE" 2>/dev/null || echo 0)
-  ESCALATED=$(jq '[.agents[] | select(.state == "escalated")] | length' \
-    "$STATE_FILE" 2>/dev/null || echo 0)
 
-  echo "[$(date +%H:%M:%S)] Poll — ${RUNNING} running  ${KICKED} kicked  ${DONE} recycled  ${ESCALATED} escalated"
-
+  echo "[$(date +%H:%M:%S)] Poll — ${RUNNING} running  ${KICKED} kicked  ${DONE} recycled"
   sleep "$POLL_INTERVAL"
 done

--- a/.claude/skills/orchestrate/scripts/run-loop.sh
+++ b/.claude/skills/orchestrate/scripts/run-loop.sh
@@ -59,14 +59,27 @@ handle_kick() {
 
   echo "[$(date +%H:%M:%S)] KICK restart  $window — agent exited, restarting"
   tmux send-keys -t "$window" "cd '${worktree_path}' && claude --permission-mode bypassPermissions" Enter
-  sleep 3
 
-  # Auto-dismiss settings error dialog
-  local pane
-  pane=$(tmux capture-pane -t "$window" -p 2>/dev/null || echo "")
-  if echo "$pane" | grep -q "Enter to confirm"; then
-    tmux send-keys -t "$window" Down Enter
-    sleep 2
+  # Wait up to 60s for claude to be fully interactive: node + ❯ prompt visible
+  local kick_prompt_found=false
+  for i in $(seq 1 60); do
+    local kick_cmd kick_pane
+    kick_cmd=$(tmux display-message -t "$window" -p '#{pane_current_command}' 2>/dev/null || echo "")
+    kick_pane=$(tmux capture-pane -t "$window" -p 2>/dev/null || echo "")
+    if echo "$kick_pane" | grep -q "Enter to confirm"; then
+      tmux send-keys -t "$window" Down Enter
+      sleep 2
+      continue
+    fi
+    if [[ "$kick_cmd" == "node" ]] && echo "$kick_pane" | grep -q "❯"; then
+      kick_prompt_found=true
+      break
+    fi
+    sleep 1
+  done
+
+  if ! $kick_prompt_found; then
+    echo "[$(date +%H:%M:%S)] KICK WARNING  $window — timed out waiting for ❯, sending objective anyway"
   fi
 
   tmux send-keys -t "$window" "${objective}. When all work is done, output the exact string: ORCHESTRATOR:DONE" Enter
@@ -78,7 +91,7 @@ handle_kick() {
 handle_approve() {
   local window="$1"
   local pane_tail
-  pane_tail=$(tmux capture-pane -t "$window" -p 2>/dev/null | tail -10 || echo "")
+  pane_tail=$(tmux capture-pane -t "$window" -p 2>/dev/null | tail -3 || echo "")
 
   # Settings error dialog at startup
   if echo "$pane_tail" | grep -q "Enter to confirm"; then

--- a/.claude/skills/orchestrate/scripts/run-loop.sh
+++ b/.claude/skills/orchestrate/scripts/run-loop.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 # run-loop.sh — Mechanical babysitter for the agent fleet (runs in its own tmux window)
 #
-# Handles ONLY things that need no intelligence:
-#   idle    → restart claude (agent process crashed/exited)
+# Handles ONLY two things that need no intelligence:
+#   idle    → restart claude using --resume SESSION_ID (or --continue) to restore context
 #   approve → auto-approve safe dialogs, press Enter on numbered-option dialogs
-#   complete → verify + mark done + notify (NO auto-recycle — user must explicitly recycle)
 #
-# Worktrees are NEVER recycled automatically. Recycling requires explicit user consent.
-# To recycle a completed window: bash recycle-agent.sh WINDOW WORKTREE_PATH SPARE_BRANCH
-# Sessions can be resumed at any time: claude --resume SESSION_ID --permission-mode bypassPermissions
+# Everything else — ORCHESTRATOR:DONE, verification, /pr-test, final evaluation,
+# marking done, deciding to close windows — is the orchestrating Claude's job.
+# poll-cycle.sh sets state to pending_evaluation when ORCHESTRATOR:DONE is detected;
+# the orchestrator's background poll loop handles it from there.
 #
 # Usage: run-loop.sh
 # Env:   POLL_INTERVAL (default: 30), ORCHESTRATOR_STATE_FILE
@@ -28,7 +28,6 @@ SCRIPTS_DIR="$STABLE_SCRIPTS_DIR"
 
 STATE_FILE="${ORCHESTRATOR_STATE_FILE:-$HOME/.claude/orchestrator-state.json}"
 POLL_INTERVAL="${POLL_INTERVAL:-30}"
-REBRIEFED_COOLDOWN=300  # 5 minutes between re-briefs for the same agent
 
 # ---------------------------------------------------------------------------
 # update_state WINDOW FIELD VALUE
@@ -129,86 +128,6 @@ handle_approve() {
 }
 
 # ---------------------------------------------------------------------------
-# handle_complete WINDOW — verify; re-brief if not done; mark done+notify (NO recycle)
-# ---------------------------------------------------------------------------
-handle_complete() {
-  local window="$1"
-  local objective
-  objective=$(agent_field "$window" "objective")
-
-  # Verify completion: checkpoints, CI, unresolved threads, CHANGES_REQUESTED
-  local verify_msg
-  if ! verify_msg=$(bash "$SCRIPTS_DIR/verify-complete.sh" "$window" 2>&1); then
-    # Enforce re-brief cooldown — don't spam the agent every 30s
-    local now last_rebriefed elapsed
-    now=$(date +%s)
-    last_rebriefed=$(agent_field "$window" "last_rebriefed_at")
-    last_rebriefed=${last_rebriefed:-0}
-    [[ "$last_rebriefed" == "null" || -z "$last_rebriefed" ]] && last_rebriefed=0
-    elapsed=$(( now - last_rebriefed ))
-
-    if [ "$elapsed" -lt "$REBRIEFED_COOLDOWN" ]; then
-      local wait_secs=$(( REBRIEFED_COOLDOWN - elapsed ))
-      echo "[$(date +%H:%M:%S)] RE-BRIEF COOLDOWN $window — next in ${wait_secs}s ($verify_msg)"
-      return
-    fi
-
-    echo "[$(date +%H:%M:%S)] NOT DONE       $window — $verify_msg"
-    echo "[$(date +%H:%M:%S)] RE-BRIEFING    $window — sending task context from state file"
-    local pr_number
-    pr_number=$(agent_field "$window" "pr_number")
-    tmux send-keys -t "$window" "You output ORCHESTRATOR:DONE but work is not complete: $verify_msg. Re-read your task: cat ~/.claude/orchestrator-state.json | jq '.agents[] | select(.window==\"$window\")' and gh pr view $pr_number --json title,body to reorient. Fix what is missing, then output ORCHESTRATOR:DONE again."
-    sleep 0.3
-    tmux send-keys -t "$window" Enter
-    update_state "$window" "state" "running"
-    update_state_int "$window" "last_rebriefed_at" "$(date +%s)"
-    return
-  fi
-
-  # Verified complete — mark done and notify. DO NOT recycle the window.
-  # The worktree stays on its branch, the session stays alive, the window stays open.
-  # Recycling requires explicit user/orchestrator consent.
-  echo "[$(date +%H:%M:%S)] COMPLETE ✓     $window — $verify_msg"
-  echo "[$(date +%H:%M:%S)] MARKED DONE    $window — window kept open; recycle when ready"
-  update_state "$window" "state" "done"
-
-  local worktree spare_branch session_id
-  worktree=$(agent_field "$window" "worktree")
-  spare_branch=$(agent_field "$window" "spare_branch")
-  session_id=$(agent_field "$window" "session_id")
-
-  local resume_hint=""
-  [ -n "$session_id" ] && resume_hint=" Resume: claude --resume $session_id --permission-mode bypassPermissions"
-
-  bash "$SCRIPTS_DIR/notify.sh" "✓ $window ($worktree) done — window kept open.${resume_hint} To recycle: recycle-agent.sh $window WORKTREE_PATH $spare_branch" || true
-}
-
-# ---------------------------------------------------------------------------
-# check_all_done — notify and optionally stop when every agent is terminal
-# ---------------------------------------------------------------------------
-NOTIFIED_DONE=false
-
-check_all_done() {
-  $NOTIFIED_DONE && return  # already notified this run
-
-  local total running
-  total=$(jq '.agents | length' "$STATE_FILE" 2>/dev/null || echo 0)
-  [ "$total" -eq 0 ] && return
-
-  running=$(jq '[.agents[] | select(.state | test("running|stuck|waiting_approval|idle"))] | length' \
-    "$STATE_FILE" 2>/dev/null || echo 1)
-
-  if [ "$running" -eq 0 ]; then
-    local done_count escalated_count
-    done_count=$(jq '[.agents[] | select(.state == "done")] | length' "$STATE_FILE" 2>/dev/null || echo 0)
-    escalated_count=$(jq '[.agents[] | select(.state == "escalated")] | length' "$STATE_FILE" 2>/dev/null || echo 0)
-    echo "[$(date +%H:%M:%S)] ALL DONE ✓     ${done_count} done, ${escalated_count} escalated"
-    bash "$SCRIPTS_DIR/notify.sh" "🏁 Fleet complete — ${done_count}/${total} done, ${escalated_count} escalated. Run capacity.sh to see free worktrees." || true
-    NOTIFIED_DONE=true
-  fi
-}
-
-# ---------------------------------------------------------------------------
 # Main loop
 # ---------------------------------------------------------------------------
 echo "[$(date +%H:%M:%S)] run-loop started (mechanical only, poll every ${POLL_INTERVAL}s)"
@@ -233,12 +152,9 @@ while true; do
     case "$ACTION" in
       kick)     handle_kick "$WINDOW" "$STATE" || true; KICKED=$(( KICKED + 1 )) ;;
       approve)  handle_approve "$WINDOW" || true ;;
-      complete) handle_complete "$WINDOW" || true; DONE=$(( DONE + 1 )) ;;
+      complete) DONE=$(( DONE + 1 )) ;;  # poll-cycle already set state=pending_evaluation; orchestrator handles
     esac
   done < <(echo "$ACTIONS" | jq -c '.[]' 2>/dev/null || true)
-
-  # Check if fleet is fully complete
-  check_all_done || true
 
   RUNNING=$(jq '[.agents[] | select(.state | test("running|stuck|waiting_approval|idle"))] | length' \
     "$STATE_FILE" 2>/dev/null || echo 0)

--- a/.claude/skills/orchestrate/scripts/run-loop.sh
+++ b/.claude/skills/orchestrate/scripts/run-loop.sh
@@ -180,57 +180,6 @@ handle_complete() {
 }
 
 # ---------------------------------------------------------------------------
-# check_supervisor — restart supervisor Claude window if its process has exited
-# ---------------------------------------------------------------------------
-check_supervisor() {
-  local sup_win
-  sup_win=$(jq -r '.supervisor_window // ""' "$STATE_FILE" 2>/dev/null || echo "")
-  [[ -z "$sup_win" || "$sup_win" == "null" ]] && return
-
-  local cmd
-  cmd=$(tmux display-message -t "$sup_win" -p '#{pane_current_command}' 2>/dev/null || echo "unknown")
-  case "$cmd" in
-    zsh|bash|fish|sh|dash|tcsh|ksh)
-      echo "[$(date +%H:%M:%S)] SUPERVISOR DEAD — restarting $sup_win"
-      # Use first agent's worktree_path as working directory (any valid git root works)
-      local work_dir
-      work_dir=$(jq -r '(.agents // []) | map(select(.worktree_path != "")) | .[0].worktree_path // ""' "$STATE_FILE" 2>/dev/null || echo "")
-      [[ -z "$work_dir" ]] && work_dir="$HOME"
-
-      tmux send-keys -t "$sup_win" "cd '${work_dir}' && claude --permission-mode bypassPermissions" Enter
-
-      # Wait up to 60s for claude to be fully interactive: node + ❯ prompt visible
-      local sup_prompt_found=false
-      for i in $(seq 1 60); do
-        local sup_cmd sup_pane
-        sup_cmd=$(tmux display-message -t "$sup_win" -p '#{pane_current_command}' 2>/dev/null || echo "")
-        sup_pane=$(tmux capture-pane -t "$sup_win" -p 2>/dev/null || echo "")
-        if echo "$sup_pane" | grep -q "Enter to confirm"; then
-          tmux send-keys -t "$sup_win" Down Enter
-          sleep 2
-          continue
-        fi
-        if [[ "$sup_cmd" == "node" ]] && echo "$sup_pane" | grep -q "❯"; then
-          sup_prompt_found=true
-          break
-        fi
-        sleep 1
-      done
-
-      if ! $sup_prompt_found; then
-        echo "[$(date +%H:%M:%S)] SUPERVISOR WARNING — timed out waiting for ❯, sending recovery prompt anyway"
-      fi
-
-      # Send recovery prompt — reads full state from file so no hardcoded context needed
-      local state_file_path="$STATE_FILE"
-      tmux send-keys -t "$sup_win" "You are the fleet supervisor. Your prior context was lost. Start by reading: cat ${state_file_path} | jq — then capture each running agent's pane (tmux capture-pane -t WINDOW -p -S -200 | tail -80) and resume active supervision: nudge stalled agents, fix CI failures, answer questions. Loop every 2-3 minutes until all agents are done."
-      sleep 0.3
-      tmux send-keys -t "$sup_win" Enter
-      ;;
-  esac
-}
-
-# ---------------------------------------------------------------------------
 # check_all_done — notify and optionally stop when every agent is terminal
 # ---------------------------------------------------------------------------
 NOTIFIED_DONE=false
@@ -259,7 +208,7 @@ check_all_done() {
 # Main loop
 # ---------------------------------------------------------------------------
 echo "[$(date +%H:%M:%S)] run-loop started (mechanical only, poll every ${POLL_INTERVAL}s)"
-echo "[$(date +%H:%M:%S)] Supervisor: dedicated window (see .supervisor_window in state file)"
+echo "[$(date +%H:%M:%S)] Supervisor: orchestrating Claude session (not a separate window)"
 echo "---"
 
 while true; do
@@ -283,9 +232,6 @@ while true; do
       complete) handle_complete "$WINDOW" || true; DONE=$(( DONE + 1 )) ;;
     esac
   done < <(echo "$ACTIONS" | jq -c '.[]' 2>/dev/null || true)
-
-  # Monitor supervisor health — restart if Claude has exited
-  check_supervisor || true
 
   # Check if fleet is fully complete
   check_all_done || true

--- a/.claude/skills/orchestrate/scripts/run-loop.sh
+++ b/.claude/skills/orchestrate/scripts/run-loop.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# run-loop.sh — Orchestrator polling loop (runs in its own dedicated tmux window)
+#
+# Calls poll-cycle.sh every POLL_INTERVAL seconds and handles all actions in bash:
+#   kick (idle)  → restart agent (spawn claude + send objective)
+#   kick (stuck) → nudge running agent
+#   approve      → auto-approve safe ops; escalate destructive ones
+#   complete     → recycle via recycle-agent.sh + mark done in state file
+#
+# Usage: run-loop.sh
+# Env:   POLL_INTERVAL (default: 30), ORCHESTRATOR_STATE_FILE
+
+set -euo pipefail
+
+SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STATE_FILE="${ORCHESTRATOR_STATE_FILE:-$HOME/.claude/orchestrator-state.json}"
+POLL_INTERVAL="${POLL_INTERVAL:-30}"
+
+# Auto-approve: command matches one of these patterns (case-insensitive, extended regex)
+SAFE_PATTERNS="(^git |^npm |^pnpm |^poetry |^pytest|^docker |^make |^cargo |^pip |^yarn |^npx |curl .*(localhost|127\.0\.0\.1))"
+
+# Escalate immediately: never auto-approve these
+ESCALATE_PATTERNS="(rm -rf [^.~/]|--force.*(main|master)|sudo |GITHUB_TOKEN|API_KEY|SECRET)"
+
+# ---------------------------------------------------------------------------
+# update_state WINDOW FIELD VALUE — atomically update one agent field
+# ---------------------------------------------------------------------------
+update_state() {
+  local window="$1" field="$2" value="$3"
+  jq --arg w "$window" --arg f "$field" --arg v "$value" \
+    '.agents |= map(if .window == $w then .[$f] = $v else . end)' \
+    "$STATE_FILE" > "${STATE_FILE}.tmp" && mv "${STATE_FILE}.tmp" "$STATE_FILE"
+}
+
+# ---------------------------------------------------------------------------
+# agent_field WINDOW FIELD — read a field from state file for one agent
+# ---------------------------------------------------------------------------
+agent_field() {
+  jq -r --arg w "$1" --arg f "$2" \
+    '.agents[] | select(.window == $w) | .[$f] // ""' \
+    "$STATE_FILE" 2>/dev/null
+}
+
+# ---------------------------------------------------------------------------
+# handle_kick WINDOW STATE
+# ---------------------------------------------------------------------------
+handle_kick() {
+  local window="$1" state="$2"
+  local worktree_path objective
+
+  worktree_path=$(agent_field "$window" "worktree_path")
+  objective=$(agent_field "$window" "objective")
+
+  if [[ "$state" == "idle" ]]; then
+    echo "[$(date +%H:%M:%S)] KICK restart  $window"
+    tmux send-keys -t "$window" "cd '${worktree_path}' && claude --permission-mode bypassPermissions" Enter
+    sleep 3
+    # Auto-dismiss settings error dialog if present
+    local pane
+    pane=$(tmux capture-pane -t "$window" -p 2>/dev/null || echo "")
+    if echo "$pane" | grep -q "Enter to confirm"; then
+      tmux send-keys -t "$window" Down Enter
+      sleep 2
+    fi
+    tmux send-keys -t "$window" "${objective}. When all work is done, output the exact string: ORCHESTRATOR:DONE" Enter
+  else
+    # stuck — claude is running but output is frozen, nudge it
+    echo "[$(date +%H:%M:%S)] KICK nudge    $window (stuck)"
+    tmux send-keys -t "$window" "Continue with your task. Review any errors and proceed. When done output ORCHESTRATOR:DONE" Enter
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# handle_approve WINDOW
+# ---------------------------------------------------------------------------
+handle_approve() {
+  local window="$1"
+  local pane_tail
+  pane_tail=$(tmux capture-pane -t "$window" -p 2>/dev/null | tail -10 || echo "")
+
+  # Settings error dialog
+  if echo "$pane_tail" | grep -q "Enter to confirm"; then
+    echo "[$(date +%H:%M:%S)] APPROVE dialog $window — dismissing settings error"
+    tmux send-keys -t "$window" Down Enter
+    return
+  fi
+
+  # Escalation patterns — never auto-approve
+  if echo "$pane_tail" | grep -qiE "$ESCALATE_PATTERNS"; then
+    echo "[$(date +%H:%M:%S)] ESCALATE       $window — destructive pattern, needs human review:"
+    echo "$pane_tail" | tail -5 | sed 's/^/    /'
+    update_state "$window" "state" "escalated"
+    printf '\a'  # terminal bell
+    return
+  fi
+
+  # Safe patterns — auto-approve
+  if echo "$pane_tail" | grep -qiE "$SAFE_PATTERNS"; then
+    echo "[$(date +%H:%M:%S)] APPROVE auto   $window"
+    tmux send-keys -t "$window" "y" Enter
+    return
+  fi
+
+  # Unknown — escalate to be safe
+  echo "[$(date +%H:%M:%S)] ESCALATE       $window — unknown approval request:"
+  echo "$pane_tail" | tail -5 | sed 's/^/    /'
+  update_state "$window" "state" "escalated"
+  printf '\a'
+}
+
+# ---------------------------------------------------------------------------
+# handle_complete WINDOW
+# ---------------------------------------------------------------------------
+handle_complete() {
+  local window="$1"
+  local worktree_path spare_branch
+  worktree_path=$(agent_field "$window" "worktree_path")
+  spare_branch=$(agent_field "$window" "spare_branch")
+
+  echo "[$(date +%H:%M:%S)] COMPLETE       $window — recycling to $spare_branch"
+  bash "$SCRIPTS_DIR/recycle-agent.sh" "$window" "$worktree_path" "$spare_branch"
+  update_state "$window" "state" "done"
+}
+
+# ---------------------------------------------------------------------------
+# Main loop
+# ---------------------------------------------------------------------------
+echo "[$(date +%H:%M:%S)] Orchestrator loop started (poll every ${POLL_INTERVAL}s)"
+echo "[$(date +%H:%M:%S)] State: $STATE_FILE"
+echo "---"
+
+while true; do
+  # Stop if orchestrator was deactivated
+  if ! jq -e '.active == true' "$STATE_FILE" >/dev/null 2>&1; then
+    echo "[$(date +%H:%M:%S)] active=false — loop exiting."
+    exit 0
+  fi
+
+  ACTIONS=$("$SCRIPTS_DIR/poll-cycle.sh" 2>/dev/null || echo "[]")
+  KICKED=0; DONE=0
+
+  while IFS= read -r action; do
+    [ -z "$action" ] && continue
+
+    WINDOW=$(echo "$action" | jq -r '.window // ""')
+    ACTION=$(echo "$action" | jq -r '.action // ""')
+    STATE=$(echo "$action"  | jq -r '.state // ""')
+
+    case "$ACTION" in
+      kick)
+        handle_kick "$WINDOW" "$STATE" || true
+        KICKED=$(( KICKED + 1 ))
+        ;;
+      approve)
+        handle_approve "$WINDOW" || true
+        ;;
+      complete)
+        handle_complete "$WINDOW" || true
+        DONE=$(( DONE + 1 ))
+        ;;
+    esac
+  done < <(echo "$ACTIONS" | jq -c '.[]' 2>/dev/null || true)
+
+  RUNNING=$(jq '[.agents[] | select(.state | test("running|stuck|waiting_approval|idle"))] | length' \
+    "$STATE_FILE" 2>/dev/null || echo 0)
+  ESCALATED=$(jq '[.agents[] | select(.state == "escalated")] | length' \
+    "$STATE_FILE" 2>/dev/null || echo 0)
+
+  echo "[$(date +%H:%M:%S)] Poll — ${RUNNING} running  ${KICKED} kicked  ${DONE} recycled  ${ESCALATED} escalated"
+
+  sleep "$POLL_INTERVAL"
+done

--- a/.claude/skills/orchestrate/scripts/run-loop.sh
+++ b/.claude/skills/orchestrate/scripts/run-loop.sh
@@ -18,7 +18,17 @@
 
 set -euo pipefail
 
-SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Copy scripts to a stable location outside the repo so they survive branch
+# checkouts (e.g. recycle-agent.sh switching spare/N back into this worktree
+# would wipe .claude/skills/orchestrate/scripts if the skill only exists on the
+# current branch).
+_ORIGIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STABLE_SCRIPTS_DIR="$HOME/.claude/orchestrator/scripts"
+mkdir -p "$STABLE_SCRIPTS_DIR"
+cp "$_ORIGIN_DIR"/*.sh "$STABLE_SCRIPTS_DIR/"
+chmod +x "$STABLE_SCRIPTS_DIR"/*.sh
+SCRIPTS_DIR="$STABLE_SCRIPTS_DIR"
+
 STATE_FILE="${ORCHESTRATOR_STATE_FILE:-$HOME/.claude/orchestrator-state.json}"
 POLL_INTERVAL="${POLL_INTERVAL:-30}"
 REBRIEFED_COOLDOWN=300  # 5 minutes between re-briefs for the same agent

--- a/.claude/skills/orchestrate/scripts/run-loop.sh
+++ b/.claude/skills/orchestrate/scripts/run-loop.sh
@@ -78,10 +78,19 @@ handle_approve() {
   local pane_tail
   pane_tail=$(tmux capture-pane -t "$window" -p 2>/dev/null | tail -10 || echo "")
 
-  # Settings error dialog
+  # Settings error dialog (startup)
   if echo "$pane_tail" | grep -q "Enter to confirm"; then
     echo "[$(date +%H:%M:%S)] APPROVE dialog $window — dismissing settings error"
     tmux send-keys -t "$window" Down Enter
+    return
+  fi
+
+  # Numbered-option dialog (e.g. "Do you want to make this edit?" / "1. Yes / 2. Yes, and... / 3. No")
+  # These appear when claude edits files in .claude/ or needs session-level permission.
+  # Always pick option 1 (Yes) for safe operations.
+  if echo "$pane_tail" | grep -qE "^\s*[❯>]\s*1\." || echo "$pane_tail" | grep -q "Esc to cancel"; then
+    echo "[$(date +%H:%M:%S)] APPROVE numbered $window — sending 1 (Yes)"
+    tmux send-keys -t "$window" "1" Enter
     return
   fi
 
@@ -94,7 +103,7 @@ handle_approve() {
     return
   fi
 
-  # Safe patterns — auto-approve
+  # Safe patterns — auto-approve with y
   if echo "$pane_tail" | grep -qiE "$SAFE_PATTERNS"; then
     echo "[$(date +%H:%M:%S)] APPROVE auto   $window"
     tmux send-keys -t "$window" "y" Enter

--- a/.claude/skills/orchestrate/scripts/run-loop.sh
+++ b/.claude/skills/orchestrate/scripts/run-loop.sh
@@ -95,15 +95,29 @@ handle_approve() {
 }
 
 # ---------------------------------------------------------------------------
-# handle_complete WINDOW
+# handle_complete WINDOW — verify before recycling
 # ---------------------------------------------------------------------------
 handle_complete() {
   local window="$1"
-  local worktree_path spare_branch
+  local worktree_path spare_branch objective
   worktree_path=$(agent_field "$window" "worktree_path")
   spare_branch=$(agent_field "$window" "spare_branch")
+  objective=$(agent_field "$window" "objective")
 
-  echo "[$(date +%H:%M:%S)] COMPLETE       $window — recycling to $spare_branch"
+  # Verify completion: check unresolved threads, CI, checkpoints
+  local verify_msg
+  if ! verify_msg=$(bash "$SCRIPTS_DIR/verify-complete.sh" "$window" 2>&1); then
+    echo "[$(date +%H:%M:%S)] NOT DONE       $window — $verify_msg"
+    echo "[$(date +%H:%M:%S)] RE-BRIEFING    $window — sending task context from state file"
+    local pr_number
+    pr_number=$(agent_field "$window" "pr_number")
+    tmux send-keys -t "$window" "You output ORCHESTRATOR:DONE but work is not complete: $verify_msg. Re-read your task: cat ~/.claude/orchestrator-state.json | jq '.agents[] | select(.window==\"$window\")' and gh pr view $pr_number --json title,body to reorient. Fix what is missing, then output ORCHESTRATOR:DONE again." Enter
+    update_state "$window" "state" "running"
+    return
+  fi
+
+  echo "[$(date +%H:%M:%S)] COMPLETE ✓     $window — $verify_msg"
+  echo "[$(date +%H:%M:%S)] RECYCLING      $window → $spare_branch"
   bash "$SCRIPTS_DIR/recycle-agent.sh" "$window" "$worktree_path" "$spare_branch"
   update_state "$window" "state" "done"
 }

--- a/.claude/skills/orchestrate/scripts/spawn-agent.sh
+++ b/.claude/skills/orchestrate/scripts/spawn-agent.sh
@@ -36,22 +36,25 @@ WINDOW="${SESSION}:${WIN_IDX}"
 # Launch claude — single-quote path so spaces and special chars are safe
 tmux send-keys -t "$WINDOW" "cd '${WORKTREE_PATH}' && claude --permission-mode bypassPermissions" Enter
 
-# Wait up to 30s for the foreground process to become 'node'
-for i in $(seq 1 30); do
+# Wait up to 60s for claude to be fully interactive:
+# both pane_current_command == 'node' AND the '❯' prompt is visible.
+# Checking the prompt avoids sending the objective to the shell before
+# claude finishes initializing (which silently drops the message).
+for i in $(seq 1 60); do
   CMD=$(tmux display-message -t "$WINDOW" -p '#{pane_current_command}' 2>/dev/null || echo "")
-  [[ "$CMD" == "node" ]] && break
-  sleep 1
-done
-
-# Auto-dismiss settings error dialog ("Enter to confirm") if claude didn't start cleanly
-CMD=$(tmux display-message -t "$WINDOW" -p '#{pane_current_command}' 2>/dev/null || echo "")
-if [[ "$CMD" != "node" ]]; then
   PANE=$(tmux capture-pane -t "$WINDOW" -p 2>/dev/null || echo "")
+  # Auto-dismiss settings error dialog if present
   if echo "$PANE" | grep -q "Enter to confirm"; then
     tmux send-keys -t "$WINDOW" Down Enter
     sleep 2
+    continue
   fi
-fi
+  # Ready when node is running AND the interactive prompt is visible
+  if [[ "$CMD" == "node" ]] && echo "$PANE" | grep -q "❯"; then
+    break
+  fi
+  sleep 1
+done
 
 # Send the task — agent must output ORCHESTRATOR:DONE when finished
 tmux send-keys -t "$WINDOW" "${OBJECTIVE}. When all work is done, output the exact string: ORCHESTRATOR:DONE" Enter

--- a/.claude/skills/orchestrate/scripts/spawn-agent.sh
+++ b/.claude/skills/orchestrate/scripts/spawn-agent.sh
@@ -30,6 +30,10 @@ STEPS=("${@:7}")
 WORKTREE_NAME=$(basename "$WORKTREE_PATH")
 STATE_FILE="${ORCHESTRATOR_STATE_FILE:-$HOME/.claude/orchestrator-state.json}"
 
+# Generate a stable session ID so this agent's Claude session can always be resumed:
+#   claude --resume $SESSION_ID --permission-mode bypassPermissions
+SESSION_ID=$(uuidgen 2>/dev/null || python3 -c "import uuid; print(uuid.uuid4())")
+
 # Create (or switch to) the task branch
 git -C "$WORKTREE_PATH" checkout -b "$NEW_BRANCH" 2>/dev/null \
   || git -C "$WORKTREE_PATH" checkout "$NEW_BRANCH"
@@ -48,6 +52,7 @@ if [ -f "$STATE_FILE" ]; then
      --arg spare_branch "$SPARE_BRANCH" \
      --arg branch "$NEW_BRANCH" \
      --arg objective "$OBJECTIVE" \
+     --arg session_id "$SESSION_ID" \
      --argjson now "$NOW" \
      '.agents += [{
        "window": $window,
@@ -56,6 +61,7 @@ if [ -f "$STATE_FILE" ]; then
        "spare_branch": $spare_branch,
        "branch": $branch,
        "objective": $objective,
+       "session_id": $session_id,
        "state": "running",
        "checkpoints": [],
        "last_output_hash": "",
@@ -80,14 +86,9 @@ if [ -n "$PR_NUMBER" ] && [ -f "$STATE_FILE" ]; then
     "$STATE_FILE" > "${STATE_FILE}.tmp" && mv "${STATE_FILE}.tmp" "$STATE_FILE"
 fi
 
-# Build recovery instruction — agent reads state file + gh pr view to reorient after compaction
-RECOVERY=""
-if [ -n "$PR_NUMBER" ]; then
-  RECOVERY=" If your context compacts and you lose track of what to do, run: cat ~/.claude/orchestrator-state.json | jq '.agents[] | select(.window==\"$WINDOW\")' and gh pr view $PR_NUMBER --json title,body,headRefName to reorient. Output each completed step as a checkpoint: CHECKPOINT:<step-name> on its own line."
-fi
-
-# Launch claude — single-quote path so spaces and special chars are safe
-tmux send-keys -t "$WINDOW" "cd '${WORKTREE_PATH}' && claude --permission-mode bypassPermissions" Enter
+# Launch claude with a stable session ID so it can always be resumed after a crash:
+#   claude --resume SESSION_ID --permission-mode bypassPermissions
+tmux send-keys -t "$WINDOW" "cd '${WORKTREE_PATH}' && claude --permission-mode bypassPermissions --session-id '${SESSION_ID}'" Enter
 
 # Wait up to 60s for claude to be fully interactive:
 # both pane_current_command == 'node' AND the '❯' prompt is visible.
@@ -111,10 +112,9 @@ if ! $PROMPT_FOUND; then
   echo "[spawn-agent] WARNING: timed out waiting for ❯ prompt on $WINDOW — sending objective anyway" >&2
 fi
 
-# Send the task with checkpoint protocol and recovery instructions.
-# Split text and Enter into separate calls — if sent together, Enter can fire before
-# the full string is buffered into Claude's input, leaving the message stuck unsent.
-tmux send-keys -t "$WINDOW" "${OBJECTIVE}${RECOVERY} When ALL steps are done, output ORCHESTRATOR:DONE on its own line."
+# Send the task. Split text and Enter — if combined, Enter can fire before the string
+# is fully buffered, leaving the message stuck as "[Pasted text +N lines]" unsent.
+tmux send-keys -t "$WINDOW" "${OBJECTIVE} Output each completed step as CHECKPOINT:<step-name>. When ALL steps are done, output ORCHESTRATOR:DONE on its own line."
 sleep 0.3
 tmux send-keys -t "$WINDOW" Enter
 

--- a/.claude/skills/orchestrate/scripts/spawn-agent.sh
+++ b/.claude/skills/orchestrate/scripts/spawn-agent.sh
@@ -38,7 +38,36 @@ git -C "$WORKTREE_PATH" checkout -b "$NEW_BRANCH" 2>/dev/null \
 WIN_IDX=$(tmux new-window -t "$SESSION" -n "$WORKTREE_NAME" -P -F '#{window_index}')
 WINDOW="${SESSION}:${WIN_IDX}"
 
-# Store pr_number + steps in state file if provided (enables verify-complete.sh)
+# Append the initial agent record to the state file so subsequent jq updates find it.
+# This must happen before the pr_number/steps update below.
+if [ -f "$STATE_FILE" ]; then
+  NOW=$(date +%s)
+  jq --arg window "$WINDOW" \
+     --arg worktree "$WORKTREE_NAME" \
+     --arg worktree_path "$WORKTREE_PATH" \
+     --arg spare_branch "$SPARE_BRANCH" \
+     --arg branch "$NEW_BRANCH" \
+     --arg objective "$OBJECTIVE" \
+     --argjson now "$NOW" \
+     '.agents += [{
+       "window": $window,
+       "worktree": $worktree,
+       "worktree_path": $worktree_path,
+       "spare_branch": $spare_branch,
+       "branch": $branch,
+       "objective": $objective,
+       "state": "running",
+       "checkpoints": [],
+       "last_output_hash": "",
+       "last_seen_at": $now,
+       "idle_since": 0,
+       "revision_count": 0,
+       "last_rebriefed_at": 0
+     }]' "$STATE_FILE" > "${STATE_FILE}.tmp" && mv "${STATE_FILE}.tmp" "$STATE_FILE"
+fi
+
+# Store pr_number + steps in state file if provided (enables verify-complete.sh).
+# The agent record was appended above so the jq select now finds it.
 if [ -n "$PR_NUMBER" ] && [ -f "$STATE_FILE" ]; then
   STEPS_JSON=$(printf '%s\n' "${STEPS[@]}" | jq -R . | jq -s .)
   jq --arg w "$WINDOW" --arg pr "$PR_NUMBER" --argjson steps "$STEPS_JSON" \

--- a/.claude/skills/orchestrate/scripts/spawn-agent.sh
+++ b/.claude/skills/orchestrate/scripts/spawn-agent.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# spawn-agent.sh — create tmux window, checkout branch, launch claude, send task
+#
+# Usage: spawn-agent.sh SESSION WORKTREE_PATH SPARE_BRANCH NEW_BRANCH OBJECTIVE
+#   SESSION       — tmux session name, e.g. autogpt1
+#   WORKTREE_PATH — absolute path to the git worktree
+#   SPARE_BRANCH  — spare branch being replaced, e.g. spare/6 (saved for recycle)
+#   NEW_BRANCH    — task branch to create, e.g. feat/my-feature
+#   OBJECTIVE     — task description sent to the agent
+#
+# Stdout: SESSION:WINDOW_INDEX (nothing else — callers rely on this)
+# Exit non-zero on failure.
+
+set -euo pipefail
+
+if [ $# -lt 5 ]; then
+  echo "Usage: spawn-agent.sh SESSION WORKTREE_PATH SPARE_BRANCH NEW_BRANCH OBJECTIVE" >&2
+  exit 1
+fi
+
+SESSION="$1"
+WORKTREE_PATH="$2"
+SPARE_BRANCH="$3"
+NEW_BRANCH="$4"
+OBJECTIVE="$5"
+WORKTREE_NAME=$(basename "$WORKTREE_PATH")
+
+# Create (or switch to) the task branch
+git -C "$WORKTREE_PATH" checkout -b "$NEW_BRANCH" 2>/dev/null \
+  || git -C "$WORKTREE_PATH" checkout "$NEW_BRANCH"
+
+# Open a new named tmux window; capture its numeric index
+WIN_IDX=$(tmux new-window -t "$SESSION" -n "$WORKTREE_NAME" -P -F '#{window_index}')
+WINDOW="${SESSION}:${WIN_IDX}"
+
+# Launch claude — single-quote path so spaces and special chars are safe
+tmux send-keys -t "$WINDOW" "cd '${WORKTREE_PATH}' && claude --permission-mode bypassPermissions" Enter
+
+# Wait up to 30s for the foreground process to become 'node'
+for i in $(seq 1 30); do
+  CMD=$(tmux display-message -t "$WINDOW" -p '#{pane_current_command}' 2>/dev/null || echo "")
+  [[ "$CMD" == "node" ]] && break
+  sleep 1
+done
+
+# Auto-dismiss settings error dialog ("Enter to confirm") if claude didn't start cleanly
+CMD=$(tmux display-message -t "$WINDOW" -p '#{pane_current_command}' 2>/dev/null || echo "")
+if [[ "$CMD" != "node" ]]; then
+  PANE=$(tmux capture-pane -t "$WINDOW" -p 2>/dev/null || echo "")
+  if echo "$PANE" | grep -q "Enter to confirm"; then
+    tmux send-keys -t "$WINDOW" Down Enter
+    sleep 2
+  fi
+fi
+
+# Send the task — agent must output ORCHESTRATOR:DONE when finished
+tmux send-keys -t "$WINDOW" "${OBJECTIVE}. When all work is done, output the exact string: ORCHESTRATOR:DONE" Enter
+
+# Only output the window address — nothing else (callers parse this)
+echo "$WINDOW"

--- a/.claude/skills/orchestrate/scripts/spawn-agent.sh
+++ b/.claude/skills/orchestrate/scripts/spawn-agent.sh
@@ -77,8 +77,12 @@ if ! $PROMPT_FOUND; then
   echo "[spawn-agent] WARNING: timed out waiting for ❯ prompt on $WINDOW — sending objective anyway" >&2
 fi
 
-# Send the task with checkpoint protocol and recovery instructions
-tmux send-keys -t "$WINDOW" "${OBJECTIVE}${RECOVERY} When ALL steps are done, output ORCHESTRATOR:DONE on its own line." Enter
+# Send the task with checkpoint protocol and recovery instructions.
+# Split text and Enter into separate calls — if sent together, Enter can fire before
+# the full string is buffered into Claude's input, leaving the message stuck unsent.
+tmux send-keys -t "$WINDOW" "${OBJECTIVE}${RECOVERY} When ALL steps are done, output ORCHESTRATOR:DONE on its own line."
+sleep 0.3
+tmux send-keys -t "$WINDOW" Enter
 
 # Only output the window address — nothing else (callers parse this)
 echo "$WINDOW"

--- a/.claude/skills/orchestrate/scripts/spawn-agent.sh
+++ b/.claude/skills/orchestrate/scripts/spawn-agent.sh
@@ -57,6 +57,7 @@ tmux send-keys -t "$WINDOW" "cd '${WORKTREE_PATH}' && claude --permission-mode b
 
 # Wait up to 60s for claude to be fully interactive:
 # both pane_current_command == 'node' AND the '❯' prompt is visible.
+PROMPT_FOUND=false
 for i in $(seq 1 60); do
   CMD=$(tmux display-message -t "$WINDOW" -p '#{pane_current_command}' 2>/dev/null || echo "")
   PANE=$(tmux capture-pane -t "$WINDOW" -p 2>/dev/null || echo "")
@@ -66,10 +67,15 @@ for i in $(seq 1 60); do
     continue
   fi
   if [[ "$CMD" == "node" ]] && echo "$PANE" | grep -q "❯"; then
+    PROMPT_FOUND=true
     break
   fi
   sleep 1
 done
+
+if ! $PROMPT_FOUND; then
+  echo "[spawn-agent] WARNING: timed out waiting for ❯ prompt on $WINDOW — sending objective anyway" >&2
+fi
 
 # Send the task with checkpoint protocol and recovery instructions
 tmux send-keys -t "$WINDOW" "${OBJECTIVE}${RECOVERY} When ALL steps are done, output ORCHESTRATOR:DONE on its own line." Enter

--- a/.claude/skills/orchestrate/scripts/spawn-agent.sh
+++ b/.claude/skills/orchestrate/scripts/spawn-agent.sh
@@ -60,6 +60,7 @@ if [ -f "$STATE_FILE" ]; then
        "checkpoints": [],
        "last_output_hash": "",
        "last_seen_at": $now,
+       "spawned_at": $now,
        "idle_since": 0,
        "revision_count": 0,
        "last_rebriefed_at": 0
@@ -69,7 +70,11 @@ fi
 # Store pr_number + steps in state file if provided (enables verify-complete.sh).
 # The agent record was appended above so the jq select now finds it.
 if [ -n "$PR_NUMBER" ] && [ -f "$STATE_FILE" ]; then
-  STEPS_JSON=$(printf '%s\n' "${STEPS[@]}" | jq -R . | jq -s .)
+  if [ "${#STEPS[@]}" -gt 0 ]; then
+    STEPS_JSON=$(printf '%s\n' "${STEPS[@]}" | jq -R . | jq -s .)
+  else
+    STEPS_JSON='[]'
+  fi
   jq --arg w "$WINDOW" --arg pr "$PR_NUMBER" --argjson steps "$STEPS_JSON" \
     '.agents |= map(if .window == $w then . + {pr_number: $pr, steps: $steps, checkpoints: []} else . end)' \
     "$STATE_FILE" > "${STATE_FILE}.tmp" && mv "${STATE_FILE}.tmp" "$STATE_FILE"

--- a/.claude/skills/orchestrate/scripts/spawn-agent.sh
+++ b/.claude/skills/orchestrate/scripts/spawn-agent.sh
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
 # spawn-agent.sh — create tmux window, checkout branch, launch claude, send task
 #
-# Usage: spawn-agent.sh SESSION WORKTREE_PATH SPARE_BRANCH NEW_BRANCH OBJECTIVE
+# Usage: spawn-agent.sh SESSION WORKTREE_PATH SPARE_BRANCH NEW_BRANCH OBJECTIVE [PR_NUMBER] [STEPS...]
 #   SESSION       — tmux session name, e.g. autogpt1
 #   WORKTREE_PATH — absolute path to the git worktree
 #   SPARE_BRANCH  — spare branch being replaced, e.g. spare/6 (saved for recycle)
 #   NEW_BRANCH    — task branch to create, e.g. feat/my-feature
 #   OBJECTIVE     — task description sent to the agent
+#   PR_NUMBER     — (optional) GitHub PR number for completion verification
+#   STEPS...      — (optional) required checkpoint names, e.g. pr-address pr-test
 #
 # Stdout: SESSION:WINDOW_INDEX (nothing else — callers rely on this)
 # Exit non-zero on failure.
@@ -14,7 +16,7 @@
 set -euo pipefail
 
 if [ $# -lt 5 ]; then
-  echo "Usage: spawn-agent.sh SESSION WORKTREE_PATH SPARE_BRANCH NEW_BRANCH OBJECTIVE" >&2
+  echo "Usage: spawn-agent.sh SESSION WORKTREE_PATH SPARE_BRANCH NEW_BRANCH OBJECTIVE [PR_NUMBER] [STEPS...]" >&2
   exit 1
 fi
 
@@ -23,7 +25,10 @@ WORKTREE_PATH="$2"
 SPARE_BRANCH="$3"
 NEW_BRANCH="$4"
 OBJECTIVE="$5"
+PR_NUMBER="${6:-}"
+STEPS=("${@:7}")
 WORKTREE_NAME=$(basename "$WORKTREE_PATH")
+STATE_FILE="${ORCHESTRATOR_STATE_FILE:-$HOME/.claude/orchestrator-state.json}"
 
 # Create (or switch to) the task branch
 git -C "$WORKTREE_PATH" checkout -b "$NEW_BRANCH" 2>/dev/null \
@@ -33,31 +38,41 @@ git -C "$WORKTREE_PATH" checkout -b "$NEW_BRANCH" 2>/dev/null \
 WIN_IDX=$(tmux new-window -t "$SESSION" -n "$WORKTREE_NAME" -P -F '#{window_index}')
 WINDOW="${SESSION}:${WIN_IDX}"
 
+# Store pr_number + steps in state file if provided (enables verify-complete.sh)
+if [ -n "$PR_NUMBER" ] && [ -f "$STATE_FILE" ]; then
+  STEPS_JSON=$(printf '%s\n' "${STEPS[@]}" | jq -R . | jq -s .)
+  jq --arg w "$WINDOW" --arg pr "$PR_NUMBER" --argjson steps "$STEPS_JSON" \
+    '.agents |= map(if .window == $w then . + {pr_number: $pr, steps: $steps, checkpoints: []} else . end)' \
+    "$STATE_FILE" > "${STATE_FILE}.tmp" && mv "${STATE_FILE}.tmp" "$STATE_FILE"
+fi
+
+# Build recovery instruction — agent reads state file + gh pr view to reorient after compaction
+RECOVERY=""
+if [ -n "$PR_NUMBER" ]; then
+  RECOVERY=" If your context compacts and you lose track of what to do, run: cat ~/.claude/orchestrator-state.json | jq '.agents[] | select(.window==\"$WINDOW\")' and gh pr view $PR_NUMBER --json title,body,headRefName to reorient. Output each completed step as a checkpoint: CHECKPOINT:<step-name> on its own line."
+fi
+
 # Launch claude — single-quote path so spaces and special chars are safe
 tmux send-keys -t "$WINDOW" "cd '${WORKTREE_PATH}' && claude --permission-mode bypassPermissions" Enter
 
 # Wait up to 60s for claude to be fully interactive:
 # both pane_current_command == 'node' AND the '❯' prompt is visible.
-# Checking the prompt avoids sending the objective to the shell before
-# claude finishes initializing (which silently drops the message).
 for i in $(seq 1 60); do
   CMD=$(tmux display-message -t "$WINDOW" -p '#{pane_current_command}' 2>/dev/null || echo "")
   PANE=$(tmux capture-pane -t "$WINDOW" -p 2>/dev/null || echo "")
-  # Auto-dismiss settings error dialog if present
   if echo "$PANE" | grep -q "Enter to confirm"; then
     tmux send-keys -t "$WINDOW" Down Enter
     sleep 2
     continue
   fi
-  # Ready when node is running AND the interactive prompt is visible
   if [[ "$CMD" == "node" ]] && echo "$PANE" | grep -q "❯"; then
     break
   fi
   sleep 1
 done
 
-# Send the task — agent must output ORCHESTRATOR:DONE when finished
-tmux send-keys -t "$WINDOW" "${OBJECTIVE}. When all work is done, output the exact string: ORCHESTRATOR:DONE" Enter
+# Send the task with checkpoint protocol and recovery instructions
+tmux send-keys -t "$WINDOW" "${OBJECTIVE}${RECOVERY} When ALL steps are done, output ORCHESTRATOR:DONE on its own line." Enter
 
 # Only output the window address — nothing else (callers parse this)
 echo "$WINDOW"

--- a/.claude/skills/orchestrate/scripts/status.sh
+++ b/.claude/skills/orchestrate/scripts/status.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# status.sh — print orchestrator status: state file summary + live tmux pane commands
+#
+# Usage: status.sh
+# Reads: ~/.claude/orchestrator-state.json
+
+set -euo pipefail
+
+STATE_FILE="${ORCHESTRATOR_STATE_FILE:-$HOME/.claude/orchestrator-state.json}"
+
+if [ ! -f "$STATE_FILE" ] || ! jq -e '.' "$STATE_FILE" >/dev/null 2>&1; then
+  echo "No orchestrator state found at $STATE_FILE"
+  exit 0
+fi
+
+# Header: active status, session, thresholds, last poll
+jq -r '
+  "=== Orchestrator [\(if .active then "RUNNING" else "STOPPED" end)] ===",
+  "Session: \(.tmux_session // "unknown")  |  Idle threshold: \(.idle_threshold_seconds // 300)s",
+  "Last poll: \(if (.last_poll_at // 0) == 0 then "never" else (.last_poll_at | strftime("%H:%M:%S")) end)",
+  ""
+' "$STATE_FILE"
+
+# Each agent: state, window, worktree/branch, truncated objective
+AGENT_COUNT=$(jq '.agents | length' "$STATE_FILE")
+if [ "$AGENT_COUNT" -eq 0 ]; then
+  echo "  (no agents registered)"
+else
+  jq -r '
+    .agents[] |
+    "  [\(.state | ascii_upcase)] \(.window)  \(.worktree)/\(.branch)",
+    "    \(.objective // "" | .[0:70])"
+  ' "$STATE_FILE"
+fi
+
+echo ""
+
+# Live pane_current_command for non-done agents
+while IFS= read -r WINDOW; do
+  [ -z "$WINDOW" ] && continue
+  CMD=$(tmux display-message -t "$WINDOW" -p '#{pane_current_command}' 2>/dev/null || echo "unreachable")
+  echo "  $WINDOW live: $CMD"
+done < <(jq -r '.agents[] | select(.state != "done") | .window' "$STATE_FILE" 2>/dev/null || true)

--- a/.claude/skills/orchestrate/scripts/verify-complete.sh
+++ b/.claude/skills/orchestrate/scripts/verify-complete.sh
@@ -1,22 +1,22 @@
 #!/usr/bin/env bash
-# verify-complete.sh — verify a PR task is truly done before the worktree is recycled
+# verify-complete.sh — verify a PR task is truly done before marking the agent done
 #
-# Reads the agent's pr_number + steps from the state file, then checks:
-#   1. All required steps are checkpointed
-#   2. No unresolved review threads on the PR
-#   3. No failing CI checks
-#
-# Repo is read from state file (.repo), falling back to the worktree's git remote.
+# Check order matters:
+#   1. Checkpoints — did the agent do all required steps?
+#   2. CI complete — no pending (bots post comments AFTER their check runs, must wait)
+#   3. CI passing — no failures (agent must fix before done)
+#   4. spawned_at — a new CI run was triggered after agent spawned (proves real work)
+#   5. Unresolved threads — checked AFTER CI so bot-posted comments are included
+#   6. CHANGES_REQUESTED — checked AFTER CI so bot reviews are included
 #
 # Usage: verify-complete.sh WINDOW
-# Exit 0 = verified complete; exit 1 = not complete (with reason on stderr)
+# Exit 0 = verified complete; exit 1 = not complete (stderr has reason)
 
 set -euo pipefail
 
 WINDOW="$1"
 STATE_FILE="${ORCHESTRATOR_STATE_FILE:-$HOME/.claude/orchestrator-state.json}"
 
-# Read agent fields from state file
 PR_NUMBER=$(jq -r --arg w "$WINDOW" '.agents[] | select(.window == $w) | .pr_number // ""' "$STATE_FILE" 2>/dev/null)
 STEPS=$(jq -r --arg w "$WINDOW" '.agents[] | select(.window == $w) | .steps // [] | .[]' "$STATE_FILE" 2>/dev/null || true)
 CHECKPOINTS=$(jq -r --arg w "$WINDOW" '.agents[] | select(.window == $w) | .checkpoints // [] | .[]' "$STATE_FILE" 2>/dev/null || true)
@@ -24,17 +24,10 @@ WORKTREE_PATH=$(jq -r --arg w "$WINDOW" '.agents[] | select(.window == $w) | .wo
 BRANCH=$(jq -r --arg w "$WINDOW" '.agents[] | select(.window == $w) | .branch // ""' "$STATE_FILE" 2>/dev/null)
 SPAWNED_AT=$(jq -r --arg w "$WINDOW" '.agents[] | select(.window == $w) | .spawned_at // "0"' "$STATE_FILE" 2>/dev/null || echo "0")
 
-# No PR number = cannot verify — refuse to recycle (supervisor must handle)
+# No PR number = cannot verify
 if [ -z "$PR_NUMBER" ]; then
-  echo "NOT COMPLETE: no pr_number in state — cannot verify; set pr_number or mark done manually" >&2
+  echo "NOT COMPLETE: no pr_number in state — set pr_number or mark done manually" >&2
   exit 1
-fi
-
-# --- Resolve repo: state file .repo → worktree git remote → fail gracefully ---
-REPO=$(jq -r '.repo // ""' "$STATE_FILE" 2>/dev/null || echo "")
-if [ -z "$REPO" ] && [ -n "$WORKTREE_PATH" ] && [ -d "$WORKTREE_PATH" ]; then
-  REPO=$(git -C "$WORKTREE_PATH" remote get-url origin 2>/dev/null \
-    | sed 's|.*github\.com[:/]||; s|\.git$||' || echo "")
 fi
 
 # --- Check 1: all required steps are checkpointed ---
@@ -51,74 +44,86 @@ if [ -n "$MISSING" ]; then
   exit 1
 fi
 
-# --- Check 2: unresolved review threads ---
-# Requires REPO to be resolved; skip gracefully if not
+# Resolve repo for all GitHub checks below
+REPO=$(jq -r '.repo // ""' "$STATE_FILE" 2>/dev/null || echo "")
+if [ -z "$REPO" ] && [ -n "$WORKTREE_PATH" ] && [ -d "$WORKTREE_PATH" ]; then
+  REPO=$(git -C "$WORKTREE_PATH" remote get-url origin 2>/dev/null \
+    | sed 's|.*github\.com[:/]||; s|\.git$||' || echo "")
+fi
+
 if [ -z "$REPO" ]; then
-  echo "Warning: cannot resolve repo — skipping thread + CI checks" >&2
-else
-  # Split REPO into owner/name for GraphQL
-  OWNER=$(echo "$REPO" | cut -d/ -f1)
-  REPONAME=$(echo "$REPO" | cut -d/ -f2)
+  echo "Warning: cannot resolve repo — skipping CI/thread checks" >&2
+  echo "VERIFIED: PR #$PR_NUMBER — checkpoints ✓ (CI/thread checks skipped — no repo)"
+  exit 0
+fi
 
-  UNRESOLVED=$(gh api graphql -f query="
-    { repository(owner: \"${OWNER}\", name: \"${REPONAME}\") {
-        pullRequest(number: ${PR_NUMBER}) {
-          reviewThreads(first: 50) { nodes { isResolved } }
-        }
-      }
-    }
-  " --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length' 2>/dev/null || echo "0")
+CI_BUCKETS=$(gh pr checks "$PR_NUMBER" --repo "$REPO" --json bucket 2>/dev/null || echo "[]")
 
-  if [ "$UNRESOLVED" -gt 0 ]; then
-    echo "NOT COMPLETE: $UNRESOLVED unresolved review threads on PR #$PR_NUMBER" >&2
-    exit 1
-  fi
+# --- Check 2: CI fully complete — no pending checks ---
+# Pending checks MUST finish before we check threads/reviews:
+# bots (Seer, Check PR Status, etc.) post comments and CHANGES_REQUESTED AFTER their CI check runs.
+PENDING=$(echo "$CI_BUCKETS" | jq '[.[] | select(.bucket == "pending")] | length' 2>/dev/null || echo "0")
+if [ "$PENDING" -gt 0 ]; then
+  PENDING_NAMES=$(gh pr checks "$PR_NUMBER" --repo "$REPO" --json bucket,name 2>/dev/null \
+    | jq -r '[.[] | select(.bucket == "pending") | .name] | join(", ")' 2>/dev/null || echo "unknown")
+  echo "NOT COMPLETE: $PENDING CI checks still pending on PR #$PR_NUMBER ($PENDING_NAMES)" >&2
+  exit 1
+fi
 
-  # --- Check 3: no CHANGES_REQUESTED reviews (from any reviewer, bot or human) ---
-  CHANGES_REQUESTED=$(gh pr view "$PR_NUMBER" --repo "$REPO" \
-    --json reviews --jq '[.reviews[] | select(.state == "CHANGES_REQUESTED")] | length' 2>/dev/null || echo "0")
+# --- Check 3: CI passing — no failures ---
+FAILING=$(echo "$CI_BUCKETS" | jq '[.[] | select(.bucket == "fail")] | length' 2>/dev/null || echo "0")
+if [ "$FAILING" -gt 0 ]; then
+  FAILING_NAMES=$(gh pr checks "$PR_NUMBER" --repo "$REPO" --json bucket,name 2>/dev/null \
+    | jq -r '[.[] | select(.bucket == "fail") | .name] | join(", ")' 2>/dev/null || echo "unknown")
+  echo "NOT COMPLETE: $FAILING failing CI checks on PR #$PR_NUMBER ($FAILING_NAMES)" >&2
+  exit 1
+fi
 
-  if [ "$CHANGES_REQUESTED" -gt 0 ]; then
-    REQUESTERS=$(gh pr view "$PR_NUMBER" --repo "$REPO" \
-      --json reviews --jq '[.reviews[] | select(.state == "CHANGES_REQUESTED") | .author.login] | join(", ")' 2>/dev/null || echo "unknown")
-    echo "NOT COMPLETE: CHANGES_REQUESTED from ${REQUESTERS} on PR #$PR_NUMBER" >&2
-    exit 1
-  fi
-
-  # --- Check 5: CI not failing ---
-  # gh pr checks --json may return an empty array if checks haven't started yet — that's fine.
-  # We only fail if bucket == "fail" is present.
-  FAILING=$(gh pr checks "$PR_NUMBER" --repo "$REPO" --json bucket 2>/dev/null \
-    | jq '[.[] | select(.bucket == "fail")] | length' 2>/dev/null || echo "0")
-
-  if [ "$FAILING" -gt 0 ]; then
-    echo "NOT COMPLETE: $FAILING failing CI checks on PR #$PR_NUMBER" >&2
-    exit 1
-  fi
-
-  # --- Check 6: a new CI run was triggered AFTER the agent spawned ---
-  # Guards against agents that output CHECKPOINT:* from the objective text itself
-  # (copied from spawn message) without actually doing work, while CI was already
-  # green from a previous run.
-  if [ -n "$BRANCH" ] && [ "${SPAWNED_AT:-0}" -gt 0 ]; then
-    LATEST_RUN_AT=$(gh run list --repo "$REPO" --branch "$BRANCH" \
-      --json createdAt --limit 1 2>/dev/null | jq -r '.[0].createdAt // ""')
-    if [ -n "$LATEST_RUN_AT" ]; then
-      # Convert ISO 8601 timestamp to epoch — handle both macOS (BSD date) and Linux (GNU date)
-      if date --version >/dev/null 2>&1; then
-        LATEST_RUN_EPOCH=$(date -d "$LATEST_RUN_AT" "+%s" 2>/dev/null || echo "0")
-      else
-        # macOS BSD date: must set TZ=UTC so the GitHub ISO 8601 UTC timestamp
-        # is parsed as UTC, not local time (which would give a wrong epoch).
-        LATEST_RUN_EPOCH=$(TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%SZ" "$LATEST_RUN_AT" "+%s" 2>/dev/null || echo "0")
-      fi
-      if [ "$LATEST_RUN_EPOCH" -le "$SPAWNED_AT" ]; then
-        echo "NOT COMPLETE: latest CI run on $BRANCH predates agent spawn — no new CI triggered yet" >&2
-        exit 1
-      fi
+# --- Check 4: a new CI run was triggered AFTER the agent spawned ---
+if [ -n "$BRANCH" ] && [ "${SPAWNED_AT:-0}" -gt 0 ]; then
+  LATEST_RUN_AT=$(gh run list --repo "$REPO" --branch "$BRANCH" \
+    --json createdAt --limit 1 2>/dev/null | jq -r '.[0].createdAt // ""')
+  if [ -n "$LATEST_RUN_AT" ]; then
+    if date --version >/dev/null 2>&1; then
+      LATEST_RUN_EPOCH=$(date -d "$LATEST_RUN_AT" "+%s" 2>/dev/null || echo "0")
+    else
+      LATEST_RUN_EPOCH=$(TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%SZ" "$LATEST_RUN_AT" "+%s" 2>/dev/null || echo "0")
+    fi
+    if [ "$LATEST_RUN_EPOCH" -le "$SPAWNED_AT" ]; then
+      echo "NOT COMPLETE: latest CI run on $BRANCH predates agent spawn — agent may not have pushed yet" >&2
+      exit 1
     fi
   fi
 fi
 
-echo "VERIFIED: PR #$PR_NUMBER — checkpoints ✓, 0 unresolved threads, CI green"
+OWNER=$(echo "$REPO" | cut -d/ -f1)
+REPONAME=$(echo "$REPO" | cut -d/ -f2)
+
+# --- Check 5: no unresolved review threads (checked AFTER CI — bots post after their check) ---
+UNRESOLVED=$(gh api graphql -f query="
+  { repository(owner: \"${OWNER}\", name: \"${REPONAME}\") {
+      pullRequest(number: ${PR_NUMBER}) {
+        reviewThreads(first: 50) { nodes { isResolved } }
+      }
+    }
+  }
+" --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length' 2>/dev/null || echo "0")
+
+if [ "$UNRESOLVED" -gt 0 ]; then
+  echo "NOT COMPLETE: $UNRESOLVED unresolved review threads on PR #$PR_NUMBER" >&2
+  exit 1
+fi
+
+# --- Check 6: no CHANGES_REQUESTED (checked AFTER CI — bots post reviews after their check) ---
+CHANGES_REQUESTED=$(gh pr view "$PR_NUMBER" --repo "$REPO" \
+  --json reviews --jq '[.reviews[] | select(.state == "CHANGES_REQUESTED")] | length' 2>/dev/null || echo "0")
+
+if [ "$CHANGES_REQUESTED" -gt 0 ]; then
+  REQUESTERS=$(gh pr view "$PR_NUMBER" --repo "$REPO" \
+    --json reviews --jq '[.reviews[] | select(.state == "CHANGES_REQUESTED") | .author.login] | join(", ")' 2>/dev/null || echo "unknown")
+  echo "NOT COMPLETE: CHANGES_REQUESTED from ${REQUESTERS} on PR #$PR_NUMBER" >&2
+  exit 1
+fi
+
+echo "VERIFIED: PR #$PR_NUMBER — checkpoints ✓, CI complete + green, 0 unresolved threads, no CHANGES_REQUESTED"
 exit 0

--- a/.claude/skills/orchestrate/scripts/verify-complete.sh
+++ b/.claude/skills/orchestrate/scripts/verify-complete.sh
@@ -24,10 +24,10 @@ WORKTREE_PATH=$(jq -r --arg w "$WINDOW" '.agents[] | select(.window == $w) | .wo
 BRANCH=$(jq -r --arg w "$WINDOW" '.agents[] | select(.window == $w) | .branch // ""' "$STATE_FILE" 2>/dev/null)
 SPAWNED_AT=$(jq -r --arg w "$WINDOW" '.agents[] | select(.window == $w) | .spawned_at // "0"' "$STATE_FILE" 2>/dev/null || echo "0")
 
-# No PR number = no verification possible, assume done
+# No PR number = cannot verify — refuse to recycle (supervisor must handle)
 if [ -z "$PR_NUMBER" ]; then
-  echo "No pr_number in state — skipping verification"
-  exit 0
+  echo "NOT COMPLETE: no pr_number in state — cannot verify; set pr_number or mark done manually" >&2
+  exit 1
 fi
 
 # --- Resolve repo: state file .repo → worktree git remote → fail gracefully ---
@@ -74,7 +74,18 @@ else
     exit 1
   fi
 
-  # --- Check 3: CI not failing ---
+  # --- Check 3: no CHANGES_REQUESTED reviews (from any reviewer, bot or human) ---
+  CHANGES_REQUESTED=$(gh pr view "$PR_NUMBER" --repo "$REPO" \
+    --json reviews --jq '[.reviews[] | select(.state == "CHANGES_REQUESTED")] | length' 2>/dev/null || echo "0")
+
+  if [ "$CHANGES_REQUESTED" -gt 0 ]; then
+    REQUESTERS=$(gh pr view "$PR_NUMBER" --repo "$REPO" \
+      --json reviews --jq '[.reviews[] | select(.state == "CHANGES_REQUESTED") | .author.login] | join(", ")' 2>/dev/null || echo "unknown")
+    echo "NOT COMPLETE: CHANGES_REQUESTED from ${REQUESTERS} on PR #$PR_NUMBER" >&2
+    exit 1
+  fi
+
+  # --- Check 5: CI not failing ---
   # gh pr checks --json may return an empty array if checks haven't started yet — that's fine.
   # We only fail if bucket == "fail" is present.
   FAILING=$(gh pr checks "$PR_NUMBER" --repo "$REPO" --json bucket 2>/dev/null \
@@ -85,7 +96,7 @@ else
     exit 1
   fi
 
-  # --- Check 4: a new CI run was triggered AFTER the agent spawned ---
+  # --- Check 6: a new CI run was triggered AFTER the agent spawned ---
   # Guards against agents that output CHECKPOINT:* from the objective text itself
   # (copied from spawn message) without actually doing work, while CI was already
   # green from a previous run.

--- a/.claude/skills/orchestrate/scripts/verify-complete.sh
+++ b/.claude/skills/orchestrate/scripts/verify-complete.sh
@@ -21,6 +21,8 @@ PR_NUMBER=$(jq -r --arg w "$WINDOW" '.agents[] | select(.window == $w) | .pr_num
 STEPS=$(jq -r --arg w "$WINDOW" '.agents[] | select(.window == $w) | .steps // [] | .[]' "$STATE_FILE" 2>/dev/null || true)
 CHECKPOINTS=$(jq -r --arg w "$WINDOW" '.agents[] | select(.window == $w) | .checkpoints // [] | .[]' "$STATE_FILE" 2>/dev/null || true)
 WORKTREE_PATH=$(jq -r --arg w "$WINDOW" '.agents[] | select(.window == $w) | .worktree_path // ""' "$STATE_FILE" 2>/dev/null)
+BRANCH=$(jq -r --arg w "$WINDOW" '.agents[] | select(.window == $w) | .branch // ""' "$STATE_FILE" 2>/dev/null)
+SPAWNED_AT=$(jq -r --arg w "$WINDOW" '.agents[] | select(.window == $w) | .spawned_at // "0"' "$STATE_FILE" 2>/dev/null || echo "0")
 
 # No PR number = no verification possible, assume done
 if [ -z "$PR_NUMBER" ]; then
@@ -39,7 +41,7 @@ fi
 MISSING=""
 while IFS= read -r step; do
   [ -z "$step" ] && continue
-  if ! echo "$CHECKPOINTS" | grep -qF "$step"; then
+  if ! echo "$CHECKPOINTS" | grep -qFx "$step"; then
     MISSING="$MISSING $step"
   fi
 done <<< "$STEPS"
@@ -81,6 +83,27 @@ else
   if [ "$FAILING" -gt 0 ]; then
     echo "NOT COMPLETE: $FAILING failing CI checks on PR #$PR_NUMBER" >&2
     exit 1
+  fi
+
+  # --- Check 4: a new CI run was triggered AFTER the agent spawned ---
+  # Guards against agents that output CHECKPOINT:* from the objective text itself
+  # (copied from spawn message) without actually doing work, while CI was already
+  # green from a previous run.
+  if [ -n "$BRANCH" ] && [ "${SPAWNED_AT:-0}" -gt 0 ]; then
+    LATEST_RUN_AT=$(gh run list --repo "$REPO" --branch "$BRANCH" \
+      --json createdAt --limit 1 2>/dev/null | jq -r '.[0].createdAt // ""')
+    if [ -n "$LATEST_RUN_AT" ]; then
+      # Convert ISO 8601 timestamp to epoch — handle both macOS (BSD date) and Linux (GNU date)
+      if date --version >/dev/null 2>&1; then
+        LATEST_RUN_EPOCH=$(date -d "$LATEST_RUN_AT" "+%s" 2>/dev/null || echo "0")
+      else
+        LATEST_RUN_EPOCH=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$LATEST_RUN_AT" "+%s" 2>/dev/null || echo "0")
+      fi
+      if [ "$LATEST_RUN_EPOCH" -le "$SPAWNED_AT" ]; then
+        echo "NOT COMPLETE: latest CI run on $BRANCH predates agent spawn — no new CI triggered yet" >&2
+        exit 1
+      fi
+    fi
   fi
 fi
 

--- a/.claude/skills/orchestrate/scripts/verify-complete.sh
+++ b/.claude/skills/orchestrate/scripts/verify-complete.sh
@@ -6,6 +6,8 @@
 #   2. No unresolved review threads on the PR
 #   3. No failing CI checks
 #
+# Repo is read from state file (.repo), falling back to the worktree's git remote.
+#
 # Usage: verify-complete.sh WINDOW
 # Exit 0 = verified complete; exit 1 = not complete (with reason on stderr)
 
@@ -18,11 +20,19 @@ STATE_FILE="${ORCHESTRATOR_STATE_FILE:-$HOME/.claude/orchestrator-state.json}"
 PR_NUMBER=$(jq -r --arg w "$WINDOW" '.agents[] | select(.window == $w) | .pr_number // ""' "$STATE_FILE" 2>/dev/null)
 STEPS=$(jq -r --arg w "$WINDOW" '.agents[] | select(.window == $w) | .steps // [] | .[]' "$STATE_FILE" 2>/dev/null || true)
 CHECKPOINTS=$(jq -r --arg w "$WINDOW" '.agents[] | select(.window == $w) | .checkpoints // [] | .[]' "$STATE_FILE" 2>/dev/null || true)
+WORKTREE_PATH=$(jq -r --arg w "$WINDOW" '.agents[] | select(.window == $w) | .worktree_path // ""' "$STATE_FILE" 2>/dev/null)
 
 # No PR number = no verification possible, assume done
 if [ -z "$PR_NUMBER" ]; then
-  echo "No pr_number in state — skipping verification" >&2
+  echo "No pr_number in state — skipping verification"
   exit 0
+fi
+
+# --- Resolve repo: state file .repo → worktree git remote → fail gracefully ---
+REPO=$(jq -r '.repo // ""' "$STATE_FILE" 2>/dev/null || echo "")
+if [ -z "$REPO" ] && [ -n "$WORKTREE_PATH" ] && [ -d "$WORKTREE_PATH" ]; then
+  REPO=$(git -C "$WORKTREE_PATH" remote get-url origin 2>/dev/null \
+    | sed 's|.*github\.com[:/]||; s|\.git$||' || echo "")
 fi
 
 # --- Check 1: all required steps are checkpointed ---
@@ -40,27 +50,38 @@ if [ -n "$MISSING" ]; then
 fi
 
 # --- Check 2: unresolved review threads ---
-UNRESOLVED=$(gh api graphql -f query="
-  { repository(owner: \"Significant-Gravitas\", name: \"AutoGPT\") {
-      pullRequest(number: $PR_NUMBER) {
-        reviewThreads(first: 50) { nodes { isResolved } }
+# Requires REPO to be resolved; skip gracefully if not
+if [ -z "$REPO" ]; then
+  echo "Warning: cannot resolve repo — skipping thread + CI checks" >&2
+else
+  # Split REPO into owner/name for GraphQL
+  OWNER=$(echo "$REPO" | cut -d/ -f1)
+  REPONAME=$(echo "$REPO" | cut -d/ -f2)
+
+  UNRESOLVED=$(gh api graphql -f query="
+    { repository(owner: \"${OWNER}\", name: \"${REPONAME}\") {
+        pullRequest(number: ${PR_NUMBER}) {
+          reviewThreads(first: 50) { nodes { isResolved } }
+        }
       }
     }
-  }
-" --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length' 2>/dev/null || echo "0")
+  " --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length' 2>/dev/null || echo "0")
 
-if [ "$UNRESOLVED" -gt 0 ]; then
-  echo "NOT COMPLETE: $UNRESOLVED unresolved review threads on PR #$PR_NUMBER" >&2
-  exit 1
-fi
+  if [ "$UNRESOLVED" -gt 0 ]; then
+    echo "NOT COMPLETE: $UNRESOLVED unresolved review threads on PR #$PR_NUMBER" >&2
+    exit 1
+  fi
 
-# --- Check 3: CI not failing ---
-FAILING=$(gh pr checks "$PR_NUMBER" --repo Significant-Gravitas/AutoGPT --json bucket 2>/dev/null \
-  | jq '[.[] | select(.bucket == "fail")] | length' 2>/dev/null || echo "0")
+  # --- Check 3: CI not failing ---
+  # gh pr checks --json may return an empty array if checks haven't started yet — that's fine.
+  # We only fail if bucket == "fail" is present.
+  FAILING=$(gh pr checks "$PR_NUMBER" --repo "$REPO" --json bucket 2>/dev/null \
+    | jq '[.[] | select(.bucket == "fail")] | length' 2>/dev/null || echo "0")
 
-if [ "$FAILING" -gt 0 ]; then
-  echo "NOT COMPLETE: $FAILING failing CI checks on PR #$PR_NUMBER" >&2
-  exit 1
+  if [ "$FAILING" -gt 0 ]; then
+    echo "NOT COMPLETE: $FAILING failing CI checks on PR #$PR_NUMBER" >&2
+    exit 1
+  fi
 fi
 
 echo "VERIFIED: PR #$PR_NUMBER — checkpoints ✓, 0 unresolved threads, CI green"

--- a/.claude/skills/orchestrate/scripts/verify-complete.sh
+++ b/.claude/skills/orchestrate/scripts/verify-complete.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# verify-complete.sh — verify a PR task is truly done before the worktree is recycled
+#
+# Reads the agent's pr_number + steps from the state file, then checks:
+#   1. All required steps are checkpointed
+#   2. No unresolved review threads on the PR
+#   3. No failing CI checks
+#
+# Usage: verify-complete.sh WINDOW
+# Exit 0 = verified complete; exit 1 = not complete (with reason on stderr)
+
+set -euo pipefail
+
+WINDOW="$1"
+STATE_FILE="${ORCHESTRATOR_STATE_FILE:-$HOME/.claude/orchestrator-state.json}"
+
+# Read agent fields from state file
+PR_NUMBER=$(jq -r --arg w "$WINDOW" '.agents[] | select(.window == $w) | .pr_number // ""' "$STATE_FILE" 2>/dev/null)
+STEPS=$(jq -r --arg w "$WINDOW" '.agents[] | select(.window == $w) | .steps // [] | .[]' "$STATE_FILE" 2>/dev/null || true)
+CHECKPOINTS=$(jq -r --arg w "$WINDOW" '.agents[] | select(.window == $w) | .checkpoints // [] | .[]' "$STATE_FILE" 2>/dev/null || true)
+
+# No PR number = no verification possible, assume done
+if [ -z "$PR_NUMBER" ]; then
+  echo "No pr_number in state — skipping verification" >&2
+  exit 0
+fi
+
+# --- Check 1: all required steps are checkpointed ---
+MISSING=""
+while IFS= read -r step; do
+  [ -z "$step" ] && continue
+  if ! echo "$CHECKPOINTS" | grep -qF "$step"; then
+    MISSING="$MISSING $step"
+  fi
+done <<< "$STEPS"
+
+if [ -n "$MISSING" ]; then
+  echo "NOT COMPLETE: missing checkpoints:$MISSING on PR #$PR_NUMBER" >&2
+  exit 1
+fi
+
+# --- Check 2: unresolved review threads ---
+UNRESOLVED=$(gh api graphql -f query="
+  { repository(owner: \"Significant-Gravitas\", name: \"AutoGPT\") {
+      pullRequest(number: $PR_NUMBER) {
+        reviewThreads(first: 50) { nodes { isResolved } }
+      }
+    }
+  }
+" --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length' 2>/dev/null || echo "0")
+
+if [ "$UNRESOLVED" -gt 0 ]; then
+  echo "NOT COMPLETE: $UNRESOLVED unresolved review threads on PR #$PR_NUMBER" >&2
+  exit 1
+fi
+
+# --- Check 3: CI not failing ---
+FAILING=$(gh pr checks "$PR_NUMBER" --repo Significant-Gravitas/AutoGPT --json bucket 2>/dev/null \
+  | jq '[.[] | select(.bucket == "fail")] | length' 2>/dev/null || echo "0")
+
+if [ "$FAILING" -gt 0 ]; then
+  echo "NOT COMPLETE: $FAILING failing CI checks on PR #$PR_NUMBER" >&2
+  exit 1
+fi
+
+echo "VERIFIED: PR #$PR_NUMBER — checkpoints ✓, 0 unresolved threads, CI green"
+exit 0

--- a/.claude/skills/orchestrate/scripts/verify-complete.sh
+++ b/.claude/skills/orchestrate/scripts/verify-complete.sh
@@ -108,7 +108,9 @@ else
       if date --version >/dev/null 2>&1; then
         LATEST_RUN_EPOCH=$(date -d "$LATEST_RUN_AT" "+%s" 2>/dev/null || echo "0")
       else
-        LATEST_RUN_EPOCH=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$LATEST_RUN_AT" "+%s" 2>/dev/null || echo "0")
+        # macOS BSD date: must set TZ=UTC so the GitHub ISO 8601 UTC timestamp
+        # is parsed as UTC, not local time (which would give a wrong epoch).
+        LATEST_RUN_EPOCH=$(TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%SZ" "$LATEST_RUN_AT" "+%s" 2>/dev/null || echo "0")
       fi
       if [ "$LATEST_RUN_EPOCH" -le "$SPAWNED_AT" ]; then
         echo "NOT COMPLETE: latest CI run on $BRANCH predates agent spawn — no new CI triggered yet" >&2

--- a/.claude/skills/pr-address/SKILL.md
+++ b/.claude/skills/pr-address/SKILL.md
@@ -90,10 +90,12 @@ Address comments **one at a time**: fix → commit → push → inline reply →
 2. Commit and push the fix
 3. Reply **inline** (not as a new top-level comment) referencing the fixing commit — this is what resolves the conversation for bot reviewers (coderabbitai, sentry):
 
+Use a **markdown commit link** so GitHub renders it as a clickable reference. Get the full SHA with `git rev-parse HEAD` after committing:
+
 | Comment type | How to reply |
 |---|---|
-| Inline review (`pulls/{N}/comments`) | `gh api repos/Significant-Gravitas/AutoGPT/pulls/{N}/comments/{ID}/replies -f body="🤖 Fixed in <commit-sha>: <description>"` |
-| Conversation (`issues/{N}/comments`) | `gh api repos/Significant-Gravitas/AutoGPT/issues/{N}/comments -f body="🤖 Fixed in <commit-sha>: <description>"` |
+| Inline review (`pulls/{N}/comments`) | `gh api repos/Significant-Gravitas/AutoGPT/pulls/{N}/comments/{ID}/replies -f body="🤖 Fixed in [abc1234](https://github.com/Significant-Gravitas/AutoGPT/commit/FULL_SHA): <description>"` |
+| Conversation (`issues/{N}/comments`) | `gh api repos/Significant-Gravitas/AutoGPT/issues/{N}/comments -f body="🤖 Fixed in [abc1234](https://github.com/Significant-Gravitas/AutoGPT/commit/FULL_SHA): <description>"` |
 
 ## Codecov coverage
 

--- a/.claude/skills/pr-test/SKILL.md
+++ b/.claude/skills/pr-test/SKILL.md
@@ -667,6 +667,103 @@ rm -f "$COMMENT_FILE"
 
 This approach uses the GitHub Git API to create blobs, trees, commits, and refs entirely server-side. No local `git checkout` or `git push` — safe for worktrees and won't interfere with the PR branch.
 
+## Step 8: Evaluate and post a formal PR review
+
+After the test comment is posted, evaluate whether the run was thorough enough to make a merge decision, then post a formal GitHub review (approve or request changes). **This step is mandatory — every test run MUST end with a formal review decision.**
+
+### Evaluation criteria
+
+Re-read the PR description:
+```bash
+gh pr view "$PR_NUMBER" --json body --jq '.body' --repo "$REPO"
+```
+
+Score the run against each criterion:
+
+| Criterion | Pass condition |
+|-----------|---------------|
+| **Coverage** | Every feature/change described in the PR has at least one test scenario |
+| **All scenarios pass** | No FAIL rows in the results table |
+| **Negative tests** | At least one failure-path test per feature (invalid input, unauthorized, edge case) |
+| **Before/after evidence** | Every state-changing API call has before/after values logged |
+| **Screenshots are meaningful** | Screenshots show the actual state change, not just a loading spinner or blank page |
+| **No regressions** | Existing core flows (login, agent create/run) still work |
+
+### Decision logic
+
+```
+ALL criteria pass                            → APPROVE
+Any scenario FAIL or missing PR feature      → REQUEST_CHANGES (list gaps)
+Evidence weak (no before/after, vague shots) → REQUEST_CHANGES (list what's missing)
+```
+
+### Post the review
+
+```bash
+REVIEW_FILE=$(mktemp)
+
+# Count results
+PASS_COUNT=$(echo "$TEST_RESULTS_TABLE" | grep -c "PASS" || true)
+FAIL_COUNT=$(echo "$TEST_RESULTS_TABLE" | grep -c "FAIL" || true)
+TOTAL=$(( PASS_COUNT + FAIL_COUNT ))
+
+# List any coverage gaps found during evaluation (populate this array as you assess)
+# e.g. COVERAGE_GAPS=("PR claims to add X but no test covers it")
+COVERAGE_GAPS=()
+```
+
+**If APPROVING** — all criteria met, zero failures, full coverage:
+
+```bash
+cat > "$REVIEW_FILE" <<REVIEWEOF
+## E2E Test Evaluation — APPROVED
+
+**Results:** ${PASS_COUNT}/${TOTAL} scenarios passed.
+
+**Coverage:** All features described in the PR were exercised.
+
+**Evidence:** Before/after API values logged for all state-changing operations; screenshots show meaningful state transitions.
+
+**Negative tests:** Failure paths tested for each feature.
+
+No regressions observed on core flows.
+REVIEWEOF
+
+gh pr review "$PR_NUMBER" --repo "$REPO" --approve --body "$(cat "$REVIEW_FILE")"
+echo "✅ PR approved"
+```
+
+**If REQUESTING CHANGES** — any failure, coverage gap, or missing evidence:
+
+```bash
+FAIL_LIST=$(echo "$TEST_RESULTS_TABLE" | grep "FAIL" | awk -F'|' '{print "- Scenario" $2 "failed"}' || true)
+
+cat > "$REVIEW_FILE" <<REVIEWEOF
+## E2E Test Evaluation — Changes Requested
+
+**Results:** ${PASS_COUNT}/${TOTAL} scenarios passed, ${FAIL_COUNT} failed.
+
+### Required before merge
+
+${FAIL_LIST}
+$(for gap in "${COVERAGE_GAPS[@]}"; do echo "- $gap"; done)
+
+Please fix the above and re-run the E2E tests.
+REVIEWEOF
+
+gh pr review "$PR_NUMBER" --repo "$REPO" --request-changes --body "$(cat "$REVIEW_FILE")"
+echo "❌ Changes requested"
+```
+
+```bash
+rm -f "$REVIEW_FILE"
+```
+
+**Rules:**
+- In `--fix` mode, fix all failures before posting the review — the review reflects the final state after fixes
+- Never approve if any scenario failed, even if it seems like a flake — rerun that scenario first
+- Never request changes for issues already fixed in this run
+
 ## Fix mode (--fix flag)
 
 When `--fix` is present, the standard is HIGHER. Do not just note issues — FIX them immediately.

--- a/.claude/skills/pr-test/SKILL.md
+++ b/.claude/skills/pr-test/SKILL.md
@@ -674,7 +674,8 @@ gh api "repos/${REPO}/issues/$PR_NUMBER/comments" -F body=@"$COMMENT_FILE"
 rm -f "$COMMENT_FILE"
 
 # Verify the posted comment contains inline images — exit 1 if none found
-LAST_COMMENT=$(gh api "repos/${REPO}/issues/$PR_NUMBER/comments" --paginate --jq '.[-1].body' 2>/dev/null)
+# Use separate --paginate + jq pipe: --jq applies per-page, not to the full list
+LAST_COMMENT=$(gh api "repos/${REPO}/issues/$PR_NUMBER/comments" --paginate 2>/dev/null | jq -r '.[-1].body // ""')
 if ! echo "$LAST_COMMENT" | grep -q '!\['; then
   echo "ERROR: Posted comment contains no inline images (![). Bare directory links are not acceptable." >&2
   exit 1

--- a/.claude/skills/pr-test/SKILL.md
+++ b/.claude/skills/pr-test/SKILL.md
@@ -584,15 +584,27 @@ TREE_JSON+=']'
 
 # Step 2: Create tree, commit, and branch ref
 TREE_SHA=$(echo "$TREE_JSON" | jq -c '{tree: .}' | gh api "repos/${REPO}/git/trees" --input - --jq '.sha')
-COMMIT_SHA=$(gh api "repos/${REPO}/git/commits" \
-  -f message="test: add E2E test screenshots for PR #${PR_NUMBER}" \
-  -f tree="$TREE_SHA" \
-  --jq '.sha')
+
+# Resolve parent commit so screenshots are chained, not orphan root commits
+PARENT_SHA=$(gh api "repos/${REPO}/git/refs/heads/${SCREENSHOTS_BRANCH}" --jq '.object.sha' 2>/dev/null || echo "")
+if [ -n "$PARENT_SHA" ]; then
+  COMMIT_SHA=$(gh api "repos/${REPO}/git/commits" \
+    -f message="test: add E2E test screenshots for PR #${PR_NUMBER}" \
+    -f tree="$TREE_SHA" \
+    -f "parents[]=$PARENT_SHA" \
+    --jq '.sha')
+else
+  COMMIT_SHA=$(gh api "repos/${REPO}/git/commits" \
+    -f message="test: add E2E test screenshots for PR #${PR_NUMBER}" \
+    -f tree="$TREE_SHA" \
+    --jq '.sha')
+fi
+
 gh api "repos/${REPO}/git/refs" \
   -f ref="refs/heads/${SCREENSHOTS_BRANCH}" \
   -f sha="$COMMIT_SHA" 2>/dev/null \
   || gh api "repos/${REPO}/git/refs/heads/${SCREENSHOTS_BRANCH}" \
-    -X PATCH -f sha="$COMMIT_SHA" -f force=true
+    -X PATCH -f sha="$COMMIT_SHA" -F force=true
 ```
 
 Then post the comment with **inline images AND explanations for each screenshot**:

--- a/.claude/skills/pr-test/SKILL.md
+++ b/.claude/skills/pr-test/SKILL.md
@@ -547,6 +547,8 @@ Upload screenshots to the PR using the GitHub Git API (no local git operations �
 
 **This step is MANDATORY. Every test run MUST post a PR comment with screenshots. No exceptions.**
 
+**CRITICAL — NEVER post a bare directory link like `https://github.com/.../tree/...`.** Every screenshot MUST appear as `![name](raw_url)` inline in the PR comment so reviewers can see them without clicking any links. After posting, the verification step below greps the comment for `![` tags and exits 1 if none are found — the test run is considered incomplete until this passes.
+
 ```bash
 # Upload screenshots via GitHub Git API (creates blobs, tree, commit, and ref remotely)
 REPO="Significant-Gravitas/AutoGPT"
@@ -670,6 +672,14 @@ INNEREOF
 
 gh api "repos/${REPO}/issues/$PR_NUMBER/comments" -F body=@"$COMMENT_FILE"
 rm -f "$COMMENT_FILE"
+
+# Verify the posted comment contains inline images — exit 1 if none found
+LAST_COMMENT=$(gh api "repos/${REPO}/issues/$PR_NUMBER/comments" --paginate --jq '.[-1].body' 2>/dev/null)
+if ! echo "$LAST_COMMENT" | grep -q '!\['; then
+  echo "ERROR: Posted comment contains no inline images (![). Bare directory links are not acceptable." >&2
+  exit 1
+fi
+echo "✓ Inline images verified in posted comment"
 ```
 
 **The PR comment MUST include:**


### PR DESCRIPTION
### Why

When running multiple Claude Code agents in parallel worktrees, they frequently get stuck: an agent exits and sits at a shell prompt, freezes mid-task, or waits on an approval prompt with no human watching. Fixing this currently requires manually checking each tmux window.

### What

Adds a `/orchestrate` skill — a meta-agent supervisor that manages a fleet of Claude Code agents across tmux windows and spare worktrees. It auto-discovers available worktrees, spawns agents, monitors them, kicks idle/stuck ones, auto-approves safe confirmations, and recycles worktrees on completion.

### How to use

**Prerequisites:**
- One tmux session already running (the skill adds windows to it; it does not create a new session)
- Spare worktrees on `spare/N` branches (e.g. `AutoGPT3` on `spare/3`, `AutoGPT7` on `spare/7`)

**Basic workflow:**

```
/orchestrate capacity     → see how many spare worktrees are free
/orchestrate start        → enter task list, agents spawn automatically
/orchestrate status       → check what's running
/orchestrate add          → add one more task to the next free worktree
/orchestrate stop         → mark inactive (agents finish current work)
/orchestrate poll         → one manual poll cycle (debug / on-demand)
```

**Worktree lifecycle:**
```text
spare/N branch → /orchestrate add → new window + feat/branch + claude running
                                              ↓
                                     ORCHESTRATOR:DONE
                                              ↓
                              kill window + git checkout spare/N
                                              ↓
                                     spare/N (free again)
```

Windows are always capped by worktree count — no creep.

### Changes

- `.claude/skills/orchestrate/SKILL.md` — skill definition with 5 subcommands, state file schema, spawn/recycle helpers, approval policy
- `.claude/skills/orchestrate/scripts/classify-pane.sh` — pane state classifier: `idle` (shell foreground), `running` (non-shell), `waiting_approval` (pattern match), `complete` (ORCHESTRATOR:DONE)
- `.claude/skills/orchestrate/scripts/poll-cycle.sh` — poll loop: reads/updates state file atomically, outputs JSON action list, stuck detection via output-hash sampling

**State detection:**

| State | Detection method |
|---|---|
| `idle` | `pane_current_command` is a shell (zsh/bash/fish) |
| `running` | `pane_current_command` is non-shell (claude/node) |
| `stuck` | pane hash unchanged for N consecutive polls |
| `waiting_approval` | pattern match on last 40 lines of pane output |
| `complete` | `ORCHESTRATOR:DONE` string present in pane output |

**Safety policy for auto-approvals:** git ops, package installs, tests, docker compose → approve. `rm -rf` outside worktree, force push, `sudo`, secrets → escalate to user.

State file lives at `~/.claude/orchestrator-state.json` (outside repo, never committed).

### Checklist

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `classify-pane.sh`: idle shell → `idle`, running process → `running`, `ORCHESTRATOR:DONE` → `complete`, approval prompt → `waiting_approval`, nonexistent window → `error`
  - [x] `poll-cycle.sh`: inactive state → `[]`, empty agents array → `[]`, spare worktree discovery, stuck detection (3-poll hash cycle)
  - [x] Real agent spawn in `autogpt1` tmux session — agent ran, output `ORCHESTRATOR:DONE`, recycle verified
  - [x] Upfront JSON validation before `set -e`-guarded jq reads
  - [x] Idle timer reset only on `idle → running` transition (not stuck), preventing false stuck-detections
  - [x] Classify fallback only triggers when output is empty (no double-JSON on classify exit 1)