### PR TITLE
dx(frontend): remove unused custom CSS utility classes from globals.css

### DIFF
--- a/autogpt_platform/frontend/src/app/globals.css
+++ b/autogpt_platform/frontend/src/app/globals.css
@@ -121,43 +121,6 @@
   }
 }
 
-@layer utilities {
-  /* TODO: 1. remove unused utility classes */
-  /* TODO: 2. fix naming of numbered dimensions so that the number is 4*dimension */
-  /* TODO: 3. move to tailwind.config.ts spacing config */
-  .h-7\.5 {
-    height: 1.1875rem;
-  }
-  .h-18 {
-    height: 4.5rem;
-  }
-  .h-238 {
-    height: 14.875rem;
-  }
-  .top-158 {
-    top: 9.875rem;
-  }
-  .top-254 {
-    top: 15.875rem;
-  }
-  .top-284 {
-    top: 17.75rem;
-  }
-  .top-360 {
-    top: 22.5rem;
-  }
-  .left-297 {
-    left: 18.5625rem;
-  }
-  .left-34 {
-    left: 2.125rem;
-  }
-
-  .text-balance {
-    text-wrap: balance;
-  }
-}
-
 input[type="number"]::-webkit-outer-spin-button,
 input[type="number"]::-webkit-inner-spin-button {
   -webkit-appearance: none;


### PR DESCRIPTION
## Why

`globals.css` contains 3 unresolved TODO comments tracking the cleanup of unused custom utility classes. These classes add unnecessary CSS bloat and the TODOs indicate the maintainers already intended to remove them.

Without this change, the codebase carries dead CSS code and unresolved technical debt that confuses contributors.

## What

Remove 10 unused custom utility classes and their 3 associated TODO comments from `globals.css`:
- `.h-7\.5`, `.h-18`, `.h-238` (custom height utilities)
- `.top-158`, `.top-254`, `.top-284`, `.top-360` (custom top utilities)
- `.left-297`, `.left-34` (custom left utilities)
- `.text-balance` (redundant — Tailwind CSS v3.3+ provides this natively)

Only 1 file changed: `autogpt_platform/frontend/src/app/globals.css`

## How

1. Searched the entire `src/` directory for usage of each class — **zero references found** outside the CSS definition itself
2. Verified `.text-balance` is redundant since the project uses Tailwind CSS v3.4.17 which includes `text-balance` as a built-in utility
3. Removed the entire `@layer utilities` block containing the unused classes and TODO comments
4. Verified with `pnpm format`, `pnpm lint` — all pass

### Changes 🏗️

- Removed `@layer utilities` block with 10 unused CSS classes from `globals.css`
- Removed 3 TODO comments that were tracking this cleanup

### Checklist 📋

- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `pnpm format` passes
  - [x] `pnpm lint` passes (only pre-existing warnings)
  - [x] Searched codebase for usage of removed classes — none found