### PR TITLE
feat(copilot): in-process OpenRouter compat proxy for newer Claude SDK

### DIFF
--- a/autogpt_platform/backend/backend/copilot/config.py
+++ b/autogpt_platform/backend/backend/copilot/config.py
@@ -358,11 +358,20 @@ class ChatConfig(BaseSettings):
         usual truthy/falsy coercion (``"1"``, ``"true"``, ``"yes"``,
         ``"on"`` → True), so operators get the same behaviour they'd
         get from the prefixed env var.
+
+        Note: unlike the ``claude_agent_cli_path`` case, this field has
+        a non-``None`` default (``False``), so Pydantic passes the
+        default bool into the validator when no value is set — a
+        simple ``if v is None`` check wouldn't fire. We instead inspect
+        the raw process env directly: if the prefixed var is set we
+        let Pydantic's value stand; otherwise the unprefixed var wins.
         """
-        if v is None:
-            v = os.getenv("CHAT_CLAUDE_AGENT_USE_COMPAT_PROXY")
-            if v is None:
-                v = os.getenv("CLAUDE_AGENT_USE_COMPAT_PROXY")
+        if os.getenv("CHAT_CLAUDE_AGENT_USE_COMPAT_PROXY") is not None:
+            # Prefixed var is set — trust Pydantic's parsed value.
+            return v
+        unprefixed = os.getenv("CLAUDE_AGENT_USE_COMPAT_PROXY")
+        if unprefixed is not None:
+            return unprefixed
         return v
 
     # Prompt paths for different contexts

--- a/autogpt_platform/backend/backend/copilot/config.py
+++ b/autogpt_platform/backend/backend/copilot/config.py
@@ -182,7 +182,9 @@ class ChatConfig(BaseSettings):
         "features (the bundled CLI version in 0.1.46+ is broken against "
         "OpenRouter — see PR #12294 and "
         "anthropics/claude-agent-sdk-python#789). Falls back to the "
-        "bundled binary when unset.",
+        "bundled binary when unset. Reads from `CHAT_CLAUDE_AGENT_CLI_PATH` "
+        "or the unprefixed `CLAUDE_AGENT_CLI_PATH` environment variable "
+        "(same pattern as `api_key` / `base_url`).",
     )
     use_openrouter: bool = Field(
         default=True,
@@ -304,6 +306,26 @@ class ChatConfig(BaseSettings):
                 v = os.getenv("OPENAI_BASE_URL")
             if not v:
                 v = OPENROUTER_BASE_URL
+        return v
+
+    @field_validator("claude_agent_cli_path", mode="before")
+    @classmethod
+    def get_claude_agent_cli_path(cls, v):
+        """Resolve the Claude Code CLI override path from environment.
+
+        Accepts either the Pydantic-prefixed ``CHAT_CLAUDE_AGENT_CLI_PATH``
+        or the unprefixed ``CLAUDE_AGENT_CLI_PATH`` (matching the same
+        fallback pattern used by ``api_key`` / ``base_url``). Keeping the
+        unprefixed form working is important because the field is
+        primarily an operator escape hatch set via container/host env,
+        and the unprefixed name is what the PR description, the field
+        docstrings, and the reproduction test in
+        ``cli_openrouter_compat_test.py`` refer to.
+        """
+        if not v:
+            v = os.getenv("CHAT_CLAUDE_AGENT_CLI_PATH")
+            if not v:
+                v = os.getenv("CLAUDE_AGENT_CLI_PATH")
         return v
 
     # Prompt paths for different contexts

--- a/autogpt_platform/backend/backend/copilot/config.py
+++ b/autogpt_platform/backend/backend/copilot/config.py
@@ -172,6 +172,18 @@ class ChatConfig(BaseSettings):
         description="Maximum number of retries for transient API errors "
         "(429, 5xx, ECONNRESET) before surfacing the error to the user.",
     )
+    claude_agent_cli_path: str | None = Field(
+        default=None,
+        description="Optional explicit path to a Claude Code CLI binary. "
+        "When set, the SDK uses this binary instead of the version bundled "
+        "with the installed `claude-agent-sdk` package — letting us pin "
+        "the Python SDK and the CLI independently. Critical for keeping "
+        "OpenRouter compatibility while still picking up newer SDK API "
+        "features (the bundled CLI version in 0.1.46+ is broken against "
+        "OpenRouter — see PR #12294 and "
+        "anthropics/claude-agent-sdk-python#789). Falls back to the "
+        "bundled binary when unset.",
+    )
     use_openrouter: bool = Field(
         default=True,
         description="Enable routing API calls through the OpenRouter proxy. "

--- a/autogpt_platform/backend/backend/copilot/config.py
+++ b/autogpt_platform/backend/backend/copilot/config.py
@@ -195,7 +195,13 @@ class ChatConfig(BaseSettings):
         "field from outgoing requests so newer SDK / CLI versions stop "
         "tripping OpenRouter's stricter validation. Orthogonal to "
         "`claude_agent_cli_path` — the override picks the binary, the "
-        "proxy rewrites whatever the binary sends.",
+        "proxy rewrites whatever the binary sends. Reads from "
+        "`CHAT_CLAUDE_AGENT_USE_COMPAT_PROXY` or the unprefixed "
+        "`CLAUDE_AGENT_USE_COMPAT_PROXY` environment variable (same "
+        "pattern as `claude_agent_cli_path`). Only takes effect when "
+        "the session has an Anthropic-compatible upstream to forward "
+        "to — direct-Anthropic sessions skip the proxy entirely to "
+        "avoid silently re-routing through OpenRouter.",
     )
     use_openrouter: bool = Field(
         default=True,
@@ -337,6 +343,26 @@ class ChatConfig(BaseSettings):
             v = os.getenv("CHAT_CLAUDE_AGENT_CLI_PATH")
             if not v:
                 v = os.getenv("CLAUDE_AGENT_CLI_PATH")
+        return v
+
+    @field_validator("claude_agent_use_compat_proxy", mode="before")
+    @classmethod
+    def get_claude_agent_use_compat_proxy(cls, v):
+        """Resolve the compat-proxy opt-in from environment.
+
+        Accepts either ``CHAT_CLAUDE_AGENT_USE_COMPAT_PROXY`` (the
+        Pydantic-prefixed form) or the unprefixed
+        ``CLAUDE_AGENT_USE_COMPAT_PROXY`` — same dual-name pattern as
+        ``claude_agent_cli_path`` above and ``api_key`` / ``base_url``
+        further up. Returning the raw string lets Pydantic handle the
+        usual truthy/falsy coercion (``"1"``, ``"true"``, ``"yes"``,
+        ``"on"`` → True), so operators get the same behaviour they'd
+        get from the prefixed env var.
+        """
+        if v is None:
+            v = os.getenv("CHAT_CLAUDE_AGENT_USE_COMPAT_PROXY")
+            if v is None:
+                v = os.getenv("CLAUDE_AGENT_USE_COMPAT_PROXY")
         return v
 
     # Prompt paths for different contexts

--- a/autogpt_platform/backend/backend/copilot/config.py
+++ b/autogpt_platform/backend/backend/copilot/config.py
@@ -186,6 +186,17 @@ class ChatConfig(BaseSettings):
         "or the unprefixed `CLAUDE_AGENT_CLI_PATH` environment variable "
         "(same pattern as `api_key` / `base_url`).",
     )
+    claude_agent_use_compat_proxy: bool = Field(
+        default=False,
+        description="Run the in-process OpenRouter compatibility proxy "
+        "(`backend.copilot.sdk.openrouter_compat_proxy`) in front of the "
+        "Claude Code CLI. The proxy strips `tool_reference` content "
+        "blocks and the `context-management-2025-06-27` beta header / "
+        "field from outgoing requests so newer SDK / CLI versions stop "
+        "tripping OpenRouter's stricter validation. Orthogonal to "
+        "`claude_agent_cli_path` — the override picks the binary, the "
+        "proxy rewrites whatever the binary sends.",
+    )
     use_openrouter: bool = Field(
         default=True,
         description="Enable routing API calls through the OpenRouter proxy. "

--- a/autogpt_platform/backend/backend/copilot/config_test.py
+++ b/autogpt_platform/backend/backend/copilot/config_test.py
@@ -17,6 +17,10 @@ _ENV_VARS_TO_CLEAR = (
     "CHAT_BASE_URL",
     "OPENROUTER_BASE_URL",
     "OPENAI_BASE_URL",
+    "CHAT_CLAUDE_AGENT_CLI_PATH",
+    "CLAUDE_AGENT_CLI_PATH",
+    "CHAT_CLAUDE_AGENT_USE_COMPAT_PROXY",
+    "CLAUDE_AGENT_USE_COMPAT_PROXY",
 )
 
 
@@ -87,3 +91,87 @@ class TestE2BActive:
         """e2b_active is False when use_e2b_sandbox=False regardless of key."""
         cfg = ChatConfig(use_e2b_sandbox=False, e2b_api_key="test-key")
         assert cfg.e2b_active is False
+
+
+class TestClaudeAgentCliPathEnvFallback:
+    """``claude_agent_cli_path`` accepts both the Pydantic-prefixed
+    ``CHAT_CLAUDE_AGENT_CLI_PATH`` env var and the unprefixed
+    ``CLAUDE_AGENT_CLI_PATH`` form (mirrors ``api_key`` / ``base_url``).
+    """
+
+    def test_prefixed_env_var_is_picked_up(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CHAT_CLAUDE_AGENT_CLI_PATH", "/opt/claude-prefixed")
+        cfg = ChatConfig()
+        assert cfg.claude_agent_cli_path == "/opt/claude-prefixed"
+
+    def test_unprefixed_env_var_is_picked_up(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CLAUDE_AGENT_CLI_PATH", "/opt/claude-unprefixed")
+        cfg = ChatConfig()
+        assert cfg.claude_agent_cli_path == "/opt/claude-unprefixed"
+
+    def test_prefixed_wins_over_unprefixed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CHAT_CLAUDE_AGENT_CLI_PATH", "/opt/claude-prefixed")
+        monkeypatch.setenv("CLAUDE_AGENT_CLI_PATH", "/opt/claude-unprefixed")
+        cfg = ChatConfig()
+        assert cfg.claude_agent_cli_path == "/opt/claude-prefixed"
+
+    def test_no_env_var_defaults_to_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        cfg = ChatConfig()
+        assert cfg.claude_agent_cli_path is None
+
+
+class TestClaudeAgentUseCompatProxyEnvFallback:
+    """``claude_agent_use_compat_proxy`` accepts both the Pydantic-
+    prefixed ``CHAT_CLAUDE_AGENT_USE_COMPAT_PROXY`` env var and the
+    unprefixed ``CLAUDE_AGENT_USE_COMPAT_PROXY`` form.  Regression
+    guard for the bool-default pitfall: the field has a non-None
+    default (``False``), so Pydantic passes the default into the
+    validator when no value is provided and a naive ``if v is None``
+    check would never fire.
+    """
+
+    def test_prefixed_env_var_enables_proxy(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CHAT_CLAUDE_AGENT_USE_COMPAT_PROXY", "true")
+        cfg = ChatConfig()
+        assert cfg.claude_agent_use_compat_proxy is True
+
+    def test_unprefixed_env_var_enables_proxy(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CLAUDE_AGENT_USE_COMPAT_PROXY", "true")
+        cfg = ChatConfig()
+        assert cfg.claude_agent_use_compat_proxy is True
+
+    def test_unprefixed_env_var_respects_falsy_value(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CLAUDE_AGENT_USE_COMPAT_PROXY", "false")
+        cfg = ChatConfig()
+        assert cfg.claude_agent_use_compat_proxy is False
+
+    def test_prefixed_wins_over_unprefixed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When both are set, the Pydantic-prefixed var is authoritative
+        so the validator doesn't silently clobber an explicit
+        ``CHAT_...=false`` with an unprefixed ``=true``."""
+        monkeypatch.setenv("CHAT_CLAUDE_AGENT_USE_COMPAT_PROXY", "false")
+        monkeypatch.setenv("CLAUDE_AGENT_USE_COMPAT_PROXY", "true")
+        cfg = ChatConfig()
+        assert cfg.claude_agent_use_compat_proxy is False
+
+    def test_no_env_var_uses_field_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cfg = ChatConfig()
+        # Default is False on this branch; the dev-preview branch
+        # flips it to True but that's a separate PR.
+        assert cfg.claude_agent_use_compat_proxy is False

--- a/autogpt_platform/backend/backend/copilot/executor/processor.py
+++ b/autogpt_platform/backend/backend/copilot/executor/processor.py
@@ -174,13 +174,25 @@ class CoPilotProcessor:
         logger.info(f"[CoPilotExecutor] Worker {self.tid} started")
 
     def _prewarm_cli(self) -> None:
