### PR TITLE
fix(frontend/copilot): show loading skeleton when retrying a failed artifact fetch (SECRT-2224)

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ArtifactPanel/components/__tests__/ArtifactContent.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ArtifactPanel/components/__tests__/ArtifactContent.test.tsx
@@ -379,6 +379,115 @@ describe("ArtifactContent", () => {
     expect(retryButtons.length).toBeGreaterThan(0);
   });
 
+  // SECRT-2224: "try again doesn't do anything". The retry itself works — the
+  // user's complaint is that there's no visible feedback when the same error
+  // returns (e.g. a 404 for a deleted file). Clicking Try Again must flip the
+  // UI into the loading skeleton immediately so the user can tell their click
+  // registered, instead of the error UI re-flashing in place.
+  it("clicking Try Again shows the loading skeleton before the next fetch settles (SECRT-2224)", async () => {
+    let resolveSecond: (value: unknown) => void = () => {};
+    let callCount = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          return Promise.resolve({
+            ok: false,
+            status: 404,
+            text: () => Promise.resolve("Not found"),
+          });
+        }
+        return new Promise((resolve) => {
+          resolveSecond = resolve;
+        });
+      }),
+    );
+
+    const artifact = makeArtifact({
+      id: "retry-skeleton-001",
+      title: "flaky.html",
+      mimeType: "text/html",
+    });
+    const classification = makeClassification({ type: "html" });
+
+    const { container } = render(
+      <ArtifactContent
+        artifact={artifact}
+        isSourceView={false}
+        classification={classification}
+      />,
+    );
+
+    await screen.findByText("Failed to load content");
+    fireEvent.click(screen.getByRole("button", { name: /try again/i }));
+
+    // Before the second fetch resolves, the error must be gone and a skeleton
+    // visible (animate-pulse is the Skeleton component's signature class).
+    await waitFor(() => {
+      expect(screen.queryByText("Failed to load content")).toBeNull();
+      expect(container.querySelector('[class*="animate-pulse"]')).toBeTruthy();
+    });
+
+    // Let the second fetch complete so the test doesn't leak pending state.
+    resolveSecond({
+      ok: true,
+      text: () => Promise.resolve("<html><body>ok</body></html>"),
+    });
+  });
+
+  // SECRT-2224 end-to-end: Try Again actually recovers when the next fetch
+  // succeeds. Covers the full click → re-fetch → iframe-render loop.
+  it("clicking Try Again re-fetches and renders recovered HTML content (SECRT-2224)", async () => {
+    let callCount = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          return Promise.resolve({
+            ok: false,
+            status: 404,
+            text: () => Promise.resolve("Not found"),
+          });
+        }
+        return Promise.resolve({
+          ok: true,
+          text: () =>
+            Promise.resolve(
+              "<html><body><h1 id='ok'>recovered</h1></body></html>",
+            ),
+        });
+      }),
+    );
+
+    const artifact = makeArtifact({
+      id: "retry-recover-001",
+      title: "flaky.html",
+      mimeType: "text/html",
+    });
+    const classification = makeClassification({ type: "html" });
+
+    const { container } = render(
+      <ArtifactContent
+        artifact={artifact}
+        isSourceView={false}
+        classification={classification}
+      />,
+    );
+
+    await screen.findByText("Failed to load content");
+    fireEvent.click(screen.getByRole("button", { name: /try again/i }));
+
+    await waitFor(() => {
+      const iframe = container.querySelector("iframe");
+      expect(iframe).toBeTruthy();
+      expect(iframe?.getAttribute("srcdoc")).toContain("recovered");
+    });
+    expect(screen.queryByText("Failed to load content")).toBeNull();
+    expect(callCount).toBeGreaterThanOrEqual(2);
+  });
+
   // ── HTML ──────────────────────────────────────────────────────────
 
   it("renders HTML content in sandboxed iframe", async () => {

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ArtifactPanel/components/useArtifactContent.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ArtifactPanel/components/useArtifactContent.ts
@@ -141,6 +141,11 @@ export function useArtifactContent(
   function retry() {
     // Drop any cached failure/content for this id so we actually re-fetch.
     contentCache.delete(artifact.id);
+    // Flip into loading + clear error synchronously with the click so the
+    // user always sees the skeleton (rather than the error UI re-flashing
+    // instantly for same-error retries). See SECRT-2224.
+    setIsLoading(true);
+    setError(null);
     setRetryNonce((n) => n + 1);
   }
 


### PR DESCRIPTION
### Why / What / How

**Why** — User reported (SECRT-2224) "the content won't render html and try again doesn't do anything". After reproducing, the retry itself works: clicking Try Again clears the cache and re-fetches. The problem is visual feedback. The loading-state flip happened inside the effect that runs *after* the click commit, so for a retry that lands on the same error (deleted file, persistent 500) the UI went `error → error` with no visible intermediate state. It looked like the button was dead.

**What** — Inside `retry()`, flip `isLoading: true` and `error: null` synchronously with the click, before bumping the fetch nonce. React batches the updates so the next render shows the skeleton regardless of how fast the next fetch resolves.

**How** — Tiny change to the hook's `retry()` function. Two new tests at the component level:
1. Clicking Try Again flips into the loading skeleton *before* the second fetch settles.
2. End-to-end recovery: failing fetch → click Try Again → second fetch succeeds → iframe renders with recovered content.

### Changes 🏗️

- `frontend/src/app/(platform)/copilot/components/ArtifactPanel/components/useArtifactContent.ts` — `retry()` now sets `isLoading: true` and `error: null` synchronously, then bumps the nonce.
- `frontend/src/app/(platform)/copilot/components/ArtifactPanel/components/__tests__/ArtifactContent.test.tsx` — two new SECRT-2224 regression tests.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `pnpm vitest run src/app/\(platform\)/copilot/components/ArtifactPanel` — 46/46 pass (2 new)
  - [x] `pnpm format && pnpm types` clean
  - [ ] Manual: open an artifact where the backend will 404, click Try Again — skeleton flashes briefly before the same error lands (confirms the click registered)
  - [ ] Manual: open a flaky artifact, click Try Again on transient failure, content loads

Fixes SECRT-2224.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized UI state update in `useArtifactContent.retry()` plus test coverage; minimal behavioral risk beyond loading/error rendering timing.
> 
> **Overview**
> Improves the artifact viewer retry UX so clicking `Try again` immediately clears the error state and shows the loading skeleton while the next fetch is in-flight (fixing the “button does nothing” perception when retries return the same error).
> 
> Adds two regression tests in `ArtifactContent.test.tsx` to assert (1) the skeleton appears before the retried fetch settles and (2) a failed HTML fetch can recover on retry and render into the iframe.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a05226e1ec9ff5ab6c0eb9db1048bc2569a3dad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->