### PR TITLE
fix(frontend): forward sentry-trace and baggage across API proxy

### DIFF
--- a/autogpt_platform/frontend/src/app/api/mutators/__tests__/custom-mutator.test.ts
+++ b/autogpt_platform/frontend/src/app/api/mutators/__tests__/custom-mutator.test.ts
@@ -151,4 +151,35 @@ describe("customMutator — Sentry trace propagation", () => {
 
     expect(mockGetTraceData).not.toHaveBeenCalled();
   });
+
+  it("skips non-string values returned by Sentry.getTraceData", async () => {
+    // Simulate a non-string slipping into the trace-data object
+    mockGetTraceData.mockReturnValue({
+      "sentry-trace": "real-trace",
+      "sentry-sampled": 1,
+    } as unknown as ReturnType<typeof Sentry.getTraceData>);
+
+    await customMutator("/test", { method: "GET" });
+
+    const fetchCall = vi.mocked(fetch).mock.calls[0];
+    const headers = fetchCall[1]?.headers as Record<string, string>;
+    expect(headers["sentry-trace"]).toBe("real-trace");
+    expect(headers["sentry-sampled"]).toBeUndefined();
+  });
+
+  it("falls back to an empty object when Sentry.getTraceData is undefined", async () => {
+    // Simulate an older @sentry/nextjs build where getTraceData isn't exported
+    (Sentry as { getTraceData?: unknown }).getTraceData =
+      undefined as unknown as typeof Sentry.getTraceData;
+
+    await customMutator("/test", { method: "GET" });
+
+    const fetchCall = vi.mocked(fetch).mock.calls[0];
+    const headers = fetchCall[1]?.headers as Record<string, string>;
+    expect(headers["sentry-trace"]).toBeUndefined();
+    expect(headers["baggage"]).toBeUndefined();
+
+    // Restore for subsequent tests
+    (Sentry as { getTraceData?: unknown }).getTraceData = mockGetTraceData;
+  });
 });

--- a/autogpt_platform/frontend/src/app/api/mutators/__tests__/custom-mutator.test.ts
+++ b/autogpt_platform/frontend/src/app/api/mutators/__tests__/custom-mutator.test.ts
@@ -26,13 +26,19 @@ vi.mock("@/lib/autogpt-server-api/helpers", () => ({
   getServerAuthToken: vi.fn(),
 }));
 
+vi.mock("@sentry/nextjs", () => ({
+  getTraceData: vi.fn(() => ({})),
+}));
+
 import { customMutator } from "../custom-mutator";
 import { getSystemHeaders } from "@/lib/impersonation";
 import { environment } from "@/services/environment";
 import { IMPERSONATION_HEADER_NAME } from "@/lib/constants";
+import * as Sentry from "@sentry/nextjs";
 
 const mockIsClientSide = vi.mocked(environment.isClientSide);
 const mockGetSystemHeaders = vi.mocked(getSystemHeaders);
+const mockGetTraceData = vi.mocked(Sentry.getTraceData);
 
 describe("customMutator — impersonation header", () => {
   beforeEach(() => {
@@ -86,5 +92,63 @@ describe("customMutator — impersonation header", () => {
     const headers = fetchCall[1]?.headers as Record<string, string>;
     expect(headers[IMPERSONATION_HEADER_NAME]).toBe("impersonated-user-abc");
     expect(headers["X-Custom-Header"]).toBe("custom-value");
+  });
+});
+
+describe("customMutator — Sentry trace propagation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsClientSide.mockReturnValue(true);
+    mockGetSystemHeaders.mockReturnValue({});
+    mockGetTraceData.mockReturnValue({});
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: new Headers({ "content-type": "application/json" }),
+        json: () => Promise.resolve({}),
+      }),
+    );
+  });
+
+  it("attaches sentry-trace and baggage headers from Sentry trace data on client-side", async () => {
+    mockGetTraceData.mockReturnValue({
+      "sentry-trace": "0123456789abcdef0123456789abcdef-0123456789abcdef-1",
+      baggage: "sentry-environment=local,sentry-public_key=abc",
+    });
+
+    await customMutator("/test", { method: "GET" });
+
+    const fetchCall = vi.mocked(fetch).mock.calls[0];
+    const headers = fetchCall[1]?.headers as Record<string, string>;
+    expect(headers["sentry-trace"]).toBe(
+      "0123456789abcdef0123456789abcdef-0123456789abcdef-1",
+    );
+    expect(headers["baggage"]).toBe(
+      "sentry-environment=local,sentry-public_key=abc",
+    );
+  });
+
+  it("omits sentry-trace headers when Sentry has no active trace", async () => {
+    mockGetTraceData.mockReturnValue({});
+
+    await customMutator("/test", { method: "GET" });
+
+    const fetchCall = vi.mocked(fetch).mock.calls[0];
+    const headers = fetchCall[1]?.headers as Record<string, string>;
+    expect(headers["sentry-trace"]).toBeUndefined();
+    expect(headers["baggage"]).toBeUndefined();
+  });
+
+  it("does not attach Sentry trace headers on server-side", async () => {
+    mockIsClientSide.mockReturnValue(false);
+    mockGetTraceData.mockReturnValue({
+      "sentry-trace": "should-not-appear",
+    });
+
+    await customMutator("/test", { method: "GET" });
+
+    expect(mockGetTraceData).not.toHaveBeenCalled();
   });
 });

