### PR TITLE
fix(backend): default copilot sonnet to 4.6

### DIFF
--- a/autogpt_platform/backend/backend/copilot/baseline/transcript_integration_test.py
+++ b/autogpt_platform/backend/backend/copilot/baseline/transcript_integration_test.py
@@ -68,7 +68,7 @@ class TestResolveBaselineModel:
         assert _resolve_baseline_model(None) == config.model
 
     def test_default_and_fast_models_same(self):
-        """SDK 0.1.58: both tiers now use the same model (anthropic/claude-sonnet-4)."""
+        """SDK defaults currently keep standard and fast on Sonnet 4.6."""
         assert config.model == config.fast_model
 
 

--- a/autogpt_platform/backend/backend/copilot/config.py
+++ b/autogpt_platform/backend/backend/copilot/config.py
@@ -29,13 +29,13 @@ class ChatConfig(BaseSettings):
 
     # OpenAI API Configuration
     model: str = Field(
-        default="anthropic/claude-sonnet-4",
+        default="anthropic/claude-sonnet-4-6",
         description="Default model for extended thinking mode. "
-        "Changed from Opus ($15/$75 per M) to Sonnet ($3/$15 per M) — "
-        "5x cheaper. Override via CHAT_MODEL env var for Opus.",
+        "Uses Sonnet 4.6 as the balanced default. "
+        "Override via CHAT_MODEL env var if you want a different default.",
     )
     fast_model: str = Field(
-        default="anthropic/claude-sonnet-4",
+        default="anthropic/claude-sonnet-4-6",
         description="Model for fast mode (baseline path). Should be faster/cheaper than the default model.",
     )
     title_model: str = Field(
@@ -156,7 +156,7 @@ class ChatConfig(BaseSettings):
         "history compression. Falls back to compression when unavailable.",
     )
     claude_agent_fallback_model: str = Field(
-        default="claude-sonnet-4-20250514",
+        default="claude-sonnet-4-6",
         description="Fallback model when the primary model is unavailable (e.g. 529 "
         "overloaded). The SDK automatically retries with this cheaper model.",
     )

--- a/autogpt_platform/backend/backend/copilot/sdk/service_helpers_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service_helpers_test.py
@@ -392,7 +392,9 @@ class TestNormalizeModelName:
 
     def test_sonnet_openrouter_model(self):
         """Sonnet model as stored in config (OpenRouter-prefixed) strips cleanly."""
-        assert _normalize_model_name("anthropic/claude-sonnet-4") == "claude-sonnet-4"
+        assert (
+            _normalize_model_name("anthropic/claude-sonnet-4-6") == "claude-sonnet-4-6"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Why / What / How

Why: Copilot/Autopilot standard requests were still defaulting to Claude Sonnet 4, while the expected default for this path is Sonnet 4.6.

What: This PR updates the backend Copilot defaults so the standard/default path and fast path use Sonnet 4.6, and aligns the SDK fallback model and related test expectations.

How: It changes `ChatConfig.model`, `ChatConfig.fast_model`, and `ChatConfig.claude_agent_fallback_model` to Sonnet 4.6 values, then updates backend tests that assert the default Sonnet model strings.

### Changes 🏗️

- Switch `ChatConfig.model` from `anthropic/claude-sonnet-4` to `anthropic/claude-sonnet-4-6`
- Switch `ChatConfig.fast_model` from `anthropic/claude-sonnet-4` to `anthropic/claude-sonnet-4-6`
- Switch `ChatConfig.claude_agent_fallback_model` from `claude-sonnet-4-20250514` to `claude-sonnet-4-6`
- Update backend Copilot tests that assert the default Sonnet model strings
- Configuration changes:
  - No new environment variables or docker-compose changes are required
  - Existing `.env.default` and compose files remain compatible because this only changes backend default model values in code

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `poetry run format`
  - [x] `poetry run pytest backend/copilot/baseline/transcript_integration_test.py`
  - [x] `poetry run pytest backend/copilot/sdk/service_helpers_test.py`
  - [x] `poetry run pytest backend/copilot/sdk/service_test.py`
  - [x] `poetry run pytest backend/copilot/sdk/p0_guardrails_test.py`

<details>
  <summary>Example test plan</summary>
  
  - [ ] Create from scratch and execute an agent with at least 3 blocks
  - [ ] Import an agent from file upload, and confirm it executes correctly
  - [ ] Upload agent to marketplace
  - [ ] Import an agent from marketplace and confirm it executes correctly
  - [ ] Edit an agent from monitor, and confirm it executes correctly
</details>

#### For configuration changes:

- [x] `.env.default` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes
- [x] I have included a list of my configuration changes in the PR description (under **Changes**)

<details>
  <summary>Examples of configuration changes</summary>

  - Changing ports
  - Adding new services that need to communicate with each other
  - Secrets or environment variable changes
  - New or infrastructure changes such as databases
</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default/fallback LLM model identifiers for Copilot requests, which can affect runtime behavior, cost, and availability characteristics across both baseline and SDK paths. Risk is mitigated by being a small, config-only change with updated tests.
> 
> **Overview**
> Updates Copilot backend defaults so both the standard (`model`) and fast (`fast_model`) paths use `anthropic/claude-sonnet-4-6`, and aligns the Claude Agent SDK fallback model to `claude-sonnet-4-6`.
> 
> Adjusts related test expectations in baseline transcript integration and SDK helper tests to match the new Sonnet 4.6 model strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 563361ac11d46d36c553e0b62fcfd1fb339e2837. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->