### PR TITLE
docs(skill): add coverage guidance to pr-address skill

### DIFF
--- a/.claude/skills/pr-address/SKILL.md
+++ b/.claude/skills/pr-address/SKILL.md
@@ -141,6 +141,22 @@ Then commit and **push immediately** — never batch commits without pushing. Ea
 
 For backend commits in worktrees: `poetry run git commit` (pre-commit hooks).
 
+## Coverage
+
+Codecov enforces patch coverage on new/changed lines — new code you write must be tested. Before pushing, verify you haven't left new lines uncovered:
+
+```bash
+cd autogpt_platform/backend
+poetry run pytest --cov=. --cov-report=term-missing {path/to/changed/module}
+```
+
+Look for lines marked `miss` — those are uncovered. Add tests for any new code you wrote as part of addressing comments.
+
+**Rules:**
+- New code you add should have tests
+- Don't remove existing tests when fixing comments
+- If a reviewer asks you to delete code, also delete its tests, but verify coverage hasn't dropped on remaining lines
+
 ## The loop
 
 ```text


### PR DESCRIPTION
Requested by @majdyz

## Why

As we enforce patch coverage targets via Codecov (see #12694), the `pr-address` skill needs to guide agents to verify test coverage when they write new code while addressing review comments. Without this, an agent could address a comment by adding untested code and create a new CI failure to fix.

## What

Adds a **Coverage** section to `.claude/skills/pr-address/SKILL.md` with:
- The `pytest --cov` command to check coverage locally on changed files
- Clear rules: new code needs tests, don't remove existing tests, clean up dead test code when deleting code

## Impact

Agents using `/pr-address` will now run coverage checks as part of their workflow and won't land untested new code.

Linear: SECRT-2217