--- a/autogpt_platform/frontend/src/app/api/mutators/custom-mutator.ts
+++ b/autogpt_platform/frontend/src/app/api/mutators/custom-mutator.ts
@@ -3,6 +3,7 @@ import {
   createRequestHeaders,
   getServerAuthToken,
 } from "@/lib/autogpt-server-api/helpers";
+import * as Sentry from "@sentry/nextjs";
 
 import { getSystemHeaders } from "@/lib/impersonation";
 import { environment } from "@/services/environment";
@@ -53,6 +54,12 @@ export const customMutator = async <
   };
 
   if (environment.isClientSide()) {
+    const traceData = Sentry.getTraceData?.() ?? {};
+    for (const [key, value] of Object.entries(traceData)) {
+      if (typeof value === "string") {
+        headers[key] = value;
+      }
+    }
     Object.assign(headers, getSystemHeaders());
   }
 

--- a/autogpt_platform/frontend/src/lib/autogpt-server-api/helpers.test.ts
+++ b/autogpt_platform/frontend/src/lib/autogpt-server-api/helpers.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/supabase/server/getServerSupabase", () => ({
+  getServerSupabase: vi.fn(),
+}));
+
+vi.mock("@/services/environment", () => ({
+  environment: {
+    isServerSide: vi.fn(() => true),
+    isClientSide: vi.fn(() => false),
+    getAGPTServerApiUrl: vi.fn(() => "http://localhost:8006/api"),
+  },
+}));
+
+import { createRequestHeaders } from "./helpers";
+import {
+  API_KEY_HEADER_NAME,
+  IMPERSONATION_HEADER_NAME,
+} from "@/lib/constants";
+
+function makeRequest(headers: Record<string, string>): Request {
+  return new Request("http://example.com/test", { headers });
+}
+
+describe("createRequestHeaders — basics", () => {
+  it("adds Content-Type when hasRequestBody is true", () => {
+    const headers = createRequestHeaders("token-abc", true);
+    expect(headers["Content-Type"]).toBe("application/json");
+  });
+
+  it("omits Content-Type when hasRequestBody is false", () => {
+    const headers = createRequestHeaders("token-abc", false);
+    expect(headers["Content-Type"]).toBeUndefined();
+  });
+
+  it("uses the provided contentType override", () => {
+    const headers = createRequestHeaders(
+      "token-abc",
+      true,
+      "application/x-www-form-urlencoded",
+    );
+    expect(headers["Content-Type"]).toBe("application/x-www-form-urlencoded");
+  });
+
+  it("adds Authorization header when token is a real value", () => {
+    const headers = createRequestHeaders("token-abc", false);
+    expect(headers["Authorization"]).toBe("Bearer token-abc");
+  });
+
+  it("omits Authorization when token is the 'no-token-found' sentinel", () => {
+    const headers = createRequestHeaders("no-token-found", false);
+    expect(headers["Authorization"]).toBeUndefined();
+  });
+
+  it("omits Authorization when token is empty", () => {
+    const headers = createRequestHeaders("", false);
+    expect(headers["Authorization"]).toBeUndefined();
+  });
+});
+
+describe("createRequestHeaders — Sentry trace forwarding", () => {
+  it("forwards sentry-trace and baggage headers when present on originalRequest", () => {
+    const request = makeRequest({
+      "sentry-trace": "0123456789abcdef0123456789abcdef-0123456789abcdef-1",
+      baggage: "sentry-environment=local,sentry-public_key=abc",
+    });
+
+    const headers = createRequestHeaders(
+      "token-abc",
+      false,
+      undefined,
+      request,
+    );
+
+    expect(headers["sentry-trace"]).toBe(
+      "0123456789abcdef0123456789abcdef-0123456789abcdef-1",
+    );
+    expect(headers["baggage"]).toBe(
+      "sentry-environment=local,sentry-public_key=abc",
+    );
+  });
+
+  it("forwards only sentry-trace when baggage is absent", () => {
+    const request = makeRequest({
+      "sentry-trace": "trace-id-only",
+    });
+
+    const headers = createRequestHeaders(
+      "token-abc",
+      false,
+      undefined,
+      request,
+    );
+
+    expect(headers["sentry-trace"]).toBe("trace-id-only");
+    expect(headers["baggage"]).toBeUndefined();
+  });
+
+  it("forwards only baggage when sentry-trace is absent", () => {
+    const request = makeRequest({
+      baggage: "sentry-environment=prod",
+    });
+
+    const headers = createRequestHeaders(
+      "token-abc",
+      false,
+      undefined,
+      request,
+    );
+
+    expect(headers["sentry-trace"]).toBeUndefined();
+    expect(headers["baggage"]).toBe("sentry-environment=prod");
+  });
+
+  it("does not forward sentry headers when originalRequest has none", () => {
+    const request = makeRequest({ "X-Other-Header": "something" });
+
+    const headers = createRequestHeaders(
+      "token-abc",
+      false,
+      undefined,
+      request,
+    );
+
+    expect(headers["sentry-trace"]).toBeUndefined();
+    expect(headers["baggage"]).toBeUndefined();
+  });
+
+  it("does not attempt to forward sentry headers when originalRequest is omitted", () => {
+    const headers = createRequestHeaders("token-abc", false);
+
+    expect(headers["sentry-trace"]).toBeUndefined();
+    expect(headers["baggage"]).toBeUndefined();
+  });
+});
+
+describe("createRequestHeaders — impersonation and API-key forwarding", () => {
+  it("forwards the impersonation header alongside sentry headers", () => {
+    const request = makeRequest({
+      [IMPERSONATION_HEADER_NAME]: "impersonated-user-xyz",
+      "sentry-trace": "trace-id",
+    });
+
+    const headers = createRequestHeaders(
+      "token-abc",
+      false,
+      undefined,
+      request,
+    );
+
+    expect(headers[IMPERSONATION_HEADER_NAME]).toBe("impersonated-user-xyz");
+    expect(headers["sentry-trace"]).toBe("trace-id");
+  });
+
+  it("forwards the API key header alongside sentry headers", () => {
+    const request = makeRequest({
+      [API_KEY_HEADER_NAME]: "api-key-value",
+      baggage: "sentry-environment=local",
+    });
+
+    const headers = createRequestHeaders(
+      "token-abc",
+      false,
+      undefined,
+      request,
+    );
+
+    expect(headers[API_KEY_HEADER_NAME]).toBe("api-key-value");
+    expect(headers["baggage"]).toBe("sentry-environment=local");
+  });
+});

