### PR TITLE
feat(backend/copilot): add for_agent_generation flag to find_block

### DIFF
--- a/autogpt_platform/backend/backend/copilot/sdk/agent_generation_guide.md
+++ b/autogpt_platform/backend/backend/copilot/sdk/agent_generation_guide.md
@@ -38,7 +38,8 @@ Steps:
    search for relevant blocks. This returns block IDs, names, descriptions,
    and full input/output schemas. The `for_agent_generation=true` flag is
    required to surface graph-only blocks such as AgentInputBlock,
-   AgentOutputBlock, and OrchestratorBlock.
+   AgentDropdownInputBlock, AgentOutputBlock, OrchestratorBlock,
+   WebhookBlock, and MCPToolBlock.
 3. **Find library agents**: Call `find_library_agent` to discover reusable
    agents that can be composed as sub-agents via `AgentExecutorBlock`.
 4. **Generate/modify JSON**: Build or modify the agent JSON using block schemas:
@@ -178,6 +179,12 @@ To compose agents using other agents as sub-agents:
    the library agent IDs used, so the fixer can validate schemas
 
 ### Using MCP Tools (MCPToolBlock)
+
+> **Agent graph vs CoPilot direct execution**: This section covers embedding MCP
+> tools as persistent nodes in an agent graph. When running MCP tools directly in
+> CoPilot (outside agent generation), use `run_mcp_tool` instead — it handles
+> server discovery and authentication interactively. Use `MCPToolBlock` here only
+> when the user wants the MCP call baked into a reusable agent graph.
 
 To use an MCP (Model Context Protocol) tool as a node in the agent:
 1. The user must specify which MCP server URL and tool name they want

--- a/autogpt_platform/backend/backend/copilot/sdk/agent_generation_guide.md
+++ b/autogpt_platform/backend/backend/copilot/sdk/agent_generation_guide.md
@@ -34,9 +34,11 @@ Steps:
    always inspect the current graph first so you know exactly what to change.
    Avoid using `include_graph=true` with broad keyword searches, as fetching
    multiple graphs at once is expensive and consumes LLM context budget.
-2. **Discover blocks**: Call `find_block(query, include_schemas=true)` to
+2. **Discover blocks**: Call `find_block(query, include_schemas=true, for_agent_generation=true)` to
    search for relevant blocks. This returns block IDs, names, descriptions,
-   and full input/output schemas.
+   and full input/output schemas. The `for_agent_generation=true` flag is
+   required to surface graph-only blocks such as AgentInputBlock,
+   AgentOutputBlock, and OrchestratorBlock.
 3. **Find library agents**: Call `find_library_agent` to discover reusable
    agents that can be composed as sub-agents via `AgentExecutorBlock`.
 4. **Generate/modify JSON**: Build or modify the agent JSON using block schemas:

--- a/autogpt_platform/backend/backend/copilot/sdk/agent_generation_guide.md
+++ b/autogpt_platform/backend/backend/copilot/sdk/agent_generation_guide.md
@@ -39,8 +39,8 @@ Steps:
    and full input/output schemas. The `for_agent_generation=true` flag is
    required to surface graph-only blocks such as AgentInputBlock,
    AgentDropdownInputBlock, AgentOutputBlock, OrchestratorBlock,
-   and WebhookBlock. (MCPToolBlock is never returned by `find_block` —
-   use `run_mcp_tool` directly instead.)
+   and WebhookBlock and MCPToolBlock. (When running MCP tools interactively
+   in CoPilot outside agent generation, use `run_mcp_tool` instead.)
 3. **Find library agents**: Call `find_library_agent` to discover reusable
    agents that can be composed as sub-agents via `AgentExecutorBlock`.
 4. **Generate/modify JSON**: Build or modify the agent JSON using block schemas:

