### PR TITLE
fix(frontend/copilot): stop size-gating large images/videos/PDFs; cache-bust retry (SECRT-2221)

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ArtifactPanel/components/ArtifactContent.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ArtifactPanel/components/ArtifactContent.tsx
@@ -64,9 +64,18 @@ function ArtifactContentLoader({
   );
 }
 
+function withCacheBust(src: string, nonce: number): string {
+  if (nonce === 0) return src;
+  const sep = src.includes("?") ? "&" : "?";
+  return `${src}${sep}_retry=${nonce}`;
+}
+
 function ArtifactImage({ src, alt }: { src: string; alt: string }) {
   const [loaded, setLoaded] = useState(false);
   const [error, setError] = useState(false);
+  // Incremented on every Try Again so the URL changes and the browser
+  // can't reuse a negative-cached response (SECRT-2221).
+  const [retryNonce, setRetryNonce] = useState(0);
 
   if (error) {
     return (
@@ -80,6 +89,7 @@ function ArtifactImage({ src, alt }: { src: string; alt: string }) {
           onClick={() => {
             setError(false);
             setLoaded(false);
+            setRetryNonce((n) => n + 1);
           }}
           className="rounded-md border border-zinc-200 bg-white px-3 py-1.5 text-xs font-medium text-zinc-700 shadow-sm transition-colors hover:bg-zinc-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-400"
         >
@@ -96,7 +106,7 @@ function ArtifactImage({ src, alt }: { src: string; alt: string }) {
       )}
       {/* eslint-disable-next-line @next/next/no-img-element */}
       <img
-        src={src}
+        src={withCacheBust(src, retryNonce)}
         alt={alt}
         className={`max-h-full max-w-full object-contain transition-opacity ${loaded ? "opacity-100" : "opacity-0"}`}
         onLoad={() => setLoaded(true)}
@@ -109,6 +119,7 @@ function ArtifactImage({ src, alt }: { src: string; alt: string }) {
 function ArtifactVideo({ src }: { src: string }) {
   const [loaded, setLoaded] = useState(false);
   const [error, setError] = useState(false);
+  const [retryNonce, setRetryNonce] = useState(0);
 
   if (error) {
     return (
@@ -122,6 +133,7 @@ function ArtifactVideo({ src }: { src: string }) {
           onClick={() => {
             setError(false);
             setLoaded(false);
+            setRetryNonce((n) => n + 1);
           }}
           className="rounded-md border border-zinc-200 bg-white px-3 py-1.5 text-xs font-medium text-zinc-700 shadow-sm transition-colors hover:bg-zinc-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-400"
         >
@@ -137,7 +149,7 @@ function ArtifactVideo({ src }: { src: string }) {
         <Skeleton className="absolute inset-4 h-[calc(100%-2rem)] w-[calc(100%-2rem)] rounded-md" />
       )}
       <video
-        src={src}
+        src={withCacheBust(src, retryNonce)}
         controls
         preload="metadata"
         className={`max-h-full max-w-full rounded-md transition-opacity ${loaded ? "opacity-100" : "opacity-0"}`}

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ArtifactPanel/components/__tests__/ArtifactContent.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ArtifactPanel/components/__tests__/ArtifactContent.test.tsx
@@ -199,6 +199,79 @@ describe("ArtifactContent", () => {
     });
   });
 
+  // SECRT-2221 integration: the classification-level fix (hi-res PNGs stop
+  // being size-gated) only matters if the end-to-end rendering pipeline
+  // actually reaches the <img> path. Pass in the real classifyArtifact
+  // result for a 25 MB .png and assert the panel renders an img element
+  // rather than routing to the download-only surface.
+  it("renders a 25 MB PNG through the <img> path, not download-only (SECRT-2221)", () => {
+    const artifact = makeArtifact({
+      id: "hires-png-001",
+      title: "poster.png",
+      mimeType: "image/png",
+      sourceUrl: "/api/proxy/api/workspace/files/hires-png-001/download",
+      sizeBytes: 25 * 1024 * 1024,
+    });
+    const classification = classifyArtifact(
+      artifact.mimeType,
+      artifact.title,
+      artifact.sizeBytes,
+    );
+    expect(classification.type).toBe("image");
+    expect(classification.openable).toBe(true);
+
+    const { container } = render(
+      <ArtifactContent
+        artifact={artifact}
+        isSourceView={false}
+        classification={classification}
+      />,
+    );
+
+    const img = container.querySelector("img");
+    expect(img).toBeTruthy();
+    expect(img?.getAttribute("src")).toBe(artifact.sourceUrl);
+  });
+
+  // SECRT-2221: image retry appends a cache-busting query so the browser
+  // can't reuse a previously-failed response. Without this, a transient
+  // 5xx that gets negative-cached keeps showing "Failed to load image" no
+  // matter how many times the user clicks Try again.
+  it("image retry appends a cache-busting query so the browser re-fetches (SECRT-2221)", async () => {
+    const artifact = makeArtifact({
+      id: "img-cachebust",
+      title: "hires.png",
+      mimeType: "image/png",
+      sourceUrl: "/api/proxy/api/workspace/files/img-cachebust/download",
+    });
+    const classification = makeClassification({ type: "image" });
+
+    const { container } = render(
+      <ArtifactContent
+        artifact={artifact}
+        isSourceView={false}
+        classification={classification}
+      />,
+    );
+
+    const firstImg = container.querySelector("img");
+    const firstSrc = firstImg?.getAttribute("src");
+    expect(firstSrc).toBe(artifact.sourceUrl);
+
+    fireEvent.error(firstImg!);
+    await waitFor(() => {
+      expect(screen.queryByText("Failed to load image")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByRole("button", { name: /try again/i }));
+
+    await waitFor(() => {
+      const nextImg = container.querySelector("img");
+      const nextSrc = nextImg?.getAttribute("src") ?? "";
+      expect(nextSrc).not.toBe(firstSrc);
+      expect(nextSrc.startsWith(artifact.sourceUrl)).toBe(true);
+    });
+  });
+
   // ── Video ─────────────────────────────────────────────────────────
 
   it("renders video artifact with video tag and controls", () => {

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ArtifactPanel/helpers.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ArtifactPanel/helpers.test.ts
@@ -45,10 +45,31 @@ describe("classifyArtifact", () => {
     expect(classifyArtifact("text/markdown", "x").type).toBe("markdown");
   });
 
-  it("gates files > 10MB to download-only", () => {
+  it("gates text/code files > 10MB to download-only", () => {
     const c = classifyArtifact("text/plain", "big.txt", 20 * 1024 * 1024);
     expect(c.openable).toBe(false);
     expect(c.type).toBe("download-only");
+  });
+
+  // SECRT-2221: large images (hi-res PNGs, etc.) were getting force-classified
+  // as download-only by the generic >10MB gate, so clicking them started a
+  // download instead of previewing — and the preview was "broken" in the
+  // sense that it never appeared. Images, videos, and PDFs are decoded
+  // natively by the browser and don't run through our JS render pipeline,
+  // so the size gate shouldn't apply to them.
+  it("does NOT size-gate large images, videos, or PDFs (SECRT-2221)", () => {
+    expect(
+      classifyArtifact("image/png", "hires.png", 25 * 1024 * 1024).type,
+    ).toBe("image");
+    expect(
+      classifyArtifact("image/jpeg", "huge.jpg", 50 * 1024 * 1024).type,
+    ).toBe("image");
+    expect(
+      classifyArtifact("video/mp4", "long.mp4", 500 * 1024 * 1024).type,
+    ).toBe("video");
+    expect(
+      classifyArtifact("application/pdf", "book.pdf", 80 * 1024 * 1024).type,
+    ).toBe("pdf");
   });
 
   it("treats binary/octet-stream MIME as download-only", () => {

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ArtifactPanel/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ArtifactPanel/helpers.ts
@@ -257,14 +257,34 @@ function getExtension(filename?: string): string {
   return filename.slice(lastDot).toLowerCase();
 }
 
+// Types the browser renders natively — we don't run their bytes through our
+// React/JS pipeline, so the size gate doesn't need to apply.
+const NATIVELY_RENDERED = new Set<ArtifactClassification["type"]>([
+  "image",
+  "video",
+  "pdf",
+]);
+
 export function classifyArtifact(
   mimeType: string | null,
   filename?: string,
   sizeBytes?: number,
 ): ArtifactClassification {
-  // Size gate: >10MB is download-only regardless of type.
-  if (sizeBytes && sizeBytes > TEN_MB) return KIND["download-only"];
+  const kind = classifyByTypeOnly(mimeType, filename);
+  // Size gate: >10MB is download-only, but only for content we actually
+  // render in JS. Images, videos, and PDFs are handled natively by the
+  // browser — gating them produced "broken previews" for hi-res files
+  // (SECRT-2221).
+  if (sizeBytes && sizeBytes > TEN_MB && !NATIVELY_RENDERED.has(kind.type)) {
+    return KIND["download-only"];
+  }
+  return kind;
+}
 
+function classifyByTypeOnly(
+  mimeType: string | null,
+  filename?: string,
+): ArtifactClassification {
   const basename = getBasename(filename);
   const exactKind = EXACT_FILENAME_KIND[basename];
   if (exactKind) return KIND[exactKind];


### PR DESCRIPTION
### Why / What / How

**Why** — Reinier reported "broken artifact previews" in SECRT-2221, specifically "Hi-res PNG gives a broken preview when I click on it." Large images were being size-gated as `download-only` by the generic >10 MB rule in `classifyArtifact`, so clicking them started a download instead of opening a preview panel. The gate exists to protect our JS/React render pipeline from big text files; it shouldn't apply to content the browser renders natively.

Secondary: after a transient image/video load failure, the browser's negative-cached response could defeat Try Again — the URL was identical, so the browser reused the failed response.

**What** —
1. Split the size gate out of the type classifier. Images, videos, and PDFs now classify on their real type regardless of size. Text/HTML/code/etc. still gate to download-only above 10 MB.
2. Add a cache-busting `_retry=N` query to `<img>` and `<video>` src on Try Again so the browser can't reuse a negative-cached response.

**How** — `helpers.ts` refactored into `classifyByTypeOnly` + a size gate that checks `NATIVELY_RENDERED`. `ArtifactContent.tsx` image/video components carry a retry nonce that's appended as a query string when non-zero. Three test layers:
- `helpers.test.ts`: 25 MB PNG → `image`, 500 MB MP4 → `video`, 80 MB PDF → `pdf`, 20 MB TXT → `download-only`.
- Integration: `ArtifactContent` with a 25 MB PNG reaches the `<img>` path.
- Retry: clicking Try Again changes the img src to a non-identical URL that starts with the original.

### Changes 🏗️

- `frontend/src/app/(platform)/copilot/components/ArtifactPanel/helpers.ts` — split classifier; `NATIVELY_RENDERED` excludes image/video/pdf from the size gate.
- `frontend/src/app/(platform)/copilot/components/ArtifactPanel/helpers.test.ts` — existing large-text-gate test kept; added large-media-not-gated test.
- `frontend/src/app/(platform)/copilot/components/ArtifactPanel/components/ArtifactContent.tsx` — `withCacheBust` helper; image and video carry a retry nonce.
- `frontend/src/app/(platform)/copilot/components/ArtifactPanel/components/__tests__/ArtifactContent.test.tsx` — 25 MB PNG integration test + image retry cache-bust test.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `pnpm vitest run src/app/\(platform\)/copilot/components/ArtifactPanel` — 156/156 pass
  - [x] `pnpm format && pnpm types` clean
  - [ ] Manual: upload a ~25 MB PNG artifact, click it — preview opens as image
  - [ ] Manual: simulate a transient image failure, click Try Again — URL visibly changes (`?_retry=1`) and fresh fetch happens

Fixes SECRT-2221.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to artifact preview classification and media element retry behavior; main risk is changed UX for very large media files, but logic is small and covered by new tests.
> 
> **Overview**
> Fixes "broken" artifact previews for large media by changing `classifyArtifact` so the >10MB download-only gate applies only to JS-rendered types, while images/videos/PDFs remain previewable regardless of size.
> 
> Improves image/video retry UX by cache-busting the `src` on each "Try again" (adds a `_retry` query param) to avoid browsers reusing a negative-cached failed response, and adds unit/integration tests covering large PNG preview routing and the retry URL change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cec0a12cc1a496f569bcd5f015c179308cd9a771. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->