### PR TITLE
fix(backend/copilot): stop flag-gating Graphiti supplement in system prompt

### DIFF
--- a/autogpt_platform/backend/backend/copilot/baseline/service.py
+++ b/autogpt_platform/backend/backend/copilot/baseline/service.py
@@ -1384,11 +1384,18 @@ async def stream_chat_completion_baseline(
 
     message_id = str(uuid.uuid4())
 
-    # Append tool documentation, technical notes, and Graphiti memory instructions
+    # The system prompt MUST be identical across users — the cacheable prefix
+    # ends at the ``cache_control`` breakpoint on this block, so any per-user
+    # content here forks the cache by user cohort and each cohort pays for
+    # its own write.  The Graphiti memory instructions are therefore always
+    # appended: memory tools are in the registry for every user and gate
+    # themselves at handler level (``is_enabled_for_user`` in each
+    # graphiti_* tool), so flag-off users get a "memory disabled" response
+    # from the handler instead of a divergent system prompt.  Warm context
+    # and ingest still honor the flag below — those are per-user data, not
+    # per-user instructions.
     graphiti_enabled = await is_enabled_for_user(user_id)
-
-    graphiti_supplement = get_graphiti_supplement() if graphiti_enabled else ""
-    system_prompt = base_system_prompt + SHARED_TOOL_NOTES + graphiti_supplement
+    system_prompt = base_system_prompt + SHARED_TOOL_NOTES + get_graphiti_supplement()
 
     # Warm context: pre-load relevant facts from Graphiti on first turn.
     # Use the pre-drain count so pending messages drained at turn start

--- a/autogpt_platform/backend/backend/copilot/prompt_static_invariant_test.py
+++ b/autogpt_platform/backend/backend/copilot/prompt_static_invariant_test.py
@@ -1,0 +1,61 @@
+"""Regression guards: the baseline + SDK system prompts must stay identical
+across users regardless of the ``GRAPHITI_MEMORY`` LaunchDarkly flag.
+
+Background: the Langfuse prompt is compiled with ``users_information=""`` and
+both paths append ``SHARED_TOOL_NOTES`` / ``get_sdk_supplement()`` plus the
+Graphiti memory instructions.  A previous bug flag-gated the supplement on
+``is_enabled_for_user(user_id)`` — which meant flag-on users and flag-off
+users got different system-prompt byte sequences, forking the Anthropic
+prompt cache by cohort and burning a fresh ~500-token cache write on every
+cross-cohort first call.
+
+These tests pin the contract at the source level so the conditional never
+silently returns.  A richer end-to-end test would be nice but would require
+exercising the entire streaming pipeline; for a contract this localised the
+source assertion is tighter and costs nothing to run.
+"""
+
+import inspect
+import re
+
+_GATED_SUPPLEMENT_PATTERNS = [
+    # Pattern 1: direct ternary on graphiti_enabled
+    re.compile(r"get_graphiti_supplement\(\)\s+if\s+graphiti_enabled"),
+    # Pattern 2: variable-assignment ternary
+    re.compile(
+        r"graphiti_supplement\s*=\s*get_graphiti_supplement\(\)\s+if\s+\w+\s+else\s+\"\""
+    ),
+]
+
+
+def _assert_supplement_always_appended(src: str, path: str) -> None:
+    for pat in _GATED_SUPPLEMENT_PATTERNS:
+        assert not pat.search(src), (
+            f"{path}: Graphiti supplement is flag-gated again — this forks the "
+            f"Anthropic prompt cache per-user cohort.  Always append the "
+            f"supplement; memory tools self-gate at handler level."
+        )
+    assert "get_graphiti_supplement()" in src, (
+        f"{path}: Graphiti supplement call is missing — the memory instructions "
+        f"must be present so every user's system prompt hashes identically."
+    )
+
+
+def test_baseline_graphiti_supplement_unconditionally_appended():
+    from backend.copilot.baseline import service
+
+    src = inspect.getsource(service.stream_chat_completion_baseline)
+    _assert_supplement_always_appended(
+        src, "baseline/service.py::stream_chat_completion_baseline"
+    )
+
+
+def test_sdk_graphiti_supplement_unconditionally_appended():
+    from backend.copilot.sdk import service
+
+    # SDK path: find the streaming entrypoint — the supplement assembly sits
+    # inside one of a handful of top-level streaming coroutines.  We check all
+    # async def declarations in the module so the guard doesn't rely on a
+    # stable function name.
+    src = inspect.getsource(service)
+    _assert_supplement_always_appended(src, "sdk/service.py")

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -2953,13 +2953,19 @@ async def stream_chat_completion_sdk(
         use_e2b = e2b_sandbox is not None
         # Append appropriate supplement (Claude gets tool schemas automatically)
 
+        # Always append the Graphiti memory instructions so the system prompt
+        # — the cacheable prefix on the SDK path — stays identical across
+        # users regardless of the ``GRAPHITI_MEMORY`` flag.  Memory tools
+        # self-gate at handler level (``is_enabled_for_user`` in each
+        # graphiti_* tool), so flag-off users never see memory side effects.
+        # Warm context + ingest still honor the flag below — those operate
+        # on per-user data, not on the static instructions.
         graphiti_enabled = await is_enabled_for_user(user_id)
 
-        graphiti_supplement = get_graphiti_supplement() if graphiti_enabled else ""
         system_prompt = (
             base_system_prompt
             + get_sdk_supplement(use_e2b=use_e2b)
-            + graphiti_supplement
+            + get_graphiti_supplement()
         )
 
         # Warm context: pre-load relevant facts from Graphiti on first turn.


### PR DESCRIPTION
### Why / What / How

**Why:** Baseline + SDK prompt caching was forking per LaunchDarkly cohort. Cross-user test on dev stack (post-#12870 merge):

```
9:17:28 PM  gmail         Baseline Opus    17.8K in / 0 cached / 17.2K write
9:18:55 PM  example.com   Baseline Opus     5.6K in / 11.6K cached / 5.1K write  ← partial hit
9:17:40 PM  example.com   Baseline Sonnet  12.8K in / 0 cached / 12.4K write
9:19:41 PM  gmail         Baseline Sonnet   4.6K in / 8.6K cached / 4.2K write   ← partial hit
```

Tools block hits across users (11.6K cached on the same-model second call), but the system block misses every time — ~5K / ~500 tokens get rewritten. That cluster matches exactly the 1,816-char `get_graphiti_supplement()` text that was conditionally appended to the system prompt when the `GRAPHITI_MEMORY` flag was true for the user. Flag-on vs flag-off users each ended up with their own cache cohort and burned a fresh write on every cross-cohort first call.

Also breaks the documented invariant from `_fetch_langfuse_prompt()` at [service.py:297-330](autogpt_platform/backend/backend/copilot/service.py#L297-L330): "the prompt text is identical across all users (enabling cross-session caching)."

**What:** Always append the Graphiti memory-tool instructions to the system prompt. The tools themselves already self-gate at handler level (`is_enabled_for_user` in each `graphiti_*` tool, e.g. [graphiti_search.py:89](autogpt_platform/backend/backend/copilot/tools/graphiti_search.py#L89)), so flag-off users never trigger memory side effects even if the model attempts to call them.

**How:**
- `baseline/service.py:1390` — drop the `if graphiti_enabled else ""` ternary; always include the supplement. Kept the `graphiti_enabled` flag because warm-context fetch + ingest still gate on it (correct: those operate on per-user *data*, not static instructions).
- `sdk/service.py:2958` — same treatment.
- New `prompt_static_invariant_test.py` — source-level regression guard that fails if either call site re-introduces the flag-gated pattern.

Trade-off: ~500 tokens extra in the system prompt for flag-off users. Amortised in one cache write — cross-user cache now hits 100% of the prefix instead of ~67%.

### Changes

- `copilot/baseline/service.py` — unconditional Graphiti supplement append
- `copilot/sdk/service.py` — same
- `copilot/prompt_static_invariant_test.py` — new regression guard

### Checklist

For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [x] `poetry run pytest backend/copilot/prompt_static_invariant_test.py backend/copilot/prompt_cache_test.py backend/copilot/baseline/` — 115 pass
  - [ ] Manual: on a dev deploy with two users (one flag-on, one flag-off), second user's first Baseline call shows `cached_tokens ≈ full prefix` instead of `~67% cached + 5K write`.
  - [ ] Manual: flag-off user can send a prompt that would normally benefit from memory — confirm the `memory_search` tool handler returns "disabled" gracefully, no crash.
  - [ ] Manual: `CHAT_USE_CLAUDE_AGENT_SDK=true` SDK path — same cross-user cache improvement, no regression in SDK session persistence.