### PR TITLE
fix(backend/copilot): idempotency guard + frontend dedup fix for duplicate messages

### DIFF
--- a/autogpt_platform/backend/backend/api/features/chat/routes.py
+++ b/autogpt_platform/backend/backend/api/features/chat/routes.py
@@ -1,7 +1,6 @@
 """Chat API routes for chat session management and streaming via SSE."""
 
 import asyncio
-import hashlib
 import logging
 import re
 from collections.abc import AsyncGenerator
@@ -16,6 +15,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from backend.copilot import service as chat_service
 from backend.copilot import stream_registry
+from backend.copilot.message_dedup import acquire_dedup_lock
 from backend.copilot.config import ChatConfig, CopilotMode
 from backend.copilot.db import get_chat_messages_paginated
 from backend.copilot.executor.utils import enqueue_cancel_task, enqueue_copilot_turn
@@ -813,7 +813,7 @@ async def stream_chat_post(
     sanitized_file_ids: list[str] | None = None
     # Capture the original message text BEFORE any mutation (attachment enrichment)
     # so the idempotency hash is stable across retries.
-    _original_message = request.message
+    original_message = request.message
     if request.file_ids and user_id:
         # Filter to valid UUIDs only to prevent DB abuse
         valid_ids = [fid for fid in request.file_ids if _UUID_RE.match(fid)]
@@ -843,31 +843,14 @@ async def stream_chat_post(
                 request.message += files_block
 
     # ── Idempotency guard ────────────────────────────────────────────────────
-    # Prevent duplicate executor tasks from concurrent/retry POSTs (e.g. k8s
-    # rolling-deploy retries, nginx upstream retries, rapid double-clicks).
-    # We set a Redis NX key keyed on session_id + stable message hash. The key
-    # is released only on StreamFinish (turn complete) or on generator error
-    # (allow retry). On client disconnect (GeneratorExit) the key is intentionally
-    # retained because the backend turn is still running — releasing it there
-    # would re-open the duplicate-submit window. The 30 s TTL is the fallback.
-    # We hash the *original* message (before attachment enrichment) plus a
-    # sorted file ID list so the fingerprint is stable across retries.
-    _dedup_key: str | None = None
-    _dedup_redis = None
-    if request.is_user_message and (_original_message or sanitized_file_ids):
-        _sorted_file_ids = ":".join(sorted(sanitized_file_ids or []))
-        _content_hash = hashlib.sha256(
-            f"{session_id}:{_original_message}:{_sorted_file_ids}".encode()
-        ).hexdigest()[:16]
-        _dedup_key = f"chat:msg_dedup:{session_id}:{_content_hash}"
-        _dedup_redis = await get_redis_async()
-        _is_new_msg = await _dedup_redis.set(_dedup_key, "1", ex=30, nx=True)
-        if not _is_new_msg:
-            logger.warning(
-                f"[STREAM] Duplicate user message blocked for session {session_id}, "
-                f"hash={_content_hash} — returning empty SSE",
-                extra={"json_fields": log_meta},
-            )
+    # Blocks duplicate executor tasks from concurrent/retried POSTs.
+    # See backend/copilot/message_dedup.py for the full lifecycle description.
+    dedup_lock = None
+    if request.is_user_message:
+        dedup_lock = await acquire_dedup_lock(
+            session_id, original_message, sanitized_file_ids
+        )
+        if dedup_lock is None and (original_message or sanitized_file_ids):
 
             async def _empty_sse() -> AsyncGenerator[str, None]:
                 yield StreamFinish().to_sse()
@@ -964,11 +947,8 @@ async def stream_chat_post(
 
             if subscriber_queue is None:
                 yield StreamFinish().to_sse()
-                if _dedup_key and _dedup_redis:
-                    try:
-                        await _dedup_redis.delete(_dedup_key)
-                    except Exception:
-                        pass
+                if dedup_lock:
+                    await dedup_lock.release()
                 return
 
             # Read from the subscriber queue and yield to SSE
@@ -1014,11 +994,8 @@ async def stream_chat_post(
                         )
                         # Release dedup key only on true turn completion.
                         # The 30 s TTL is the fallback if this delete fails.
-                        if _dedup_key and _dedup_redis:
-                            try:
-                                await _dedup_redis.delete(_dedup_key)
-                            except Exception:
-                                pass
+                        if dedup_lock:
+                            await dedup_lock.release()
                         break
                 except asyncio.TimeoutError:
                     yield StreamHeartbeat().to_sse()
@@ -1034,7 +1011,7 @@ async def stream_chat_post(
                     }
                 },
             )
-            # Do NOT release the dedup key on client disconnect — the backend
+            # Do NOT release the dedup lock on client disconnect — the backend
             # turn is still running, and releasing here would reopen the window
             # for infra-level retries to create duplicate turns.
             pass  # Client disconnected - background task continues
@@ -1052,12 +1029,9 @@ async def stream_chat_post(
                 code="stream_error",
             ).to_sse()
             yield StreamFinish().to_sse()
-            # Release dedup key — turn failed, allow retry.
-            if _dedup_key and _dedup_redis:
-                try:
-                    await _dedup_redis.delete(_dedup_key)
-                except Exception:
-                    pass
+            # Release dedup lock — turn failed, allow retry.
+            if dedup_lock:
+                await dedup_lock.release()
         finally:
             # Unsubscribe when client disconnects or stream ends
             if subscriber_queue is not None:

--- a/autogpt_platform/backend/backend/api/features/chat/routes.py
+++ b/autogpt_platform/backend/backend/api/features/chat/routes.py
@@ -1,6 +1,7 @@
 """Chat API routes for chat session management and streaming via SSE."""
 
 import asyncio
+import hashlib
 import logging
 import re
 from collections.abc import AsyncGenerator
@@ -837,6 +838,37 @@ async def stream_chat_post(
                     + "\nUse read_workspace_file with the file_id to access file contents."
                 )
                 request.message += files_block
+
+    # ── Idempotency guard ────────────────────────────────────────────────────
+    # Prevent duplicate executor tasks from concurrent/retry POSTs (e.g. k8s
+    # rolling-deploy retries, nginx upstream retries, rapid double-clicks).
+    # We set a Redis NX key keyed on session_id + message hash with a 30 s TTL.
+    # The first POST wins; any subsequent identical POST within the window gets
+    # an empty SSE stream back so the frontend marks the turn done without
+    # creating a ghost response.
+    if request.message and request.is_user_message:
+        _content_hash = hashlib.sha256(
+            f"{session_id}:{request.message}".encode()
+        ).hexdigest()[:16]
+        _dedup_key = f"chat:msg_dedup:{session_id}:{_content_hash}"
+        _redis = await get_redis_async()
+        _is_new_msg = await _redis.set(_dedup_key, "1", ex=30, nx=True)
+        if not _is_new_msg:
+            logger.warning(
+                f"[STREAM] Duplicate user message blocked for session {session_id}, "
+                f"hash={_content_hash} — returning empty SSE",
+                extra={"json_fields": log_meta},
+            )
+
+            async def _empty_sse() -> AsyncGenerator[str, None]:
+                yield StreamFinish().to_sse()
+                yield "data: [DONE]\n\n"
+
+            return StreamingResponse(
+                _empty_sse(),
+                media_type="text/event-stream",
+                headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+            )
 
     # Atomically append user message to session BEFORE creating task to avoid
     # race condition where GET_SESSION sees task as "running" but message isn't

--- a/autogpt_platform/backend/backend/api/features/chat/routes.py
+++ b/autogpt_platform/backend/backend/api/features/chat/routes.py
@@ -859,7 +859,12 @@ async def stream_chat_post(
             return StreamingResponse(
                 _empty_sse(),
                 media_type="text/event-stream",
-                headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+                headers={
+                    "Cache-Control": "no-cache",
+                    "X-Accel-Buffering": "no",
+                    "Connection": "keep-alive",
+                    "x-vercel-ai-ui-message-stream": "v1",
+                },
             )
 
     # Atomically append user message to session BEFORE creating task to avoid

--- a/autogpt_platform/backend/backend/api/features/chat/routes.py
+++ b/autogpt_platform/backend/backend/api/features/chat/routes.py
@@ -946,7 +946,7 @@ async def stream_chat_post(
         # there would reopen the infra-retry duplicate window. The 30 s TTL
         # is the fallback. All other exits (normal finish, early return, error)
         # should release so the user can re-send the same message.
-        release_dedup_on_exit = True
+        release_dedup_lock_on_exit = True
         try:
             # Subscribe from the position we captured before enqueuing
             # This avoids replaying old messages while catching all new ones
@@ -1016,7 +1016,7 @@ async def stream_chat_post(
                     }
                 },
             )
-            release_dedup_on_exit = False
+            release_dedup_lock_on_exit = False
         except Exception as e:
             elapsed = (time_module.perf_counter() - event_gen_start) * 1000
             logger.error(
@@ -1033,7 +1033,7 @@ async def stream_chat_post(
             yield StreamFinish().to_sse()
             # finally releases dedup_lock
         finally:
-            if dedup_lock and release_dedup_on_exit:
+            if dedup_lock and release_dedup_lock_on_exit:
                 await dedup_lock.release()
             # Unsubscribe when client disconnects or stream ends
             if subscriber_queue is not None:

--- a/autogpt_platform/backend/backend/api/features/chat/routes.py
+++ b/autogpt_platform/backend/backend/api/features/chat/routes.py
@@ -842,17 +842,19 @@ async def stream_chat_post(
     # ── Idempotency guard ────────────────────────────────────────────────────
     # Prevent duplicate executor tasks from concurrent/retry POSTs (e.g. k8s
     # rolling-deploy retries, nginx upstream retries, rapid double-clicks).
-    # We set a Redis NX key keyed on session_id + message hash with a 30 s TTL.
-    # The first POST wins; any subsequent identical POST within the window gets
-    # an empty SSE stream back so the frontend marks the turn done without
-    # creating a ghost response.
+    # We set a Redis NX key keyed on session_id + message hash. The key is
+    # deleted in event_generator's finally block so it only lives while the
+    # request is actively being processed — intentional re-sends of the same
+    # text after the turn completes are never blocked.
+    _dedup_key: str | None = None
+    _dedup_redis = None
     if request.message and request.is_user_message:
         _content_hash = hashlib.sha256(
             f"{session_id}:{request.message}".encode()
         ).hexdigest()[:16]
         _dedup_key = f"chat:msg_dedup:{session_id}:{_content_hash}"
-        _redis = await get_redis_async()
-        _is_new_msg = await _redis.set(_dedup_key, "1", ex=30, nx=True)
+        _dedup_redis = await get_redis_async()
+        _is_new_msg = await _dedup_redis.set(_dedup_key, "1", ex=30, nx=True)
         if not _is_new_msg:
             logger.warning(
                 f"[STREAM] Duplicate user message blocked for session {session_id}, "
@@ -1030,6 +1032,15 @@ async def stream_chat_post(
             ).to_sse()
             yield StreamFinish().to_sse()
         finally:
+            # Release the idempotency key so the user can re-send the same
+            # message after this turn completes. The key was only meant to
+            # block infra-level retries during active processing, not to
+            # prevent intentional re-asks indefinitely.
+            if _dedup_key and _dedup_redis:
+                try:
+                    await _dedup_redis.delete(_dedup_key)
+                except Exception:
+                    pass  # Best-effort; the 30 s TTL is the fallback
             # Unsubscribe when client disconnects or stream ends
             if subscriber_queue is not None:
                 try:

--- a/autogpt_platform/backend/backend/api/features/chat/routes.py
+++ b/autogpt_platform/backend/backend/api/features/chat/routes.py
@@ -941,6 +941,12 @@ async def stream_chat_post(
         subscriber_queue = None
         first_chunk_yielded = False
         chunks_yielded = 0
+        # True for every exit path except GeneratorExit (client disconnect).
+        # On disconnect the backend turn is still running — releasing the lock
+        # there would reopen the infra-retry duplicate window. The 30 s TTL
+        # is the fallback. All other exits (normal finish, early return, error)
+        # should release so the user can re-send the same message.
+        release_dedup_on_exit = True
         try:
             # Subscribe from the position we captured before enqueuing
             # This avoids replaying old messages while catching all new ones
@@ -952,9 +958,7 @@ async def stream_chat_post(
 
             if subscriber_queue is None:
                 yield StreamFinish().to_sse()
-                if dedup_lock:
-                    await dedup_lock.release()
-                return
+                return  # finally releases dedup_lock
 
             # Read from the subscriber queue and yield to SSE
             logger.info(
@@ -983,7 +987,6 @@ async def stream_chat_post(
 
                     yield chunk.to_sse()
 
-                    # Check for finish signal
                     if isinstance(chunk, StreamFinish):
                         total_time = time_module.perf_counter() - event_gen_start
                         logger.info(
@@ -997,11 +1000,8 @@ async def stream_chat_post(
                                 }
                             },
                         )
-                        # Release dedup key only on true turn completion.
-                        # The 30 s TTL is the fallback if this delete fails.
-                        if dedup_lock:
-                            await dedup_lock.release()
-                        break
+                        break  # finally releases dedup_lock
+
                 except asyncio.TimeoutError:
                     yield StreamHeartbeat().to_sse()
 
@@ -1016,10 +1016,7 @@ async def stream_chat_post(
                     }
                 },
             )
-            # Do NOT release the dedup lock on client disconnect — the backend
-            # turn is still running, and releasing here would reopen the window
-            # for infra-level retries to create duplicate turns.
-            pass  # Client disconnected - background task continues
+            release_dedup_on_exit = False
         except Exception as e:
             elapsed = (time_module.perf_counter() - event_gen_start) * 1000
             logger.error(
@@ -1034,10 +1031,10 @@ async def stream_chat_post(
                 code="stream_error",
             ).to_sse()
             yield StreamFinish().to_sse()
-            # Release dedup lock — turn failed, allow retry.
-            if dedup_lock:
-                await dedup_lock.release()
+            # finally releases dedup_lock
         finally:
+            if dedup_lock and release_dedup_on_exit:
+                await dedup_lock.release()
             # Unsubscribe when client disconnects or stream ends
             if subscriber_queue is not None:
                 try:

--- a/autogpt_platform/backend/backend/api/features/chat/routes.py
+++ b/autogpt_platform/backend/backend/api/features/chat/routes.py
@@ -15,10 +15,10 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from backend.copilot import service as chat_service
 from backend.copilot import stream_registry
-from backend.copilot.message_dedup import acquire_dedup_lock
 from backend.copilot.config import ChatConfig, CopilotMode
 from backend.copilot.db import get_chat_messages_paginated
 from backend.copilot.executor.utils import enqueue_cancel_task, enqueue_copilot_turn
+from backend.copilot.message_dedup import acquire_dedup_lock
 from backend.copilot.model import (
     ChatMessage,
     ChatSession,

--- a/autogpt_platform/backend/backend/api/features/chat/routes.py
+++ b/autogpt_platform/backend/backend/api/features/chat/routes.py
@@ -811,6 +811,9 @@ async def stream_chat_post(
     # Also sanitise file_ids so only validated, workspace-scoped IDs are
     # forwarded downstream (e.g. to the executor via enqueue_copilot_turn).
     sanitized_file_ids: list[str] | None = None
+    # Capture the original message text BEFORE any mutation (attachment enrichment)
+    # so the idempotency hash is stable across retries.
+    _original_message = request.message
     if request.file_ids and user_id:
         # Filter to valid UUIDs only to prevent DB abuse
         valid_ids = [fid for fid in request.file_ids if _UUID_RE.match(fid)]
@@ -842,15 +845,19 @@ async def stream_chat_post(
     # ── Idempotency guard ────────────────────────────────────────────────────
     # Prevent duplicate executor tasks from concurrent/retry POSTs (e.g. k8s
     # rolling-deploy retries, nginx upstream retries, rapid double-clicks).
-    # We set a Redis NX key keyed on session_id + message hash. The key is
-    # deleted in event_generator's finally block so it only lives while the
-    # request is actively being processed — intentional re-sends of the same
-    # text after the turn completes are never blocked.
+    # We set a Redis NX key keyed on session_id + stable message hash. The key
+    # is released only on StreamFinish (turn complete) or on generator error
+    # (allow retry). On client disconnect (GeneratorExit) the key is intentionally
+    # retained because the backend turn is still running — releasing it there
+    # would re-open the duplicate-submit window. The 30 s TTL is the fallback.
+    # We hash the *original* message (before attachment enrichment) plus a
+    # sorted file ID list so the fingerprint is stable across retries.
     _dedup_key: str | None = None
     _dedup_redis = None
-    if request.message and request.is_user_message:
+    if _original_message and request.is_user_message:
+        _sorted_file_ids = ":".join(sorted(sanitized_file_ids or []))
         _content_hash = hashlib.sha256(
-            f"{session_id}:{request.message}".encode()
+            f"{session_id}:{_original_message}:{_sorted_file_ids}".encode()
         ).hexdigest()[:16]
         _dedup_key = f"chat:msg_dedup:{session_id}:{_content_hash}"
         _dedup_redis = await get_redis_async()
@@ -958,6 +965,11 @@ async def stream_chat_post(
             if subscriber_queue is None:
                 yield StreamFinish().to_sse()
                 yield "data: [DONE]\n\n"
+                if _dedup_key and _dedup_redis:
+                    try:
+                        await _dedup_redis.delete(_dedup_key)
+                    except Exception:
+                        pass
                 return
 
             # Read from the subscriber queue and yield to SSE
@@ -1001,6 +1013,13 @@ async def stream_chat_post(
                                 }
                             },
                         )
+                        # Release dedup key only on true turn completion.
+                        # The 30 s TTL is the fallback if this delete fails.
+                        if _dedup_key and _dedup_redis:
+                            try:
+                                await _dedup_redis.delete(_dedup_key)
+                            except Exception:
+                                pass
                         break
                 except asyncio.TimeoutError:
                     yield StreamHeartbeat().to_sse()
@@ -1016,6 +1035,9 @@ async def stream_chat_post(
                     }
                 },
             )
+            # Do NOT release the dedup key on client disconnect — the backend
+            # turn is still running, and releasing here would reopen the window
+            # for infra-level retries to create duplicate turns.
             pass  # Client disconnected - background task continues
         except Exception as e:
             elapsed = (time_module.perf_counter() - event_gen_start) * 1000
@@ -1031,16 +1053,13 @@ async def stream_chat_post(
                 code="stream_error",
             ).to_sse()
             yield StreamFinish().to_sse()
-        finally:
-            # Release the idempotency key so the user can re-send the same
-            # message after this turn completes. The key was only meant to
-            # block infra-level retries during active processing, not to
-            # prevent intentional re-asks indefinitely.
+            # Release dedup key — turn failed, allow retry.
             if _dedup_key and _dedup_redis:
                 try:
                     await _dedup_redis.delete(_dedup_key)
                 except Exception:
-                    pass  # Best-effort; the 30 s TTL is the fallback
+                    pass
+        finally:
             # Unsubscribe when client disconnects or stream ends
             if subscriber_queue is not None:
                 try:

--- a/autogpt_platform/backend/backend/api/features/chat/routes.py
+++ b/autogpt_platform/backend/backend/api/features/chat/routes.py
@@ -854,7 +854,7 @@ async def stream_chat_post(
     # sorted file ID list so the fingerprint is stable across retries.
     _dedup_key: str | None = None
     _dedup_redis = None
-    if _original_message and request.is_user_message:
+    if request.is_user_message and (_original_message or sanitized_file_ids):
         _sorted_file_ids = ":".join(sorted(sanitized_file_ids or []))
         _content_hash = hashlib.sha256(
             f"{session_id}:{_original_message}:{_sorted_file_ids}".encode()
@@ -964,7 +964,6 @@ async def stream_chat_post(
 
             if subscriber_queue is None:
                 yield StreamFinish().to_sse()
-                yield "data: [DONE]\n\n"
                 if _dedup_key and _dedup_redis:
                     try:
                         await _dedup_redis.delete(_dedup_key)

--- a/autogpt_platform/backend/backend/api/features/chat/routes.py
+++ b/autogpt_platform/backend/backend/api/features/chat/routes.py
@@ -871,62 +871,70 @@ async def stream_chat_post(
     # race condition where GET_SESSION sees task as "running" but message isn't
     # saved yet.  append_and_save_message re-fetches inside a lock to prevent
     # message loss from concurrent requests.
-    if request.message:
-        message = ChatMessage(
-            role="user" if request.is_user_message else "assistant",
-            content=request.message,
-        )
-        if request.is_user_message:
-            track_user_message(
-                user_id=user_id,
-                session_id=session_id,
-                message_length=len(request.message),
+    #
+    # If any of these operations raises, release the dedup lock before propagating
+    # so subsequent retries are not blocked for 30 s.
+    try:
+        if request.message:
+            message = ChatMessage(
+                role="user" if request.is_user_message else "assistant",
+                content=request.message,
             )
-        logger.info(f"[STREAM] Saving user message to session {session_id}")
-        await append_and_save_message(session_id, message)
-        logger.info(f"[STREAM] User message saved for session {session_id}")
+            if request.is_user_message:
+                track_user_message(
+                    user_id=user_id,
+                    session_id=session_id,
+                    message_length=len(request.message),
+                )
+            logger.info(f"[STREAM] Saving user message to session {session_id}")
+            await append_and_save_message(session_id, message)
+            logger.info(f"[STREAM] User message saved for session {session_id}")
 
-    # Create a task in the stream registry for reconnection support
-    turn_id = str(uuid4())
-    log_meta["turn_id"] = turn_id
+        # Create a task in the stream registry for reconnection support
+        turn_id = str(uuid4())
+        log_meta["turn_id"] = turn_id
 
-    session_create_start = time.perf_counter()
-    await stream_registry.create_session(
-        session_id=session_id,
-        user_id=user_id,
-        tool_call_id="chat_stream",
-        tool_name="chat",
-        turn_id=turn_id,
-    )
-    logger.info(
-        f"[TIMING] create_session completed in {(time.perf_counter() - session_create_start) * 1000:.1f}ms",
-        extra={
-            "json_fields": {
-                **log_meta,
-                "duration_ms": (time.perf_counter() - session_create_start) * 1000,
-            }
-        },
-    )
+        session_create_start = time.perf_counter()
+        await stream_registry.create_session(
+            session_id=session_id,
+            user_id=user_id,
+            tool_call_id="chat_stream",
+            tool_name="chat",
+            turn_id=turn_id,
+        )
+        logger.info(
+            f"[TIMING] create_session completed in {(time.perf_counter() - session_create_start) * 1000:.1f}ms",
+            extra={
+                "json_fields": {
+                    **log_meta,
+                    "duration_ms": (time.perf_counter() - session_create_start) * 1000,
+                }
+            },
+        )
 
-    # Per-turn stream is always fresh (unique turn_id), subscribe from beginning
-    subscribe_from_id = "0-0"
-
-    await enqueue_copilot_turn(
-        session_id=session_id,
-        user_id=user_id,
-        message=request.message,
-        turn_id=turn_id,
-        is_user_message=request.is_user_message,
-        context=request.context,
-        file_ids=sanitized_file_ids,
-        mode=request.mode,
-    )
+        await enqueue_copilot_turn(
+            session_id=session_id,
+            user_id=user_id,
+            message=request.message,
+            turn_id=turn_id,
+            is_user_message=request.is_user_message,
+            context=request.context,
+            file_ids=sanitized_file_ids,
+            mode=request.mode,
+        )
+    except Exception:
+        if dedup_lock:
+            await dedup_lock.release()
+        raise
 
     setup_time = (time.perf_counter() - stream_start_time) * 1000
     logger.info(
         f"[TIMING] Task enqueued to RabbitMQ, setup={setup_time:.1f}ms",
         extra={"json_fields": {**log_meta, "setup_time_ms": setup_time}},
     )
+
+    # Per-turn stream is always fresh (unique turn_id), subscribe from beginning
+    subscribe_from_id = "0-0"
 
     # SSE endpoint that subscribes to the task's stream
     async def event_generator() -> AsyncGenerator[str, None]:

--- a/autogpt_platform/backend/backend/api/features/chat/routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/chat/routes_test.py
@@ -134,7 +134,7 @@ def test_stream_chat_rejects_too_many_file_ids():
 
 
 def _mock_stream_internals(
-    mocker: pytest_mock.MockFixture,
+    mocker: pytest_mock.MockerFixture,
     *,
     redis_set_returns: object = True,
 ):
@@ -145,12 +145,18 @@ def _mock_stream_internals(
         redis_set_returns: Value returned by the mocked Redis ``set`` call.
             ``True`` (default) simulates a fresh key (new message);
             ``None`` simulates a collision (duplicate blocked).
+
+    Returns:
+        A namespace with ``redis``, ``save``, and ``enqueue`` mock objects so
+        callers can make additional assertions about side-effects.
     """
+    import types
+
     mocker.patch(
         "backend.api.features.chat.routes._validate_and_get_session",
         return_value=None,
     )
-    mocker.patch(
+    mock_save = mocker.patch(
         "backend.api.features.chat.routes.append_and_save_message",
         return_value=None,
     )
@@ -160,7 +166,7 @@ def _mock_stream_internals(
         "backend.api.features.chat.routes.stream_registry",
         mock_registry,
     )
-    mocker.patch(
+    mock_enqueue = mocker.patch(
         "backend.api.features.chat.routes.enqueue_copilot_turn",
         return_value=None,
     )
@@ -175,10 +181,11 @@ def _mock_stream_internals(
         new_callable=AsyncMock,
         return_value=mock_redis,
     )
-    return mock_redis
+    ns = types.SimpleNamespace(redis=mock_redis, save=mock_save, enqueue=mock_enqueue)
+    return ns
 
 
-def test_stream_chat_accepts_20_file_ids(mocker: pytest_mock.MockFixture):
+def test_stream_chat_accepts_20_file_ids(mocker: pytest_mock.MockerFixture):
     """Exactly 20 file_ids should be accepted (not rejected by validation)."""
     _mock_stream_internals(mocker)
     # Patch workspace lookup as imported by the routes module
@@ -207,7 +214,7 @@ def test_stream_chat_accepts_20_file_ids(mocker: pytest_mock.MockFixture):
 # ─── UUID format filtering ─────────────────────────────────────────────
 
 
-def test_file_ids_filters_invalid_uuids(mocker: pytest_mock.MockFixture):
+def test_file_ids_filters_invalid_uuids(mocker: pytest_mock.MockerFixture):
     """Non-UUID strings in file_ids should be silently filtered out
     and NOT passed to the database query."""
     _mock_stream_internals(mocker)
@@ -246,7 +253,7 @@ def test_file_ids_filters_invalid_uuids(mocker: pytest_mock.MockFixture):
 # ─── Cross-workspace file_ids ─────────────────────────────────────────
 
 
-def test_file_ids_scoped_to_workspace(mocker: pytest_mock.MockFixture):
+def test_file_ids_scoped_to_workspace(mocker: pytest_mock.MockerFixture):
     """The batch query should scope to the user's workspace."""
     _mock_stream_internals(mocker)
     mocker.patch(
@@ -275,7 +282,7 @@ def test_file_ids_scoped_to_workspace(mocker: pytest_mock.MockFixture):
 # ─── Rate limit → 429 ─────────────────────────────────────────────────
 
 
-def test_stream_chat_returns_429_on_daily_rate_limit(mocker: pytest_mock.MockFixture):
+def test_stream_chat_returns_429_on_daily_rate_limit(mocker: pytest_mock.MockerFixture):
     """When check_rate_limit raises RateLimitExceeded for daily limit the endpoint returns 429."""
     from backend.copilot.rate_limit import RateLimitExceeded
 
@@ -296,7 +303,9 @@ def test_stream_chat_returns_429_on_daily_rate_limit(mocker: pytest_mock.MockFix
     assert "daily" in response.json()["detail"].lower()
 
 
-def test_stream_chat_returns_429_on_weekly_rate_limit(mocker: pytest_mock.MockFixture):
+def test_stream_chat_returns_429_on_weekly_rate_limit(
+    mocker: pytest_mock.MockerFixture,
+):
     """When check_rate_limit raises RateLimitExceeded for weekly limit the endpoint returns 429."""
     from backend.copilot.rate_limit import RateLimitExceeded
 
@@ -319,7 +328,7 @@ def test_stream_chat_returns_429_on_weekly_rate_limit(mocker: pytest_mock.MockFi
     assert "resets in" in detail
 
 
-def test_stream_chat_429_includes_reset_time(mocker: pytest_mock.MockFixture):
+def test_stream_chat_429_includes_reset_time(mocker: pytest_mock.MockerFixture):
     """The 429 response detail should include the human-readable reset time."""
     from backend.copilot.rate_limit import RateLimitExceeded
 
@@ -701,13 +710,13 @@ class TestStripInjectedContext:
 
 
 def test_stream_chat_blocks_duplicate_post_returns_empty_sse(
-    mocker: pytest_mock.MockFixture,
+    mocker: pytest_mock.MockerFixture,
 ) -> None:
     """A second POST with the same message within the 30-s window must return
     an empty SSE stream (StreamFinish + [DONE]) so the frontend marks the
     turn complete without creating a ghost response."""
     # redis_set_returns=None simulates a collision: the NX key already exists.
-    _mock_stream_internals(mocker, redis_set_returns=None)
+    ns = _mock_stream_internals(mocker, redis_set_returns=None)
 
     response = client.post(
         "/sessions/sess-dup/stream",
@@ -719,14 +728,17 @@ def test_stream_chat_blocks_duplicate_post_returns_empty_sse(
     # The response must contain StreamFinish (type=finish) and the SSE [DONE] terminator.
     assert '"finish"' in body
     assert "[DONE]" in body
+    # The duplicate guard must prevent save/enqueue side effects.
+    ns.save.assert_not_called()
+    ns.enqueue.assert_not_called()
 
 
 def test_stream_chat_first_post_proceeds_normally(
-    mocker: pytest_mock.MockFixture,
+    mocker: pytest_mock.MockerFixture,
 ) -> None:
     """The first POST (Redis NX key set successfully) must proceed through the
     normal streaming path — no early return."""
-    mock_redis = _mock_stream_internals(mocker, redis_set_returns=True)
+    ns = _mock_stream_internals(mocker, redis_set_returns=True)
 
     response = client.post(
         "/sessions/sess-new/stream",
@@ -735,17 +747,17 @@ def test_stream_chat_first_post_proceeds_normally(
 
     assert response.status_code == 200
     # Redis set must have been called once with the NX flag.
-    mock_redis.set.assert_called_once()
-    call_kwargs = mock_redis.set.call_args
+    ns.redis.set.assert_called_once()
+    call_kwargs = ns.redis.set.call_args
     assert call_kwargs.kwargs.get("nx") is True
 
 
 def test_stream_chat_dedup_skipped_for_non_user_messages(
-    mocker: pytest_mock.MockFixture,
+    mocker: pytest_mock.MockerFixture,
 ) -> None:
     """System/assistant messages (is_user_message=False) bypass the dedup
     guard — they are injected programmatically and must always be processed."""
-    mock_redis = _mock_stream_internals(mocker, redis_set_returns=None)
+    ns = _mock_stream_internals(mocker, redis_set_returns=None)
 
     response = client.post(
         "/sessions/sess-sys/stream",
@@ -755,31 +767,61 @@ def test_stream_chat_dedup_skipped_for_non_user_messages(
     # Even though redis_set_returns=None (would block a user message),
     # the endpoint must proceed because is_user_message=False.
     assert response.status_code == 200
-    mock_redis.set.assert_not_called()
+    ns.redis.set.assert_not_called()
 
 
 def test_stream_chat_dedup_hash_uses_original_message_not_mutated(
-    mocker: pytest_mock.MockFixture,
+    mocker: pytest_mock.MockerFixture,
 ) -> None:
     """The dedup hash must be computed from the original request message,
     not the mutated version that has the [Attached files] block appended.
-    This ensures retries with the same text + same files produce the same key."""
+    A file_id is sent so the route actually appends the [Attached files] block,
+    exercising the mutation path — the hash must still match the original text."""
     import hashlib
 
-    mock_redis = _mock_stream_internals(mocker, redis_set_returns=True)
+    ns = _mock_stream_internals(mocker, redis_set_returns=True)
+
+    file_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    # Mock workspace + prisma so the attachment block is actually appended.
+    mocker.patch(
+        "backend.api.features.chat.routes.get_or_create_workspace",
+        return_value=type("W", (), {"id": "ws-1"})(),
+    )
+    fake_file = type(
+        "F",
+        (),
+        {
+            "id": file_id,
+            "name": "doc.pdf",
+            "mimeType": "application/pdf",
+            "sizeBytes": 1024,
+        },
+    )()
+    mock_prisma = mocker.MagicMock()
+    mock_prisma.find_many = mocker.AsyncMock(return_value=[fake_file])
+    mocker.patch(
+        "prisma.models.UserWorkspaceFile.prisma",
+        return_value=mock_prisma,
+    )
 
     response = client.post(
         "/sessions/sess-hash/stream",
-        json={"message": "plain message", "is_user_message": True},
+        json={
+            "message": "plain message",
+            "is_user_message": True,
+            "file_ids": [file_id],
+        },
     )
 
     assert response.status_code == 200
-    mock_redis.set.assert_called_once()
-    call_args = mock_redis.set.call_args
+    ns.redis.set.assert_called_once()
+    call_args = ns.redis.set.call_args
     dedup_key = call_args.args[0]
 
-    # Recompute the expected hash using only the original message and no file IDs
-    expected_hash = hashlib.sha256("sess-hash:plain message:".encode()).hexdigest()[:16]
+    # Hash must use the original message + sorted file IDs, not the mutated text.
+    expected_hash = hashlib.sha256(
+        f"sess-hash:plain message:{file_id}".encode()
+    ).hexdigest()[:16]
     expected_key = f"chat:msg_dedup:sess-hash:{expected_hash}"
     assert dedup_key == expected_key, (
         f"Dedup key {dedup_key!r} does not match expected {expected_key!r} — "
@@ -788,7 +830,7 @@ def test_stream_chat_dedup_hash_uses_original_message_not_mutated(
 
 
 def test_stream_chat_dedup_key_released_after_stream_finish(
-    mocker: pytest_mock.MockFixture,
+    mocker: pytest_mock.MockerFixture,
 ) -> None:
     """The dedup Redis key must be deleted after the turn completes (when
     subscriber_queue is None the route yields StreamFinish immediately and
@@ -841,7 +883,7 @@ def test_stream_chat_dedup_key_released_after_stream_finish(
 
 
 def test_stream_chat_dedup_key_released_even_when_redis_delete_raises(
-    mocker: pytest_mock.MockFixture,
+    mocker: pytest_mock.MockerFixture,
 ) -> None:
     """The route must not crash when the dedup Redis delete fails on the
     subscriber_queue-is-None early-finish path (except Exception: pass)."""
@@ -888,3 +930,5 @@ def test_stream_chat_dedup_key_released_even_when_redis_delete_raises(
 
     assert response.status_code == 200
     assert '"finish"' in response.text
+    # delete must have been attempted — the except-pass branch silenced the error.
+    mock_redis.delete.assert_called_once()

--- a/autogpt_platform/backend/backend/api/features/chat/routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/chat/routes_test.py
@@ -177,7 +177,7 @@ def _mock_stream_internals(
     mock_redis = AsyncMock()
     mock_redis.set = AsyncMock(return_value=redis_set_returns)
     mocker.patch(
-        "backend.api.features.chat.routes.get_redis_async",
+        "backend.copilot.message_dedup.get_redis_async",
         new_callable=AsyncMock,
         return_value=mock_redis,
     )
@@ -865,7 +865,7 @@ def test_stream_chat_dedup_key_released_after_stream_finish(
     mock_redis = mocker.AsyncMock()
     mock_redis.set = _AsyncMock(return_value=True)
     mocker.patch(
-        "backend.api.features.chat.routes.get_redis_async",
+        "backend.copilot.message_dedup.get_redis_async",
         new_callable=_AsyncMock,
         return_value=mock_redis,
     )
@@ -917,7 +917,7 @@ def test_stream_chat_dedup_key_released_even_when_redis_delete_raises(
     # Make the delete raise so the except-pass branch is exercised.
     mock_redis.delete = _AsyncMock(side_effect=RuntimeError("redis gone"))
     mocker.patch(
-        "backend.api.features.chat.routes.get_redis_async",
+        "backend.copilot.message_dedup.get_redis_async",
         new_callable=_AsyncMock,
         return_value=mock_redis,
     )

--- a/autogpt_platform/backend/backend/api/features/chat/routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/chat/routes_test.py
@@ -133,9 +133,19 @@ def test_stream_chat_rejects_too_many_file_ids():
     assert response.status_code == 422
 
 
-def _mock_stream_internals(mocker: pytest_mock.MockFixture):
+def _mock_stream_internals(
+    mocker: pytest_mock.MockFixture,
+    *,
+    redis_set_returns: object = True,
+):
     """Mock the async internals of stream_chat_post so tests can exercise
-    validation and enrichment logic without needing Redis/RabbitMQ."""
+    validation and enrichment logic without needing Redis/RabbitMQ.
+
+    Args:
+        redis_set_returns: Value returned by the mocked Redis ``set`` call.
+            ``True`` (default) simulates a fresh key (new message);
+            ``None`` simulates a collision (duplicate blocked).
+    """
     mocker.patch(
         "backend.api.features.chat.routes._validate_and_get_session",
         return_value=None,
@@ -158,6 +168,14 @@ def _mock_stream_internals(mocker: pytest_mock.MockFixture):
         "backend.api.features.chat.routes.track_user_message",
         return_value=None,
     )
+    mock_redis = AsyncMock()
+    mock_redis.set = AsyncMock(return_value=redis_set_returns)
+    mocker.patch(
+        "backend.api.features.chat.routes.get_redis_async",
+        new_callable=AsyncMock,
+        return_value=mock_redis,
+    )
+    return mock_redis
 
 
 def test_stream_chat_accepts_20_file_ids(mocker: pytest_mock.MockFixture):
@@ -677,3 +695,66 @@ class TestStripInjectedContext:
         result = _strip_injected_context(msg)
         # Without a role, the helper short-circuits without touching content.
         assert result["content"] == "hello"
+
+
+# ─── Idempotency / duplicate-POST guard ──────────────────────────────
+
+
+def test_stream_chat_blocks_duplicate_post_returns_empty_sse(
+    mocker: pytest_mock.MockFixture,
+) -> None:
+    """A second POST with the same message within the 30-s window must return
+    an empty SSE stream (StreamFinish + [DONE]) so the frontend marks the
+    turn complete without creating a ghost response."""
+    # redis_set_returns=None simulates a collision: the NX key already exists.
+    _mock_stream_internals(mocker, redis_set_returns=None)
+
+    response = client.post(
+        "/sessions/sess-dup/stream",
+        json={"message": "duplicate message", "is_user_message": True},
+    )
+
+    assert response.status_code == 200
+    body = response.text
+    # The response must contain StreamFinish (type=finish) and the SSE [DONE] terminator.
+    assert '"finish"' in body
+    assert "[DONE]" in body
+
+
+def test_stream_chat_first_post_proceeds_normally(
+    mocker: pytest_mock.MockFixture,
+) -> None:
+    """The first POST (Redis NX key set successfully) must proceed through the
+    normal streaming path — no early return."""
+    mock_redis = _mock_stream_internals(mocker, redis_set_returns=True)
+
+    response = client.post(
+        "/sessions/sess-new/stream",
+        json={"message": "first message", "is_user_message": True},
+    )
+
+    assert response.status_code == 200
+    # Redis set must have been called once with the NX flag.
+    mock_redis.set.assert_called_once()
+    call_kwargs = mock_redis.set.call_args
+    assert call_kwargs.kwargs.get("nx") is True or (
+        len(call_kwargs.args) > 3 and call_kwargs.args[3] is True
+    )
+
+
+def test_stream_chat_dedup_skipped_for_non_user_messages(
+    mocker: pytest_mock.MockFixture,
+) -> None:
+    """System/assistant messages (is_user_message=False) bypass the dedup
+    guard — they are injected programmatically and must always be processed."""
+    mock_redis = _mock_stream_internals(mocker, redis_set_returns=None)
+
+    response = client.post(
+        "/sessions/sess-sys/stream",
+        json={"message": "system context", "is_user_message": False},
+    )
+
+    # Even though redis_set_returns=None (would block a user message),
+    # the endpoint must proceed because is_user_message=False.
+    assert response.status_code == 200
+    mock_redis.set.assert_not_called()

--- a/autogpt_platform/backend/backend/api/features/chat/routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/chat/routes_test.py
@@ -838,3 +838,53 @@ def test_stream_chat_dedup_key_released_after_stream_finish(
     assert '"finish"' in body
     # The dedup key must be released so intentional re-sends are allowed.
     mock_redis.delete.assert_called_once()
+
+
+def test_stream_chat_dedup_key_released_even_when_redis_delete_raises(
+    mocker: pytest_mock.MockFixture,
+) -> None:
+    """The route must not crash when the dedup Redis delete fails on the
+    subscriber_queue-is-None early-finish path (except Exception: pass)."""
+    from unittest.mock import AsyncMock as _AsyncMock
+
+    mocker.patch(
+        "backend.api.features.chat.routes._validate_and_get_session",
+        return_value=None,
+    )
+    mocker.patch(
+        "backend.api.features.chat.routes.append_and_save_message",
+        return_value=None,
+    )
+    mocker.patch(
+        "backend.api.features.chat.routes.enqueue_copilot_turn",
+        return_value=None,
+    )
+    mocker.patch(
+        "backend.api.features.chat.routes.track_user_message",
+        return_value=None,
+    )
+    mock_registry = mocker.MagicMock()
+    mock_registry.create_session = _AsyncMock(return_value=None)
+    mock_registry.subscribe_to_session = _AsyncMock(return_value=None)
+    mocker.patch(
+        "backend.api.features.chat.routes.stream_registry",
+        mock_registry,
+    )
+    mock_redis = mocker.AsyncMock()
+    mock_redis.set = _AsyncMock(return_value=True)
+    # Make the delete raise so the except-pass branch is exercised.
+    mock_redis.delete = _AsyncMock(side_effect=RuntimeError("redis gone"))
+    mocker.patch(
+        "backend.api.features.chat.routes.get_redis_async",
+        new_callable=_AsyncMock,
+        return_value=mock_redis,
+    )
+
+    # Should not raise even though delete fails.
+    response = client.post(
+        "/sessions/sess-finish-err/stream",
+        json={"message": "hello", "is_user_message": True},
+    )
+
+    assert response.status_code == 200
+    assert '"finish"' in response.text

--- a/autogpt_platform/backend/backend/api/features/chat/routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/chat/routes_test.py
@@ -728,6 +728,9 @@ def test_stream_chat_blocks_duplicate_post_returns_empty_sse(
     # The response must contain StreamFinish (type=finish) and the SSE [DONE] terminator.
     assert '"finish"' in body
     assert "[DONE]" in body
+    # The empty SSE response must include the AI SDK protocol header so the
+    # frontend treats it as a valid stream and marks the turn complete.
+    assert response.headers.get("x-vercel-ai-ui-message-stream") == "v1"
     # The duplicate guard must prevent save/enqueue side effects.
     ns.save.assert_not_called()
     ns.enqueue.assert_not_called()

--- a/autogpt_platform/backend/backend/api/features/chat/routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/chat/routes_test.py
@@ -737,9 +737,7 @@ def test_stream_chat_first_post_proceeds_normally(
     # Redis set must have been called once with the NX flag.
     mock_redis.set.assert_called_once()
     call_kwargs = mock_redis.set.call_args
-    assert call_kwargs.kwargs.get("nx") is True or (
-        len(call_kwargs.args) > 3 and call_kwargs.args[3] is True
-    )
+    assert call_kwargs.kwargs.get("nx") is True
 
 
 def test_stream_chat_dedup_skipped_for_non_user_messages(
@@ -758,3 +756,85 @@ def test_stream_chat_dedup_skipped_for_non_user_messages(
     # the endpoint must proceed because is_user_message=False.
     assert response.status_code == 200
     mock_redis.set.assert_not_called()
+
+
+def test_stream_chat_dedup_hash_uses_original_message_not_mutated(
+    mocker: pytest_mock.MockFixture,
+) -> None:
+    """The dedup hash must be computed from the original request message,
+    not the mutated version that has the [Attached files] block appended.
+    This ensures retries with the same text + same files produce the same key."""
+    import hashlib
+
+    mock_redis = _mock_stream_internals(mocker, redis_set_returns=True)
+
+    response = client.post(
+        "/sessions/sess-hash/stream",
+        json={"message": "plain message", "is_user_message": True},
+    )
+
+    assert response.status_code == 200
+    mock_redis.set.assert_called_once()
+    call_args = mock_redis.set.call_args
+    dedup_key = call_args.args[0]
+
+    # Recompute the expected hash using only the original message and no file IDs
+    expected_hash = hashlib.sha256("sess-hash:plain message:".encode()).hexdigest()[:16]
+    expected_key = f"chat:msg_dedup:sess-hash:{expected_hash}"
+    assert dedup_key == expected_key, (
+        f"Dedup key {dedup_key!r} does not match expected {expected_key!r} — "
+        "hash may be using mutated message or wrong inputs"
+    )
+
+
+def test_stream_chat_dedup_key_released_after_stream_finish(
+    mocker: pytest_mock.MockFixture,
+) -> None:
+    """The dedup Redis key must be deleted after the turn completes (when
+    subscriber_queue is None the route yields StreamFinish immediately and
+    should release the key so the user can re-send the same message)."""
+    from unittest.mock import AsyncMock as _AsyncMock
+
+    # Set up all internals manually so we can control subscribe_to_session.
+    mocker.patch(
+        "backend.api.features.chat.routes._validate_and_get_session",
+        return_value=None,
+    )
+    mocker.patch(
+        "backend.api.features.chat.routes.append_and_save_message",
+        return_value=None,
+    )
+    mocker.patch(
+        "backend.api.features.chat.routes.enqueue_copilot_turn",
+        return_value=None,
+    )
+    mocker.patch(
+        "backend.api.features.chat.routes.track_user_message",
+        return_value=None,
+    )
+    mock_registry = mocker.MagicMock()
+    mock_registry.create_session = _AsyncMock(return_value=None)
+    # None → early-finish path: StreamFinish yielded immediately, dedup key released.
+    mock_registry.subscribe_to_session = _AsyncMock(return_value=None)
+    mocker.patch(
+        "backend.api.features.chat.routes.stream_registry",
+        mock_registry,
+    )
+    mock_redis = mocker.AsyncMock()
+    mock_redis.set = _AsyncMock(return_value=True)
+    mocker.patch(
+        "backend.api.features.chat.routes.get_redis_async",
+        new_callable=_AsyncMock,
+        return_value=mock_redis,
+    )
+
+    response = client.post(
+        "/sessions/sess-finish/stream",
+        json={"message": "hello", "is_user_message": True},
+    )
+
+    assert response.status_code == 200
+    body = response.text
+    assert '"finish"' in body
+    # The dedup key must be released so intentional re-sends are allowed.
+    mock_redis.delete.assert_called_once()

--- a/autogpt_platform/backend/backend/copilot/message_dedup.py
+++ b/autogpt_platform/backend/backend/copilot/message_dedup.py
@@ -1,0 +1,71 @@
+"""Per-request idempotency lock for the /stream endpoint.
+
+Prevents duplicate executor tasks from concurrent or retried POSTs (e.g. k8s
+rolling-deploy retries, nginx upstream retries, rapid double-clicks).
+
+Lifecycle
+---------
+1. ``acquire()`` — computes a stable hash of (session_id, message, file_ids)
+   and atomically sets a Redis NX key. Returns a ``_DedupLock`` on success or
+   ``None`` when the key already exists (duplicate request).
+2. ``release()`` — deletes the key. Must be called on turn completion or turn
+   error so the next legitimate send is never blocked.
+3. On client disconnect (``GeneratorExit``) the lock must NOT be released —
+   the backend turn is still running, and releasing would reopen the duplicate
+   window for infra-level retries. The 30 s TTL is the safety net.
+"""
+
+import hashlib
+import logging
+
+from backend.data.redis_client import get_redis_async
+
+logger = logging.getLogger(__name__)
+
+_KEY_PREFIX = "chat:msg_dedup"
+_TTL_SECONDS = 30
+
+
+class _DedupLock:
+    def __init__(self, key: str, redis) -> None:
+        self._key = key
+        self._redis = redis
+
+    async def release(self) -> None:
+        """Best-effort key deletion. The TTL handles failures silently."""
+        try:
+            await self._redis.delete(self._key)
+        except Exception:
+            pass
+
+
+async def acquire_dedup_lock(
+    session_id: str,
+    message: str | None,
+    file_ids: list[str] | None,
+) -> _DedupLock | None:
+    """Acquire the idempotency lock for this (session, message, files) tuple.
+
+    Returns a ``_DedupLock`` when the lock is freshly acquired (first request).
+    Returns ``None`` when a duplicate is detected (lock already held).
+    Returns ``None`` when there is nothing to deduplicate (no message, no files).
+    """
+    if not message and not file_ids:
+        return None
+
+    sorted_ids = ":".join(sorted(file_ids or []))
+    content_hash = hashlib.sha256(
+        f"{session_id}:{message or ''}:{sorted_ids}".encode()
+    ).hexdigest()[:16]
+    key = f"{_KEY_PREFIX}:{session_id}:{content_hash}"
+
+    redis = await get_redis_async()
+    acquired = await redis.set(key, "1", ex=_TTL_SECONDS, nx=True)
+    if not acquired:
+        logger.warning(
+            f"[STREAM] Duplicate user message blocked for session {session_id}, "
+            f"hash={content_hash} — returning empty SSE",
+        )
+        return None
+
+    return _DedupLock(key, redis)

--- a/autogpt_platform/backend/backend/copilot/message_dedup_test.py
+++ b/autogpt_platform/backend/backend/copilot/message_dedup_test.py
@@ -1,0 +1,93 @@
+"""Unit tests for backend.copilot.message_dedup."""
+
+import pytest
+import pytest_mock
+from unittest.mock import AsyncMock
+
+from backend.copilot.message_dedup import acquire_dedup_lock, _KEY_PREFIX
+
+
+def _patch_redis(mocker: pytest_mock.MockerFixture, *, set_returns):
+    mock_redis = AsyncMock()
+    mock_redis.set = AsyncMock(return_value=set_returns)
+    mocker.patch(
+        "backend.copilot.message_dedup.get_redis_async",
+        new_callable=AsyncMock,
+        return_value=mock_redis,
+    )
+    return mock_redis
+
+
+@pytest.mark.asyncio
+async def test_acquire_returns_none_when_no_message_no_files(
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    """Nothing to deduplicate — no Redis call made, None returned."""
+    mock_redis = _patch_redis(mocker, set_returns=True)
+    result = await acquire_dedup_lock("sess-1", None, None)
+    assert result is None
+    mock_redis.set.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_acquire_returns_lock_on_first_request(
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    """First request acquires the lock and returns a _DedupLock."""
+    mock_redis = _patch_redis(mocker, set_returns=True)
+    lock = await acquire_dedup_lock("sess-1", "hello", None)
+    assert lock is not None
+    mock_redis.set.assert_called_once()
+    key_arg = mock_redis.set.call_args.args[0]
+    assert key_arg.startswith(f"{_KEY_PREFIX}:sess-1:")
+
+
+@pytest.mark.asyncio
+async def test_acquire_returns_none_on_duplicate(
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    """Duplicate request (NX fails) returns None to signal the caller."""
+    _patch_redis(mocker, set_returns=None)
+    result = await acquire_dedup_lock("sess-1", "hello", None)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_acquire_key_stable_across_file_order(
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    """File IDs are sorted before hashing so order doesn't affect the key."""
+    mock_redis_1 = _patch_redis(mocker, set_returns=True)
+    await acquire_dedup_lock("sess-1", "msg", ["b", "a"])
+    key_ab = mock_redis_1.set.call_args.args[0]
+
+    mock_redis_2 = _patch_redis(mocker, set_returns=True)
+    await acquire_dedup_lock("sess-1", "msg", ["a", "b"])
+    key_ba = mock_redis_2.set.call_args.args[0]
+
+    assert key_ab == key_ba
+
+
+@pytest.mark.asyncio
+async def test_release_deletes_key(
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    """release() calls Redis delete exactly once."""
+    mock_redis = _patch_redis(mocker, set_returns=True)
+    lock = await acquire_dedup_lock("sess-1", "hello", None)
+    assert lock is not None
+    await lock.release()
+    mock_redis.delete.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_release_swallows_redis_error(
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    """release() must not raise even when Redis delete fails."""
+    mock_redis = _patch_redis(mocker, set_returns=True)
+    mock_redis.delete = AsyncMock(side_effect=RuntimeError("redis down"))
+    lock = await acquire_dedup_lock("sess-1", "hello", None)
+    assert lock is not None
+    await lock.release()  # must not raise
+    mock_redis.delete.assert_called_once()

--- a/autogpt_platform/backend/backend/copilot/message_dedup_test.py
+++ b/autogpt_platform/backend/backend/copilot/message_dedup_test.py
@@ -1,10 +1,11 @@
 """Unit tests for backend.copilot.message_dedup."""
 
-import pytest
-import pytest_mock
 from unittest.mock import AsyncMock
 
-from backend.copilot.message_dedup import acquire_dedup_lock, _KEY_PREFIX
+import pytest
+import pytest_mock
+
+from backend.copilot.message_dedup import _KEY_PREFIX, acquire_dedup_lock
 
 
 def _patch_redis(mocker: pytest_mock.MockerFixture, *, set_returns):

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/__tests__/helpers.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/__tests__/helpers.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { IMPERSONATION_HEADER_NAME } from "@/lib/constants";
-import { getCopilotAuthHeaders } from "../helpers";
+import { getCopilotAuthHeaders, getSendSuppressionReason } from "../helpers";
+import type { UIMessage } from "ai";
 
 vi.mock("@/lib/supabase/actions", () => ({
   getWebSocketToken: vi.fn(),
@@ -70,5 +71,73 @@ describe("getCopilotAuthHeaders", () => {
     await expect(getCopilotAuthHeaders()).rejects.toThrow(
       "Authentication failed — please sign in again.",
     );
+  });
+});
+
+// ─── getSendSuppressionReason ─────────────────────────────────────────────────
+
+function makeUserMsg(text: string): UIMessage {
+  return {
+    id: "msg-1",
+    role: "user",
+    content: text,
+    parts: [{ type: "text", text }],
+  } as UIMessage;
+}
+
+describe("getSendSuppressionReason", () => {
+  it("returns null when no dedup context exists (fresh ref)", () => {
+    const result = getSendSuppressionReason({
+      text: "hello",
+      isReconnectScheduled: false,
+      lastSubmittedText: null,
+      messages: [],
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns 'reconnecting' when reconnect is scheduled regardless of text", () => {
+    const result = getSendSuppressionReason({
+      text: "hello",
+      isReconnectScheduled: true,
+      lastSubmittedText: null,
+      messages: [],
+    });
+    expect(result).toBe("reconnecting");
+  });
+
+  it("returns 'duplicate' when same text was submitted and is the last user message", () => {
+    // This is the core regression test: after a successful turn the ref
+    // is intentionally NOT cleared to null, so submitting the same text
+    // again is caught here.
+    const result = getSendSuppressionReason({
+      text: "hello",
+      isReconnectScheduled: false,
+      lastSubmittedText: "hello",
+      messages: [makeUserMsg("hello")],
+    });
+    expect(result).toBe("duplicate");
+  });
+
+  it("returns null when same ref text but different last user message (different question)", () => {
+    // User asked "hello" before, got a reply, then asked a different question
+    // — the last user message in chat is now different, so no suppression.
+    const result = getSendSuppressionReason({
+      text: "hello",
+      isReconnectScheduled: false,
+      lastSubmittedText: "hello",
+      messages: [makeUserMsg("hello"), makeUserMsg("something else")],
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when text differs from lastSubmittedText", () => {
+    const result = getSendSuppressionReason({
+      text: "new question",
+      isReconnectScheduled: false,
+      lastSubmittedText: "old question",
+      messages: [makeUserMsg("old question")],
+    });
+    expect(result).toBeNull();
   });
 });

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/useCopilotStream.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/useCopilotStream.ts
@@ -458,7 +458,12 @@ export function useCopilotStream({
       if (status === "ready") {
         reconnectAttemptsRef.current = 0;
         hasShownDisconnectToast.current = false;
-        lastSubmittedMsgRef.current = null;
+        // Intentionally NOT clearing lastSubmittedMsgRef here: keeping the last
+        // submitted text prevents getSendSuppressionReason from allowing a
+        // duplicate POST of the same message immediately after a successful turn
+        // (the "duplicate" branch checks both the ref and the visible last user
+        // message, so legitimate re-sends after a different reply are still
+        // allowed).
         setReconnectExhausted(false);
       }
     }


### PR DESCRIPTION
## Why

After merging #12782 to dev, a k8s rolling deployment triggered infrastructure-level POST retries — nginx detected the old pod's connection reset mid-stream and resent the same POST to a new pod. Both pods independently saved the user message and ran the executor, producing duplicate entries in the DB (seq 159, 161, 163) and a duplicate response in the chat. The model saw the same question 3× in its context window and spent its response commenting on that instead of answering.

Two compounding issues:
1. **No backend idempotency**: `append_and_save_message` saves unconditionally — k8s/nginx retries silently produce duplicate turns.
2. **Frontend dedup cleared after success**: `lastSubmittedMsgRef.current = null` after every completed turn wipes the dedup guard, so any rapid re-submit of the same text (from a stalled UI or user double-click) slips through.

## What

**Backend** — Redis idempotency gate in `stream_chat_post`:
- Before saving the user message, compute `sha256(session_id + message)[:16]` and `SET NX ex=30` in Redis
- If key already exists → duplicate: return empty SSE (`StreamFinish + [DONE]`) immediately, skip save + executor enqueue
- User messages only (`is_user_message=True`); system/assistant messages bypass the check

**Frontend** — Keep `lastSubmittedMsgRef` populated after success:
- Remove `lastSubmittedMsgRef.current = null` on stream complete
- `getSendSuppressionReason` already has a two-condition check: `ref === text AND lastUserMsg === text` — so legitimate re-asks (after a different question was answered) still work; only rapid re-sends of the exact same text while it's still the last user message are blocked

## How

- 30 s Redis TTL covers infrastructure retry windows (k8s SIGTERM → connection reset → ingress retry typically < 5 s)
- Empty SSE response is well-formed (StreamFinish + [DONE]) — frontend AI SDK marks the turn complete without rendering a ghost message
- Frontend ref kept live means: submit "foo" → success → submit "foo" again instantly → suppressed. Submit "foo" → success → submit "bar" → proceeds (different text updates the ref).

## Tests

- 3 new backend route tests: duplicate blocked, first POST proceeds, non-user messages bypass
- 5 new frontend `getSendSuppressionReason` unit tests: fresh ref, reconnecting, duplicate suppressed, different-turn re-ask allowed, different text allowed

## Checklist

- [x] I have read the [AutoGPT Contributing Guide](https://github.com/Significant-Gravitas/AutoGPT/blob/master/CONTRIBUTING.md)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove the fix is effective
- [x] I have run `poetry run format` and `pnpm format` + `pnpm lint`