--- a/autogpt_platform/frontend/src/lib/autogpt-server-api/helpers.ts
+++ b/autogpt_platform/frontend/src/lib/autogpt-server-api/helpers.ts
@@ -163,6 +163,15 @@ export function createRequestHeaders(
     if (apiKeyHeader) {
       headers[API_KEY_HEADER_NAME] = apiKeyHeader;
     }
+
+    // Forward Sentry distributed-tracing headers so the backend transaction
+    // continues the browser span instead of starting a disconnected trace.
+    for (const name of ["sentry-trace", "baggage"] as const) {
+      const value = originalRequest.headers.get(name);
+      if (value) {
+        headers[name] = value;
+      }
+    }
   }
 
   return headers;


### PR DESCRIPTION
### Why / What / How

**Why:** Every request that went through Next's rewrite proxy broke distributed tracing. The browser Sentry SDK emitted `sentry-trace` and `baggage`, but `createRequestHeaders` only forwarded impersonation + API key, so the backend started a disconnected transaction. The frontend → backend lineage never appeared in Sentry. Same gap on direct-from-browser requests: the custom mutator never attached the trace headers itself, so even non-proxied paths lost the link.

**What:**
- **Server side:** forward `sentry-trace` and `baggage` from `originalRequest.headers` alongside the existing impersonation/API key forwarding.
- **Client side:** the custom mutator pulls trace data via `Sentry.getTraceData()` and attaches it to outgoing headers when running on the client.

**How:** Inline additions — no new observability module, no new dependencies beyond `@sentry/nextjs` which the frontend already uses for Sentry init.

### Changes 🏗️

- `src/lib/autogpt-server-api/helpers.ts` — forward `sentry-trace` + `baggage` in `createRequestHeaders`.
- `src/app/api/mutators/custom-mutator.ts` — import `@sentry/nextjs`, attach `Sentry.getTraceData()` on client-side requests.
- `src/app/api/mutators/__tests__/custom-mutator.test.ts` — three new tests: trace-data present, trace-data empty, server-side no-op.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [x] `pnpm vitest run src/app/api/mutators/__tests__/custom-mutator.test.ts` passes (6/6 locally)
  - [x] `pnpm format && pnpm lint` clean
  - [x] `pnpm types` clean for touched files (pre-existing unrelated type errors on dev are untouched)
  - [ ] In a local session with Sentry enabled, a `/copilot` chat turn produces a distributed trace that spans frontend transaction → backend transaction (single trace ID in Sentry)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: header-only changes to request construction for observability, with added tests; primary risk is unintended header propagation affecting upstream/proxy behavior.
> 
> **Overview**
> Restores **Sentry distributed tracing continuity** for frontend→backend calls by propagating `sentry-trace`/`baggage` headers.
> 
> On the client, `customMutator` now reads `Sentry.getTraceData()` and attaches string trace headers to outgoing requests (guarded for server-side and older Sentry builds). On the server/proxy path, `createRequestHeaders` now forwards `sentry-trace` and `baggage` from the incoming `originalRequest` alongside existing impersonation/API-key forwarding, with new unit tests covering these cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f6946b7764b2cacc2f2d947fbcfeb75a691ca1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->