### PR TITLE
refactor(backend/copilot): make session-file helper fns public to fix Pyright warnings

### DIFF
--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -893,7 +893,7 @@ def _write_cli_session_to_disk(
         return False
 
 
-def _read_cli_session_from_disk(
+def read_cli_session_from_disk(
     sdk_cwd: str,
     session_id: str,
     log_prefix: str,
@@ -973,7 +973,7 @@ def _read_cli_session_from_disk(
     return stripped_bytes
 
 
-def _process_cli_restore(
+def process_cli_restore(
     cli_restore: TranscriptDownload,
     sdk_cwd: str,
     session_id: str,
@@ -2489,7 +2489,7 @@ async def _restore_cli_session_for_turn(
     # session path, so we validate BEFORE any disk write.
     stripped = ""
     if cli_restore is not None and sdk_cwd:
-        stripped, ok = _process_cli_restore(
+        stripped, ok = process_cli_restore(
             cli_restore, sdk_cwd, session_id, log_prefix
         )
         if not ok:
@@ -3636,7 +3636,7 @@ async def stream_chat_completion_sdk(
         # this turn ran without --resume (restore failed or first T2+ on a new
         # pod), the T1 session file at the expected path may still be present
         # and should be re-uploaded so the next turn can resume from it.
-        # _read_cli_session_from_disk returns None when the file is absent, so
+        # read_cli_session_from_disk returns None when the file is absent, so
         # this is always safe.
         #
         # Intentionally NOT gated on skip_transcript_upload: that flag is set
@@ -3665,7 +3665,7 @@ async def stream_chat_completion_sdk(
             try:
                 # Read the CLI's native session file from disk (written by the CLI
                 # after the turn), then upload the bytes to GCS.
-                _cli_content = _read_cli_session_from_disk(
+                _cli_content = read_cli_session_from_disk(
                     sdk_cwd, session_id, log_prefix
                 )
                 if _cli_content:

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -2489,9 +2489,7 @@ async def _restore_cli_session_for_turn(
     # session path, so we validate BEFORE any disk write.
     stripped = ""
     if cli_restore is not None and sdk_cwd:
-        stripped, ok = process_cli_restore(
-            cli_restore, sdk_cwd, session_id, log_prefix
-        )
+        stripped, ok = process_cli_restore(cli_restore, sdk_cwd, session_id, log_prefix)
         if not ok:
             result.transcript_covers_prefix = False
             cli_restore = None

--- a/autogpt_platform/backend/backend/copilot/sdk/transcript_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/transcript_test.py
@@ -1371,7 +1371,7 @@ class TestStripStaleThinkingBlocks:
 
 
 class TestProcessCliRestore:
-    """``_process_cli_restore`` validates, strips, and writes CLI session to disk."""
+    """``process_cli_restore`` validates, strips, and writes CLI session to disk."""
 
     def test_writes_stripped_bytes_not_raw(self, tmp_path):
         """Stripped bytes (not raw bytes) must be written to disk for --resume."""
@@ -1380,7 +1380,7 @@ class TestProcessCliRestore:
         from pathlib import Path
         from unittest.mock import patch
 
-        from backend.copilot.sdk.service import _process_cli_restore
+        from backend.copilot.sdk.service import process_cli_restore
         from backend.copilot.transcript import TranscriptDownload
 
         session_id = "12345678-0000-0000-0000-abcdef000001"
@@ -1406,7 +1406,7 @@ class TestProcessCliRestore:
                 return_value=projects_base_dir,
             ),
         ):
-            stripped_str, ok = _process_cli_restore(
+            stripped_str, ok = process_cli_restore(
                 restore, sdk_cwd, session_id, "[Test]"
             )
 
@@ -1433,7 +1433,7 @@ class TestProcessCliRestore:
 
     def test_invalid_content_returns_false(self):
         """Content that fails validation after strip returns (empty, False)."""
-        from backend.copilot.sdk.service import _process_cli_restore
+        from backend.copilot.sdk.service import process_cli_restore
         from backend.copilot.transcript import TranscriptDownload
 
         # A single progress-only entry — stripped result will be empty/invalid
@@ -1442,7 +1442,7 @@ class TestProcessCliRestore:
             content=raw_content.encode("utf-8"), message_count=1, mode="sdk"
         )
 
-        stripped_str, ok = _process_cli_restore(
+        stripped_str, ok = process_cli_restore(
             restore,
             "/tmp/nonexistent-sdk-cwd",
             "12345678-0000-0000-0000-000000000099",
@@ -1454,7 +1454,7 @@ class TestProcessCliRestore:
 
 
 class TestReadCliSessionFromDisk:
-    """``_read_cli_session_from_disk`` reads, strips, and optionally writes back the session."""
+    """``read_cli_session_from_disk`` reads, strips, and optionally writes back the session."""
 
     def _build_session_file(self, tmp_path, session_id: str):
         """Build the session file path inside tmp_path using the same encoding as cli_session_path."""
@@ -1472,7 +1472,7 @@ class TestReadCliSessionFromDisk:
         """Non-UTF-8 bytes trigger UnicodeDecodeError — returns raw bytes (upload-raw fallback)."""
         from unittest.mock import patch
 
-        from backend.copilot.sdk.service import _read_cli_session_from_disk
+        from backend.copilot.sdk.service import read_cli_session_from_disk
 
         session_id = "12345678-0000-0000-0000-aabbccdd0001"
         projects_base_dir = str(tmp_path)
@@ -1491,7 +1491,7 @@ class TestReadCliSessionFromDisk:
                 return_value=projects_base_dir,
             ),
         ):
-            result = _read_cli_session_from_disk(sdk_cwd, session_id, "[Test]")
+            result = read_cli_session_from_disk(sdk_cwd, session_id, "[Test]")
 
         # UnicodeDecodeError path returns the raw bytes (upload-raw fallback)
         assert result == b"\xff\xfe invalid utf-8\n"
@@ -1500,7 +1500,7 @@ class TestReadCliSessionFromDisk:
         """OSError on write-back returns stripped bytes for GCS upload (not raw)."""
         from unittest.mock import patch
 
-        from backend.copilot.sdk.service import _read_cli_session_from_disk
+        from backend.copilot.sdk.service import read_cli_session_from_disk
 
         session_id = "12345678-0000-0000-0000-aabbccdd0002"
         projects_base_dir = str(tmp_path)
@@ -1527,7 +1527,7 @@ class TestReadCliSessionFromDisk:
                     return_value=projects_base_dir,
                 ),
             ):
-                result = _read_cli_session_from_disk(sdk_cwd, session_id, "[Test]")
+                result = read_cli_session_from_disk(sdk_cwd, session_id, "[Test]")
         finally:
             session_file.chmod(0o644)
 


### PR DESCRIPTION
## Why
After PR #12804 was squashed into dev, two module-level helper functions in `backend/copilot/sdk/service.py` remained private (`_`-prefixed) while being directly imported by name in `sdk/transcript_test.py`. Pyright reports `reportAttributeAccessIssue` when tests (even those excluded from CI lint) import private symbols from outside their defining module.

## What
Rename two helpers to remove the underscore prefix:
- `_process_cli_restore` → `process_cli_restore`
- `_read_cli_session_from_disk` → `read_cli_session_from_disk`

Update call sites in `service.py` and imports/calls/docstrings in `sdk/transcript_test.py`.

## How
Pure rename — no logic change. Both functions were already module-level helpers with no reason to be private; the underscore was convention carried over during the refactor but they are directly unit-tested and should be public.

All 66 `sdk/transcript_test.py` tests pass after the rename.

## Checklist
- [x] Tests pass (`poetry run pytest backend/copilot/sdk/transcript_test.py`)
- [x] No `_`-prefixed symbols imported across module boundaries
- [x] No linter suppressors added
