### PR TITLE
dx(orchestrate): harden agent fleet scripts — idle detection, pagination, fake-resolution guard, parallelism

### DIFF
--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -333,6 +333,54 @@ jq -r '.agents[] | select(.state | test("running|idle|stuck|waiting_approval|pen
 ```
 and capture every window listed. If you manually added a window outside spawn-agent.sh, ensure it's in the state file first.
 
+### RUNNING count includes waiting_approval agents
+
+The `RUNNING` count from run-loop.sh includes agents in `waiting_approval` state (they match the regex `running|stuck|waiting_approval|idle`). This means a fleet that is only `waiting_approval` still shows RUNNING > 0 in the log — it does **not** mean agents are actively working.
+
+When you see `RUNNING > 0` in the run-loop log but suspect agents are actually blocked, check state directly:
+```bash
+jq '.agents[] | {window, state, worktree}' ~/.claude/orchestrator-state.json
+```
+A count of `running=1 waiting=1` in the log actually means one agent is waiting for approval — the orchestrator should check and approve, not wait.
+
+### State file staleness recovery
+
+The state file is written by scripts but can drift from reality when windows are closed, sessions expire, or the orchestrator restarts across conversations.
+
+**Signs of stale state:**
+- `loop_window` points to a window that no longer exists in the tmux session
+- An agent's `state` is `running` but tmux window is closed or shows a shell prompt (not claude)
+- `last_seen_at` is hours old but state still says `running`
+
+**Recovery steps:**
+
+1. **Verify actual tmux windows:**
+```bash
+tmux list-windows -t SESSION -F '#{window_index}: #{window_name} (#{pane_current_command})'
+```
+
+2. **Cross-reference with state file:**
+```bash
+jq -r '.agents[] | "\(.window) \(.state) \(.worktree)"' ~/.claude/orchestrator-state.json
+```
+
+3. **Fix stale entries:**
+```bash
+# Agent window closed — mark idle so run-loop.sh will restart it
+jq --arg w "SESSION:WIN" '(.agents[] | select(.window==$w)).state = "idle"' \
+  ~/.claude/orchestrator-state.json > /tmp/orch.tmp && mv /tmp/orch.tmp ~/.claude/orchestrator-state.json
+
+# loop_window gone — kill the stale reference, then restart run-loop.sh
+jq '.loop_window = null' ~/.claude/orchestrator-state.json > /tmp/orch.tmp && mv /tmp/orch.tmp ~/.claude/orchestrator-state.json
+LOOP_WIN=$(tmux new-window -t "$SESSION" -n "orchestrator" -P -F '#{window_index}')
+LOOP_WINDOW="${SESSION}:${LOOP_WIN}"
+tmux send-keys -t "$LOOP_WINDOW" "bash $SKILLS_DIR/run-loop.sh" Enter
+jq --arg w "$LOOP_WINDOW" '.loop_window = $w' ~/.claude/orchestrator-state.json \
+  > /tmp/orch.tmp && mv /tmp/orch.tmp ~/.claude/orchestrator-state.json
+```
+
+4. **After any state repair, re-run `status.sh` to confirm coherence before resuming supervision.**
+
 ### Strict ORCHESTRATOR:DONE gate
 
 `verify-complete.sh` handles the main checks automatically (checkpoints, threads, CI green, spawned_at, and CHANGES_REQUESTED). Run it:
@@ -348,6 +396,14 @@ If it passes → run-loop.sh will recycle the window automatically. No manual ac
 If it fails → re-brief the agent with the failure reason. Never manually mark state `done` to bypass this.
 
 ### Re-brief a stalled agent
+
+**Before sending any nudge, verify the pane is at an idle ❯ prompt.** Sending text into a still-processing pane produces stuck `[Pasted text +N lines]` that the agent never sees.
+
+Check:
+```bash
+tmux capture-pane -t SESSION:WIN -p 2>/dev/null | tail -5
+```
+If the last line shows a spinner (✳✽✢✶·), `Running…`, or no `❯` — wait 10–15s and check again before sending.
 
 ```bash
 OBJ=$(jq -r --arg w SESSION:WIN '.agents[] | select(.window==$w) | .objective' ~/.claude/orchestrator-state.json)
@@ -556,18 +612,49 @@ gh api graphql -f query='{ repository(owner: "OWNER", name: "REPO") { pullReques
 If unresolved > 0, the agent is NOT done — re-brief with the actual count and the rule.
 
 **Include this in every agent objective:**
-> IMPORTANT: Do NOT resolve any review thread via GraphQL unless the code fix is committed and pushed first. Fix the code → commit → push → reply with SHA → then resolve. Never resolve without a real commit.
+> IMPORTANT: Do NOT resolve any review thread via GraphQL unless the code fix is committed and pushed first. Fix the code → commit → push → reply with SHA → then resolve. Never resolve without a real commit. "Accepted" or "Acknowledged" replies are NOT resolutions — only real commits qualify.
+
+### Detecting fake resolutions
+
+When an agent claims "0 unresolved threads", query GitHub GraphQL yourself and also inspect how each thread was resolved. A resolved thread whose last comment is `"Acknowledged"`, `"Same as above"`, `"Accepted trade-off"`, or `"Deferred"` — with no commit SHA — is a fake resolution.
+
+To spot these, fetch all resolved threads and look for missing SHA links:
+```bash
+gh api graphql -f query='
+{
+  repository(owner: "Significant-Gravitas", name: "AutoGPT") {
+    pullRequest(number: PR_NUMBER) {
+      reviewThreads(first: 100) {
+        nodes {
+          isResolved
+          comments(last: 1) {
+            nodes { body author { login } }
+          }
+        }
+      }
+    }
+  }
+}' | jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == true) | {body: .comments.nodes[0].body[:120], author: .comments.nodes[0].author.login}] | map(select(.body | test("Fixed in|Removed in|Addressed in") | not))'
+```
+Any resolved thread whose last comment does NOT contain `"Fixed in"`, `"Removed in"`, or `"Addressed in"` (with a commit link) should be investigated — either the agent falsely resolved it, or it was a genuine false positive that needs explanation.
 
 ## GitHub abuse rate limits
 
-When agents post many review thread replies in quick succession, GitHub returns `{"code":"abuse"}` errors. This is expected. The fix:
+Two distinct rate limits exist with different recovery times:
 
-- Add `sleep 3` between individual thread replies
-- If rate limited, wait 60 seconds before resuming
-- Never batch all replies in a single script loop without delays
+| Error | HTTP status | Cause | Recovery |
+|---|---|---|---|
+| `{"code":"abuse"}` in body | 403 | Secondary rate limit — too many write operations (comments, mutations) in a short window | Wait **2–3 minutes**. 60s is often not enough. |
+| `API rate limit exceeded` | 429 | Primary rate limit — too many read calls per hour | Wait until `X-RateLimit-Reset` timestamp |
+
+**Prevention:** Agents must add `sleep 3` between individual thread reply API calls. For >20 unresolved threads, increase to `sleep 5`.
+
+If you see a 403 `abuse` error from an agent's pane:
+1. Nudge the agent: `"You hit a GitHub secondary rate limit (403). Stop all API writes. Wait 2 minutes, then resume with sleep 3 between each thread reply."`
+2. Do NOT nudge again during the 2-minute wait — a second nudge restarts the clock.
 
 Add this to agent briefings when there are >20 unresolved threads:
-> Post replies in batches with `sleep 3` between each reply. If you hit a GitHub abuse error, wait 60 seconds then continue.
+> Post replies with `sleep 3` between each reply. If you hit a 403 abuse error, wait 2 minutes (not 60s — secondary limits take longer to clear) then continue.
 
 ## Key rules
 

--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -632,23 +632,38 @@ If unresolved > 0, the agent is NOT done — re-brief with the actual count and 
 
 When an agent claims "0 unresolved threads", query GitHub GraphQL yourself and also inspect how each thread was resolved. A resolved thread whose last comment is `"Acknowledged"`, `"Same as above"`, `"Accepted trade-off"`, or `"Deferred"` — with no commit SHA — is a fake resolution.
 
-To spot these, fetch all resolved threads and look for missing SHA links:
+To spot these, paginate all pages and collect resolved threads with missing SHA links:
 ```bash
-gh api graphql -f query='
-{
-  repository(owner: "Significant-Gravitas", name: "AutoGPT") {
-    pullRequest(number: PR_NUMBER) {
-      reviewThreads(first: 100) {
-        nodes {
-          isResolved
-          comments(last: 1) {
-            nodes { body author { login } }
+# Paginate all pages — first:100 misses threads beyond page 1 on large PRs
+CURSOR=""; FAKE_RESOLUTIONS="[]"
+while true; do
+  AFTER=${CURSOR:+", after: \"$CURSOR\""}
+  PAGE=$(gh api graphql -f query="
+  {
+    repository(owner: \"Significant-Gravitas\", name: \"AutoGPT\") {
+      pullRequest(number: PR_NUMBER) {
+        reviewThreads(first: 100${AFTER}) {
+          pageInfo { hasNextPage endCursor }
+          nodes {
+            isResolved
+            comments(last: 1) {
+              nodes { body author { login } }
+            }
           }
         }
       }
     }
-  }
-}' | jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == true) | {body: .comments.nodes[0].body[:120], author: .comments.nodes[0].author.login}] | map(select(.body | test("Fixed in|Removed in|Addressed in") | not))'
+  }")
+  PAGE_FAKES=$(echo "$PAGE" | jq '[.data.repository.pullRequest.reviewThreads.nodes[]
+    | select(.isResolved == true)
+    | {body: .comments.nodes[0].body[:120], author: .comments.nodes[0].author.login}
+    | select(.body | test("Fixed in|Removed in|Addressed in") | not)]')
+  FAKE_RESOLUTIONS=$(echo "$FAKE_RESOLUTIONS $PAGE_FAKES" | jq -s 'add')
+  HAS_NEXT=$(echo "$PAGE" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage')
+  CURSOR=$(echo "$PAGE" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor')
+  [ "$HAS_NEXT" = "false" ] && break
+done
+echo "$FAKE_RESOLUTIONS"
 ```
 Any resolved thread whose last comment does NOT contain `"Fixed in"`, `"Removed in"`, or `"Addressed in"` (with a commit link) should be investigated — either the agent falsely resolved it, or it was a genuine false positive that needs explanation.
 

--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -605,8 +605,22 @@ This is the most common failure mode: agents call `resolveReviewThread` to make 
 **The supervisor must verify actual thread counts via GraphQL** — never trust an agent's claim of "0 unresolved." After any agent's ORCHESTRATOR:DONE, always run:
 
 ```bash
-gh api graphql -f query='{ repository(owner: "OWNER", name: "REPO") { pullRequest(number: PR) { reviewThreads(first: 1) { totalCount nodes { isResolved } } } } }' \
-  | jq '{total: .data.repository.pullRequest.reviewThreads.totalCount, unresolved: [.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved==false)] | length}'
+# Step 1: get total count
+TOTAL=$(gh api graphql -f query='{ repository(owner: "OWNER", name: "REPO") { pullRequest(number: PR) { reviewThreads { totalCount } } } }' \
+  | jq '.data.repository.pullRequest.reviewThreads.totalCount')
+echo "Total threads: $TOTAL"
+
+# Step 2: paginate all pages and count unresolved
+CURSOR=""; UNRESOLVED=0
+while true; do
+  AFTER=${CURSOR:+", after: \"$CURSOR\""}
+  PAGE=$(gh api graphql -f query="{ repository(owner: \"OWNER\", name: \"REPO\") { pullRequest(number: PR) { reviewThreads(first: 100${AFTER}) { pageInfo { hasNextPage endCursor } nodes { isResolved } } } } }")
+  UNRESOLVED=$(( UNRESOLVED + $(echo "$PAGE" | jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved==false)] | length') ))
+  HAS_NEXT=$(echo "$PAGE" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage')
+  CURSOR=$(echo "$PAGE" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor')
+  [ "$HAS_NEXT" = "false" ] && break
+done
+echo "Unresolved: $UNRESOLVED"
 ```
 
 If unresolved > 0, the agent is NOT done — re-brief with the actual count and the rule.

--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -323,8 +323,15 @@ For each agent, decide:
 | Stuck in error loop | Send targeted fix with exact error + solution |
 | Waiting for input / question | Answer and unblock via `tmux send-keys` |
 | CI red | `gh pr checks PR_NUMBER --repo REPO` → tell agent exactly what's failing |
+| GitHub abuse rate limit error | Nudge: "Wait 60 seconds then continue posting replies with sleep 3 between each" |
 | Context compacted / agent lost | Send recovery: `cat ~/.claude/orchestrator-state.json | jq '.agents[] | select(.window=="WIN")'` + `gh pr view PR_NUMBER --json title,body` |
-| `ORCHESTRATOR:DONE` in output | Run `verify-complete.sh` — if it fails, re-brief with specific reason |
+| `ORCHESTRATOR:DONE` in output | Query GraphQL for actual unresolved count. If >0, re-brief. If 0, run `verify-complete.sh` |
+
+**Poll all windows from state, not from memory.** Before each poll, run:
+```bash
+jq -r '.agents[] | select(.state | test("running|idle|stuck|waiting_approval|pending_evaluation")) | .window' ~/.claude/orchestrator-state.json
+```
+and capture every window listed. If you manually added a window outside spawn-agent.sh, ensure it's in the state file first.
 
 ### Strict ORCHESTRATOR:DONE gate
 
@@ -526,6 +533,42 @@ When `dx/orchestrate-skill` is merged into `dev`, `AutoGPT1` becomes a normal sp
 
 ---
 
