### PR TITLE
fix(backend/copilot): allow multiple compactions per turn

### DIFF
--- a/autogpt_platform/backend/backend/copilot/sdk/compaction.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/compaction.py
@@ -196,7 +196,6 @@ class CompactionTracker:
         self._active_transcript_path: str = ""
         self._pending_transcript_paths: deque[str] = deque()
         self._attempted_sources: list[str] = []
-        self._completed_count = 0
         self._completed_sources: list[str] = []
 
     @property
@@ -209,40 +208,31 @@ class CompactionTracker:
 
     @property
     def completed_count(self) -> int:
-        return self._completed_count
+        return len(self._completed_sources)
 
     @property
     def completed_sources(self) -> tuple[str, ...]:
         return tuple(self._completed_sources)
 
     def get_observability_metadata(self) -> dict[str, Any]:
-        attempt_count = self.attempt_count
-        if attempt_count <= 0 and self._completed_count <= 0:
+        if not self._attempted_sources and not self._completed_sources:
             return {}
 
         metadata: dict[str, Any] = {
-            "compaction_attempt_count": attempt_count,
+            "compaction_attempt_count": self.attempt_count,
             "compaction_attempt_sources": _summarize_sources(self._attempted_sources),
         }
-        if self._completed_count > 0:
-            metadata["compaction_count"] = self._completed_count
+        if self._completed_sources:
+            metadata["compaction_count"] = self.completed_count
             metadata["compaction_sources"] = _summarize_sources(self._completed_sources)
         return metadata
 
     def get_log_summary(self) -> dict[str, Any]:
         return {
             "attempt_count": self.attempt_count,
-            "attempt_sources": (
-                _summarize_sources(self._attempted_sources)
-                if self._attempted_sources
-                else ""
-            ),
-            "completed_count": self._completed_count,
-            "completed_sources": (
-                _summarize_sources(self._completed_sources)
-                if self._completed_sources
-                else ""
-            ),
+            "attempt_sources": _summarize_sources(self._attempted_sources),
+            "completed_count": self.completed_count,
+            "completed_sources": _summarize_sources(self._completed_sources),
         }
 
     def on_compact(self, transcript_path: str = "") -> None:
@@ -257,7 +247,6 @@ class CompactionTracker:
     def emit_pre_query(self, session: ChatSession) -> list[StreamBaseResponse]:
         """Emit + persist a self-contained compaction tool call."""
         self._attempted_sources.append("pre_query")
-        self._completed_count += 1
         self._completed_sources.append("pre_query")
         return emit_compaction(session)
 
@@ -314,7 +303,6 @@ class CompactionTracker:
         self._start_emitted = False
         self._tool_call_id = ""
         self._active_transcript_path = ""
