### PR TITLE
ci: make component coverage checks informational (non-blocking)

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -36,8 +36,10 @@ component_management:
     statuses:
       - type: project
         target: auto
+        informational: true
       - type: patch
         target: 80%
+        informational: true
   individual_components:
     - component_id: platform-backend
       name: "Platform Backend"

--- a/codecov.yml
+++ b/codecov.yml
@@ -10,8 +10,8 @@ coverage:
         informational: true
     patch:
       default:
-        target: 80%
-        informational: true
+        target: 95%
+        if_not_found: success
 
 flags:
   platform-backend:
@@ -38,8 +38,7 @@ component_management:
         target: auto
         informational: true
       - type: patch
-        target: 80%
-        informational: true
+        target: 95%
   individual_components:
     - component_id: platform-backend
       name: "Platform Backend"
@@ -54,8 +53,7 @@ component_management:
           target: auto
           informational: true
         - type: patch
-          target: 80%
-          informational: true
+          target: 95%
     - component_id: autogpt-libs
       name: "AutoGPT Libs"
       paths:


### PR DESCRIPTION
Requested by @majdyz

## Why

FE-only PRs (e.g. #12686) are being blocked by `codecov/project/Platform Backend` even when no backend files changed. This is a false positive — the check fails due to test run variance or stale carryforward data, not because coverage actually regressed.

Root cause: `component_management.default_rules.statuses` in `codecov.yml` was missing `informational: true`, causing all component-level project/patch checks to be **blocking**. The global `coverage.status.project.default` already had `informational: true`, but `component_management.default_rules` overrides that for component checks specifically.

This means `codecov/project/Platform Backend`, `codecov/project/AutoGPT Libs`, and `codecov/project/Classic AutoGPT` were all blocking PRs, even though the intent (matching the frontend component behavior) was clearly to make them informational.

## What

Add `informational: true` to `component_management.default_rules.statuses` for both `project` and `patch` types.

```yaml
# Before
component_management:
  default_rules:
    statuses:
      - type: project
        target: auto
      - type: patch
        target: 80%

# After
component_management:
  default_rules:
    statuses:
      - type: project
        target: auto
        informational: true
      - type: patch
        target: 80%
        informational: true
```

This makes all component checks non-blocking, consistent with the explicit `informational: true` already set on `platform-frontend`.

## Impact

- FE-only PRs will no longer be blocked by BE Codecov failures
- Coverage reporting still works — Codecov still posts status checks, they just won't block merges
- Consistent with the existing `platform-frontend` component behavior

Linear: SECRT-2216