-        """Run the bundled CLI binary once to warm OS page caches."""
-        try:
-            from claude_agent_sdk._internal.transport.subprocess_cli import (
-                SubprocessCLITransport,
-            )
+        """Run the Claude Code CLI binary once to warm OS page caches.
 
-            cli_path = SubprocessCLITransport._find_bundled_cli(None)  # type: ignore[arg-type]
+        Honours the ``claude_agent_cli_path`` config override (which lets
+        us run a pinned CLI version independent of the bundled one in the
+        installed ``claude-agent-sdk`` wheel — see
+        ``ChatConfig.claude_agent_cli_path`` for the rationale). Falls
+        back to the bundled binary when no override is set.
+        """
+        try:
+            from backend.copilot.config import ChatConfig
+
+            cfg = ChatConfig()
+            cli_path: str | None = cfg.claude_agent_cli_path
+            if not cli_path:
+                from claude_agent_sdk._internal.transport.subprocess_cli import (
+                    SubprocessCLITransport,
+                )
+
+                cli_path = SubprocessCLITransport._find_bundled_cli(None)  # type: ignore[arg-type]
             if cli_path:
                 result = subprocess.run(
                     [cli_path, "-v"],

--- a/autogpt_platform/backend/backend/copilot/sdk/cli_openrouter_compat_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/cli_openrouter_compat_test.py
@@ -422,3 +422,101 @@ def test_subprocess_module_available():
     main reproduction test can spawn the CLI.  Catches sandboxed CI
     runners that block subprocess execution before the slow test runs."""
     assert subprocess.__name__ == "subprocess"
+
+
+# ---------------------------------------------------------------------------
+# Pure helper unit tests — pin the forbidden-pattern detection so any
+# future drift in the scanner is caught fast, even when the slow
+# end-to-end CLI subprocess test isn't runnable.
+# ---------------------------------------------------------------------------
+
+
+class TestScanRequestForForbiddenPatterns:
+    def test_clean_body_returns_empty_findings(self):
+        body = '{"model": "claude-opus-4.6", "messages": [{"role": "user", "content": "hi"}]}'
+        assert _scan_request_for_forbidden_patterns(body, {}) == []
+
+    def test_detects_tool_reference_in_body(self):
+        body = (
+            '{"messages": [{"role": "user", "content": ['
+            '{"type": "tool_reference", "tool_name": "find"}'
+            "]}]}"
+        )
+        findings = _scan_request_for_forbidden_patterns(body, {})
+        assert len(findings) == 1
+        assert "tool_reference" in findings[0]
+        assert "PR #12294" in findings[0]
+
+    def test_detects_context_management_in_body(self):
+        body = '{"betas": ["context-management-2025-06-27"]}'
+        findings = _scan_request_for_forbidden_patterns(body, {})
+        assert len(findings) == 1
+        assert "context-management-2025-06-27" in findings[0]
+        assert "#789" in findings[0]
+
+    def test_detects_context_management_in_anthropic_beta_header(self):
+        findings = _scan_request_for_forbidden_patterns(
+            body_text="{}",
+            headers={"anthropic-beta": "context-management-2025-06-27"},
+        )
+        assert len(findings) == 1
+        assert "anthropic-beta" in findings[0]
+
+    def test_detects_context_management_in_uppercase_header_name(self):
+        # HTTP header names are case-insensitive — make sure the
+        # scanner handles a server that didn't normalise names.
+        findings = _scan_request_for_forbidden_patterns(
+            body_text="{}",
+            headers={"Anthropic-Beta": "context-management-2025-06-27, other"},
+        )
+        assert len(findings) == 1
+
+    def test_ignores_unrelated_header_values(self):
+        findings = _scan_request_for_forbidden_patterns(
+            body_text="{}",
+            headers={
+                "authorization": "Bearer secret",
+                "anthropic-beta": "fine-grained-tool-streaming-2025",
+            },
+        )
+        assert findings == []
+
+    def test_detects_both_patterns_simultaneously(self):
+        body = (
+            '{"betas": ["context-management-2025-06-27"], '
+            '"messages": [{"role": "user", "content": ['
+            '{"type": "tool_reference", "tool_name": "find"}'
+            "]}]}"
+        )
+        findings = _scan_request_for_forbidden_patterns(body, {})
+        # Both patterns hit, in stable order: tool_reference then betas.
+        assert len(findings) == 2
+        assert "tool_reference" in findings[0]
+        assert "context-management-2025-06-27" in findings[1]
+
+
+class TestResolveCliPath:
+    def test_honours_explicit_env_var_when_file_exists(self, tmp_path, monkeypatch):
+        fake_cli = tmp_path / "fake-claude"
+        fake_cli.write_text("#!/bin/sh\necho fake\n")
+        fake_cli.chmod(0o755)
+        monkeypatch.setenv("CLAUDE_AGENT_CLI_PATH", str(fake_cli))
+        resolved = _resolve_cli_path()
+        assert resolved == fake_cli
+
+    def test_returns_none_when_env_var_points_to_missing_file(self, monkeypatch):
+        monkeypatch.setenv("CLAUDE_AGENT_CLI_PATH", "/nonexistent/path/to/claude")
+        # Should fall through to the bundled binary OR return None,
+        # but never raise.
+        resolved = _resolve_cli_path()
+        # We can't assert exact value (depends on whether the bundled
+        # CLI is installed in the test env) but the function must not
+        # raise — the caller is supposed to handle None gracefully.
+        assert resolved is None or resolved.is_file()
+
+    def test_falls_back_to_bundled_when_env_var_unset(self, monkeypatch):
+        monkeypatch.delenv("CLAUDE_AGENT_CLI_PATH", raising=False)
+        # Same caveat as above — returns the bundled path or None,
+        # depending on what's installed in the test env.
+        resolved = _resolve_cli_path()
+        assert resolved is None or resolved.is_file()

--- a/autogpt_platform/backend/backend/copilot/sdk/cli_openrouter_compat_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/cli_openrouter_compat_test.py
@@ -1,0 +1,424 @@
+"""Reproduction test for the OpenRouter incompatibility in newer
+``claude-agent-sdk`` / Claude Code CLI versions.
+
+Background — there are two stacked regressions that block us from
+upgrading the ``claude-agent-sdk`` package above ``0.1.45``:
+
+1. **`tool_reference` content blocks** introduced by CLI ``2.1.69`` (=
+   SDK ``0.1.46``).  The CLI's built-in ``ToolSearch`` tool returns
+   ``{"type": "tool_reference", "tool_name": "..."}`` content blocks in
+   ``tool_result.content``.  OpenRouter's stricter Zod validation
+   rejects this with::
+
+        messages[N].content[0].content: Invalid input: expected string, received array
+
+   This is the regression that originally pinned us at 0.1.45 — see
+   https://github.com/Significant-Gravitas/AutoGPT/pull/12294 for the
+   full forensic write-up.  CLI 2.1.70 added proxy detection that
+   *should* disable the offending blocks when ``ANTHROPIC_BASE_URL`` is
+   set, but our subsequent attempts at 0.1.55 / 0.1.56 still failed.
+
+2. **`context-management-2025-06-27` beta header** — some CLI version
+   after ``2.1.91`` started injecting this header / beta flag, which
+   OpenRouter rejects with::
+
+        400 No endpoints available that support Anthropic's context
+        management features (context-management-2025-06-27). Context
+        management requires a supported provider (Anthropic).
+
+   Tracked upstream at
+   https://github.com/anthropics/claude-agent-sdk-python/issues/789.
+   Still open at the time of writing, no upstream PR linked, no
+   workaround documented.
+
+The purpose of this test:
+* Spin up a tiny in-process HTTP server that pretends to be the
+  Anthropic Messages API.
+* Capture every request body the CLI sends.
+* Inspect the captured bodies for the two forbidden patterns above.
+* Fail loudly if either is present, with a pointer to the issue
+  tracker.
+
+This is the reproduction we use as a CI gate when bisecting which SDK /
+CLI version is safe to upgrade to.  It runs against the bundled CLI by
+default (or against ``ChatConfig.claude_agent_cli_path`` when set), so
+it doubles as a regression guard for the ``cli_path`` override
+mechanism.
+
+The test does **not** need an OpenRouter API key — it reproduces the
+mechanism (forbidden content blocks / headers in the *outgoing*
+request) rather than the symptom (the 400 OpenRouter would return).
+This keeps it deterministic, free, and CI-runnable without secrets.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+from aiohttp import web
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Forbidden patterns we scan for in captured request bodies
+# ---------------------------------------------------------------------------
+
+# Substring of the `tool_reference` content block that breaks OpenRouter's
+# stricter Zod validation in tool_result.content. PR #12294 root-cause.
+_FORBIDDEN_TOOL_REFERENCE = '"type": "tool_reference"'
+
+# Beta string OpenRouter rejects in upstream issue #789. Can appear in
+# either `betas` arrays or the `anthropic-beta` header value.
+_FORBIDDEN_CONTEXT_MANAGEMENT_BETA = "context-management-2025-06-27"
+
+
+def _scan_request_for_forbidden_patterns(
+    body_text: str,
+    headers: dict[str, str],
+) -> list[str]:
+    """Return a list of forbidden patterns found in *body_text* / *headers*.
+
+    Empty list = clean request.  Non-empty = the CLI is sending one of the
+    OpenRouter-incompatible features.
+    """
+    findings: list[str] = []
+    if _FORBIDDEN_TOOL_REFERENCE in body_text:
+        findings.append(
+            "`tool_reference` content block in request body — "
+            "PR #12294 / CLI 2.1.69 regression"
+        )
+    if _FORBIDDEN_CONTEXT_MANAGEMENT_BETA in body_text:
+        findings.append(
+            f"{_FORBIDDEN_CONTEXT_MANAGEMENT_BETA!r} in request body — "
+            "anthropics/claude-agent-sdk-python#789"
+        )
+    # Header values are case-insensitive in HTTP — aiohttp normalises
+    # incoming names but values are stored as-is.
+    for header_name, header_value in headers.items():
+        if header_name.lower() == "anthropic-beta":
+            if _FORBIDDEN_CONTEXT_MANAGEMENT_BETA in header_value:
+                findings.append(
+                    f"{_FORBIDDEN_CONTEXT_MANAGEMENT_BETA!r} in "
+                    "`anthropic-beta` header — issue #789"
+                )
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Fake Anthropic Messages API
+# ---------------------------------------------------------------------------
+#
+# We need to give the CLI a *successful* response so it doesn't error out
+# before we get a chance to inspect the request.  The minimal thing the
+# CLI accepts is a streamed (SSE) message-start → content-block-delta →
+# message-stop sequence.
+#
+# We don't strictly *need* the CLI to accept the response — we already
+# have the request body by the time we send any reply — but giving it a
+# valid stream means the assertion failure (if any) is the *only*
+# failure mode in the test, not "CLI exited 1 because we sent garbage".
+
+
+def _build_streaming_message_response() -> str:
+    """Return an SSE-formatted body containing a minimal Anthropic
+    Messages API streamed response.
+
+    This is the smallest stream that the Claude Code CLI will accept
+    end-to-end without errors.  Each line is one SSE event."""
+    events: list[dict[str, Any]] = [
+        {
+            "type": "message_start",
+            "message": {
+                "id": "msg_test",
+                "type": "message",
+                "role": "assistant",
+                "content": [],
+                "model": "claude-test",
+                "stop_reason": None,
+                "stop_sequence": None,
+                "usage": {"input_tokens": 1, "output_tokens": 1},
+            },
+        },
+        {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {"type": "text", "text": ""},
+        },
+        {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "text_delta", "text": "ok"},
+        },
+        {"type": "content_block_stop", "index": 0},
+        {
+            "type": "message_delta",
+            "delta": {"stop_reason": "end_turn", "stop_sequence": None},
+            "usage": {"output_tokens": 1},
+        },
+        {"type": "message_stop"},
+    ]
+    return "".join(
+        f"event: {evt['type']}\ndata: {json.dumps(evt)}\n\n" for evt in events
+    )
+
+
+class _CapturedRequest:
+    """One request the fake server received."""
+
+    def __init__(self, path: str, headers: dict[str, str], body: str) -> None:
+        self.path = path
+        self.headers = headers
+        self.body = body
+
+
+async def _start_fake_anthropic_server(
+    captured: list[_CapturedRequest],
+) -> tuple[web.AppRunner, int]:
+    """Start an aiohttp server pretending to be the Anthropic API.
+
+    All POSTs to ``/v1/messages`` are recorded into *captured* and
+    answered with a valid streaming response.  Returns ``(runner, port)``
+    so the caller can ``await runner.cleanup()`` when finished.
+    """
+
+    async def messages_handler(request: web.Request) -> web.StreamResponse:
+        body = await request.text()
+        captured.append(
+            _CapturedRequest(
+                path=request.path,
+                headers={k: v for k, v in request.headers.items()},
+                body=body,
+            )
+        )
+        # Stream a minimal valid response so the CLI doesn't error out
+        # before we can inspect what it sent.
+        response = web.StreamResponse(
+            status=200,
+            headers={
+                "Content-Type": "text/event-stream",
+                "Cache-Control": "no-cache",
+                "Connection": "keep-alive",
+            },
+        )
+        await response.prepare(request)
+        await response.write(_build_streaming_message_response().encode("utf-8"))
+        await response.write_eof()
+        return response
+
+    app = web.Application()
+    app.router.add_post("/v1/messages", messages_handler)
+    # OAuth/profile endpoints the CLI may probe — answer 404 so it falls
+    # through quickly without retrying.
+    app.router.add_route("*", "/{tail:.*}", lambda _r: web.Response(status=404))
+
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+
+    server = site._server
+    assert server is not None
+    sockets = getattr(server, "sockets", None)
+    assert sockets is not None
+    port: int = sockets[0].getsockname()[1]
+    return runner, port
+
+
+# ---------------------------------------------------------------------------
+# CLI invocation
+# ---------------------------------------------------------------------------
+
+
+def _resolve_cli_path() -> Path | None:
+    """Return the Claude Code CLI binary the SDK would use.
+
+    Honours the same override mechanism as ``service.py``: explicit
+    ``CLAUDE_AGENT_CLI_PATH`` env var first (matching the new
+    ``ChatConfig.claude_agent_cli_path`` field), then the bundled
+    binary that ships with the installed ``claude-agent-sdk`` wheel.
+    """
+    override = os.environ.get("CLAUDE_AGENT_CLI_PATH")
+    if override:
+        candidate = Path(override)
+        return candidate if candidate.is_file() else None
+
+    try:
+        from claude_agent_sdk._internal.transport.subprocess_cli import (  # type: ignore[import-untyped]
+            SubprocessCLITransport,
+        )
+
+        bundled = SubprocessCLITransport._find_bundled_cli(None)  # type: ignore[arg-type]
+        return Path(bundled) if bundled else None
+    except Exception as e:  # pragma: no cover - import-time guard
+        logger.warning("Could not locate bundled Claude CLI: %s", e)
+        return None
+
+
+async def _run_cli_against_fake_server(
+    cli_path: Path,
+    fake_server_port: int,
+    timeout_seconds: float,
+) -> tuple[int, str, str]:
+    """Spawn the CLI pointed at the fake Anthropic server and feed it a
+    single ``user`` message via stream-json on stdin.
+
+    Returns ``(returncode, stdout, stderr)``.  The return code is not
+    asserted by the test — we only care that the CLI made at least one
+    POST to ``/v1/messages`` so the fake server captured the body.
+    """
+    fake_url = f"http://127.0.0.1:{fake_server_port}"
+    env = {
+        # Inherit basic shell variables so the CLI can find its tools,
+        # but force network/auth at our fake endpoint.
+        **os.environ,
+        "ANTHROPIC_BASE_URL": fake_url,
+        "ANTHROPIC_API_KEY": "sk-test-fake-key-not-real",
+        # Disable any features that would phone home to a different host
+        # mid-test (telemetry, plugin marketplace fetch).
+        "DISABLE_TELEMETRY": "1",
+        "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+    }
+
+    # The CLI accepts stream-json input on stdin in `query` mode.  A
+    # minimal user-message envelope is enough to trigger an API call.
+    stdin_payload = (
+        json.dumps(
+            {
+                "type": "user",
+                "message": {"role": "user", "content": "hello"},
+            }
+        )
+        + "\n"
+    )
+
+    proc = await asyncio.create_subprocess_exec(
+        str(cli_path),
+        "--output-format",
+        "stream-json",
+        "--input-format",
+        "stream-json",
+        "--verbose",
+        "--print",
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        env=env,
+    )
+    try:
+        assert proc.stdin is not None
+        proc.stdin.write(stdin_payload.encode("utf-8"))
+        await proc.stdin.drain()
+        proc.stdin.close()
+
+        stdout_bytes, stderr_bytes = await asyncio.wait_for(
+            proc.communicate(), timeout=timeout_seconds
+        )
+    except (asyncio.TimeoutError, TimeoutError):
+        # Best-effort kill — we already have whatever requests the CLI
+        # managed to send before stalling.
+        try:
+            proc.kill()
+        except ProcessLookupError:
+            pass
+        stdout_bytes, stderr_bytes = b"", b""
+
+    return (
+        proc.returncode if proc.returncode is not None else -1,
+        stdout_bytes.decode("utf-8", errors="replace"),
+        stderr_bytes.decode("utf-8", errors="replace"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# The actual test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cli_does_not_send_openrouter_incompatible_features(caplog):
+    """End-to-end OpenRouter compatibility reproduction.
+
+    Spawns the bundled (or overridden) Claude Code CLI against a fake
+    Anthropic API server, captures every request body it sends, and
+    asserts that none of them contain the two known OpenRouter-breaking
+    features (`tool_reference` content blocks or the
+    `context-management-2025-06-27` beta header).
+
+    Why this matters: pinning the CLI version via
+    ``test_bundled_cli_version_is_known_good_against_openrouter`` only
+    catches accidental SDK bumps — it doesn't tell us *why* the new
+    version would fail.  This test reproduces the exact mechanism so
+    bisecting via CI commits gives an actionable signal.
+    """
+    cli_path = _resolve_cli_path()
+    if cli_path is None or not cli_path.is_file():
+        pytest.skip(
+            "No Claude Code CLI binary available (neither bundled nor "
+            "overridden via CLAUDE_AGENT_CLI_PATH); cannot reproduce."
+        )
+
+    captured: list[_CapturedRequest] = []
+    runner, port = await _start_fake_anthropic_server(captured)
+    try:
+        returncode, stdout, stderr = await _run_cli_against_fake_server(
+            cli_path=cli_path,
+            fake_server_port=port,
+            timeout_seconds=30.0,
+        )
+    finally:
+        await runner.cleanup()
+
+    # We don't assert the CLI's exit code — depending on the CLI version
+    # and what we send back, the CLI may exit non-zero after a single
+    # successful round-trip.  All we care about is that the captured
+    # request bodies don't contain the forbidden patterns.
+    logger.info(
+        "CLI exited rc=%d; captured %d requests; stdout=%d bytes; stderr=%d bytes",
+        returncode,
+        len(captured),
+        len(stdout),
+        len(stderr),
+    )
+
+    if not captured:
+        pytest.skip(
+            "Bundled CLI did not make any HTTP requests to the fake server "
+            f"(rc={returncode}). The CLI may have failed before reaching "
+            f"the network — stderr tail: {stderr[-500:]!r}. "
+            "Nothing to assert; treating as inconclusive rather than "
+            "either passing or failing."
+        )
+
+    all_findings: list[str] = []
+    for req in captured:
+        findings = _scan_request_for_forbidden_patterns(req.body, req.headers)
+        if findings:
+            all_findings.extend(f"{req.path}: {finding}" for finding in findings)
+
+    assert not all_findings, (
+        f"Bundled Claude Code CLI sent OpenRouter-incompatible features in "
+        f"{len(all_findings)} request(s):\n  - "
+        + "\n  - ".join(all_findings)
+        + "\n\nThis is the regression that prevents us from upgrading "
+        "`claude-agent-sdk` above 0.1.45. See "
+        "https://github.com/Significant-Gravitas/AutoGPT/pull/12294 and "
+        "https://github.com/anthropics/claude-agent-sdk-python/issues/789. "
+        "If you intended to upgrade, you must use a known-good CLI binary "
+        "via `claude_agent_cli_path` (env: `CLAUDE_AGENT_CLI_PATH`) "
+        "instead of the bundled one."
+    )
+
+
+def test_subprocess_module_available():
+    """Sentinel test: the subprocess module must be importable so the
+    main reproduction test can spawn the CLI.  Catches sandboxed CI
+    runners that block subprocess execution before the slow test runs."""
+    assert subprocess.__name__ == "subprocess"

--- a/autogpt_platform/backend/backend/copilot/sdk/cli_openrouter_compat_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/cli_openrouter_compat_test.py
@@ -240,12 +240,19 @@ async def _start_fake_anthropic_server(
 def _resolve_cli_path() -> Path | None:
     """Return the Claude Code CLI binary the SDK would use.
 
-    Honours the same override mechanism as ``service.py``: explicit
-    ``CLAUDE_AGENT_CLI_PATH`` env var first (matching the new
-    ``ChatConfig.claude_agent_cli_path`` field), then the bundled
-    binary that ships with the installed ``claude-agent-sdk`` wheel.
+    Honours the same override mechanism as ``service.py`` /
+    ``ChatConfig.claude_agent_cli_path``: checks either the Pydantic-
+    prefixed ``CHAT_CLAUDE_AGENT_CLI_PATH`` or the unprefixed
+    ``CLAUDE_AGENT_CLI_PATH`` env var first, then falls back to the
+    bundled binary that ships with the installed ``claude-agent-sdk``
+    wheel. The two env var names are accepted at the config layer via
+    ``ChatConfig.get_claude_agent_cli_path`` and mirrored here so the
+    reproduction test picks up the same override regardless of which
+    form an operator sets.
     """
-    override = os.environ.get("CLAUDE_AGENT_CLI_PATH")
+    override = os.environ.get("CHAT_CLAUDE_AGENT_CLI_PATH") or os.environ.get(
+        "CLAUDE_AGENT_CLI_PATH"
+    )
     if override:
         candidate = Path(override)
         return candidate if candidate.is_file() else None
@@ -362,7 +369,8 @@ async def test_cli_does_not_send_openrouter_incompatible_features(caplog):
     if cli_path is None or not cli_path.is_file():
         pytest.skip(
             "No Claude Code CLI binary available (neither bundled nor "
-            "overridden via CLAUDE_AGENT_CLI_PATH); cannot reproduce."
+            "overridden via CLAUDE_AGENT_CLI_PATH / "
+            "CHAT_CLAUDE_AGENT_CLI_PATH); cannot reproduce."
         )
 
     captured: list[_CapturedRequest] = []
@@ -412,8 +420,8 @@ async def test_cli_does_not_send_openrouter_incompatible_features(caplog):
         "https://github.com/Significant-Gravitas/AutoGPT/pull/12294 and "
         "https://github.com/anthropics/claude-agent-sdk-python/issues/789. "
         "If you intended to upgrade, you must use a known-good CLI binary "
-        "via `claude_agent_cli_path` (env: `CLAUDE_AGENT_CLI_PATH`) "
-        "instead of the bundled one."
+        "via `claude_agent_cli_path` (env: `CLAUDE_AGENT_CLI_PATH` or "
+        "`CHAT_CLAUDE_AGENT_CLI_PATH`) instead of the bundled one."
     )
 
 
@@ -500,11 +508,31 @@ class TestResolveCliPath:
         fake_cli = tmp_path / "fake-claude"
         fake_cli.write_text("#!/bin/sh\necho fake\n")
         fake_cli.chmod(0o755)
+        monkeypatch.delenv("CHAT_CLAUDE_AGENT_CLI_PATH", raising=False)
         monkeypatch.setenv("CLAUDE_AGENT_CLI_PATH", str(fake_cli))
         resolved = _resolve_cli_path()
         assert resolved == fake_cli
 
+    def test_honours_chat_prefixed_env_var_when_file_exists(
+        self, tmp_path, monkeypatch
+    ):
+        """The Pydantic ``CHAT_`` prefix variant is also honoured.
+
+        Mirrors ``ChatConfig.get_claude_agent_cli_path`` which accepts
+        either ``CHAT_CLAUDE_AGENT_CLI_PATH`` (prefix applied by
+        ``pydantic_settings``) or the unprefixed ``CLAUDE_AGENT_CLI_PATH``
+        form documented in the PR and field docstring.
+        """
+        fake_cli = tmp_path / "fake-claude-prefixed"
+        fake_cli.write_text("#!/bin/sh\necho fake\n")
+        fake_cli.chmod(0o755)
+        monkeypatch.delenv("CLAUDE_AGENT_CLI_PATH", raising=False)
+        monkeypatch.setenv("CHAT_CLAUDE_AGENT_CLI_PATH", str(fake_cli))
+        resolved = _resolve_cli_path()
+        assert resolved == fake_cli
+
     def test_returns_none_when_env_var_points_to_missing_file(self, monkeypatch):
+        monkeypatch.delenv("CHAT_CLAUDE_AGENT_CLI_PATH", raising=False)
         monkeypatch.setenv("CLAUDE_AGENT_CLI_PATH", "/nonexistent/path/to/claude")
         # Should fall through to the bundled binary OR return None,
         # but never raise.
@@ -516,6 +544,7 @@ class TestResolveCliPath:
 
     def test_falls_back_to_bundled_when_env_var_unset(self, monkeypatch):
         monkeypatch.delenv("CLAUDE_AGENT_CLI_PATH", raising=False)
+        monkeypatch.delenv("CHAT_CLAUDE_AGENT_CLI_PATH", raising=False)
         # Same caveat as above — returns the bundled path or None,
         # depending on what's installed in the test env.
         resolved = _resolve_cli_path()

--- a/autogpt_platform/backend/backend/copilot/sdk/cli_openrouter_compat_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/cli_openrouter_compat_test.py
@@ -57,6 +57,7 @@ import asyncio
 import json
 import logging
 import os
+import re
 import subprocess
 from pathlib import Path
 from typing import Any
@@ -71,12 +72,21 @@ logger = logging.getLogger(__name__)
 # Forbidden patterns we scan for in captured request bodies
 # ---------------------------------------------------------------------------
 
-# Substring of the `tool_reference` content block that breaks OpenRouter's
-# stricter Zod validation in tool_result.content. PR #12294 root-cause.
-_FORBIDDEN_TOOL_REFERENCE = '"type": "tool_reference"'
+# Match the `tool_reference` content block that breaks OpenRouter's stricter
+# Zod validation in tool_result.content. PR #12294 root-cause.
+#
+# We use a whitespace-tolerant regex rather than a literal substring because
+# the Claude Code CLI is Node.js and `JSON.stringify` without an indent
+# argument emits no whitespace between the key, colon, and value
+# (`{"type":"tool_reference"}`), while a Python serializer would emit
+# `{"type": "tool_reference"}`. A naive substring with one specific spacing
+# would silently miss the real regression.
+_FORBIDDEN_TOOL_REFERENCE_RE = re.compile(r'"type"\s*:\s*"tool_reference"')
 
 # Beta string OpenRouter rejects in upstream issue #789. Can appear in
-# either `betas` arrays or the `anthropic-beta` header value.
+# either `betas` arrays or the `anthropic-beta` header value. This is a
+# unique opaque token (no JSON punctuation around it that could vary), so
+# a plain substring match is robust.
 _FORBIDDEN_CONTEXT_MANAGEMENT_BETA = "context-management-2025-06-27"
 
 
@@ -90,7 +100,7 @@ def _scan_request_for_forbidden_patterns(
     OpenRouter-incompatible features.
     """
     findings: list[str] = []
-    if _FORBIDDEN_TOOL_REFERENCE in body_text:
+    if _FORBIDDEN_TOOL_REFERENCE_RE.search(body_text):
         findings.append(
             "`tool_reference` content block in request body — "
             "PR #12294 / CLI 2.1.69 regression"
@@ -188,6 +198,7 @@ async def _start_fake_anthropic_server(
     answered with a valid streaming response.  Returns ``(runner, port)``
     so the caller can ``await runner.cleanup()`` when finished.
     """
+    import socket
 
     async def messages_handler(request: web.Request) -> web.StreamResponse:
         body = await request.text()
@@ -213,22 +224,28 @@ async def _start_fake_anthropic_server(
         await response.write_eof()
         return response
 
+    async def fallback_handler(_request: web.Request) -> web.Response:
+        # OAuth/profile endpoints the CLI may probe — answer 404 so it
+        # falls through quickly without retrying.
+        return web.Response(status=404)
+
     app = web.Application()
     app.router.add_post("/v1/messages", messages_handler)
-    # OAuth/profile endpoints the CLI may probe — answer 404 so it falls
-    # through quickly without retrying.
-    app.router.add_route("*", "/{tail:.*}", lambda _r: web.Response(status=404))
+    app.router.add_route("*", "/{tail:.*}", fallback_handler)
+
+    # Bind an ephemeral port ourselves so we can read it back via the
+    # public ``getsockname`` API rather than reaching into ``site._server``
+    # private aiohttp internals.
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    sock.bind(("127.0.0.1", 0))
+    port: int = sock.getsockname()[1]
 
     runner = web.AppRunner(app)
     await runner.setup()
-    site = web.TCPSite(runner, "127.0.0.1", 0)
+    site = web.SockSite(runner, sock)
     await site.start()
 
-    server = site._server
-    assert server is not None
-    sockets = getattr(server, "sockets", None)
-    assert sockets is not None
-    port: int = sockets[0].getsockname()[1]
     return runner, port
 
 
@@ -334,6 +351,14 @@ async def _run_cli_against_fake_server(
         try:
             proc.kill()
         except ProcessLookupError:
+            pass
+        # Reap the process to avoid leaving a zombie + open pipe FDs.
+        # Without this the asyncio transport keeps the stdout/stderr
+        # pipes alive until the loop exits, and in CI loops where this
+        # test runs many times the file-descriptor count creeps up.
+        try:
+            await asyncio.wait_for(proc.wait(), timeout=5.0)
+        except (asyncio.TimeoutError, TimeoutError):
             pass
         stdout_bytes, stderr_bytes = b"", b""
 
@@ -534,13 +559,14 @@ class TestResolveCliPath:
     def test_returns_none_when_env_var_points_to_missing_file(self, monkeypatch):
         monkeypatch.delenv("CHAT_CLAUDE_AGENT_CLI_PATH", raising=False)
         monkeypatch.setenv("CLAUDE_AGENT_CLI_PATH", "/nonexistent/path/to/claude")
-        # Should fall through to the bundled binary OR return None,
-        # but never raise.
+        # When the override is set but the file is missing, the resolver
+        # returns ``None`` outright — it does NOT silently fall through to
+        # the bundled binary, because doing so would defeat the purpose of
+        # the override (the operator explicitly asked for a specific path).
+        # The strict ``is None`` assertion catches any future regression
+        # that swaps this fail-loud behaviour for a silent fallback.
         resolved = _resolve_cli_path()
-        # We can't assert exact value (depends on whether the bundled
-        # CLI is installed in the test env) but the function must not
-        # raise — the caller is supposed to handle None gracefully.
-        assert resolved is None or resolved.is_file()
+        assert resolved is None
 
     def test_falls_back_to_bundled_when_env_var_unset(self, monkeypatch):
         monkeypatch.delenv("CLAUDE_AGENT_CLI_PATH", raising=False)

--- a/autogpt_platform/backend/backend/copilot/sdk/cli_openrouter_compat_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/cli_openrouter_compat_test.py
@@ -72,22 +72,41 @@ logger = logging.getLogger(__name__)
 # Forbidden patterns we scan for in captured request bodies
 # ---------------------------------------------------------------------------
 
-# Match the `tool_reference` content block that breaks OpenRouter's stricter
-# Zod validation in tool_result.content. PR #12294 root-cause.
-#
-# We use a whitespace-tolerant regex rather than a literal substring because
-# the Claude Code CLI is Node.js and `JSON.stringify` without an indent
-# argument emits no whitespace between the key, colon, and value
-# (`{"type":"tool_reference"}`), while a Python serializer would emit
-# `{"type": "tool_reference"}`. A naive substring with one specific spacing
-# would silently miss the real regression.
-_FORBIDDEN_TOOL_REFERENCE_RE = re.compile(r'"type"\s*:\s*"tool_reference"')
-
+# Substring of the `tool_reference` content block that breaks OpenRouter's
 # Beta string OpenRouter rejects in upstream issue #789. Can appear in
-# either `betas` arrays or the `anthropic-beta` header value. This is a
-# unique opaque token (no JSON punctuation around it that could vary), so
-# a plain substring match is robust.
+# either `betas` arrays or the `anthropic-beta` header value.
 _FORBIDDEN_CONTEXT_MANAGEMENT_BETA = "context-management-2025-06-27"
+
+
+def _body_contains_tool_reference_block(body_text: str) -> bool:
+    """Return True if *body_text* contains a ``tool_reference`` content
+    block anywhere in its structure.
+
+    We parse the JSON and walk it rather than relying on substring
+    matches because the CLI is free to emit either ``{"type": "tool_reference"}``
+    (with spaces) or the compact ``{"type":"tool_reference"}`` form,
+    and we must catch both.  Falls back to a whitespace-tolerant
+    regex when the body isn't valid JSON — the Messages API always
+    sends JSON, but the fallback keeps the detector honest on
+    malformed / partial bodies a fuzzer might produce.
+    """
+    try:
+        payload = json.loads(body_text)
+    except (ValueError, TypeError):
+        # Whitespace-tolerant fallback: allow any whitespace between
+        # the key, colon, and value quoted string.
+        return bool(re.search(r'"type"\s*:\s*"tool_reference"', body_text))
+
+    def _walk(node: Any) -> bool:
+        if isinstance(node, dict):
+            if node.get("type") == "tool_reference":
+                return True
+            return any(_walk(v) for v in node.values())
+        if isinstance(node, list):
+            return any(_walk(v) for v in node)
+        return False
+
+    return _walk(payload)
 
 
 def _scan_request_for_forbidden_patterns(
@@ -100,7 +119,7 @@ def _scan_request_for_forbidden_patterns(
     OpenRouter-incompatible features.
     """
     findings: list[str] = []
-    if _FORBIDDEN_TOOL_REFERENCE_RE.search(body_text):
+    if _body_contains_tool_reference_block(body_text):
         findings.append(
             "`tool_reference` content block in request body — "
             "PR #12294 / CLI 2.1.69 regression"
@@ -198,7 +217,6 @@ async def _start_fake_anthropic_server(
     answered with a valid streaming response.  Returns ``(runner, port)``
     so the caller can ``await runner.cleanup()`` when finished.
     """
-    import socket
 
     async def messages_handler(request: web.Request) -> web.StreamResponse:
         body = await request.text()
@@ -224,28 +242,22 @@ async def _start_fake_anthropic_server(
         await response.write_eof()
         return response
 
-    async def fallback_handler(_request: web.Request) -> web.Response:
-        # OAuth/profile endpoints the CLI may probe — answer 404 so it
-        # falls through quickly without retrying.
-        return web.Response(status=404)
-
     app = web.Application()
     app.router.add_post("/v1/messages", messages_handler)
-    app.router.add_route("*", "/{tail:.*}", fallback_handler)
-
-    # Bind an ephemeral port ourselves so we can read it back via the
-    # public ``getsockname`` API rather than reaching into ``site._server``
-    # private aiohttp internals.
-    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-    sock.bind(("127.0.0.1", 0))
-    port: int = sock.getsockname()[1]
+    # OAuth/profile endpoints the CLI may probe — answer 404 so it falls
+    # through quickly without retrying.
+    app.router.add_route("*", "/{tail:.*}", lambda _r: web.Response(status=404))
 
     runner = web.AppRunner(app)
     await runner.setup()
-    site = web.SockSite(runner, sock)
+    site = web.TCPSite(runner, "127.0.0.1", 0)
     await site.start()
 
+    server = site._server
+    assert server is not None
+    sockets = getattr(server, "sockets", None)
+    assert sockets is not None
+    port: int = sockets[0].getsockname()[1]
     return runner, port
 
 
@@ -352,15 +364,15 @@ async def _run_cli_against_fake_server(
             proc.kill()
         except ProcessLookupError:
             pass
-        # Reap the process to avoid leaving a zombie + open pipe FDs.
-        # Without this the asyncio transport keeps the stdout/stderr
-        # pipes alive until the loop exits, and in CI loops where this
-        # test runs many times the file-descriptor count creeps up.
+        # Reap the process after kill() so we don't leave an unreaped
+        # child behind until event-loop shutdown. Wait with its own
+        # short timeout in case the kill was ineffective.
         try:
-            await asyncio.wait_for(proc.wait(), timeout=5.0)
+            stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                proc.communicate(), timeout=5.0
+            )
         except (asyncio.TimeoutError, TimeoutError):
-            pass
-        stdout_bytes, stderr_bytes = b"", b""
+            stdout_bytes, stderr_bytes = b"", b""
 
     return (
         proc.returncode if proc.returncode is not None else -1,
@@ -527,6 +539,27 @@ class TestScanRequestForForbiddenPatterns:
         assert "tool_reference" in findings[0]
         assert "context-management-2025-06-27" in findings[1]
 
+    def test_detects_compact_tool_reference_without_spaces(self):
+        # Regression guard: the old substring matcher only caught the
+        # prettified form '"type": "tool_reference"' with a space
+        # between the key and the value, so a CLI emitting compact
+        # JSON (e.g. via `json.dumps(separators=(",", ":"))`) could
+        # slip past the scanner and false-pass. The JSON-walking
+        # detector catches both forms.
+        body = '{"messages":[{"role":"user","content":[{"type":"tool_reference","tool_name":"find"}]}]}'
+        findings = _scan_request_for_forbidden_patterns(body, {})
+        assert len(findings) == 1
+        assert "tool_reference" in findings[0]
+
+    def test_detects_tool_reference_in_malformed_body_fallback(self):
+        # When the body isn't valid JSON the helper falls back to a
+        # whitespace-tolerant regex so fuzzed / partial payloads are
+        # still caught.
+        body = 'garbage-prefix{"type"  :  "tool_reference"} trailing'
+        findings = _scan_request_for_forbidden_patterns(body, {})
+        assert len(findings) == 1
+        assert "tool_reference" in findings[0]
+
 
 class TestResolveCliPath:
     def test_honours_explicit_env_var_when_file_exists(self, tmp_path, monkeypatch):
@@ -559,14 +592,13 @@ class TestResolveCliPath:
     def test_returns_none_when_env_var_points_to_missing_file(self, monkeypatch):
         monkeypatch.delenv("CHAT_CLAUDE_AGENT_CLI_PATH", raising=False)
         monkeypatch.setenv("CLAUDE_AGENT_CLI_PATH", "/nonexistent/path/to/claude")
-        # When the override is set but the file is missing, the resolver
-        # returns ``None`` outright — it does NOT silently fall through to
-        # the bundled binary, because doing so would defeat the purpose of
-        # the override (the operator explicitly asked for a specific path).
-        # The strict ``is None`` assertion catches any future regression
-        # that swaps this fail-loud behaviour for a silent fallback.
+        # Should fall through to the bundled binary OR return None,
+        # but never raise.
         resolved = _resolve_cli_path()
-        assert resolved is None
+        # We can't assert exact value (depends on whether the bundled
+        # CLI is installed in the test env) but the function must not
+        # raise — the caller is supposed to handle None gracefully.
+        assert resolved is None or resolved.is_file()
 
     def test_falls_back_to_bundled_when_env_var_unset(self, monkeypatch):
         monkeypatch.delenv("CLAUDE_AGENT_CLI_PATH", raising=False)

--- a/autogpt_platform/backend/backend/copilot/sdk/cli_openrouter_compat_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/cli_openrouter_compat_test.py
@@ -217,6 +217,7 @@ async def _start_fake_anthropic_server(
     answered with a valid streaming response.  Returns ``(runner, port)``
     so the caller can ``await runner.cleanup()`` when finished.
     """
+    import socket
 
     async def messages_handler(request: web.Request) -> web.StreamResponse:
         body = await request.text()
@@ -242,22 +243,28 @@ async def _start_fake_anthropic_server(
         await response.write_eof()
         return response
 
+    async def fallback_handler(_request: web.Request) -> web.Response:
+        # OAuth/profile endpoints the CLI may probe — answer 404 so it
+        # falls through quickly without retrying.
+        return web.Response(status=404)
+
     app = web.Application()
     app.router.add_post("/v1/messages", messages_handler)
-    # OAuth/profile endpoints the CLI may probe — answer 404 so it falls
-    # through quickly without retrying.
-    app.router.add_route("*", "/{tail:.*}", lambda _r: web.Response(status=404))
+    app.router.add_route("*", "/{tail:.*}", fallback_handler)
+
+    # Bind an ephemeral port ourselves so we can read it back via the
+    # public ``getsockname`` API rather than reaching into ``site._server``
+    # private aiohttp internals.
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    sock.bind(("127.0.0.1", 0))
+    port: int = sock.getsockname()[1]
 
     runner = web.AppRunner(app)
     await runner.setup()
-    site = web.TCPSite(runner, "127.0.0.1", 0)
+    site = web.SockSite(runner, sock)
     await site.start()
 
-    server = site._server
-    assert server is not None
-    sockets = getattr(server, "sockets", None)
-    assert sockets is not None
-    port: int = sockets[0].getsockname()[1]
     return runner, port
 
 
@@ -592,13 +599,14 @@ class TestResolveCliPath:
     def test_returns_none_when_env_var_points_to_missing_file(self, monkeypatch):
         monkeypatch.delenv("CHAT_CLAUDE_AGENT_CLI_PATH", raising=False)
         monkeypatch.setenv("CLAUDE_AGENT_CLI_PATH", "/nonexistent/path/to/claude")
-        # Should fall through to the bundled binary OR return None,
-        # but never raise.
+        # When the override is set but the file is missing, the resolver
+        # returns ``None`` outright — it does NOT silently fall through to
+        # the bundled binary, because doing so would defeat the purpose of
+        # the override (the operator explicitly asked for a specific path).
+        # The strict ``is None`` assertion catches any future regression
+        # that swaps this fail-loud behaviour for a silent fallback.
         resolved = _resolve_cli_path()
-        # We can't assert exact value (depends on whether the bundled
-        # CLI is installed in the test env) but the function must not
-        # raise — the caller is supposed to handle None gracefully.
-        assert resolved is None or resolved.is_file()
+        assert resolved is None
 
     def test_falls_back_to_bundled_when_env_var_unset(self, monkeypatch):
         monkeypatch.delenv("CLAUDE_AGENT_CLI_PATH", raising=False)

--- a/autogpt_platform/backend/backend/copilot/sdk/openrouter_compat_proxy.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/openrouter_compat_proxy.py
@@ -469,18 +469,32 @@ class OpenRouterCompatProxy:
                 upstream_response.release()
 
         if stream_error is not None:
-            # Do NOT call ``write_eof`` — that would signal a clean end
-            # of stream to the client on top of a truncated body.
-            # Mark the connection for close (``Connection: close``) and
-            # skip the EOF so the aiohttp writer drops the connection
-            # mid-response.  The client's parser then raises a
-            # transport error and the caller can retry / surface the
-            # failure instead of silently consuming a corrupt body.
+            # Do NOT call ``write_eof`` or return the prepared
+            # ``downstream`` here — aiohttp finalises a returned
+            # StreamResponse (writing the terminating chunk /
+            # content-length / EOF) even if we skipped ``write_eof``
+            # ourselves, which would signal a clean end of stream to
+            # the client on top of the truncated body.  Instead abort
+            # the underlying transport directly so the client's
+            # parser surfaces a ``ClientPayloadError`` /
+            # ``ServerDisconnectedError`` and the caller can retry /
+            # surface the failure instead of silently consuming a
+            # corrupt body.
             try:
                 downstream.force_close()
             except Exception:  # pragma: no cover - defensive on transport
                 pass
-            return downstream
+            transport = request.transport
+            if transport is not None:
+                try:
+                    transport.abort()
+                except Exception:  # pragma: no cover - defensive on transport
+                    pass
+            # Re-raise the original stream error so aiohttp treats
+            # this handler as having failed; the transport is
+            # already aborted above so the client sees an abrupt
+            # disconnect either way.
+            raise stream_error
 
         await downstream.write_eof()
         return downstream

--- a/autogpt_platform/backend/backend/copilot/sdk/openrouter_compat_proxy.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/openrouter_compat_proxy.py
@@ -439,7 +439,15 @@ class OpenRouterCompatProxy:
             headers=clean_request_headers(dict(upstream_response.headers)),
         )
         await downstream.prepare(request)
+        # Track whether the stream terminated cleanly.  A mid-stream
+        # ``aiohttp.ClientError`` means the upstream died before
+        # finishing; calling ``write_eof()`` on that partial response
+        # would signal "complete stream" to the downstream client and
+        # silently corrupt the body.  Skip the EOF on the error path
+        # so the client's connection is dropped instead, surfacing the
+        # failure correctly.
         cancelled = False
+        stream_error: aiohttp.ClientError | None = None
         try:
             async for chunk in upstream_response.content.iter_any():
                 await downstream.write(chunk)
@@ -454,9 +462,25 @@ class OpenRouterCompatProxy:
             upstream_response.release()
             raise
         except aiohttp.ClientError as e:
+            stream_error = e
             logger.warning("OpenRouter compat proxy stream interrupted: %s", e)
         finally:
             if not cancelled:
                 upstream_response.release()
+
+        if stream_error is not None:
+            # Do NOT call ``write_eof`` — that would signal a clean end
+            # of stream to the client on top of a truncated body.
+            # Mark the connection for close (``Connection: close``) and
+            # skip the EOF so the aiohttp writer drops the connection
+            # mid-response.  The client's parser then raises a
+            # transport error and the caller can retry / surface the
+            # failure instead of silently consuming a corrupt body.
+            try:
+                downstream.force_close()
+            except Exception:  # pragma: no cover - defensive on transport
+                pass
+            return downstream
+
         await downstream.write_eof()
         return downstream

--- a/autogpt_platform/backend/backend/copilot/sdk/openrouter_compat_proxy.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/openrouter_compat_proxy.py
@@ -62,6 +62,7 @@ import asyncio
 import json
 import logging
 from typing import Any
+from urllib.parse import urlparse
 
 import aiohttp
 from aiohttp import web
@@ -295,10 +296,16 @@ class OpenRouterCompatProxy:
             raise RuntimeError("Compat proxy server has no listening sockets.")
         self._port = sockets[0].getsockname()[1]
         self._runner = runner
+        # Log only the host of the upstream — never the full URL — so a
+        # base URL that happens to embed credentials (e.g. via a path
+        # token, though OpenRouter doesn't do this) cannot leak into
+        # logs.  CodeQL `py/clear-text-logging-sensitive-data` defends
+        # against this case.
+        upstream_host = urlparse(self._target_base_url).netloc or "<unknown>"
         logger.info(
-            "OpenRouter compat proxy listening on %s -> %s",
-            self.local_url,
-            self._target_base_url,
+            "OpenRouter compat proxy listening on 127.0.0.1:%d -> %s",
+            self._port,
+            upstream_host,
         )
 
     async def stop(self) -> None:
@@ -359,10 +366,14 @@ class OpenRouterCompatProxy:
                 allow_redirects=False,
             )
         except aiohttp.ClientError as e:
+            # Log the detailed error for ops, but return a generic
+            # message to the caller — exception strings can leak
+            # internal hostnames, ports, or stack frames (CodeQL
+            # `py/stack-trace-exposure`).
             logger.warning(
                 "OpenRouter compat proxy upstream error: %s (url=%s)", e, upstream_url
             )
-            return web.Response(status=502, text=f"upstream error: {e}")
+            return web.Response(status=502, text="upstream error")
 
         # Stream the response back unchanged (apart from hop-by-hop
         # header filtering).

--- a/autogpt_platform/backend/backend/copilot/sdk/openrouter_compat_proxy.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/openrouter_compat_proxy.py
@@ -81,6 +81,13 @@ _FORBIDDEN_BETA_TOKENS: frozenset[str] = frozenset(
 # RFC 7230 §6.1, these are connection-specific and must be regenerated
 # by each intermediary.  ``host`` is also stripped because aiohttp
 # generates the correct ``Host`` header for the upstream URL itself.
+#
+# The canonical header name defined in RFC 7230 §4.4 is ``Trailer``
+# (singular); some SDKs / legacy proxies also emit the plural
+# ``Trailers`` so we accept both forms just in case.  Intermediaries
+# must additionally drop every header name listed in the incoming
+# ``Connection`` field value (§6.1 "extension hop-by-hop headers") —
+# that's handled dynamically by :func:`clean_request_headers`.
 _HOP_BY_HOP_HEADERS: frozenset[str] = frozenset(
     {
         "connection",
@@ -88,6 +95,7 @@ _HOP_BY_HOP_HEADERS: frozenset[str] = frozenset(
         "proxy-authenticate",
         "proxy-authorization",
         "te",
+        "trailer",
         "trailers",
         "transfer-encoding",
         "upgrade",
@@ -128,6 +136,13 @@ def strip_tool_reference_blocks(payload: Any) -> Any:
         cleaned_dict: dict[str, Any] = {}
         for key, value in payload.items():
             cleaned_value = strip_tool_reference_blocks(value)
+            # If a dict-valued child WAS a tool_reference block,
+            # drop the key entirely rather than writing `null` —
+            # otherwise schema-strict upstreams still reject the
+            # payload.  Only applies when the original value was a
+            # dict; genuine None values in the input are preserved.
+            if cleaned_value is None and isinstance(value, dict):
+                continue
             cleaned_dict[key] = cleaned_value
         return cleaned_dict
     if isinstance(payload, list):
@@ -203,14 +218,32 @@ def clean_request_headers(headers: dict[str, str]) -> dict[str, str]:
     forbidden tokens.  Returns a fresh dict the caller can pass through
     to the upstream client without further mutation.
 
+    Per RFC 7230 §6.1, intermediaries must drop the static hop-by-hop
+    set above **and** every header name listed in the incoming
+    ``Connection`` field value (case-insensitive).  The latter is how
+    extension hop-by-hop headers are signalled per-connection.
+
     Callers should pass an already-materialised ``dict`` (e.g.
     ``dict(request.headers)``) so this function stays simple.
     """
+    # Parse ``Connection: a, b, c`` into a lowercase token set so we
+    # can drop any header the sender explicitly marked as hop-by-hop
+    # on this connection.  This is separate from the static set
+    # above — extension headers can be anything.
+    connection_header = next(
+        (value for name, value in headers.items() if name.lower() == "connection"),
+        "",
+    )
+    connection_tokens: set[str] = {
+        token.strip().lower() for token in connection_header.split(",") if token.strip()
+    }
+
     cleaned: dict[str, str] = {}
     for name, value in headers.items():
-        if name.lower() in _HOP_BY_HOP_HEADERS:
+        lower_name = name.lower()
+        if lower_name in _HOP_BY_HOP_HEADERS or lower_name in connection_tokens:
             continue
-        if name.lower() == "anthropic-beta":
+        if lower_name == "anthropic-beta":
             stripped = strip_forbidden_anthropic_beta_header(value)
             if stripped is None:
                 continue
@@ -269,10 +302,17 @@ class OpenRouterCompatProxy:
         return self._target_base_url
 
     async def start(self) -> None:
-        """Bind to a random local port and start serving."""
+        """Bind to a random local port and start serving.
+
+        Cleans up the ``ClientSession`` and the ``AppRunner`` on any
+        failure during setup so a partially-initialised proxy never
+        leaves resources dangling (covers the
+        ``runner.setup() / site.start()`` raise paths in addition to
+        the explicit bind-failure branches below).
+        """
         if self._runner is not None:
             return  # already started
-        self._client = aiohttp.ClientSession(
+        client = aiohttp.ClientSession(
             timeout=aiohttp.ClientTimeout(total=self._request_timeout)
         )
         app = web.Application()
@@ -280,20 +320,35 @@ class OpenRouterCompatProxy:
         # (the CLI may probe profile / model endpoints).
         app.router.add_route("*", "/{tail:.*}", self._handle)
         runner = web.AppRunner(app)
-        await runner.setup()
-        site = web.TCPSite(runner, self._bind_host, 0)
-        await site.start()
-        server = site._server
-        if server is None:
-            await runner.cleanup()
-            await self._client.close()
-            raise RuntimeError("Failed to bind compat proxy server.")
-        sockets = getattr(server, "sockets", None)
-        if not sockets:
-            await runner.cleanup()
-            await self._client.close()
-            raise RuntimeError("Compat proxy server has no listening sockets.")
-        self._port = sockets[0].getsockname()[1]
+        runner_setup = False
+        try:
+            await runner.setup()
+            runner_setup = True
+            site = web.TCPSite(runner, self._bind_host, 0)
+            await site.start()
+            server = site._server
+            if server is None:
+                raise RuntimeError("Failed to bind compat proxy server.")
+            sockets = getattr(server, "sockets", None)
+            if not sockets:
+                raise RuntimeError("Compat proxy server has no listening sockets.")
+            self._port = sockets[0].getsockname()[1]
+        except BaseException:
+            # Best-effort teardown — swallow secondary errors so the
+            # caller sees the original exception.
+            if runner_setup:
+                try:
+                    await runner.cleanup()
+                except Exception:  # pragma: no cover - cleanup-only path
+                    logger.exception("compat proxy runner cleanup failed")
+            try:
+                await client.close()
+            except Exception:  # pragma: no cover - cleanup-only path
+                logger.exception("compat proxy client close failed")
+            raise
+        # Only publish the attributes after everything is wired up so
+        # ``stop()`` and ``local_url`` observe a consistent state.
+        self._client = client
         self._runner = runner
         # Deliberately log only the local bind port — never the
         # upstream URL or any derived component. CodeQL's
@@ -362,7 +417,12 @@ class OpenRouterCompatProxy:
                 headers=cleaned_headers,
                 allow_redirects=False,
             )
-        except aiohttp.ClientError as e:
+        except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+            # ``aiohttp.ClientTimeout`` raises ``asyncio.TimeoutError``
+            # (not ``aiohttp.ClientError``) on hung upstreams, so both
+            # must be caught here to surface the explicit 502 failure
+            # mode this proxy guarantees.
+            #
             # Log the detailed error for ops, but return a generic
             # message to the caller — exception strings can leak
             # internal hostnames, ports, or stack frames (CodeQL
@@ -379,12 +439,24 @@ class OpenRouterCompatProxy:
             headers=clean_request_headers(dict(upstream_response.headers)),
         )
         await downstream.prepare(request)
+        cancelled = False
         try:
             async for chunk in upstream_response.content.iter_any():
                 await downstream.write(chunk)
-        except (aiohttp.ClientError, asyncio.CancelledError) as e:
+        except asyncio.CancelledError:
+            # Never suppress cancellation — since Python 3.8 it's a
+            # ``BaseException`` subclass precisely so catching
+            # ``Exception`` won't accidentally swallow it.  Release
+            # the upstream body and re-raise so the asyncio task
+            # cooperatively unwinds (avoids hanging shutdowns /
+            # stuck request handlers).
+            cancelled = True
+            upstream_response.release()
+            raise
+        except aiohttp.ClientError as e:
             logger.warning("OpenRouter compat proxy stream interrupted: %s", e)
         finally:
-            upstream_response.release()
+            if not cancelled:
+                upstream_response.release()
         await downstream.write_eof()
         return downstream

--- a/autogpt_platform/backend/backend/copilot/sdk/openrouter_compat_proxy.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/openrouter_compat_proxy.py
@@ -62,7 +62,6 @@ import asyncio
 import json
 import logging
 from typing import Any
-from urllib.parse import urlparse
 
 import aiohttp
 from aiohttp import web
@@ -296,17 +295,15 @@ class OpenRouterCompatProxy:
             raise RuntimeError("Compat proxy server has no listening sockets.")
         self._port = sockets[0].getsockname()[1]
         self._runner = runner
-        # Log only the host of the upstream — never the full URL — so a
-        # base URL that happens to embed credentials (e.g. via a path
-        # token, though OpenRouter doesn't do this) cannot leak into
-        # logs.  CodeQL `py/clear-text-logging-sensitive-data` defends
-        # against this case.
-        upstream_host = urlparse(self._target_base_url).netloc or "<unknown>"
-        logger.info(
-            "OpenRouter compat proxy listening on 127.0.0.1:%d -> %s",
-            self._port,
-            upstream_host,
-        )
+        # Deliberately log only the local bind port — never the
+        # upstream URL or any derived component. CodeQL's
+        # `py/clear-text-logging-sensitive-data` taint analysis traces
+        # everything that originates from a config-supplied URL as
+        # potentially-sensitive even after parsing, and the upstream
+        # endpoint is anyway discoverable from the config the operator
+        # already has access to. The detailed upstream is exposed via
+        # the ``target_base_url`` property for callers that need it.
+        logger.info("OpenRouter compat proxy listening on 127.0.0.1:%d", self._port)
 
     async def stop(self) -> None:
         """Stop accepting connections and release the port."""

--- a/autogpt_platform/backend/backend/copilot/sdk/openrouter_compat_proxy.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/openrouter_compat_proxy.py
@@ -1,0 +1,382 @@
+"""Tiny in-process HTTP middleware that makes the Claude Code CLI work
+against OpenRouter on **any** ``claude-agent-sdk`` version.
+
+Background
+----------
+We've been pinned at ``claude-agent-sdk==0.1.45`` (bundled CLI 2.1.63)
+since `PR #12294`_ because every newer CLI version sends one of two
+features that OpenRouter rejects:
+
+1. **`tool_reference` content blocks** in ``tool_result.content`` —
+   introduced in CLI 2.1.69. OpenRouter's stricter Zod validation
+   refuses requests containing them with::
+
+        messages[N].content[0].content: Invalid input: expected string, received array
+
+2. **`context-management-2025-06-27` beta header** — sent in either the
+   request body's ``betas`` array or the ``anthropic-beta`` HTTP header.
+   OpenRouter responds::
+
+        400 No endpoints available that support Anthropic's context
+        management features (context-management-2025-06-27).
+
+   Tracked upstream at `claude-agent-sdk-python#789`_.
+
+This module starts a tiny aiohttp server that:
+
+* listens on ``127.0.0.1:RANDOM_PORT``,
+* receives every CLI request that would normally go to
+  ``ANTHROPIC_BASE_URL``,
+* strips the two forbidden patterns from the body and headers,
+* forwards the cleaned request to the real upstream
+  (``proxy_target_base_url``, e.g. ``https://openrouter.ai/api/v1``),
+* streams the response back to the CLI unchanged.
+
+The proxy is wired via :class:`backend.copilot.config.ChatConfig.claude_agent_use_compat_proxy`.
+When the flag is on, :mod:`backend.copilot.sdk.service` starts a proxy
+per session, sets ``ANTHROPIC_BASE_URL`` in the SDK's ``env`` to point
+at the proxy, then tears it down after the session ends.
+
+Why a separate proxy instead of a custom HTTP transport in the SDK?
+-------------------------------------------------------------------
+The Python SDK delegates **all** HTTP traffic to the bundled Claude
+Code CLI subprocess. Once the CLI is spawned, the only seam left is
+the network — there is no in-process hook for "modify outgoing
+request before it leaves the CLI". The proxy lives at that seam.
+
+This module is intentionally orthogonal to the
+:attr:`ChatConfig.claude_agent_cli_path` override:
+
+* ``cli_path`` lets us swap **which CLI binary** we run.
+* this proxy lets us **rewrite what any CLI binary sends**.
+
+The two can be combined or used independently.
+
+.. _PR #12294: https://github.com/Significant-Gravitas/AutoGPT/pull/12294
+.. _claude-agent-sdk-python#789: https://github.com/anthropics/claude-agent-sdk-python/issues/789
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import Any
+
+import aiohttp
+from aiohttp import web
+
+logger = logging.getLogger(__name__)
+
+# Header values OpenRouter rejects.  We strip exactly these tokens from
+# the comma-separated ``anthropic-beta`` header value (preserving any
+# other betas the CLI requests).
+_FORBIDDEN_BETA_TOKENS: frozenset[str] = frozenset(
+    {
+        "context-management-2025-06-27",
+    }
+)
+
+# Hop-by-hop headers we must NOT forward through the proxy.  Per
+# RFC 7230 §6.1, these are connection-specific and must be regenerated
+# by each intermediary.  ``host`` is also stripped because aiohttp
+# generates the correct ``Host`` header for the upstream URL itself.
+_HOP_BY_HOP_HEADERS: frozenset[str] = frozenset(
+    {
+        "connection",
+        "keep-alive",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "te",
+        "trailers",
+        "transfer-encoding",
+        "upgrade",
+        "host",
+        # ``content-length`` is stripped because we may rewrite the
+        # body — aiohttp will recompute it on the upstream request.
+        "content-length",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers — exported so the unit tests can drive them directly without
+# spinning up a server.
+# ---------------------------------------------------------------------------
+
+
+def strip_tool_reference_blocks(payload: Any) -> Any:
+    """Recursively remove ``tool_reference`` content blocks from
+    *payload*, returning the cleaned structure.
+
+    The CLI's built-in ``ToolSearch`` tool emits these as part of
+    ``tool_result.content``::
+
+        {"type": "tool_reference", "tool_name": "mcp__copilot__find_block"}
+
+    OpenRouter's stricter Zod validation rejects them.  Removing them
+    is safe — they are metadata about which tools were searched, not
+    real model-visible content.  The CLI's *internal* state still
+    contains them; only the wire format is rewritten.
+    """
+    if isinstance(payload, dict):
+        # Drop the dict entirely if it IS a tool_reference block.  The
+        # caller (a list comprehension below) discards None entries so
+        # we can return None to signal "remove me".
+        if payload.get("type") == "tool_reference":
+            return None
+        cleaned_dict: dict[str, Any] = {}
+        for key, value in payload.items():
+            cleaned_value = strip_tool_reference_blocks(value)
+            cleaned_dict[key] = cleaned_value
+        return cleaned_dict
+    if isinstance(payload, list):
+        cleaned_list: list[Any] = []
+        for item in payload:
+            cleaned_item = strip_tool_reference_blocks(item)
+            if cleaned_item is None and isinstance(item, dict):
+                # Item was a tool_reference block — drop it from the
+                # list rather than leaving a None hole.
+                continue
+            cleaned_list.append(cleaned_item)
+        return cleaned_list
+    return payload
+
+
+def strip_forbidden_betas_from_body(payload: Any) -> Any:
+    """Remove forbidden tokens from the ``betas`` array of an
+    Anthropic Messages API request body, if present.
+
+    The Messages API accepts a top-level ``betas: list[str]`` parameter
+    used to opt into beta features.  We drop tokens in
+    :data:`_FORBIDDEN_BETA_TOKENS` so OpenRouter's check passes.
+    """
+    if not isinstance(payload, dict):
+        return payload
+    betas = payload.get("betas")
+    if isinstance(betas, list):
+        cleaned_betas = [b for b in betas if b not in _FORBIDDEN_BETA_TOKENS]
+        if cleaned_betas:
+            payload["betas"] = cleaned_betas
+        else:
+            # Drop the empty array entirely so OpenRouter doesn't even
+            # see an empty `betas` field.
+            payload.pop("betas", None)
+    return payload
+
+
+def strip_forbidden_anthropic_beta_header(value: str | None) -> str | None:
+    """Return *value* with forbidden tokens removed.
+
+    The ``anthropic-beta`` HTTP header is a comma-separated list of
+    feature flags.  We strip exactly the forbidden tokens, preserving
+    any others.  Returns ``None`` if nothing remains (so the caller
+    can drop the header entirely).
+    """
+    if not value:
+        return value
+    tokens = [token.strip() for token in value.split(",")]
+    kept = [token for token in tokens if token and token not in _FORBIDDEN_BETA_TOKENS]
+    if not kept:
+        return None
+    return ", ".join(kept)
+
+
+def clean_request_body_bytes(body_bytes: bytes) -> bytes:
+    """Apply both body-level strippers to *body_bytes*, returning the
+    cleaned JSON.  Falls back to the original bytes when the body
+    isn't valid JSON (the CLI shouldn't be sending non-JSON to the
+    Messages API, but be defensive)."""
+    if not body_bytes:
+        return body_bytes
+    try:
+        payload = json.loads(body_bytes.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return body_bytes
+    payload = strip_tool_reference_blocks(payload)
+    payload = strip_forbidden_betas_from_body(payload)
+    return json.dumps(payload, separators=(",", ":")).encode("utf-8")
+
+
+def clean_request_headers(headers: dict[str, str]) -> dict[str, str]:
+    """Drop hop-by-hop headers and rewrite ``anthropic-beta`` to remove
+    forbidden tokens.  Returns a fresh dict the caller can pass through
+    to the upstream client without further mutation.
+
+    Callers should pass an already-materialised ``dict`` (e.g.
+    ``dict(request.headers)``) so this function stays simple.
+    """
+    cleaned: dict[str, str] = {}
+    for name, value in headers.items():
+        if name.lower() in _HOP_BY_HOP_HEADERS:
+            continue
+        if name.lower() == "anthropic-beta":
+            stripped = strip_forbidden_anthropic_beta_header(value)
+            if stripped is None:
+                continue
+            cleaned[name] = stripped
+            continue
+        cleaned[name] = value
+    return cleaned
+
+
+# ---------------------------------------------------------------------------
+# The proxy server
+# ---------------------------------------------------------------------------
+
+
+class OpenRouterCompatProxy:
+    """In-process HTTP proxy that rewrites Claude Code CLI requests on
+    the way to OpenRouter (or any other Anthropic-compatible gateway).
+
+    Usage::
+
+        proxy = OpenRouterCompatProxy(target_base_url="https://openrouter.ai/api/v1")
+        await proxy.start()
+        try:
+            # Spawn the CLI with ANTHROPIC_BASE_URL=proxy.local_url
+            ...
+        finally:
+            await proxy.stop()
+    """
+
+    def __init__(
+        self,
+        target_base_url: str,
+        *,
+        bind_host: str = "127.0.0.1",
+        request_timeout: float = 600.0,
+    ) -> None:
+        self._target_base_url = target_base_url.rstrip("/")
+        self._bind_host = bind_host
+        self._request_timeout = request_timeout
+        self._runner: web.AppRunner | None = None
+        self._client: aiohttp.ClientSession | None = None
+        self._port: int | None = None
+
+    @property
+    def local_url(self) -> str:
+        """The ``http://host:port`` URL that the CLI should use as
+        ``ANTHROPIC_BASE_URL``.  Raises if :meth:`start` has not been
+        called yet."""
+        if self._port is None:
+            raise RuntimeError("Proxy is not running — call start() first.")
+        return f"http://{self._bind_host}:{self._port}"
+
+    @property
+    def target_base_url(self) -> str:
+        """The upstream URL the proxy is forwarding to."""
+        return self._target_base_url
+
+    async def start(self) -> None:
+        """Bind to a random local port and start serving."""
+        if self._runner is not None:
+            return  # already started
+        self._client = aiohttp.ClientSession(
+            timeout=aiohttp.ClientTimeout(total=self._request_timeout)
+        )
+        app = web.Application()
+        # Catch every method + path so we can also forward GETs
+        # (the CLI may probe profile / model endpoints).
+        app.router.add_route("*", "/{tail:.*}", self._handle)
+        runner = web.AppRunner(app)
+        await runner.setup()
+        site = web.TCPSite(runner, self._bind_host, 0)
+        await site.start()
+        server = site._server
+        if server is None:
+            await runner.cleanup()
+            await self._client.close()
+            raise RuntimeError("Failed to bind compat proxy server.")
+        sockets = getattr(server, "sockets", None)
+        if not sockets:
+            await runner.cleanup()
+            await self._client.close()
+            raise RuntimeError("Compat proxy server has no listening sockets.")
+        self._port = sockets[0].getsockname()[1]
+        self._runner = runner
+        logger.info(
+            "OpenRouter compat proxy listening on %s -> %s",
+            self.local_url,
+            self._target_base_url,
+        )
+
+    async def stop(self) -> None:
+        """Stop accepting connections and release the port."""
+        if self._runner is not None:
+            await self._runner.cleanup()
+            self._runner = None
+        if self._client is not None:
+            await self._client.close()
+            self._client = None
+        self._port = None
+
+    async def __aenter__(self) -> "OpenRouterCompatProxy":
+        await self.start()
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.stop()
+
+    async def _handle(self, request: web.Request) -> web.StreamResponse:
+        """Forward *request* to the upstream after stripping forbidden
+        features.  Streams the upstream response back to the caller
+        chunk-by-chunk so SSE / streamed responses work."""
+        if self._client is None:
+            raise web.HTTPInternalServerError(reason="proxy client missing")
+
+        # Build the upstream URL.  ``request.path_qs`` includes the
+        # query string verbatim.  ``request.path`` for ``/v1/messages``
+        # is just ``/v1/messages`` — we strip a leading slash and
+        # concat with the target base URL.
+        upstream_path = request.path_qs
+        if not upstream_path.startswith("/"):
+            upstream_path = "/" + upstream_path
+        # Allow the target_base_url to itself contain a path (e.g.
+        # ``https://openrouter.ai/api/v1``).  In that case requests to
+        # ``/v1/messages`` need to become ``/api/v1/messages``, not
+        # ``/api/v1/v1/messages``.  Strip a leading ``/v1`` from the
+        # incoming path if the target already ends with ``/v1`` (or
+        # similar API-version segment).
+        target_base = self._target_base_url
+        target_lower = target_base.lower()
+        for prefix in ("/v1",):
+            if target_lower.endswith(prefix) and upstream_path.startswith(prefix + "/"):
+                upstream_path = upstream_path[len(prefix) :]
+                break
+        upstream_url = f"{target_base}{upstream_path}"
+
+        body_bytes = await request.read()
+        cleaned_body = clean_request_body_bytes(body_bytes)
+        cleaned_headers = clean_request_headers(dict(request.headers))
+
+        try:
+            upstream_response = await self._client.request(
+                method=request.method,
+                url=upstream_url,
+                data=cleaned_body if cleaned_body else None,
+                headers=cleaned_headers,
+                allow_redirects=False,
+            )
+        except aiohttp.ClientError as e:
+            logger.warning(
+                "OpenRouter compat proxy upstream error: %s (url=%s)", e, upstream_url
+            )
+            return web.Response(status=502, text=f"upstream error: {e}")
+
+        # Stream the response back unchanged (apart from hop-by-hop
+        # header filtering).
+        downstream = web.StreamResponse(
+            status=upstream_response.status,
+            headers=clean_request_headers(dict(upstream_response.headers)),
+        )
+        await downstream.prepare(request)
+        try:
+            async for chunk in upstream_response.content.iter_any():
+                await downstream.write(chunk)
+        except (aiohttp.ClientError, asyncio.CancelledError) as e:
+            logger.warning("OpenRouter compat proxy stream interrupted: %s", e)
+        finally:
+            upstream_response.release()
+        await downstream.write_eof()
+        return downstream

--- a/autogpt_platform/backend/backend/copilot/sdk/openrouter_compat_proxy_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/openrouter_compat_proxy_test.py
@@ -102,6 +102,24 @@ class TestStripToolReferenceBlocks:
         assert strip_tool_reference_blocks(42) == 42
         assert strip_tool_reference_blocks(None) is None
 
+    def test_removes_dict_valued_tool_reference_child_entirely(self):
+        # Regression guard: when a tool_reference dict is assigned to
+        # a key rather than listed, the helper used to rewrite it to
+        # `null` (leaving the parent key with a None value). That is
+        # still schema-invalid upstream — remove the key entirely.
+        payload = {
+            "wrapper": {"type": "tool_reference", "tool_name": "find_block"},
+            "keep": "value",
+        }
+        cleaned = strip_tool_reference_blocks(payload)
+        assert "wrapper" not in cleaned
+        assert cleaned["keep"] == "value"
+
+    def test_preserves_genuine_none_values_on_non_dict_children(self):
+        payload = {"explicit_null": None, "text": "ok"}
+        cleaned = strip_tool_reference_blocks(payload)
+        assert cleaned == {"explicit_null": None, "text": "ok"}
+
 
 # ---------------------------------------------------------------------------
 # strip_forbidden_betas_from_body
@@ -250,8 +268,42 @@ class TestCleanRequestHeaders:
     def test_hop_by_hop_set_completeness(self):
         # Sanity check: if upstream removes hop-by-hop headers from
         # this set we want to know — keep the canonical RFC 7230 list.
-        for required in ("connection", "transfer-encoding", "host"):
+        for required in (
+            "connection",
+            "transfer-encoding",
+            "host",
+            "trailer",
+            "trailers",
+        ):
             assert required in _HOP_BY_HOP_HEADERS
+
+    def test_drops_headers_listed_in_connection_field(self):
+        # Per RFC 7230 §6.1 intermediaries must also drop every
+        # header name listed in the incoming Connection field value
+        # (extension hop-by-hop headers signalled per-connection).
+        headers = {
+            "Connection": "X-Custom-Hop, Upgrade",
+            "X-Custom-Hop": "secret-extension",
+            "Authorization": "Bearer x",
+            "X-Keep": "ok",
+        }
+        cleaned = clean_request_headers(headers)
+        assert "X-Custom-Hop" not in cleaned
+        # Upgrade is a static hop-by-hop header; Connection itself is
+        # also dropped; the rest pass through.
+        assert "Connection" not in cleaned
+        assert cleaned["Authorization"] == "Bearer x"
+        assert cleaned["X-Keep"] == "ok"
+
+    def test_connection_token_matching_is_case_insensitive(self):
+        headers = {
+            "Connection": "x-hop-HEADER",
+            "X-Hop-Header": "drop-me",
+            "X-Keep": "ok",
+        }
+        cleaned = clean_request_headers(headers)
+        assert "X-Hop-Header" not in cleaned
+        assert cleaned["X-Keep"] == "ok"
 
 
 # ---------------------------------------------------------------------------
@@ -460,6 +512,68 @@ async def test_proxy_returns_502_on_upstream_failure():
         pass
     finally:
         await proxy.stop()
+
+
+@pytest.mark.asyncio
+async def test_proxy_returns_502_on_upstream_timeout():
+    """``aiohttp.ClientTimeout`` raises ``asyncio.TimeoutError`` (not
+    ``aiohttp.ClientError``), which previously escaped the except
+    block and surfaced as a 500.  This regression-guards the 502
+    contract for hung upstreams."""
+
+    class _HangingUpstream:
+        """Upstream that accepts the request but never finishes the
+        response body, forcing the proxy's client timeout to fire."""
+
+        def __init__(self) -> None:
+            self._runner: web.AppRunner | None = None
+            self.port: int = 0
+
+        async def start(self) -> str:
+            async def handler(request: web.Request) -> web.StreamResponse:
+                # Hold the response open longer than the proxy's
+                # client timeout so aiohttp raises TimeoutError on
+                # the proxy side.
+                await asyncio.sleep(30)
+                return web.Response(status=200)
+
+            app = web.Application()
+            app.router.add_route("*", "/{tail:.*}", handler)
+            self._runner = web.AppRunner(app)
+            await self._runner.setup()
+            site = web.TCPSite(self._runner, "127.0.0.1", 0)
+            await site.start()
+            server = site._server
+            assert server is not None
+            sockets = getattr(server, "sockets", None)
+            assert sockets is not None
+            self.port = sockets[0].getsockname()[1]
+            return f"http://127.0.0.1:{self.port}"
+
+        async def stop(self) -> None:
+            if self._runner is not None:
+                await self._runner.cleanup()
+                self._runner = None
+
+    upstream = _HangingUpstream()
+    upstream_url = await upstream.start()
+    # Short proxy timeout so the test finishes quickly.
+    proxy = OpenRouterCompatProxy(target_base_url=upstream_url, request_timeout=0.5)
+    await proxy.start()
+    try:
+        async with aiohttp.ClientSession() as client:
+            async with client.post(
+                f"{proxy.local_url}/v1/messages",
+                json={"model": "x"},
+                timeout=aiohttp.ClientTimeout(total=10),
+            ) as resp:
+                assert resp.status == 502
+                text = await resp.text()
+                # Generic error message — no internal hostname leaked.
+                assert "upstream error" in text
+    finally:
+        await proxy.stop()
+        await upstream.stop()
 
 
 @pytest.mark.asyncio

--- a/autogpt_platform/backend/backend/copilot/sdk/openrouter_compat_proxy_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/openrouter_compat_proxy_test.py
@@ -23,16 +23,15 @@ import pytest
 from aiohttp import web
 
 from backend.copilot.sdk.openrouter_compat_proxy import (
-    OpenRouterCompatProxy,
     _FORBIDDEN_BETA_TOKENS,
     _HOP_BY_HOP_HEADERS,
+    OpenRouterCompatProxy,
     clean_request_body_bytes,
     clean_request_headers,
     strip_forbidden_anthropic_beta_header,
     strip_forbidden_betas_from_body,
     strip_tool_reference_blocks,
 )
-
 
 # ---------------------------------------------------------------------------
 # strip_tool_reference_blocks

--- a/autogpt_platform/backend/backend/copilot/sdk/openrouter_compat_proxy_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/openrouter_compat_proxy_test.py
@@ -584,6 +584,96 @@ async def test_proxy_returns_502_on_upstream_timeout():
 
 
 @pytest.mark.asyncio
+async def test_proxy_does_not_signal_clean_eof_on_mid_stream_error():
+    """Regression guard: if the upstream stream dies mid-body, the
+    proxy must NOT call ``write_eof()`` — that would mark the
+    downstream response as a complete, valid stream even though the
+    client only saw a truncated body.  Instead the proxy drops the
+    connection so the client's parser surfaces a transport error.
+
+    We simulate the failure by giving the proxy an upstream that
+    closes the TCP socket mid-response.  The proxy must either drop
+    the client connection (``aiohttp.ClientPayloadError`` /
+    ``ClientConnectionError``) or — if aiohttp masks it — at least
+    not report an ``ok`` complete body.
+    """
+
+    class _TruncatingUpstream:
+        """Upstream that starts sending a response then kills the
+        connection before ``write_eof`` — mimicking a backend that
+        dies mid-stream."""
+
+        def __init__(self) -> None:
+            self._runner: web.AppRunner | None = None
+            self.port: int = 0
+
+        async def start(self) -> str:
+            async def handler(request: web.Request) -> web.StreamResponse:
+                resp = web.StreamResponse(
+                    status=200,
+                    headers={"Content-Type": "application/octet-stream"},
+                )
+                await resp.prepare(request)
+                await resp.write(b"partial-")
+                # Force-close without write_eof so the proxy's
+                # iter_any() raises mid-stream.
+                resp.force_close()
+                return resp
+
+            app = web.Application()
+            app.router.add_route("*", "/{tail:.*}", handler)
+            self._runner = web.AppRunner(app)
+            await self._runner.setup()
+            site = web.TCPSite(self._runner, "127.0.0.1", 0)
+            await site.start()
+            server = site._server
+            assert server is not None
+            sockets = getattr(server, "sockets", None)
+            assert sockets is not None
+            self.port = sockets[0].getsockname()[1]
+            return f"http://127.0.0.1:{self.port}"
+
+        async def stop(self) -> None:
+            if self._runner is not None:
+                await self._runner.cleanup()
+                self._runner = None
+
+    upstream = _TruncatingUpstream()
+    upstream_url = await upstream.start()
+    proxy = OpenRouterCompatProxy(target_base_url=upstream_url)
+    await proxy.start()
+    try:
+        async with aiohttp.ClientSession() as client:
+            client_error: Exception | None = None
+            try:
+                async with client.post(
+                    f"{proxy.local_url}/v1/messages",
+                    json={"model": "x"},
+                    timeout=aiohttp.ClientTimeout(total=10),
+                ) as resp:
+                    # The client should see either an error raising
+                    # here or a truncated body followed by a
+                    # transport-level failure on read — both are
+                    # acceptable because both surface the truncation
+                    # instead of silently reporting success.
+                    await resp.read()
+            except (
+                aiohttp.ClientPayloadError,
+                aiohttp.ClientConnectionError,
+                aiohttp.ServerDisconnectedError,
+            ) as e:
+                client_error = e
+            assert client_error is not None, (
+                "Proxy silently consumed an upstream mid-stream "
+                "failure and returned a clean EOF to the client — "
+                "regression in the stream-error path."
+            )
+    finally:
+        await proxy.stop()
+        await upstream.stop()
+
+
+@pytest.mark.asyncio
 async def test_proxy_local_url_raises_before_start():
     proxy = OpenRouterCompatProxy(target_base_url="http://example.com")
     with pytest.raises(RuntimeError):

--- a/autogpt_platform/backend/backend/copilot/sdk/openrouter_compat_proxy_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/openrouter_compat_proxy_test.py
@@ -591,56 +591,71 @@ async def test_proxy_does_not_signal_clean_eof_on_mid_stream_error():
     client only saw a truncated body.  Instead the proxy drops the
     connection so the client's parser surfaces a transport error.
 
-    We simulate the failure by giving the proxy an upstream that
-    closes the TCP socket mid-response.  The proxy must either drop
-    the client connection (``aiohttp.ClientPayloadError`` /
-    ``ClientConnectionError``) or — if aiohttp masks it — at least
-    not report an ``ok`` complete body.
+    We simulate the failure with a raw asyncio TCP server that
+    sends a chunked-encoding response header plus one partial chunk
+    and then hard-closes the socket — this is the one failure mode
+    aiohttp's ``iter_any()`` reliably surfaces as an
+    ``aiohttp.ClientError`` rather than an ordinary clean EOF.
     """
 
     class _TruncatingUpstream:
-        """Upstream that starts sending a response then kills the
-        connection before ``write_eof`` — mimicking a backend that
-        dies mid-stream."""
+        """Raw TCP server that sends a partial chunked body then
+        closes the socket without writing the terminating chunk."""
 
         def __init__(self) -> None:
-            self._runner: web.AppRunner | None = None
+            self._server: asyncio.base_events.Server | None = None
             self.port: int = 0
 
         async def start(self) -> str:
-            async def handler(request: web.Request) -> web.StreamResponse:
-                resp = web.StreamResponse(
-                    status=200,
-                    headers={"Content-Type": "application/octet-stream"},
-                )
-                await resp.prepare(request)
-                await resp.write(b"partial-")
-                # Force-close without write_eof so the proxy's
-                # iter_any() raises mid-stream.
-                resp.force_close()
-                return resp
+            async def handle_conn(
+                reader: asyncio.StreamReader,
+                writer: asyncio.StreamWriter,
+            ) -> None:
+                try:
+                    # Read and discard the request until the blank
+                    # line — we don't care what the proxy sends.
+                    while True:
+                        line = await reader.readline()
+                        if not line or line == b"\r\n":
+                            break
+                    # Chunked response with one partial chunk.
+                    writer.write(
+                        b"HTTP/1.1 200 OK\r\n"
+                        b"Content-Type: application/octet-stream\r\n"
+                        b"Transfer-Encoding: chunked\r\n"
+                        b"Connection: close\r\n"
+                        b"\r\n"
+                        # One chunk, size 8, content "partial-".
+                        b"8\r\n"
+                        b"partial-\r\n"
+                        # Deliberately DO NOT send the terminating
+                        # "0\r\n\r\n" — this is the mid-stream
+                        # truncation we're testing.
+                    )
+                    await writer.drain()
+                finally:
+                    # Hard-close the socket so the proxy's
+                    # iter_any() sees an abrupt end-of-stream.
+                    try:
+                        writer.transport.abort()
+                    except Exception:
+                        pass
 
-            app = web.Application()
-            app.router.add_route("*", "/{tail:.*}", handler)
-            self._runner = web.AppRunner(app)
-            await self._runner.setup()
-            site = web.TCPSite(self._runner, "127.0.0.1", 0)
-            await site.start()
-            server = site._server
-            assert server is not None
-            sockets = getattr(server, "sockets", None)
+            self._server = await asyncio.start_server(handle_conn, "127.0.0.1", 0)
+            sockets = self._server.sockets
             assert sockets is not None
             self.port = sockets[0].getsockname()[1]
             return f"http://127.0.0.1:{self.port}"
 
         async def stop(self) -> None:
-            if self._runner is not None:
-                await self._runner.cleanup()
-                self._runner = None
+            if self._server is not None:
+                self._server.close()
+                await self._server.wait_closed()
+                self._server = None
 
     upstream = _TruncatingUpstream()
     upstream_url = await upstream.start()
-    proxy = OpenRouterCompatProxy(target_base_url=upstream_url)
+    proxy = OpenRouterCompatProxy(target_base_url=upstream_url, request_timeout=5.0)
     await proxy.start()
     try:
         async with aiohttp.ClientSession() as client:
@@ -653,9 +668,9 @@ async def test_proxy_does_not_signal_clean_eof_on_mid_stream_error():
                 ) as resp:
                     # The client should see either an error raising
                     # here or a truncated body followed by a
-                    # transport-level failure on read — both are
-                    # acceptable because both surface the truncation
-                    # instead of silently reporting success.
+                    # transport-level failure on read — both surface
+                    # the truncation instead of silently reporting
+                    # success.
                     await resp.read()
             except (
                 aiohttp.ClientPayloadError,

--- a/autogpt_platform/backend/backend/copilot/sdk/openrouter_compat_proxy_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/openrouter_compat_proxy_test.py
@@ -492,7 +492,16 @@ async def test_proxy_passes_through_clean_request_unchanged():
 @pytest.mark.asyncio
 async def test_proxy_returns_502_on_upstream_failure():
     """If the upstream is unreachable the proxy must return a clear
-    502, not silently hang."""
+    502, not silently hang.
+
+    Note: the outer ``client.post`` talks to the *proxy* on localhost,
+    not to the dead upstream directly. The proxy is the thing under
+    test, so it should always respond with a 502 — we must NOT
+    swallow ``aiohttp.ClientError`` / ``asyncio.TimeoutError`` on the
+    outer call, because that would mask a proxy crash and turn the
+    assertion into a false positive. Let any such exception fail the
+    test.
+    """
     proxy = OpenRouterCompatProxy(
         target_base_url="http://127.0.0.1:1",  # nothing listening
     )
@@ -502,14 +511,12 @@ async def test_proxy_returns_502_on_upstream_failure():
             async with client.post(
                 f"{proxy.local_url}/v1/messages",
                 json={"model": "x"},
-                timeout=aiohttp.ClientTimeout(total=5),
+                timeout=aiohttp.ClientTimeout(total=10),
             ) as resp:
                 assert resp.status == 502
-    except (aiohttp.ClientError, asyncio.TimeoutError):
-        # Some platforms refuse the connection so quickly aiohttp
-        # raises before the proxy can respond — that also satisfies
-        # the spirit of the test (no infinite hang).
-        pass
+                text = await resp.text()
+                # Generic error message — no internal hostname leaked.
+                assert "upstream error" in text
     finally:
         await proxy.stop()
 

--- a/autogpt_platform/backend/backend/copilot/sdk/openrouter_compat_proxy_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/openrouter_compat_proxy_test.py
@@ -1,0 +1,470 @@
+"""Tests for the OpenRouter compatibility proxy.
+
+The proxy strips two known forbidden patterns from requests so newer
+``claude-agent-sdk`` / Claude Code CLI versions can talk to OpenRouter
+through the unchanged transport. These tests cover both:
+
+* the pure stripping helpers (deterministic, no I/O), and
+* the end-to-end proxy behaviour against a fake upstream server, so we
+  catch hop-by-hop header bugs and streaming regressions.
+
+See ``openrouter_compat_proxy.py`` for the rationale and the upstream
+issues being worked around.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import aiohttp
+import pytest
+from aiohttp import web
+
+from backend.copilot.sdk.openrouter_compat_proxy import (
+    OpenRouterCompatProxy,
+    _FORBIDDEN_BETA_TOKENS,
+    _HOP_BY_HOP_HEADERS,
+    clean_request_body_bytes,
+    clean_request_headers,
+    strip_forbidden_anthropic_beta_header,
+    strip_forbidden_betas_from_body,
+    strip_tool_reference_blocks,
+)
+
+
+# ---------------------------------------------------------------------------
+# strip_tool_reference_blocks
+# ---------------------------------------------------------------------------
+
+
+class TestStripToolReferenceBlocks:
+    """The CLI's built-in ToolSearch tool emits ``tool_reference``
+    content blocks in ``tool_result.content``. OpenRouter's stricter
+    Zod validation rejects them. We drop them entirely — they're
+    metadata about which tools were searched, not real model-visible
+    content."""
+
+    def test_removes_tool_reference_block_at_top_level(self):
+        block = {"type": "tool_reference", "tool_name": "find_block"}
+        assert strip_tool_reference_blocks(block) is None
+
+    def test_removes_tool_reference_block_from_list(self):
+        blocks = [
+            {"type": "text", "text": "hello"},
+            {"type": "tool_reference", "tool_name": "find_block"},
+            {"type": "text", "text": "world"},
+        ]
+        assert strip_tool_reference_blocks(blocks) == [
+            {"type": "text", "text": "hello"},
+            {"type": "text", "text": "world"},
+        ]
+
+    def test_strips_nested_tool_reference_inside_tool_result(self):
+        # The exact shape PR #12294 root-caused: tool_result.content
+        # contains the tool_reference block.
+        request = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "tu_1",
+                            "content": [
+                                {"type": "text", "text": "result text"},
+                                {
+                                    "type": "tool_reference",
+                                    "tool_name": "mcp__copilot__find_block",
+                                },
+                            ],
+                        }
+                    ],
+                }
+            ]
+        }
+        cleaned = strip_tool_reference_blocks(request)
+        tool_result_content = cleaned["messages"][0]["content"][0]["content"]
+        assert tool_result_content == [{"type": "text", "text": "result text"}]
+
+    def test_preserves_unrelated_payloads(self):
+        payload = {
+            "model": "claude-opus-4.6",
+            "messages": [{"role": "user", "content": "hi"}],
+            "temperature": 0.7,
+        }
+        assert strip_tool_reference_blocks(payload) == payload
+
+    def test_handles_empty_and_primitive_inputs(self):
+        assert strip_tool_reference_blocks({}) == {}
+        assert strip_tool_reference_blocks([]) == []
+        assert strip_tool_reference_blocks("plain string") == "plain string"
+        assert strip_tool_reference_blocks(42) == 42
+        assert strip_tool_reference_blocks(None) is None
+
+
+# ---------------------------------------------------------------------------
+# strip_forbidden_betas_from_body
+# ---------------------------------------------------------------------------
+
+
+class TestStripForbiddenBetasFromBody:
+    """OpenRouter rejects ``context-management-2025-06-27`` in the
+    request body's ``betas`` array."""
+
+    def test_removes_forbidden_token_keeps_others(self):
+        body = {
+            "model": "claude-opus-4.6",
+            "betas": [
+                "context-management-2025-06-27",
+                "fine-grained-tool-streaming-2025",
+            ],
+        }
+        cleaned = strip_forbidden_betas_from_body(body)
+        assert cleaned["betas"] == ["fine-grained-tool-streaming-2025"]
+
+    def test_removes_betas_field_entirely_when_only_forbidden(self):
+        body = {"model": "x", "betas": ["context-management-2025-06-27"]}
+        cleaned = strip_forbidden_betas_from_body(body)
+        assert "betas" not in cleaned
+
+    def test_no_op_when_no_betas_field(self):
+        body = {"model": "x"}
+        assert strip_forbidden_betas_from_body(body) == {"model": "x"}
+
+    def test_no_op_on_non_dict(self):
+        assert strip_forbidden_betas_from_body([1, 2, 3]) == [1, 2, 3]
+        assert strip_forbidden_betas_from_body("plain") == "plain"
+
+    def test_all_forbidden_tokens_constants_are_recognized(self):
+        for forbidden in _FORBIDDEN_BETA_TOKENS:
+            body = {"betas": [forbidden, "other"]}
+            cleaned = strip_forbidden_betas_from_body(body)
+            assert forbidden not in cleaned["betas"]
+
+
+# ---------------------------------------------------------------------------
+# strip_forbidden_anthropic_beta_header
+# ---------------------------------------------------------------------------
+
+
+class TestStripForbiddenAnthropicBetaHeader:
+    def test_removes_forbidden_token_keeps_others(self):
+        value = "fine-grained-tool-streaming-2025, context-management-2025-06-27, other-beta"
+        result = strip_forbidden_anthropic_beta_header(value)
+        assert result == "fine-grained-tool-streaming-2025, other-beta"
+
+    def test_returns_none_when_only_forbidden_token_present(self):
+        assert (
+            strip_forbidden_anthropic_beta_header("context-management-2025-06-27")
+            is None
+        )
+
+    def test_passes_through_clean_header(self):
+        assert strip_forbidden_anthropic_beta_header("foo, bar") == "foo, bar"
+
+    def test_handles_empty_and_none_input(self):
+        assert strip_forbidden_anthropic_beta_header("") == ""
+        assert strip_forbidden_anthropic_beta_header(None) is None
+
+    def test_handles_extra_whitespace(self):
+        value = "  context-management-2025-06-27  ,  fine-grained  "
+        result = strip_forbidden_anthropic_beta_header(value)
+        assert result == "fine-grained"
+
+
+# ---------------------------------------------------------------------------
+# clean_request_body_bytes — combined body-level cleanup
+# ---------------------------------------------------------------------------
+
+
+class TestCleanRequestBodyBytes:
+    def test_strips_both_patterns_in_one_pass(self):
+        body = {
+            "model": "claude-opus-4.6",
+            "betas": ["context-management-2025-06-27"],
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "tu_1",
+                            "content": [
+                                {"type": "tool_reference", "tool_name": "find"},
+                                {"type": "text", "text": "ok"},
+                            ],
+                        }
+                    ],
+                }
+            ],
+        }
+        cleaned_bytes = clean_request_body_bytes(json.dumps(body).encode("utf-8"))
+        cleaned = json.loads(cleaned_bytes.decode("utf-8"))
+        assert "betas" not in cleaned  # only forbidden token, dropped
+        tool_result_content = cleaned["messages"][0]["content"][0]["content"]
+        assert tool_result_content == [{"type": "text", "text": "ok"}]
+
+    def test_passes_through_non_json_body(self):
+        garbage = b"\xff\xfe not json at all"
+        assert clean_request_body_bytes(garbage) == garbage
+
+    def test_passes_through_empty_body(self):
+        assert clean_request_body_bytes(b"") == b""
+
+
+# ---------------------------------------------------------------------------
+# clean_request_headers — hop-by-hop + anthropic-beta cleanup
+# ---------------------------------------------------------------------------
+
+
+class TestCleanRequestHeaders:
+    def test_drops_hop_by_hop_headers(self):
+        headers = {
+            "Host": "example.com",
+            "Connection": "keep-alive",
+            "Content-Length": "42",
+            "Authorization": "Bearer xxx",
+            "Content-Type": "application/json",
+        }
+        cleaned = clean_request_headers(headers)
+        assert "Host" not in cleaned
+        assert "Connection" not in cleaned
+        assert "Content-Length" not in cleaned
+        assert cleaned["Authorization"] == "Bearer xxx"
+        assert cleaned["Content-Type"] == "application/json"
+
+    def test_strips_forbidden_token_from_anthropic_beta_header(self):
+        headers = {
+            "anthropic-beta": "context-management-2025-06-27, other-beta",
+            "Authorization": "Bearer x",
+        }
+        cleaned = clean_request_headers(headers)
+        assert cleaned["anthropic-beta"] == "other-beta"
+
+    def test_drops_anthropic_beta_header_when_only_forbidden(self):
+        headers = {"anthropic-beta": "context-management-2025-06-27"}
+        cleaned = clean_request_headers(headers)
+        assert "anthropic-beta" not in cleaned
+
+    def test_hop_by_hop_set_completeness(self):
+        # Sanity check: if upstream removes hop-by-hop headers from
+        # this set we want to know — keep the canonical RFC 7230 list.
+        for required in ("connection", "transfer-encoding", "host"):
+            assert required in _HOP_BY_HOP_HEADERS
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: real proxy + fake upstream
+# ---------------------------------------------------------------------------
+
+
+class _FakeUpstream:
+    """Tiny aiohttp app that records every request the proxy forwards
+    so the test can assert on the cleaned payloads."""
+
+    def __init__(self) -> None:
+        self.captured: list[dict[str, Any]] = []
+        self._runner: web.AppRunner | None = None
+        self.port: int = 0
+
+    async def start(self) -> str:
+        async def handler(request: web.Request) -> web.StreamResponse:
+            body = await request.text()
+            self.captured.append(
+                {
+                    "method": request.method,
+                    "path": request.path_qs,
+                    "headers": {k: v for k, v in request.headers.items()},
+                    "body": body,
+                }
+            )
+            # Return a minimal JSON success response so the proxy has
+            # something to stream back.
+            return web.json_response({"ok": True, "echoed": body})
+
+        app = web.Application()
+        app.router.add_route("*", "/{tail:.*}", handler)
+        self._runner = web.AppRunner(app)
+        await self._runner.setup()
+        site = web.TCPSite(self._runner, "127.0.0.1", 0)
+        await site.start()
+        server = site._server
+        assert server is not None
+        sockets = getattr(server, "sockets", None)
+        assert sockets is not None
+        self.port = sockets[0].getsockname()[1]
+        return f"http://127.0.0.1:{self.port}"
+
+    async def stop(self) -> None:
+        if self._runner is not None:
+            await self._runner.cleanup()
+            self._runner = None
+
+
+@pytest.mark.asyncio
+async def test_proxy_strips_tool_reference_block_end_to_end():
+    upstream = _FakeUpstream()
+    upstream_url = await upstream.start()
+    proxy = OpenRouterCompatProxy(target_base_url=upstream_url)
+    await proxy.start()
+    try:
+        body = {
+            "model": "claude-opus-4.6",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "hi"},
+                        {
+                            "type": "tool_reference",
+                            "tool_name": "mcp__copilot__find_block",
+                        },
+                    ],
+                }
+            ],
+        }
+        async with aiohttp.ClientSession() as client:
+            async with client.post(
+                f"{proxy.local_url}/v1/messages",
+                json=body,
+                headers={"Authorization": "Bearer test"},
+            ) as resp:
+                assert resp.status == 200
+                await resp.read()
+    finally:
+        await proxy.stop()
+        await upstream.stop()
+
+    assert len(upstream.captured) == 1
+    forwarded = json.loads(upstream.captured[0]["body"])
+    # The tool_reference block must NOT be in the upstream-visible body.
+    assert '"tool_reference"' not in upstream.captured[0]["body"]
+    assert forwarded["messages"][0]["content"] == [{"type": "text", "text": "hi"}]
+
+
+@pytest.mark.asyncio
+async def test_proxy_strips_context_management_beta_header_end_to_end():
+    upstream = _FakeUpstream()
+    upstream_url = await upstream.start()
+    proxy = OpenRouterCompatProxy(target_base_url=upstream_url)
+    await proxy.start()
+    try:
+        async with aiohttp.ClientSession() as client:
+            async with client.post(
+                f"{proxy.local_url}/v1/messages",
+                json={"model": "x", "messages": []},
+                headers={
+                    "Authorization": "Bearer test",
+                    "anthropic-beta": "context-management-2025-06-27, other-beta",
+                },
+            ) as resp:
+                assert resp.status == 200
+                await resp.read()
+    finally:
+        await proxy.stop()
+        await upstream.stop()
+
+    forwarded_headers = upstream.captured[0]["headers"]
+    # Header is rewritten to remove only the forbidden token, keeping the rest.
+    assert any(
+        k.lower() == "anthropic-beta" and v == "other-beta"
+        for k, v in forwarded_headers.items()
+    )
+
+
+@pytest.mark.asyncio
+async def test_proxy_strips_betas_from_request_body_end_to_end():
+    upstream = _FakeUpstream()
+    upstream_url = await upstream.start()
+    proxy = OpenRouterCompatProxy(target_base_url=upstream_url)
+    await proxy.start()
+    try:
+        body = {
+            "model": "x",
+            "betas": [
+                "context-management-2025-06-27",
+                "fine-grained-tool-streaming-2025",
+            ],
+            "messages": [],
+        }
+        async with aiohttp.ClientSession() as client:
+            async with client.post(
+                f"{proxy.local_url}/v1/messages",
+                json=body,
+            ) as resp:
+                assert resp.status == 200
+                await resp.read()
+    finally:
+        await proxy.stop()
+        await upstream.stop()
+
+    forwarded = json.loads(upstream.captured[0]["body"])
+    # Only the surviving beta should be present.
+    assert forwarded["betas"] == ["fine-grained-tool-streaming-2025"]
+
+
+@pytest.mark.asyncio
+async def test_proxy_passes_through_clean_request_unchanged():
+    """The proxy must be a no-op for requests that don't contain any of
+    the forbidden patterns — no other rewriting allowed."""
+    upstream = _FakeUpstream()
+    upstream_url = await upstream.start()
+    proxy = OpenRouterCompatProxy(target_base_url=upstream_url)
+    await proxy.start()
+    try:
+        body = {
+            "model": "claude-opus-4.6",
+            "messages": [{"role": "user", "content": "hello"}],
+            "temperature": 0.7,
+        }
+        async with aiohttp.ClientSession() as client:
+            async with client.post(
+                f"{proxy.local_url}/v1/messages",
+                json=body,
+                headers={
+                    "Authorization": "Bearer test",
+                    "Content-Type": "application/json",
+                },
+            ) as resp:
+                assert resp.status == 200
+                await resp.read()
+    finally:
+        await proxy.stop()
+        await upstream.stop()
+
+    forwarded = json.loads(upstream.captured[0]["body"])
+    assert forwarded == body
+
+
+@pytest.mark.asyncio
+async def test_proxy_returns_502_on_upstream_failure():
+    """If the upstream is unreachable the proxy must return a clear
+    502, not silently hang."""
+    proxy = OpenRouterCompatProxy(
+        target_base_url="http://127.0.0.1:1",  # nothing listening
+    )
+    await proxy.start()
+    try:
+        async with aiohttp.ClientSession() as client:
+            async with client.post(
+                f"{proxy.local_url}/v1/messages",
+                json={"model": "x"},
+                timeout=aiohttp.ClientTimeout(total=5),
+            ) as resp:
+                assert resp.status == 502
+    except (aiohttp.ClientError, asyncio.TimeoutError):
+        # Some platforms refuse the connection so quickly aiohttp
+        # raises before the proxy can respond — that also satisfies
+        # the spirit of the test (no infinite hang).
+        pass
+    finally:
+        await proxy.stop()
+
+
+@pytest.mark.asyncio
+async def test_proxy_local_url_raises_before_start():
+    proxy = OpenRouterCompatProxy(target_base_url="http://example.com")
+    with pytest.raises(RuntimeError):
+        _ = proxy.local_url

--- a/autogpt_platform/backend/backend/copilot/sdk/sdk_compat_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/sdk_compat_test.py
@@ -196,3 +196,79 @@ def test_sdk_exports_hook_event_type(hook_event: str):
     # HookEvent is a Literal type — check that our events are valid values.
     # We can't easily inspect Literal at runtime, so just verify the type exists.
     assert HookEvent is not None
+
+
+# ---------------------------------------------------------------------------
+# OpenRouter compatibility — bundled CLI version pin
+# ---------------------------------------------------------------------------
+#
+# We're stuck on ``claude-agent-sdk==0.1.45`` (bundled CLI ``2.1.63``)
+# because every version above introduces a 400 against OpenRouter:
+#
+# 1. CLI ``2.1.69`` (= SDK ``0.1.46``) shipped a `tool_reference` content
+#    block in `tool_result.content` that OpenRouter's stricter Zod
+#    validation rejects.  See PR
+#    https://github.com/Significant-Gravitas/AutoGPT/pull/12294 for the
+#    forensic write-up that originally pinned us.  CLI ``2.1.70`` added
+#    proxy detection that *should* disable the offending block, but two
+#    later attempts (Dependabot bumps to 0.1.55 / 0.1.56) still failed.
+#
+# 2. A second regression — the ``context-management-2025-06-27`` beta
+#    header — appeared in some CLI version after ``2.1.91``.  Tracked
+#    upstream at
+#    https://github.com/anthropics/claude-agent-sdk-python/issues/789
+#    (still open at the time of writing, no upstream PR yet).
+#
+# This test is the cheapest possible regression guard: it pins the
+# bundled CLI to a known-good version.  If anyone bumps
+# ``claude-agent-sdk`` in ``pyproject.toml``, the bundled CLI version in
+# ``_cli_version.py`` will change and this test will fail with a clear
+# message that points the next person at the OpenRouter compat issue
+# instead of letting them silently re-break production.
+#
+# Workaround for actually upgrading: set the
+# ``claude_agent_cli_path`` config option (or the matching env var) to
+# point at a separately-installed Claude Code CLI binary at a known-good
+# version, so the SDK Python API surface and the CLI binary version can
+# be picked independently.
+
+# CLI versions verified to work against OpenRouter from production
+# traffic.  When upstream lands a fix and we can confirm a newer version
+# works, add it to this set rather than blanket-removing the assertion.
+_KNOWN_GOOD_BUNDLED_CLI_VERSIONS: frozenset[str] = frozenset({"2.1.63"})
+
+
+def test_bundled_cli_version_is_known_good_against_openrouter():
+    """Pin the bundled CLI version so accidental SDK bumps cause a loud,
+    fast failure with a pointer to the OpenRouter compatibility issue."""
+    from claude_agent_sdk._cli_version import __cli_version__
+
+    assert __cli_version__ in _KNOWN_GOOD_BUNDLED_CLI_VERSIONS, (
+        f"Bundled Claude Code CLI version is {__cli_version__!r}, which is "
+        f"not in the OpenRouter-known-good set "
+        f"{sorted(_KNOWN_GOOD_BUNDLED_CLI_VERSIONS)!r}. "
+        "If you intentionally bumped `claude-agent-sdk`, verify the new "
+        "bundled CLI works with OpenRouter against the reproduction test "
+        "in `cli_openrouter_compat_test.py`, then add the new CLI version "
+        "to `_KNOWN_GOOD_BUNDLED_CLI_VERSIONS`. If you cannot make the "
+        "bundled CLI work, set `claude_agent_cli_path` to a known-good "
+        "binary instead and skip the bundled one. See "
+        "https://github.com/anthropics/claude-agent-sdk-python/issues/789 "
+        "and https://github.com/Significant-Gravitas/AutoGPT/pull/12294."
+    )
+
+
+def test_sdk_exposes_cli_path_option():
+    """Sanity-check that the SDK still exposes the `cli_path` option we use
+    for the OpenRouter workaround.  If upstream removes it we need to know."""
+    import inspect
+
+    from claude_agent_sdk import ClaudeAgentOptions
+
+    sig = inspect.signature(ClaudeAgentOptions)
+    assert "cli_path" in sig.parameters, (
+        "ClaudeAgentOptions no longer accepts `cli_path` — our "
+        "claude_agent_cli_path config override would be silently ignored. "
+        "Either find an alternative override mechanism or pin the SDK to a "
+        "version that still exposes it."
+    )

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -2245,6 +2245,12 @@ async def stream_chat_completion_sdk(
             sdk_options_kwargs["env"] = sdk_env
         if use_resume and resume_file:
             sdk_options_kwargs["resume"] = resume_file
+        # Optional explicit Claude Code CLI binary path (decouples the
+        # bundled SDK version from the CLI version we run — needed because
+        # the CLI bundled in 0.1.46+ is broken against OpenRouter).  Falls
+        # back to the bundled binary when unset.
+        if config.claude_agent_cli_path:
+            sdk_options_kwargs["cli_path"] = config.claude_agent_cli_path
 
         options = ClaudeAgentOptions(**sdk_options_kwargs)  # type: ignore[arg-type]  # dynamic kwargs
 

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -2277,10 +2277,34 @@ async def stream_chat_completion_sdk(
             # feature is opt-in and documented as "OpenRouter
             # compatibility", so quietly no-oping on direct-Anthropic
             # sessions is the safe default.
-            target_base_url: str | None = (sdk_env or {}).get(
-                "ANTHROPIC_BASE_URL"
-            ) or os.environ.get("ANTHROPIC_BASE_URL")
-            if not target_base_url and config.openrouter_active:
+            # Claude Code subscription mode intentionally sets
+            # ``sdk_env['ANTHROPIC_BASE_URL'] = ""`` to *disable* any
+            # base-URL override and keep the CLI talking to Anthropic
+            # directly. Treat an explicit empty string as a hard
+            # "no-proxy" signal so we never silently start the proxy
+            # against a host-wide ``ANTHROPIC_BASE_URL`` or fall back
+            # to OpenRouter when the caller has opted out.
+            sdk_env_map = sdk_env or {}
+            explicit_sdk_env = "ANTHROPIC_BASE_URL" in sdk_env_map
+            sdk_env_value = (
+                sdk_env_map["ANTHROPIC_BASE_URL"] if explicit_sdk_env else None
+            )
+            if explicit_sdk_env and not sdk_env_value:
+                # Empty string from sdk_env → subscription mode opt-out.
+                target_base_url: str | None = None
+                explicit_opt_out = True
+            else:
+                target_base_url = sdk_env_value or os.environ.get("ANTHROPIC_BASE_URL")
+                explicit_opt_out = False
+            # Only fall back to OpenRouter when the session actually
+            # has no base-URL plumbing of its own AND OpenRouter is
+            # the active routing provider AND the caller hasn't
+            # explicitly opted out via an empty sdk_env override.
+            if (
+                not target_base_url
+                and not explicit_opt_out
+                and config.openrouter_active
+            ):
                 from backend.util.clients import OPENROUTER_BASE_URL
 
                 target_base_url = OPENROUTER_BASE_URL

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -2258,35 +2258,63 @@ async def stream_chat_completion_sdk(
         # versions can talk to OpenRouter without their stricter
         # validation rejecting the request.
         if config.claude_agent_use_compat_proxy:
-            from backend.copilot.sdk.openrouter_compat_proxy import (
-                OpenRouterCompatProxy,
-            )
+            # Only start the compat proxy when there's already an
+            # explicit Anthropic-compatible upstream to forward to.
+            # Otherwise we'd be silently routing direct Anthropic /
+            # Claude Code subscription sessions through OpenRouter,
+            # which would break auth and change providers without
+            # operator consent.  The explicit upstream can come from:
+            #
+            # 1. ``sdk_env['ANTHROPIC_BASE_URL']`` — caller override;
+            # 2. the process env — lowest-precedence host override;
+            # 3. ``ChatConfig.openrouter_active`` — OpenRouter is
+            #    configured as the session's routing provider (i.e.
+            #    the only case in which falling back to
+            #    ``OPENROUTER_BASE_URL`` is intentional).
+            #
+            # When none of the above hold, log a warning and leave
+            # the CLI to talk to Anthropic directly as usual — the
+            # feature is opt-in and documented as "OpenRouter
+            # compatibility", so quietly no-oping on direct-Anthropic
+            # sessions is the safe default.
+            target_base_url: str | None = (sdk_env or {}).get(
+                "ANTHROPIC_BASE_URL"
+            ) or os.environ.get("ANTHROPIC_BASE_URL")
+            if not target_base_url and config.openrouter_active:
+                from backend.util.clients import OPENROUTER_BASE_URL
 
-            # Use the same upstream URL the SDK would have hit directly.
-            # Prefer an explicit override in ``sdk_env`` (e.g. set by a
-            # caller wanting to test against a specific gateway), then
-            # the parent process env, then the platform-wide
-            # ``OPENROUTER_BASE_URL`` constant.
-            from backend.util.clients import OPENROUTER_BASE_URL
+                target_base_url = OPENROUTER_BASE_URL
 
-            target_base_url = (
-                (sdk_env or {}).get("ANTHROPIC_BASE_URL")
-                or os.environ.get("ANTHROPIC_BASE_URL")
-                or OPENROUTER_BASE_URL
-            )
-            _compat_proxy = OpenRouterCompatProxy(target_base_url=target_base_url)
-            await _compat_proxy.start()
-            # Inject the proxy URL into the SDK env so the spawned CLI
-            # subprocess uses the proxy as its Anthropic endpoint.
-            if sdk_env is None:
-                sdk_env = {}
-            sdk_env["ANTHROPIC_BASE_URL"] = _compat_proxy.local_url
-            logger.info(
-                "%s OpenRouter compat proxy active: %s -> %s",
-                log_prefix,
-                _compat_proxy.local_url,
-                _compat_proxy.target_base_url,
-            )
+            if target_base_url:
+                from backend.copilot.sdk.openrouter_compat_proxy import (
+                    OpenRouterCompatProxy,
+                )
+
+                _compat_proxy = OpenRouterCompatProxy(target_base_url=target_base_url)
+                await _compat_proxy.start()
+                # Inject the proxy URL into the SDK env so the spawned
+                # CLI subprocess uses the proxy as its Anthropic
+                # endpoint.
+                if sdk_env is None:
+                    sdk_env = {}
+                sdk_env["ANTHROPIC_BASE_URL"] = _compat_proxy.local_url
+                # Log only the local bind URL — upstream is redacted
+                # to match the taint-analysis guidance applied in
+                # ``openrouter_compat_proxy.start``.
+                logger.info(
+                    "%s OpenRouter compat proxy active (listening on %s)",
+                    log_prefix,
+                    _compat_proxy.local_url,
+                )
+            else:
+                logger.warning(
+                    "%s claude_agent_use_compat_proxy is enabled but no "
+                    "Anthropic-compatible upstream is configured for this "
+                    "session (no ANTHROPIC_BASE_URL override and "
+                    "openrouter_active is False); skipping proxy startup "
+                    "so the CLI keeps talking to Anthropic directly.",
+                    log_prefix,
+                )
 
         if sdk_env:
             sdk_options_kwargs["env"] = sdk_env

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -1980,6 +1980,13 @@ async def stream_chat_completion_sdk(
     transcript_content: str = ""
     state: _RetryState | None = None
 
+    # OpenRouter compat proxy — started inside the try and stopped in finally
+    # when ``ChatConfig.claude_agent_use_compat_proxy`` is enabled. The proxy
+    # rewrites outgoing CLI requests to strip ``tool_reference`` content
+    # blocks and the ``context-management-2025-06-27`` beta so the latest
+    # SDK / CLI versions stop tripping OpenRouter's validation.
+    _compat_proxy: Any = None  # OpenRouterCompatProxy | None — lazy import
+
     # Token usage accumulators — populated from ResultMessage at end of turn
     turn_prompt_tokens = 0  # uncached input tokens only
     turn_completion_tokens = 0
@@ -2241,6 +2248,46 @@ async def stream_chat_completion_sdk(
         }
         if sdk_model:
             sdk_options_kwargs["model"] = sdk_model
+
+        # OpenRouter compatibility proxy — started here so its local URL
+        # can be injected into the CLI subprocess env BEFORE the env dict
+        # is passed to ``ClaudeAgentOptions``.  When this flag is on we
+        # transparently rewrite outgoing CLI requests via the proxy
+        # (stripping ``tool_reference`` blocks and the
+        # ``context-management-2025-06-27`` beta) so newer SDK / CLI
+        # versions can talk to OpenRouter without their stricter
+        # validation rejecting the request.
+        if config.claude_agent_use_compat_proxy:
+            from backend.copilot.sdk.openrouter_compat_proxy import (
+                OpenRouterCompatProxy,
+            )
+
+            # Use the same upstream URL the SDK would have hit directly.
+            # Prefer an explicit override in ``sdk_env`` (e.g. set by a
+            # caller wanting to test against a specific gateway), then
+            # the parent process env, then the platform-wide
+            # ``OPENROUTER_BASE_URL`` constant.
+            from backend.util.clients import OPENROUTER_BASE_URL
+
+            target_base_url = (
+                (sdk_env or {}).get("ANTHROPIC_BASE_URL")
+                or os.environ.get("ANTHROPIC_BASE_URL")
+                or OPENROUTER_BASE_URL
+            )
+            _compat_proxy = OpenRouterCompatProxy(target_base_url=target_base_url)
+            await _compat_proxy.start()
+            # Inject the proxy URL into the SDK env so the spawned CLI
+            # subprocess uses the proxy as its Anthropic endpoint.
+            if sdk_env is None:
+                sdk_env = {}
+            sdk_env["ANTHROPIC_BASE_URL"] = _compat_proxy.local_url
+            logger.info(
+                "%s OpenRouter compat proxy active: %s -> %s",
+                log_prefix,
+                _compat_proxy.local_url,
+                _compat_proxy.target_base_url,
+            )
+
         if sdk_env:
             sdk_options_kwargs["env"] = sdk_env
         if use_resume and resume_file:
@@ -2913,5 +2960,18 @@ async def stream_chat_completion_sdk(
         except Exception:
             logger.warning("%s SDK cleanup failed", log_prefix, exc_info=True)
         finally:
+            # Tear down the OpenRouter compat proxy if it was started for
+            # this session — releases the bound port and the aiohttp
+            # client. Wrapped so a stop failure can never block the
+            # downstream lock release.
+            if _compat_proxy is not None:
+                try:
+                    await _compat_proxy.stop()
+                except Exception:
+                    logger.warning(
+                        "%s OpenRouter compat proxy stop failed",
+                        log_prefix,
+                        exc_info=True,
+                    )
             # Release stream lock to allow new streams for this session
             await lock.release()

--- a/autogpt_platform/backend/backend/data/platform_cost_test.py
+++ b/autogpt_platform/backend/backend/data/platform_cost_test.py
@@ -35,7 +35,6 @@ class TestUsdToMicrodollars:
         assert usd_to_microdollars(1.0) == 1_000_000
 
 
-
 class TestMaskEmail:
     def test_typical_email(self):
         assert _mask_email("user@example.com") == "us***@example.com"


### PR DESCRIPTION
## Why

The Claude Code CLI in any `claude-agent-sdk` version above 0.1.47 sends the `context-management-2025-06-27` beta header / body field that OpenRouter rejects with HTTP 400. This blocks us from upgrading to take features we want — `exclude_dynamic_sections` cross-user prompt caching in 0.1.57 (directly amplifies #12725), `AssistantMessage.usage` per-turn token tracking in 0.1.49 (cost attribution), the MCP large-tool-result truncation fix in 0.1.55, `task_budget` in 0.1.51, `get_context_usage()` in 0.1.52, the MCP HTTP/SSE buffer leak fix in CLI 2.1.97, and the 429 retry exponential-backoff fix in CLI 2.1.97. Tracked upstream at [anthropics/claude-agent-sdk-python#789](https://github.com/anthropics/claude-agent-sdk-python/issues/789), no fix released yet.

**Bisect verdict from #12742 / #12743 / #12744** confirmed via the reproduction test in #12741:

| SDK version | Bundled CLI | Reproduction test | Failure mode |
|---|---|---|---|
| 0.1.45 (current pin) | 2.1.63 | ✅ pass | none (baseline) |
| **0.1.47** | 2.1.70 | ✅ pass | none — `tool_reference` proxy fix from CLI 2.1.70 works |
| 0.1.55 | 2.1.91 | ❌ fail | `context-management-2025-06-27` in `anthropic-beta` header |
| 0.1.58 | 2.1.97 | ❌ fail | same — `context-management-2025-06-27` in `anthropic-beta` header |

So:

* **0.1.47 is a free immediate upgrade** — no compat workaround needed. (Separate small PR will follow.)
* For anything 0.1.55+ we need this compat proxy.

Importantly, the `tool_reference` regression from CLI 2.1.69 IS resolved upstream by the proxy detection in 2.1.70 — only the new context-management beta blocks us today. The proxy still strips both as defense in depth.

## What

A tiny in-process aiohttp middleware (`backend/copilot/sdk/openrouter_compat_proxy.py`) that:

* listens on `127.0.0.1:RANDOM_PORT`,
* receives every CLI request that would normally go to `ANTHROPIC_BASE_URL`,
* **strips `tool_reference` content blocks** anywhere in the JSON body (defensive),
* **strips `context-management-2025-06-27`** from both the body's `betas` array and the `anthropic-beta` HTTP header (preserving any other betas the CLI requests),
* forwards the cleaned request upstream and **streams the response back unchanged** (so SSE responses still work),
* drops hop-by-hop headers per RFC 7230 §6.1 (`Connection`, `Transfer-Encoding`, `Host`, `Content-Length`, etc.) so the proxied request is well-formed.

Wired via `ChatConfig.claude_agent_use_compat_proxy` (default `False`, opt-in). When the flag is on, the SDK service starts a proxy per session, injects its local URL into the spawned CLI subprocess `env` as `ANTHROPIC_BASE_URL`, and tears it down in the session's `finally` block.

The proxy is intentionally orthogonal to the `claude_agent_cli_path` override added in #12741:

* `cli_path` picks **which** CLI binary we run.
* compat proxy rewrites **whatever the chosen binary sends**.

Both can be combined or used independently.

## How (operationally)

To take this PR + a newer SDK version, the change is two lines in production env:

```
COPILOT__CLAUDE_AGENT_USE_COMPAT_PROXY=true
# (then bump pyproject.toml to e.g. claude-agent-sdk = "0.1.58")
```

The proxy consumes one ephemeral local port per active SDK session. There's no shared state, so concurrent sessions get independent proxies. Memory overhead is roughly one aiohttp `ClientSession` + one server runner per active session (~hundreds of KB).

## Test plan

- [x] Pure helper unit tests for `strip_tool_reference_blocks`, `strip_forbidden_betas_from_body`, `strip_forbidden_anthropic_beta_header`, `clean_request_body_bytes`, `clean_request_headers` — covers nested structures, empty/non-JSON bodies, hop-by-hop header completeness, the canonical RFC 7230 set, and whitespace-tolerant header parsing.
- [x] End-to-end tests against a fake upstream server: stripping `tool_reference` in nested `tool_result.content`, rewriting `anthropic-beta` header, removing forbidden token from body `betas`, passing through clean requests unchanged, returning 502 on upstream failure (no infinite hang).
- [x] `black` / `ruff` / `pyright` clean on all four touched files
- [ ] CI runs on this PR and passes
- [ ] Follow-up integration validation: open a probe PR that combines this PR + a 0.1.58 bump + the compat-proxy flag to confirm end-to-end CLI → proxy → upstream works against the *real* claude-agent-sdk request shape
- [ ] Production rollout sequence: this PR → bump SDK to 0.1.58 in a separate PR with the flag on by default → monitor → optionally remove the pin assertion from `sdk_compat_test.py`

## Related

- #12741 — companion PR with `claude_agent_cli_path` plumbing + reproduction test
- #12742, #12743, #12744 — bisect probes that confirmed 0.1.47 is safe and 0.1.55+ trips the new regression
- #12294 — original 0.1.45 pin
- anthropics/claude-agent-sdk-python#789 — upstream issue (commented from us as a production user)