### PR TITLE
fix(frontend): remove debug console.log statements

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/profile/(user)/settings/components/SettingsForm/components/TimezoneForm/TimezoneForm.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/profile/(user)/settings/components/SettingsForm/components/TimezoneForm/TimezoneForm.tsx
@@ -33,7 +33,6 @@ type Props = {
 };
 
 export function TimezoneForm({ user, currentTimezone = "not-set" }: Props) {
-  console.log("currentTimezone", currentTimezone);
   // If timezone is not set, try to detect it from the browser
   const effectiveTimezone = React.useMemo(() => {
     if (currentTimezone === "not-set") {

--- a/autogpt_platform/frontend/src/components/contextual/EditAgentModal/components/EditAgentForm.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/EditAgentModal/components/EditAgentForm.tsx
@@ -96,7 +96,6 @@ export function EditAgentForm({
             control={form.control}
             name="category"
             render={({ field }) => {
-              console.log("Edit Category field value:", field.value);
               return (
                 <Select
                   id={field.name}

--- a/autogpt_platform/frontend/src/components/layout/Navbar/components/Wallet/components/WalletRefill.tsx
+++ b/autogpt_platform/frontend/src/components/layout/Navbar/components/Wallet/components/WalletRefill.tsx
@@ -59,8 +59,6 @@ export function WalletRefill() {
     resolver: zodResolver(autoRefillSchema),
   });
 
-  console.log("autoRefillForm");
-
   // Pre-fill the auto-refill form with existing values
   useEffect(() => {
     if (

--- a/autogpt_platform/frontend/src/components/layout/Navbar/useNavbar.ts
+++ b/autogpt_platform/frontend/src/components/layout/Navbar/useNavbar.ts
@@ -6,8 +6,6 @@ export function useNavbar() {
   const { isLoggedIn, isUserLoading } = useSupabase();
   const logoutInProgress = isLogoutInProgress();
 
-  console.log("isLoggedIn", isLoggedIn);
-
   const {
     data: profileResponse,
     isLoading: isProfileLoading,


### PR DESCRIPTION
## Why
Debug console.log statements were left in production code, which can leak 
sensitive information and pollute browser developer consoles.

## What
Removed console.log from 4 non-legacy frontend components:
- useNavbar.ts: isLoggedIn debug log
- WalletRefill.tsx: autoRefillForm debug log  
- EditAgentForm.tsx: category field debug log
- TimezoneForm.tsx: currentTimezone debug log

## How
Simply deleted the console.log lines as they served no purpose 
other than debugging during development.

## Checklist
- [x] Code follows project conventions
- [x] Only frontend changes (4 files, 6 lines removed)
- [x] No functionality changes