-        self._completed_count += 1
         self._completed_sources.append("sdk_internal")
         _persist(session, persist_id, COMPACTION_DONE_MSG)
         return CompactionResult(

--- a/autogpt_platform/backend/backend/copilot/sdk/compaction.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/compaction.py
@@ -9,8 +9,8 @@ persistence, and the ``CompactionTracker`` state machine.
 """
 
 import asyncio
-import logging
 import uuid
+from collections import Counter, deque
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -24,8 +24,6 @@ from ..response_model import (
     StreamToolInputStart,
     StreamToolOutputAvailable,
 )
-
-logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -71,6 +69,14 @@ def _end_events(tool_call_id: str, message: str) -> list[StreamBaseResponse]:
 
 def _new_tool_call_id() -> str:
     return f"compaction-{uuid.uuid4().hex[:12]}"
+
+
+def _summarize_sources(sources: list[str]) -> str:
+    counts = Counter(sources)
+    parts: list[str] = []
+    for source, count in counts.items():
+        parts.append(f"{source}:{count}" if count > 1 else source)
+    return ",".join(parts)
 
 
 # ---------------------------------------------------------------------------
@@ -185,26 +191,64 @@ class CompactionTracker:
     """
 
     def __init__(self) -> None:
-        self._compact_start = asyncio.Event()
         self._start_emitted = False
-        self._done = False
         self._tool_call_id = ""
-        self._transcript_path: str = ""
+        self._active_transcript_path: str = ""
+        self._pending_transcript_paths: deque[str] = deque()
+        self._attempted_sources: list[str] = []
+        self._completed_count = 0
+        self._completed_sources: list[str] = []
+
+    @property
+    def attempt_count(self) -> int:
+        return len(self._attempted_sources)
+
+    @property
+    def attempt_sources(self) -> tuple[str, ...]:
+        return tuple(self._attempted_sources)
+
+    @property
+    def completed_count(self) -> int:
+        return self._completed_count
+
+    @property
+    def completed_sources(self) -> tuple[str, ...]:
+        return tuple(self._completed_sources)
+
+    def get_observability_metadata(self) -> dict[str, Any]:
+        attempt_count = self.attempt_count
+        if attempt_count <= 0 and self._completed_count <= 0:
+            return {}
+
+        metadata: dict[str, Any] = {
+            "compaction_attempt_count": attempt_count,
+            "compaction_attempt_sources": _summarize_sources(self._attempted_sources),
+        }
+        if self._completed_count > 0:
+            metadata["compaction_count"] = self._completed_count
+            metadata["compaction_sources"] = _summarize_sources(self._completed_sources)
+        return metadata
+
+    def get_log_summary(self) -> dict[str, Any]:
+        return {
+            "attempt_count": self.attempt_count,
+            "attempt_sources": (
+                _summarize_sources(self._attempted_sources)
+                if self._attempted_sources
+                else ""
+            ),
+            "completed_count": self._completed_count,
+            "completed_sources": (
+                _summarize_sources(self._completed_sources)
+                if self._completed_sources
+                else ""
+            ),
+        }
 
     def on_compact(self, transcript_path: str = "") -> None:
-        """Callback for the PreCompact hook. Stores transcript_path."""
-        if (
-            self._transcript_path
-            and transcript_path
-            and self._transcript_path != transcript_path
-        ):
-            logger.warning(
-                "[Compaction] Overwriting transcript_path %s -> %s",
-                self._transcript_path,
-                transcript_path,
-            )
-        self._transcript_path = transcript_path
-        self._compact_start.set()
+        """Callback for the PreCompact hook. Queues an SDK compaction attempt."""
+        self._attempted_sources.append("sdk_internal")
+        self._pending_transcript_paths.append(transcript_path)
 
     # ------------------------------------------------------------------
     # Pre-query compaction
@@ -212,7 +256,9 @@ class CompactionTracker:
 
     def emit_pre_query(self, session: ChatSession) -> list[StreamBaseResponse]:
         """Emit + persist a self-contained compaction tool call."""
-        self._done = True
+        self._attempted_sources.append("pre_query")
+        self._completed_count += 1
+        self._completed_sources.append("pre_query")
         return emit_compaction(session)
 
     # ------------------------------------------------------------------
@@ -221,18 +267,17 @@ class CompactionTracker:
 
     def reset_for_query(self) -> None:
         """Reset per-query state before a new SDK query."""
-        self._compact_start.clear()
-        self._done = False
         self._start_emitted = False
         self._tool_call_id = ""
-        self._transcript_path = ""
+        self._active_transcript_path = ""
+        self._pending_transcript_paths.clear()
 
     def emit_start_if_ready(self) -> list[StreamBaseResponse]:
         """If the PreCompact hook fired, emit start events (spinning tool)."""
-        if self._compact_start.is_set() and not self._start_emitted and not self._done:
-            self._compact_start.clear()
+        if self._pending_transcript_paths and not self._start_emitted:
             self._start_emitted = True
             self._tool_call_id = _new_tool_call_id()
+            self._active_transcript_path = self._pending_transcript_paths.popleft()
             return _start_events(self._tool_call_id)
         return []
 
@@ -246,27 +291,31 @@ class CompactionTracker:
         # Yield so pending hook tasks can set compact_start
         await asyncio.sleep(0)
 
-        if self._done:
-            return CompactionResult()
-        if not self._start_emitted and not self._compact_start.is_set():
+        if not self._start_emitted and not self._pending_transcript_paths:
             return CompactionResult()
 
         if self._start_emitted:
             # Close the open spinner
             done_events = _end_events(self._tool_call_id, COMPACTION_DONE_MSG)
             persist_id = self._tool_call_id
+            transcript_path = self._active_transcript_path
         else:
             # PreCompact fired but start never emitted — self-contained
             persist_id = _new_tool_call_id()
             done_events = compaction_events(
                 COMPACTION_DONE_MSG, tool_call_id=persist_id
             )
+            transcript_path = (
+                self._pending_transcript_paths.popleft()
+                if self._pending_transcript_paths
+                else ""
+            )
 
-        transcript_path = self._transcript_path
-        self._compact_start.clear()
         self._start_emitted = False
-        self._done = True
-        self._transcript_path = ""
+        self._tool_call_id = ""
+        self._active_transcript_path = ""
+        self._completed_count += 1
+        self._completed_sources.append("sdk_internal")
         _persist(session, persist_id, COMPACTION_DONE_MSG)
         return CompactionResult(
             events=done_events, just_ended=True, transcript_path=transcript_path

--- a/autogpt_platform/backend/backend/copilot/sdk/compaction_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/compaction_test.py
@@ -162,10 +162,11 @@ class TestFilterCompactionMessages:
 
 
 class TestCompactionTracker:
-    def test_on_compact_sets_event(self):
+    def test_on_compact_registers_pending_attempt(self):
         tracker = CompactionTracker()
         tracker.on_compact()
-        assert tracker._compact_start.is_set()
+        assert tracker.attempt_count == 1
+        assert list(tracker._pending_transcript_paths) == [""]
 
     def test_emit_start_if_ready_no_event(self):
         tracker = CompactionTracker()
@@ -244,36 +245,39 @@ class TestCompactionTracker:
         evts = tracker.emit_pre_query(session)
         assert len(evts) == 5
         assert len(session.messages) == 2
-        assert tracker._done is True
+        assert tracker.attempt_count == 1
+        assert tracker.completed_count == 1
+        assert tracker.get_observability_metadata() == {
+            "compaction_attempt_count": 1,
+            "compaction_attempt_sources": "pre_query",
+            "compaction_count": 1,
+            "compaction_sources": "pre_query",
+        }
 
     def test_reset_for_query(self):
         tracker = CompactionTracker()
-        tracker._done = True
+        tracker.on_compact("/some/path")
         tracker._start_emitted = True
         tracker._tool_call_id = "old"
-        tracker._transcript_path = "/some/path"
+        tracker._active_transcript_path = "/active/path"
         tracker.reset_for_query()
-        assert tracker._done is False
         assert tracker._start_emitted is False
         assert tracker._tool_call_id == ""
-        assert tracker._transcript_path == ""
+        assert tracker._active_transcript_path == ""
+        assert list(tracker._pending_transcript_paths) == []
 
     @pytest.mark.asyncio
-    async def test_pre_query_blocks_sdk_compaction_until_reset(self):
-        """After pre-query compaction, SDK compaction is blocked until
-        reset_for_query is called."""
+    async def test_pre_query_does_not_block_sdk_compaction_within_query(self):
+        """SDK auto-compaction can still fire after a pre-query compaction."""
         tracker = CompactionTracker()
         session = _make_session()
         tracker.emit_pre_query(session)
         tracker.on_compact()
-        # _done is True so emit_start_if_ready is blocked
-        evts = tracker.emit_start_if_ready()
-        assert evts == []
-        # Reset clears _done, allowing subsequent compaction
-        tracker.reset_for_query()
-        tracker.on_compact()
         evts = tracker.emit_start_if_ready()
         assert len(evts) == 3
+        result = await tracker.emit_end_if_ready(session)
+        assert result.just_ended is True
+        assert tracker.completed_count == 2
 
     @pytest.mark.asyncio
     async def test_reset_allows_new_compaction(self):
@@ -318,43 +322,18 @@ class TestCompactionTracker:
         assert len(result1.events) == 2
         assert result1.transcript_path == "/path/1"
 
-        # Second compaction cycle (should NOT be blocked — _done resets
-        # because emit_end_if_ready sets it True, but the next on_compact
-        # + emit_start_if_ready checks !_done which IS True now.
-        # So we need reset_for_query between queries, but within a single
-        # query multiple compactions work because _done blocks emit_start
-        # until the next message arrives, at which point emit_end detects it)
-        #
-        # Actually: _done=True blocks emit_start_if_ready, so we need
-        # the stream loop to reset. In practice service.py doesn't call
-        # reset between compactions within the same query — let's verify
-        # the actual behavior.
+        # Second compaction cycle in the same query
         tracker.on_compact("/path/2")
-        # _done is True from first compaction, so start is blocked
         start_evts = tracker.emit_start_if_ready()
-        assert start_evts == []
-        # But emit_end returns no-op because _done is True
+        assert len(start_evts) == 3
         result2 = await tracker.emit_end_if_ready(session)
-        assert result2.just_ended is False
+        assert result2.just_ended is True
+        assert result2.transcript_path == "/path/2"
+        assert tracker.completed_count == 2
 
     @pytest.mark.asyncio
     async def test_multiple_compactions_with_intervening_message(self):
-        """Multiple compactions work when the stream loop processes messages between them.
-
-        In the real service.py flow:
-        1. PreCompact fires → on_compact()
-        2. emit_start shows spinner
-        3. Next message arrives → emit_end completes compaction (_done=True)
-        4. Stream continues processing messages...
-        5. If a second PreCompact fires, _done=True blocks emit_start
-        6. But the next message triggers emit_end, which sees _done=True → no-op
-        7. The stream loop needs to detect this and handle accordingly
-
-        The actual flow for multiple compactions within a query requires
-        _done to be cleared between them. The service.py code uses
-        CompactionResult.just_ended to trigger replace_entries, and _done
-        stays True until reset_for_query.
-        """
+        """Multiple compactions remain supported across query boundaries."""
         tracker = CompactionTracker()
         session = _make_session()
 
@@ -376,10 +355,10 @@ class TestCompactionTracker:
         assert result2.just_ended is True
         assert result2.transcript_path == "/path/2"
 
-    def test_on_compact_stores_transcript_path(self):
+    def test_on_compact_queues_transcript_path(self):
         tracker = CompactionTracker()
         tracker.on_compact("/some/path.jsonl")
-        assert tracker._transcript_path == "/some/path.jsonl"
+        assert list(tracker._pending_transcript_paths) == ["/some/path.jsonl"]
 
     @pytest.mark.asyncio
     async def test_emit_end_returns_transcript_path(self):
@@ -391,17 +370,71 @@ class TestCompactionTracker:
         result = await tracker.emit_end_if_ready(session)
         assert result.just_ended is True
         assert result.transcript_path == "/my/session.jsonl"
-        # transcript_path is cleared after emit_end
-        assert tracker._transcript_path == ""
+        assert tracker._active_transcript_path == ""
 
     @pytest.mark.asyncio
-    async def test_emit_end_clears_transcript_path(self):
-        """After emit_end, _transcript_path is reset so it doesn't leak to
-        subsequent non-compaction emit_end calls."""
+    async def test_emit_end_clears_active_transcript_path(self):
+        """After emit_end, the active transcript path is reset."""
         tracker = CompactionTracker()
         session = _make_session()
         tracker.on_compact("/first/path.jsonl")
         tracker.emit_start_if_ready()
         await tracker.emit_end_if_ready(session)
-        # After compaction, _transcript_path is cleared
-        assert tracker._transcript_path == ""
+        assert tracker._active_transcript_path == ""
+
+    @pytest.mark.asyncio
+    async def test_multiple_pending_hooks_are_counted_even_before_completion(self):
+        tracker = CompactionTracker()
+        session = _make_session()
+
+        tracker.on_compact("/path/1")
+        tracker.emit_start_if_ready()
+        tracker.on_compact("/path/2")
+        tracker.on_compact("/path/3")
+
+        result1 = await tracker.emit_end_if_ready(session)
+        assert result1.just_ended is True
+        assert result1.transcript_path == "/path/1"
+        assert tracker.attempt_count == 3
+        assert tracker.completed_count == 1
+
+        tracker.emit_start_if_ready()
+        result2 = await tracker.emit_end_if_ready(session)
+        assert result2.just_ended is True
+        assert result2.transcript_path == "/path/2"
+
+        tracker.emit_start_if_ready()
+        result3 = await tracker.emit_end_if_ready(session)
+        assert result3.just_ended is True
+        assert result3.transcript_path == "/path/3"
+        assert tracker.completed_count == 3
+
+    def test_get_observability_metadata_includes_attempts_and_completions(self):
+        tracker = CompactionTracker()
+        session = _make_session()
+
+        tracker.emit_pre_query(session)
+        tracker.on_compact("/path/1")
+        tracker.on_compact("/path/2")
+
+        assert tracker.get_observability_metadata() == {
+            "compaction_attempt_count": 3,
+            "compaction_attempt_sources": "pre_query,sdk_internal:2",
+            "compaction_count": 1,
+            "compaction_sources": "pre_query",
+        }
+
+    def test_get_log_summary_includes_attempts_and_completions(self):
+        tracker = CompactionTracker()
+        session = _make_session()
+
+        tracker.emit_pre_query(session)
+        tracker.on_compact("/path/1")
+        tracker.on_compact("/path/2")
+
+        assert tracker.get_log_summary() == {
+            "attempt_count": 3,
+            "attempt_sources": "pre_query,sdk_internal:2",
+            "completed_count": 1,
+            "completed_sources": "pre_query",
+        }

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -3458,15 +3458,17 @@ async def stream_chat_completion_sdk(
 
         if ended_with_stream_error:
             logger.warning(
-                "%s Stream ended with SDK error after %d messages",
+                "%s Stream ended with SDK error after %d messages (compaction=%s)",
                 log_prefix,
                 len(session.messages),
+                compaction.get_log_summary(),
             )
         else:
             logger.info(
-                "%s Stream completed successfully with %d messages",
+                "%s Stream completed successfully with %d messages (compaction=%s)",
                 log_prefix,
                 len(session.messages),
+                compaction.get_log_summary(),
             )
     except GeneratorExit:
         # GeneratorExit is raised when the async generator is closed by the


### PR DESCRIPTION
### Why / What / How

**Why:** The old `CompactionTracker` set a `_done` flag after the first completion and short-circuited every subsequent compaction in the same turn. That blocked the SDK-internal compaction from running after a pre-query compaction had already fired, so prompt-too-long errors couldn't actually recover — retries saw the flag, bailed, and we re-hit the context limit.

**What:** Drop the `_done` flag, track attempts and completions as separate lists, and expose counters + an observability metadata builder so callers can record compaction activity per turn.

**How:**
- Remove `_done` and `_compact_start` short-circuits.
- Track `_attempted_sources` / `_completed_sources` / `_completed_count`.
- Expose `attempt_count`, `completed_count`, and `get_observability_metadata()` / `get_log_summary()` for downstream instrumentation (no caller change required in this PR).

### Changes 🏗️

- `backend/copilot/sdk/compaction.py` — rewritten `CompactionTracker` internals; adds properties + observability helpers.
- `backend/copilot/sdk/compaction_test.py` — tests for multi-compaction flow + new counters.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [ ] `poetry run pytest backend/copilot/sdk/compaction_test.py -xvs` passes
  - [ ] Local chat that hits prompt-too-long now recovers via SDK compaction instead of failing the turn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core streaming compaction state transitions and persistence timing, which could affect UI event sequencing or compaction completion behavior under concurrency; coverage is improved with new multi-compaction tests.
> 
> **Overview**
> Fixes `CompactionTracker` so compaction is no longer single-shot per turn: removes the `_done`/event-gate behavior, queues multiple `on_compact()` hook firings via a pending transcript-path deque, and allows subsequent SDK-internal compactions after a pre-query compaction within the same query.
> 
> Adds lightweight instrumentation by tracking attempt/completion sources and counts, plus `get_observability_metadata()` and `get_log_summary()` (including source summaries like `sdk_internal:2`). Updates/expands tests to cover multi-compaction flows, transcript-path handling, and the new counters/metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bf8cdd3676c6ec71f492a70cc29de19de643cf9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->