### PR TITLE
feat(frontend): collapse unconnected object sub-outputs by default

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/nodes/OutputHandler.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/nodes/OutputHandler.tsx
@@ -87,8 +87,9 @@ export const OutputHandler = ({
           getTypeDisplayInfo(fieldSchema);
         const isExpanded = expandedObjects[fullKey] ?? false;
 
-        // User expanded → show all children; auto-expanded → filter to connected only
-        const shouldRenderChildren = isExpanded || descendantIsRelevant;
+        // Default collapse object outputs to save canvas real-estate
+        // User must manually expand to see sub-outputs
+        const shouldRenderChildren = isExpanded;
 
         return shouldShow ? (
           <div


### PR DESCRIPTION
toolName: view_files
            
status: success
          
            
filePath: /Users/Zhuanz/Documents/trae_projects/autogpt/PR_DESCRIPTION.md
          
## Why

Object sub-outputs were previously auto-expanded whenever there was any connected descendant, which wasted a lot of Builder canvas real-estate. Hiding unused sub-outputs by default significantly improves usability and saves valuable screen space, keeping the builder clean and focused.

## What

This PR changes the default behavior of object outputs in the Flow Builder:
- Object sub-outputs are now collapsed by default
- Users must manually click the expand/collapse arrow (CaretRightIcon/CaretDownIcon) to view sub-outputs
- This applies to all object outputs, regardless of whether they have connected descendants or not

Key change in `OutputHandler.tsx`:
- Removed automatic expansion logic that triggered based on `descendantIsRelevant`
- Now only renders children when `isExpanded` is true (user manually expanded)

## How

Modified `shouldRenderChildren` condition in `OutputHandler.tsx` (line 92) to only render sub-outputs when the user has explicitly expanded the object output.

**Before:**
```typescript
const shouldRenderChildren = isExpanded || descendantIsRelevant;
```

**After:**
```typescript
const shouldRenderChildren = isExpanded;
```

The connectedOnly flag logic is preserved (line 166), so if a user does expand an object, they will still see all sub-outputs, while collapsed objects only show the top-level output handle.

## Related Issues

Closes #11044

## Checklist

- [x] Code follows project conventions
- [ ] Ran pnpm format && pnpm lint && pnpm types
- [ ] Added necessary tests (N/A - behavior change)
- [ ] Updated relevant documentation (N/A)