### PR TITLE
fix(frontend): suppress Sentry noise from expected 401s in OnboardingProvider

### DIFF
--- a/autogpt_platform/frontend/src/providers/onboarding/onboarding-provider.tsx
+++ b/autogpt_platform/frontend/src/providers/onboarding/onboarding-provider.tsx
@@ -19,6 +19,7 @@ import {
 import { useToast } from "@/components/molecules/Toast/use-toast";
 import { useOnboardingTimezoneDetection } from "@/hooks/useOnboardingTimezoneDetection";
 import {
+  ApiError,
   UserOnboarding,
   WebSocketNotification,
 } from "@/lib/autogpt-server-api";
@@ -164,6 +165,10 @@ export default function OnboardingProvider({
           router.replace("/copilot");
         }
       } catch (error) {
+        if (error instanceof ApiError && error.status === 401) {
+          return;
+        }
+
         console.error("Failed to initialize onboarding:", error);
 
         toast({

--- a/autogpt_platform/frontend/src/providers/onboarding/onboarding-provider.tsx
+++ b/autogpt_platform/frontend/src/providers/onboarding/onboarding-provider.tsx
@@ -166,6 +166,7 @@ export default function OnboardingProvider({
         }
       } catch (error) {
         if (error instanceof ApiError && error.status === 401) {
+          hasInitialized.current = false;
           return;
         }
 


### PR DESCRIPTION
## Why
`OnboardingProvider` was generating a Sentry alert (BUILDER-7ME: "Authorization header is missing") on every behave test run. The root cause: when a user's session expires mid-flow, they get redirected to `/login`. The provider remounts on the login page, calls `getV1CheckIfOnboardingIsCompleted()` while unauthenticated, and the 401 falls into the catch block which calls `console.error`. Sentry's `captureConsole` integration auto-captures all `console.error` calls as events, triggering the alert.

This is expected behavior — the auth middleware handles the redirect, there's nothing broken. It was just noisy.

## What
- In `OnboardingProvider`'s `initializeOnboarding` catch block, return early and silently on `ApiError` with status 401 — no `console.error`, no toast
- Only unexpected errors (non-401) still surface via `console.error` and the destructive toast

## How
```ts
} catch (error) {
  if (error instanceof ApiError && error.status === 401) {
    return;
  }
  // ... existing error handling
}
```

## Checklist
- [x] `pnpm format && pnpm lint && pnpm types` pass
- [x] Change is minimal and scoped to the one catch block
- [x] No new test needed — this is a logging/noise fix, not a behavioral change
