### PR TITLE
fix(backend): make User RPC model forward-compatible during rolling deploys

### DIFF
--- a/autogpt_platform/backend/backend/data/model.py
+++ b/autogpt_platform/backend/backend/data/model.py
@@ -54,7 +54,6 @@ class User(BaseModel):
     """Application-layer User model with snake_case convention."""
 
     model_config = ConfigDict(
-        extra="ignore",
         str_strip_whitespace=True,
     )
 

--- a/autogpt_platform/backend/backend/data/model.py
+++ b/autogpt_platform/backend/backend/data/model.py
@@ -54,7 +54,7 @@ class User(BaseModel):
     """Application-layer User model with snake_case convention."""
 
     model_config = ConfigDict(
-        extra="forbid",
+        extra="ignore",
         str_strip_whitespace=True,
     )
 

--- a/autogpt_platform/backend/backend/executor/utils_test.py
+++ b/autogpt_platform/backend/backend/executor/utils_test.py
@@ -1,10 +1,13 @@
+from datetime import datetime, timezone
 from typing import cast
 
 import pytest
 from pytest_mock import MockerFixture
 
 from backend.data.dynamic_fields import merge_execution_input, parse_execution_output
-from backend.data.execution import ExecutionStatus
+from backend.data.execution import ExecutionStatus, GraphExecutionWithNodes
+from backend.data.model import User
+from backend.executor.utils import add_graph_execution
 from backend.util.mock import MockObject
 
 
@@ -483,19 +486,12 @@ async def test_add_graph_execution_via_rpc_returns_typed_user(
     mocker: MockerFixture,
 ):
     """
-    Regression test: when prisma is NOT connected (executor/scheduler process),
-    udb is the DatabaseManagerAsyncClient whose get_user_by_id goes through the
-    RPC layer (_get_return in service.py). _get_return must deserialize the JSON
-    dict into a typed User model — not silently return a raw dict. Without the
-    fix, _get_return's silent fallback returned a raw dict and accessing
-    user.timezone raised AttributeError: 'dict' object has no attribute 'timezone'.
+    Regression test: `add_graph_execution` accesses `user.timezone` on the User
+    returned by `get_user_by_id`. This test verifies the downstream code path
+    completes without AttributeError when `get_user_by_id` returns a proper typed
+    User model. Note: the mock returns a User directly — _get_return deserialization
+    is not exercised here; see TestGetReturn in util/service_test.py for that.
     """
-    from datetime import datetime, timezone
-
-    from backend.data.execution import GraphExecutionWithNodes
-    from backend.data.model import User
-    from backend.executor.utils import add_graph_execution
-
     graph_id = "test-graph-id"
     user_id = "test-user-id"
 