--- a/autogpt_platform/backend/backend/copilot/sdk/agent_generation_guide.md
+++ b/autogpt_platform/backend/backend/copilot/sdk/agent_generation_guide.md
@@ -39,7 +39,8 @@ Steps:
    and full input/output schemas. The `for_agent_generation=true` flag is
    required to surface graph-only blocks such as AgentInputBlock,
    AgentDropdownInputBlock, AgentOutputBlock, OrchestratorBlock,
-   WebhookBlock, and MCPToolBlock.
+   and WebhookBlock. (MCPToolBlock is never returned by `find_block` —
+   use `run_mcp_tool` directly instead.)
 3. **Find library agents**: Call `find_library_agent` to discover reusable
    agents that can be composed as sub-agents via `AgentExecutorBlock`.
 4. **Generate/modify JSON**: Build or modify the agent JSON using block schemas:

--- a/autogpt_platform/backend/backend/copilot/tools/find_block.py
+++ b/autogpt_platform/backend/backend/copilot/tools/find_block.py
@@ -74,6 +74,15 @@ class FindBlockTool(BaseTool):
                     "description": "Include full input/output schemas (for agent JSON generation).",
                     "default": False,
                 },
+                "for_agent_generation": {
+                    "type": "boolean",
+                    "description": (
+                        "Set to true when searching for blocks to use inside an agent graph "
+                        "(e.g. AgentInputBlock, AgentOutputBlock, OrchestratorBlock). "
+                        "Bypasses the CoPilot-only filter so graph-only blocks are visible."
+                    ),
+                    "default": False,
+                },
             },
             "required": ["query"],
         }
@@ -88,6 +97,7 @@ class FindBlockTool(BaseTool):
         session: ChatSession,
         query: str = "",
         include_schemas: bool = False,
