### PR TITLE
docs: convert in-code comments to admonitions in block-sdk-guide.md

### DIFF
--- a/docs/platform/block-sdk-guide.md
+++ b/docs/platform/block-sdk-guide.md
@@ -12,36 +12,37 @@ Blocks are reusable components that perform specific tasks in AutoGPT workflows.
 
 First, create a `_config.py` file to configure your provider using the `ProviderBuilder`:
 
-```python
-from backend.sdk import BlockCostType, ProviderBuilder
+!!! note "Simple API key provider"
+    ```python
+    from backend.sdk import BlockCostType, ProviderBuilder
 
-# Simple API key provider
-my_provider = (
-    ProviderBuilder("my_provider")
-    .with_api_key("MY_PROVIDER_API_KEY", "My Provider API Key")
-    .with_base_cost(1, BlockCostType.RUN)
-    .build()
-)
-```
+    my_provider = (
+        ProviderBuilder("my_provider")
+        .with_api_key("MY_PROVIDER_API_KEY", "My Provider API Key")
+        .with_base_cost(1, BlockCostType.RUN)
+        .build()
+    )
+    ```
 
 For OAuth providers:
 
-```python
-from backend.sdk import BlockCostType, ProviderBuilder
-from ._oauth import MyProviderOAuthHandler
+!!! note "OAuth provider configuration"
+    ```python
+    from backend.sdk import BlockCostType, ProviderBuilder
+    from ._oauth import MyProviderOAuthHandler
 
