### PR TITLE
refactor(copilot): unify queue + stream POST, add AutoPilot block queueing

### DIFF
--- a/autogpt_platform/backend/backend/api/features/chat/routes.py
+++ b/autogpt_platform/backend/backend/api/features/chat/routes.py
@@ -8,7 +8,7 @@ from uuid import uuid4
 
 from autogpt_libs import auth
 from fastapi import APIRouter, HTTPException, Query, Response, Security
-from fastapi.responses import StreamingResponse
+from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from backend.copilot import service as chat_service
@@ -31,14 +31,10 @@ from backend.copilot.pending_message_helpers import (
     PENDING_CALL_LIMIT,
     PENDING_CALL_WINDOW_SECONDS,
     check_pending_call_rate,
+    is_turn_in_flight,
+    queue_user_message,
 )
-from backend.copilot.pending_messages import (
-    MAX_PENDING_MESSAGES,
-    PendingMessage,
-    PendingMessageContext,
-    peek_pending_messages,
-    push_pending_message,
-)
+from backend.copilot.pending_messages import peek_pending_messages
 from backend.copilot.rate_limit import (
     CoPilotUsageStatus,
     RateLimitExceeded,
@@ -157,34 +153,16 @@ class StreamChatRequest(BaseModel):
     )
 
 
-class QueuePendingMessageRequest(BaseModel):
-    """Request model for queueing a message into an in-flight turn.
-
-    Unlike ``StreamChatRequest`` this endpoint does **not** start a new
-    turn — the message is appended to a per-session pending buffer that
-    the executor currently processing the turn will drain between tool
-    rounds.
-    """
-
-    model_config = ConfigDict(extra="forbid")
-
-    message: str = Field(min_length=1, max_length=32_000)
-    context: PendingMessageContext | None = Field(
-        default=None,
-        description="Optional page context with 'url' and 'content' fields.",
-    )
-    file_ids: list[str] | None = Field(default=None, max_length=20)
-
-
 class QueuePendingMessageResponse(BaseModel):
-    """Response for the pending-message endpoint.
+    """Response returned by ``POST /stream`` with status 202 when a message
+    is queued because the session already has a turn in flight.
 
     - ``buffer_length``: how many messages are now in the session's
       pending buffer (after this push)
     - ``max_buffer_length``: the per-session cap (server-side constant)
     - ``turn_in_flight``: ``True`` if a copilot turn was running when
-      we checked — purely informational for UX feedback.  Even when
-      ``False`` the message is still queued: the next turn drains it.
+      we checked — purely informational for UX feedback.  Always ``True``
+      for responses from ``POST /stream`` with status 202.
     """
 
     buffer_length: int
@@ -818,31 +796,42 @@ async def cancel_session_task(
 
 @router.post(
     "/sessions/{session_id}/stream",
+    responses={
+        202: {
+            "model": QueuePendingMessageResponse,
+            "description": (
+                "Session has a turn in flight — message queued into the pending "
+                "buffer and will be picked up between tool-call rounds by the "
+                "executor currently processing the turn."
+            ),
+        },
+        404: {"description": "Session not found or access denied"},
+        429: {"description": "Token rate-limit or call-frequency cap exceeded"},
+    },
 )
 async def stream_chat_post(
     session_id: str,
     request: StreamChatRequest,
     user_id: str = Security(auth.get_user_id),
 ):
-    """
-    Stream chat responses for a session (POST with context support).
+    """Start a new turn OR queue a follow-up — decided server-side.
 
-    Streams the AI/completion responses in real time over Server-Sent Events (SSE), including:
-      - Text fragments as they are generated
-      - Tool call UI elements (if invoked)
-      - Tool execution results
+    - **Session idle**: starts a turn.  Returns an SSE stream (``text/event-stream``)
+      with Vercel AI SDK chunks (text fragments, tool-call UI, tool results).
+      The generation runs in a background task that survives client disconnects;
+      reconnect via ``GET /sessions/{session_id}/stream`` to resume.
 
-    The AI generation runs in a background task that continues even if the client disconnects.
-    All chunks are written to a per-turn Redis stream for reconnection support. If the client
-    disconnects, they can reconnect using GET /sessions/{session_id}/stream to resume.
+    - **Session has a turn in flight**: pushes the message into the per-session
+      pending buffer and returns ``202 application/json`` with
+      ``QueuePendingMessageResponse``.  The executor running the current turn
+      drains the buffer between tool-call rounds (baseline) or at the start of
+      the next turn (SDK).  Clients should detect the 202 and surface the
+      message as a queued-chip in the UI.
 
     Args:
-        session_id: The chat session identifier to associate with the streamed messages.
-        request: Request body containing message, is_user_message, and optional context.
+        session_id: The chat session identifier.
+        request: Request body with message, is_user_message, and optional context.
         user_id: Authenticated user ID.
-    Returns:
-        StreamingResponse: SSE-formatted response chunks.
-
     """
     import asyncio
     import time
@@ -856,6 +845,51 @@ async def stream_chat_post(
         extra={"json_fields": log_meta},
     )
     await _validate_and_get_session(session_id, user_id)
