### PR TITLE
fix(frontend/copilot): close artifact panel on copilot page unmount (SECRT-2254/2223/2220)

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatContainer/useAutoOpenArtifacts.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatContainer/useAutoOpenArtifacts.test.ts
@@ -88,4 +88,53 @@ describe("useAutoOpenArtifacts", () => {
     expect(s.activeArtifact?.id).toBe("c");
     expect(s.history).toEqual([]);
   });
+
+  // SECRT-2254: "had agent panel open then went to profile then went to home
+  // and agent panel was still open". Nav-away unmounts the copilot page; if
+  // the panel state persists in the store, coming back re-renders it open.
+  it("closes the panel on unmount so nav-away → nav-back doesn't resurrect it (SECRT-2254)", () => {
+    useCopilotUIStore.getState().openArtifact(makeArtifact(A_ID, "a.txt"));
+    expect(useCopilotUIStore.getState().artifactPanel.isOpen).toBe(true);
+
+    const { unmount } = renderHook(() =>
+      useAutoOpenArtifacts({ sessionId: "s1" }),
+    );
+
+    act(() => {
+      unmount();
+    });
+
+    const s = useCopilotUIStore.getState().artifactPanel;
+    expect(s.isOpen).toBe(false);
+    expect(s.activeArtifact).toBeNull();
+    expect(s.history).toEqual([]);
+  });
+
+  // SECRT-2220: "keep closed by default" — a fresh mount (e.g. user returns to
+  // /copilot) must start with a closed panel even if the store somehow carries
+  // stale state from a prior life.
+  it("does not re-open a panel whose store state is stale on fresh mount (SECRT-2220)", () => {
+    // Simulate the store being left in an open state by a previous page life.
+    useCopilotUIStore.setState({
+      artifactPanel: {
+        isOpen: true,
+        isMinimized: false,
+        isMaximized: false,
+        width: 600,
+        activeArtifact: makeArtifact(A_ID, "stale.txt"),
+        history: [],
+      },
+    });
+
+    const { unmount } = renderHook(() =>
+      useAutoOpenArtifacts({ sessionId: "s1" }),
+    );
+    act(() => {
+      unmount();
+    });
+
+    // Next mount of the page should see a clean store.
+    renderHook(() => useAutoOpenArtifacts({ sessionId: "s1" }));
+    expect(useCopilotUIStore.getState().artifactPanel.isOpen).toBe(false);
+  });
 });

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatContainer/useAutoOpenArtifacts.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatContainer/useAutoOpenArtifacts.ts
@@ -26,4 +26,13 @@ export function useAutoOpenArtifacts({
       resetArtifactPanel();
     }
   }, [sessionId, resetArtifactPanel]);
+
+  // Reset on unmount so navigating away from /copilot (to /profile, /home,
+  // etc.) can't leave the panel open in the Zustand store, which would then
+  // render the panel re-open when the user returns. See SECRT-2254/2220.
+  useEffect(() => {
+    return () => {
+      resetArtifactPanel();
+    };
+  }, [resetArtifactPanel]);
 }


### PR DESCRIPTION
### Why / What / How

**Why** — Three separate tickets in the Artifact project all have the same root cause: the artifact panel's `isOpen` state lives in a global Zustand store that outlives copilot page unmounts. Open the panel, navigate to `/profile`, come back to `/copilot` — panel re-renders open with whatever artifact was last shown (which may belong to a different session). The user has filed this bug multiple times:

- **SECRT-2254** "Artifact Randomly Stays Open" — panel stays open after navigating through `/profile` and `/home`.
- **SECRT-2223** "Artifact Panel Should Close on New Chat or Different Thread" — within-page session switches.
- **SECRT-2220** "Don't open Artifact Side-Panel by Default" — fresh visit to a session should start closed.

Session-change reset was already implemented in `useAutoOpenArtifacts`, covering SECRT-2223. What was missing: the nav-away case. That's what this PR fixes.

**What** — Add an unmount cleanup to `useAutoOpenArtifacts` that calls `resetArtifactPanel()`, so leaving the copilot page can never leave a stale `isOpen: true` in the store.

**How** — One small `useEffect` with a cleanup. On every unmount of the hook (which is co-mounted with `ChatContainer`), the panel is reset. On the next mount the store is clean, and the existing session-change logic handles in-page switches.

Two repro tests drive the fix:
1. `closes the panel on unmount so nav-away → nav-back doesn't resurrect it (SECRT-2254)` — opens an artifact, unmounts the hook, asserts `isOpen === false`.
2. `does not re-open a panel whose store state is stale on fresh mount (SECRT-2220)` — seeds the store with `isOpen: true`, mounts+unmounts, remounts, asserts `isOpen === false`.

Both were failing before the fix (confirmed locally) and pass after.

### Changes 🏗️

- `frontend/src/app/(platform)/copilot/components/ChatContainer/useAutoOpenArtifacts.ts` — add unmount cleanup that calls `resetArtifactPanel()`.
- `frontend/src/app/(platform)/copilot/components/ChatContainer/useAutoOpenArtifacts.test.ts` — two new regression tests referencing SECRT-2254 and SECRT-2220.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `pnpm vitest run src/app/\(platform\)/copilot/components/ChatContainer/useAutoOpenArtifacts.test.ts` — 6/6 pass (2 new)
  - [x] `pnpm vitest run src/app/\(platform\)/copilot` — 590/590 pass (full copilot suite regression check)
  - [x] `pnpm format && pnpm types` clean
  - [ ] Manual: load `/copilot?sessionId=<id-with-artifacts>`, click an artifact to open the panel, navigate to `/profile`, come back to `/copilot` — panel should be closed
  - [ ] Manual: panel open in session A, click a different session in the sidebar, panel closes (SECRT-2223)
  - [ ] Manual: panel open in session A, click "New Chat", panel closes (SECRT-2220)

Fixes SECRT-2254, SECRT-2223, SECRT-2220.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized UI-state change (Zustand store reset on unmount) with focused test coverage; low likelihood of impacting data or security.
> 
> **Overview**
> Prevents the Copilot artifact side panel from persisting in an open/stale state across navigation by resetting `artifactPanel` state when `useAutoOpenArtifacts` unmounts (in addition to the existing session-change reset).
> 
> Adds regression tests covering nav-away → nav-back behavior and ensuring a fresh mount does not resurrect a panel left open in the global Zustand store (SECRT-2254/2220).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db014cf7a2f09c672ad72511fb1b67311864e72e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->