--- a/autogpt_platform/backend/backend/executor/utils_test.py
+++ b/autogpt_platform/backend/backend/executor/utils_test.py
@@ -515,7 +515,9 @@ async def test_add_graph_execution_via_rpc_returns_typed_user(
     mock_validate.return_value = (mock_graph, [], {}, set())
 
     mock_prisma = mocker.patch("backend.executor.utils.prisma")
-    mock_prisma.is_connected.return_value = False  # ← executor/scheduler path
+    mock_prisma.is_connected.return_value = (
+        False  # prisma not connected: uses RPC path instead
+    )
 
     # The RPC layer (_get_return) deserializes JSON dicts into typed Pydantic models.
     # The mock simulates what add_graph_execution receives after that deserialization:

--- a/autogpt_platform/backend/backend/executor/utils_test.py
+++ b/autogpt_platform/backend/backend/executor/utils_test.py
@@ -474,6 +474,109 @@ async def test_add_graph_execution_is_repeatable(mocker: MockerFixture):
 
 
 # ============================================================================
+# Regression test: RPC layer returns typed User model, not raw dict
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_add_graph_execution_via_rpc_returns_typed_user(
+    mocker: MockerFixture,
+):
+    """
+    Regression test: when prisma is NOT connected (executor/scheduler process),
+    udb is the DatabaseManagerAsyncClient whose get_user_by_id goes through the
+    RPC layer (_get_return in service.py). _get_return must deserialize the JSON
+    dict into a typed User model — not silently return a raw dict. Without the
+    fix, _get_return's silent fallback returned a raw dict and accessing
+    user.timezone raised AttributeError: 'dict' object has no attribute 'timezone'.
+    """
+    from datetime import datetime, timezone
+
+    from backend.data.execution import GraphExecutionWithNodes
+    from backend.data.model import User
+    from backend.executor.utils import add_graph_execution
+
+    graph_id = "test-graph-id"
+    user_id = "test-user-id"
+
+    mock_graph = mocker.MagicMock()
+    mock_graph.version = 1
+
+    mock_graph_exec = mocker.MagicMock(spec=GraphExecutionWithNodes)
+    mock_graph_exec.id = "exec-id-rpc"
+    mock_graph_exec.node_executions = []
+    mock_graph_exec.status = ExecutionStatus.QUEUED
+    mock_graph_exec.graph_version = 1
+    mock_graph_exec.to_graph_execution_entry.return_value = mocker.MagicMock()
+
+    mock_queue = mocker.AsyncMock()
+    mock_event_bus = mocker.MagicMock()
+    mock_event_bus.publish = mocker.AsyncMock()
+
+    mock_validate = mocker.patch(
+        "backend.executor.utils.validate_and_construct_node_execution_input"
+    )
+    mock_validate.return_value = (mock_graph, [], {}, set())
+
+    mock_prisma = mocker.patch("backend.executor.utils.prisma")
+    mock_prisma.is_connected.return_value = False  # ← executor/scheduler path
+
+    # The RPC layer (_get_return) deserializes JSON dicts into typed Pydantic models.
+    # The mock simulates what add_graph_execution receives after that deserialization:
+    # a proper User model, not a raw dict.
+    mock_user = User(
+        id=user_id,
+        email="test@example.com",
+        name=None,
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+        stripe_customer_id=None,
+        top_up_config=None,
+        timezone="UTC",
+    )
+
+    mock_db_client = mocker.MagicMock()
+    mock_db_client.get_user_by_id = mocker.AsyncMock(return_value=mock_user)
+    mock_db_client.get_graph_settings = mocker.AsyncMock(
+        return_value=mocker.MagicMock(
+            human_in_the_loop_safe_mode=False, sensitive_action_safe_mode=False
+        )
+    )
+    mock_db_client.create_graph_execution = mocker.AsyncMock(
+        return_value=mock_graph_exec
+    )
+    mock_db_client.update_graph_execution_stats = mocker.AsyncMock(
+        return_value=mock_graph_exec
+    )
+    mock_db_client.update_node_execution_status_batch = mocker.AsyncMock()
+    mock_workspace = mocker.MagicMock()
+    mock_workspace.id = "ws-id"
+    mock_db_client.get_or_create_workspace = mocker.AsyncMock(
+        return_value=mock_workspace
+    )
+    mock_db_client.increment_onboarding_runs = mocker.AsyncMock()
+
+    mocker.patch(
+        "backend.executor.utils.get_database_manager_async_client",
+        return_value=mock_db_client,
+    )
+    mocker.patch(
+        "backend.executor.utils.get_async_execution_queue", return_value=mock_queue
+    )
+    mocker.patch(
+        "backend.executor.utils.get_async_execution_event_bus",
+        return_value=mock_event_bus,
+    )
+
+    # Must not raise AttributeError: 'dict' object has no attribute 'timezone'
+    result = await add_graph_execution(
+        graph_id=graph_id,
+        user_id=user_id,
+    )
+    assert result == mock_graph_exec
+
+
+# ============================================================================
 # Tests for Optional Credentials Feature
 # ============================================================================
 

--- a/autogpt_platform/backend/backend/util/service.py
+++ b/autogpt_platform/backend/backend/util/service.py
@@ -709,19 +709,9 @@ def get_service_client(
             return kwargs
 
         def _get_return(self, expected_return: TypeAdapter | None, result: Any) -> Any:
-            """Validate and coerce the RPC result to the expected return type.
-
-            Falls back to the raw result with a warning if validation fails.
-            """
+            """Validate and coerce the RPC result to the expected return type."""
             if expected_return:
-                try:
-                    return expected_return.validate_python(result)
-                except Exception as e:
-                    logger.warning(
-                        "RPC return type validation failed, using raw result: %s",
-                        type(e).__name__,
-                    )
-                    return result
+                return expected_return.validate_python(result)
             return result
 
         def __getattr__(self, name: str) -> Callable[..., Any]:

--- a/autogpt_platform/backend/backend/util/service.py
+++ b/autogpt_platform/backend/backend/util/service.py
@@ -710,15 +710,16 @@ def get_service_client(
             return kwargs
 
         def _get_return(self, expected_return: TypeAdapter | None, result: Any) -> Any:
-            """Validate and coerce the RPC result to the expected return type."""
+            """Validate and coerce the RPC result to the expected return type.
+
+            Falls back to the raw result with a warning and Sentry capture if validation fails.
+            """
             if expected_return:
                 try:
                     return expected_return.validate_python(result)
                 except Exception as e:
                     logger.warning(
-                        "RPC return type validation failed for %s: %s",
-                        type(e).__name__,
-                        str(e),
+                        f"RPC return type validation failed for {type(e).__name__}: {e}"
                     )
                     sentry_sdk.capture_exception(e)
                     return result

--- a/autogpt_platform/backend/backend/util/service.py
+++ b/autogpt_platform/backend/backend/util/service.py
@@ -9,6 +9,8 @@ import sys
 import threading
 import time
 from abc import ABC, abstractmethod
+
+import sentry_sdk
 from contextlib import asynccontextmanager
 from functools import update_wrapper
 from typing import (
@@ -711,7 +713,16 @@ def get_service_client(
         def _get_return(self, expected_return: TypeAdapter | None, result: Any) -> Any:
             """Validate and coerce the RPC result to the expected return type."""
             if expected_return:
-                return expected_return.validate_python(result)
+                try:
+                    return expected_return.validate_python(result)
+                except Exception as e:
+                    logger.warning(
+                        "RPC return type validation failed for %s: %s",
+                        type(e).__name__,
+                        str(e),
+                    )
+                    sentry_sdk.capture_exception(e)
+                    return result
             return result
 
         def __getattr__(self, name: str) -> Callable[..., Any]:

--- a/autogpt_platform/backend/backend/util/service.py
+++ b/autogpt_platform/backend/backend/util/service.py
@@ -9,8 +9,6 @@ import sys
 import threading
 import time
 from abc import ABC, abstractmethod
-
-import sentry_sdk
 from contextlib import asynccontextmanager
 from functools import update_wrapper
 from typing import (
@@ -28,6 +26,7 @@ from typing import (
 )
 
 import httpx
+import sentry_sdk
 import uvicorn
 from fastapi import FastAPI, Request, responses
 from prisma.errors import DataError, UniqueViolationError

--- a/autogpt_platform/backend/backend/util/service_test.py
+++ b/autogpt_platform/backend/backend/util/service_test.py
@@ -3,12 +3,13 @@ import contextlib
 import time
 from datetime import datetime, timezone
 from functools import cached_property
+from typing import Any, Protocol, cast
 from unittest.mock import Mock
 
 import httpx
 import pytest
 from prisma.errors import DataError, UniqueViolationError
-from pydantic import TypeAdapter, ValidationError
+from pydantic import TypeAdapter
 
 from backend.data.model import User
 from backend.util.service import (
@@ -22,6 +23,10 @@ from backend.util.service import (
 )
 
 TEST_SERVICE_PORT = 8765
+
+
+class _SupportsGetReturn(Protocol):
+    def _get_return(self, expected_return: TypeAdapter | None, result: Any) -> Any: ...
 
 
 class ServiceTest(AppService):
@@ -701,8 +706,8 @@ async def test_health_check_during_shutdown(test_service):
 class TestGetReturn:
     """Direct unit tests for DynamicClient._get_return typed-return contract."""
 
-    def _make_client(self):
-        return get_service_client(ServiceTestClient)
+    def _make_client(self) -> _SupportsGetReturn:
+        return cast(_SupportsGetReturn, get_service_client(ServiceTestClient))
 
     def test_valid_dict_is_deserialized_to_user_model(self):
         """TypeAdapter(User) + valid dict → User model returned with .timezone accessible.
@@ -721,16 +726,16 @@ class TestGetReturn:
         }
         client = self._make_client()
         adapter = TypeAdapter(User)
-        result = client._get_return(adapter, valid_dict)  # type: ignore[attr-defined]
+        result = client._get_return(adapter, valid_dict)
 
         assert isinstance(result, User)
         assert result.timezone is not None
 
-    def test_invalid_dict_raises_validation_error(self):
-        """TypeAdapter(User) + invalid dict (missing required fields) → ValidationError raised."""
+    def test_invalid_dict_falls_back_to_raw_result(self):
+        """TypeAdapter(User) + invalid dict (missing required fields) → fallback returns raw dict."""
         invalid_dict = {"id": "user-id"}  # missing email, created_at, updated_at
         client = self._make_client()
         adapter = TypeAdapter(User)
 
-        with pytest.raises(ValidationError):
-            client._get_return(adapter, invalid_dict)  # type: ignore[attr-defined]
+        result = client._get_return(adapter, invalid_dict)
+        assert result == invalid_dict

--- a/autogpt_platform/backend/backend/util/service_test.py
+++ b/autogpt_platform/backend/backend/util/service_test.py
@@ -705,13 +705,19 @@ class TestGetReturn:
         return get_service_client(ServiceTestClient)
 
     def test_valid_dict_is_deserialized_to_user_model(self):
-        """TypeAdapter(User) + valid dict → User model returned with .timezone accessible."""
+        """TypeAdapter(User) + valid dict → User model returned with .timezone accessible.
+
+        User.model_config uses extra='ignore' so unknown fields (e.g. new columns added
+        in a newer database-manager deploy) are silently dropped instead of raising
+        ValidationError — making the RPC layer forward-compatible during rolling deploys.
+        """
         now = datetime.now(timezone.utc).isoformat()
         valid_dict = {
             "id": "user-id",
             "email": "test@example.com",
             "created_at": now,
             "updated_at": now,
+            "unknown_future_field": "some_value",  # simulates a new DB field during deploy
         }
         client = self._make_client()
         adapter = TypeAdapter(User)

--- a/autogpt_platform/backend/backend/util/service_test.py
+++ b/autogpt_platform/backend/backend/util/service_test.py
@@ -1,13 +1,16 @@
 import asyncio
 import contextlib
 import time
+from datetime import datetime, timezone
 from functools import cached_property
 from unittest.mock import Mock
 
 import httpx
 import pytest
 from prisma.errors import DataError, UniqueViolationError
+from pydantic import TypeAdapter, ValidationError
 
+from backend.data.model import User
 from backend.util.service import (
     AppService,
     AppServiceClient,
@@ -688,3 +691,40 @@ async def test_health_check_during_shutdown(test_service):
     except (httpx.ConnectError, httpx.ConnectTimeout):
         # Connection refused/timeout is also acceptable
         pass
+
+
+# ============================================================================
+# Unit tests for DynamicClient._get_return
+# ============================================================================
+
+
+class TestGetReturn:
+    """Direct unit tests for DynamicClient._get_return typed-return contract."""
+
+    def _make_client(self):
+        return get_service_client(ServiceTestClient)
+
+    def test_valid_dict_is_deserialized_to_user_model(self):
+        """TypeAdapter(User) + valid dict → User model returned with .timezone accessible."""
+        now = datetime.now(timezone.utc).isoformat()
+        valid_dict = {
+            "id": "user-id",
+            "email": "test@example.com",
+            "created_at": now,
+            "updated_at": now,
+        }
+        client = self._make_client()
+        adapter = TypeAdapter(User)
+        result = client._get_return(adapter, valid_dict)  # type: ignore[attr-defined]
+
+        assert isinstance(result, User)
+        assert result.timezone is not None
+
+    def test_invalid_dict_raises_validation_error(self):
+        """TypeAdapter(User) + invalid dict (missing required fields) → ValidationError raised."""
+        invalid_dict = {"id": "user-id"}  # missing email, created_at, updated_at
+        client = self._make_client()
+        adapter = TypeAdapter(User)
+
+        with pytest.raises(ValidationError):
+            client._get_return(adapter, invalid_dict)  # type: ignore[attr-defined]


### PR DESCRIPTION
## Why

A Sentry `AttributeError: 'dict' object has no attribute 'timezone'` was traced to the scheduler accessing `user.timezone` on a value that was a raw `dict` instead of a typed `User` model.

**Root cause (two-part):**

1. `User.model_config` had `extra='forbid'`. During a rolling deploy, the database manager (newer pod) can return fields that the client (older pod) doesn't yet know about. `extra='forbid'` caused `TypeAdapter(User).validate_python()` to raise `ValidationError` on those unknown fields.

2. `DynamicClient._get_return` had a silent `try/except` that swallowed the `ValidationError` and fell back to returning the raw `dict`. The scheduler then received a `dict` and crashed on `.timezone`.

## What

- **`backend/data/model.py`**: Change `User.model_config` `extra='forbid'` → `extra='ignore'`. Unknown fields from a newer database manager are silently dropped, making the RPC layer forward-compatible during rolling deploys. This is the primary fix.

- **`backend/util/service.py`**: Restore the `try/except` fallback in `_get_return`, but make it **observable**: log the full error message at `WARNING` (so ValidationError details — field name, value — appear in logs) and call `sentry_sdk.capture_exception(e)` so every fallback is tracked and alerted without crashing the caller. The raw result is still returned as before (continuity).

- **`backend/util/service_test.py`**: Add `TestGetReturn` with two direct unit tests: valid dict (including an unknown future field) → typed `User` returned; invalid dict (missing required fields) → fallback returns raw dict (no crash). Uses a typed `_SupportsGetReturn` Protocol + `cast` instead of `# type: ignore` suppressors.

- **`backend/executor/utils_test.py`**: Fix misleading docstring; move inner imports to module top level per code style.

## How

`extra='ignore'` is the standard Pydantic pattern for forward-compatible models at service boundaries. It means a rolling deploy where the DB manager has a new column will not break older client pods — the extra field is simply dropped on deserialization.

The restored `_get_return` fallback preserves continuity (callers don't crash) while the `logger.warning` + `sentry_sdk.capture_exception` ensure no schema mismatch goes undetected. Silent degradation is replaced by observable degradation.

## Checklist

- [x] Changes are backward-compatible (unknown fields ignored, not rejected)
- [x] Regression tests added for `_get_return` typed deserialization contract
- [x] Fallback preserved with observable logging and Sentry capture (no silent degradation)
- [x] `extra='ignore'` is consistent with forward-compatibility requirements at service boundaries
- [x] No `# type: ignore` suppressors introduced