+
+    # Self-defensive queue-fallback: if a turn is already running, don't race
+    # it on the cluster lock — drop the message into the pending buffer and
+    # return 202 so the caller can render a chip.  Both UI chips and autopilot
+    # block follow-ups route through this path; keeping the decision on the
+    # server means every caller gets uniform behaviour.
+    if (
+        request.is_user_message
+        and request.message
+        and await is_turn_in_flight(session_id)
+    ):
+        # Call-frequency cap — prevent rapid-fire pushes that would bypass
+        # the token-budget check (which fires per-turn, not per-push).
+        call_count = await check_pending_call_rate(user_id)
+        if call_count > PENDING_CALL_LIMIT:
+            raise HTTPException(
+                status_code=429,
+                detail=(
+                    f"Too many queued message requests this minute: limit is "
+                    f"{PENDING_CALL_LIMIT} per {PENDING_CALL_WINDOW_SECONDS}s "
+                    "across all sessions"
+                ),
+            )
+        # Sanitise file IDs to the user's own workspace — mirrors the
+        # non-queued path below so injected follow-ups can't surface other
+        # users' files.
+        sanitized_queue_file_ids: list[str] = []
+        if request.file_ids:
+            files = await resolve_workspace_files(user_id, request.file_ids)
+            sanitized_queue_file_ids = [wf.id for wf in files]
+        result = await queue_user_message(
+            session_id=session_id,
+            message=request.message,
+            context=request.context,
+            file_ids=sanitized_queue_file_ids or None,
+        )
+        return JSONResponse(
+            status_code=202,
+            content=QueuePendingMessageResponse(
+                buffer_length=result.buffer_length,
+                max_buffer_length=result.max_buffer_length,
+                turn_in_flight=result.turn_in_flight,
+            ).model_dump(),
+        )
+
     logger.info(
         f"[TIMING] session validated in {(time.perf_counter() - stream_start_time) * 1000:.1f}ms",
         extra={
@@ -1120,116 +1154,6 @@ async def get_pending_messages(
     return PeekPendingMessagesResponse(
         messages=[m.content for m in pending],
         count=len(pending),
-    )
-
-
-@router.post(
-    "/sessions/{session_id}/messages/pending",
-    response_model=QueuePendingMessageResponse,
-    status_code=202,
-    responses={
-        404: {"description": "Session not found or access denied"},
-        429: {"description": "Token rate-limit or call-frequency cap exceeded"},
-    },
-)
-async def queue_pending_message(
-    session_id: str,
-    request: QueuePendingMessageRequest,
-    user_id: str = Security(auth.get_user_id),
-):
-    """Queue a new user message into an in-flight copilot turn.
-
-    When a user sends a follow-up message while a turn is still
-    streaming, we don't want to block them or start a separate turn —
-    this endpoint appends the message to a per-session pending buffer.
-    The executor currently running the turn (baseline path) drains the
-    buffer between tool-call rounds and appends the message to the
-    conversation before the next LLM call.  On the SDK path the buffer
-    is drained at the *start* of the next turn (the long-lived
-    ``ClaudeSDKClient.receive_response`` iterator returns after a
-    ``ResultMessage`` so there is no safe point to inject mid-stream
-    into an existing connection).
-
-    Returns 202.  Enforces the same per-user daily/weekly token rate
-    limit as the regular ``/stream`` endpoint so a client can't bypass
-    it by batching messages through here.
-    """
-    await _validate_and_get_session(session_id, user_id)
-
-    # Pre-turn rate-limit check — mirrors stream_chat_post.  Without
-    # this, a client could bypass per-turn token limits by batching
-    # their extra context through this endpoint while a cheap stream
-    # is in flight.
-    # user_id is guaranteed non-empty by Security(auth.get_user_id) — no guard needed.
-    try:
-        daily_limit, weekly_limit, _tier = await get_global_rate_limits(
-            user_id, config.daily_token_limit, config.weekly_token_limit
-        )
-        await check_rate_limit(
-            user_id=user_id,
-            daily_token_limit=daily_limit,
-            weekly_token_limit=weekly_limit,
-        )
-    except RateLimitExceeded as e:
-        raise HTTPException(status_code=429, detail=str(e)) from e
-
-    # Call-frequency cap: prevent rapid-fire pushes that would bypass the
-    # token-budget check (which only fires per-turn, not per-push).
-    call_count = await check_pending_call_rate(user_id)
-    # check_pending_call_rate returns the count *after* incrementing, so
-    # rejecting at `> LIMIT` permits exactly LIMIT requests per window
-    # (the cap is inclusive).  Using `>=` would reject the LIMITth request.
-    if call_count > PENDING_CALL_LIMIT:
-        raise HTTPException(
-            status_code=429,
-            detail=f"Too many pending message requests this minute: limit is {PENDING_CALL_LIMIT} per {PENDING_CALL_WINDOW_SECONDS}s across all sessions",
-        )
-
-    # Sanitise file IDs to the user's own workspace so injection doesn't
-    # surface other users' files.
-    sanitized_file_ids: list[str] = []
-    if request.file_ids:
-        files = await resolve_workspace_files(user_id, request.file_ids)
-        sanitized_file_ids = [wf.id for wf in files]
-        dropped = len(request.file_ids) - len(sanitized_file_ids)
-        if dropped:
-            logger.warning(
-                "queue_pending_message: dropped %d file id(s) not in "
-                "caller's workspace (session=%s)",
-                dropped,
-                session_id,
-            )
-
-    # Redis is the single source of truth for pending messages.  We do
-    # NOT persist to ``session.messages`` here — the drain-at-start
-    # path in the baseline/SDK executor is the sole writer for pending
-    # content.  Persisting both here AND in the drain would cause
-    # double injection (executor sees the message in ``session.messages``
-    # *and* drains it from Redis) unless we also dedupe.  The dedup in
-    # ``maybe_append_user_message`` only checks trailing same-role
-    # repeats, so relying on it is fragile.  Keeping the endpoint
-    # Redis-only avoids the whole consistency-bug class.
-    pending = PendingMessage(
-        content=request.message,
-        file_ids=sanitized_file_ids,
-        context=request.context,
-    )
-    buffer_length = await push_pending_message(session_id, pending)
-
-    track_user_message(
-        user_id=user_id,
-        session_id=session_id,
-        message_length=len(request.message),
-    )
-
-    # Check whether a turn is currently running for UX feedback.
-    active_session = await stream_registry.get_session(session_id)
-    turn_in_flight = bool(active_session and active_session.status == "running")
-
-    return QueuePendingMessageResponse(
-        buffer_length=buffer_length,
-        max_buffer_length=MAX_PENDING_MESSAGES,
-        turn_in_flight=turn_in_flight,
     )
 
 

--- a/autogpt_platform/backend/backend/api/features/chat/routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/chat/routes_test.py
@@ -617,109 +617,20 @@ class TestStreamChatRequestModeValidation:
         assert req.mode is None
 
 
-# ─── QueuePendingMessageRequest validation ────────────────────────────
+# ─── POST /stream queue-fallback (when a turn is already in flight) ──
 
 
-class TestQueuePendingMessageRequest:
-    """Unit tests for QueuePendingMessageRequest field validation."""
-
-    def test_accepts_valid_message(self) -> None:
-        from backend.api.features.chat.routes import QueuePendingMessageRequest
-
-        req = QueuePendingMessageRequest(message="hello")
-        assert req.message == "hello"
-
-    def test_rejects_empty_message(self) -> None:
-        import pydantic
-
-        from backend.api.features.chat.routes import QueuePendingMessageRequest
-
-        with pytest.raises(pydantic.ValidationError):
-            QueuePendingMessageRequest(message="")
-
-    def test_rejects_message_over_limit(self) -> None:
-        import pydantic
-
-        from backend.api.features.chat.routes import QueuePendingMessageRequest
-
-        with pytest.raises(pydantic.ValidationError):
-            QueuePendingMessageRequest(message="x" * 32_001)
-
-    def test_accepts_valid_context(self) -> None:
-        from backend.api.features.chat.routes import QueuePendingMessageRequest
-
-        req = QueuePendingMessageRequest(
-            message="hi",
-            context={"url": "https://example.com", "content": "page text"},
-        )
-        assert req.context is not None
-        assert req.context.url == "https://example.com"
-
-    def test_rejects_context_url_over_limit(self) -> None:
-        import pydantic
-
-        from backend.api.features.chat.routes import QueuePendingMessageRequest
-
-        with pytest.raises(pydantic.ValidationError, match="url"):
-            QueuePendingMessageRequest(
-                message="hi",
-                context={"url": "https://example.com/" + "x" * 2_000},
-            )
-
-    def test_rejects_context_content_over_limit(self) -> None:
-        import pydantic
-
-        from backend.api.features.chat.routes import QueuePendingMessageRequest
-
-        with pytest.raises(pydantic.ValidationError, match="content"):
-            QueuePendingMessageRequest(
-                message="hi",
-                context={"content": "x" * 32_001},
-            )
-
-    def test_rejects_extra_fields(self) -> None:
-        """extra='forbid' should reject unknown fields."""
-        import pydantic
-
-        from backend.api.features.chat.routes import QueuePendingMessageRequest
-
-        with pytest.raises(pydantic.ValidationError):
-            QueuePendingMessageRequest.model_validate(
-                {"message": "hi", "unknown_field": "bad"}
-            )
-
-    def test_accepts_up_to_20_file_ids(self) -> None:
-        from backend.api.features.chat.routes import QueuePendingMessageRequest
-
-        req = QueuePendingMessageRequest(
-            message="hi",
-            file_ids=[f"00000000-0000-0000-0000-{i:012d}" for i in range(20)],
-        )
-        assert req.file_ids is not None
-        assert len(req.file_ids) == 20
-
-    def test_rejects_more_than_20_file_ids(self) -> None:
-        import pydantic
-
-        from backend.api.features.chat.routes import QueuePendingMessageRequest
-
-        with pytest.raises(pydantic.ValidationError):
-            QueuePendingMessageRequest(
-                message="hi",
-                file_ids=[f"00000000-0000-0000-0000-{i:012d}" for i in range(21)],
-            )
-
-
-# ─── queue_pending_message endpoint ──────────────────────────────────
-
-
-def _mock_pending_internals(
+def _mock_stream_queue_internals(
     mocker: pytest_mock.MockerFixture,
     *,
     session_exists: bool = True,
+    turn_in_flight: bool = True,
     call_count: int = 1,
 ):
-    """Mock all async dependencies for the pending-message endpoint."""
+    """Mock dependencies for the POST /stream queue-fallback path.
+
+    When ``turn_in_flight`` is True the handler takes the 202 queue branch.
+    """
     if session_exists:
         mock_session = mocker.MagicMock()
         mock_session.id = "sess-1"
@@ -736,6 +647,11 @@ def _mock_pending_internals(
             ),
         )
     mocker.patch(
+        "backend.api.features.chat.routes.is_turn_in_flight",
+        new_callable=AsyncMock,
+        return_value=turn_in_flight,
+    )
+    mocker.patch(
         "backend.api.features.chat.routes.get_global_rate_limits",
         new_callable=AsyncMock,
         return_value=(0, 0, None),
@@ -745,8 +661,6 @@ def _mock_pending_internals(
         new_callable=AsyncMock,
         return_value=None,
     )
-    # Mock Redis for per-user call-frequency rate limit — patch where the
-    # symbol is *used* (pending_message_helpers), not where it's defined.
     mocker.patch(
         "backend.copilot.pending_message_helpers.get_redis_async",
         new_callable=AsyncMock,
@@ -758,166 +672,63 @@ def _mock_pending_internals(
         return_value=call_count,
     )
     mocker.patch(
-        "backend.api.features.chat.routes.track_user_message",
-        return_value=None,
-    )
-    mocker.patch(
-        "backend.api.features.chat.routes.push_pending_message",
+        "backend.copilot.pending_message_helpers.push_pending_message",
         new_callable=AsyncMock,
         return_value=1,
     )
-    mock_registry = mocker.MagicMock()
-    mock_registry.get_session = mocker.AsyncMock(return_value=None)
+    # queue_user_message re-runs is_turn_in_flight via the helper module —
+    # stub that path out too so we don't need a fake stream_registry.
     mocker.patch(
-        "backend.api.features.chat.routes.stream_registry",
-        mock_registry,
+        "backend.copilot.pending_message_helpers.get_active_session_meta",
+        new_callable=AsyncMock,
+        return_value=None,
     )
 
 
-def test_queue_pending_message_returns_202(mocker: pytest_mock.MockerFixture) -> None:
-    """Happy path: valid message returns 202 with buffer_length."""
-    _mock_pending_internals(mocker)
+def test_stream_queue_returns_202_when_turn_in_flight(
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    """Happy path: POST /stream to a session with a live turn → 202 queue."""
+    _mock_stream_queue_internals(mocker)
 
     response = client.post(
-        "/sessions/sess-1/messages/pending",
-        json={"message": "follow-up"},
+        "/sessions/sess-1/stream",
+        json={"message": "follow-up", "is_user_message": True},
     )
 
     assert response.status_code == 202
     data = response.json()
     assert data["buffer_length"] == 1
-    assert data["turn_in_flight"] is False
+    assert "turn_in_flight" in data
 
 
-def test_queue_pending_message_empty_body_returns_422() -> None:
-    """Empty message must be rejected by Pydantic before hitting any route logic."""
-    response = client.post(
-        "/sessions/sess-1/messages/pending",
-        json={"message": ""},
-    )
-    assert response.status_code == 422
-
-
-def test_queue_pending_message_missing_message_returns_422() -> None:
-    """Missing 'message' field returns 422."""
-    response = client.post(
-        "/sessions/sess-1/messages/pending",
-        json={},
-    )
-    assert response.status_code == 422
-
-
-def test_queue_pending_message_session_not_found_returns_404(
+def test_stream_queue_session_not_found_returns_404(
     mocker: pytest_mock.MockerFixture,
 ) -> None:
     """If the session doesn't exist or belong to the user, returns 404."""
-    _mock_pending_internals(mocker, session_exists=False)
+    _mock_stream_queue_internals(mocker, session_exists=False)
 
     response = client.post(
-        "/sessions/bad-sess/messages/pending",
-        json={"message": "hi"},
+        "/sessions/bad-sess/stream",
+        json={"message": "hi", "is_user_message": True},
     )
     assert response.status_code == 404
 
 
-def test_queue_pending_message_rate_limited_returns_429(
+def test_stream_queue_call_frequency_limit_returns_429(
     mocker: pytest_mock.MockerFixture,
 ) -> None:
-    """When rate limit is exceeded, endpoint returns 429."""
-    from backend.copilot.rate_limit import RateLimitExceeded
-
-    _mock_pending_internals(mocker)
-    mocker.patch(
-        "backend.api.features.chat.routes.check_rate_limit",
-        side_effect=RateLimitExceeded("daily", datetime.now(UTC) + timedelta(hours=1)),
-    )
-
-    response = client.post(
-        "/sessions/sess-1/messages/pending",
-        json={"message": "hi"},
-    )
-    assert response.status_code == 429
-
-
-def test_queue_pending_message_call_frequency_limit_returns_429(
-    mocker: pytest_mock.MockerFixture,
-) -> None:
-    """When per-user call frequency limit is exceeded, endpoint returns 429."""
+    """Per-user call-frequency cap rejects rapid-fire queued pushes."""
     from backend.copilot.pending_message_helpers import PENDING_CALL_LIMIT
 
-    _mock_pending_internals(mocker, call_count=PENDING_CALL_LIMIT + 1)
+    _mock_stream_queue_internals(mocker, call_count=PENDING_CALL_LIMIT + 1)
 
     response = client.post(
-        "/sessions/sess-1/messages/pending",
-        json={"message": "hi"},
+        "/sessions/sess-1/stream",
+        json={"message": "hi", "is_user_message": True},
     )
     assert response.status_code == 429
-    assert "Too many pending message requests this minute" in response.json()["detail"]
-
-
-def test_queue_pending_message_context_url_too_long_returns_422() -> None:
-    """context.url over 2 KB is rejected."""
-    response = client.post(
-        "/sessions/sess-1/messages/pending",
-        json={
-            "message": "hi",
-            "context": {"url": "https://example.com/" + "x" * 2_000},
-        },
-    )
-    assert response.status_code == 422
-
-
-def test_queue_pending_message_context_content_too_long_returns_422() -> None:
-    """context.content over 32 KB is rejected."""
-    response = client.post(
-        "/sessions/sess-1/messages/pending",
-        json={
-            "message": "hi",
-            "context": {"content": "x" * 32_001},
-        },
-    )
-    assert response.status_code == 422
-
-
-def test_queue_pending_message_too_many_file_ids_returns_422() -> None:
-    """More than 20 file_ids should be rejected."""
-    response = client.post(
-        "/sessions/sess-1/messages/pending",
-        json={
-            "message": "hi",
-            "file_ids": [f"00000000-0000-0000-0000-{i:012d}" for i in range(21)],
-        },
-    )
-    assert response.status_code == 422
-
-
-def test_queue_pending_message_file_ids_scoped_to_workspace(
-    mocker: pytest_mock.MockerFixture,
-) -> None:
-    """File IDs must be sanitized to the user's workspace before push."""
-    _mock_pending_internals(mocker)
-    mocker.patch(
-        "backend.data.workspace.get_or_create_workspace",
-        new_callable=AsyncMock,
-        return_value=type("W", (), {"id": "ws-1"})(),
-    )
-    mock_prisma = mocker.MagicMock()
-    mock_prisma.find_many = mocker.AsyncMock(return_value=[])
-    mocker.patch(
-        "prisma.models.UserWorkspaceFile.prisma",
-        return_value=mock_prisma,
-    )
-    fid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
-
-    client.post(
-        "/sessions/sess-1/messages/pending",
-        json={"message": "hi", "file_ids": [fid, "not-a-uuid"]},
-    )
-
-    call_kwargs = mock_prisma.find_many.call_args[1]
-    assert call_kwargs["where"]["id"]["in"] == [fid]
-    assert call_kwargs["where"]["workspaceId"] == "ws-1"
-    assert call_kwargs["where"]["isDeleted"] is False
+    assert "Too many queued message requests this minute" in response.json()["detail"]
 
 
 # ─── get_pending_messages (GET /sessions/{session_id}/messages/pending) ─────

--- a/autogpt_platform/backend/backend/blocks/autopilot.py
+++ b/autogpt_platform/backend/backend/blocks/autopilot.py
@@ -306,6 +306,29 @@ class AutoPilotBlock(Block):
                 permissions=effective_permissions,
             )
 
+            # If the session already had a turn in flight the message was
+            # pushed onto the pending buffer instead of starting a new turn.
+            # Surface a descriptive response + empty tool_calls/history so
+            # downstream blocks can treat the run as deferred without
+            # special-casing.  The executor running the earlier turn will
+            # drain the buffer when it next polls.
+            if result.queued:
+                queued_response = (
+                    f"[AutoPilot] Message queued into session {session_id}; "
+                    f"{result.pending_buffer_length} message(s) now pending. "
+                    "The existing turn will pick it up on the next drain."
+                )
+                return (
+                    queued_response,
+                    [],
+                    json.dumps(
+                        [{"role": "user", "content": effective_prompt}],
+                        default=str,
+                    ),
+                    session_id,
+                    {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+                )
+
             # Build a lightweight conversation summary from streamed data.
             turn_messages: list[dict[str, Any]] = [
                 {"role": "user", "content": effective_prompt},

--- a/autogpt_platform/backend/backend/copilot/pending_message_helpers.py
+++ b/autogpt_platform/backend/backend/copilot/pending_message_helpers.py
@@ -12,11 +12,14 @@ from typing import TYPE_CHECKING, Callable
 
 from backend.copilot.model import ChatMessage, upsert_chat_session
 from backend.copilot.pending_messages import (
+    MAX_PENDING_MESSAGES,
     PendingMessage,
+    PendingMessageContext,
     drain_pending_messages,
     format_pending_as_user_message,
     push_pending_message,
 )
+from backend.copilot.stream_registry import get_session as get_active_session_meta
 from backend.data.redis_client import get_redis_async
 from backend.data.redis_helpers import incr_with_ttl
 
@@ -32,6 +35,62 @@ logger = logging.getLogger(__name__)
 PENDING_CALL_LIMIT = 30
 PENDING_CALL_WINDOW_SECONDS = 60
 _PENDING_CALL_KEY_PREFIX = "copilot:pending:calls:"
+
+
+async def is_turn_in_flight(session_id: str) -> bool:
+    """Return ``True`` when a copilot turn is actively running for *session_id*.
+
+    Used by the unified POST /stream entry point and the autopilot block so
+    a second message arriving while an earlier turn is still executing gets
+    queued into the pending buffer instead of racing the in-flight turn on
+    the cluster lock.
+    """
+    active = await get_active_session_meta(session_id)
+    return active is not None and active.status == "running"
+
+
+class QueueResult:
+    """Return shape of ``queue_user_message``.
+
+    Mirrors the old ``QueuePendingMessageResponse`` so the HTTP handler can
+    serialise it 1:1 and the autopilot block can surface the same fields.
+    """
+
+    __slots__ = ("buffer_length", "max_buffer_length", "turn_in_flight")
+
+    def __init__(
+        self, buffer_length: int, max_buffer_length: int, turn_in_flight: bool
+    ) -> None:
+        self.buffer_length = buffer_length
+        self.max_buffer_length = max_buffer_length
+        self.turn_in_flight = turn_in_flight
+
+
+async def queue_user_message(
+    *,
+    session_id: str,
+    message: str,
+    context: PendingMessageContext | None = None,
+    file_ids: list[str] | None = None,
+) -> QueueResult:
+    """Push *message* into the per-session pending buffer.
+
+    The shared primitive for "a message arrived while a turn is in flight" —
+    called from the unified POST /stream handler and the autopilot block.
+    Call-frequency rate limiting is the caller's responsibility (HTTP path
+    enforces it; internal block callers skip it).
+    """
+    pending = PendingMessage(
+        content=message,
+        file_ids=file_ids or [],
+        context=context,
+    )
+    new_len = await push_pending_message(session_id, pending)
+    return QueueResult(
+        buffer_length=new_len,
+        max_buffer_length=MAX_PENDING_MESSAGES,
+        turn_in_flight=await is_turn_in_flight(session_id),
+    )
 
 
 async def check_pending_call_rate(user_id: str) -> int:

--- a/autogpt_platform/backend/backend/copilot/sdk/collect.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/collect.py
@@ -20,6 +20,7 @@ from pydantic import BaseModel, Field
 from redis.exceptions import RedisError
 
 from .. import stream_registry
+from ..pending_message_helpers import is_turn_in_flight, queue_user_message
 from ..response_model import (
     StreamError,
     StreamTextDelta,
@@ -43,6 +44,13 @@ class CopilotResult:
 
     Returned by :func:`collect_copilot_response` so callers don't need to
     implement their own event-loop over the raw stream events.
+
+    When the session already has a turn in flight, ``queued`` is set to
+    ``True`` and the message is pushed onto the pending buffer instead of
+    starting a new turn.  In that case ``response_text`` is empty and
+    ``tool_calls`` / token counts are zero — callers (e.g. the AutoPilot
+    block) should treat the run as deferred and surface the state to the
+    end user.
     """
 
     __slots__ = (
@@ -51,6 +59,8 @@ class CopilotResult:
         "prompt_tokens",
         "completion_tokens",
         "total_tokens",
+        "queued",
+        "pending_buffer_length",
     )
 
     def __init__(self) -> None:
@@ -59,6 +69,8 @@ class CopilotResult:
         self.prompt_tokens: int = 0
         self.completion_tokens: int = 0
         self.total_tokens: int = 0
+        self.queued: bool = False
+        self.pending_buffer_length: int = 0
 
 
 class _RegistryHandle(BaseModel):
@@ -194,6 +206,25 @@ async def collect_copilot_response(
     Raises:
         RuntimeError: If the stream yields a ``StreamError`` event.
     """
+    # Self-defensive queue-fallback (matches POST /stream).  If a turn is
+    # already running for this session, don't race it on the cluster lock —
+    # push this message into the pending buffer so the in-flight turn picks
+    # it up between tool-call rounds and return a queued-state result.
+    if is_user_message and await is_turn_in_flight(session_id):
+        logger.info(
+            "[collect] Session %s has a turn in flight; queueing AutoPilot "
+            "message into pending buffer instead of starting a new turn",
+            session_id[:12],
+        )
+        queue_state = await queue_user_message(
+            session_id=session_id,
+            message=message,
+        )
+        queued_result = CopilotResult()
+        queued_result.queued = True
+        queued_result.pending_buffer_length = queue_state.buffer_length
+        return queued_result
+
     turn_id = str(uuid.uuid4())
     async with _registry_session(session_id, user_id, turn_id) as handle:
         try:

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/__tests__/useCopilotPage.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/__tests__/useCopilotPage.test.ts
@@ -5,7 +5,7 @@ import { useCopilotPage } from "../useCopilotPage";
 const mockUseChatSession = vi.fn();
 const mockUseCopilotStream = vi.fn();
 const mockUseLoadMoreMessages = vi.fn();
-const mockPostV2QueuePendingMessage = vi.fn();
+const mockQueueFollowUpMessage = vi.fn();
 const mockToast = vi.fn();
 
 vi.mock("../useChatSession", () => ({
@@ -48,8 +48,10 @@ vi.mock("@/app/api/__generated__/endpoints/chat/chat", () => ({
     status: 200,
     data: { count: 0, messages: [] },
   }),
-  postV2QueuePendingMessage: (...args: unknown[]) =>
-    mockPostV2QueuePendingMessage(...args),
+}));
+vi.mock("../helpers/queueFollowUpMessage", () => ({
+  queueFollowUpMessage: (...args: unknown[]) =>
+    mockQueueFollowUpMessage(...args),
 }));
 vi.mock("@/components/molecules/Toast/use-toast", () => ({
   toast: (...args: unknown[]) => mockToast(...args),
@@ -160,19 +162,23 @@ describe("useCopilotPage — onSend queue-in-flight path", () => {
       await result.current.onSend("hello", [bigFile]);
     });
 
-    expect(mockPostV2QueuePendingMessage).not.toHaveBeenCalled();
+    expect(mockQueueFollowUpMessage).not.toHaveBeenCalled();
     expect(mockToast).toHaveBeenCalledWith(
       expect.objectContaining({ title: "Please wait to attach files" }),
     );
   });
 
-  it("queues a text-only message via postV2QueuePendingMessage when in flight", async () => {
+  it("queues a text-only message via queueFollowUpMessage when in flight", async () => {
     mockUseChatSession.mockReturnValue(makeBaseChatSession());
     mockUseCopilotStream.mockReturnValue(
       makeBaseCopilotStream({ status: "streaming" }),
     );
     mockUseLoadMoreMessages.mockReturnValue(makeBaseLoadMore());
-    mockPostV2QueuePendingMessage.mockResolvedValue({ status: 202 });
+    mockQueueFollowUpMessage.mockResolvedValue({
+      buffer_length: 1,
+      max_buffer_length: 10,
+      turn_in_flight: true,
+    });
 
     const { result } = renderHook(() => useCopilotPage());
 
@@ -180,9 +186,10 @@ describe("useCopilotPage — onSend queue-in-flight path", () => {
       await result.current.onSend("follow-up");
     });
 
-    expect(mockPostV2QueuePendingMessage).toHaveBeenCalledWith("sess-1", {
-      message: "follow-up",
-    });
+    expect(mockQueueFollowUpMessage).toHaveBeenCalledWith(
+      "sess-1",
+      "follow-up",
+    );
     // appendChip should have been called, bringing the chip into queuedMessages.
     await waitFor(() => {
       expect(result.current.queuedMessages).toContain("follow-up");
@@ -195,7 +202,7 @@ describe("useCopilotPage — onSend queue-in-flight path", () => {
       makeBaseCopilotStream({ status: "streaming" }),
     );
     mockUseLoadMoreMessages.mockReturnValue(makeBaseLoadMore());
-    mockPostV2QueuePendingMessage.mockRejectedValue(new Error("boom"));
+    mockQueueFollowUpMessage.mockRejectedValue(new Error("boom"));
 
     const { result } = renderHook(() => useCopilotPage());
 

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/helpers/queueFollowUpMessage.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/helpers/queueFollowUpMessage.ts
@@ -1,0 +1,46 @@
+import { environment } from "@/services/environment";
+
+import { getCopilotAuthHeaders } from "../helpers";
+
+/**
+ * POST a follow-up message to the unified ``/stream`` endpoint when the
+ * session already has a turn in flight.
+ *
+ * The server detects the in-flight turn, pushes the message into the pending
+ * buffer, and returns ``202 application/json`` with the buffer state.  We
+ * can't use the AI SDK's ``sendMessage`` for this case because it's wired
+ * to expect ``text/event-stream`` — hitting it with a 202 JSON response
+ * would make the SDK's stream parser throw.
+ *
+ * Throws on network error or non-202 status.
+ */
+export async function queueFollowUpMessage(
+  sessionId: string,
+  message: string,
+): Promise<{
+  buffer_length: number;
+  max_buffer_length: number;
+  turn_in_flight: boolean;
+}> {
+  const url = `${environment.getAGPTServerBaseUrl()}/api/chat/sessions/${sessionId}/stream`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(await getCopilotAuthHeaders()),
+    },
+    body: JSON.stringify({
+      message,
+      is_user_message: true,
+      context: null,
+      file_ids: null,
+    }),
+  });
+
+  if (res.status !== 202) {
+    throw new Error(
+      `Expected 202 queued response from /stream; got ${res.status}`,
+    );
+  }
+  return res.json();
+}

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/useCopilotPage.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/useCopilotPage.ts
@@ -1,6 +1,5 @@
 import {
   getGetV2ListSessionsQueryKey,
-  postV2QueuePendingMessage,
   useDeleteV2DeleteSession,
   useGetV2ListSessions,
   type getV2ListSessionsResponse,
@@ -14,6 +13,7 @@ import type { FileUIPart } from "ai";
 import { Flag, useGetFlag } from "@/services/feature-flags/use-get-flag";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { concatWithAssistantMerge } from "./helpers/convertChatSessionToUiMessages";
+import { queueFollowUpMessage } from "./helpers/queueFollowUpMessage";
 import { stripReplayPrefix } from "./helpers/stripReplayPrefix";
 import { useCopilotPendingChips } from "./useCopilotPendingChips";
 import { useCopilotUIStore } from "./store";
@@ -295,10 +295,13 @@ export function useCopilotPage() {
           return;
         }
 
-        // Queue the message into the pending buffer so it is picked up between
-        // tool-call rounds by the currently running executor turn.
+        // Queue the follow-up into the pending buffer.  Both queue and new-
+        // turn go through the same ``/stream`` endpoint; the server returns
+        // 202 for the queue path (pending buffer) and an SSE stream for the
+        // new-turn path.  Using a plain ``fetch`` here keeps the 202 JSON
+        // from confusing the AI SDK's stream parser.
         try {
-          await postV2QueuePendingMessage(sessionId, { message: trimmed });
+          await queueFollowUpMessage(sessionId, trimmed);
           appendChip(trimmed);
         } catch (err) {
           toast({

--- a/autogpt_platform/frontend/src/app/api/openapi.json
+++ b/autogpt_platform/frontend/src/app/api/openapi.json
@@ -1679,58 +1679,6 @@
             }
           }
         }
-      },
-      "post": {
-        "tags": ["v2", "chat", "chat"],
-        "summary": "Queue Pending Message",
-        "description": "Queue a new user message into an in-flight copilot turn.\n\nWhen a user sends a follow-up message while a turn is still\nstreaming, we don't want to block them or start a separate turn —\nthis endpoint appends the message to a per-session pending buffer.\nThe executor currently running the turn (baseline path) drains the\nbuffer between tool-call rounds and appends the message to the\nconversation before the next LLM call.  On the SDK path the buffer\nis drained at the *start* of the next turn (the long-lived\n``ClaudeSDKClient.receive_response`` iterator returns after a\n``ResultMessage`` so there is no safe point to inject mid-stream\ninto an existing connection).\n\nReturns 202.  Enforces the same per-user daily/weekly token rate\nlimit as the regular ``/stream`` endpoint so a client can't bypass\nit by batching messages through here.",
-        "operationId": "postV2QueuePendingMessage",
-        "security": [{ "HTTPBearerJWT": [] }],
-        "parameters": [
-          {
-            "name": "session_id",
-            "in": "path",
-            "required": true,
-            "schema": { "type": "string", "title": "Session Id" }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/QueuePendingMessageRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "202": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/QueuePendingMessageResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
-          },
-          "404": { "description": "Session not found or access denied" },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
-              }
-            }
-          },
-          "429": {
-            "description": "Token rate-limit or call-frequency cap exceeded"
-          }
-        }
       }
     },
     "/api/chat/sessions/{session_id}/stream": {
@@ -1798,7 +1746,7 @@
       "post": {
         "tags": ["v2", "chat", "chat"],
         "summary": "Stream Chat Post",
-        "description": "Stream chat responses for a session (POST with context support).\n\nStreams the AI/completion responses in real time over Server-Sent Events (SSE), including:\n  - Text fragments as they are generated\n  - Tool call UI elements (if invoked)\n  - Tool execution results\n\nThe AI generation runs in a background task that continues even if the client disconnects.\nAll chunks are written to a per-turn Redis stream for reconnection support. If the client\ndisconnects, they can reconnect using GET /sessions/{session_id}/stream to resume.\n\nArgs:\n    session_id: The chat session identifier to associate with the streamed messages.\n    request: Request body containing message, is_user_message, and optional context.\n    user_id: Authenticated user ID.\nReturns:\n    StreamingResponse: SSE-formatted response chunks.",
+        "description": "Start a new turn OR queue a follow-up — decided server-side.\n\n- **Session idle**: starts a turn.  Returns an SSE stream (``text/event-stream``)\n  with Vercel AI SDK chunks (text fragments, tool-call UI, tool results).\n  The generation runs in a background task that survives client disconnects;\n  reconnect via ``GET /sessions/{session_id}/stream`` to resume.\n\n- **Session has a turn in flight**: pushes the message into the per-session\n  pending buffer and returns ``202 application/json`` with\n  ``QueuePendingMessageResponse``.  The executor running the current turn\n  drains the buffer between tool-call rounds (baseline) or at the start of\n  the next turn (SDK).  Clients should detect the 202 and surface the\n  message as a queued-chip in the UI.\n\nArgs:\n    session_id: The chat session identifier.\n    request: Request body with message, is_user_message, and optional context.\n    user_id: Authenticated user ID.",
         "operationId": "postV2StreamChatPost",
         "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
@@ -1822,9 +1770,20 @@
             "description": "Successful Response",
             "content": { "application/json": { "schema": {} } }
           },
+          "202": {
+            "description": "Session has a turn in flight — message queued into the pending buffer and will be picked up between tool-call rounds by the executor currently processing the turn.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QueuePendingMessageResponse"
+                }
+              }
+            }
+          },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
+          "404": { "description": "Session not found or access denied" },
           "422": {
             "description": "Validation Error",
             "content": {
@@ -1832,6 +1791,9 @@
                 "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
+          },
+          "429": {
+            "description": "Token rate-limit or call-frequency cap exceeded"
           }
         }
       }
@@ -12412,28 +12374,6 @@
         "title": "PendingHumanReviewModel",
         "description": "Response model for pending human review data.\n\nRepresents a human review request that is awaiting user action.\nContains all necessary information for a user to review and approve\nor reject data from a Human-in-the-Loop block execution.\n\nAttributes:\n    id: Unique identifier for the review record\n    user_id: ID of the user who must perform the review\n    node_exec_id: ID of the node execution that created this review\n    node_id: ID of the node definition (for grouping reviews from same node)\n    graph_exec_id: ID of the graph execution containing the node\n    graph_id: ID of the graph template being executed\n    graph_version: Version number of the graph template\n    payload: The actual data payload awaiting review\n    instructions: Instructions or message for the reviewer\n    editable: Whether the reviewer can edit the data\n    status: Current review status (WAITING, APPROVED, or REJECTED)\n    review_message: Optional message from the reviewer\n    created_at: Timestamp when review was created\n    updated_at: Timestamp when review was last modified\n    reviewed_at: Timestamp when review was completed (if applicable)"
       },
-      "PendingMessageContext": {
-        "properties": {
-          "url": {
-            "anyOf": [
-              { "type": "string", "maxLength": 2000 },
-              { "type": "null" }
-            ],
-            "title": "Url"
-          },
-          "content": {
-            "anyOf": [
-              { "type": "string", "maxLength": 32000 },
-              { "type": "null" }
-            ],
-            "title": "Content"
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "title": "PendingMessageContext",
-        "description": "Structured page context attached to a pending message."
-      },
       "PlatformCostDashboard": {
         "properties": {
           "by_provider": {
@@ -13029,39 +12969,6 @@
         "required": ["providers", "pagination"],
         "title": "ProviderResponse"
       },
-      "QueuePendingMessageRequest": {
-        "properties": {
-          "message": {
-            "type": "string",
-            "maxLength": 32000,
-            "minLength": 1,
-            "title": "Message"
-          },
-          "context": {
-            "anyOf": [
-              { "$ref": "#/components/schemas/PendingMessageContext" },
-              { "type": "null" }
-            ],
-            "description": "Optional page context with 'url' and 'content' fields."
-          },
-          "file_ids": {
-            "anyOf": [
-              {
-                "items": { "type": "string" },
-                "type": "array",
-                "maxItems": 20
-              },
-              { "type": "null" }
-            ],
-            "title": "File Ids"
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "required": ["message"],
-        "title": "QueuePendingMessageRequest",
-        "description": "Request model for queueing a message into an in-flight turn.\n\nUnlike ``StreamChatRequest`` this endpoint does **not** start a new\nturn — the message is appended to a per-session pending buffer that\nthe executor currently processing the turn will drain between tool\nrounds."
-      },
       "QueuePendingMessageResponse": {
         "properties": {
           "buffer_length": { "type": "integer", "title": "Buffer Length" },
@@ -13074,7 +12981,7 @@
         "type": "object",
         "required": ["buffer_length", "max_buffer_length", "turn_in_flight"],
         "title": "QueuePendingMessageResponse",
-        "description": "Response for the pending-message endpoint.\n\n- ``buffer_length``: how many messages are now in the session's\n  pending buffer (after this push)\n- ``max_buffer_length``: the per-session cap (server-side constant)\n- ``turn_in_flight``: ``True`` if a copilot turn was running when\n  we checked — purely informational for UX feedback.  Even when\n  ``False`` the message is still queued: the next turn drains it."
+        "description": "Response returned by ``POST /stream`` with status 202 when a message\nis queued because the session already has a turn in flight.\n\n- ``buffer_length``: how many messages are now in the session's\n  pending buffer (after this push)\n- ``max_buffer_length``: the per-session cap (server-side constant)\n- ``turn_in_flight``: ``True`` if a copilot turn was running when\n  we checked — purely informational for UX feedback.  Always ``True``\n  for responses from ``POST /stream`` with status 202."
       },
       "RateLimitResetResponse": {
         "properties": {


### PR DESCRIPTION
## Why

Before this PR:

- **Two POST endpoints** did conceptually one thing — \`POST /sessions/{id}/stream\` starts a turn, \`POST /sessions/{id}/messages/pending\` queues a follow-up against an in-flight turn. The frontend decided which to call based on its local \`isInflight\` flag.
- The **AutoPilot block** (\`backend/blocks/autopilot.py\`) bypasses the HTTP API entirely and calls \`stream_chat_completion_sdk\` directly. If the block was handed an existing \`session_id\` whose turn was still running, it would **race the in-flight turn on the cluster lock** instead of queueing — latent correctness bug.

## What

- Collapse \`POST /messages/pending\` into \`POST /stream\`. Same URL, server decides:
  - session idle → \`text/event-stream\` (SSE, as today)
  - session has turn in flight → \`202 application/json\` with \`{buffer_length, max_buffer_length, turn_in_flight}\`
- Extract the \"busy? queue it\" decision into a shared primitive (\`is_turn_in_flight\` + \`queue_user_message\` in \`pending_message_helpers.py\`).
- Wire the primitive into \`collect_copilot_response\` so the **AutoPilot block auto-queues** when fed a busy session instead of racing the lock. A new \`CopilotResult.queued: bool\` flag lets the block surface the deferred state to downstream blocks (response text explains it was queued, tool_calls empty, tokens zero).

## How

Server-side unification:

| caller | code path on busy | code path on idle |
|---|---|---|
| HTTP \`POST /stream\` | \`202 + QueuePendingMessageResponse\` | SSE stream (unchanged) |
| AutoPilot block \`collect_copilot_response\` | \`CopilotResult(queued=True, pending_buffer_length=N)\` | normal stream consumption (unchanged) |

Frontend:

- \`useCopilotPage.onSend\` still branches on \`isInflight\`, but now both branches hit the same \`/stream\` URL.
- New thin helper \`queueFollowUpMessage.ts\` does a plain \`fetch\` for the 202 case because the AI SDK's \`useChat\` fetcher expects SSE and chokes on JSON.
- Generated API client regenerated — \`postV2QueuePendingMessage\` removed.
- \`GET /messages/pending\` (peek) preserved unchanged — it's used by the UI to restore the chip state on page reload.

Net diff: **-189 LoC**.

## Test plan

Backend:
- \`pytest backend/api/features/chat/routes_test.py\` — 46/46 ✅ (existing queue tests rewritten to hit \`/stream\` with \`is_turn_in_flight\` mocked true)
- \`pytest backend/copilot/pending_messages_test.py\` — 34/34 ✅

Frontend:
- \`pnpm vitest run copilot\` — 630/630 ✅ (useCopilotPage test updated to mock \`queueFollowUpMessage\`)
- \`pnpm types\` ✅
- \`pnpm lint\` ✅

Manual (to do once merged onto master):
- UI chip flow still promotes to bubble during a tool boundary (mid-turn drain covered by parent PR #12737's PostToolUse hook)
- AutoPilot block pointed at a session with a live UI turn queues instead of racing

## Notes

This PR is stacked on **#12737** (\`feat/copilot-pending-messages\`). GitHub will re-target the base to \`master\` automatically once #12737 merges.