### PR TITLE
fix(copilot): strip <internal_reasoning> tags from Sonnet response stream

### DIFF
--- a/autogpt_platform/backend/backend/copilot/baseline/service.py
+++ b/autogpt_platform/backend/backend/copilot/baseline/service.py
@@ -26,7 +26,6 @@ from openai.types.chat import ChatCompletionMessageParam, ChatCompletionToolPara
 from opentelemetry import trace as otel_trace
 
 from backend.copilot.config import CopilotMode
-from backend.copilot.thinking_stripper import ThinkingStripper as _ThinkingStripper
 from backend.copilot.context import get_workspace_manager, set_execution_context
 from backend.copilot.db import update_message_content_by_sequence
 from backend.copilot.graphiti.config import is_enabled_for_user
@@ -59,6 +58,7 @@ from backend.copilot.service import (
     _update_title_async,
     config,
 )
+from backend.copilot.thinking_stripper import ThinkingStripper as _ThinkingStripper
 from backend.copilot.token_tracking import persist_and_record_usage
 from backend.copilot.tools import execute_tool, get_available_tools
 from backend.copilot.tracking import track_user_message

--- a/autogpt_platform/backend/backend/copilot/baseline/service.py
+++ b/autogpt_platform/backend/backend/copilot/baseline/service.py
@@ -26,6 +26,7 @@ from openai.types.chat import ChatCompletionMessageParam, ChatCompletionToolPara
 from opentelemetry import trace as otel_trace
 
 from backend.copilot.config import CopilotMode
+from backend.copilot.thinking_stripper import ThinkingStripper as _ThinkingStripper
 from backend.copilot.context import get_workspace_manager, set_execution_context
 from backend.copilot.db import update_message_content_by_sequence
 from backend.copilot.graphiti.config import is_enabled_for_user
@@ -229,98 +230,6 @@ def _resolve_baseline_model(mode: CopilotMode | None) -> str:
     if mode == "fast":
         return config.fast_model
     return config.model
-
-
-# Tag pairs to strip from baseline streaming output.  Different models use
-# different tag names for their internal reasoning (Claude uses <thinking>,
-# Gemini uses <internal_reasoning>, etc.).
-_REASONING_TAG_PAIRS: list[tuple[str, str]] = [
-    ("<thinking>", "</thinking>"),
-    ("<internal_reasoning>", "</internal_reasoning>"),
-]
-
-# Longest opener — used to size the partial-tag buffer.
-_MAX_OPEN_TAG_LEN = max(len(o) for o, _ in _REASONING_TAG_PAIRS)
-
-
-class _ThinkingStripper:
-    """Strip reasoning blocks from a stream of text deltas.
-
-    Handles multiple tag patterns (``<thinking>``, ``<internal_reasoning>``,
-    etc.) so the same stripper works across Claude, Gemini, and other models.
-
-    Buffers just enough characters to detect a tag that may be split
-    across chunks; emits text immediately when no tag is in-flight.
-    Robust to single chunks that open and close a block, multiple
-    blocks per stream, and tags that straddle chunk boundaries.
-    """
-
-    def __init__(self) -> None:
-        self._buffer: str = ""
-        self._in_thinking: bool = False
-        self._close_tag: str = ""  # closing tag for the currently open block
-
-    def _find_open_tag(self) -> tuple[int, str, str]:
-        """Find the earliest opening tag in the buffer.
-
-        Returns (position, open_tag, close_tag) or (-1, "", "") if none.
-        """
-        best_pos = -1
-        best_open = ""
-        best_close = ""
-        for open_tag, close_tag in _REASONING_TAG_PAIRS:
-            pos = self._buffer.find(open_tag)
-            if pos != -1 and (best_pos == -1 or pos < best_pos):
-                best_pos = pos
-                best_open = open_tag
-                best_close = close_tag
-        return best_pos, best_open, best_close
-
-    def process(self, chunk: str) -> str:
-        """Feed a chunk and return the text that is safe to emit now."""
-        self._buffer += chunk
-        out: list[str] = []
-        while self._buffer:
-            if self._in_thinking:
-                end = self._buffer.find(self._close_tag)
-                if end == -1:
-                    keep = len(self._close_tag) - 1
-                    self._buffer = self._buffer[-keep:] if keep else ""
-                    return "".join(out)
-                self._buffer = self._buffer[end + len(self._close_tag) :]
-                self._in_thinking = False
-                self._close_tag = ""
-            else:
-                start, open_tag, close_tag = self._find_open_tag()
-                if start == -1:
-                    # No opening tag; emit everything except a tail that
-                    # could start a partial opener on the next chunk.
-                    safe_end = len(self._buffer)
-                    for keep in range(
-                        min(_MAX_OPEN_TAG_LEN - 1, len(self._buffer)), 0, -1
-                    ):
-                        tail = self._buffer[-keep:]
-                        if any(o[:keep] == tail for o, _ in _REASONING_TAG_PAIRS):
-                            safe_end = len(self._buffer) - keep
-                            break
-                    out.append(self._buffer[:safe_end])
-                    self._buffer = self._buffer[safe_end:]
-                    return "".join(out)
-                out.append(self._buffer[:start])
-                self._buffer = self._buffer[start + len(open_tag) :]
-                self._in_thinking = True
-                self._close_tag = close_tag
-        return "".join(out)
-
-    def flush(self) -> str:
-        """Return any remaining emittable text when the stream ends."""
-        if self._in_thinking:
-            # Unclosed thinking block — discard the buffered reasoning.
-            self._buffer = ""
-            return ""
-        out = self._buffer
-        self._buffer = ""
-        return out
 
 
 @dataclass
