### PR TITLE
fix(backend): remove extra blank line in platform_cost_test.py

### DIFF
--- a/autogpt_platform/backend/backend/data/platform_cost_test.py
+++ b/autogpt_platform/backend/backend/data/platform_cost_test.py
@@ -35,7 +35,6 @@ class TestUsdToMicrodollars:
         assert usd_to_microdollars(1.0) == 1_000_000
 
 
-
 class TestMaskEmail:
     def test_typical_email(self):
         assert _mask_email("user@example.com") == "us***@example.com"


### PR DESCRIPTION
## Why
`platform_cost_test.py` had an extra blank line between `TestUsdToMicrodollars.test_large_value` and `class TestMaskEmail`, causing black to flag it. This failure was appearing in the CI merge checks of unrelated PRs that target `dev`.

## What
Remove the extra blank line (3 → 2) to satisfy black's formatting rules.

## How
Single-character diff — no logic changes.
