### PR TITLE
refactor(frontend): remove stale feature flags and stabilize share execution

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/selected-views/SelectedRunView/components/SelectedRunActions/SelectedRunActions.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/selected-views/SelectedRunView/components/SelectedRunActions/SelectedRunActions.tsx
@@ -2,7 +2,6 @@ import { GraphExecution } from "@/app/api/__generated__/models/graphExecution";
 import { LibraryAgent } from "@/app/api/__generated__/models/libraryAgent";
 import { Button } from "@/components/atoms/Button/Button";
 import { LoadingSpinner } from "@/components/atoms/LoadingSpinner/LoadingSpinner";
-import { Flag, useGetFlag } from "@/services/feature-flags/use-get-flag";
 import {
   ArrowBendLeftUpIcon,
   ArrowBendRightDownIcon,
@@ -47,7 +46,6 @@ export function SelectedRunActions({
     onSelectRun: onSelectRun,
   });
 
-  const shareExecutionResultsEnabled = useGetFlag(Flag.SHARE_EXECUTION_RESULTS);
   const isRunning = run?.status === "RUNNING";
 
   if (!run || !agent) return null;
@@ -104,14 +102,12 @@ export function SelectedRunActions({
           <EyeIcon weight="bold" size={18} className="text-zinc-700" />
         </Button>
       ) : null}
-      {shareExecutionResultsEnabled && (
-        <ShareRunButton
-          graphId={agent.graph_id}
-          executionId={run.id}
-          isShared={run.is_shared}
-          shareToken={run.share_token}
-        />
-      )}
+      <ShareRunButton
+        graphId={agent.graph_id}
+        executionId={run.id}
+        isShared={run.is_shared}
+        shareToken={run.share_token}
+      />
       {canRunManually && (
         <>
           <Button

--- a/autogpt_platform/frontend/src/services/feature-flags/use-get-flag.ts
+++ b/autogpt_platform/frontend/src/services/feature-flags/use-get-flag.ts
@@ -6,11 +6,6 @@ import { useFlags } from "launchdarkly-react-client-sdk";
 
 export enum Flag {
   BETA_BLOCKS = "beta-blocks",
-  NEW_BLOCK_MENU = "new-block-menu",
-  GRAPH_SEARCH = "graph-search",
-  ENABLE_ENHANCED_OUTPUT_HANDLING = "enable-enhanced-output-handling",
-  SHARE_EXECUTION_RESULTS = "share-execution-results",
-  AGENT_FAVORITING = "agent-favoriting",
   MARKETPLACE_SEARCH_TERMS = "marketplace-search-terms",
   ENABLE_PLATFORM_PAYMENT = "enable-platform-payment",
   ARTIFACTS = "artifacts",
@@ -21,11 +16,6 @@ const isPwMockEnabled = process.env.NEXT_PUBLIC_PW_TEST === "true";
 
 const defaultFlags = {
   [Flag.BETA_BLOCKS]: [],
-  [Flag.NEW_BLOCK_MENU]: false,
-  [Flag.GRAPH_SEARCH]: false,
-  [Flag.ENABLE_ENHANCED_OUTPUT_HANDLING]: false,
-  [Flag.SHARE_EXECUTION_RESULTS]: false,
-  [Flag.AGENT_FAVORITING]: false,
   [Flag.MARKETPLACE_SEARCH_TERMS]: DEFAULT_SEARCH_TERMS,
   [Flag.ENABLE_PLATFORM_PAYMENT]: false,
   [Flag.ARTIFACTS]: false,


### PR DESCRIPTION
## Why

Stale feature flags add noise to the codebase and make it harder to understand which flags are actually gating live features. Four flags were defined but never referenced anywhere in the frontend, and the "Share Execution Results" flag has been stable long enough to remove its gate.

## What

- Remove 4 unused flags from the `Flag` enum and `defaultFlags`: `NEW_BLOCK_MENU`, `GRAPH_SEARCH`, `ENABLE_ENHANCED_OUTPUT_HANDLING`, `AGENT_FAVORITING`
- Remove the `SHARE_EXECUTION_RESULTS` flag and its conditional — the `ShareRunButton` now always renders

## How

- Deleted enum entries and default values in `use-get-flag.ts`
- Removed the `useGetFlag` call and conditional wrapper around `<ShareRunButton />` in `SelectedRunActions.tsx`

## Changes

- `src/services/feature-flags/use-get-flag.ts` — removed 5 flags from enum + defaults
- `src/app/(platform)/library/.../SelectedRunActions.tsx` — removed flag import, condition; share button always renders

### Checklist

- [x] My PR is small and focused on one change
- [x] I've tested my changes locally
- [x] `pnpm format && pnpm lint` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