-my_provider = (
-    ProviderBuilder("my_provider")
-    .with_oauth(
-        MyProviderOAuthHandler,
-        scopes=["read", "write"],
-        client_id_env_var="MY_PROVIDER_CLIENT_ID",
-        client_secret_env_var="MY_PROVIDER_CLIENT_SECRET",
+    my_provider = (
+        ProviderBuilder("my_provider")
+        .with_oauth(
+            MyProviderOAuthHandler,
+            scopes=["read", "write"],
+            client_id_env_var="MY_PROVIDER_CLIENT_ID",
+            client_secret_env_var="MY_PROVIDER_CLIENT_SECRET",
+        )
+        .with_base_cost(1, BlockCostType.RUN)
+        .build()
     )
-    .with_base_cost(1, BlockCostType.RUN)
-    .build()
-)
-```
+    ```
 
 ### 2. Create the Block Class
 
@@ -65,65 +66,80 @@ from ._config import my_provider
 
 class MyBlock(Block):
     class Input(BlockSchemaInput):
-        # Define input fields
         credentials: CredentialsMetaInput = my_provider.credentials_field(
             description="API credentials for My Provider"
         )
         query: str = SchemaField(description="The query to process")
         limit: int = SchemaField(
-            description="Number of results", 
+            description="Number of results",
             default=10,
-            ge=1,  # Greater than or equal to 1
-            le=100  # Less than or equal to 100
+            ge=1,
+            le=100,
         )
         advanced_option: str = SchemaField(
             description="Advanced setting",
             default="",
-            advanced=True  # Hidden by default in UI
+            advanced=True,
         )
 
     class Output(BlockSchemaOutput):
-        # Define output fields
         results: list = SchemaField(description="List of results")
         count: int = SchemaField(description="Total count")
-        # error output pin is already defined on BlockSchemaOutput
 
     def __init__(self):
         super().__init__(
-            id=str(uuid.uuid4()),  # Generate unique ID
+            id=str(uuid.uuid4()),
             description="Brief description of what this block does",
-            categories={BlockCategory.SEARCH},  # Choose appropriate categories
+            categories={BlockCategory.SEARCH},
             input_schema=self.Input,
             output_schema=self.Output,
         )
 
     async def run(
-        self, 
-        input_data: Input, 
-        *, 
+        self,
+        input_data: Input,
+        *,
         credentials: APIKeyCredentials,
         **kwargs
     ) -> BlockOutput:
         try:
-            # Your block logic here
             results = await self.process_data(
                 input_data.query,
                 input_data.limit,
                 credentials
             )
-            
-            # Yield outputs
+
             yield "results", results
             yield "count", len(results)
-            
+
         except Exception as e:
             yield "error", str(e)
 
     async def process_data(self, query, limit, credentials):
-        # Implement your logic
-        # Use credentials.api_key.get_secret_value() to access the API key
         pass
 ```
+
+!!! note "Input Schema Fields"
+    - **`credentials`**: Use `my_provider.credentials_field()` to add provider authentication
+    - **`query`**: Simple string field with description
+    - **`limit`**: Integer field with validation constraints (`ge=1`, `le=100`)
+    - **`advanced_option`**: Marked with `advanced=True` to hide from basic UI
+
+!!! note "Output Schema Fields"
+    - **`results`**: List of results from the block
+    - **`count`**: Total count of results
+    - The `error` output pin is already defined on `BlockSchemaOutput`
+
+!!! note "Block Initialization"
+    - **`id`**: Generate a unique ID using `uuid.uuid4()`
+    - **`description`**: Brief description of what the block does
+    - **`categories`**: Choose from `BlockCategory` enum (e.g., SEARCH, AI, PRODUCTIVITY)
+    - **`input_schema` / `output_schema`**: Assign the Input and Output classes
+
+!!! note "Run Method"
+    - Implement your block logic in `process_data()` helper method
+    - Use `credentials.api_key.get_secret_value()` to access the API key
+    - Use `yield` to output results
 
 ## Key Components Explained
 
@@ -131,7 +147,7 @@ class MyBlock(Block):
 
 The `ProviderBuilder` allows you to:
 - **`.with_api_key()`**: Add API key authentication
-- **`.with_oauth()`**: Add OAuth authentication  
+- **`.with_oauth()`**: Add OAuth authentication
 - **`.with_base_cost()`**: Set resource costs for the block
 - **`.with_webhook_manager()`**: Add webhook support
 - **`.with_user_password()`**: Add username/password auth
@@ -155,69 +171,72 @@ The `ProviderBuilder` allows you to:
 
 Add test configuration to your block:
 
-```python
-def __init__(self):
-    super().__init__(
-        # ... other config ...
-        test_input={
-            "query": "test query",
-            "limit": 5,
-            "credentials": {
-                "provider": "my_provider",
-                "id": str(uuid.uuid4()),
-                "type": "api_key"
+!!! note "Test Configuration"
+    ```python
+    def __init__(self):
+        super().__init__(
+            # ... other config ...
+            test_input={
+                "query": "test query",
+                "limit": 5,
+                "credentials": {
+                    "provider": "my_provider",
+                    "id": str(uuid.uuid4()),
+                    "type": "api_key"
+                }
+            },
+            test_output=[
+                ("results", ["result1", "result2"]),
+                ("count", 2)
+            ],
+            test_mock={
+                "process_data": lambda *args, **kwargs: ["result1", "result2"]
             }
-        },
-        test_output=[
-            ("results", ["result1", "result2"]),
-            ("count", 2)
-        ],
-        test_mock={
-            "process_data": lambda *args, **kwargs: ["result1", "result2"]
-        }
-    )
-```
+        )
+    ```
 
 ### OAuth Support
 
 Create an OAuth handler in `_oauth.py`:
 
-```python
-from backend.integrations.oauth.base import BaseOAuthHandler
+!!! note "OAuth Handler Implementation"
+    ```python
+    from backend.integrations.oauth.base import BaseOAuthHandler
 
-class MyProviderOAuthHandler(BaseOAuthHandler):
-    PROVIDER_NAME = "my_provider"
-    
-    def _get_authorization_url(self, scopes: list[str], state: str) -> str:
-        # Implementation
-        pass
-    
-    def _exchange_code_for_token(self, code: str, scopes: list[str]) -> dict:
-        # Implementation
-        pass
-```
+    class MyProviderOAuthHandler(BaseOAuthHandler):
+        PROVIDER_NAME = "my_provider"
+
+        def _get_authorization_url(self, scopes: list[str], state: str) -> str:
+            # Implement URL generation for OAuth flow
+            pass
+
+        def _exchange_code_for_token(self, code: str, scopes: list[str]) -> dict:
+            # Implement token exchange logic
+            pass
+    ```
 
 ### Webhook Support
 
 Create a webhook manager in `_webhook.py`:
 
-```python
-from backend.integrations.webhooks._base import BaseWebhooksManager
+!!! note "Webhook Manager Implementation"
+    ```python
+    from backend.integrations.webhooks._base import BaseWebhooksManager
 
-class MyProviderWebhookManager(BaseWebhooksManager):
-    PROVIDER_NAME = "my_provider"
-    
-    async def validate_event(self, event: dict) -> bool:
-        # Implementation
-        pass
-```
+    class MyProviderWebhookManager(BaseWebhooksManager):
+        PROVIDER_NAME = "my_provider"
+
+        async def validate_event(self, event: dict) -> bool:
+            # Implement event validation logic
+            pass
+    ```
 
 ## File Organization
 
 ```
 backend/blocks/my_provider/
 ├── __init__.py          # Export your blocks
-├── _config.py           # Provider configuration  
+├── _config.py           # Provider configuration
 ├── _oauth.py           # OAuth handler (optional)
 ├── _webhook.py         # Webhook manager (optional)
 ├── _api.py             # API client wrapper (optional)
@@ -248,13 +267,13 @@ async def run(self, input_data: Input, *, credentials: APIKeyCredentials, **kwar
         "Authorization": f"Bearer {credentials.api_key.get_secret_value()}",
         "Content-Type": "application/json"
     }
-    
+
     response = await Requests().post(
         "https://api.example.com/endpoint",
         headers=headers,
         json={"query": input_data.query}
     )
-    
+
     data = response.json()
     yield "results", data.get("results", [])
 ```
@@ -263,19 +282,23 @@ async def run(self, input_data: Input, *, credentials: APIKeyCredentials, **kwar
 
 ```python
 async def run(
-    self, 
-    input_data: Input, 
-    *, 
+    self,
+    input_data: Input,
+    *,
     credentials: OAuth2Credentials | APIKeyCredentials,
     **kwargs
 ):
     if isinstance(credentials, OAuth2Credentials):
-        # Handle OAuth
+        # Handle OAuth credentials
         token = credentials.access_token.get_secret_value()
     else:
-        # Handle API key
+        # Handle API key credentials
         token = credentials.api_key.get_secret_value()
 ```
+
+!!! note "Authentication Types"
+    - **`OAuth2Credentials`**: Access token via `credentials.access_token.get_secret_value()`
+    - **`APIKeyCredentials`**: API key via `credentials.api_key.get_secret_value()`
 
 ### Handling Files
 
@@ -311,10 +334,15 @@ async def run(
     result = await store_media_file(
         file=generated_url,
         execution_context=execution_context,
-        return_format="for_block_output",  # workspace:// in CoPilot, data URI in graphs
+        return_format="for_block_output",
     )
     yield "image_url", result
 ```
+
+!!! note "File Handling Patterns"
+    - **PROCESSING**: Use `"for_local_processing"` when you need a local file path for tools like ffmpeg, MoviePy, PIL
+    - **EXTERNAL API**: Use `"for_external_api"` when sending content to APIs like Replicate or OpenAI (returns base64 data URI)
+    - **OUTPUT**: Use `"for_block_output"` to return results - this automatically adapts: `workspace://` in CoPilot, data URI in graphs
 
 **Return format options:**
 - `"for_local_processing"` - Local file path for processing tools


### PR DESCRIPTION
### Why / What / How

<!-- Why: Why does this PR exist? What problem does it solve, or what's broken/missing without it? -->
This PR converts inline Python comments in code examples within `block-sdk-guide.md` into MkDocs `!!! note` admonitions. This makes code examples cleaner and more copy-paste friendly while preserving all explanatory content.

<!-- What: What does this PR change? Summarize the changes at a high level. -->
Converts inline comments in code blocks to admonitions following the pattern established in PR #12396 (new_blocks.md) and PR #12313.

<!-- How: How does it work? Describe the approach, key implementation details, or architecture decisions. -->
- Wrapped code examples with `!!! note` admonitions
- Removed inline comments from code blocks for clean copy-paste
- Added explanatory admonitions after each code block

### Changes 🏗️

- Provider configuration examples (API key and OAuth)
- Block class Input/Output schema annotations
- Block initialization parameters
- Test configuration
- OAuth and webhook handler implementations
- Authentication types and file handling patterns

### Checklist 📋

#### For documentation changes:
- [x] Follows the admonition pattern from PR #12396
- [x] No code changes, documentation only
- [x] Admonition syntax verified correct

#### For configuration changes:
- [ ] `.env.default` is updated or already compatible with my changes
- [ ] `docker-compose.yml` is updated or already compatible with my changes

---

**Related Issues**: Closes #8946