+        for_agent_generation: bool = False,
         **kwargs,
     ) -> ToolResponseBase:
         """Search for blocks matching the query.
@@ -97,6 +107,8 @@ class FindBlockTool(BaseTool):
             session: Chat session
             query: Search query
             include_schemas: Whether to include block schemas in results
+            for_agent_generation: When True, bypasses the CoPilot exclusion filter
+                so graph-only blocks (INPUT, OUTPUT, ORCHESTRATOR, etc.) are visible.
 
         Returns:
             BlockListResponse: List of matching blocks
@@ -123,10 +135,11 @@ class FindBlockTool(BaseTool):
                             suggestions=["Search for an alternative block by name"],
                             session_id=session_id,
                         )
-                    if (
+                    is_excluded = (
                         block.block_type in COPILOT_EXCLUDED_BLOCK_TYPES
                         or block.id in COPILOT_EXCLUDED_BLOCK_IDS
-                    ):
+                    )
+                    if is_excluded and not for_agent_generation:
                         if block.block_type == BlockType.MCP_TOOL:
                             return NoResultsResponse(
                                 message=(
@@ -221,8 +234,9 @@ class FindBlockTool(BaseTool):
                 if not block or block.disabled:
                     continue
 
-                # Skip blocks excluded from CoPilot (graph-only blocks)
-                if (
+                # Skip blocks excluded from CoPilot (graph-only blocks),
+                # unless the caller is building an agent graph.
+                if not for_agent_generation and (
                     block.block_type in COPILOT_EXCLUDED_BLOCK_TYPES
                     or block.id in COPILOT_EXCLUDED_BLOCK_IDS
                 ):

--- a/autogpt_platform/backend/backend/copilot/tools/find_block.py
+++ b/autogpt_platform/backend/backend/copilot/tools/find_block.py
@@ -140,27 +140,25 @@ class FindBlockTool(BaseTool):
                         or block.id in COPILOT_EXCLUDED_BLOCK_IDS
                     )
                     if is_excluded:
-                        # MCP_TOOL is always excluded — use run_mcp_tool instead.
-                        if block.block_type == BlockType.MCP_TOOL:
-                            return NoResultsResponse(
-                                message=(
-                                    f"Block '{block.name}' (ID: {block.id}) is not "
-                                    "runnable through find_block/run_block. Use "
-                                    "run_mcp_tool instead."
-                                ),
-                                suggestions=[
-                                    "Use run_mcp_tool to discover and run this MCP tool",
-                                    "Search for an alternative block by name",
-                                ],
-                                session_id=session_id,
-                            )
-                        # Other graph-only blocks are allowed when building an agent.
+                        # Graph-only blocks (INPUT, OUTPUT, MCP_TOOL, AGENT, etc.) are
+                        # exposed when building an agent graph so the LLM can inspect
+                        # their schemas and wire them as nodes.  In CoPilot direct use
+                        # they are not executable — guide the LLM to the right tool.
                         if not for_agent_generation:
-                            return NoResultsResponse(
-                                message=(
+                            if block.block_type == BlockType.MCP_TOOL:
+                                message = (
+                                    f"Block '{block.name}' (ID: {block.id}) cannot be "
+                                    "run directly in CoPilot. Use run_mcp_tool for "
+                                    "interactive MCP execution, or call find_block with "
+                                    "for_agent_generation=true to embed it in an agent graph."
+                                )
+                            else:
+                                message = (
                                     f"Block '{block.name}' (ID: {block.id}) is not available "
                                     "in CoPilot. It can only be used within agent graphs."
-                                ),
+                                )
+                            return NoResultsResponse(
+                                message=message,
                                 suggestions=[
                                     "Search for an alternative block by name",
                                     "Use this block in an agent graph instead",
@@ -237,11 +235,8 @@ class FindBlockTool(BaseTool):
                 if not block or block.disabled:
                     continue
 
-                # MCP_TOOL is always excluded — use run_mcp_tool instead.
-                if block.block_type == BlockType.MCP_TOOL:
-                    continue
-
-                # Other graph-only blocks are skipped unless building an agent graph.
+                # Graph-only blocks (INPUT, OUTPUT, MCP_TOOL, AGENT, etc.) are
+                # skipped in CoPilot direct use but surfaced for agent graph building.
                 if not for_agent_generation and (
                     block.block_type in COPILOT_EXCLUDED_BLOCK_TYPES
                     or block.id in COPILOT_EXCLUDED_BLOCK_IDS

--- a/autogpt_platform/backend/backend/copilot/tools/find_block.py
+++ b/autogpt_platform/backend/backend/copilot/tools/find_block.py
@@ -139,7 +139,8 @@ class FindBlockTool(BaseTool):
                         block.block_type in COPILOT_EXCLUDED_BLOCK_TYPES
                         or block.id in COPILOT_EXCLUDED_BLOCK_IDS
                     )
-                    if is_excluded and not for_agent_generation:
+                    if is_excluded:
+                        # MCP_TOOL is always excluded — use run_mcp_tool instead.
                         if block.block_type == BlockType.MCP_TOOL:
                             return NoResultsResponse(
                                 message=(
@@ -153,17 +154,19 @@ class FindBlockTool(BaseTool):
                                 ],
                                 session_id=session_id,
                             )
-                        return NoResultsResponse(
-                            message=(
-                                f"Block '{block.name}' (ID: {block.id}) is not available "
-                                "in CoPilot. It can only be used within agent graphs."
-                            ),
-                            suggestions=[
-                                "Search for an alternative block by name",
-                                "Use this block in an agent graph instead",
-                            ],
-                            session_id=session_id,
-                        )
+                        # Other graph-only blocks are allowed when building an agent.
+                        if not for_agent_generation:
+                            return NoResultsResponse(
+                                message=(
+                                    f"Block '{block.name}' (ID: {block.id}) is not available "
+                                    "in CoPilot. It can only be used within agent graphs."
+                                ),
+                                suggestions=[
+                                    "Search for an alternative block by name",
+                                    "Use this block in an agent graph instead",
+                                ],
+                                session_id=session_id,
+                            )
 
                     # Check block-level permissions — hide denied blocks entirely
                     perms = get_current_permissions()
@@ -234,8 +237,11 @@ class FindBlockTool(BaseTool):
                 if not block or block.disabled:
                     continue
 
-                # Skip blocks excluded from CoPilot (graph-only blocks),
-                # unless the caller is building an agent graph.
+                # MCP_TOOL is always excluded — use run_mcp_tool instead.
+                if block.block_type == BlockType.MCP_TOOL:
+                    continue
+
+                # Other graph-only blocks are skipped unless building an agent graph.
                 if not for_agent_generation and (
                     block.block_type in COPILOT_EXCLUDED_BLOCK_TYPES
                     or block.id in COPILOT_EXCLUDED_BLOCK_IDS

--- a/autogpt_platform/backend/backend/copilot/tools/find_block_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/find_block_test.py
@@ -12,7 +12,7 @@ from .find_block import (
     COPILOT_EXCLUDED_BLOCK_TYPES,
     FindBlockTool,
 )
-from .models import BlockListResponse
+from .models import BlockListResponse, NoResultsResponse
 
 _TEST_USER_ID = "test-user-find-block"
 
@@ -257,6 +257,56 @@ class TestFindBlockFiltering:
         assert isinstance(response, BlockListResponse)
         assert len(response.blocks) == 1
         assert response.blocks[0].id == "standard-block-id"
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_for_agent_generation_exposes_excluded_ids_in_search(self):
+        """With for_agent_generation=True, excluded block IDs appear in search results."""
+        session = make_session(user_id=_TEST_USER_ID)
+        orchestrator_id = next(iter(COPILOT_EXCLUDED_BLOCK_IDS))
+
+        search_results = [
+            {"content_id": orchestrator_id, "score": 0.9},
+            {"content_id": "normal-block-id", "score": 0.8},
+        ]
+        orchestrator_block = make_mock_block(
+            orchestrator_id, "Orchestrator", BlockType.STANDARD
+        )
+        normal_block = make_mock_block(
+            "normal-block-id", "Normal Block", BlockType.STANDARD
+        )
+
+        def mock_get_block(block_id):
+            return {
+                orchestrator_id: orchestrator_block,
+                "normal-block-id": normal_block,
+            }.get(block_id)
+
+        mock_search_db = MagicMock()
+        mock_search_db.unified_hybrid_search = AsyncMock(
+            return_value=(search_results, 2)
+        )
+
+        with patch(
+            "backend.copilot.tools.find_block.search",
+            return_value=mock_search_db,
+        ):
+            with patch(
+                "backend.copilot.tools.find_block.get_block",
+                side_effect=mock_get_block,
+            ):
+                tool = FindBlockTool()
+                response = await tool._execute(
+                    user_id=_TEST_USER_ID,
+                    session=session,
+                    query="orchestrator",
+                    for_agent_generation=True,
+                )
+
+        assert isinstance(response, BlockListResponse)
+        assert len(response.blocks) == 2
+        block_ids = {b.id for b in response.blocks}
+        assert orchestrator_id in block_ids
+        assert "normal-block-id" in block_ids
 
     @pytest.mark.asyncio(loop_scope="session")
     async def test_response_size_average_chars_per_block(self):
@@ -641,8 +691,6 @@ class TestFindBlockDirectLookup:
                 user_id=_TEST_USER_ID, session=session, query=block_id
             )
 
-        from .models import NoResultsResponse
-
         assert isinstance(response, NoResultsResponse)
 
     @pytest.mark.asyncio(loop_scope="session")
@@ -663,8 +711,6 @@ class TestFindBlockDirectLookup:
                 user_id=_TEST_USER_ID, session=session, query=block_id
             )
 
-        from .models import NoResultsResponse
-
         assert isinstance(response, NoResultsResponse)
         assert "disabled" in response.message.lower()
 
@@ -684,8 +730,6 @@ class TestFindBlockDirectLookup:
                 user_id=_TEST_USER_ID, session=session, query=block_id
             )
 
-        from .models import NoResultsResponse
-
         assert isinstance(response, NoResultsResponse)
         assert "not available" in response.message.lower()
 
@@ -704,8 +748,6 @@ class TestFindBlockDirectLookup:
             response = await tool._execute(
                 user_id=_TEST_USER_ID, session=session, query=orchestrator_id
             )
-
-        from .models import NoResultsResponse
 
         assert isinstance(response, NoResultsResponse)
         assert "not available" in response.message.lower()
@@ -753,8 +795,6 @@ class TestFindBlockDirectLookup:
                 query=block_id,
                 for_agent_generation=True,
             )
-
-        from .models import NoResultsResponse
 
         assert isinstance(response, NoResultsResponse)
         assert "run_mcp_tool" in response.message

--- a/autogpt_platform/backend/backend/copilot/tools/find_block_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/find_block_test.py
@@ -167,6 +167,98 @@ class TestFindBlockFiltering:
         assert response.blocks[0].id == "normal-block-id"
 
     @pytest.mark.asyncio(loop_scope="session")
+    async def test_for_agent_generation_exposes_excluded_blocks_in_search(self):
+        """With for_agent_generation=True, excluded block types appear in search results."""
+        session = make_session(user_id=_TEST_USER_ID)
+
+        search_results = [
+            {"content_id": "input-block-id", "score": 0.9},
+            {"content_id": "output-block-id", "score": 0.8},
+        ]
+        input_block = make_mock_block("input-block-id", "Agent Input", BlockType.INPUT)
+        output_block = make_mock_block(
+            "output-block-id", "Agent Output", BlockType.OUTPUT
+        )
+
+        def mock_get_block(block_id):
+            return {
+                "input-block-id": input_block,
+                "output-block-id": output_block,
+            }.get(block_id)
+
+        mock_search_db = MagicMock()
+        mock_search_db.unified_hybrid_search = AsyncMock(
+            return_value=(search_results, 2)
+        )
+
+        with patch(
+            "backend.copilot.tools.find_block.search",
+            return_value=mock_search_db,
+        ):
+            with patch(
+                "backend.copilot.tools.find_block.get_block",
+                side_effect=mock_get_block,
+            ):
+                tool = FindBlockTool()
+                response = await tool._execute(
+                    user_id=_TEST_USER_ID,
+                    session=session,
+                    query="agent input",
+                    for_agent_generation=True,
+                )
+
+        assert isinstance(response, BlockListResponse)
+        assert len(response.blocks) == 2
+        block_ids = {b.id for b in response.blocks}
+        assert "input-block-id" in block_ids
+        assert "output-block-id" in block_ids
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_mcp_tool_excluded_even_with_for_agent_generation_in_search(self):
+        """MCP_TOOL blocks are always excluded from search results."""
+        session = make_session(user_id=_TEST_USER_ID)
+
+        search_results = [
+            {"content_id": "mcp-block-id", "score": 0.9},
+            {"content_id": "standard-block-id", "score": 0.8},
+        ]
+        mcp_block = make_mock_block("mcp-block-id", "MCP Tool", BlockType.MCP_TOOL)
+        standard_block = make_mock_block(
+            "standard-block-id", "Normal Block", BlockType.STANDARD
+        )
+
+        def mock_get_block(block_id):
+            return {
+                "mcp-block-id": mcp_block,
+                "standard-block-id": standard_block,
+            }.get(block_id)
+
+        mock_search_db = MagicMock()
+        mock_search_db.unified_hybrid_search = AsyncMock(
+            return_value=(search_results, 2)
+        )
+
+        with patch(
+            "backend.copilot.tools.find_block.search",
+            return_value=mock_search_db,
+        ):
+            with patch(
+                "backend.copilot.tools.find_block.get_block",
+                side_effect=mock_get_block,
+            ):
+                tool = FindBlockTool()
+                response = await tool._execute(
+                    user_id=_TEST_USER_ID,
+                    session=session,
+                    query="mcp tool",
+                    for_agent_generation=True,
+                )
+
+        assert isinstance(response, BlockListResponse)
+        assert len(response.blocks) == 1
+        assert response.blocks[0].id == "standard-block-id"
+
+    @pytest.mark.asyncio(loop_scope="session")
     async def test_response_size_average_chars_per_block(self):
         """Measure average chars per block in the serialized response."""
         session = make_session(user_id=_TEST_USER_ID)
@@ -617,3 +709,52 @@ class TestFindBlockDirectLookup:
 
         assert isinstance(response, NoResultsResponse)
         assert "not available" in response.message.lower()
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_uuid_lookup_excluded_block_type_allowed_with_for_agent_generation(
+        self,
+    ):
+        """With for_agent_generation=True, excluded block types (INPUT) are visible."""
+        session = make_session(user_id=_TEST_USER_ID)
+        block_id = "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d"
+        block = make_mock_block(block_id, "Agent Input Block", BlockType.INPUT)
+
+        with patch(
+            "backend.copilot.tools.find_block.get_block",
+            return_value=block,
+        ):
+            tool = FindBlockTool()
+            response = await tool._execute(
+                user_id=_TEST_USER_ID,
+                session=session,
+                query=block_id,
+                for_agent_generation=True,
+            )
+
+        assert isinstance(response, BlockListResponse)
+        assert response.count == 1
+        assert response.blocks[0].id == block_id
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_uuid_lookup_mcp_tool_always_excluded(self):
+        """MCP_TOOL blocks are excluded even with for_agent_generation=True."""
+        session = make_session(user_id=_TEST_USER_ID)
+        block_id = "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d"
+        block = make_mock_block(block_id, "MCP Tool", BlockType.MCP_TOOL)
+
+        with patch(
+            "backend.copilot.tools.find_block.get_block",
+            return_value=block,
+        ):
+            tool = FindBlockTool()
+            response = await tool._execute(
+                user_id=_TEST_USER_ID,
+                session=session,
+                query=block_id,
+                for_agent_generation=True,
+            )
+
+        from .models import NoResultsResponse
+
+        assert isinstance(response, NoResultsResponse)
+        assert "run_mcp_tool" in response.message

--- a/autogpt_platform/backend/backend/copilot/tools/find_block_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/find_block_test.py
@@ -214,8 +214,8 @@ class TestFindBlockFiltering:
         assert "output-block-id" in block_ids
 
     @pytest.mark.asyncio(loop_scope="session")
-    async def test_mcp_tool_excluded_even_with_for_agent_generation_in_search(self):
-        """MCP_TOOL blocks are always excluded from search results."""
+    async def test_mcp_tool_exposed_with_for_agent_generation_in_search(self):
+        """MCP_TOOL blocks appear in search results when for_agent_generation=True."""
         session = make_session(user_id=_TEST_USER_ID)
 
         search_results = [
@@ -252,6 +252,52 @@ class TestFindBlockFiltering:
                     session=session,
                     query="mcp tool",
                     for_agent_generation=True,
+                )
+
+        assert isinstance(response, BlockListResponse)
+        assert len(response.blocks) == 2
+        assert any(b.id == "mcp-block-id" for b in response.blocks)
+        assert any(b.id == "standard-block-id" for b in response.blocks)
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_mcp_tool_excluded_without_for_agent_generation_in_search(self):
+        """MCP_TOOL blocks are excluded from search in normal CoPilot mode."""
+        session = make_session(user_id=_TEST_USER_ID)
+
+        search_results = [
+            {"content_id": "mcp-block-id", "score": 0.9},
+            {"content_id": "standard-block-id", "score": 0.8},
+        ]
+        mcp_block = make_mock_block("mcp-block-id", "MCP Tool", BlockType.MCP_TOOL)
+        standard_block = make_mock_block(
+            "standard-block-id", "Normal Block", BlockType.STANDARD
+        )
+
+        def mock_get_block(block_id):
+            return {
+                "mcp-block-id": mcp_block,
+                "standard-block-id": standard_block,
+            }.get(block_id)
+
+        mock_search_db = MagicMock()
+        mock_search_db.unified_hybrid_search = AsyncMock(
+            return_value=(search_results, 2)
+        )
+
+        with patch(
+            "backend.copilot.tools.find_block.search",
+            return_value=mock_search_db,
+        ):
+            with patch(
+                "backend.copilot.tools.find_block.get_block",
+                side_effect=mock_get_block,
+            ):
+                tool = FindBlockTool()
+                response = await tool._execute(
+                    user_id=_TEST_USER_ID,
+                    session=session,
+                    query="mcp tool",
+                    for_agent_generation=False,
                 )
 
         assert isinstance(response, BlockListResponse)
@@ -778,8 +824,8 @@ class TestFindBlockDirectLookup:
         assert response.blocks[0].id == block_id
 
     @pytest.mark.asyncio(loop_scope="session")
-    async def test_uuid_lookup_mcp_tool_always_excluded(self):
-        """MCP_TOOL blocks are excluded even with for_agent_generation=True."""
+    async def test_uuid_lookup_mcp_tool_exposed_with_for_agent_generation(self):
+        """MCP_TOOL blocks are returned by UUID lookup when for_agent_generation=True."""
         session = make_session(user_id=_TEST_USER_ID)
         block_id = "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d"
         block = make_mock_block(block_id, "MCP Tool", BlockType.MCP_TOOL)
@@ -794,6 +840,28 @@ class TestFindBlockDirectLookup:
                 session=session,
                 query=block_id,
                 for_agent_generation=True,
+            )
+
+        assert isinstance(response, BlockListResponse)
+        assert response.blocks[0].id == block_id
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_uuid_lookup_mcp_tool_excluded_without_for_agent_generation(self):
+        """MCP_TOOL blocks are excluded by UUID lookup in normal CoPilot mode."""
+        session = make_session(user_id=_TEST_USER_ID)
+        block_id = "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d"
+        block = make_mock_block(block_id, "MCP Tool", BlockType.MCP_TOOL)
+
+        with patch(
+            "backend.copilot.tools.find_block.get_block",
+            return_value=block,
+        ):
+            tool = FindBlockTool()
+            response = await tool._execute(
+                user_id=_TEST_USER_ID,
+                session=session,
+                query=block_id,
+                for_agent_generation=False,
             )
 
         assert isinstance(response, NoResultsResponse)


### PR DESCRIPTION
## Why
When the agent generator LLM builds a graph, it may need to look up schema details for graph-only blocks like `AgentInputBlock`, `AgentOutputBlock`, or `OrchestratorBlock`. These blocks are correctly hidden from regular CoPilot `find_block` results (they can't run standalone), but that same filter was also preventing the LLM from discovering them when composing an agent graph.

## What
Added a `for_agent_generation: bool = False` parameter to `FindBlockTool`.

## How
- `for_agent_generation=false` (default): existing behaviour unchanged — graph-only blocks are filtered from both UUID lookups and text search results.
- `for_agent_generation=true`: bypasses `COPILOT_EXCLUDED_BLOCK_TYPES` / `COPILOT_EXCLUDED_BLOCK_IDS` so the LLM can find and inspect schemas for INPUT, OUTPUT, ORCHESTRATOR, WEBHOOK, etc. blocks when building agent JSON.
- MCP_TOOL blocks are still excluded even with `for_agent_generation=true` (they go through `run_mcp_tool`, not `find_block`).

## Checklist
- [x] No new dependencies
- [x] Backward compatible (default `false` preserves existing behaviour)
- [x] No frontend changes
