### PR TITLE
fix(backend/executor): OrchestratorBlock dry-run credentials + Responses API status field

### DIFF
--- a/autogpt_platform/backend/backend/blocks/orchestrator.py
+++ b/autogpt_platform/backend/backend/blocks/orchestrator.py
@@ -251,8 +251,13 @@ def _convert_raw_response_to_dict(
         # Already a dict (from tests or some providers)
         return raw_response
     elif _is_responses_api_object(raw_response):
-        # OpenAI Responses API: extract individual output items
-        items = [json.to_dict(item) for item in raw_response.output]
+        # OpenAI Responses API: extract individual output items.
+        # Strip 'status' — it's a response-only field that OpenAI rejects
+        # when the item is sent back as input on the next API call.
+        items = [
+            {k: v for k, v in json.to_dict(item).items() if k != "status"}
+            for item in raw_response.output
+        ]
         return items if items else [{"role": "assistant", "content": ""}]
     else:
         # Chat Completions / Anthropic return message objects

--- a/autogpt_platform/backend/backend/blocks/test/test_orchestrator_responses_api.py
+++ b/autogpt_platform/backend/backend/blocks/test/test_orchestrator_responses_api.py
@@ -211,6 +211,30 @@ class TestConvertRawResponseToDict:
             # A single dict is wrong — there are two distinct items
             pytest.fail("Expected a list of output items, got a single dict")
 
+    def test_responses_api_strips_status_from_function_call(self):
+        """Responses API function_call items have a 'status' field that OpenAI
+        rejects when sent back as input ('Unknown parameter: input[N].status').
+        It must be stripped before the item is stored in conversation history."""
+        resp = _MockResponse(
+            output=[_MockFunctionCall("my_tool", '{"x": 1}', call_id="call_xyz")]
+        )
+        result = _convert_raw_response_to_dict(resp)
+        assert isinstance(result, list)
+        for item in result:
+            assert (
+                "status" not in item
+            ), f"'status' must be stripped from Responses API items: {item}"
+
+    def test_responses_api_strips_status_from_message(self):
+        """Responses API message items also carry 'status'; it must be stripped."""
+        resp = _MockResponse(output=[_MockOutputMessage("Hello")])
+        result = _convert_raw_response_to_dict(resp)
+        assert isinstance(result, list)
+        for item in result:
+            assert (
+                "status" not in item
+            ), f"'status' must be stripped from Responses API items: {item}"
+
 
 # ───────────────────────────────────────────────────────────────────────────
 # _get_tool_requests  (lines 61-86)

--- a/autogpt_platform/backend/backend/executor/manager.py
+++ b/autogpt_platform/backend/backend/executor/manager.py
@@ -312,7 +312,7 @@ async def execute_node(
         # doesn't fail on the required field.  If no metadata is present,
         # synthesize a minimal placeholder from the platform credentials.
         if _dry_run_creds is not None:
-            if not input_data.get(field_name):
+            if input_data.get(field_name) is None:
                 input_data[field_name] = {
                     "id": _dry_run_creds.id,
                     "provider": _dry_run_creds.provider,

--- a/autogpt_platform/backend/backend/executor/manager.py
+++ b/autogpt_platform/backend/backend/executor/manager.py
@@ -307,9 +307,18 @@ async def execute_node(
 
     # Handle regular credentials fields
     for field_name, input_type in input_model.get_credentials_fields().items():
-        # Dry-run platform credentials bypass the credential store
+        # Dry-run platform credentials bypass the credential store.
+        # Keep the existing credential metadata so _execute's input_schema(**...)
+        # doesn't fail on the required field.  If no metadata is present,
+        # synthesize a minimal placeholder from the platform credentials.
         if _dry_run_creds is not None:
-            input_data[field_name] = None
+            if not input_data.get(field_name):
+                input_data[field_name] = {
+                    "id": _dry_run_creds.id,
+                    "provider": _dry_run_creds.provider,
+                    "type": _dry_run_creds.type,
+                    "title": _dry_run_creds.title,
+                }
             extra_exec_kwargs[field_name] = _dry_run_creds
             continue
 

--- a/autogpt_platform/backend/backend/executor/simulator_test.py
+++ b/autogpt_platform/backend/backend/executor/simulator_test.py
@@ -261,10 +261,12 @@ class TestGetDryRunCredentials:
     def test_credentials_have_metadata_fields_for_placeholder(self) -> None:
         """The returned credentials must have id, provider, type, and title so
         manager.py can synthesise a valid CredentialsMetaInput placeholder."""
+        from backend.integrations.providers import ProviderName
+
         creds = get_dry_run_credentials({"_dry_run_api_key": "sk-or-test"})
         assert creds is not None
         assert creds.id == "dry-run-platform"
-        assert str(creds.provider) in ("open_router", "ProviderName.OPEN_ROUTER")
+        assert creds.provider == ProviderName.OPEN_ROUTER
         assert creds.type == "api_key"
         assert creds.title is not None
 

--- a/autogpt_platform/backend/backend/executor/simulator_test.py
+++ b/autogpt_platform/backend/backend/executor/simulator_test.py
@@ -18,6 +18,7 @@ from backend.executor.simulator import (
     _truncate_input_values,
     _truncate_value,
     build_simulation_prompt,
+    get_dry_run_credentials,
     prepare_dry_run,
     simulate_block,
 )
@@ -232,6 +233,40 @@ class TestPrepareDryRun:
         block = _make_block()
         result = prepare_dry_run(block, {"query": "test"})
         assert result is None
+
+
+class TestGetDryRunCredentials:
+    """get_dry_run_credentials pops _dry_run_api_key and returns APIKeyCredentials.
+
+    The returned object must have fields that can be serialised into a valid
+    CredentialsMetaInput placeholder dict for manager.py's schema-construction fix
+    (Bug: manager.py nullified input_data[field_name] = None, which caused
+    _execute's input_schema(**...) to fail because required credential fields were
+    missing after the None-filter pass).
+    """
+
+    def test_returns_credentials_when_key_present(self) -> None:
+        input_data = {"_dry_run_api_key": "sk-or-test", "other": "val"}
+        creds = get_dry_run_credentials(input_data)
+        assert creds is not None
+        assert creds.api_key.get_secret_value() == "sk-or-test"
+        # key is consumed from input_data
+        assert "_dry_run_api_key" not in input_data
+
+    def test_returns_none_when_key_absent(self) -> None:
+        input_data: dict = {"other": "val"}
+        creds = get_dry_run_credentials(input_data)
+        assert creds is None
+
+    def test_credentials_have_metadata_fields_for_placeholder(self) -> None:
+        """The returned credentials must have id, provider, type, and title so
+        manager.py can synthesise a valid CredentialsMetaInput placeholder."""
+        creds = get_dry_run_credentials({"_dry_run_api_key": "sk-or-test"})
+        assert creds is not None
+        assert creds.id == "dry-run-platform"
+        assert str(creds.provider) in ("open_router", "ProviderName.OPEN_ROUTER")
+        assert creds.type == "api_key"
+        assert creds.title is not None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why
Two bugs block OrchestratorBlock from working correctly:

1. **Dry-run always fails with "credentials required"** even when `OPEN_ROUTER_API_KEY` is set on dev. The n8n conversion dry-run hits this.
2. **Agent-mode OrchestratorBlock fails on the second LLM call** with `Error code: 400 – Unknown parameter: 'input[2].status'` when using OpenAI models (Responses API path).

## What
**Bug 1 — manager.py credential null** (`backend/executor/manager.py`):
The dry-run path called `input_data[field_name] = None` to "clear" the credential slot, but `_execute` in `_base.py` filters out `None` values before calling `input_schema(**...)`. This drops the required `credentials` field from the schema constructor, causing a Pydantic validation error.

Fix: Don't null out the field. If the user already has credential metadata in `input_data` (normal case), leave it intact. If not (no credentials configured), synthesise a minimal `CredentialsMetaInput`-compatible placeholder from the platform credentials so schema construction passes. The actual `APIKeyCredentials` (platform key) is still injected via `extra_exec_kwargs`.

**Bug 2 — Responses API `status` field** (`backend/blocks/orchestrator.py`):
OpenAI returns output items (function calls, messages) with a `status: "completed"` field. When `_convert_raw_response_to_dict` serialises these items and they are stored in `conversation_history`, they are sent back as input on the next call — but OpenAI rejects `status` as an input-only field.

Fix: Strip `status` from each output item before it enters the history.

## How
- `manager.py` lines 311-314: removed the `input_data[field_name] = None` nullification; added a conditional placeholder when no credential metadata is present.
- `orchestrator.py` `_convert_raw_response_to_dict`: filter `k != "status"` when extracting Responses API output items.
- Tests added for both fixes.

## Checklist
- [x] Tests written and passing (94 total, all green)
- [x] Pre-commit hooks passed (Black, Ruff, isort, typecheck)
- [x] No out-of-scope changes