+## Thread resolution integrity (critical)
+
+**Agents MUST NOT resolve review threads via GraphQL unless a real code fix has been committed and pushed first.**
+
+This is the most common failure mode: agents call `resolveReviewThread` to make unresolved counts drop without actually fixing anything. This produces a false "done" signal that gets past verify-complete.sh.
+
+**The only valid resolution sequence:**
+1. Read the thread and understand what it's asking
+2. Make the actual code change
+3. `git commit` and `git push`
+4. Reply to the thread with the commit SHA (e.g. "Fixed in `abc1234`")
+5. THEN call `resolveReviewThread`
+
+**The supervisor must verify actual thread counts via GraphQL** — never trust an agent's claim of "0 unresolved." After any agent's ORCHESTRATOR:DONE, always run:
+
+```bash
+gh api graphql -f query='{ repository(owner: "OWNER", name: "REPO") { pullRequest(number: PR) { reviewThreads(first: 1) { totalCount nodes { isResolved } } } } }' \
+  | jq '{total: .data.repository.pullRequest.reviewThreads.totalCount, unresolved: [.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved==false)] | length}'
+```
+
+If unresolved > 0, the agent is NOT done — re-brief with the actual count and the rule.
+
+**Include this in every agent objective:**
+> IMPORTANT: Do NOT resolve any review thread via GraphQL unless the code fix is committed and pushed first. Fix the code → commit → push → reply with SHA → then resolve. Never resolve without a real commit.
+
+## GitHub abuse rate limits
+
+When agents post many review thread replies in quick succession, GitHub returns `{"code":"abuse"}` errors. This is expected. The fix:
+
+- Add `sleep 3` between individual thread replies
+- If rate limited, wait 60 seconds before resuming
+- Never batch all replies in a single script loop without delays
+
+Add this to agent briefings when there are >20 unresolved threads:
+> Post replies in batches with `sleep 3` between each reply. If you hit a GitHub abuse error, wait 60 seconds then continue.
+
 ## Key rules
 
 1. **Scripts do all the heavy lifting** — don't reimplement their logic inline in this file
@@ -543,3 +586,8 @@ When `dx/orchestrate-skill` is merged into `dev`, `AutoGPT1` becomes a normal sp
 13. **Protected worktrees** — never use the worktree hosting the skill scripts as a spare
 14. **Images via file path** — save screenshots to `/tmp/orchestrator-context-<ts>.png`, pass path in objective; agents read with the `Read` tool
 15. **Split send-keys** — always separate text and Enter with `sleep 0.3` between calls for long strings
+16. **Poll ALL windows from state file** — never hardcode window count. Derive active windows dynamically: `jq -r '.agents[] | select(.state | test("running|idle|stuck")) | .window' ~/.claude/orchestrator-state.json`. If you added a window mid-session outside spawn-agent.sh, add it to the state file immediately.
+20. **Orchestrator handles its own approvals** — when spawning a subagent to make edits (SKILL.md, scripts, config), review the diff yourself and approve/reject without surfacing it to the user. The user should never have to open a file to check the orchestrator's work. Use the Agent tool with `subagent_type: general-purpose` for drafting, then verify the result yourself before considering the task done.
+17. **Update state file on re-task** — whenever an agent is re-tasked mid-session (objective changes, new PR assigned), update the state file record immediately so objectives stay accurate for re-briefing after compaction.
+18. **No GraphQL resolveReviewThread without a commit** — see Thread resolution integrity above. This is rule #1 for pr-address work.
+19. **Verify thread counts yourself** — after any agent claims "0 unresolved threads", query GitHub GraphQL directly before accepting. Never trust the agent's self-report.

--- a/.claude/skills/orchestrate/scripts/run-loop.sh
+++ b/.claude/skills/orchestrate/scripts/run-loop.sh
@@ -170,7 +170,7 @@ while true; do
   if (( KICKED > 0 || DONE > 0 || WAITING > 0 )); then
     POLL_CURRENT=$POLL_INTERVAL
   else
-    POLL_CURRENT=$(( POLL_CURRENT * 3 / 2 ))
+    POLL_CURRENT=$(( POLL_CURRENT + POLL_CURRENT / 2 + 1 ))
     (( POLL_CURRENT > POLL_IDLE_MAX )) && POLL_CURRENT=$POLL_IDLE_MAX
   fi
 

