### PR TITLE
fix(copilot): multi-layer defence against Write tool truncation errors

### DIFF
--- a/autogpt_platform/backend/backend/copilot/prompting.py
+++ b/autogpt_platform/backend/backend/copilot/prompting.py
@@ -75,11 +75,12 @@ Example — committing an image file to GitHub:
 }}
 ```
 
-### Writing large files — CRITICAL
-**Never write an entire large document in a single tool call.**  When the
-content you want to write exceeds ~2000 words the tool call's output token
-limit will silently truncate the arguments, producing an empty `{{}}` input
-that fails repeatedly.
+### Writing large files — CRITICAL (causes production failures)
+**NEVER write an entire large document in a single tool call.**  When the
+content you want to write exceeds ~2000 words the API output-token limit
+will silently truncate the tool call arguments mid-JSON, losing all content
+and producing an opaque error.  This is unrecoverable — the user's work is
+lost and retrying with the same approach fails in an infinite loop.
 
 **Preferred: compose from file references.**  If the data is already in
 files (tool outputs, workspace files), compose the report in one call

--- a/autogpt_platform/backend/backend/copilot/sdk/e2b_file_tools.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/e2b_file_tools.py
@@ -179,6 +179,11 @@ async def _handle_read_file(args: dict[str, Any]) -> dict[str, Any]:
     return _mcp(numbered)
 
 
+# Inline content above this threshold triggers a warning — it survived this
+# time but is dangerously close to the API output-token truncation limit.
+_LARGE_CONTENT_WARN_CHARS = 50_000
+
+
 async def _handle_write_file(args: dict[str, Any]) -> dict[str, Any]:
     """Write content to a sandbox file, creating parent directories as needed."""
     file_path: str = args.get("file_path", "")
@@ -207,7 +212,20 @@ async def _handle_write_file(args: dict[str, Any]) -> dict[str, Any]:
     except Exception as exc:
         return _mcp(f"Failed to write {remote}: {exc}", error=True)
 
-    return _mcp(f"Successfully wrote to {remote}")
+    msg = f"Successfully wrote to {remote}"
+    if len(content) > _LARGE_CONTENT_WARN_CHARS:
+        logger.warning(
+            "[E2B] write_file: large inline content (%d chars) for %s",
+            len(content),
+            remote,
+        )
+        msg += (
+            f"\n\nWARNING: The content was very large ({len(content)} chars). "
+            "Next time, write large files in sections using bash_exec with "
+            "'cat > file << EOF ... EOF' and 'cat >> file << EOF ... EOF' "
+            "to avoid output-token truncation."
+        )
+    return _mcp(msg)
 
 
 async def _handle_edit_file(args: dict[str, Any]) -> dict[str, Any]:

--- a/autogpt_platform/backend/backend/copilot/sdk/tool_adapter.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/tool_adapter.py
@@ -527,6 +527,28 @@ def _make_truncating_wrapper(
                 f"be truncated again."
             )
 
+        # Partial truncation: the API cut the JSON mid-way — `content` or
+        # `new_string` survived but `file_path` (emitted later) was lost.
+        if (
+            tool_name in ("write_file", "write_workspace_file", "edit_file")
+            and args
+            and "file_path" not in args
+            and ("content" in args or "new_string" in args)
+        ):
+            logger.warning(
+                "[MCP] %s: partial truncation detected — file_path missing",
+                tool_name,
+            )
+            return _mcp_error(
+                f"Your {tool_name} call was truncated (file_path missing). "
+                "The content was too large for a single tool call. "
+                "Write in chunks: use bash_exec with "
+                "'cat > file << EOF ... EOF' for the first section, "
+                "'cat >> file << EOF ... EOF' to append subsequent "
+                "sections, then reference the file with "
+                "@@agptfile:/path/to/file if needed."
+            )
+
         original_args = args
         stop_msg = _check_circuit_breaker(tool_name, original_args)
         if stop_msg:
@@ -655,10 +677,17 @@ _SDK_BUILTIN_TOOLS = [*_SDK_BUILTIN_FILE_TOOLS, *_SDK_BUILTIN_ALWAYS]
 # WebFetch: SSRF risk — can reach internal network (localhost, 10.x, etc.).
 #   Agent uses the SSRF-protected mcp__copilot__web_fetch tool instead.
 # AskUserQuestion: interactive CLI tool — no terminal in copilot context.
+# Write: the CLI's built-in Write tool has no defence against output-token
+#   truncation.  When the LLM generates a very large `content` argument the
+#   API truncates the response mid-JSON and Ajv rejects it with the opaque
+#   "'file_path' is a required property" error, losing the user's work.
+#   All writes go through our MCP write_file / write_workspace_file tools
+#   where we control validation and return actionable guidance.
 SDK_DISALLOWED_TOOLS = [
     "Bash",
     "WebFetch",
     "AskUserQuestion",
+    "Write",
 ]
 
 # Tools that are blocked entirely in security hooks (defence-in-depth).

--- a/autogpt_platform/backend/backend/copilot/sdk/tool_adapter_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/tool_adapter_test.py
@@ -929,3 +929,101 @@ class TestStripLlmFields:
         stashed = pop_pending_tool_output("fake_tool_normal")
         assert stashed is not None
         assert '"is_dry_run": true' in stashed
+
+
+# ---------------------------------------------------------------------------
+# Partial truncation detection (Layer 2 of write-tool-truncation fix)
+# ---------------------------------------------------------------------------
+
+
+class TestPartialTruncationDetection:
+    """When the API truncates a write tool call mid-JSON, `content` may survive
+    but `file_path` is lost.  The wrapper must detect this and return actionable
+    guidance instead of letting the call through to fail with an opaque error.
+    """
+
+    @pytest.mark.asyncio
+    async def test_write_file_partial_truncation_detected(self):
+        """write_file with content but no file_path returns truncation error."""
+
+        async def fake_tool_fn(_args: dict) -> dict:
+            raise AssertionError("Should not be called")
+
+        wrapper = _make_truncating_wrapper(
+            fake_tool_fn,
+            "write_file",
+            input_schema={"required": ["file_path", "content"]},
+        )
+        result = await wrapper({"content": "some data"})
+        assert result["isError"] is True
+        text = result["content"][0]["text"]
+        assert "truncated" in text
+        assert "file_path" in text
+
+    @pytest.mark.asyncio
+    async def test_edit_file_partial_truncation_detected(self):
+        """edit_file with new_string but no file_path returns truncation error."""
+
+        async def fake_tool_fn(_args: dict) -> dict:
+            raise AssertionError("Should not be called")
+
+        wrapper = _make_truncating_wrapper(
+            fake_tool_fn,
+            "edit_file",
+            input_schema={"required": ["file_path", "old_string", "new_string"]},
+        )
+        result = await wrapper({"new_string": "replacement"})
+        assert result["isError"] is True
+        text = result["content"][0]["text"]
+        assert "truncated" in text
+
+    @pytest.mark.asyncio
+    async def test_write_file_with_file_path_passes_through(self):
+        """write_file with file_path present should NOT trigger truncation guard."""
+        called = False
+
+        async def fake_tool_fn(_args: dict) -> dict:
+            nonlocal called
+            called = True
+            return {
+                "content": [{"type": "text", "text": "ok"}],
+                "isError": False,
+            }
+
+        normal_session = MagicMock()
+        normal_session.dry_run = False
+        set_execution_context(user_id="test", session=normal_session, sandbox=None, sdk_cwd="/tmp/test")  # type: ignore[arg-type]
+
+        wrapper = _make_truncating_wrapper(
+            fake_tool_fn,
+            "write_file",
+            input_schema={"required": ["file_path", "content"]},
+        )
+        result = await wrapper({"file_path": "/home/user/f.txt", "content": "data"})
+        assert called
+        assert result["isError"] is False
+
+    @pytest.mark.asyncio
+    async def test_non_write_tool_not_affected(self):
+        """Partial truncation guard only applies to write/edit tools."""
+        called = False
+
+        async def fake_tool_fn(_args: dict) -> dict:
+            nonlocal called
+            called = True
+            return {
+                "content": [{"type": "text", "text": "ok"}],
+                "isError": False,
+            }
+
+        normal_session = MagicMock()
+        normal_session.dry_run = False
+        set_execution_context(user_id="test", session=normal_session, sandbox=None, sdk_cwd="/tmp/test")  # type: ignore[arg-type]
+
+        wrapper = _make_truncating_wrapper(
+            fake_tool_fn,
+            "bash_exec",
+            input_schema={"required": ["command"]},
+        )
+        await wrapper({"content": "some data"})
+        assert called

--- a/autogpt_platform/backend/backend/copilot/tools/workspace_files.py
+++ b/autogpt_platform/backend/backend/copilot/tools/workspace_files.py
@@ -800,14 +800,18 @@ class WriteWorkspaceFileTool(BaseTool):
             if not has_any_content:
                 return ErrorResponse(
                     message=(
-                        "Tool call appears truncated (no arguments received). "
-                        "This happens when the content is too large for a "
-                        "single tool call. Instead of passing content inline, "
-                        "first write the file to the working directory using "
-                        "bash_exec (e.g. cat > /home/user/file.md << 'EOF'... "
-                        "EOF), then use source_path to copy it to workspace: "
-                        "write_workspace_file(filename='file.md', "
-                        "source_path='/home/user/file.md')"
+                        "Your file write was truncated because the content "
+                        "was too large for a single tool call (all arguments "
+                        "were lost). Instead of passing content inline, write "
+                        "the file in sections:\n"
+                        '1. Use bash_exec with \'cat > filename << "EOF"\\n'
+                        "...\\nEOF' for the first section\n"
+                        "2. Use 'cat >> filename << \"EOF\"\\n...\\nEOF' to "
+                        "append more sections\n"
+                        "3. Then use write_workspace_file(filename=..., "
+                        "source_path=...) to save it to workspace\n"
+                        "Do NOT retry with the same approach — it will be "
+                        "truncated again."
                     ),
                     session_id=session_id,
                 )

--- a/autogpt_platform/backend/backend/copilot/tools/workspace_files_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/workspace_files_test.py
@@ -623,3 +623,46 @@ async def test_read_workspace_file_no_fallback_when_resolve_succeeds(setup_test_
     # Normal workspace path must have produced a content response.
     assert isinstance(result, WorkspaceFileContentResponse)
     assert base64.b64decode(result.content_base64) == fake_content
+
+
+# ---------------------------------------------------------------------------
+# Truncation error message (Layer 4 of write-tool-truncation fix)
+# ---------------------------------------------------------------------------
+
+
+class TestWriteTruncationMessage:
+    """When write_workspace_file receives empty args due to API output-token
+    truncation, the error message must give actionable step-by-step guidance."""
+
+    @pytest.mark.asyncio
+    async def test_empty_args_returns_actionable_truncation_message(
+        self, ephemeral_dir
+    ):
+        """Calling write with no args at all should mention cat > and cat >>."""
+        write_tool = WriteWorkspaceFileTool()
+        result = await write_tool._execute(
+            user_id="test-user",
+            session=make_session(),
+            filename=None,  # type: ignore[arg-type]
+        )
+        assert isinstance(result, ErrorResponse)
+        assert "truncated" in result.message.lower()
+        assert "cat >" in result.message
+        assert "cat >>" in result.message
+        assert "source_path" in result.message
+
+    @pytest.mark.asyncio
+    async def test_missing_filename_with_content_gives_simple_error(
+        self, ephemeral_dir
+    ):
+        """When content is present but filename is missing, it's not truncation —
+        just a missing required field."""
+        write_tool = WriteWorkspaceFileTool()
+        result = await write_tool._execute(
+            user_id="test-user",
+            session=make_session(),
+            filename=None,  # type: ignore[arg-type]
+            content="some content",
+        )
+        assert isinstance(result, ErrorResponse)
+        assert "filename" in result.message.lower()


### PR DESCRIPTION
## Summary

- **Layer 1**: Disable the CLI built-in `Write` tool (added to `SDK_DISALLOWED_TOOLS`) so all file writes route through our MCP `write_file` / `write_workspace_file` tools where we control schema validation and error messages
- **Layer 2**: Detect partial truncation in `tool_adapter.py` — when `content`/`new_string` is present but `file_path` is missing, return actionable chunking guidance instead of letting the call fail with an opaque Ajv error
- **Layer 3**: Warn on large inline content (>50K chars) in E2B `write_file` — if the write succeeds but was dangerously close to the truncation threshold, suggest chunking for next time
- **Layer 4**: Improve the `workspace_files.py` truncation error message with step-by-step instructions (`cat >`, `cat >>`, `source_path`)
- **Layer 5**: Strengthen the system prompt guidance about large file writes to be more emphatic about the production failure mode

### Root cause
When the LLM generates a very large `content` argument for a Write tool call, the API output-token limit truncates the response mid-JSON. The CLI's built-in Ajv JSON Schema validator then rejects the truncated arguments with `'file_path' is a required property` — an opaque, unhelpful error. The user's work is lost and the LLM retries with the same approach, failing in a loop.

### Affected sessions
- `1a0ef47f-9711-41d2-91b8-df9dff9ecfc6`
- `2bb9fb0d-05bd-4194-8f3f-88fbe3d8b965`
- `8226d82e-bf9c-48e3-826f-80048d0fb7b4`

## Test plan
- [x] Unit tests for partial-truncation detection in `tool_adapter_test.py` (4 cases: write_file truncated, edit_file truncated, write_file with file_path passes through, non-write tool not affected)
- [x] Unit tests for improved workspace_files truncation error message (empty args, missing filename with content)
- [ ] Verify `ruff check` and `pyright` pass on all modified files
- [ ] Manual test: confirm large inline write_file calls return actionable guidance instead of opaque errors