@@ -972,16 +881,17 @@ async def stream_chat_completion_baseline(
     # Run download + prompt build concurrently — both are independent I/O
     # on the request critical path.
     if user_id and len(session.messages) > 1:
-        transcript_covers_prefix, (base_system_prompt, understanding) = (
-            await asyncio.gather(
-                _load_prior_transcript(
-                    user_id=user_id,
-                    session_id=session_id,
-                    session_msg_count=len(session.messages),
-                    transcript_builder=transcript_builder,
-                ),
-                prompt_task,
-            )
+        (
+            transcript_covers_prefix,
+            (base_system_prompt, understanding),
+        ) = await asyncio.gather(
+            _load_prior_transcript(
+                user_id=user_id,
+                session_id=session_id,
+                session_msg_count=len(session.messages),
+                transcript_builder=transcript_builder,
+            ),
+            prompt_task,
         )
     else:
         base_system_prompt, understanding = await prompt_task
@@ -1107,7 +1017,7 @@ async def stream_chat_completion_baseline(
         content_text = context.get("content", "")
         if content_text:
             context_hint = (
-                f"\n[The user shared a URL: {url}\n" f"Content:\n{content_text[:8000]}]"
+                f"\n[The user shared a URL: {url}\nContent:\n{content_text[:8000]}]"
             )
         else:
             context_hint = f"\n[The user shared a URL: {url}]"

--- a/autogpt_platform/backend/backend/copilot/baseline/service_unit_test.py
+++ b/autogpt_platform/backend/backend/copilot/baseline/service_unit_test.py
@@ -13,7 +13,6 @@ from backend.copilot.baseline.service import (
     _baseline_conversation_updater,
     _BaselineStreamState,
     _compress_session_messages,
-    _ThinkingStripper,
 )
 from backend.copilot.model import ChatMessage
 from backend.copilot.transcript_builder import TranscriptBuilder
@@ -367,64 +366,6 @@ class TestCompressSessionMessagesPreservesToolCalls:
         assert out[0].tool_calls is not None
         assert out[0].tool_calls[0]["id"] == "t1"
         assert out[1].tool_call_id == "t1"
-
-
-# ---- _ThinkingStripper tests ---- #
-
-
-def test_thinking_stripper_basic_thinking_tag() -> None:
-    """<thinking>...</thinking> blocks are fully stripped."""
-    s = _ThinkingStripper()
-    assert s.process("<thinking>internal reasoning here</thinking>Hello!") == "Hello!"
-
-
-def test_thinking_stripper_internal_reasoning_tag() -> None:
-    """<internal_reasoning>...</internal_reasoning> blocks (Gemini) are stripped."""
-    s = _ThinkingStripper()
-    assert (
-        s.process("<internal_reasoning>step by step</internal_reasoning>Answer")
-        == "Answer"
-    )
-
-
-def test_thinking_stripper_split_across_chunks() -> None:
-    """Tags split across multiple chunks are handled correctly."""
-    s = _ThinkingStripper()
-    out = s.process("Hello <thin")
-    out += s.process("king>secret</thinking> world")
-    assert out == "Hello  world"
-
-
-def test_thinking_stripper_plain_text_preserved() -> None:
-    """Plain text with the word 'thinking' is not stripped."""
-    s = _ThinkingStripper()
-    assert (
-        s.process("I am thinking about this problem")
-        == "I am thinking about this problem"
-    )
-
-
-def test_thinking_stripper_multiple_blocks() -> None:
-    """Multiple reasoning blocks in one stream are all stripped."""
-    s = _ThinkingStripper()
-    result = s.process(
-        "A<thinking>x</thinking>B<internal_reasoning>y</internal_reasoning>C"
-    )
-    assert result == "ABC"
-
-
-def test_thinking_stripper_flush_discards_unclosed() -> None:
-    """Unclosed reasoning block is discarded on flush."""
-    s = _ThinkingStripper()
-    s.process("Start<thinking>never closed")
-    flushed = s.flush()
-    assert "never closed" not in flushed
-
-
-def test_thinking_stripper_empty_block() -> None:
-    """Empty reasoning blocks are handled gracefully."""
-    s = _ThinkingStripper()
-    assert s.process("Before<thinking></thinking>After") == "BeforeAfter"
 
 
 # ---- _filter_tools_by_permissions tests ---- #

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -83,6 +83,7 @@ from ..response_model import (
     StreamStartStep,
     StreamStatus,
     StreamTextDelta,
+    StreamTextEnd,
     StreamToolInputAvailable,
     StreamToolInputStart,
     StreamToolOutputAvailable,
@@ -1743,7 +1744,31 @@ async def _run_stream_attempt(
                 break
 
             # --- Dispatch adapter responses ---
-            for response in state.adapter.convert_message(sdk_msg):
+            adapter_responses = state.adapter.convert_message(sdk_msg)
+            # When StreamFinish is in this batch (ResultMessage), flush any
+            # text buffered by the thinking stripper and inject it as a
+            # StreamTextDelta BEFORE the StreamTextEnd so the Vercel AI SDK
+            # receives the tail inside the still-open text block (correct
+            # protocol order: TextDelta → TextEnd → FinishStep → Finish).
+            if any(isinstance(r, StreamFinish) for r in adapter_responses):
+                tail = acc.thinking_stripper.flush()
+                if tail and not ended_with_stream_error:
+                    acc.assistant_response.content = (
+                        acc.assistant_response.content or ""
+                    ) + tail
+                    tail_delta = StreamTextDelta(
+                        id=state.adapter.text_block_id, delta=tail
+                    )
+                    insert_at = next(
+                        (
+                            i
+                            for i, r in enumerate(adapter_responses)
+                            if isinstance(r, (StreamTextEnd, StreamFinish))
+                        ),
+                        len(adapter_responses),
+                    )
+                    adapter_responses.insert(insert_at, tail_delta)
+            for response in adapter_responses:
                 dispatched = _dispatch_response(
                     response, acc, ctx, state, entries_replaced, ctx.log_prefix
                 )
@@ -1806,16 +1831,6 @@ async def _run_stream_attempt(
                 break
     finally:
         await _safe_close_sdk_client(sdk_client, ctx.log_prefix)
-
-    # --- Flush any text buffered by the thinking stripper ---
-    tail = acc.thinking_stripper.flush()
-    if tail:
-        acc.assistant_response.content = (acc.assistant_response.content or "") + tail
-        # Only yield to the client when the stream succeeded; on error the outer
-        # retry loop rolls back session.messages, so emitting tail would create
-        # a UI-to-session inconsistency (text shown but not persisted).
-        if not ended_with_stream_error:
-            yield StreamTextDelta(id="", delta=tail)
 
     # --- Post-stream processing (only on success) ---
     if state.adapter.has_unresolved_tool_calls:

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -12,7 +12,7 @@ import sys
 import time
 import uuid
 from collections.abc import AsyncGenerator, AsyncIterator
-from dataclasses import dataclass
+from dataclasses import dataclass, field as dataclass_field
 from typing import TYPE_CHECKING, Any, NamedTuple, cast
 
 if TYPE_CHECKING:
@@ -95,6 +95,7 @@ from ..service import (
 from ..token_tracking import persist_and_record_usage
 from ..tools.e2b_sandbox import get_or_create_sandbox, pause_sandbox_direct
 from ..tools.sandbox import WORKSPACE_PREFIX, make_session_path
+from ..thinking_stripper import ThinkingStripper
 from ..tracking import track_user_message
 from .compaction import CompactionTracker, filter_compaction_messages
 from .env import build_sdk_env  # noqa: F401 — re-export for backward compat
@@ -1130,6 +1131,9 @@ class _StreamAccumulator:
     has_appended_assistant: bool = False
     has_tool_results: bool = False
     stream_completed: bool = False
+    thinking_stripper: ThinkingStripper = dataclass_field(
+        default_factory=ThinkingStripper,
+    )
 
 
 def _dispatch_response(
@@ -1186,7 +1190,15 @@ def _dispatch_response(
         )
 
     if isinstance(response, StreamTextDelta):
-        delta = response.delta or ""
+        raw_delta = response.delta or ""
+        # Strip <internal_reasoning> / <thinking> tags that non-extended-
+        # thinking models (e.g. Sonnet) may emit as visible text.
+        delta = acc.thinking_stripper.process(raw_delta)
+        if not delta:
+            # Stripper is buffering a potential tag — suppress this event.
+            return None
+        # Replace the delta with the stripped version for the SSE client.
+        response = StreamTextDelta(id=response.id, delta=delta)
         if acc.has_tool_results and acc.has_appended_assistant:
             acc.assistant_response = ChatMessage(role="assistant", content=delta)
             acc.accumulated_tool_calls = []
@@ -1793,6 +1805,12 @@ async def _run_stream_attempt(
                 break
     finally:
         await _safe_close_sdk_client(sdk_client, ctx.log_prefix)
+
+    # --- Flush any text buffered by the thinking stripper ---
+    tail = acc.thinking_stripper.flush()
+    if tail:
+        acc.assistant_response.content = (acc.assistant_response.content or "") + tail
+        yield StreamTextDelta(id="", delta=tail)
 
     # --- Post-stream processing (only on success) ---
     if state.adapter.has_unresolved_tool_calls:

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -12,7 +12,8 @@ import sys
 import time
 import uuid
 from collections.abc import AsyncGenerator, AsyncIterator
-from dataclasses import dataclass, field as dataclass_field
+from dataclasses import dataclass
+from dataclasses import field as dataclass_field
 from typing import TYPE_CHECKING, Any, NamedTuple, cast
 
 if TYPE_CHECKING:
@@ -92,10 +93,10 @@ from ..service import (
     _is_langfuse_configured,
     _update_title_async,
 )
+from ..thinking_stripper import ThinkingStripper
 from ..token_tracking import persist_and_record_usage
 from ..tools.e2b_sandbox import get_or_create_sandbox, pause_sandbox_direct
 from ..tools.sandbox import WORKSPACE_PREFIX, make_session_path
-from ..thinking_stripper import ThinkingStripper
 from ..tracking import track_user_message
 from .compaction import CompactionTracker, filter_compaction_messages
 from .env import build_sdk_env  # noqa: F401 — re-export for backward compat
@@ -1810,7 +1811,11 @@ async def _run_stream_attempt(
     tail = acc.thinking_stripper.flush()
     if tail:
         acc.assistant_response.content = (acc.assistant_response.content or "") + tail
-        yield StreamTextDelta(id="", delta=tail)
+        # Only yield to the client when the stream succeeded; on error the outer
+        # retry loop rolls back session.messages, so emitting tail would create
+        # a UI-to-session inconsistency (text shown but not persisted).
+        if not ended_with_stream_error:
+            yield StreamTextDelta(id="", delta=tail)
 
     # --- Post-stream processing (only on success) ---
     if state.adapter.has_unresolved_tool_calls:

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -1145,6 +1145,7 @@ def _dispatch_response(
     state: "_RetryState",
     entries_replaced: bool,
     log_prefix: str,
+    skip_strip: bool = False,
 ) -> StreamBaseResponse | None:
     """Process a single adapter response and update session/accumulator state.
 
@@ -1157,6 +1158,10 @@ def _dispatch_response(
     - Accumulating text deltas into `assistant_response`
     - Appending tool input/output to session messages and transcript
     - Detecting `StreamFinish`
+
+    Args:
+        skip_strip: When True, bypass ThinkingStripper.process() for this delta.
+            Used for the flushed tail delta which is already stripped content.
     """
     if isinstance(response, StreamStart):
         return None
@@ -1193,12 +1198,17 @@ def _dispatch_response(
 
     if isinstance(response, StreamTextDelta):
         raw_delta = response.delta or ""
-        # Strip <internal_reasoning> / <thinking> tags that non-extended-
-        # thinking models (e.g. Sonnet) may emit as visible text.
-        delta = acc.thinking_stripper.process(raw_delta)
-        if not delta:
-            # Stripper is buffering a potential tag — suppress this event.
-            return None
+        if skip_strip:
+            # Pre-stripped tail from ThinkingStripper.flush() — bypass process()
+            # to avoid re-suppressing content that looks like a partial tag opener.
+            delta = raw_delta
+        else:
+            # Strip <internal_reasoning> / <thinking> tags that non-extended-
+            # thinking models (e.g. Sonnet) may emit as visible text.
+            delta = acc.thinking_stripper.process(raw_delta)
+            if not delta:
+                # Stripper is buffering a potential tag — suppress this event.
+                return None
         # Replace the delta with the stripped version for the SSE client.
         response = StreamTextDelta(id=response.id, delta=delta)
         if acc.has_tool_results and acc.has_appended_assistant:
@@ -1750,12 +1760,17 @@ async def _run_stream_attempt(
             # StreamTextDelta BEFORE the StreamTextEnd so the Vercel AI SDK
             # receives the tail inside the still-open text block (correct
             # protocol order: TextDelta → TextEnd → FinishStep → Finish).
+            tail_delta: StreamTextDelta | None = None
             if any(isinstance(r, StreamFinish) for r in adapter_responses):
                 tail = acc.thinking_stripper.flush()
                 if tail and not ended_with_stream_error:
-                    acc.assistant_response.content = (
-                        acc.assistant_response.content or ""
-                    ) + tail
+                    # Do NOT manually append tail to acc.assistant_response.content
+                    # here — _dispatch_response handles that.  Doing it here would
+                    # double-append because _dispatch_response also updates the
+                    # accumulator.  Instead, mark the delta as pre-stripped so
+                    # _dispatch_response bypasses ThinkingStripper.process() for it
+                    # (re-processing could suppress a tail that looks like a partial
+                    # tag opener, e.g. "Hello <inter" → buffered again → lost).
                     tail_delta = StreamTextDelta(
                         id=state.adapter.text_block_id, delta=tail
                     )
@@ -1770,7 +1785,13 @@ async def _run_stream_attempt(
                     adapter_responses.insert(insert_at, tail_delta)
             for response in adapter_responses:
                 dispatched = _dispatch_response(
-                    response, acc, ctx, state, entries_replaced, ctx.log_prefix
+                    response,
+                    acc,
+                    ctx,
+                    state,
+                    entries_replaced,
+                    ctx.log_prefix,
+                    skip_strip=response is tail_delta,
                 )
                 if dispatched is not None:
                     yield dispatched

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -37,6 +37,7 @@ from pydantic import BaseModel
 from backend.copilot.context import get_workspace_manager
 from backend.copilot.permissions import apply_tool_permissions
 from backend.copilot.rate_limit import get_user_tier
+from backend.copilot.thinking_stripper import ThinkingStripper
 from backend.copilot.transcript import (
     _run_compression,
     cleanup_stale_project_dirs,
@@ -94,7 +95,6 @@ from ..service import (
     _is_langfuse_configured,
     _update_title_async,
 )
-from ..thinking_stripper import ThinkingStripper
 from ..token_tracking import persist_and_record_usage
 from ..tools.e2b_sandbox import get_or_create_sandbox, pause_sandbox_direct
 from ..tools.sandbox import WORKSPACE_PREFIX, make_session_path

--- a/autogpt_platform/backend/backend/copilot/sdk/thinking_strip_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/thinking_strip_test.py
@@ -7,25 +7,27 @@ stripped from the SSE stream and the persisted assistant message.
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from unittest.mock import MagicMock
 
 from backend.copilot.model import ChatMessage, ChatSession
 from backend.copilot.response_model import StreamTextDelta
-from backend.copilot.sdk.service import (
-    _dispatch_response,
-    _StreamAccumulator,
-)
+from backend.copilot.sdk.service import _dispatch_response, _StreamAccumulator
+
+_NOW = datetime(2024, 1, 1, tzinfo=timezone.utc)
 
 
 def _make_ctx() -> MagicMock:
     """Build a minimal _StreamContext mock."""
     ctx = MagicMock()
     ctx.session = ChatSession(
-        id="test",
+        session_id="test",
+        user_id="test-user",
         title="test",
         messages=[],
-        created_at="",
-        updated_at="",
+        usage=[],
+        started_at=_NOW,
+        updated_at=_NOW,
     )
     ctx.log_prefix = "[test]"
     return ctx

--- a/autogpt_platform/backend/backend/copilot/sdk/thinking_strip_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/thinking_strip_test.py
@@ -183,7 +183,5 @@ class TestDispatchResponseThinkingStrip:
             False,
             "[test]",
         )
-        # Either None (suppressed) or empty delta
-        if result is not None:
-            assert result.delta == ""
+        assert result is None
         assert acc.assistant_response.content == ""

--- a/autogpt_platform/backend/backend/copilot/sdk/thinking_strip_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/thinking_strip_test.py
@@ -1,0 +1,187 @@
+"""Tests for <internal_reasoning> / <thinking> tag stripping in the SDK path.
+
+Covers the ThinkingStripper integration in ``_dispatch_response`` — verifying
+that reasoning tags emitted by non-extended-thinking models (e.g. Sonnet) are
+stripped from the SSE stream and the persisted assistant message.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from backend.copilot.model import ChatMessage, ChatSession
+from backend.copilot.response_model import StreamTextDelta
+from backend.copilot.sdk.service import (
+    _dispatch_response,
+    _StreamAccumulator,
+)
+
+
+def _make_ctx() -> MagicMock:
+    """Build a minimal _StreamContext mock."""
+    ctx = MagicMock()
+    ctx.session = ChatSession(
+        id="test",
+        title="test",
+        messages=[],
+        created_at="",
+        updated_at="",
+    )
+    ctx.log_prefix = "[test]"
+    return ctx
+
+
+def _make_state() -> MagicMock:
+    """Build a minimal _RetryState mock."""
+    state = MagicMock()
+    state.transcript_builder = MagicMock()
+    return state
+
+
+def _make_acc() -> _StreamAccumulator:
+    return _StreamAccumulator(
+        assistant_response=ChatMessage(role="assistant", content=""),
+        accumulated_tool_calls=[],
+    )
+
+
+class TestDispatchResponseThinkingStrip:
+    """Verify _dispatch_response strips reasoning tags from text deltas."""
+
+    def test_internal_reasoning_stripped_from_delta(self) -> None:
+        """Full <internal_reasoning> block in one delta is stripped."""
+        acc = _make_acc()
+        ctx = _make_ctx()
+        state = _make_state()
+
+        response = StreamTextDelta(
+            id="t1",
+            delta="<internal_reasoning>step by step</internal_reasoning>The answer is 42",
+        )
+        result = _dispatch_response(response, acc, ctx, state, False, "[test]")
+
+        assert result is not None
+        assert isinstance(result, StreamTextDelta)
+        assert "internal_reasoning" not in result.delta
+        assert result.delta == "The answer is 42"
+        assert acc.assistant_response.content == "The answer is 42"
+
+    def test_thinking_tag_stripped(self) -> None:
+        """<thinking> blocks are also stripped."""
+        acc = _make_acc()
+        ctx = _make_ctx()
+        state = _make_state()
+
+        response = StreamTextDelta(
+            id="t1",
+            delta="<thinking>hmm</thinking>Hello!",
+        )
+        result = _dispatch_response(response, acc, ctx, state, False, "[test]")
+
+        assert result is not None
+        assert result.delta == "Hello!"
+        assert acc.assistant_response.content == "Hello!"
+
+    def test_partial_tag_buffers(self) -> None:
+        """A partial opening tag causes the delta to be suppressed."""
+        acc = _make_acc()
+        ctx = _make_ctx()
+        state = _make_state()
+
+        # First chunk ends mid-tag — stripper buffers, nothing to emit.
+        r1 = _dispatch_response(
+            StreamTextDelta(id="t1", delta="Hello <inter"),
+            acc,
+            ctx,
+            state,
+            False,
+            "[test]",
+        )
+        # The stripper emits "Hello " but buffers "<inter".
+        # With "Hello " the dispatch should still yield.
+        if r1 is None:
+            # If the entire chunk was buffered, the accumulated content is empty.
+            assert acc.assistant_response.content == ""
+        else:
+            assert "inter" not in r1.delta
+
+        # Second chunk completes the tag + provides visible text.
+        _dispatch_response(
+            StreamTextDelta(
+                id="t1", delta="nal_reasoning>secret</internal_reasoning> world"
+            ),
+            acc,
+            ctx,
+            state,
+            False,
+            "[test]",
+        )
+        content = acc.assistant_response.content or ""
+        tail = acc.thinking_stripper.flush()
+        full = content + tail
+        assert "secret" not in full
+        assert "world" in full
+
+    def test_plain_text_unchanged(self) -> None:
+        """Text without reasoning tags passes through unmodified."""
+        acc = _make_acc()
+        ctx = _make_ctx()
+        state = _make_state()
+
+        response = StreamTextDelta(id="t1", delta="Just normal text")
+        result = _dispatch_response(response, acc, ctx, state, False, "[test]")
+
+        assert result is not None
+        # The stripper may buffer trailing chars that look like tag starts.
+        # Flush to get everything.
+        flushed = acc.thinking_stripper.flush()
+        full = (result.delta or "") + flushed
+        assert full == "Just normal text"
+
+    def test_multi_delta_accumulation(self) -> None:
+        """Multiple clean deltas accumulate correctly."""
+        acc = _make_acc()
+        ctx = _make_ctx()
+        state = _make_state()
+
+        _dispatch_response(
+            StreamTextDelta(id="t1", delta="Hello "),
+            acc,
+            ctx,
+            state,
+            False,
+            "[test]",
+        )
+        _dispatch_response(
+            StreamTextDelta(id="t1", delta="world"),
+            acc,
+            ctx,
+            state,
+            False,
+            "[test]",
+        )
+        tail = acc.thinking_stripper.flush()
+        full = (acc.assistant_response.content or "") + tail
+        assert full == "Hello world"
+
+    def test_reasoning_only_delta_suppressed(self) -> None:
+        """A delta containing only reasoning content emits nothing."""
+        acc = _make_acc()
+        ctx = _make_ctx()
+        state = _make_state()
+
+        result = _dispatch_response(
+            StreamTextDelta(
+                id="t1",
+                delta="<internal_reasoning>all hidden</internal_reasoning>",
+            ),
+            acc,
+            ctx,
+            state,
+            False,
+            "[test]",
+        )
+        # Either None (suppressed) or empty delta
+        if result is not None:
+            assert result.delta == ""
+        assert acc.assistant_response.content == ""

--- a/autogpt_platform/backend/backend/copilot/thinking_stripper.py
+++ b/autogpt_platform/backend/backend/copilot/thinking_stripper.py
@@ -1,0 +1,102 @@
+"""Streaming tag stripper for model reasoning blocks.
+
+Different LLMs wrap internal chain-of-thought in different XML-style tags
+(Claude uses ``<thinking>``, Gemini uses ``<internal_reasoning>``, etc.).
+When extended thinking is **not** enabled, these tags may appear as plain text
+in the response stream and must be stripped before the content reaches the
+user.
+
+The :class:`ThinkingStripper` handles chunk-boundary splitting so it can be
+plugged into any delta-based streaming pipeline.
+"""
+
+from __future__ import annotations
+
+# Tag pairs to strip.  Each entry is (open_tag, close_tag).
+REASONING_TAG_PAIRS: list[tuple[str, str]] = [
+    ("<thinking>", "</thinking>"),
+    ("<internal_reasoning>", "</internal_reasoning>"),
+]
+
+# Longest opener — used to size the partial-tag buffer.
+_MAX_OPEN_TAG_LEN = max(len(o) for o, _ in REASONING_TAG_PAIRS)
+
+
+class ThinkingStripper:
+    """Strip reasoning blocks from a stream of text deltas.
+
+    Handles multiple tag patterns (``<thinking>``, ``<internal_reasoning>``,
+    etc.) so the same stripper works across Claude, Gemini, and other models.
+
+    Buffers just enough characters to detect a tag that may be split
+    across chunks; emits text immediately when no tag is in-flight.
+    Robust to single chunks that open and close a block, multiple
+    blocks per stream, and tags that straddle chunk boundaries.
+    """
+
+    def __init__(self) -> None:
+        self._buffer: str = ""
+        self._in_thinking: bool = False
+        self._close_tag: str = ""  # closing tag for the currently open block
+
+    def _find_open_tag(self) -> tuple[int, str, str]:
+        """Find the earliest opening tag in the buffer.
+
+        Returns (position, open_tag, close_tag) or (-1, "", "") if none.
+        """
+        best_pos = -1
+        best_open = ""
+        best_close = ""
+        for open_tag, close_tag in REASONING_TAG_PAIRS:
+            pos = self._buffer.find(open_tag)
+            if pos != -1 and (best_pos == -1 or pos < best_pos):
+                best_pos = pos
+                best_open = open_tag
+                best_close = close_tag
+        return best_pos, best_open, best_close
+
+    def process(self, chunk: str) -> str:
+        """Feed a chunk and return the text that is safe to emit now."""
+        self._buffer += chunk
+        out: list[str] = []
+        while self._buffer:
+            if self._in_thinking:
+                end = self._buffer.find(self._close_tag)
+                if end == -1:
+                    keep = len(self._close_tag) - 1
+                    self._buffer = self._buffer[-keep:] if keep else ""
+                    return "".join(out)
+                self._buffer = self._buffer[end + len(self._close_tag) :]
+                self._in_thinking = False
+                self._close_tag = ""
+            else:
+                start, open_tag, close_tag = self._find_open_tag()
+                if start == -1:
+                    # No opening tag; emit everything except a tail that
+                    # could start a partial opener on the next chunk.
+                    safe_end = len(self._buffer)
+                    for keep in range(
+                        min(_MAX_OPEN_TAG_LEN - 1, len(self._buffer)), 0, -1
+                    ):
+                        tail = self._buffer[-keep:]
+                        if any(o[:keep] == tail for o, _ in REASONING_TAG_PAIRS):
+                            safe_end = len(self._buffer) - keep
+                            break
+                    out.append(self._buffer[:safe_end])
+                    self._buffer = self._buffer[safe_end:]
+                    return "".join(out)
+                out.append(self._buffer[:start])
+                self._buffer = self._buffer[start + len(open_tag) :]
+                self._in_thinking = True
+                self._close_tag = close_tag
+        return "".join(out)
+
+    def flush(self) -> str:
+        """Return any remaining emittable text when the stream ends."""
+        if self._in_thinking:
+            # Unclosed thinking block — discard the buffered reasoning.
+            self._buffer = ""
+            return ""
+        out = self._buffer
+        self._buffer = ""
+        return out

--- a/autogpt_platform/backend/backend/copilot/thinking_stripper.py
+++ b/autogpt_platform/backend/backend/copilot/thinking_stripper.py
@@ -13,13 +13,13 @@ plugged into any delta-based streaming pipeline.
 from __future__ import annotations
 
 # Tag pairs to strip.  Each entry is (open_tag, close_tag).
-REASONING_TAG_PAIRS: list[tuple[str, str]] = [
+_REASONING_TAG_PAIRS: list[tuple[str, str]] = [
     ("<thinking>", "</thinking>"),
     ("<internal_reasoning>", "</internal_reasoning>"),
 ]
 
 # Longest opener — used to size the partial-tag buffer.
-_MAX_OPEN_TAG_LEN = max(len(o) for o, _ in REASONING_TAG_PAIRS)
+_MAX_OPEN_TAG_LEN = max(len(o) for o, _ in _REASONING_TAG_PAIRS)
 
 
 class ThinkingStripper:
@@ -32,12 +32,17 @@ class ThinkingStripper:
     across chunks; emits text immediately when no tag is in-flight.
     Robust to single chunks that open and close a block, multiple
     blocks per stream, and tags that straddle chunk boundaries.
+    Handles nested same-type tags via a per-tag depth counter so that
+    ``<thinking><thinking>inner</thinking>after</thinking>`` correctly
+    strips both levels and does not leak ``after``.
     """
 
     def __init__(self) -> None:
         self._buffer: str = ""
         self._in_thinking: bool = False
         self._close_tag: str = ""  # closing tag for the currently open block
+        self._open_tag: str = ""  # opening tag for the currently open block
+        self._depth: int = 0  # nesting depth for the current tag type
 
     def _find_open_tag(self) -> tuple[int, str, str]:
         """Find the earliest opening tag in the buffer.
@@ -47,7 +52,7 @@ class ThinkingStripper:
         best_pos = -1
         best_open = ""
         best_close = ""
-        for open_tag, close_tag in REASONING_TAG_PAIRS:
+        for open_tag, close_tag in _REASONING_TAG_PAIRS:
             pos = self._buffer.find(open_tag)
             if pos != -1 and (best_pos == -1 or pos < best_pos):
                 best_pos = pos
@@ -61,14 +66,28 @@ class ThinkingStripper:
         out: list[str] = []
         while self._buffer:
             if self._in_thinking:
-                end = self._buffer.find(self._close_tag)
-                if end == -1:
-                    keep = len(self._close_tag) - 1
+                # Search for both the open and close tags to track nesting.
+                open_pos = self._buffer.find(self._open_tag)
+                close_pos = self._buffer.find(self._close_tag)
+                if close_pos == -1:
+                    # Neither a complete close nor open tag is present; keep
+                    # a tail that could be the start of either tag.
+                    keep = max(len(self._open_tag), len(self._close_tag)) - 1
                     self._buffer = self._buffer[-keep:] if keep else ""
                     return "".join(out)
-                self._buffer = self._buffer[end + len(self._close_tag) :]
-                self._in_thinking = False
-                self._close_tag = ""
+                if open_pos != -1 and open_pos < close_pos:
+                    # A nested open tag appears before the close tag — increase
+                    # depth and skip past the nested opener.
+                    self._depth += 1
+                    self._buffer = self._buffer[open_pos + len(self._open_tag) :]
+                else:
+                    # Close tag is next; decrease depth.
+                    self._buffer = self._buffer[close_pos + len(self._close_tag) :]
+                    self._depth -= 1
+                    if self._depth == 0:
+                        self._in_thinking = False
+                        self._open_tag = ""
+                        self._close_tag = ""
             else:
                 start, open_tag, close_tag = self._find_open_tag()
                 if start == -1:
@@ -79,7 +98,7 @@ class ThinkingStripper:
                         min(_MAX_OPEN_TAG_LEN - 1, len(self._buffer)), 0, -1
                     ):
                         tail = self._buffer[-keep:]
-                        if any(o[:keep] == tail for o, _ in REASONING_TAG_PAIRS):
+                        if any(o[:keep] == tail for o, _ in _REASONING_TAG_PAIRS):
                             safe_end = len(self._buffer) - keep
                             break
                     out.append(self._buffer[:safe_end])
@@ -88,7 +107,9 @@ class ThinkingStripper:
                 out.append(self._buffer[:start])
                 self._buffer = self._buffer[start + len(open_tag) :]
                 self._in_thinking = True
+                self._open_tag = open_tag
                 self._close_tag = close_tag
+                self._depth = 1
         return "".join(out)
 
     def flush(self) -> str:

--- a/autogpt_platform/backend/backend/copilot/thinking_stripper.py
+++ b/autogpt_platform/backend/backend/copilot/thinking_stripper.py
@@ -70,8 +70,15 @@ class ThinkingStripper:
                 open_pos = self._buffer.find(self._open_tag)
                 close_pos = self._buffer.find(self._close_tag)
                 if close_pos == -1:
-                    # Neither a complete close nor open tag is present; keep
-                    # a tail that could be the start of either tag.
+                    # No closing tag yet.  Consume any complete nested open
+                    # tags first so depth stays accurate even when open and
+                    # close tags straddle a chunk boundary.
+                    if open_pos != -1:
+                        self._depth += 1
+                        self._buffer = self._buffer[open_pos + len(self._open_tag) :]
+                        continue
+                    # No complete close or open tag — keep a tail that could
+                    # be the start of either tag.
                     keep = max(len(self._open_tag), len(self._close_tag)) - 1
                     self._buffer = self._buffer[-keep:] if keep else ""
                     return "".join(out)

--- a/autogpt_platform/backend/backend/copilot/thinking_stripper_test.py
+++ b/autogpt_platform/backend/backend/copilot/thinking_stripper_test.py
@@ -1,0 +1,93 @@
+"""Tests for the shared ThinkingStripper."""
+
+from backend.copilot.thinking_stripper import ThinkingStripper
+
+
+def test_basic_thinking_tag() -> None:
+    """<thinking>...</thinking> blocks are fully stripped."""
+    s = ThinkingStripper()
+    assert s.process("<thinking>internal reasoning here</thinking>Hello!") == "Hello!"
+
+
+def test_internal_reasoning_tag() -> None:
+    """<internal_reasoning>...</internal_reasoning> blocks are stripped."""
+    s = ThinkingStripper()
+    assert (
+        s.process("<internal_reasoning>step by step</internal_reasoning>Answer")
+        == "Answer"
+    )
+
+
+def test_split_across_chunks() -> None:
+    """Tags split across multiple chunks are handled correctly."""
+    s = ThinkingStripper()
+    out = s.process("Hello <thin")
+    out += s.process("king>secret</thinking> world")
+    assert out == "Hello  world"
+
+
+def test_plain_text_preserved() -> None:
+    """Plain text with the word 'thinking' is not stripped."""
+    s = ThinkingStripper()
+    assert (
+        s.process("I am thinking about this problem")
+        == "I am thinking about this problem"
+    )
+
+
+def test_multiple_blocks() -> None:
+    """Multiple reasoning blocks in one stream are all stripped."""
+    s = ThinkingStripper()
+    result = s.process(
+        "A<thinking>x</thinking>B<internal_reasoning>y</internal_reasoning>C"
+    )
+    assert result == "ABC"
+
+
+def test_flush_discards_unclosed() -> None:
+    """Unclosed reasoning block is discarded on flush."""
+    s = ThinkingStripper()
+    s.process("Start<thinking>never closed")
+    flushed = s.flush()
+    assert "never closed" not in flushed
+
+
+def test_empty_block() -> None:
+    """Empty reasoning blocks are handled gracefully."""
+    s = ThinkingStripper()
+    assert s.process("Before<thinking></thinking>After") == "BeforeAfter"
+
+
+def test_flush_emits_remaining_plain_text() -> None:
+    """flush() returns any plain text still in the buffer."""
+    s = ThinkingStripper()
+    # The trailing '<' could be a partial tag, so process buffers it.
+    out = s.process("Hello")
+    flushed = s.flush()
+    assert out + flushed == "Hello"
+
+
+def test_internal_reasoning_split_open_tag() -> None:
+    """<internal_reasoning> split across three chunks."""
+    s = ThinkingStripper()
+    out = s.process("OK <inter")
+    out += s.process("nal_reaso")
+    out += s.process("ning>secret stuff</internal_reasoning> visible")
+    out += s.flush()
+    assert out == "OK  visible"
+
+
+def test_no_tags_passthrough() -> None:
+    """Text without any tags passes through unchanged."""
+    s = ThinkingStripper()
+    out = s.process("Hello world, this is fine.")
+    out += s.flush()
+    assert out == "Hello world, this is fine."
+
+
+def test_reasoning_at_end_of_stream() -> None:
+    """Reasoning block at end of stream with no trailing text."""
+    s = ThinkingStripper()
+    out = s.process("Answer<internal_reasoning>my thoughts</internal_reasoning>")
+    out += s.flush()
+    assert out == "Answer"

--- a/autogpt_platform/backend/backend/copilot/thinking_stripper_test.py
+++ b/autogpt_platform/backend/backend/copilot/thinking_stripper_test.py
@@ -91,3 +91,24 @@ def test_reasoning_at_end_of_stream() -> None:
     out = s.process("Answer<internal_reasoning>my thoughts</internal_reasoning>")
     out += s.flush()
     assert out == "Answer"
+
+
+def test_nested_same_type_tags_do_not_leak() -> None:
+    """Nested same-type tags use a depth counter so inner close-tag does not end the block."""
+    s = ThinkingStripper()
+    out = s.process("<thinking><thinking>inner</thinking>after</thinking>final")
+    out += s.flush()
+    assert "inner" not in out
+    assert "after" not in out
+    assert out == "final"
+
+
+def test_nested_tags_split_across_chunks() -> None:
+    """Nested same-type tag nesting tracked correctly across chunk boundaries."""
+    s = ThinkingStripper()
+    out = s.process("<thinking><thin")
+    out += s.process("king>inner</thinking>still_inside</thinking>visible")
+    out += s.flush()
+    assert "inner" not in out
+    assert "still_inside" not in out
+    assert out == "visible"

--- a/autogpt_platform/backend/backend/copilot/thinking_stripper_test.py
+++ b/autogpt_platform/backend/backend/copilot/thinking_stripper_test.py
@@ -112,3 +112,26 @@ def test_nested_tags_split_across_chunks() -> None:
     assert "inner" not in out
     assert "still_inside" not in out
     assert out == "visible"
+
+
+def test_flush_tail_not_re_suppressed_on_next_process() -> None:
+    """Regression: a stream ending with a partial tag opener must survive flush().
+
+    flush() returns the buffered prefix that was withheld because it *might* be
+    the start of a reasoning tag (e.g. "Hello <inter").  After flush() the
+    buffer is empty.  Calling process() on that flushed tail in a fresh context
+    must return it unchanged — the tail is safe plain text, not a live tag.
+    """
+    s = ThinkingStripper()
+    # Stream ends mid-way through a potential tag opener — stripper buffers " <inter".
+    out = s.process("Hello <inter")
+    tail = s.flush()
+    # The full text "Hello <inter" must be delivered.
+    assert out + tail == "Hello <inter"
+    # After flush, the stripper is reset.  Calling process on the flushed tail
+    # (simulating what _dispatch_response does when skip_strip=False) would
+    # re-buffer " <inter" and return "".  This test documents that flush() clears
+    # the buffer so a new process() call starts clean — caller must use skip_strip.
+    s2 = ThinkingStripper()
+    out2 = s2.process("safe text")
+    assert out2 == "safe text"  # unaffected by prior flush

--- a/autogpt_platform/backend/backend/copilot/thinking_stripper_test.py
+++ b/autogpt_platform/backend/backend/copilot/thinking_stripper_test.py
@@ -135,3 +135,24 @@ def test_flush_tail_not_re_suppressed_on_next_process() -> None:
     s2 = ThinkingStripper()
     out2 = s2.process("safe text")
     assert out2 == "safe text"  # unaffected by prior flush
+
+
+def test_nested_open_tag_depth_tracked_across_chunk_boundary() -> None:
+    """Regression: nested open tag in chunk without close tag must increment depth.
+
+    If a chunk contains a complete nested opening tag but no closing tag, the
+    depth counter must still be incremented.  Without the fix, the trim at
+    'close_pos == -1' would discard the nested opener, leaving depth=1.  On
+    the next chunk the first </thinking> decrements depth to 0 and exits
+    thinking mode prematurely, leaking the content after it.
+    """
+    s = ThinkingStripper()
+    # Chunk 1: outer open + nested open (complete), no close yet
+    out = s.process("<thinking>outer<thinking>inner")
+    # Chunk 2: first close ends nested block, second close ends outer block
+    out += s.process("</thinking>middle</thinking>final")
+    out += s.flush()
+    # All reasoning content must be stripped; only "final" is visible
+    assert "inner" not in out
+    assert "middle" not in out
+    assert out == "final"

--- a/autogpt_platform/backend/backend/data/platform_cost_test.py
+++ b/autogpt_platform/backend/backend/data/platform_cost_test.py
@@ -35,7 +35,6 @@ class TestUsdToMicrodollars:
         assert usd_to_microdollars(1.0) == 1_000_000
 
 
-
 class TestMaskEmail:
     def test_typical_email(self):
         assert _mask_email("user@example.com") == "us***@example.com"


### PR DESCRIPTION
## Summary
- Extract `ThinkingStripper` from `baseline/service.py` into a shared `copilot/thinking_stripper.py` module
- Apply thinking-tag stripping to the SDK streaming path (`_dispatch_response`) so `<internal_reasoning>` and `<thinking>` tags emitted by non-extended-thinking models (e.g. Sonnet) are stripped before reaching the SSE client
- Flush any buffered text from the stripper at stream end so no content is lost
- Add unit tests for the shared `ThinkingStripper` and integration tests for the SDK dispatch path

## Problem
When using Claude Sonnet (which doesn't have extended thinking), the model sometimes outputs `<internal_reasoning>...</internal_reasoning>` tags as visible text in the response stream. The baseline path already stripped these, but the SDK path did not.

## Test plan
- [ ] CI passes (unit tests for ThinkingStripper and SDK dispatch stripping)
- [ ] Manual test: send a message via Sonnet and verify no `<internal_reasoning>` tags appear in the response