--- a/.claude/skills/orchestrate/scripts/run-loop.sh
+++ b/.claude/skills/orchestrate/scripts/run-loop.sh
@@ -84,11 +84,12 @@ wait_for_claude_idle() {
   local timeout="${2:-30}"
   local elapsed=0
   while (( elapsed < timeout )); do
-    local cmd pane_tail
+    local cmd pane pane_tail
     cmd=$(tmux display-message -t "$window" -p '#{pane_current_command}' 2>/dev/null || echo "")
-    pane_tail=$(tmux capture-pane -t "$window" -p 2>/dev/null | tail -3 || echo "")
-    # Handle settings error dialog before checking for idle prompt
-    if echo "$pane_tail" | grep -q "Enter to confirm"; then
+    pane=$(tmux capture-pane -t "$window" -p 2>/dev/null || echo "")
+    pane_tail=$(echo "$pane" | tail -3)
+    # Check full pane (not just tail) — 'Enter to confirm' dialog can scroll above last 3 lines
+    if echo "$pane" | grep -q "Enter to confirm"; then
       tmux send-keys -t "$window" Down Enter
       elapsed=0; sleep 2; continue
     fi

--- a/.claude/skills/orchestrate/scripts/run-loop.sh
+++ b/.claude/skills/orchestrate/scripts/run-loop.sh
@@ -30,7 +30,7 @@ STATE_FILE="${ORCHESTRATOR_STATE_FILE:-$HOME/.claude/orchestrator-state.json}"
 # Adaptive polling: starts at base interval, backs off up to POLL_IDLE_MAX when
 # no agents need attention, resets on any activity or waiting_approval state.
 POLL_INTERVAL="${POLL_INTERVAL:-30}"
-POLL_IDLE_MAX=300
+POLL_IDLE_MAX=${POLL_IDLE_MAX:-300}
 POLL_CURRENT=$POLL_INTERVAL
 
 # ---------------------------------------------------------------------------
@@ -163,8 +163,6 @@ while true; do
   RUNNING=$(jq '[.agents[] | select(.state | test("running|stuck|waiting_approval|idle"))] | length' \
     "$STATE_FILE" 2>/dev/null || echo 0)
 
-  echo "[$(date +%H:%M:%S)] Poll — ${RUNNING} running  ${KICKED} kicked  ${DONE} recycled  (next in ${POLL_CURRENT}s)"
-
   # Adaptive backoff: reset to base on activity or waiting_approval agents; back off when truly idle
   WAITING=$(jq '[.agents[] | select(.state == "waiting_approval")] | length' "$STATE_FILE" 2>/dev/null || echo 0)
   if (( KICKED > 0 || DONE > 0 || WAITING > 0 )); then
@@ -174,5 +172,6 @@ while true; do
     (( POLL_CURRENT > POLL_IDLE_MAX )) && POLL_CURRENT=$POLL_IDLE_MAX
   fi
 
+  echo "[$(date +%H:%M:%S)] Poll — ${RUNNING} running  ${KICKED} kicked  ${DONE} recycled  (next in ${POLL_CURRENT}s)"
   sleep "$POLL_CURRENT"
 done

--- a/.claude/skills/orchestrate/scripts/run-loop.sh
+++ b/.claude/skills/orchestrate/scripts/run-loop.sh
@@ -88,10 +88,11 @@ wait_for_claude_idle() {
     cmd=$(tmux display-message -t "$window" -p '#{pane_current_command}' 2>/dev/null || echo "")
     pane=$(tmux capture-pane -t "$window" -p 2>/dev/null || echo "")
     pane_tail=$(echo "$pane" | tail -3)
-    # Check full pane (not just tail) — 'Enter to confirm' dialog can scroll above last 3 lines
+    # Check full pane (not just tail) — 'Enter to confirm' dialog can scroll above last 3 lines.
+    # Do NOT reset elapsed — resetting allows an infinite loop if the dialog never clears.
     if echo "$pane" | grep -q "Enter to confirm"; then
       tmux send-keys -t "$window" Down Enter
-      elapsed=0; sleep 2; continue
+      sleep 2; (( elapsed += 2 )); continue
     fi
     # Must be running under node (Claude is live)
     if [[ "$cmd" == "node" ]]; then

--- a/.claude/skills/orchestrate/scripts/run-loop.sh
+++ b/.claude/skills/orchestrate/scripts/run-loop.sh
@@ -27,7 +27,9 @@ chmod +x "$STABLE_SCRIPTS_DIR"/*.sh
 SCRIPTS_DIR="$STABLE_SCRIPTS_DIR"
 
 STATE_FILE="${ORCHESTRATOR_STATE_FILE:-$HOME/.claude/orchestrator-state.json}"
-POLL_INTERVAL="${POLL_INTERVAL:-30}"
+POLL_INTERVAL="${POLL_INTERVAL:-30}"   # base interval: 30 seconds
+POLL_IDLE_MAX=300                       # back off up to 5 minutes when nothing is happening
+POLL_CURRENT=$POLL_INTERVAL             # adaptive: starts at base, increases when idle
 
 # ---------------------------------------------------------------------------
 # update_state WINDOW FIELD VALUE
@@ -130,7 +132,7 @@ handle_approve() {
 # ---------------------------------------------------------------------------
 # Main loop
 # ---------------------------------------------------------------------------
-echo "[$(date +%H:%M:%S)] run-loop started (mechanical only, poll every ${POLL_INTERVAL}s)"
+echo "[$(date +%H:%M:%S)] run-loop started (mechanical only, poll ${POLL_INTERVAL}s→${POLL_IDLE_MAX}s adaptive)"
 echo "[$(date +%H:%M:%S)] Supervisor: orchestrating Claude session (not a separate window)"
 echo "---"
 
@@ -159,6 +161,15 @@ while true; do
   RUNNING=$(jq '[.agents[] | select(.state | test("running|stuck|waiting_approval|idle"))] | length' \
     "$STATE_FILE" 2>/dev/null || echo 0)
 
-  echo "[$(date +%H:%M:%S)] Poll — ${RUNNING} running  ${KICKED} kicked  ${DONE} recycled"
-  sleep "$POLL_INTERVAL"
+  echo "[$(date +%H:%M:%S)] Poll — ${RUNNING} running  ${KICKED} kicked  ${DONE} recycled  (next in ${POLL_CURRENT}s)"
+
+  # Adaptive backoff: reset to base on activity, back off toward max when idle
+  if (( KICKED > 0 || DONE > 0 )); then
+    POLL_CURRENT=$POLL_INTERVAL
+  else
+    POLL_CURRENT=$(( POLL_CURRENT * 3 / 2 ))
+    (( POLL_CURRENT > POLL_IDLE_MAX )) && POLL_CURRENT=$POLL_IDLE_MAX
+  fi
+
+  sleep "$POLL_CURRENT"
 done

--- a/.claude/skills/orchestrate/scripts/run-loop.sh
+++ b/.claude/skills/orchestrate/scripts/run-loop.sh
@@ -163,8 +163,9 @@ while true; do
 
   echo "[$(date +%H:%M:%S)] Poll — ${RUNNING} running  ${KICKED} kicked  ${DONE} recycled  (next in ${POLL_CURRENT}s)"
 
-  # Adaptive backoff: reset to base on activity, back off toward max when idle
-  if (( KICKED > 0 || DONE > 0 )); then
+  # Adaptive backoff: reset to base on activity or waiting_approval agents; back off when truly idle
+  WAITING=$(jq '[.agents[] | select(.state == "waiting_approval")] | length' "$STATE_FILE" 2>/dev/null || echo 0)
+  if (( KICKED > 0 || DONE > 0 || WAITING > 0 )); then
     POLL_CURRENT=$POLL_INTERVAL
   else
     POLL_CURRENT=$(( POLL_CURRENT * 3 / 2 ))

--- a/.claude/skills/orchestrate/scripts/run-loop.sh
+++ b/.claude/skills/orchestrate/scripts/run-loop.sh
@@ -27,9 +27,11 @@ chmod +x "$STABLE_SCRIPTS_DIR"/*.sh
 SCRIPTS_DIR="$STABLE_SCRIPTS_DIR"
 
 STATE_FILE="${ORCHESTRATOR_STATE_FILE:-$HOME/.claude/orchestrator-state.json}"
-POLL_INTERVAL="${POLL_INTERVAL:-30}"   # base interval: 30 seconds
-POLL_IDLE_MAX=300                       # back off up to 5 minutes when nothing is happening
-POLL_CURRENT=$POLL_INTERVAL             # adaptive: starts at base, increases when idle
+# Adaptive polling: starts at base interval, backs off up to POLL_IDLE_MAX when
+# no agents need attention, resets on any activity or waiting_approval state.
+POLL_INTERVAL="${POLL_INTERVAL:-30}"
+POLL_IDLE_MAX=300
+POLL_CURRENT=$POLL_INTERVAL
 
 # ---------------------------------------------------------------------------
 # update_state WINDOW FIELD VALUE

--- a/.claude/skills/orchestrate/scripts/run-loop.sh
+++ b/.claude/skills/orchestrate/scripts/run-loop.sh
@@ -75,6 +75,33 @@ wait_for_prompt() {
 }
 
 # ---------------------------------------------------------------------------
+# wait_for_claude_idle WINDOW — wait up to 30s for Claude to reach idle ❯ prompt
+# (no spinner or busy indicator visible in the last 3 lines of pane output)
+# Returns 0 when idle, 1 on timeout.
+# ---------------------------------------------------------------------------
+wait_for_claude_idle() {
+  local window="$1"
+  local timeout="${2:-30}"
+  local elapsed=0
+  while (( elapsed < timeout )); do
+    local cmd pane_tail
+    cmd=$(tmux display-message -t "$window" -p '#{pane_current_command}' 2>/dev/null || echo "")
+    pane_tail=$(tmux capture-pane -t "$window" -p 2>/dev/null | tail -3 || echo "")
+    # Must be running under node (Claude is live)
+    if [[ "$cmd" == "node" ]]; then
+      # Idle: ❯ prompt visible AND no spinner/busy text in last 3 lines
+      if echo "$pane_tail" | grep -q "❯" && \
+         ! echo "$pane_tail" | grep -qE '[✳✽✢✶·✻✼✿❋✤]|Running…|Compacting'; then
+        return 0
+      fi
+    fi
+    sleep 2
+    (( elapsed += 2 ))
+  done
+  return 1  # timed out
+}
+
+# ---------------------------------------------------------------------------
 # handle_kick WINDOW STATE — only for idle (crashed) agents, not stuck
 # ---------------------------------------------------------------------------
 handle_kick() {
@@ -86,6 +113,10 @@ handle_kick() {
   session_id=$(agent_field "$window" "session_id")
 
   echo "[$(date +%H:%M:%S)] KICK restart  $window — agent exited, resuming session"
+
+  # Wait for the shell prompt before typing — avoids sending into a still-draining pane
+  wait_for_claude_idle "$window" 30 \
+    || echo "[$(date +%H:%M:%S)] KICK WARNING  $window — pane still busy before resume, sending anyway"
 
   # Resume the exact session so the agent retains full context — no need to re-send objective
   if [ -n "$session_id" ]; then

--- a/.claude/skills/orchestrate/scripts/run-loop.sh
+++ b/.claude/skills/orchestrate/scripts/run-loop.sh
@@ -87,6 +87,11 @@ wait_for_claude_idle() {
     local cmd pane_tail
     cmd=$(tmux display-message -t "$window" -p '#{pane_current_command}' 2>/dev/null || echo "")
     pane_tail=$(tmux capture-pane -t "$window" -p 2>/dev/null | tail -3 || echo "")
+    # Handle settings error dialog before checking for idle prompt
+    if echo "$pane_tail" | grep -q "Enter to confirm"; then
+      tmux send-keys -t "$window" Down Enter
+      elapsed=0; sleep 2; continue
+    fi
     # Must be running under node (Claude is live)
     if [[ "$cmd" == "node" ]]; then
       # Idle: ❯ prompt visible AND no spinner/busy text in last 3 lines

--- a/.claude/skills/orchestrate/scripts/spawn-agent.sh
+++ b/.claude/skills/orchestrate/scripts/spawn-agent.sh
@@ -97,8 +97,10 @@ _wait_idle() {
   while (( elapsed < timeout )); do
     local cmd pane_tail
     cmd=$(tmux display-message -t "$window" -p '#{pane_current_command}' 2>/dev/null || echo "")
-    pane_tail=$(tmux capture-pane -t "$window" -p 2>/dev/null | tail -3 || echo "")
-    if echo "$pane_tail" | grep -q "Enter to confirm"; then
+    pane=$(tmux capture-pane -t "$window" -p 2>/dev/null || echo "")
+    pane_tail=$(echo "$pane" | tail -3)
+    # Check full pane (not just tail) — 'Enter to confirm' dialog can appear above the last 3 lines
+    if echo "$pane" | grep -q "Enter to confirm"; then
       tmux send-keys -t "$window" Down Enter
       sleep 2; (( elapsed += 2 )); continue
     fi

--- a/.claude/skills/orchestrate/scripts/spawn-agent.sh
+++ b/.claude/skills/orchestrate/scripts/spawn-agent.sh
@@ -90,26 +90,31 @@ fi
 #   claude --resume SESSION_ID --permission-mode bypassPermissions
 tmux send-keys -t "$WINDOW" "cd '${WORKTREE_PATH}' && claude --permission-mode bypassPermissions --session-id '${SESSION_ID}'" Enter
 
-# Wait up to 60s for claude to be fully interactive:
-# both pane_current_command == 'node' AND the '❯' prompt is visible.
-PROMPT_FOUND=false
-for i in $(seq 1 60); do
-  CMD=$(tmux display-message -t "$WINDOW" -p '#{pane_current_command}' 2>/dev/null || echo "")
-  PANE=$(tmux capture-pane -t "$WINDOW" -p 2>/dev/null || echo "")
-  if echo "$PANE" | grep -q "Enter to confirm"; then
-    tmux send-keys -t "$WINDOW" Down Enter
-    sleep 2
-    continue
-  fi
-  if [[ "$CMD" == "node" ]] && echo "$PANE" | grep -q "❯"; then
-    PROMPT_FOUND=true
-    break
-  fi
-  sleep 1
-done
+# wait_for_claude_idle — poll until the pane shows idle ❯ with no spinner in the last 3 lines.
+# Returns 0 when idle, 1 on timeout.
+_wait_idle() {
+  local window="$1" timeout="${2:-60}" elapsed=0
+  while (( elapsed < timeout )); do
+    local cmd pane_tail
+    cmd=$(tmux display-message -t "$window" -p '#{pane_current_command}' 2>/dev/null || echo "")
+    pane_tail=$(tmux capture-pane -t "$window" -p 2>/dev/null | tail -3 || echo "")
+    if echo "$pane_tail" | grep -q "Enter to confirm"; then
+      tmux send-keys -t "$window" Down Enter
+      sleep 2; (( elapsed += 2 )); continue
+    fi
+    if [[ "$cmd" == "node" ]] && \
+       echo "$pane_tail" | grep -q "❯" && \
+       ! echo "$pane_tail" | grep -qE '[✳✽✢✶·✻✼✿❋✤]|Running…|Compacting'; then
+      return 0
+    fi
+    sleep 2; (( elapsed += 2 ))
+  done
+  return 1
+}
 
-if ! $PROMPT_FOUND; then
-  echo "[spawn-agent] WARNING: timed out waiting for ❯ prompt on $WINDOW — sending objective anyway" >&2
+# Wait up to 60s for claude to be fully interactive and idle (❯ visible, no spinner).
+if ! _wait_idle "$WINDOW" 60; then
+  echo "[spawn-agent] WARNING: timed out waiting for idle ❯ prompt on $WINDOW — sending objective anyway" >&2
 fi
 
 # Send the task. Split text and Enter — if combined, Enter can fire before the string

--- a/.claude/skills/pr-address/SKILL.md
+++ b/.claude/skills/pr-address/SKILL.md
@@ -29,30 +29,71 @@ gh pr view {N} --json body --jq '.body'
 
 ### 1. Inline review threads — GraphQL (primary source of actionable items)
 
-Use GraphQL to fetch inline threads. It natively exposes `isResolved`, returns threads already grouped with all replies, and paginates via cursor — no manual thread reconstruction needed.
+> ⚠️ **WARNING — PAGINATE ALL PAGES BEFORE ADDRESSING ANYTHING**
+>
+> `reviewThreads(first: 100)` returns at most 100 threads per page. A PR with many review cycles can have 140+ threads across 2+ pages. **If you start addressing threads after fetching only page 1, you will miss all threads on subsequent pages and silently leave them unresolved.**
+>
+> PR #12636 had 142 total threads: page 1 returned 69 unresolved, page 2 had 42 more (111 total unresolved). An agent that stopped after page 1 addressed only 69 and falsely reported "done".
+>
+> **The rule: collect ALL thread IDs from ALL pages into a single list, then address them.**
+
+**Step 1 — Fetch total count first:**
 
 ```bash
 gh api graphql -f query='
 {
   repository(owner: "Significant-Gravitas", name: "AutoGPT") {
     pullRequest(number: {N}) {
-      reviewThreads(first: 100) {
-        pageInfo { hasNextPage endCursor }
-        nodes {
-          id
-          isResolved
-          path
-          comments(last: 1) {
-            nodes { databaseId body author { login } createdAt }
+      reviewThreads { totalCount }
+    }
+  }
+}' | jq '.data.repository.pullRequest.reviewThreads.totalCount'
+```
+
+If `totalCount > 100`, you have multiple pages. Fetch them all before doing anything else.
+
+**Step 2 — Collect all unresolved thread IDs across all pages:**
+
+```bash
+# Accumulate all unresolved threads — loop until hasNextPage == false
+CURSOR=""
+ALL_THREADS="[]"
+while true; do
+  AFTER=${CURSOR:+", after: \"$CURSOR\""}
+  PAGE=$(gh api graphql -f query="
+  {
+    repository(owner: \"Significant-Gravitas\", name: \"AutoGPT\") {
+      pullRequest(number: {N}) {
+        reviewThreads(first: 100${AFTER}) {
+          pageInfo { hasNextPage endCursor }
+          nodes {
+            id
+            isResolved
+            path
+            line
+            comments(last: 1) {
+              nodes { databaseId body author { login } }
+            }
           }
         }
       }
     }
-  }
-}'
+  }")
+  # Append unresolved nodes from this page
+  PAGE_THREADS=$(echo "$PAGE" | jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)]')
+  ALL_THREADS=$(echo "$ALL_THREADS $PAGE_THREADS" | jq -s 'add')
+  HAS_NEXT=$(echo "$PAGE" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage')
+  CURSOR=$(echo "$PAGE" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor')
+  [ "$HAS_NEXT" = "false" ] && break
+done
+
+echo "Total unresolved threads: $(echo "$ALL_THREADS" | jq 'length')"
+echo "$ALL_THREADS" | jq '[.[] | {id, path, line, body: .comments.nodes[0].body[:200]}]'
 ```
 
-If `pageInfo.hasNextPage` is true, fetch subsequent pages by adding `after: "<endCursor>"` to `reviewThreads(first: 100, after: "...")` and repeat until `hasNextPage` is false.
+**Step 3 — Address every thread in `ALL_THREADS`, then resolve.**
+
+Only after this loop completes (all pages fetched, count confirmed) should you begin making fixes.
 
 **Filter to unresolved threads only** — skip any thread where `isResolved: true`. `comments(last: 1)` returns the most recent comment in the thread — act on that; it reflects the reviewer's final ask. Use the thread `id` (Relay global ID) to track threads across polls.
 

--- a/.claude/skills/pr-address/SKILL.md
+++ b/.claude/skills/pr-address/SKILL.md
@@ -318,6 +318,47 @@ Two distinct rate limits exist — they have different causes and recovery times
 
 Never batch all replies in a tight loop — always space them out.
 
+## Parallel thread resolution
+
+When a PR has more than 10 unresolved threads, addressing one commit per thread is slow. Use this strategy instead:
+
+### Group by file, batch per commit
+
+1. Sort `ALL_THREADS` by `path` — threads in the same file can share a single commit.
+2. Fix all threads in one file → `git commit` → `git push` → reply to **all** those threads with the same SHA → resolve them all.
+3. Move to the next file group and repeat.
+
+This reduces N commits to (number of files touched), which is usually 3–5 instead of 15–30.
+
+### Posting replies concurrently (for large batches)
+
+For truly independent thread groups (different files, no shared logic), you can post replies in parallel using background subshells — but always space out API writes:
+
+```bash
+# Post replies to a batch of threads concurrently, 3s apart
+(
+  sleep 3
+  gh api repos/Significant-Gravitas/AutoGPT/pulls/{N}/comments/{ID1}/replies \
+    -f body="🤖 Fixed in [${FULL_SHA:0:9}](https://github.com/Significant-Gravitas/AutoGPT/commit/${FULL_SHA}): ..."
+) &
+(
+  sleep 6
+  gh api repos/Significant-Gravitas/AutoGPT/pulls/{N}/comments/{ID2}/replies \
+    -f body="🤖 Fixed in [${FULL_SHA:0:9}](https://github.com/Significant-Gravitas/AutoGPT/commit/${FULL_SHA}): ..."
+) &
+wait  # wait for all background replies before resolving
+```
+
+Then resolve sequentially (GraphQL mutations):
+```bash
+for THREAD_ID in "$THREAD1" "$THREAD2" "$THREAD3"; do
+  gh api graphql -f query="mutation { resolveReviewThread(input: {threadId: \"${THREAD_ID}\"}) { thread { isResolved } } }"
+  sleep 3
+done
+```
+
+**Always sleep 3s between individual API writes** — GitHub's secondary rate limit (403) triggers on bursts of >20 writes. Increase to `sleep 5` when posting more than 20 replies in a batch.
+
 ## Resolving threads via GraphQL
 
 Use `resolveReviewThread` **only after** the commit is pushed and the reply is posted:
@@ -330,32 +371,40 @@ gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "THREA
 
 ### Verify actual count before outputting ORCHESTRATOR:DONE
 
-Before claiming "0 unresolved threads", always query GitHub directly — don't rely on your own bookkeeping:
+Before claiming "0 unresolved threads", always query GitHub directly — don't rely on your own bookkeeping. Paginate all pages — a single `first: 100` query misses threads beyond page 1:
 
 ```bash
+# Step 1: get total thread count
 gh api graphql -f query='
 {
   repository(owner: "Significant-Gravitas", name: "AutoGPT") {
     pullRequest(number: {N}) {
-      reviewThreads(first: 1) {
-        totalCount
-      }
+      reviewThreads { totalCount }
     }
   }
-}' | jq '.data.repository.pullRequest.reviewThreads'
-# Then fetch unresolved count:
-gh api graphql -f query='
-{
-  repository(owner: "Significant-Gravitas", name: "AutoGPT") {
-    pullRequest(number: {N}) {
-      reviewThreads(first: 100) {
-        nodes { isResolved }
+}' | jq '.data.repository.pullRequest.reviewThreads.totalCount'
+
+# Step 2: paginate all pages, count truly unresolved
+CURSOR=""; UNRESOLVED=0
+while true; do
+  AFTER=${CURSOR:+", after: \"$CURSOR\""}
+  PAGE=$(gh api graphql -f query="
+  {
+    repository(owner: \"Significant-Gravitas\", name: \"AutoGPT\") {
+      pullRequest(number: {N}) {
+        reviewThreads(first: 100${AFTER}) {
+          pageInfo { hasNextPage endCursor }
+          nodes { isResolved }
+        }
       }
     }
-  }
-}' | jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length'
+  }")
+  UNRESOLVED=$(( UNRESOLVED + $(echo "$PAGE" | jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved==false)] | length') ))
+  HAS_NEXT=$(echo "$PAGE" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage')
+  CURSOR=$(echo "$PAGE" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor')
+  [ "$HAS_NEXT" = "false" ] && break
+done
+echo "Unresolved threads: $UNRESOLVED"
 ```
 
-If `totalCount > 100`, paginate with `after:` cursor until `hasNextPage` is false.
-
-Only output `ORCHESTRATOR:DONE` after this query returns 0.
+Only output `ORCHESTRATOR:DONE` after this loop reports 0.

--- a/.claude/skills/pr-address/SKILL.md
+++ b/.claude/skills/pr-address/SKILL.md
@@ -84,7 +84,11 @@ Mostly contains: bot summaries (`coderabbitai[bot]`), CI/conflict detection (`gi
 
 ## For each unaddressed comment
 
-Address comments **one at a time**: fix → commit → push → inline reply → next.
+**CRITICAL: The only valid sequence is fix → commit → push → reply → resolve. Never resolve a thread without a real code commit.**
+
+Resolving a thread via `resolveReviewThread` without an actual fix is the most common failure mode — it makes unresolved counts drop without any real change, producing a false "done" signal. If the issue was genuinely a false positive (no code change needed), reply explaining why and then resolve. Otherwise:
+
+Address comments **one at a time**: fix → commit → push → inline reply → resolve.
 
 1. Read the referenced code, make the fix (or reply explaining why it's not needed)
 2. Commit and push the fix
@@ -232,3 +236,24 @@ git push
 ```
 
 5. Restart the polling loop from the top — new commits reset CI status.
+
+## GitHub abuse rate limits
+
+When posting many thread replies in quick succession, GitHub returns `{"code":"abuse"}` errors. This is throttling, not a permissions problem.
+
+**Fix:** Add `sleep 3` between individual thread reply API calls. If you hit an abuse error:
+1. Stop posting immediately
+2. Wait 60 seconds
+3. Resume with `sleep 3` between each call
+
+Never batch all replies in a tight loop — always space them out.
+
+## Resolving threads via GraphQL
+
+Use `resolveReviewThread` **only after** the commit is pushed and the reply is posted:
+
+```bash
+gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "THREAD_ID"}) { thread { isResolved } } }'
+```
+
+**Never call this mutation before committing the fix.** The orchestrator will verify actual unresolved counts via GraphQL after you output `ORCHESTRATOR:DONE` — false resolutions will be caught and you will be re-briefed.

--- a/.claude/skills/pr-address/SKILL.md
+++ b/.claude/skills/pr-address/SKILL.md
@@ -94,12 +94,33 @@ Address comments **one at a time**: fix → commit → push → inline reply →
 2. Commit and push the fix
 3. Reply **inline** (not as a new top-level comment) referencing the fixing commit — this is what resolves the conversation for bot reviewers (coderabbitai, sentry):
 
-Use a **markdown commit link** so GitHub renders it as a clickable reference. Get the full SHA with `git rev-parse HEAD` after committing:
+Use a **markdown commit link** so GitHub renders it as a clickable reference. Always get the full SHA with `git rev-parse HEAD` **after** committing — never copy a SHA from a previous commit or hardcode one:
+
+```bash
+FULL_SHA=$(git rev-parse HEAD)
+gh api repos/Significant-Gravitas/AutoGPT/pulls/{N}/comments/{ID}/replies \
+  -f body="🤖 Fixed in [${FULL_SHA:0:9}](https://github.com/Significant-Gravitas/AutoGPT/commit/${FULL_SHA}): <description>"
+```
 
 | Comment type | How to reply |
 |---|---|
 | Inline review (`pulls/{N}/comments`) | `gh api repos/Significant-Gravitas/AutoGPT/pulls/{N}/comments/{ID}/replies -f body="🤖 Fixed in [abc1234](https://github.com/Significant-Gravitas/AutoGPT/commit/FULL_SHA): <description>"` |
 | Conversation (`issues/{N}/comments`) | `gh api repos/Significant-Gravitas/AutoGPT/issues/{N}/comments -f body="🤖 Fixed in [abc1234](https://github.com/Significant-Gravitas/AutoGPT/commit/FULL_SHA): <description>"` |
+
+### What counts as a valid resolution
+
+Only two situations justify calling `resolveReviewThread`:
+
+1. **Real code fix**: you changed the code, committed + pushed, and replied with the SHA. The commit diff must actually address the concern — not just touch the same file.
+2. **Genuine false positive**: the reviewer's concern does not apply to this code, and you can give a specific technical reason (e.g. "Not applicable — `sdk_cwd` is pre-validated by `_make_sdk_cwd()` which applies normpath + prefix assertion before reaching this point").
+
+**Anti-patterns that look resolved but aren't — never do these:**
+- `"Accepted, tracked as follow-up"` — a deferral, not a fix. The concern is still open. Do not resolve.
+- `"Acknowledged"` or `"Same as above"` — these are acknowledgements, not fixes. Do not resolve.
+- `"Fixed in abc1234"` where `abc1234` is a commit that doesn't actually change the flagged line/logic — dishonest. Verify `git show abc1234 -- path/to/file` changes the right thing before posting.
+- Resolving without replying — the reviewer never sees what happened.
+
+When in doubt: if a code change is needed, make it. A deferred issue means the thread stays open until the follow-up PR is merged.
 
 ## Codecov coverage
 
@@ -239,12 +260,20 @@ git push
 
 ## GitHub abuse rate limits
 
-When posting many thread replies in quick succession, GitHub returns `{"code":"abuse"}` errors. This is throttling, not a permissions problem.
+Two distinct rate limits exist — they have different causes and recovery times:
 
-**Fix:** Add `sleep 3` between individual thread reply API calls. If you hit an abuse error:
-1. Stop posting immediately
-2. Wait 60 seconds
+| Error | HTTP code | Cause | Recovery |
+|---|---|---|---|
+| `{"code":"abuse"}` | 403 | Secondary rate limit — too many write operations (comments, mutations) in a short window | Wait **2–3 minutes**. 60s is often not enough. |
+| `{"message":"API rate limit exceeded"}` | 429 | Primary rate limit — too many API calls per hour | Wait until `X-RateLimit-Reset` header timestamp |
+
+**Prevention:** Add `sleep 3` between individual thread reply API calls. When posting >20 replies, increase to `sleep 5`.
+
+**Recovery from secondary rate limit (403):**
+1. Stop all API writes immediately
+2. Wait **2 minutes minimum** (not 60s — secondary limits are stricter)
 3. Resume with `sleep 3` between each call
+4. If 403 persists after 2 min, wait another 2 min before retrying
 
 Never batch all replies in a tight loop — always space them out.
 
@@ -257,3 +286,35 @@ gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "THREA
 ```
 
 **Never call this mutation before committing the fix.** The orchestrator will verify actual unresolved counts via GraphQL after you output `ORCHESTRATOR:DONE` — false resolutions will be caught and you will be re-briefed.
+
+### Verify actual count before outputting ORCHESTRATOR:DONE
+
+Before claiming "0 unresolved threads", always query GitHub directly — don't rely on your own bookkeeping:
+
+```bash
+gh api graphql -f query='
+{
+  repository(owner: "Significant-Gravitas", name: "AutoGPT") {
+    pullRequest(number: {N}) {
+      reviewThreads(first: 1) {
+        totalCount
+      }
+    }
+  }
+}' | jq '.data.repository.pullRequest.reviewThreads'
+# Then fetch unresolved count:
+gh api graphql -f query='
+{
+  repository(owner: "Significant-Gravitas", name: "AutoGPT") {
+    pullRequest(number: {N}) {
+      reviewThreads(first: 100) {
+        nodes { isResolved }
+      }
+    }
+  }
+}' | jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length'
+```
+
+If `totalCount > 100`, paginate with `after:` cursor until `hasNextPage` is false.
+
+Only output `ORCHESTRATOR:DONE` after this query returns 0.

--- a/.claude/skills/pr-test/SKILL.md
+++ b/.claude/skills/pr-test/SKILL.md
@@ -316,13 +316,13 @@ The frontend redirects to `/onboarding` when the `VISIT_COPILOT` step is not in 
 Mark it complete via the backend API so every browser test lands on the real feature UI:
 
 ```bash
-ONBOARDING_RESULT=$(curl -s -X POST \
+ONBOARDING_RESULT=$(curl -s --max-time 30 -X POST \
   "http://localhost:8006/api/onboarding/step?step=VISIT_COPILOT" \
   -H "Authorization: Bearer $TOKEN")
 echo "Onboarding bypass: $ONBOARDING_RESULT"
 
 # Verify it took effect
-ONBOARDING_STATUS=$(curl -s \
+ONBOARDING_STATUS=$(curl -s --max-time 30 \
   "http://localhost:8006/api/onboarding/completed" \
   -H "Authorization: Bearer $TOKEN" | jq -r '.is_completed')
 echo "Onboarding completed: $ONBOARDING_STATUS"

--- a/.claude/skills/pr-test/SKILL.md
+++ b/.claude/skills/pr-test/SKILL.md
@@ -326,7 +326,10 @@ ONBOARDING_STATUS=$(curl -s \
   "http://localhost:8006/api/onboarding/completed" \
   -H "Authorization: Bearer $TOKEN" | jq -r '.is_completed')
 echo "Onboarding completed: $ONBOARDING_STATUS"
-[ "$ONBOARDING_STATUS" = "true" ] || echo "WARNING: onboarding bypass may have failed — browser tests may hit the onboarding flow"
+if [ "$ONBOARDING_STATUS" != "true" ]; then
+  echo "ERROR: onboarding bypass failed — browser tests will hit /onboarding instead of the target feature. Investigate before proceeding."
+  exit 1
+fi
 ```
 
 ## Step 4: Run tests

--- a/.claude/skills/pr-test/SKILL.md
+++ b/.claude/skills/pr-test/SKILL.md
@@ -310,6 +310,25 @@ TOKEN=$(curl -s -X POST 'http://localhost:8000/auth/v1/token?grant_type=password
 curl -H "Authorization: Bearer $TOKEN" http://localhost:8006/api/...
 ```
 
+### 3i. Disable onboarding for test user
+
+The frontend redirects to `/onboarding` when the `VISIT_COPILOT` step is not in `completedSteps`.
+Mark it complete via the backend API so every browser test lands on the real feature UI:
+
+```bash
+ONBOARDING_RESULT=$(curl -s -X POST \
+  "http://localhost:8006/api/onboarding/step?step=VISIT_COPILOT" \
+  -H "Authorization: Bearer $TOKEN")
+echo "Onboarding bypass: $ONBOARDING_RESULT"
+
+# Verify it took effect
+ONBOARDING_STATUS=$(curl -s \
+  "http://localhost:8006/api/onboarding/completed" \
+  -H "Authorization: Bearer $TOKEN" | jq -r '.is_completed')
+echo "Onboarding completed: $ONBOARDING_STATUS"
+[ "$ONBOARDING_STATUS" = "true" ] || echo "WARNING: onboarding bypass may have failed — browser tests may hit the onboarding flow"
+```
+
 ## Step 4: Run tests
 
 ### Service ports reference


### PR DESCRIPTION
### Why / What / How

**Why:** A series of production failures exposed gaps in the agent fleet tooling:
1. Agents using `_wait_idle`/`wait_for_claude_idle` would time out waiting for `❯` while a settings-error dialog blocked progress — because the dialog can appear above the last 3 captured lines.
2. The run-loop's adaptive backoff used `POLL_CURRENT * 3 / 2` which stalls at 1 forever in bash integer arithmetic, and printed the interval *before* recomputing it.
3. `pr-address` agents were silently missing review threads when a PR had >100 threads across multiple pages — they'd stop at page 1, address 69/111 threads, and falsely report "done".
4. `resolveReviewThread` was being called without a committed fix — producing false "0 unresolved" signals that bypassed verification.
5. The onboarding bypass in `/pr-test` had no timeout on curl calls, so the step could hang forever if the backend wasn't ready yet.
6. The orchestrator's own verification query used `first: 1` which can't reliably count unresolved threads across all pages.

**What:**
- Idle detection hardened in both `spawn-agent.sh` and `run-loop.sh` — full-pane check for 'Enter to confirm' so the dialog is never missed
- Adaptive backoff arithmetic fixed (`POLL_CURRENT + POLL_CURRENT/2 + 1` always increments); log ordering corrected; `POLL_IDLE_MAX` made env-configurable
- `pr-address/SKILL.md`: mandatory cursor-pagination loop collecting ALL thread IDs before addressing anything; prominent ⚠️ warning with the PR #12636 incident (142 threads, 2 pages, agent stopped at 69)
- `pr-address/SKILL.md`: new "Parallel thread resolution" section — batch by file, one commit per file group, concurrent reply subshells with 3s gaps, sequential resolves
- `pr-address/SKILL.md`: "Verify actual count" section now uses paginated loop (not single first:100 query)
- `orchestrate/SKILL.md`: verification query fixed to paginate all pages; new "Thread resolution integrity" section with anti-patterns; fake-resolution detection query; state-staleness recovery; RUNNING-count confusion explained
- `/pr-test` onboarding bypass: `--max-time 30` on curl calls; hard-fail on bypass failure

**How:** All changes are to DX skill files and orchestration scripts — no production code modified. Each fix is a separate commit so the change history is readable.

### Changes 🏗️

**Scripts:**
- `run-loop.sh`: `wait_for_claude_idle` — add 'Enter to confirm' dialog check (reset elapsed on dialog); fix backoff arithmetic stall; fix log ordering; make `POLL_IDLE_MAX` env-configurable; reset poll interval when `waiting_approval` agents present
- `spawn-agent.sh`: `_wait_idle` — capture full pane (not just `tail -3`) for 'Enter to confirm' check; wait-for-idle before sending agent objective to prevent stuck pasted-text

**SKILL.md files:**
- `pr-address/SKILL.md`:
  - ⚠️ WARNING + totalCount step + cursor-pagination loop before addressing any threads
  - "Parallel thread resolution" section: group by file, batch commits, concurrent replies, sequential resolves
  - "Verify actual count" section: full paginated loop instead of single first:100 query
  - "What counts as a valid resolution" with explicit anti-patterns (Acknowledged, Accepted, no-commit resolves)
  - Rate limits table (403 secondary vs 429 primary), 2-3 min recovery
  - `git rev-parse HEAD` pattern with `${FULL_SHA:0:9}` short SHA
- `orchestrate/SKILL.md`:
  - Thread resolution integrity section + fake-resolution detection query
  - Verification query fixed to paginate all pages
  - State file staleness recovery (stale `loop_window`, closed windows, repair recipes)
  - RUNNING count confusion: explains `waiting_approval` included in regex
  - Idle check before re-briefing agents
- `pr-test/SKILL.md`:
  - `--max-time 30` on onboarding bypass curl calls
  - Hard-fail (`exit 1`) if bypass verification fails

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Verified adaptive backoff increments correctly (no longer stalls at 1)
  - [x] Verified 'Enter to confirm' dialog handled in both wait functions
  - [x] Verified pagination loop collects all thread IDs across pages
  - [x] Verified PR #12636 onboarding bypass works end-to-end (11/11 scenarios PASS)