### PR TITLE
fix(backend): lower PlatformCostLog DataError to warning during schema mismatch

### DIFF
--- a/autogpt_platform/backend/backend/copilot/token_tracking.py
+++ b/autogpt_platform/backend/backend/copilot/token_tracking.py
@@ -57,12 +57,9 @@ def _schedule_cost_log(entry: PlatformCostEntry) -> None:
                 # stale Prisma client (e.g. during a rolling deploy after a schema
                 # migration). Log at WARNING so Sentry is not spammed.
                 logger.warning(
-                    "Skipping platform cost log (schema mismatch?) for "
-                    "user=%s provider=%s block=%s: %s",
-                    entry.user_id,
-                    entry.provider,
-                    entry.block_name,
-                    e,
+                    f"Skipping platform cost log (schema mismatch?) for "
+                    f"user={entry.user_id} provider={entry.provider} "
+                    f"block={entry.block_name}: {e}"
                 )
             except Exception:
                 logger.exception(

--- a/autogpt_platform/backend/backend/copilot/token_tracking.py
+++ b/autogpt_platform/backend/backend/copilot/token_tracking.py
@@ -15,6 +15,8 @@ import math
 import re
 import threading
 
+from prisma.errors import DataError
+
 from backend.data.db_accessors import platform_cost_db
 from backend.data.platform_cost import PlatformCostEntry, usd_to_microdollars
 
@@ -50,6 +52,18 @@ def _schedule_cost_log(entry: PlatformCostEntry) -> None:
         async with _get_log_semaphore():
             try:
                 await platform_cost_db().log_platform_cost(entry)
+            except DataError as e:
+                # Prisma DataError typically means the DB manager pod is running a
+                # stale Prisma client (e.g. during a rolling deploy after a schema
+                # migration). Log at WARNING so Sentry is not spammed.
+                logger.warning(
+                    "Skipping platform cost log (schema mismatch?) for "
+                    "user=%s provider=%s block=%s: %s",
+                    entry.user_id,
+                    entry.provider,
+                    entry.block_name,
+                    e,
+                )
             except Exception:
                 logger.exception(
                     "Failed to log platform cost for user=%s provider=%s block=%s",

--- a/autogpt_platform/backend/backend/copilot/token_tracking_test.py
+++ b/autogpt_platform/backend/backend/copilot/token_tracking_test.py
@@ -9,9 +9,27 @@ from datetime import UTC, datetime
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from prisma.errors import DataError
+
+from backend.data.platform_cost import PlatformCostEntry
 
 from .model import ChatSession, Usage
-from .token_tracking import persist_and_record_usage
+from .token_tracking import _schedule_cost_log, persist_and_record_usage
+
+
+def _make_data_error(msg: str = "stale schema") -> DataError:
+    """Construct a valid prisma DataError (requires a dict, not a bare string)."""
+    return DataError(
+        {
+            "user_facing_error": {
+                "is_panic": False,
+                "message": msg,
+                "meta": {},
+                "error_code": "P2006",
+                "batch_request_idx": 0,
+            }
+        }
+    )
 
 
 def _make_session() -> ChatSession:
@@ -567,3 +585,53 @@ class TestPlatformCostLogging:
         # Negative cost rejected — falls back to token-based tracking
         assert entry.cost_microdollars is None
         assert entry.metadata["tracking_type"] == "tokens"
+
+
+def _make_cost_entry(**overrides: object) -> PlatformCostEntry:
+    return PlatformCostEntry.model_validate(
+        {
+            "user_id": "user-1",
+            "block_id": "copilot",
+            "block_name": "copilot:SDK",
+            "provider": "anthropic",
+            **overrides,
+        }
+    )
+
+
+class TestScheduleCostLogDataError:
+    @pytest.mark.asyncio
+    async def test_data_error_logs_warning_not_error(self, caplog):
+        """DataError from stale Prisma client should be logged at WARNING, not ERROR."""
+        import logging
+
+        mock_log = AsyncMock(side_effect=_make_data_error())
+        with patch(
+            "backend.copilot.token_tracking.platform_cost_db",
+            return_value=type(
+                "FakePlatformCostDb", (), {"log_platform_cost": mock_log}
+            )(),
+        ):
+            entry = _make_cost_entry()
+            with caplog.at_level(
+                logging.WARNING, logger="backend.copilot.token_tracking"
+            ):
+                _schedule_cost_log(entry)
+                await asyncio.sleep(0)
+        warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert warning_records, "Expected a WARNING log record for DataError"
+        assert "schema mismatch" in warning_records[0].message.lower()
+
+    @pytest.mark.asyncio
+    async def test_data_error_does_not_propagate(self):
+        """DataError in the scheduled task must not crash the event loop."""
+        mock_log = AsyncMock(side_effect=_make_data_error())
+        with patch(
+            "backend.copilot.token_tracking.platform_cost_db",
+            return_value=type(
+                "FakePlatformCostDb", (), {"log_platform_cost": mock_log}
+            )(),
+        ):
+            entry = _make_cost_entry()
+            _schedule_cost_log(entry)
+            await asyncio.sleep(0)  # must not raise

--- a/autogpt_platform/backend/backend/data/platform_cost.py
+++ b/autogpt_platform/backend/backend/data/platform_cost.py
@@ -3,6 +3,7 @@ import logging
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
+from prisma.errors import DataError
 from prisma.models import PlatformCostLog as PrismaLog
 from pydantic import BaseModel
 
@@ -87,6 +88,18 @@ async def log_platform_cost_safe(entry: PlatformCostEntry) -> None:
     try:
         async with _log_semaphore:
             await log_platform_cost(entry)
+    except DataError as e:
+        # Prisma DataError typically means the DB manager pod is running a stale
+        # Prisma client (e.g. during a rolling deploy after a schema migration).
+        # Log at WARNING so Sentry is not spammed.
+        logger.warning(
+            "Skipping platform cost log (schema mismatch?) for "
+            "user=%s provider=%s block=%s: %s",
+            entry.user_id,
+            entry.provider,
+            entry.block_name,
+            e,
+        )
     except Exception:
         logger.exception(
             "Failed to log platform cost for user=%s provider=%s block=%s",

--- a/autogpt_platform/backend/backend/data/platform_cost.py
+++ b/autogpt_platform/backend/backend/data/platform_cost.py
@@ -93,12 +93,9 @@ async def log_platform_cost_safe(entry: PlatformCostEntry) -> None:
         # Prisma client (e.g. during a rolling deploy after a schema migration).
         # Log at WARNING so Sentry is not spammed.
         logger.warning(
-            "Skipping platform cost log (schema mismatch?) for "
-            "user=%s provider=%s block=%s: %s",
-            entry.user_id,
-            entry.provider,
-            entry.block_name,
-            e,
+            f"Skipping platform cost log (schema mismatch?) for "
+            f"user={entry.user_id} provider={entry.provider} "
+            f"block={entry.block_name}: {e}"
         )
     except Exception:
         logger.exception(

--- a/autogpt_platform/backend/backend/data/platform_cost_test.py
+++ b/autogpt_platform/backend/backend/data/platform_cost_test.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from prisma.errors import DataError
 
 from .platform_cost import (
     PlatformCostEntry,
@@ -14,6 +15,21 @@ from .platform_cost import (
     log_platform_cost,
     log_platform_cost_safe,
 )
+
+
+def _make_data_error(msg: str = "stale schema") -> DataError:
+    """Construct a valid prisma DataError (requires a dict, not a bare string)."""
+    return DataError(
+        {
+            "user_facing_error": {
+                "is_panic": False,
+                "message": msg,
+                "meta": {},
+                "error_code": "P2006",
+                "batch_request_idx": 0,
+            }
+        }
+    )
 
 
 class TestMaskEmail:
@@ -155,6 +171,28 @@ class TestLogPlatformCostSafe:
             entry = _make_entry()
             await log_platform_cost_safe(entry)
         mock_create.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_data_error_logs_warning_not_error(self, caplog):
+        """DataError (stale Prisma client) should be logged at WARNING, not ERROR."""
+        import logging
+
+        with patch("backend.data.platform_cost.PrismaLog.prisma") as mock_prisma:
+            mock_prisma.return_value.create = AsyncMock(side_effect=_make_data_error())
+            entry = _make_entry()
+            with caplog.at_level(logging.WARNING, logger="backend.data.platform_cost"):
+                await log_platform_cost_safe(entry)
+        warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert warning_records, "Expected a WARNING log record for DataError"
+        assert "schema mismatch" in warning_records[0].message.lower()
+
+    @pytest.mark.asyncio
+    async def test_data_error_does_not_raise(self):
+        """DataError must be swallowed — log_platform_cost_safe never raises."""
+        with patch("backend.data.platform_cost.PrismaLog.prisma") as mock_prisma:
+            mock_prisma.return_value.create = AsyncMock(side_effect=_make_data_error())
+            entry = _make_entry()
+            await log_platform_cost_safe(entry)  # must not raise
 
 
 class TestGetPlatformCostDashboard:


### PR DESCRIPTION
### Why / What / How

**Why:** After merging #12696 (platform cost tracking), the `autogpt-database-manager` pod was running a stale Prisma client that didn't yet know about the new `PlatformCostLog` fields (`userId`, `metadata`, etc.). Every copilot cost-log attempt raised `prisma.errors.DataError`, which was caught by `logger.exception()` — logging at ERROR level and spamming Sentry (issue AUTOGPT-SERVER-8GS, 33+ events, escalating).

**What:** Both `log_platform_cost_safe` (in `platform_cost.py`) and `_safe_log` (in `token_tracking.py`) now catch `prisma.errors.DataError` specifically before the generic `Exception` handler, logging at WARNING instead of ERROR. All other unexpected exceptions still go to Sentry as before.

**How:** Added a targeted `except DataError` block that logs a human-readable warning with a "schema mismatch?" hint. Once the DB manager pod rolls over with the updated Prisma client, the warnings stop automatically — no code changes needed at that point.

### Changes 🏗️

- `backend/data/platform_cost.py`: catch `DataError` in `log_platform_cost_safe` → WARNING
- `backend/copilot/token_tracking.py`: catch `DataError` in `_safe_log` → WARNING

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Verified Sentry issue AUTOGPT-SERVER-8GS is caused by stale Prisma client (deployment gap), not a code bug
  - [x] Confirmed `DataError` handler fires before generic `Exception` handler
  - [x] Pre-commit hooks pass