### PR TITLE
fix(backend/copilot): sync safety net for Redis-induced zombie sessions

### DIFF
--- a/.claude/skills/pr-polish/SKILL.md
+++ b/.claude/skills/pr-polish/SKILL.md
@@ -33,7 +33,12 @@ Update the `current` round counter at the start of each iteration; mark `complet
 ## Find the PR
 
 ```bash
-PR=${ARG:-$(gh pr list --head "$(git branch --show-current)" --repo Significant-Gravitas/AutoGPT --json number --jq '.[0].number')}
+ARG_PR="${ARG:-}"
+# Normalize URL → numeric ID if the skill arg is a pull-request URL.
+if [[ "$ARG_PR" =~ ^https?://github\.com/[^/]+/[^/]+/pull/([0-9]+) ]]; then
+  ARG_PR="${BASH_REMATCH[1]}"
+fi
+PR="${ARG_PR:-$(gh pr list --head "$(git branch --show-current)" --repo Significant-Gravitas/AutoGPT --json number --jq '.[0].number')}"
 if [ -z "$PR" ] || [ "$PR" = "null" ]; then
   echo "No PR found for current branch. Provide a PR number or URL as the skill arg."
   exit 1

--- a/.claude/skills/pr-polish/SKILL.md
+++ b/.claude/skills/pr-polish/SKILL.md
@@ -2,7 +2,7 @@
 name: pr-polish
 description: Alternate /pr-review and /pr-address on a PR until the PR is truly mergeable — no new review findings, zero unresolved inline threads, zero unaddressed top-level reviews or issue comments, all CI checks green, and two consecutive quiet polls after CI settles. Use when the user wants a PR polished to merge-ready without setting a fixed number of rounds.
 user-invocable: true
-args: "[PR number or URL] — if omitted, finds PR for current branch."
+argument-hint: "[PR number or URL] — if omitted, finds PR for current branch."
 metadata:
   author: autogpt-team
   version: "1.0.0"
@@ -178,6 +178,18 @@ Skill(skill="pr-address", args=pr_url)
 ```
 
 After each child invocation, re-query GitHub state directly — never trust a summary for the stop condition. The orchestrator's `ORCHESTRATOR:DONE` is verified against actual GraphQL / REST responses per the rules in `pr-address`'s "Verify actual count before outputting ORCHESTRATOR:DONE" section.
+
+### **Auto-continue: do NOT end your response between child skills**
+
+`/pr-polish` is a single orchestration task — one invocation drives the PR all the way to merge-ready. When a child `Skill()` call returns control to you:
+
+- Do NOT summarize and stop.
+- Do NOT wait for user confirmation to continue.
+- Immediately, in the same response, perform the next loop step: state diff → decide next action → next `Skill()` call or polling sleep.
+
+The child skill returning is a **loop iteration boundary**, not a conversation turn boundary. You are expected to keep going until one of the exit conditions in the opening section is met (2 consecutive clean polls, `_MAX_ROUNDS` hit, or an unrecoverable error).
+
+If the user needs to approve a risky action mid-loop (e.g., a force-push or a destructive git operation), pause there — but not at the routine "round N finished, round N+1 needed" boundary. Those are silent transitions.
 
 ## GitHub rate limits
 

--- a/.claude/skills/pr-polish/SKILL.md
+++ b/.claude/skills/pr-polish/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: pr-polish
+description: Alternate /pr-review and /pr-address on a PR until the PR is truly mergeable — no new review findings, zero unresolved inline threads, zero unaddressed top-level reviews or issue comments, all CI checks green, and two consecutive quiet polls after CI settles. Use when the user wants a PR polished to merge-ready without setting a fixed number of rounds.
+user-invocable: true
+args: "[PR number or URL] — if omitted, finds PR for current branch."
+metadata:
+  author: autogpt-team
+  version: "1.0.0"
+---
+
+# PR Polish
+
+**Goal.** Drive a PR to merge-ready by alternating `/pr-review` and `/pr-address` until **all** of the following hold:
+
+1. The most recent `/pr-review` produces **zero new findings** (no new inline comments, no new top-level reviews with a non-empty body).
+2. Every inline review thread reachable via GraphQL reports `isResolved: true`.
+3. Every non-bot, non-author top-level review has been acknowledged (replied-to) OR resolved via a thread it spawned.
+4. Every non-bot, non-author issue comment has been acknowledged (replied-to).
+5. Every CI check is `conclusion: "success"` or `"skipped"` / `"neutral"` — none `"failure"` or still pending.
+6. **Two consecutive post-CI polls** (≥60s apart) stay clean — no new threads, no new non-empty reviews, no new issue comments. Bots (coderabbitai, sentry, autogpt-reviewer) frequently post late after CI settles; a single green snapshot is not sufficient.
+
+**Do not stop at a fixed number of rounds.** If round N introduces new comments, round N+1 is required. Cap at `_MAX_ROUNDS = 10` as a safety valve, but expect 2–5 in practice.
+
+## TodoWrite
+
+Before starting, write two todos so the user can see the loop progression:
+
+- `Round {current}: /pr-review + /pr-address on PR #{N}` — current iteration.
+- `Final polish polling: 2 consecutive clean polls, CI green, 0 unresolved` — runs after the last non-empty review round.
+
+Update the `current` round counter at the start of each iteration; mark `completed` only when the round's address step finishes (all new threads addressed + resolved).
+
+## Find the PR
+
+```bash
+PR=${ARG:-$(gh pr list --head "$(git branch --show-current)" --repo Significant-Gravitas/AutoGPT --json number --jq '.[0].number')}
+echo "Polishing PR #$PR"
+```
+
+## The outer loop
+
+```text
+round = 0
+while round < _MAX_ROUNDS:
+    round += 1
+    baseline = snapshot_state(PR)   # see "Snapshotting state" below
+    invoke_skill("pr-review", PR)   # posts findings as inline comments / top-level review
+    findings = diff_state(PR, baseline)
+    if findings.total == 0:
+        break  # no new findings → go to polish polling
+    invoke_skill("pr-address", PR)  # resolves every unresolved thread + CI failure
+# Post-loop: polish polling (see below).
+polish_polling(PR)
+```
+
+### Snapshotting state
+
+Before each `/pr-review`, capture a baseline so the diff after the review reflects **only** what the review just added (not pre-existing threads):
+
+```bash
+# Inline threads — total count + latest databaseId per thread
+gh api graphql -f query="
+{
+  repository(owner: \"Significant-Gravitas\", name: \"AutoGPT\") {
+    pullRequest(number: ${PR}) {
+      reviewThreads(first: 100) {
+        totalCount
+        nodes {
+          id
+          isResolved
+          comments(last: 1) { nodes { databaseId } }
+        }
+      }
+    }
+  }
+}" > /tmp/baseline_threads.json
+
+# Top-level reviews — count + latest id per non-empty review
+gh api "repos/Significant-Gravitas/AutoGPT/pulls/${PR}/reviews" --paginate \
+  --jq '[.[] | select((.body // "") != "") | {id, user: .user.login, state, submitted_at}]' \
+  > /tmp/baseline_reviews.json
+
+# Issue comments — count + latest id per non-bot, non-author comment
+gh api "repos/Significant-Gravitas/AutoGPT/issues/${PR}/comments" --paginate \
+  --jq '[.[] | {id, user: .user.login, created_at}]' \
+  > /tmp/baseline_issue_comments.json
+```
+
+### Diffing after a review
+
+After `/pr-review` runs, any of these counting as "new findings" means another address round is needed:
+
+- New inline thread `id` not in the baseline.
+- An existing thread whose latest comment `databaseId` is higher than the baseline's (new reply on an old thread).
+- A new top-level review `id` with a non-empty body.
+- A new issue comment `id` from a non-bot, non-author user.
+
+If any of the four buckets is non-empty → not done; invoke `/pr-address` and loop.
+
+## Polish polling
+
+Once `/pr-review` produces zero new findings, do **not** exit yet. Bots (coderabbitai, sentry, autogpt-reviewer) commonly post late reviews after CI settles — 30–90 seconds after the final push. Poll at 60-second intervals:
+
+```text
+clean_polls = 0
+required_clean = 2
+while clean_polls < required_clean:
+    # 1. CI gate
+    ci = fetch_check_runs(PR)
+    if any ci.conclusion == "failure":
+        invoke_skill("pr-address", PR)  # address failures + any new comments
+        clean_polls = 0
+        continue
+    if any ci.conclusion is None (still in_progress):
+        sleep 60; continue  # wait without counting this as clean
+
+    # 2. Comment / thread gate
+    threads = fetch_unresolved_threads(PR)
+    new_issue_comments = diff_against_baseline(issue_comments)
+    new_reviews = diff_against_baseline(reviews)
+    if threads or new_issue_comments or new_reviews:
+        invoke_skill("pr-address", PR)
+        clean_polls = 0
+        continue
+
+    # 3. Mergeability gate
+    mergeable = gh api repos/.../pulls/${PR} --jq '.mergeable'
+    if mergeable == false (CONFLICTING):
+        resolve_conflicts(PR)  # see pr-address skill
+        clean_polls = 0
+        continue
+    if mergeable is null (UNKNOWN):
+        sleep 60; continue
+
+    clean_polls += 1
+    sleep 60
+```
+
+Only after `clean_polls == 2` do you report `ORCHESTRATOR:DONE`.
+
+### Why 2 clean polls, not 1
+
+A single green snapshot can be misleading — the final CI check often completes ~30s before a bot posts its delayed review. One quiet cycle does not prove the PR is stable; two consecutive cycles with no new threads, reviews, or issue comments arriving gives high confidence nothing else is incoming.
+
+### Why checking every source each poll
+
+`/pr-address` polling inside a single round already re-checks its own comments, but `/pr-polish` sits a level above and must also catch:
+
+- New top-level reviews (autogpt-reviewer sometimes posts structured feedback only after several CI green cycles).
+- Issue comments from human reviewers (not caught by inline thread polling).
+- Sentry bug predictions that land on new line numbers post-push.
+- Merge conflicts introduced by a race between your push and a merge to `dev`.
+
+## Invocation pattern
+
+Delegate to existing skills with the `Skill` tool; do not re-implement the review or address logic inline. This keeps the polish loop focused on orchestration and lets the child skills evolve independently.
+
+```python
+Skill(skill="pr-review",  args=pr_url)
+Skill(skill="pr-address", args=pr_url)
+```
+
+After each child invocation, re-query GitHub state directly — never trust a summary for the stop condition. The orchestrator's `ORCHESTRATOR:DONE` is verified against actual GraphQL / REST responses per the rules in `pr-address`'s "Verify actual count before outputting ORCHESTRATOR:DONE" section.
+
+## GitHub rate limits
+
+This skill issues many GraphQL calls (one review-thread query per outer iteration plus per-poll queries inside polish polling). Expect the GraphQL budget to be tight on large PRs. When `gh api rate_limit --jq .resources.graphql.remaining` drops below ~200, back off:
+
+- Fall back to REST for reads (flat `/pulls/{N}/comments`, `/pulls/{N}/reviews`, `/issues/{N}/comments`) per the `pr-address` skill's GraphQL-fallback section.
+- Queue thread resolutions (GraphQL-only) until the budget resets; keep making progress on fixes + REST replies meanwhile.
+- `sleep 5` between any batch of ≥20 writes to avoid secondary rate limits.
+
+## Safety valves
+
+- `_MAX_ROUNDS = 10` — if review+address rounds exceed this, stop and escalate to the user with a summary of what's still unresolved. A PR that cannot converge in 10 rounds has systemic issues that need human judgment.
+- After each commit, run `poetry run format` / `pnpm format && pnpm lint && pnpm types` per the target codebase's conventions. A failing format check is CI `failure` that will never self-resolve.
+- Every `/pr-review` round checks for **duplicate** concerns first (via `pr-review`'s own "Fetch existing review comments" step) so the loop does not re-post the same finding that a prior round already resolved.
+
+## Reporting
+
+When the skill finishes (either via two clean polls or hitting `_MAX_ROUNDS`), produce a compact summary:
+
+```
+PR #{N} polish complete ({rounds_completed} rounds):
+- {X} inline threads opened and resolved
+- {Y} CI failures fixed
+- {Z} new commits pushed
+Final state: CI green, {total} threads all resolved, mergeable.
+```
+
+If exiting via `_MAX_ROUNDS`, flag explicitly:
+
+```
+PR #{N} polish stopped at {_MAX_ROUNDS} rounds — NOT merge-ready:
+- {N} threads still unresolved: {titles}
+- CI status: {summary}
+Needs human review.
+```
+
+## When to use this skill
+
+Use when the user says any of:
+- "polish this PR"
+- "keep reviewing and addressing until it's mergeable"
+- "loop /pr-review + /pr-address until done"
+- "make sure the PR is actually merge-ready"
+
+Do **not** use when:
+- User wants just one review pass (→ `/pr-review`).
+- User wants to address already-posted comments without further self-review (→ `/pr-address`).
+- A fixed round count is explicitly requested (e.g., "do 3 rounds") — honour the count instead of converging.

--- a/.claude/skills/pr-polish/SKILL.md
+++ b/.claude/skills/pr-polish/SKILL.md
@@ -34,6 +34,10 @@ Update the `current` round counter at the start of each iteration; mark `complet
 
 ```bash
 PR=${ARG:-$(gh pr list --head "$(git branch --show-current)" --repo Significant-Gravitas/AutoGPT --json number --jq '.[0].number')}
+if [ -z "$PR" ] || [ "$PR" = "null" ]; then
+  echo "No PR found for current branch. Provide a PR number or URL as the skill arg."
+  exit 1
+fi
 echo "Polishing PR #$PR"
 ```
 
@@ -80,9 +84,15 @@ gh api "repos/Significant-Gravitas/AutoGPT/pulls/${PR}/reviews" --paginate \
   --jq '[.[] | select((.body // "") != "") | {id, user: .user.login, state, submitted_at}]' \
   > /tmp/baseline_reviews.json
 
-# Issue comments — count + latest id per non-bot, non-author comment
+# Issue comments — count + latest id per non-bot, non-author comment.
+# Bots are filtered by User.type == "Bot" (GitHub sets this for app/bot
+# accounts like coderabbitai, github-actions, sentry-io). The author is
+# filtered by comparing login to the PR author — export it so jq can see it.
+AUTHOR=$(gh api "repos/Significant-Gravitas/AutoGPT/pulls/${PR}" --jq '.user.login')
 gh api "repos/Significant-Gravitas/AutoGPT/issues/${PR}/comments" --paginate \
-  --jq '[.[] | {id, user: .user.login, created_at}]' \
+  --jq --arg author "$AUTHOR" \
+      '[.[] | select(.user.type != "Bot" and .user.login != $author)
+            | {id, user: .user.login, created_at}]' \
   > /tmp/baseline_issue_comments.json
 ```
 
@@ -102,13 +112,18 @@ If any of the four buckets is non-empty → not done; invoke `/pr-address` and l
 Once `/pr-review` produces zero new findings, do **not** exit yet. Bots (coderabbitai, sentry, autogpt-reviewer) commonly post late reviews after CI settles — 30–90 seconds after the final push. Poll at 60-second intervals:
 
 ```text
+NON_SUCCESS_TERMINAL = {"failure", "cancelled", "timed_out", "action_required", "startup_failure"}
 clean_polls = 0
 required_clean = 2
 while clean_polls < required_clean:
-    # 1. CI gate
+    # 1. CI gate — any terminal non-success conclusion (not just "failure")
+    # must trigger /pr-address. "success", "skipped", "neutral" are clean;
+    # anything else (including cancelled, timed_out, action_required) is a
+    # blocker that won't self-resolve.
     ci = fetch_check_runs(PR)
-    if any ci.conclusion == "failure":
+    if any ci.conclusion in NON_SUCCESS_TERMINAL:
         invoke_skill("pr-address", PR)  # address failures + any new comments
+        baseline = snapshot_state(PR)   # reset — push during address invalidates old baseline
         clean_polls = 0
         continue
     if any ci.conclusion is None (still in_progress):
@@ -120,6 +135,8 @@ while clean_polls < required_clean:
     new_reviews = diff_against_baseline(reviews)
     if threads or new_issue_comments or new_reviews:
         invoke_skill("pr-address", PR)
+        baseline = snapshot_state(PR)   # reset — the address loop just dealt with these,
+                                        # otherwise they stay "new" relative to the old baseline forever
         clean_polls = 0
         continue
 

--- a/.claude/skills/pr-test/SKILL.md
+++ b/.claude/skills/pr-test/SKILL.md
@@ -260,6 +260,32 @@ Use a `trap` so release runs even on `exit 1`:
 trap 'kill "$HEARTBEAT_PID" 2>/dev/null; rm -f "$LOCK"' EXIT INT TERM
 ```
 
+### **Release the lock AS SOON AS the test run is done**
+
+The lock guards **test execution**, not **app lifecycle**. Once Step 5 (record results) and Step 6 (post PR comment) are complete, release the lock IMMEDIATELY — even if:
+
+- The native `poetry run app` / `pnpm dev` processes are still running so the user can keep poking at the app manually.
+- You're leaving docker containers up.
+- You're tailing logs for a minute or two.
+
+Keeping the lock held past the test run is the single most common way `/pr-test` stalls other agents. **The app staying up is orthogonal to the lock; don't conflate them.** Sibling worktrees running their own `/pr-test` will kill the stray processes and free the ports themselves (Step 3c/3e-native handle that) — they just need the lock file gone.
+
+Concretely, the sequence at the end of every `/pr-test` run (success or failure) is:
+
+```bash
+# 1. Write the final report + post PR comment — done above in Step 5/6.
+# 2. Release the lock right now, even if the app is still up.
+kill "$HEARTBEAT_PID" 2>/dev/null
+rm -f "$LOCK" /tmp/pr-test-heartbeat.pid
+echo "$(date -u +%Y-%m-%dT%H:%MZ) [pr-${PR_NUMBER}] released lock (app may still be running)" \
+    >> /Users/majdyz/Code/AutoGPT/.ign.testing.log
+# 3. Optionally leave the app running and note it so the user knows:
+echo "Native stack still running on :3000 / :8006 for manual poking. Kill with:"
+echo "  pkill -9 -f 'poetry run app'; pkill -9 -f 'next-server|next dev'"
+```
+
+If a sibling agent's `/pr-test` needs to take over, it'll do the kill+rebuild dance from Step 3c/3e-native on its own — your only job is to not hold the lock file past the end of your test.
+
 ### Shared status log
 
 `/Users/majdyz/Code/AutoGPT/.ign.testing.log` is an append-only channel any agent can read/write. Use it for "I'm waiting", "I'm done, resources free", or post-run notes:

--- a/.claude/skills/pr-test/SKILL.md
+++ b/.claude/skills/pr-test/SKILL.md
@@ -781,6 +781,19 @@ Upload screenshots to the PR using the GitHub Git API (no local git operations �
 
 **CRITICAL — NEVER post a bare directory link like `https://github.com/.../tree/...`.** Every screenshot MUST appear as `![name](raw_url)` inline in the PR comment so reviewers can see them without clicking any links. After posting, the verification step below greps the comment for `![` tags and exits 1 if none are found — the test run is considered incomplete until this passes.
 
+**CRITICAL — NEVER paste absolute local paths into the PR comment.** Strings like `/Users/…`, `/home/…`, `C:\…` are useless to every reviewer except you. Before posting, grep the final body for `/Users/`, `/home/`, `/tmp/`, `/private/`, `C:\`, `~/` and either drop those lines entirely or rewrite them as repo-relative paths (`autogpt_platform/backend/…`). The PR comment is an artifact reviewers on GitHub read — it must be self-contained on github.com. Keep local paths in `$RESULTS_DIR/test-report.md` for yourself; only copy the *content* they reference (excerpts, test names, log lines) into the PR comment, not the path.
+
+**Pre-post sanity check** (paste after building the comment body, before `gh api ... comments`):
+
+```bash
+# Reject any local-looking absolute path or home-dir shortcut in the body
+if grep -nE '(^|[^A-Za-z])(/Users/|/home/|/tmp/|/private/|C:\\|~/)[A-Za-z0-9]' "$COMMENT_FILE" ; then
+  echo "ABORT: local filesystem paths detected in PR comment body."
+  echo "Remove or rewrite as repo-relative (autogpt_platform/...) before posting."
+  exit 1
+fi
+```
+
 ```bash
 # Upload screenshots via GitHub Git API (creates blobs, tree, commit, and ref remotely)
 REPO="Significant-Gravitas/AutoGPT"

--- a/autogpt_platform/backend/backend/copilot/executor/manager.py
+++ b/autogpt_platform/backend/backend/copilot/executor/manager.py
@@ -11,16 +11,12 @@ import threading
 import time
 import uuid
 from concurrent.futures import Future, ThreadPoolExecutor
-from dataclasses import dataclass
-from typing import Callable
 
 from pika.adapters.blocking_connection import BlockingChannel
 from pika.exceptions import AMQPChannelError, AMQPConnectionError
 from pika.spec import Basic, BasicProperties
 from prometheus_client import Gauge, start_http_server
 
-from backend.copilot import stream_registry
-from backend.copilot.pending_messages import clear_pending_messages_unsafe
 from backend.data import redis_client as redis
 from backend.data.rabbitmq import SyncRabbitMQ
 from backend.executor.cluster_lock import ClusterLock
@@ -30,7 +26,7 @@ from backend.util.process import AppProcess
 from backend.util.retry import continuous_retry
 from backend.util.settings import Settings
 
-from .processor import SHUTDOWN_ERROR_MESSAGE, execute_copilot_turn, init_worker
+from .processor import execute_copilot_turn, init_worker
 from .utils import (
     COPILOT_CANCEL_QUEUE_NAME,
     COPILOT_EXECUTION_QUEUE_NAME,
@@ -40,29 +36,6 @@ from .utils import (
     create_copilot_queue_config,
     get_session_lock_key,
 )
-
-# Type alias for the RabbitMQ ack/nack closure — (reject, requeue) → None.
-# Stored per-session so cleanup's fail-close can reject orphan deliveries
-# (RabbitMQ otherwise redelivers them, producing duplicate execution on a
-# turn we already marked ``failed``).
-_AckCallback = Callable[[bool, bool], None]
-
-
-@dataclass
-class _ActiveTask:
-    """Per-session handles cleanup needs to terminate a turn cleanly.
-
-    Packs everything ``cleanup()`` may need — the future to observe, the
-    cancel event to signal, the ack callback to reject the delivery on
-    fail-close, and the cluster lock to release. Kept as a dataclass so the
-    intent of each field is self-documenting at the call site.
-    """
-
-    future: Future
-    cancel_event: threading.Event
-    ack: _AckCallback
-    cluster_lock: ClusterLock
-
 
 logger = TruncatedLogger(logging.getLogger(__name__), prefix="[CoPilotExecutor]")
 settings = Settings()
@@ -100,10 +73,7 @@ class CoPilotExecutor(AppProcess):
     def __init__(self):
         super().__init__()
         self.pool_size = settings.config.num_copilot_workers
-        # Single authoritative per-session record. Packs future + cancel +
-        # ack + lock so cleanup can drive termination through one structure
-        # instead of juggling parallel dicts.
-        self.active_tasks: dict[str, _ActiveTask] = {}
+        self.active_tasks: dict[str, tuple[Future, threading.Event]] = {}
         self.executor_id = str(uuid.uuid4())
 
         self._executor = None
@@ -114,6 +84,7 @@ class CoPilotExecutor(AppProcess):
         self._run_thread = None
         self._run_client = None
 
+        self._task_locks: dict[str, ClusterLock] = {}
         self._active_tasks_lock = threading.Lock()
 
     # ============ Main Entry Points (AppProcess interface) ============ #
@@ -134,122 +105,97 @@ class CoPilotExecutor(AppProcess):
             time.sleep(1e5)
 
     def cleanup(self):
-        """Graceful shutdown — let in-flight turns finish naturally.
+        """Graceful shutdown — mirrors ``backend.executor.manager`` pattern.
 
-        Runs as four sequential phases:
+        1. Stop consumer immediately (both the Python flag that gates
+           ``_handle_run_message`` and ``channel.stop_consuming()`` at
+           the broker), so no new work enters.
+        2. Passively wait for ``active_tasks`` to drain — each turn's
+           own ``finally`` publishes its terminal state via
+           ``mark_session_completed``. When a turn exits, ``on_run_done``
+           removes it from ``active_tasks`` and releases its cluster lock.
+        3. Shut down the thread-pool executor (cancels pending, leaves
+           running threads alone — process exit handles them).
+        4. Release any cluster locks still held (defensive — on_run_done's
+           finally should have already released them).
+        5. Stop message consumer threads + disconnect pika clients.
 
-        1. :meth:`_phase_reject_new_work` — set the flag that gates
-           ``_handle_run_message``; any new deliveries get nacked.
-        2. :meth:`_phase_wait_for_drain` — passively wait for in-flight
-           turns to finish on their own (no pre-emptive cancellation).
-           Each turn's own ``finally`` publishes its terminal state.
-        3. :meth:`_phase_fail_close` — for turns still running after the
-           grace window (truly stuck), mark them failed + reject the
-           RabbitMQ delivery + clear pending buffer + release lock.
-        4. :meth:`_phase_teardown` — stop consumers, clean up workers,
-           release any remaining locks.
-
-        Why no pre-emptive cancel of healthy turns: the goal is to let
-        every in-flight turn complete on its own. The zombie-session bug
-        this PR targets was never caused by SIGTERM killing the turn —
-        it was caused by a transient Redis failure mid-turn whose
-        reporting path (``_execute_async.finally → mark_session_completed``)
-        *also* hit the failure and silently swallowed it. That's handled
-        by :func:`sync_fail_close_session` in ``execute()``'s finally
-        (fresh asyncio loop + fresh Redis client on every turn exit).
-        Phase 3 is the safety net for the much rarer case where a turn
-        genuinely cannot finish inside the grace window.
-
-        Order invariant: ``_phase_teardown`` must run LAST because it
-        calls ``channel.stop_consuming()`` — once that returns, any
-        ``add_callback_threadsafe`` calls queued to that connection
-        (including the ones in phase 3's nack path) silently fail to
-        execute.
+        The zombie-session bug this PR targets is handled inside each
+        turn's own lifecycle by :func:`sync_fail_close_session`, NOT by
+        cleanup — so cleanup can stay as a simple "wait, then teardown"
+        and matches agent-executor's proven pattern.
         """
         pid = os.getpid()
-        logger.info(f"[cleanup {pid}] Starting graceful shutdown...")
+        prefix = f"[cleanup {pid}]"
+        logger.info(f"{prefix} Starting graceful shutdown...")
 
-        self._phase_reject_new_work(pid)
-        self._phase_wait_for_drain(pid)
-        self._phase_fail_close(pid)
-        self._phase_teardown(pid)
+        # 1. Stop consumer — flag AND broker-side
+        try:
+            self.stop_consuming.set()
+            run_channel = self.run_client.get_channel()
+            run_channel.connection.add_callback_threadsafe(
+                lambda: run_channel.stop_consuming()
+            )
+            logger.info(f"{prefix} Consumer has been signaled to stop")
+        except Exception as e:
+            logger.error(f"{prefix} Error stopping consumer: {e}")
 
-        logger.info(f"[cleanup {pid}] Graceful shutdown completed")
+        # 2. Wait for in-flight turns to finish naturally
+        if self.active_tasks:
+            logger.info(
+                f"{prefix} Waiting for {len(self.active_tasks)} active tasks "
+                f"to complete (timeout: {GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS}s)..."
+            )
 
-    # --- cleanup phases ----------------------------------------------------
+            start_time = time.monotonic()
+            last_refresh = start_time
+            lock_refresh_interval = settings.config.cluster_lock_timeout / 10
 
-    def _phase_reject_new_work(self, pid: int) -> None:
-        """Phase 1: flag the consumer to nack newly-arriving deliveries.
+            while (
+                self.active_tasks
+                and (time.monotonic() - start_time)
+                < GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS
+            ):
+                self._cleanup_completed_tasks()
+                if not self.active_tasks:
+                    break
 
-        Only sets the Python ``stop_consuming`` event that
-        ``_handle_run_message`` checks — does NOT call
-        ``channel.stop_consuming()`` yet. That call exits pika's ioloop,
-        which would prevent phase 3's threadsafe-queued ``basic_nack``
-        callbacks from ever executing. Actual consumer shutdown is
-        deferred to :meth:`_phase_teardown`.
-        """
-        self.stop_consuming.set()
-        logger.info(
-            f"[cleanup {pid}] Consumer flagged: new deliveries will be nacked "
-            f"(channel.stop_consuming deferred to teardown)"
-        )
+                now = time.monotonic()
+                if now - last_refresh >= lock_refresh_interval:
+                    for lock in list(self._task_locks.values()):
+                        try:
+                            lock.refresh()
+                        except Exception as e:
+                            logger.warning(f"{prefix} Failed to refresh lock: {e}")
+                    last_refresh = now
 
-    def _phase_wait_for_drain(self, pid: int) -> None:
-        """Phase 2: passively wait for in-flight turns to finish naturally.
+                logger.info(
+                    f"{prefix} {len(self.active_tasks)} tasks still active, waiting..."
+                )
+                time.sleep(10.0)
 
-        No pre-emptive cancellation — in-flight turns keep running until
-        they finish on their own. Each turn's own ``finally`` publishes
-        the terminal state via ``mark_session_completed``. When a turn
-        exits, ``on_run_done`` removes it from ``active_tasks`` and
-        releases the cluster lock; we observe that through the drain
-        loop below.
+            if self.active_tasks:
+                logger.warning(
+                    f"{prefix} {len(self.active_tasks)} tasks still running after "
+                    f"{GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS}s — process exit will "
+                    f"abandon them; RabbitMQ redelivery handles the message."
+                )
 
-        Runs up to ``GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS``. Anything still
-        running after that is handled by :meth:`_phase_fail_close`.
-        """
-        self._wait_for_active_to_drain(pid)
-
-    def _phase_fail_close(self, pid: int) -> None:
-        """Phase 3: force-terminate any turn that didn't drain in time.
-
-        Marks the Redis session ``failed``, rejects the RabbitMQ delivery
-        (non-requeued — we already marked it failed, so redelivery would
-        produce duplicate execution on another pod), clears its pending
-        buffer, and releases the cluster lock. All steps are idempotent.
-        """
-        with self._active_tasks_lock:
-            orphan_ids = list(self.active_tasks.keys())
-        if not orphan_ids:
-            return
-
-        logger.warning(
-            f"[cleanup {pid}] {len(orphan_ids)} task(s) still running "
-            f"after {GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS}s — fail-closing"
-        )
-        self._fail_close_redis_state(orphan_ids, pid)
-        for session_id in orphan_ids:
-            self._reject_orphan_delivery(session_id, pid)
-
-    def _phase_teardown(self, pid: int) -> None:
-        """Phase 4: tear down consumers, worker threads, and remaining locks.
-
-        Runs last because tearing down earlier would prevent phase 3's
-        RabbitMQ rejections (the channel would already be closed) and
-        cluster-lock releases (Redis teardown may already be in flight).
-        """
+        # 3. Stop message consumer threads
         if self._run_thread:
             self._stop_message_consumers(
-                self._run_thread, self.run_client, "[cleanup][run]"
+                self._run_thread, self.run_client, f"{prefix} [run]"
             )
         if self._cancel_thread:
             self._stop_message_consumers(
-                self._cancel_thread, self.cancel_client, "[cleanup][cancel]"
+                self._cancel_thread, self.cancel_client, f"{prefix} [cancel]"
             )
 
+        # 4. Worker cleanup + executor shutdown
         if self._executor:
             from .processor import cleanup_worker
 
-            logger.info(f"[cleanup {pid}] Cleaning up workers...")
+            logger.info(f"{prefix} Cleaning up workers...")
             futures = []
             for _ in range(self._executor._max_workers):
                 futures.append(self._executor.submit(cleanup_worker))
@@ -257,133 +203,22 @@ class CoPilotExecutor(AppProcess):
                 try:
                     f.result(timeout=10)
                 except Exception as e:
-                    logger.warning(f"[cleanup {pid}] Worker cleanup error: {e}")
+                    logger.warning(f"{prefix} Worker cleanup error: {e}")
 
-            logger.info(f"[cleanup {pid}] Shutting down executor...")
+            logger.info(f"{prefix} Shutting down executor...")
             self._executor.shutdown(wait=False)
 
-        # Release any cluster locks for sessions that completed normally via
-        # on_run_done but whose release hasn't been observed yet. Orphan
-        # sessions already had their locks released in phase 3.
-        with self._active_tasks_lock:
-            remaining = list(self.active_tasks.items())
-        for session_id, task in remaining:
-            self._release_lock(session_id, task.cluster_lock, pid)
-
-    # --- cleanup helpers ---------------------------------------------------
-
-    def _wait_for_active_to_drain(self, pid: int) -> None:
-        """Block until ``active_tasks`` is empty or the grace window expires."""
-        if not self.active_tasks:
-            return
-
-        logger.info(
-            f"[cleanup {pid}] Waiting for {len(self.active_tasks)} active tasks "
-            f"to complete (timeout: {GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS}s)..."
-        )
-
-        start_time = time.monotonic()
-        last_refresh = start_time
-        lock_refresh_interval = settings.config.cluster_lock_timeout / 10
-
-        while (
-            self.active_tasks
-            and (time.monotonic() - start_time) < GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS
-        ):
-            self._cleanup_completed_tasks()
-            if not self.active_tasks:
-                return
-
-            now = time.monotonic()
-            if now - last_refresh >= lock_refresh_interval:
-                self._refresh_all_cluster_locks(pid)
-                last_refresh = now
-
-            logger.info(
-                f"[cleanup {pid}] {len(self.active_tasks)} tasks still active, waiting..."
-            )
-            time.sleep(10.0)
-
-    def _refresh_all_cluster_locks(self, pid: int) -> None:
-        """Keep the cluster locks alive while we wait for turns to finish."""
-        with self._active_tasks_lock:
-            locks = [task.cluster_lock for task in self.active_tasks.values()]
-        for lock in locks:
+        # 5. Release any cluster locks still held
+        for session_id, lock in list(self._task_locks.items()):
             try:
-                lock.refresh()
-            except Exception as e:
-                logger.warning(f"[cleanup {pid}] Failed to refresh lock: {e}")
-
-    def _fail_close_redis_state(self, session_ids: list[str], pid: int) -> None:
-        """Mark orphan sessions ``failed`` + clear their pending buffers.
-
-        Uses a fresh ``asyncio.run`` loop because cleanup runs on the main
-        (sync) thread of ``execute_run_command`` and the per-worker
-        execution loops may already be stopped. A new loop also gives us
-        a new thread-local Redis client that doesn't inherit any bad
-        state from the turn that got stuck.
-        """
-
-        async def _fail_one(session_id: str) -> None:
-            try:
-                await stream_registry.mark_session_completed(
-                    session_id, error_message=SHUTDOWN_ERROR_MESSAGE
-                )
+                lock.release()
+                logger.info(f"{prefix} Released lock for {session_id}")
             except Exception as e:
                 logger.error(
-                    f"[cleanup {pid}] mark_session_completed failed for "
-                    f"{session_id}: {e}"
-                )
-            try:
-                await clear_pending_messages_unsafe(session_id)
-            except Exception as e:
-                logger.warning(
-                    f"[cleanup {pid}] clear_pending_messages_unsafe failed for "
-                    f"{session_id}: {e}"
+                    f"{prefix} Failed to release lock for {session_id}: {e}"
                 )
 
-        async def _fail_all() -> None:
-            await asyncio.gather(
-                *(_fail_one(sid) for sid in session_ids),
-                return_exceptions=True,
-            )
-
-        try:
-            asyncio.run(_fail_all())
-        except Exception as e:
-            logger.error(
-                f"[cleanup {pid}] fail-close redis loop failed: {e}", exc_info=True
-            )
-
-    def _reject_orphan_delivery(self, session_id: str, pid: int) -> None:
-        """Reject the RabbitMQ delivery + release the cluster lock.
-
-        Must run AFTER marking the session failed — otherwise RabbitMQ
-        could redeliver to another pod that still sees ``status=running``
-        and run the turn again.
-        """
-        with self._active_tasks_lock:
-            task = self.active_tasks.pop(session_id, None)
-        if task is None:
-            return
-        try:
-            task.ack(True, False)  # reject without requeue
-        except Exception as e:
-            logger.warning(
-                f"[cleanup {pid}] Failed to reject orphan delivery for "
-                f"{session_id}: {e}"
-            )
-        self._release_lock(session_id, task.cluster_lock, pid)
-
-    def _release_lock(self, session_id: str, lock: ClusterLock, pid: int) -> None:
-        """Release one cluster lock, logging any failure."""
-        try:
-            lock.release()
-            logger.info(f"[cleanup {pid}] Released lock for {session_id}")
-        except Exception as e:
-            logger.error(
-                f"[cleanup {pid}] Failed to release lock for {session_id}: {e}"
-            )
+        logger.info(f"{prefix} Graceful shutdown completed")
 
     # ============ RabbitMQ Consumer Methods ============ #
 
@@ -468,10 +303,10 @@ class CoPilotExecutor(AppProcess):
             logger.debug(f"Cancel received for {session_id} but not active")
             return
 
-        task = self.active_tasks[session_id]
+        _, cancel_event = self.active_tasks[session_id]
         logger.info(f"Received cancel for {session_id}")
-        if not task.cancel_event.is_set():
-            task.cancel_event.set()
+        if not cancel_event.is_set():
+            cancel_event.set()
         else:
             logger.debug(f"Cancel already set for {session_id}")
 
@@ -583,20 +418,17 @@ class CoPilotExecutor(AppProcess):
                 f"executor_id={self.executor_id}"
             )
 
+            self._task_locks[session_id] = cluster_lock
             cancel_event = threading.Event()
             future = self.executor.submit(
                 execute_copilot_turn, entry, cancel_event, cluster_lock
             )
-            with self._active_tasks_lock:
-                self.active_tasks[session_id] = _ActiveTask(
-                    future=future,
-                    cancel_event=cancel_event,
-                    ack=ack_message,
-                    cluster_lock=cluster_lock,
-                )
+            self.active_tasks[session_id] = (future, cancel_event)
         except Exception as e:
             logger.warning(f"Failed to setup execution for {session_id}: {e}")
             cluster_lock.release()
+            if session_id in self._task_locks:
+                del self._task_locks[session_id]
             ack_message(reject=True, requeue=True)
             return
 
@@ -618,20 +450,11 @@ class CoPilotExecutor(AppProcess):
                 error_msg = str(e) or type(e).__name__
                 logger.exception(f"Error in run completion callback: {error_msg}")
             finally:
-                # Release the cluster lock — if the task was still tracked in
-                # active_tasks, it holds the authoritative reference.
-                with self._active_tasks_lock:
-                    task = self.active_tasks.pop(session_id, None)
-                if task is not None:
+                if session_id in self._task_locks:
                     logger.info(f"Releasing cluster lock for {session_id}")
-                    try:
-                        task.cluster_lock.release()
-                    except Exception as release_err:
-                        logger.warning(
-                            f"Failed to release cluster lock for {session_id}: "
-                            f"{release_err}"
-                        )
-                self._update_metrics()
+                    self._task_locks[session_id].release()
+                    del self._task_locks[session_id]
+                self._cleanup_completed_tasks()
 
         future.add_done_callback(on_run_done)
 
@@ -641,8 +464,8 @@ class CoPilotExecutor(AppProcess):
         """Remove completed futures from active_tasks and update metrics."""
         completed_tasks = []
         with self._active_tasks_lock:
-            for session_id, task in list(self.active_tasks.items()):
-                if task.future.done():
+            for session_id, (future, _) in list(self.active_tasks.items()):
+                if future.done():
                     completed_tasks.append(session_id)
                     self.active_tasks.pop(session_id, None)
                     logger.info(f"Cleaned up completed session {session_id}")

--- a/autogpt_platform/backend/backend/copilot/executor/manager.py
+++ b/autogpt_platform/backend/backend/copilot/executor/manager.py
@@ -153,8 +153,7 @@ class CoPilotExecutor(AppProcess):
 
             while (
                 self.active_tasks
-                and (time.monotonic() - start_time)
-                < GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS
+                and (time.monotonic() - start_time) < GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS
             ):
                 self._cleanup_completed_tasks()
                 if not self.active_tasks:
@@ -214,9 +213,7 @@ class CoPilotExecutor(AppProcess):
                 lock.release()
                 logger.info(f"{prefix} Released lock for {session_id}")
             except Exception as e:
-                logger.error(
-                    f"{prefix} Failed to release lock for {session_id}: {e}"
-                )
+                logger.error(f"{prefix} Failed to release lock for {session_id}: {e}")
 
         logger.info(f"{prefix} Graceful shutdown completed")
 

--- a/autogpt_platform/backend/backend/copilot/executor/manager.py
+++ b/autogpt_platform/backend/backend/copilot/executor/manager.py
@@ -140,22 +140,30 @@ class CoPilotExecutor(AppProcess):
         and its own logging. See each ``_phase_*`` method's docstring for
         what that step does and why it happens in that order.
 
-        Happy path: SIGTERM → :meth:`_phase_stop_new_work` stops the
-        consumer → :meth:`_phase_drain_inflight` signals cancel and waits
-        → each turn hits its own ``finally`` and marks the session
-        ``failed`` → ``active_tasks`` drains → :meth:`_phase_fail_close`
-        is a no-op → :meth:`_phase_teardown` releases resources.
+        Happy path: SIGTERM → :meth:`_phase_reject_new_work` sets the flag
+        that gates ``_handle_run_message`` (new deliveries get nacked) →
+        :meth:`_phase_drain_inflight` signals cancel and waits → each
+        turn hits its own ``finally`` and marks the session ``failed`` →
+        ``active_tasks`` drains → :meth:`_phase_fail_close` is a no-op →
+        :meth:`_phase_teardown` tells pika to exit ``start_consuming()``
+        and releases resources.
 
-        Stuck-turn path: if a turn can't be cancelled within the grace
-        window (network hang, event loop dead), :meth:`_phase_fail_close`
-        force-marks it failed, rejects the RabbitMQ delivery (so it's not
-        redelivered and double-executed on another pod), clears its
-        pending buffer, and releases the cluster lock.
+        Stuck-turn path: :meth:`_phase_fail_close` force-marks stuck
+        turns ``failed``, rejects their RabbitMQ deliveries (while the
+        channel is still consuming — threadsafe callbacks only fire
+        while pika's ioloop is active), clears their pending buffer,
+        and releases the cluster lock.
+
+        Order invariant: ``_phase_teardown`` must run LAST because it
+        calls ``channel.stop_consuming()`` — once that returns, any
+        ``add_callback_threadsafe`` calls queued to that connection
+        (including the ones in phase 3's nack path) silently fail to
+        execute.
         """
         pid = os.getpid()
         logger.info(f"[cleanup {pid}] Starting graceful shutdown...")
 
-        self._phase_stop_new_work(pid)
+        self._phase_reject_new_work(pid)
         self._phase_drain_inflight(pid)
         self._phase_fail_close(pid)
         self._phase_teardown(pid)
@@ -164,21 +172,21 @@ class CoPilotExecutor(AppProcess):
 
     # --- cleanup phases ----------------------------------------------------
 
-    def _phase_stop_new_work(self, pid: int) -> None:
-        """Phase 1: tell the RabbitMQ consumer to stop taking new deliveries.
+    def _phase_reject_new_work(self, pid: int) -> None:
+        """Phase 1: flag the consumer to nack newly-arriving deliveries.
 
-        ``stop_consuming`` also gates ``_handle_run_message`` — messages
-        that arrive after this point are nacked+requeued for another pod.
+        Only sets the Python ``stop_consuming`` event that
+        ``_handle_run_message`` checks — does NOT call
+        ``channel.stop_consuming()`` yet. That call exits pika's ioloop,
+        which would prevent phase 3's threadsafe-queued ``basic_nack``
+        callbacks from ever executing. Actual consumer shutdown is
+        deferred to :meth:`_phase_teardown`.
         """
-        try:
-            self.stop_consuming.set()
-            run_channel = self.run_client.get_channel()
-            run_channel.connection.add_callback_threadsafe(
-                lambda: run_channel.stop_consuming()
-            )
-            logger.info(f"[cleanup {pid}] Consumer has been signaled to stop")
-        except Exception as e:
-            logger.error(f"[cleanup {pid}] Error stopping consumer: {e}")
+        self.stop_consuming.set()
+        logger.info(
+            f"[cleanup {pid}] Consumer flagged: new deliveries will be nacked "
+            f"(channel.stop_consuming deferred to teardown)"
+        )
 
     def _phase_drain_inflight(self, pid: int) -> None:
         """Phase 2: signal cancel to every in-flight turn and wait it out.

--- a/autogpt_platform/backend/backend/copilot/executor/manager.py
+++ b/autogpt_platform/backend/backend/copilot/executor/manager.py
@@ -134,25 +134,31 @@ class CoPilotExecutor(AppProcess):
             time.sleep(1e5)
 
     def cleanup(self):
-        """Graceful shutdown.
+        """Graceful shutdown — let in-flight turns finish naturally.
 
-        Runs as four sequential phases, each with a single responsibility
-        and its own logging. See each ``_phase_*`` method's docstring for
-        what that step does and why it happens in that order.
+        Runs as four sequential phases:
 
-        Happy path: SIGTERM → :meth:`_phase_reject_new_work` sets the flag
-        that gates ``_handle_run_message`` (new deliveries get nacked) →
-        :meth:`_phase_drain_inflight` signals cancel and waits → each
-        turn hits its own ``finally`` and marks the session ``failed`` →
-        ``active_tasks`` drains → :meth:`_phase_fail_close` is a no-op →
-        :meth:`_phase_teardown` tells pika to exit ``start_consuming()``
-        and releases resources.
+        1. :meth:`_phase_reject_new_work` — set the flag that gates
+           ``_handle_run_message``; any new deliveries get nacked.
+        2. :meth:`_phase_wait_for_drain` — passively wait for in-flight
+           turns to finish on their own (no pre-emptive cancellation).
+           Each turn's own ``finally`` publishes its terminal state.
+        3. :meth:`_phase_fail_close` — for turns still running after the
+           grace window (truly stuck), mark them failed + reject the
+           RabbitMQ delivery + clear pending buffer + release lock.
+        4. :meth:`_phase_teardown` — stop consumers, clean up workers,
+           release any remaining locks.
 
-        Stuck-turn path: :meth:`_phase_fail_close` force-marks stuck
-        turns ``failed``, rejects their RabbitMQ deliveries (while the
-        channel is still consuming — threadsafe callbacks only fire
-        while pika's ioloop is active), clears their pending buffer,
-        and releases the cluster lock.
+        Why no pre-emptive cancel of healthy turns: the goal is to let
+        every in-flight turn complete on its own. The zombie-session bug
+        this PR targets was never caused by SIGTERM killing the turn —
+        it was caused by a transient Redis failure mid-turn whose
+        reporting path (``_execute_async.finally → mark_session_completed``)
+        *also* hit the failure and silently swallowed it. That's handled
+        by :func:`sync_fail_close_session` in ``execute()``'s finally
+        (fresh asyncio loop + fresh Redis client on every turn exit).
+        Phase 3 is the safety net for the much rarer case where a turn
+        genuinely cannot finish inside the grace window.
 
         Order invariant: ``_phase_teardown`` must run LAST because it
         calls ``channel.stop_consuming()`` — once that returns, any
@@ -164,7 +170,7 @@ class CoPilotExecutor(AppProcess):
         logger.info(f"[cleanup {pid}] Starting graceful shutdown...")
 
         self._phase_reject_new_work(pid)
-        self._phase_drain_inflight(pid)
+        self._phase_wait_for_drain(pid)
         self._phase_fail_close(pid)
         self._phase_teardown(pid)
 
@@ -188,16 +194,19 @@ class CoPilotExecutor(AppProcess):
             f"(channel.stop_consuming deferred to teardown)"
         )
 
-    def _phase_drain_inflight(self, pid: int) -> None:
-        """Phase 2: signal cancel to every in-flight turn and wait it out.
+    def _phase_wait_for_drain(self, pid: int) -> None:
+        """Phase 2: passively wait for in-flight turns to finish naturally.
 
-        Setting each task's ``cancel_event`` lets the async stream loop
-        break and hit its own ``finally`` (which publishes the accurate
-        terminal state). Without the active signal, the wait below is
-        passive and turns keep running until SIGKILL — which is what
-        caused the zombie-session bug this PR fixes.
+        No pre-emptive cancellation — in-flight turns keep running until
+        they finish on their own. Each turn's own ``finally`` publishes
+        the terminal state via ``mark_session_completed``. When a turn
+        exits, ``on_run_done`` removes it from ``active_tasks`` and
+        releases the cluster lock; we observe that through the drain
+        loop below.
+
+        Runs up to ``GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS``. Anything still
+        running after that is handled by :meth:`_phase_fail_close`.
         """
-        self._signal_cancel_to_active()
         self._wait_for_active_to_drain(pid)
 
     def _phase_fail_close(self, pid: int) -> None:
@@ -262,24 +271,6 @@ class CoPilotExecutor(AppProcess):
             self._release_lock(session_id, task.cluster_lock, pid)
 
     # --- cleanup helpers ---------------------------------------------------
-
-    def _signal_cancel_to_active(self) -> None:
-        """Set ``cancel_event`` on every active task so they exit fast."""
-        with self._active_tasks_lock:
-            tasks = list(self.active_tasks.items())
-        if not tasks:
-            return
-        pid = os.getpid()
-        logger.info(
-            f"[cleanup {pid}] Signalling cancel to {len(tasks)} in-flight task(s)"
-        )
-        for session_id, task in tasks:
-            try:
-                task.cancel_event.set()
-            except Exception as e:
-                logger.warning(
-                    f"[cleanup {pid}] Failed to signal cancel for {session_id}: {e}"
-                )
 
     def _wait_for_active_to_drain(self, pid: int) -> None:
         """Block until ``active_tasks`` is empty or the grace window expires."""

--- a/autogpt_platform/backend/backend/copilot/executor/manager.py
+++ b/autogpt_platform/backend/backend/copilot/executor/manager.py
@@ -17,6 +17,8 @@ from pika.exceptions import AMQPChannelError, AMQPConnectionError
 from pika.spec import Basic, BasicProperties
 from prometheus_client import Gauge, start_http_server
 
+from backend.copilot import stream_registry
+from backend.copilot.pending_messages import clear_pending_messages_unsafe
 from backend.data import redis_client as redis
 from backend.data.rabbitmq import SyncRabbitMQ
 from backend.executor.cluster_lock import ClusterLock
@@ -105,7 +107,20 @@ class CoPilotExecutor(AppProcess):
             time.sleep(1e5)
 
     def cleanup(self):
-        """Graceful shutdown with active execution waiting."""
+        """Graceful shutdown with active execution waiting.
+
+        The expected path: SIGTERM → consumer stops taking new jobs → any
+        in-flight turns wind down through their own ``cancel_event`` →
+        processor's ``finally`` calls ``mark_session_completed`` → future
+        completes → ``active_tasks`` drains → cleanup exits.
+
+        Fail-close path: if a turn ignores the cancel or is stuck on a
+        blocking I/O call when the grace window expires, we still mark the
+        session ``failed`` and clear its pending-message buffer here so the
+        frontend sees a clean terminal state instead of a zombie
+        ``status=running`` that only the 65-minute stale-watchdog would
+        eventually reap.
+        """
         pid = os.getpid()
         logger.info(f"[cleanup {pid}] Starting graceful shutdown...")
 
@@ -119,6 +134,28 @@ class CoPilotExecutor(AppProcess):
             logger.info(f"[cleanup {pid}] Consumer has been signaled to stop")
         except Exception as e:
             logger.error(f"[cleanup {pid}] Error stopping consumer: {e}")
+
+        # Signal cancellation to all in-flight turns so they break out of the
+        # stream loop, hit the finally in processor._execute_async, and call
+        # mark_session_completed on their own. Without this the wait loop
+        # below is purely passive and the turns keep running until the pod
+        # is SIGKILL'd — leaving the session status "running" in Redis and
+        # the frontend stuck on queued bubbles.
+        with self._active_tasks_lock:
+            pending_cancels = list(self.active_tasks.items())
+        if pending_cancels:
+            logger.info(
+                f"[cleanup {pid}] Signalling cancel to {len(pending_cancels)} "
+                f"in-flight task(s)"
+            )
+            for session_id, (_future, cancel_event) in pending_cancels:
+                try:
+                    cancel_event.set()
+                except Exception as e:
+                    logger.warning(
+                        f"[cleanup {pid}] Failed to signal cancel for "
+                        f"{session_id}: {e}"
+                    )
 
         # Wait for active executions to complete
         if self.active_tasks:
@@ -154,6 +191,19 @@ class CoPilotExecutor(AppProcess):
                     f"[cleanup {pid}] {len(self.active_tasks)} tasks still active, waiting..."
                 )
                 time.sleep(10.0)
+
+        # Fail-close any turn that didn't drain — mark the Redis session
+        # "failed" and drop its pending buffer so the frontend sees a
+        # terminal state immediately instead of a zombie running session.
+        # Idempotent: mark_session_completed no-ops if already terminal.
+        with self._active_tasks_lock:
+            orphan_sessions = list(self.active_tasks.keys())
+        if orphan_sessions:
+            logger.warning(
+                f"[cleanup {pid}] {len(orphan_sessions)} task(s) still running "
+                f"after {GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS}s — fail-closing"
+            )
+            self._fail_close_orphan_sessions(orphan_sessions, pid)
 
         # Stop message consumers
         if self._run_thread:
@@ -193,6 +243,47 @@ class CoPilotExecutor(AppProcess):
                 )
 
         logger.info(f"[cleanup {pid}] Graceful shutdown completed")
+
+    def _fail_close_orphan_sessions(self, session_ids: list[str], pid: int) -> None:
+        """Mark sessions as failed + clear their pending buffers.
+
+        Runs a fresh asyncio loop because ``cleanup()`` is called from the
+        main (sync) thread of ``execute_run_command`` — the per-worker
+        execution loops belong to worker threads and may already be stopped.
+        """
+
+        async def _do_one(session_id: str) -> None:
+            try:
+                await stream_registry.mark_session_completed(
+                    session_id,
+                    error_message=(
+                        "Copilot executor shut down before this turn finished. "
+                        "Please retry."
+                    ),
+                )
+            except Exception as e:
+                logger.error(
+                    f"[cleanup {pid}] Failed to mark session completed "
+                    f"for {session_id}: {e}"
+                )
+            try:
+                await clear_pending_messages_unsafe(session_id)
+            except Exception as e:
+                logger.warning(
+                    f"[cleanup {pid}] Failed to clear pending buffer "
+                    f"for {session_id}: {e}"
+                )
+
+        async def _do_all() -> None:
+            await asyncio.gather(
+                *(_do_one(sid) for sid in session_ids),
+                return_exceptions=True,
+            )
+
+        try:
+            asyncio.run(_do_all())
+        except Exception as e:
+            logger.error(f"[cleanup {pid}] fail-close loop failed: {e}", exc_info=True)
 
     # ============ RabbitMQ Consumer Methods ============ #
 

--- a/autogpt_platform/backend/backend/copilot/executor/manager.py
+++ b/autogpt_platform/backend/backend/copilot/executor/manager.py
@@ -11,6 +11,8 @@ import threading
 import time
 import uuid
 from concurrent.futures import Future, ThreadPoolExecutor
+from dataclasses import dataclass
+from typing import Callable
 
 from pika.adapters.blocking_connection import BlockingChannel
 from pika.exceptions import AMQPChannelError, AMQPConnectionError
@@ -28,7 +30,7 @@ from backend.util.process import AppProcess
 from backend.util.retry import continuous_retry
 from backend.util.settings import Settings
 
-from .processor import execute_copilot_turn, init_worker
+from .processor import SHUTDOWN_ERROR_MESSAGE, execute_copilot_turn, init_worker
 from .utils import (
     COPILOT_CANCEL_QUEUE_NAME,
     COPILOT_EXECUTION_QUEUE_NAME,
@@ -38,6 +40,29 @@ from .utils import (
     create_copilot_queue_config,
     get_session_lock_key,
 )
+
+# Type alias for the RabbitMQ ack/nack closure — (reject, requeue) → None.
+# Stored per-session so cleanup's fail-close can reject orphan deliveries
+# (RabbitMQ otherwise redelivers them, producing duplicate execution on a
+# turn we already marked ``failed``).
+_AckCallback = Callable[[bool, bool], None]
+
+
+@dataclass
+class _ActiveTask:
+    """Per-session handles cleanup needs to terminate a turn cleanly.
+
+    Packs everything ``cleanup()`` may need — the future to observe, the
+    cancel event to signal, the ack callback to reject the delivery on
+    fail-close, and the cluster lock to release. Kept as a dataclass so the
+    intent of each field is self-documenting at the call site.
+    """
+
+    future: Future
+    cancel_event: threading.Event
+    ack: _AckCallback
+    cluster_lock: ClusterLock
+
 
 logger = TruncatedLogger(logging.getLogger(__name__), prefix="[CoPilotExecutor]")
 settings = Settings()
@@ -75,7 +100,10 @@ class CoPilotExecutor(AppProcess):
     def __init__(self):
         super().__init__()
         self.pool_size = settings.config.num_copilot_workers
-        self.active_tasks: dict[str, tuple[Future, threading.Event]] = {}
+        # Single authoritative per-session record. Packs future + cancel +
+        # ack + lock so cleanup can drive termination through one structure
+        # instead of juggling parallel dicts.
+        self.active_tasks: dict[str, _ActiveTask] = {}
         self.executor_id = str(uuid.uuid4())
 
         self._executor = None
@@ -86,7 +114,6 @@ class CoPilotExecutor(AppProcess):
         self._run_thread = None
         self._run_client = None
 
-        self._task_locks: dict[str, ClusterLock] = {}
         self._active_tasks_lock = threading.Lock()
 
     # ============ Main Entry Points (AppProcess interface) ============ #
@@ -107,24 +134,42 @@ class CoPilotExecutor(AppProcess):
             time.sleep(1e5)
 
     def cleanup(self):
-        """Graceful shutdown with active execution waiting.
+        """Graceful shutdown.
 
-        The expected path: SIGTERM → consumer stops taking new jobs → any
-        in-flight turns wind down through their own ``cancel_event`` →
-        processor's ``finally`` calls ``mark_session_completed`` → future
-        completes → ``active_tasks`` drains → cleanup exits.
+        Runs as four sequential phases, each with a single responsibility
+        and its own logging. See each ``_phase_*`` method's docstring for
+        what that step does and why it happens in that order.
 
-        Fail-close path: if a turn ignores the cancel or is stuck on a
-        blocking I/O call when the grace window expires, we still mark the
-        session ``failed`` and clear its pending-message buffer here so the
-        frontend sees a clean terminal state instead of a zombie
-        ``status=running`` that only the 65-minute stale-watchdog would
-        eventually reap.
+        Happy path: SIGTERM → :meth:`_phase_stop_new_work` stops the
+        consumer → :meth:`_phase_drain_inflight` signals cancel and waits
+        → each turn hits its own ``finally`` and marks the session
+        ``failed`` → ``active_tasks`` drains → :meth:`_phase_fail_close`
+        is a no-op → :meth:`_phase_teardown` releases resources.
+
+        Stuck-turn path: if a turn can't be cancelled within the grace
+        window (network hang, event loop dead), :meth:`_phase_fail_close`
+        force-marks it failed, rejects the RabbitMQ delivery (so it's not
+        redelivered and double-executed on another pod), clears its
+        pending buffer, and releases the cluster lock.
         """
         pid = os.getpid()
         logger.info(f"[cleanup {pid}] Starting graceful shutdown...")
 
-        # Signal the consumer thread to stop
+        self._phase_stop_new_work(pid)
+        self._phase_drain_inflight(pid)
+        self._phase_fail_close(pid)
+        self._phase_teardown(pid)
+
+        logger.info(f"[cleanup {pid}] Graceful shutdown completed")
+
+    # --- cleanup phases ----------------------------------------------------
+
+    def _phase_stop_new_work(self, pid: int) -> None:
+        """Phase 1: tell the RabbitMQ consumer to stop taking new deliveries.
+
+        ``stop_consuming`` also gates ``_handle_run_message`` — messages
+        that arrive after this point are nacked+requeued for another pod.
+        """
         try:
             self.stop_consuming.set()
             run_channel = self.run_client.get_channel()
@@ -135,77 +180,46 @@ class CoPilotExecutor(AppProcess):
         except Exception as e:
             logger.error(f"[cleanup {pid}] Error stopping consumer: {e}")
 
-        # Signal cancellation to all in-flight turns so they break out of the
-        # stream loop, hit the finally in processor._execute_async, and call
-        # mark_session_completed on their own. Without this the wait loop
-        # below is purely passive and the turns keep running until the pod
-        # is SIGKILL'd — leaving the session status "running" in Redis and
-        # the frontend stuck on queued bubbles.
+    def _phase_drain_inflight(self, pid: int) -> None:
+        """Phase 2: signal cancel to every in-flight turn and wait it out.
+
+        Setting each task's ``cancel_event`` lets the async stream loop
+        break and hit its own ``finally`` (which publishes the accurate
+        terminal state). Without the active signal, the wait below is
+        passive and turns keep running until SIGKILL — which is what
+        caused the zombie-session bug this PR fixes.
+        """
+        self._signal_cancel_to_active()
+        self._wait_for_active_to_drain(pid)
+
+    def _phase_fail_close(self, pid: int) -> None:
+        """Phase 3: force-terminate any turn that didn't drain in time.
+
+        Marks the Redis session ``failed``, rejects the RabbitMQ delivery
+        (non-requeued — we already marked it failed, so redelivery would
+        produce duplicate execution on another pod), clears its pending
+        buffer, and releases the cluster lock. All steps are idempotent.
+        """
         with self._active_tasks_lock:
-            pending_cancels = list(self.active_tasks.items())
-        if pending_cancels:
-            logger.info(
-                f"[cleanup {pid}] Signalling cancel to {len(pending_cancels)} "
-                f"in-flight task(s)"
-            )
-            for session_id, (_future, cancel_event) in pending_cancels:
-                try:
-                    cancel_event.set()
-                except Exception as e:
-                    logger.warning(
-                        f"[cleanup {pid}] Failed to signal cancel for "
-                        f"{session_id}: {e}"
-                    )
+            orphan_ids = list(self.active_tasks.keys())
+        if not orphan_ids:
+            return
 
-        # Wait for active executions to complete
-        if self.active_tasks:
-            logger.info(
-                f"[cleanup {pid}] Waiting for {len(self.active_tasks)} active tasks to complete (timeout: {GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS}s)..."
-            )
+        logger.warning(
+            f"[cleanup {pid}] {len(orphan_ids)} task(s) still running "
+            f"after {GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS}s — fail-closing"
+        )
+        self._fail_close_redis_state(orphan_ids, pid)
+        for session_id in orphan_ids:
+            self._reject_orphan_delivery(session_id, pid)
 
-            start_time = time.monotonic()
-            last_refresh = start_time
-            lock_refresh_interval = settings.config.cluster_lock_timeout / 10
+    def _phase_teardown(self, pid: int) -> None:
+        """Phase 4: tear down consumers, worker threads, and remaining locks.
 
-            while (
-                self.active_tasks
-                and (time.monotonic() - start_time) < GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS
-            ):
-                self._cleanup_completed_tasks()
-                if not self.active_tasks:
-                    break
-
-                # Refresh cluster locks periodically
-                current_time = time.monotonic()
-                if current_time - last_refresh >= lock_refresh_interval:
-                    for lock in list(self._task_locks.values()):
-                        try:
-                            lock.refresh()
-                        except Exception as e:
-                            logger.warning(
-                                f"[cleanup {pid}] Failed to refresh lock: {e}"
-                            )
-                    last_refresh = current_time
-
-                logger.info(
-                    f"[cleanup {pid}] {len(self.active_tasks)} tasks still active, waiting..."
-                )
-                time.sleep(10.0)
-
-        # Fail-close any turn that didn't drain — mark the Redis session
-        # "failed" and drop its pending buffer so the frontend sees a
-        # terminal state immediately instead of a zombie running session.
-        # Idempotent: mark_session_completed no-ops if already terminal.
-        with self._active_tasks_lock:
-            orphan_sessions = list(self.active_tasks.keys())
-        if orphan_sessions:
-            logger.warning(
-                f"[cleanup {pid}] {len(orphan_sessions)} task(s) still running "
-                f"after {GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS}s — fail-closing"
-            )
-            self._fail_close_orphan_sessions(orphan_sessions, pid)
-
-        # Stop message consumers
+        Runs last because tearing down earlier would prevent phase 3's
+        RabbitMQ rejections (the channel would already be closed) and
+        cluster-lock releases (Redis teardown may already be in flight).
+        """
         if self._run_thread:
             self._stop_message_consumers(
                 self._run_thread, self.run_client, "[cleanup][run]"
@@ -215,7 +229,6 @@ class CoPilotExecutor(AppProcess):
                 self._cancel_thread, self.cancel_client, "[cleanup][cancel]"
             )
 
-        # Clean up worker threads (closes per-loop workspace storage sessions)
         if self._executor:
             from .processor import cleanup_worker
 
@@ -232,58 +245,146 @@ class CoPilotExecutor(AppProcess):
             logger.info(f"[cleanup {pid}] Shutting down executor...")
             self._executor.shutdown(wait=False)
 
-        # Release any remaining locks
-        for session_id, lock in list(self._task_locks.items()):
+        # Release any cluster locks for sessions that completed normally via
+        # on_run_done but whose release hasn't been observed yet. Orphan
+        # sessions already had their locks released in phase 3.
+        with self._active_tasks_lock:
+            remaining = list(self.active_tasks.items())
+        for session_id, task in remaining:
+            self._release_lock(session_id, task.cluster_lock, pid)
+
+    # --- cleanup helpers ---------------------------------------------------
+
+    def _signal_cancel_to_active(self) -> None:
+        """Set ``cancel_event`` on every active task so they exit fast."""
+        with self._active_tasks_lock:
+            tasks = list(self.active_tasks.items())
+        if not tasks:
+            return
+        pid = os.getpid()
+        logger.info(
+            f"[cleanup {pid}] Signalling cancel to {len(tasks)} in-flight task(s)"
+        )
+        for session_id, task in tasks:
             try:
-                lock.release()
-                logger.info(f"[cleanup {pid}] Released lock for {session_id}")
+                task.cancel_event.set()
             except Exception as e:
-                logger.error(
-                    f"[cleanup {pid}] Failed to release lock for {session_id}: {e}"
+                logger.warning(
+                    f"[cleanup {pid}] Failed to signal cancel for {session_id}: {e}"
                 )
 
-        logger.info(f"[cleanup {pid}] Graceful shutdown completed")
+    def _wait_for_active_to_drain(self, pid: int) -> None:
+        """Block until ``active_tasks`` is empty or the grace window expires."""
+        if not self.active_tasks:
+            return
 
-    def _fail_close_orphan_sessions(self, session_ids: list[str], pid: int) -> None:
-        """Mark sessions as failed + clear their pending buffers.
+        logger.info(
+            f"[cleanup {pid}] Waiting for {len(self.active_tasks)} active tasks "
+            f"to complete (timeout: {GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS}s)..."
+        )
 
-        Runs a fresh asyncio loop because ``cleanup()`` is called from the
-        main (sync) thread of ``execute_run_command`` — the per-worker
-        execution loops belong to worker threads and may already be stopped.
+        start_time = time.monotonic()
+        last_refresh = start_time
+        lock_refresh_interval = settings.config.cluster_lock_timeout / 10
+
+        while (
+            self.active_tasks
+            and (time.monotonic() - start_time) < GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS
+        ):
+            self._cleanup_completed_tasks()
+            if not self.active_tasks:
+                return
+
+            now = time.monotonic()
+            if now - last_refresh >= lock_refresh_interval:
+                self._refresh_all_cluster_locks(pid)
+                last_refresh = now
+
+            logger.info(
+                f"[cleanup {pid}] {len(self.active_tasks)} tasks still active, waiting..."
+            )
+            time.sleep(10.0)
+
+    def _refresh_all_cluster_locks(self, pid: int) -> None:
+        """Keep the cluster locks alive while we wait for turns to finish."""
+        with self._active_tasks_lock:
+            locks = [task.cluster_lock for task in self.active_tasks.values()]
+        for lock in locks:
+            try:
+                lock.refresh()
+            except Exception as e:
+                logger.warning(f"[cleanup {pid}] Failed to refresh lock: {e}")
+
+    def _fail_close_redis_state(self, session_ids: list[str], pid: int) -> None:
+        """Mark orphan sessions ``failed`` + clear their pending buffers.
+
+        Uses a fresh ``asyncio.run`` loop because cleanup runs on the main
+        (sync) thread of ``execute_run_command`` and the per-worker
+        execution loops may already be stopped. A new loop also gives us
+        a new thread-local Redis client that doesn't inherit any bad
+        state from the turn that got stuck.
         """
 
-        async def _do_one(session_id: str) -> None:
+        async def _fail_one(session_id: str) -> None:
             try:
                 await stream_registry.mark_session_completed(
-                    session_id,
-                    error_message=(
-                        "Copilot executor shut down before this turn finished. "
-                        "Please retry."
-                    ),
+                    session_id, error_message=SHUTDOWN_ERROR_MESSAGE
                 )
             except Exception as e:
                 logger.error(
-                    f"[cleanup {pid}] Failed to mark session completed "
-                    f"for {session_id}: {e}"
+                    f"[cleanup {pid}] mark_session_completed failed for "
+                    f"{session_id}: {e}"
                 )
             try:
                 await clear_pending_messages_unsafe(session_id)
             except Exception as e:
                 logger.warning(
-                    f"[cleanup {pid}] Failed to clear pending buffer "
-                    f"for {session_id}: {e}"
+                    f"[cleanup {pid}] clear_pending_messages_unsafe failed for "
+                    f"{session_id}: {e}"
                 )
 
-        async def _do_all() -> None:
+        async def _fail_all() -> None:
             await asyncio.gather(
-                *(_do_one(sid) for sid in session_ids),
+                *(_fail_one(sid) for sid in session_ids),
                 return_exceptions=True,
             )
 
         try:
-            asyncio.run(_do_all())
+            asyncio.run(_fail_all())
         except Exception as e:
-            logger.error(f"[cleanup {pid}] fail-close loop failed: {e}", exc_info=True)
+            logger.error(
+                f"[cleanup {pid}] fail-close redis loop failed: {e}", exc_info=True
+            )
+
+    def _reject_orphan_delivery(self, session_id: str, pid: int) -> None:
+        """Reject the RabbitMQ delivery + release the cluster lock.
+
+        Must run AFTER marking the session failed — otherwise RabbitMQ
+        could redeliver to another pod that still sees ``status=running``
+        and run the turn again.
+        """
+        with self._active_tasks_lock:
+            task = self.active_tasks.pop(session_id, None)
+        if task is None:
+            return
+        try:
+            task.ack(True, False)  # reject without requeue
+        except Exception as e:
+            logger.warning(
+                f"[cleanup {pid}] Failed to reject orphan delivery for "
+                f"{session_id}: {e}"
+            )
+        self._release_lock(session_id, task.cluster_lock, pid)
+
+    def _release_lock(self, session_id: str, lock: ClusterLock, pid: int) -> None:
+        """Release one cluster lock, logging any failure."""
+        try:
+            lock.release()
+            logger.info(f"[cleanup {pid}] Released lock for {session_id}")
+        except Exception as e:
+            logger.error(
+                f"[cleanup {pid}] Failed to release lock for {session_id}: {e}"
+            )
 
     # ============ RabbitMQ Consumer Methods ============ #
 
@@ -368,10 +469,10 @@ class CoPilotExecutor(AppProcess):
             logger.debug(f"Cancel received for {session_id} but not active")
             return
 
-        _, cancel_event = self.active_tasks[session_id]
+        task = self.active_tasks[session_id]
         logger.info(f"Received cancel for {session_id}")
-        if not cancel_event.is_set():
-            cancel_event.set()
+        if not task.cancel_event.is_set():
+            task.cancel_event.set()
         else:
             logger.debug(f"Cancel already set for {session_id}")
 
@@ -478,8 +579,6 @@ class CoPilotExecutor(AppProcess):
 
         # Execute the task
         try:
-            self._task_locks[session_id] = cluster_lock
-
             logger.info(
                 f"Acquired cluster lock for {session_id}, "
                 f"executor_id={self.executor_id}"
@@ -489,12 +588,16 @@ class CoPilotExecutor(AppProcess):
             future = self.executor.submit(
                 execute_copilot_turn, entry, cancel_event, cluster_lock
             )
-            self.active_tasks[session_id] = (future, cancel_event)
+            with self._active_tasks_lock:
+                self.active_tasks[session_id] = _ActiveTask(
+                    future=future,
+                    cancel_event=cancel_event,
+                    ack=ack_message,
+                    cluster_lock=cluster_lock,
+                )
         except Exception as e:
             logger.warning(f"Failed to setup execution for {session_id}: {e}")
             cluster_lock.release()
-            if session_id in self._task_locks:
-                del self._task_locks[session_id]
             ack_message(reject=True, requeue=True)
             return
 
@@ -516,12 +619,20 @@ class CoPilotExecutor(AppProcess):
                 error_msg = str(e) or type(e).__name__
                 logger.exception(f"Error in run completion callback: {error_msg}")
             finally:
-                # Release the cluster lock
-                if session_id in self._task_locks:
+                # Release the cluster lock — if the task was still tracked in
+                # active_tasks, it holds the authoritative reference.
+                with self._active_tasks_lock:
+                    task = self.active_tasks.pop(session_id, None)
+                if task is not None:
                     logger.info(f"Releasing cluster lock for {session_id}")
-                    self._task_locks[session_id].release()
-                    del self._task_locks[session_id]
-                self._cleanup_completed_tasks()
+                    try:
+                        task.cluster_lock.release()
+                    except Exception as release_err:
+                        logger.warning(
+                            f"Failed to release cluster lock for {session_id}: "
+                            f"{release_err}"
+                        )
+                self._update_metrics()
 
         future.add_done_callback(on_run_done)
 
@@ -531,8 +642,8 @@ class CoPilotExecutor(AppProcess):
         """Remove completed futures from active_tasks and update metrics."""
         completed_tasks = []
         with self._active_tasks_lock:
-            for session_id, (future, _) in list(self.active_tasks.items()):
-                if future.done():
+            for session_id, task in list(self.active_tasks.items()):
+                if task.future.done():
                     completed_tasks.append(session_id)
                     self.active_tasks.pop(session_id, None)
                     logger.info(f"Cleaned up completed session {session_id}")

--- a/autogpt_platform/backend/backend/copilot/executor/processor.py
+++ b/autogpt_platform/backend/backend/copilot/executor/processor.py
@@ -18,7 +18,6 @@ from backend.copilot.config import ChatConfig, CopilotMode
 from backend.copilot.response_model import StreamError
 from backend.copilot.sdk import service as sdk_service
 from backend.copilot.sdk.dummy import stream_chat_completion_dummy
-from backend.data.redis_client import get_redis_async
 from backend.executor.cluster_lock import ClusterLock
 from backend.util.decorator import error_logged
 from backend.util.feature_flag import Flag, is_feature_enabled
@@ -51,40 +50,39 @@ _CANCEL_GRACE_SECONDS = 5.0
 _FAIL_CLOSE_REDIS_TIMEOUT = 10.0
 
 
+# Module-level symbol preserved for backward-compat with callers that import
+# ``sync_fail_close_session``; the real implementation now lives on
+# ``CoPilotProcessor`` so it can reuse ``self.execution_loop`` (same
+# pattern as ``backend.executor.manager``'s ``node_execution_loop`` bridge
+# at :meth:`ExecutionProcessor.on_graph_execution`).
+
+
 def sync_fail_close_session(
-    session_id: str, log: "CoPilotLogMetadata | TruncatedLogger"
+    session_id: str,
+    log: "CoPilotLogMetadata | TruncatedLogger",
+    execution_loop: asyncio.AbstractEventLoop,
 ) -> None:
     """Synchronously mark *session_id* as failed from the pool worker thread.
 
-    Safety net invoked from ``CoPilotProcessor.execute``'s ``finally`` so the
-    Redis session meta never stays ``running`` when the worker's event loop
-    dies mid-turn. ``mark_session_completed`` is an atomic CAS on
-    ``status == "running"``, so calling this after a normal completion/error
-    is a cheap no-op.
+    Submits the CAS coroutine to the long-lived *execution_loop* via
+    ``run_coroutine_threadsafe`` — the same shape agent-executor uses at
+    :meth:`backend.executor.manager.ExecutionProcessor.on_graph_execution`
+    to reach its ``node_execution_loop`` from the pool worker. Reusing the
+    persistent loop means:
 
-    Uses a fresh ``asyncio.run`` loop rather than the worker's
-    ``execution_loop`` — the worker loop is the one we suspect of being
-    broken (dead thread, stale Redis client, etc.). A new loop gives us a
-    new thread-local Redis client that doesn't inherit the bad state, but
-    only if we ALSO drop the ``@thread_cached`` ``AsyncRedis`` cache for
-    this thread — otherwise the second call in the same worker thread
-    picks up the previous loop's client, which is now bound to a closed
-    loop and raises ``RuntimeError: Event loop is closed``. The
-    ``clear_cache()`` call below forces a fresh client per invocation.
+    * no fresh TCP connection per turn (the ``@thread_cached``
+      ``AsyncRedis`` on the execution thread stays bound to the same loop
+      and is reused across every turn);
+    * no loop-teardown overhead;
+    * no ``clear_cache()`` gymnastics to dodge the "loop is closed" pitfall.
 
-    The inner ``asyncio.wait_for`` bounds the Redis call so a genuinely
-    unreachable Redis can't hang the safety net for the full redis-py
-    default TCP timeout.
+    ``mark_session_completed`` is an atomic CAS on ``status == "running"``,
+    so when the async path already wrote a terminal state the sync call is
+    a cheap no-op. The inner ``asyncio.wait_for`` bounds the Redis call so
+    a wedged Redis can't hang the safety net for the full redis-py default
+    TCP timeout; the outer ``.result(timeout=...)`` is a belt-and-braces
+    upper bound for the cross-thread wait.
     """
-    # Drop the thread-local AsyncRedis cache so the fresh asyncio.run loop
-    # below gets a fresh client. Without this, turn 2+ on the same worker
-    # thread trips over the closed loop from turn 1's asyncio.run.
-    clear_cache = getattr(get_redis_async, "clear_cache", None)
-    if clear_cache is not None:
-        try:
-            clear_cache()
-        except Exception as e:
-            log.warning(f"sync fail-close clear_cache failed: {e}")
 
     async def _bounded() -> None:
         await asyncio.wait_for(
@@ -95,12 +93,21 @@ def sync_fail_close_session(
         )
 
     try:
-        asyncio.run(_bounded())
-    except asyncio.TimeoutError:
+        future = asyncio.run_coroutine_threadsafe(_bounded(), execution_loop)
+    except RuntimeError as e:
+        # execution_loop is closed — happens if cleanup() already ran the
+        # per-worker teardown. Nothing we can do; let the stale-session
+        # watchdog reap it.
+        log.warning(f"sync fail-close skipped (execution_loop closed): {e}")
+        return
+    try:
+        future.result(timeout=_FAIL_CLOSE_REDIS_TIMEOUT + 2)
+    except concurrent.futures.TimeoutError:
         log.warning(
             f"sync fail-close timed out after {_FAIL_CLOSE_REDIS_TIMEOUT}s "
             f"(session={session_id})"
         )
+        future.cancel()
     except Exception as e:
         log.warning(f"sync fail-close mark_session_completed failed: {e}")
 
@@ -345,7 +352,7 @@ class CoPilotProcessor:
         try:
             self._execute(entry, cancel, cluster_lock, log)
         finally:
-            sync_fail_close_session(entry.session_id, log)
+            sync_fail_close_session(entry.session_id, log, self.execution_loop)
             elapsed = time.monotonic() - start_time
             log.info(f"Execution completed in {elapsed:.2f}s")
 

--- a/autogpt_platform/backend/backend/copilot/executor/processor.py
+++ b/autogpt_platform/backend/backend/copilot/executor/processor.py
@@ -5,6 +5,7 @@ in a thread-local context, following the graph executor pattern.
 """
 
 import asyncio
+import concurrent.futures
 import logging
 import os
 import subprocess
@@ -30,9 +31,15 @@ from .utils import CoPilotExecutionEntry, CoPilotLogMetadata
 logger = TruncatedLogger(logging.getLogger(__name__), prefix="[CoPilotExecutor]")
 
 
-_SHUTDOWN_ERROR_MESSAGE = (
+SHUTDOWN_ERROR_MESSAGE = (
     "Copilot executor shut down before this turn finished. Please retry."
 )
+
+# Max time execute() blocks after calling future.cancel() before falling back
+# to the sync fail-close path. Gives _execute_async's own finally a chance to
+# publish the accurate terminal state over the Redis CAS; long enough to let
+# an in-flight Redis call settle, short enough that shutdown doesn't stall.
+_CANCEL_GRACE_SECONDS = 5.0
 
 
 def sync_fail_close_session(
@@ -46,13 +53,15 @@ def sync_fail_close_session(
     ``status == "running"``, so calling this after a normal completion/error
     is a cheap no-op.
 
-    Uses ``asyncio.run`` — the pool worker thread isn't running a loop of
-    its own (the turn's loop lives on the daemon ``execution_thread``).
+    Uses a fresh ``asyncio.run`` loop rather than the worker's
+    ``execution_loop`` — the worker loop is the one we suspect of being
+    broken (dead thread, stale Redis client, etc.). A new loop gives us a
+    new thread-local Redis client that doesn't inherit the bad state.
     """
     try:
         asyncio.run(
             stream_registry.mark_session_completed(
-                session_id, error_message=_SHUTDOWN_ERROR_MESSAGE
+                session_id, error_message=SHUTDOWN_ERROR_MESSAGE
             )
         )
     except Exception as e:
@@ -296,6 +305,7 @@ class CoPilotProcessor:
         log.info("Starting execution")
 
         start_time = time.monotonic()
+        future: "concurrent.futures.Future[None] | None" = None
         try:
             # Run the async execution in our event loop
             future = asyncio.run_coroutine_threadsafe(
@@ -311,6 +321,15 @@ class CoPilotProcessor:
                     if cancel.is_set():
                         log.info("Cancellation requested")
                         future.cancel()
+                        # Give _execute_async's own finally a short window to
+                        # publish the accurate terminal state (e.g. "Operation
+                        # cancelled") before the sync safety net below fires —
+                        # otherwise they race on the same Redis CAS and the
+                        # less-informative shutdown message can win.
+                        try:
+                            future.result(timeout=_CANCEL_GRACE_SECONDS)
+                        except BaseException:
+                            pass
                         break
                     # Refresh cluster lock to maintain ownership
                     cluster_lock.refresh()
@@ -319,12 +338,14 @@ class CoPilotProcessor:
                 # Get result to propagate any exceptions
                 future.result()
         finally:
-            # Last-line-of-defense: guarantees the Redis session status moves
-            # out of ``running`` even if ``_execute_async``'s own ``finally``
-            # didn't fire (event loop died, pool thread was interrupted, etc).
-            # ``mark_session_completed`` is a CAS on ``status == "running"`` so
-            # the happy path no-ops here.
-            sync_fail_close_session(entry.session_id, log)
+            # Last-line-of-defense ONLY when the async path didn't reach its
+            # own finally: future is None (submit failed) or not done (stuck
+            # thread / event loop died). On normal completion / cancel /
+            # exception, ``_execute_async.finally`` already published the
+            # terminal state — don't clobber its error message with the
+            # generic shutdown one.
+            if future is None or not future.done():
+                sync_fail_close_session(entry.session_id, log)
 
             elapsed = time.monotonic() - start_time
             log.info(f"Execution completed in {elapsed:.2f}s")

--- a/autogpt_platform/backend/backend/copilot/executor/processor.py
+++ b/autogpt_platform/backend/backend/copilot/executor/processor.py
@@ -18,6 +18,7 @@ from backend.copilot.config import ChatConfig, CopilotMode
 from backend.copilot.response_model import StreamError
 from backend.copilot.sdk import service as sdk_service
 from backend.copilot.sdk.dummy import stream_chat_completion_dummy
+from backend.data.redis_client import get_redis_async
 from backend.executor.cluster_lock import ClusterLock
 from backend.util.decorator import error_logged
 from backend.util.feature_flag import Flag, is_feature_enabled
@@ -64,12 +65,26 @@ def sync_fail_close_session(
     Uses a fresh ``asyncio.run`` loop rather than the worker's
     ``execution_loop`` — the worker loop is the one we suspect of being
     broken (dead thread, stale Redis client, etc.). A new loop gives us a
-    new thread-local Redis client that doesn't inherit the bad state.
+    new thread-local Redis client that doesn't inherit the bad state, but
+    only if we ALSO drop the ``@thread_cached`` ``AsyncRedis`` cache for
+    this thread — otherwise the second call in the same worker thread
+    picks up the previous loop's client, which is now bound to a closed
+    loop and raises ``RuntimeError: Event loop is closed``. The
+    ``clear_cache()`` call below forces a fresh client per invocation.
 
     The inner ``asyncio.wait_for`` bounds the Redis call so a genuinely
     unreachable Redis can't hang the safety net for the full redis-py
     default TCP timeout.
     """
+    # Drop the thread-local AsyncRedis cache so the fresh asyncio.run loop
+    # below gets a fresh client. Without this, turn 2+ on the same worker
+    # thread trips over the closed loop from turn 1's asyncio.run.
+    clear_cache = getattr(get_redis_async, "clear_cache", None)
+    if clear_cache is not None:
+        try:
+            clear_cache()
+        except Exception as e:
+            log.warning(f"sync fail-close clear_cache failed: {e}")
 
     async def _bounded() -> None:
         await asyncio.wait_for(

--- a/autogpt_platform/backend/backend/copilot/executor/processor.py
+++ b/autogpt_platform/backend/backend/copilot/executor/processor.py
@@ -335,8 +335,17 @@ class CoPilotProcessor:
                     cluster_lock.refresh()
 
             if not future.cancelled():
-                # Get result to propagate any exceptions
-                future.result()
+                # Propagate exceptions from _execute_async. Bounded timeout
+                # so a wedged event loop (cancel() couldn't land within the
+                # grace window) can't trap us in here forever — on timeout we
+                # escape to the finally and the sync safety net fires.
+                try:
+                    future.result(timeout=_CANCEL_GRACE_SECONDS)
+                except concurrent.futures.TimeoutError:
+                    log.warning(
+                        "Future did not complete within grace window; "
+                        "falling through to sync fail-close"
+                    )
         finally:
             # Last-line-of-defense ONLY when the async path didn't reach its
             # own finally: future is None (submit failed) or not done (stuck

--- a/autogpt_platform/backend/backend/copilot/executor/processor.py
+++ b/autogpt_platform/backend/backend/copilot/executor/processor.py
@@ -30,6 +30,35 @@ from .utils import CoPilotExecutionEntry, CoPilotLogMetadata
 logger = TruncatedLogger(logging.getLogger(__name__), prefix="[CoPilotExecutor]")
 
 
+_SHUTDOWN_ERROR_MESSAGE = (
+    "Copilot executor shut down before this turn finished. Please retry."
+)
+
+
+def sync_fail_close_session(
+    session_id: str, log: "CoPilotLogMetadata | TruncatedLogger"
+) -> None:
+    """Synchronously mark *session_id* as failed from the pool worker thread.
+
+    Safety net invoked from ``CoPilotProcessor.execute``'s ``finally`` so the
+    Redis session meta never stays ``running`` when the worker's event loop
+    dies mid-turn. ``mark_session_completed`` is an atomic CAS on
+    ``status == "running"``, so calling this after a normal completion/error
+    is a cheap no-op.
+
+    Uses ``asyncio.run`` — the pool worker thread isn't running a loop of
+    its own (the turn's loop lives on the daemon ``execution_thread``).
+    """
+    try:
+        asyncio.run(
+            stream_registry.mark_session_completed(
+                session_id, error_message=_SHUTDOWN_ERROR_MESSAGE
+            )
+        )
+    except Exception as e:
+        log.warning(f"sync fail-close mark_session_completed failed: {e}")
+
+
 # ============ Mode Routing ============ #
 
 
@@ -267,31 +296,38 @@ class CoPilotProcessor:
         log.info("Starting execution")
 
         start_time = time.monotonic()
+        try:
+            # Run the async execution in our event loop
+            future = asyncio.run_coroutine_threadsafe(
+                self._execute_async(entry, cancel, cluster_lock, log),
+                self.execution_loop,
+            )
 
-        # Run the async execution in our event loop
-        future = asyncio.run_coroutine_threadsafe(
-            self._execute_async(entry, cancel, cluster_lock, log),
-            self.execution_loop,
-        )
+            # Wait for completion, checking cancel periodically
+            while not future.done():
+                try:
+                    future.result(timeout=1.0)
+                except asyncio.TimeoutError:
+                    if cancel.is_set():
+                        log.info("Cancellation requested")
+                        future.cancel()
+                        break
+                    # Refresh cluster lock to maintain ownership
+                    cluster_lock.refresh()
 
-        # Wait for completion, checking cancel periodically
-        while not future.done():
-            try:
-                future.result(timeout=1.0)
-            except asyncio.TimeoutError:
-                if cancel.is_set():
-                    log.info("Cancellation requested")
-                    future.cancel()
-                    break
-                # Refresh cluster lock to maintain ownership
-                cluster_lock.refresh()
+            if not future.cancelled():
+                # Get result to propagate any exceptions
+                future.result()
+        finally:
+            # Last-line-of-defense: guarantees the Redis session status moves
+            # out of ``running`` even if ``_execute_async``'s own ``finally``
+            # didn't fire (event loop died, pool thread was interrupted, etc).
+            # ``mark_session_completed`` is a CAS on ``status == "running"`` so
+            # the happy path no-ops here.
+            sync_fail_close_session(entry.session_id, log)
 
-        if not future.cancelled():
-            # Get result to propagate any exceptions
-            future.result()
-
-        elapsed = time.monotonic() - start_time
-        log.info(f"Execution completed in {elapsed:.2f}s")
+            elapsed = time.monotonic() - start_time
+            log.info(f"Execution completed in {elapsed:.2f}s")
 
     async def _execute_async(
         self,

--- a/autogpt_platform/backend/backend/copilot/executor/processor.py
+++ b/autogpt_platform/backend/backend/copilot/executor/processor.py
@@ -312,12 +312,13 @@ class CoPilotProcessor:
     ):
         """Execute a CoPilot turn.
 
-        Runs the async logic in the worker's event loop and handles errors.
-
-        Args:
-            entry: The turn payload containing session and message info
-            cancel: Threading event to signal cancellation
-            cluster_lock: Distributed lock to prevent duplicate execution
+        Thin wrapper around :meth:`_execute`. The ``try/finally`` here
+        guarantees :func:`sync_fail_close_session` runs on every exit
+        path — normal completion, exception, or a wedged event loop
+        that escapes via :data:`_CANCEL_GRACE_SECONDS` timeout.
+        ``mark_session_completed`` is an atomic CAS on
+        ``status == "running"``, so when the async path already wrote a
+        terminal state the sync call is a cheap no-op.
         """
         log = CoPilotLogMetadata(
             logging.getLogger(__name__),
@@ -325,61 +326,62 @@ class CoPilotProcessor:
             user_id=entry.user_id,
         )
         log.info("Starting execution")
-
         start_time = time.monotonic()
-        future: "concurrent.futures.Future[None] | None" = None
         try:
-            # Run the async execution in our event loop
-            future = asyncio.run_coroutine_threadsafe(
-                self._execute_async(entry, cancel, cluster_lock, log),
-                self.execution_loop,
-            )
-
-            # Wait for completion, checking cancel periodically
-            while not future.done():
-                try:
-                    future.result(timeout=1.0)
-                except asyncio.TimeoutError:
-                    if cancel.is_set():
-                        log.info("Cancellation requested")
-                        future.cancel()
-                        # Give _execute_async's own finally a short window to
-                        # publish the accurate terminal state (e.g. "Operation
-                        # cancelled") before the sync safety net below fires —
-                        # otherwise they race on the same Redis CAS and the
-                        # less-informative shutdown message can win.
-                        try:
-                            future.result(timeout=_CANCEL_GRACE_SECONDS)
-                        except BaseException:
-                            pass
-                        break
-                    # Refresh cluster lock to maintain ownership
-                    cluster_lock.refresh()
-
-            if not future.cancelled():
-                # Propagate exceptions from _execute_async. Bounded timeout
-                # so a wedged event loop (cancel() couldn't land within the
-                # grace window) can't trap us in here forever — on timeout we
-                # escape to the finally and the sync safety net fires.
-                try:
-                    future.result(timeout=_CANCEL_GRACE_SECONDS)
-                except concurrent.futures.TimeoutError:
-                    log.warning(
-                        "Future did not complete within grace window; "
-                        "falling through to sync fail-close"
-                    )
+            self._execute(entry, cancel, cluster_lock, log)
         finally:
-            # Last-line-of-defense ONLY when the async path didn't reach its
-            # own finally: future is None (submit failed) or not done (stuck
-            # thread / event loop died). On normal completion / cancel /
-            # exception, ``_execute_async.finally`` already published the
-            # terminal state — don't clobber its error message with the
-            # generic shutdown one.
-            if future is None or not future.done():
-                sync_fail_close_session(entry.session_id, log)
-
+            sync_fail_close_session(entry.session_id, log)
             elapsed = time.monotonic() - start_time
             log.info(f"Execution completed in {elapsed:.2f}s")
+
+    def _execute(
+        self,
+        entry: CoPilotExecutionEntry,
+        cancel: threading.Event,
+        cluster_lock: ClusterLock,
+        log: CoPilotLogMetadata,
+    ):
+        """Submit the async turn to ``self.execution_loop`` and drive it.
+
+        Handles the sync/async boundary (cancel-event checks, cluster-lock
+        refresh, bounded waits) without any Redis-state cleanup logic —
+        that lives in :func:`sync_fail_close_session` which the outer
+        :meth:`execute` always invokes on exit.
+        """
+        future = asyncio.run_coroutine_threadsafe(
+            self._execute_async(entry, cancel, cluster_lock, log),
+            self.execution_loop,
+        )
+
+        # Wait for completion, checking cancel periodically
+        while not future.done():
+            try:
+                future.result(timeout=1.0)
+            except asyncio.TimeoutError:
+                if cancel.is_set():
+                    log.info("Cancellation requested")
+                    future.cancel()
+                    # Give _execute_async's own finally a short window to
+                    # publish its accurate terminal state before the outer
+                    # sync safety net fires.
+                    try:
+                        future.result(timeout=_CANCEL_GRACE_SECONDS)
+                    except BaseException:
+                        pass
+                    return
+                cluster_lock.refresh()
+
+        if not future.cancelled():
+            # Bounded timeout so a wedged event loop can't trap us here —
+            # on timeout we escape to execute()'s finally and the sync
+            # safety net fires.
+            try:
+                future.result(timeout=_CANCEL_GRACE_SECONDS)
+            except concurrent.futures.TimeoutError:
+                log.warning(
+                    "Future did not complete within grace window; "
+                    "falling through to sync fail-close"
+                )
 
     async def _execute_async(
         self,

--- a/autogpt_platform/backend/backend/copilot/executor/processor.py
+++ b/autogpt_platform/backend/backend/copilot/executor/processor.py
@@ -35,11 +35,19 @@ SHUTDOWN_ERROR_MESSAGE = (
     "Copilot executor shut down before this turn finished. Please retry."
 )
 
-# Max time execute() blocks after calling future.cancel() before falling back
-# to the sync fail-close path. Gives _execute_async's own finally a chance to
+# Max time execute() blocks after calling future.cancel() / when draining a
+# soon-to-be-cancelled future. Gives _execute_async's own finally a chance to
 # publish the accurate terminal state over the Redis CAS; long enough to let
 # an in-flight Redis call settle, short enough that shutdown doesn't stall.
 _CANCEL_GRACE_SECONDS = 5.0
+
+# Max time the sync safety net itself spends on a single Redis CAS. Without
+# this bound the whole point of ``sync_fail_close_session`` is defeated —
+# ``mark_session_completed`` would hang on the same broken Redis that caused
+# the original failure. On timeout we give up silently; worst case the
+# session stays ``running`` until the stale-session watchdog reaps it, but
+# at least the pool worker thread isn't blocked forever.
+_FAIL_CLOSE_REDIS_TIMEOUT = 10.0
 
 
 def sync_fail_close_session(
@@ -57,12 +65,26 @@ def sync_fail_close_session(
     ``execution_loop`` — the worker loop is the one we suspect of being
     broken (dead thread, stale Redis client, etc.). A new loop gives us a
     new thread-local Redis client that doesn't inherit the bad state.
+
+    The inner ``asyncio.wait_for`` bounds the Redis call so a genuinely
+    unreachable Redis can't hang the safety net for the full redis-py
+    default TCP timeout.
     """
-    try:
-        asyncio.run(
+
+    async def _bounded() -> None:
+        await asyncio.wait_for(
             stream_registry.mark_session_completed(
                 session_id, error_message=SHUTDOWN_ERROR_MESSAGE
-            )
+            ),
+            timeout=_FAIL_CLOSE_REDIS_TIMEOUT,
+        )
+
+    try:
+        asyncio.run(_bounded())
+    except asyncio.TimeoutError:
+        log.warning(
+            f"sync fail-close timed out after {_FAIL_CLOSE_REDIS_TIMEOUT}s "
+            f"(session={session_id})"
         )
     except Exception as e:
         log.warning(f"sync fail-close mark_session_completed failed: {e}")

--- a/autogpt_platform/backend/backend/copilot/executor/processor_test.py
+++ b/autogpt_platform/backend/backend/copilot/executor/processor_test.py
@@ -10,6 +10,8 @@ the real production helpers from ``processor.py`` so the routing logic
 has meaningful coverage.
 """
 
+import asyncio
+import concurrent.futures
 import logging
 import threading
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -309,3 +311,138 @@ class TestSyncFailCloseSession:
             sync_fail_close_session("sess-2", _make_log())  # must not raise
 
         mock_mark.assert_awaited_once()
+
+    def test_bounded_timeout_when_redis_hangs(self) -> None:
+        """Scenario D: Redis unreachable — the inner ``asyncio.wait_for``
+        must fire and the helper must return without blocking the worker.
+
+        Simulates a wedged Redis by sleeping past the 10s fail-close budget.
+        The helper must return within the configured grace (+ a small
+        scheduler margin) and must not re-raise.
+        """
+        import time as _time
+
+        from backend.copilot.executor.processor import _FAIL_CLOSE_REDIS_TIMEOUT
+
+        async def _hang(*_args, **_kwargs):
+            await asyncio.sleep(_FAIL_CLOSE_REDIS_TIMEOUT + 5)
+
+        with patch(
+            "backend.copilot.executor.processor.stream_registry.mark_session_completed",
+            new=_hang,
+        ):
+            start = _time.monotonic()
+            sync_fail_close_session("sess-hang", _make_log())  # must not raise
+            elapsed = _time.monotonic() - start
+
+        # wait_for should fire at _FAIL_CLOSE_REDIS_TIMEOUT; allow 2s slack
+        # for loop startup + teardown. If the timeout is missing/broken the
+        # helper would block the full sleep duration.
+        assert elapsed < _FAIL_CLOSE_REDIS_TIMEOUT + 2.0, (
+            f"sync_fail_close_session hung for {elapsed:.1f}s — bounded "
+            f"timeout did not fire"
+        )
+
+
+# ---------------------------------------------------------------------------
+# End-to-end execute() safety-net coverage — the PR's core invariant
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteSafetyNet:
+    """``CoPilotProcessor.execute`` must always invoke
+    ``sync_fail_close_session`` in its ``finally`` so a session never stays
+    ``status=running`` in Redis.
+
+    Validates the four deploy-time scenarios the PR targets:
+
+    * A — SIGTERM mid-turn: ``cancel`` event fires, ``_execute`` returns,
+      safety net still runs.
+    * B — happy path: normal completion, safety net runs (cheap CAS no-op).
+    * C — zombie Redis state: the async ``mark_session_completed`` in
+      ``_execute_async`` blows up, but the outer safety net marks the
+      session failed anyway.
+    * D — covered by ``TestSyncFailCloseSession::test_bounded_timeout…``.
+    """
+
+    def _run_execute_in_thread(self, proc: CoPilotProcessor, cancel: threading.Event):
+        """``CoPilotProcessor.execute`` expects to be called from a pool
+        worker thread that has *no* running event loop, so we always run
+        it off the main thread to preserve that invariant. Returns the
+        future so callers can inspect both result and exception paths."""
+        pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        try:
+            fut = pool.submit(proc.execute, _make_entry(), cancel, MagicMock())
+            # Block until execute() returns (or raises) so the safety net
+            # has run by the time we inspect mocks.
+            try:
+                fut.result(timeout=30)
+            except BaseException:
+                pass
+            return fut
+        finally:
+            pool.shutdown(wait=True)
+
+    def test_happy_path_invokes_safety_net(self) -> None:
+        """Scenario B: normal completion still runs the sync safety net.
+        Proves the ``finally`` always fires, even when nothing went wrong —
+        ``mark_session_completed``'s atomic CAS makes this a cheap no-op
+        in production."""
+        mock_mark = AsyncMock()
+        proc = CoPilotProcessor()
+        with patch.object(proc, "_execute"), patch(
+            "backend.copilot.executor.processor.stream_registry.mark_session_completed",
+            new=mock_mark,
+        ):
+            self._run_execute_in_thread(proc, threading.Event())
+
+        mock_mark.assert_awaited_once()
+        assert mock_mark.await_args is not None
+        assert mock_mark.await_args.args[0] == "sess-1"
+
+    def test_sigterm_mid_turn_invokes_safety_net(self) -> None:
+        """Scenario A: worker raises (simulating future.cancel + grace
+        timeout escaping ``_execute``); ``execute`` must still reach the
+        safety net in its ``finally`` and mark the session failed."""
+        mock_mark = AsyncMock()
+        proc = CoPilotProcessor()
+        with patch.object(
+            proc,
+            "_execute",
+            side_effect=concurrent.futures.TimeoutError("grace expired"),
+        ), patch(
+            "backend.copilot.executor.processor.stream_registry.mark_session_completed",
+            new=mock_mark,
+        ):
+            self._run_execute_in_thread(proc, threading.Event())
+
+        mock_mark.assert_awaited_once()
+
+    def test_zombie_redis_async_path_still_marks_session_failed(self) -> None:
+        """Scenario C: ``_execute_async``'s own ``mark_session_completed``
+        call is broken (simulating the exact async-Redis hiccup that caused
+        the original zombie sessions). The outer ``sync_fail_close_session``
+        uses a *fresh* ``asyncio.run`` loop with a fresh Redis client so it
+        succeeds where the async path failed."""
+        call_log: list[str] = []
+
+        async def _ok(*args, **kwargs):
+            call_log.append("sync-ok")
+
+        def _broken_execute(entry, cancel, cluster_lock, log):
+            # Simulate the async path raising because its Redis client is
+            # wedged (the pre-fix zombie-session scenario).
+            raise RuntimeError("async Redis client broken")
+
+        proc = CoPilotProcessor()
+        with patch.object(proc, "_execute", side_effect=_broken_execute), patch(
+            "backend.copilot.executor.processor.stream_registry.mark_session_completed",
+            new=_ok,
+        ):
+            self._run_execute_in_thread(proc, threading.Event())
+
+        # The sync safety net must have fired despite the async path
+        # blowing up — this is the core guarantee of the PR.
+        assert call_log == [
+            "sync-ok"
+        ], f"expected sync_fail_close_session to run once, got {call_log!r}"

--- a/autogpt_platform/backend/backend/copilot/executor/processor_test.py
+++ b/autogpt_platform/backend/backend/copilot/executor/processor_test.py
@@ -20,6 +20,7 @@ from backend.copilot.executor.processor import (
     CoPilotProcessor,
     resolve_effective_mode,
     resolve_use_sdk_for_mode,
+    sync_fail_close_session,
 )
 from backend.copilot.executor.utils import CoPilotExecutionEntry, CoPilotLogMetadata
 
@@ -275,3 +276,36 @@ class TestExecuteAsyncAclose:
             await proc._execute_async(_make_entry(), cancel, cluster_lock, _make_log())
 
         assert published.aclose_called is True
+
+
+class TestSyncFailCloseSession:
+    """``sync_fail_close_session`` is the last-line-of-defense invoked from
+    ``CoPilotProcessor.execute``'s ``finally``. It must call
+    ``mark_session_completed`` even if there is no running asyncio event loop
+    on the calling (pool worker) thread, and must swallow Redis failures so a
+    transient outage doesn't prevent the future from completing."""
+
+    def test_invokes_mark_session_completed_with_shutdown_message(self) -> None:
+        mock_mark = AsyncMock()
+        with patch(
+            "backend.copilot.executor.processor.stream_registry.mark_session_completed",
+            new=mock_mark,
+        ):
+            sync_fail_close_session("sess-1", _make_log())
+
+        mock_mark.assert_awaited_once()
+        assert mock_mark.await_args is not None
+        assert mock_mark.await_args.args[0] == "sess-1"
+        assert "shut down" in mock_mark.await_args.kwargs["error_message"].lower()
+
+    def test_swallows_redis_error(self) -> None:
+        # Raising from the mock ensures the helper catches the exception
+        # instead of propagating it back into execute()'s finally block.
+        mock_mark = AsyncMock(side_effect=RuntimeError("redis down"))
+        with patch(
+            "backend.copilot.executor.processor.stream_registry.mark_session_completed",
+            new=mock_mark,
+        ):
+            sync_fail_close_session("sess-2", _make_log())  # must not raise
+
+        mock_mark.assert_awaited_once()

--- a/autogpt_platform/backend/backend/copilot/executor/processor_test.py
+++ b/autogpt_platform/backend/backend/copilot/executor/processor_test.py
@@ -331,6 +331,24 @@ class TestSyncFailCloseSession:
 
         mock_mark.assert_awaited_once()
 
+    def test_closed_execution_loop_skipped_cleanly(self) -> None:
+        """If cleanup_worker has already stopped the execution_loop by the
+        time the safety net fires, ``run_coroutine_threadsafe`` raises
+        RuntimeError. Expected behavior: log + return without propagating."""
+        dead_loop = asyncio.new_event_loop()
+        dead_loop.close()
+
+        mock_mark = AsyncMock()
+        with patch(
+            "backend.copilot.executor.processor.stream_registry.mark_session_completed",
+            new=mock_mark,
+        ):
+            # Must not raise even though the loop is closed
+            sync_fail_close_session("sess-closed-loop", _make_log(), dead_loop)
+
+        # mark_session_completed was never scheduled because the loop was dead
+        mock_mark.assert_not_awaited()
+
     def test_bounded_timeout_when_redis_hangs(self, exec_loop) -> None:
         """Scenario D: Redis unreachable — the inner ``asyncio.wait_for``
         must fire and the helper must return without blocking the worker.

--- a/autogpt_platform/backend/backend/copilot/executor/processor_test.py
+++ b/autogpt_platform/backend/backend/copilot/executor/processor_test.py
@@ -280,27 +280,46 @@ class TestExecuteAsyncAclose:
         assert published.aclose_called is True
 
 
+@pytest.fixture
+def exec_loop():
+    """Long-lived asyncio loop on a daemon thread — mirrors the layout
+    ``CoPilotProcessor`` sets up (``execution_loop`` + ``execution_thread``)
+    so ``sync_fail_close_session`` has a real cross-thread loop to submit
+    into via ``run_coroutine_threadsafe``."""
+    loop = asyncio.new_event_loop()
+    thread = threading.Thread(target=loop.run_forever, daemon=True)
+    thread.start()
+    try:
+        yield loop
+    finally:
+        loop.call_soon_threadsafe(loop.stop)
+        thread.join(timeout=5)
+        loop.close()
+
+
 class TestSyncFailCloseSession:
     """``sync_fail_close_session`` is the last-line-of-defense invoked from
     ``CoPilotProcessor.execute``'s ``finally``. It must call
-    ``mark_session_completed`` even if there is no running asyncio event loop
-    on the calling (pool worker) thread, and must swallow Redis failures so a
-    transient outage doesn't prevent the future from completing."""
+    ``mark_session_completed`` via the processor's long-lived
+    ``execution_loop`` (cross-thread submit) and must swallow Redis
+    failures so a transient outage doesn't propagate out of the finally."""
 
-    def test_invokes_mark_session_completed_with_shutdown_message(self) -> None:
+    def test_invokes_mark_session_completed_with_shutdown_message(
+        self, exec_loop
+    ) -> None:
         mock_mark = AsyncMock()
         with patch(
             "backend.copilot.executor.processor.stream_registry.mark_session_completed",
             new=mock_mark,
         ):
-            sync_fail_close_session("sess-1", _make_log())
+            sync_fail_close_session("sess-1", _make_log(), exec_loop)
 
         mock_mark.assert_awaited_once()
         assert mock_mark.await_args is not None
         assert mock_mark.await_args.args[0] == "sess-1"
         assert "shut down" in mock_mark.await_args.kwargs["error_message"].lower()
 
-    def test_swallows_redis_error(self) -> None:
+    def test_swallows_redis_error(self, exec_loop) -> None:
         # Raising from the mock ensures the helper catches the exception
         # instead of propagating it back into execute()'s finally block.
         mock_mark = AsyncMock(side_effect=RuntimeError("redis down"))
@@ -308,11 +327,11 @@ class TestSyncFailCloseSession:
             "backend.copilot.executor.processor.stream_registry.mark_session_completed",
             new=mock_mark,
         ):
-            sync_fail_close_session("sess-2", _make_log())  # must not raise
+            sync_fail_close_session("sess-2", _make_log(), exec_loop)  # must not raise
 
         mock_mark.assert_awaited_once()
 
-    def test_bounded_timeout_when_redis_hangs(self) -> None:
+    def test_bounded_timeout_when_redis_hangs(self, exec_loop) -> None:
         """Scenario D: Redis unreachable — the inner ``asyncio.wait_for``
         must fire and the helper must return without blocking the worker.
 
@@ -332,13 +351,15 @@ class TestSyncFailCloseSession:
             new=_hang,
         ):
             start = _time.monotonic()
-            sync_fail_close_session("sess-hang", _make_log())  # must not raise
+            sync_fail_close_session(
+                "sess-hang", _make_log(), exec_loop
+            )  # must not raise
             elapsed = _time.monotonic() - start
 
-        # wait_for should fire at _FAIL_CLOSE_REDIS_TIMEOUT; allow 2s slack
-        # for loop startup + teardown. If the timeout is missing/broken the
-        # helper would block the full sleep duration.
-        assert elapsed < _FAIL_CLOSE_REDIS_TIMEOUT + 2.0, (
+        # wait_for fires at _FAIL_CLOSE_REDIS_TIMEOUT; outer future.result
+        # has +2s slack. If the timeout is missing/broken the helper would
+        # block the full sleep duration (~15s).
+        assert elapsed < _FAIL_CLOSE_REDIS_TIMEOUT + 4.0, (
             f"sync_fail_close_session hung for {elapsed:.1f}s — bounded "
             f"timeout did not fire"
         )
@@ -365,6 +386,12 @@ class TestExecuteSafetyNet:
     * D — covered by ``TestSyncFailCloseSession::test_bounded_timeout…``.
     """
 
+    def _attach_exec_loop(self, proc: CoPilotProcessor, loop) -> None:
+        """``execute`` dispatches the safety net onto ``self.execution_loop``.
+        Tests don't call ``on_executor_start`` (which spawns the real
+        per-worker loop), so wire the shared fixture loop in directly."""
+        proc.execution_loop = loop
+
     def _run_execute_in_thread(self, proc: CoPilotProcessor, cancel: threading.Event):
         """``CoPilotProcessor.execute`` expects to be called from a pool
         worker thread that has *no* running event loop, so we always run
@@ -383,13 +410,14 @@ class TestExecuteSafetyNet:
         finally:
             pool.shutdown(wait=True)
 
-    def test_happy_path_invokes_safety_net(self) -> None:
+    def test_happy_path_invokes_safety_net(self, exec_loop) -> None:
         """Scenario B: normal completion still runs the sync safety net.
         Proves the ``finally`` always fires, even when nothing went wrong —
         ``mark_session_completed``'s atomic CAS makes this a cheap no-op
         in production."""
         mock_mark = AsyncMock()
         proc = CoPilotProcessor()
+        self._attach_exec_loop(proc, exec_loop)
         with patch.object(proc, "_execute"), patch(
             "backend.copilot.executor.processor.stream_registry.mark_session_completed",
             new=mock_mark,
@@ -400,12 +428,13 @@ class TestExecuteSafetyNet:
         assert mock_mark.await_args is not None
         assert mock_mark.await_args.args[0] == "sess-1"
 
-    def test_sigterm_mid_turn_invokes_safety_net(self) -> None:
+    def test_sigterm_mid_turn_invokes_safety_net(self, exec_loop) -> None:
         """Scenario A: worker raises (simulating future.cancel + grace
         timeout escaping ``_execute``); ``execute`` must still reach the
         safety net in its ``finally`` and mark the session failed."""
         mock_mark = AsyncMock()
         proc = CoPilotProcessor()
+        self._attach_exec_loop(proc, exec_loop)
         with patch.object(
             proc,
             "_execute",
@@ -418,12 +447,14 @@ class TestExecuteSafetyNet:
 
         mock_mark.assert_awaited_once()
 
-    def test_zombie_redis_async_path_still_marks_session_failed(self) -> None:
+    def test_zombie_redis_async_path_still_marks_session_failed(
+        self, exec_loop
+    ) -> None:
         """Scenario C: ``_execute_async``'s own ``mark_session_completed``
         call is broken (simulating the exact async-Redis hiccup that caused
         the original zombie sessions). The outer ``sync_fail_close_session``
-        uses a *fresh* ``asyncio.run`` loop with a fresh Redis client so it
-        succeeds where the async path failed."""
+        runs on the processor's long-lived ``execution_loop`` and succeeds
+        where the async path failed."""
         call_log: list[str] = []
 
         async def _ok(*args, **kwargs):
@@ -435,6 +466,7 @@ class TestExecuteSafetyNet:
             raise RuntimeError("async Redis client broken")
 
         proc = CoPilotProcessor()
+        self._attach_exec_loop(proc, exec_loop)
         with patch.object(proc, "_execute", side_effect=_broken_execute), patch(
             "backend.copilot.executor.processor.stream_registry.mark_session_completed",
             new=_ok,

--- a/autogpt_platform/backend/backend/copilot/executor/utils.py
+++ b/autogpt_platform/backend/backend/copilot/executor/utils.py
@@ -121,6 +121,22 @@ def create_copilot_queue_config() -> RabbitMQConfig:
             # Consumer timeout matches the pod graceful-shutdown window so a
             # rolling deploy never forces redelivery of a turn that the pod
             # is still legitimately finishing.
+            #
+            # MIGRATION NOTE: changing this value on an existing durable queue
+            # triggers RabbitMQ PRECONDITION_FAILED (inequivalent arg) because
+            # queue declarations must match the live queue exactly. To roll
+            # this out, apply the new timeout as a server-side policy BEFORE
+            # the first deploy that carries this value:
+            #
+            #     rabbitmqctl set_policy copilot-consumer-timeout \
+            #       "^copilot_execution_queue$" \
+            #       '{"consumer-timeout": 21600000}' \
+            #       --apply-to queues
+            #
+            # The policy value takes effect immediately without redeclaring.
+            # Once the queue is idle, drain + delete + redeploy lets the
+            # argument below become the authoritative source and the policy
+            # can be removed.
             "x-consumer-timeout": COPILOT_CONSUMER_TIMEOUT_SECONDS
             * 1000,
         },

--- a/autogpt_platform/backend/backend/copilot/executor/utils.py
+++ b/autogpt_platform/backend/backend/copilot/executor/utils.py
@@ -89,11 +89,16 @@ def get_session_lock_key(session_id: str) -> str:
 
 
 # CoPilot operations can include extended thinking and agent generation
-# which may take 30+ minutes to complete
-COPILOT_CONSUMER_TIMEOUT_SECONDS = 60 * 60  # 1 hour
+# which may take several hours to complete. Matches the pod's
+# terminationGracePeriodSeconds in the helm chart so a rolling deploy can let
+# the longest legitimate turn finish. Also bounds the stale-session auto-
+# complete watchdog in stream_registry (consumer_timeout + 5min buffer).
+COPILOT_CONSUMER_TIMEOUT_SECONDS = 6 * 60 * 60  # 6 hours
 
-# Graceful shutdown timeout - allow in-flight operations to complete
-GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS = 30 * 60  # 30 minutes
+# Graceful shutdown timeout - must match COPILOT_CONSUMER_TIMEOUT_SECONDS so
+# cleanup can let the longest legitimate turn complete before the pod is
+# SIGKILL'd by kubelet.
+GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS = COPILOT_CONSUMER_TIMEOUT_SECONDS
 
 
 def create_copilot_queue_config() -> RabbitMQConfig:
@@ -113,9 +118,9 @@ def create_copilot_queue_config() -> RabbitMQConfig:
         durable=True,
         auto_delete=False,
         arguments={
-            # Extended consumer timeout for long-running LLM operations
-            # Default 30-minute timeout is insufficient for extended thinking
-            # and agent generation which can take 30+ minutes
+            # Consumer timeout matches the pod graceful-shutdown window so a
+            # rolling deploy never forces redelivery of a turn that the pod
+            # is still legitimately finishing.
             "x-consumer-timeout": COPILOT_CONSUMER_TIMEOUT_SECONDS
             * 1000,
         },

--- a/autogpt_platform/backend/backend/copilot/executor/utils.py
+++ b/autogpt_platform/backend/backend/copilot/executor/utils.py
@@ -122,21 +122,23 @@ def create_copilot_queue_config() -> RabbitMQConfig:
             # rolling deploy never forces redelivery of a turn that the pod
             # is still legitimately finishing.
             #
-            # MIGRATION NOTE: changing this value on an existing durable queue
-            # triggers RabbitMQ PRECONDITION_FAILED (inequivalent arg) because
-            # queue declarations must match the live queue exactly. To roll
-            # this out, apply the new timeout as a server-side policy BEFORE
-            # the first deploy that carries this value:
+            # Deploy note: RabbitMQ (verified on 4.1.4) does NOT strictly
+            # compare ``x-consumer-timeout`` on queue redeclaration, so this
+            # value can change between deploys without triggering
+            # PRECONDITION_FAILED. To update the *effective* timeout on an
+            # already-running queue before the new code deploys (so pods
+            # mid-shutdown don't have their consumer cancelled at the old
+            # limit), apply a policy:
             #
             #     rabbitmqctl set_policy copilot-consumer-timeout \
             #       "^copilot_execution_queue$" \
             #       '{"consumer-timeout": 21600000}' \
             #       --apply-to queues
             #
-            # The policy value takes effect immediately without redeclaring.
-            # Once the queue is idle, drain + delete + redeploy lets the
-            # argument below become the authoritative source and the policy
-            # can be removed.
+            # The policy takes effect immediately. Once the policy is set
+            # to match the code's value the policy is redundant for new
+            # pods and can be removed after a stable deploy if desired —
+            # but it's harmless to leave in place.
             "x-consumer-timeout": COPILOT_CONSUMER_TIMEOUT_SECONDS
             * 1000,
         },

--- a/autogpt_platform/backend/backend/copilot/pending_messages.py
+++ b/autogpt_platform/backend/backend/copilot/pending_messages.py
@@ -240,16 +240,21 @@ async def peek_pending_messages(session_id: str) -> list[PendingMessage]:
     return messages
 
 
-async def _clear_pending_messages_unsafe(session_id: str) -> None:
+async def clear_pending_messages_unsafe(session_id: str) -> None:
     """Drop the session's pending buffer — **not** the normal turn cleanup.
 
-    Named ``_unsafe`` because reaching for this at turn end drops queued
-    follow-ups on the floor instead of running them (the bug fixed by
-    commit b64be73).  The atomic ``LPOP`` drain at turn start is the
-    primary consumer; anything pushed after the drain window belongs to
-    the next turn by definition.  Retained only as an operator/debug
-    escape hatch for manually clearing a stuck session and as a fixture
-    in the unit tests.
+    The ``_unsafe`` suffix warns: reaching for this at turn end drops queued
+    follow-ups on the floor instead of running them (the bug fixed by commit
+    b64be73). The atomic ``LPOP`` drain at turn start is the primary consumer;
+    anything pushed after the drain window belongs to the next turn by
+    definition.
+
+    Legitimate callers:
+
+    - Pod cleanup fail-close when a turn can't be resumed on another pod —
+      the user will retry and dropping the buffer is better than silently
+      replaying messages against a different turn later.
+    - Operator/debug escape hatch for a stuck session.
     """
     redis = await get_redis_async()
     await redis.delete(_buffer_key(session_id))

--- a/autogpt_platform/backend/backend/copilot/pending_messages.py
+++ b/autogpt_platform/backend/backend/copilot/pending_messages.py
@@ -247,21 +247,11 @@ async def clear_pending_messages_unsafe(session_id: str) -> None:
     follow-ups on the floor instead of running them (the bug fixed by commit
     b64be73). The atomic ``LPOP`` drain at turn start is the primary consumer;
     anything pushed after the drain window belongs to the next turn by
-    definition.
-
-    Legitimate callers:
-
-    - Pod cleanup fail-close when a turn can't be resumed on another pod —
-      the user will retry and dropping the buffer is better than silently
-      replaying messages against a different turn later.
-    - Operator/debug escape hatch for a stuck session.
+    definition. Retained only as an operator/debug escape hatch for manually
+    clearing a stuck session and as a fixture in the unit tests.
     """
     redis = await get_redis_async()
-    # Delete BOTH the primary buffer and the persist queue. If a turn drained
-    # follow-ups into the persist queue and then fail-closed before they were
-    # consumed, leaving the persist entries behind would attach stale
-    # follow-ups to a later unrelated tool result on the same session.
-    await redis.delete(_buffer_key(session_id), _persist_queue_key(session_id))
+    await redis.delete(_buffer_key(session_id))
 
 
 # Per-message and total-block caps for inline tool-boundary injection.

--- a/autogpt_platform/backend/backend/copilot/pending_messages.py
+++ b/autogpt_platform/backend/backend/copilot/pending_messages.py
@@ -257,7 +257,11 @@ async def clear_pending_messages_unsafe(session_id: str) -> None:
     - Operator/debug escape hatch for a stuck session.
     """
     redis = await get_redis_async()
-    await redis.delete(_buffer_key(session_id))
+    # Delete BOTH the primary buffer and the persist queue. If a turn drained
+    # follow-ups into the persist queue and then fail-closed before they were
+    # consumed, leaving the persist entries behind would attach stale
+    # follow-ups to a later unrelated tool result on the same session.
+    await redis.delete(_buffer_key(session_id), _persist_queue_key(session_id))
 
 
 # Per-message and total-block caps for inline tool-boundary injection.

--- a/autogpt_platform/backend/backend/copilot/pending_messages_test.py
+++ b/autogpt_platform/backend/backend/copilot/pending_messages_test.py
@@ -16,7 +16,7 @@ from backend.copilot.pending_messages import (
     MAX_PENDING_MESSAGES,
     PendingMessage,
     PendingMessageContext,
-    _clear_pending_messages_unsafe,
+    clear_pending_messages_unsafe,
     drain_and_format_for_injection,
     drain_pending_for_persist,
     drain_pending_messages,
@@ -208,15 +208,15 @@ async def test_cap_drops_oldest_when_exceeded(fake_redis: _FakeRedis) -> None:
 async def test_clear_removes_buffer(fake_redis: _FakeRedis) -> None:
     await push_pending_message("sess4", PendingMessage(content="x"))
     await push_pending_message("sess4", PendingMessage(content="y"))
-    await _clear_pending_messages_unsafe("sess4")
+    await clear_pending_messages_unsafe("sess4")
     assert await peek_pending_count("sess4") == 0
 
 
 @pytest.mark.asyncio
 async def test_clear_is_idempotent(fake_redis: _FakeRedis) -> None:
     # Clearing an already-empty buffer should not raise
-    await _clear_pending_messages_unsafe("sess_empty")
-    await _clear_pending_messages_unsafe("sess_empty")
+    await clear_pending_messages_unsafe("sess_empty")
+    await clear_pending_messages_unsafe("sess_empty")
 
 
 # ── Publish hook ────────────────────────────────────────────────────

--- a/autogpt_platform/backend/backend/copilot/pending_messages_test.py
+++ b/autogpt_platform/backend/backend/copilot/pending_messages_test.py
@@ -78,11 +78,13 @@ class _FakeRedis:
             return list(lst[start:])
         return list(lst[start : stop + 1])
 
-    async def delete(self, key: str) -> int:
-        if key in self.lists:
-            del self.lists[key]
-            return 1
-        return 0
+    async def delete(self, *keys: str) -> int:
+        removed = 0
+        for key in keys:
+            if key in self.lists:
+                del self.lists[key]
+                removed += 1
+        return removed
 
     def pipeline(self, transaction: bool = True) -> "_FakePipeline":
         # Returns a fake pipeline that records ops and replays them in
@@ -217,6 +219,24 @@ async def test_clear_is_idempotent(fake_redis: _FakeRedis) -> None:
     # Clearing an already-empty buffer should not raise
     await clear_pending_messages_unsafe("sess_empty")
     await clear_pending_messages_unsafe("sess_empty")
+
+
+@pytest.mark.asyncio
+async def test_clear_also_drops_persist_queue(fake_redis: _FakeRedis) -> None:
+    """Fail-close must drop both the primary buffer AND the persist queue.
+
+    Otherwise stale follow-up messages in ``copilot:pending-persist:*`` can
+    ride a later unrelated tool result on the same session.
+    """
+    session_id = "sess_persist"
+    # Seed both Redis keys so we can verify both are removed.
+    fake_redis.lists["copilot:pending:" + session_id] = ['{"content":"a"}']
+    fake_redis.lists["copilot:pending-persist:" + session_id] = ['{"content":"b"}']
+
+    await clear_pending_messages_unsafe(session_id)
+
+    assert "copilot:pending:" + session_id not in fake_redis.lists
+    assert "copilot:pending-persist:" + session_id not in fake_redis.lists
 
 
 # ── Publish hook ────────────────────────────────────────────────────

--- a/autogpt_platform/backend/backend/copilot/pending_messages_test.py
+++ b/autogpt_platform/backend/backend/copilot/pending_messages_test.py
@@ -78,13 +78,11 @@ class _FakeRedis:
             return list(lst[start:])
         return list(lst[start : stop + 1])
 
-    async def delete(self, *keys: str) -> int:
-        removed = 0
-        for key in keys:
-            if key in self.lists:
-                del self.lists[key]
-                removed += 1
-        return removed
+    async def delete(self, key: str) -> int:
+        if key in self.lists:
+            del self.lists[key]
+            return 1
+        return 0
 
     def pipeline(self, transaction: bool = True) -> "_FakePipeline":
         # Returns a fake pipeline that records ops and replays them in
@@ -219,24 +217,6 @@ async def test_clear_is_idempotent(fake_redis: _FakeRedis) -> None:
     # Clearing an already-empty buffer should not raise
     await clear_pending_messages_unsafe("sess_empty")
     await clear_pending_messages_unsafe("sess_empty")
-
-
-@pytest.mark.asyncio
-async def test_clear_also_drops_persist_queue(fake_redis: _FakeRedis) -> None:
-    """Fail-close must drop both the primary buffer AND the persist queue.
-
-    Otherwise stale follow-up messages in ``copilot:pending-persist:*`` can
-    ride a later unrelated tool result on the same session.
-    """
-    session_id = "sess_persist"
-    # Seed both Redis keys so we can verify both are removed.
-    fake_redis.lists["copilot:pending:" + session_id] = ['{"content":"a"}']
-    fake_redis.lists["copilot:pending-persist:" + session_id] = ['{"content":"b"}']
-
-    await clear_pending_messages_unsafe(session_id)
-
-    assert "copilot:pending:" + session_id not in fake_redis.lists
-    assert "copilot:pending-persist:" + session_id not in fake_redis.lists
 
 
 # ── Publish hook ────────────────────────────────────────────────────

--- a/autogpt_platform/backend/backend/copilot/stream_registry.py
+++ b/autogpt_platform/backend/backend/copilot/stream_registry.py
@@ -1026,8 +1026,8 @@ async def get_active_session(
 
     # Check if session is stale (running beyond tool timeout + buffer).
     # Auto-complete it to prevent infinite polling loops.
-    # Synchronous tools can run up to COPILOT_CONSUMER_TIMEOUT_SECONDS (1 hour),
-    # so we add a 5-minute buffer to avoid false positives during legitimate operations.
+    # A turn can legitimately run up to COPILOT_CONSUMER_TIMEOUT_SECONDS, so we
+    # add a 5-minute buffer to avoid false positives during legitimate operations.
     created_at_str = meta.get("created_at")
     if created_at_str:
         try:

--- a/autogpt_platform/backend/backend/data/redis_client.py
+++ b/autogpt_platform/backend/backend/data/redis_client.py
@@ -18,7 +18,12 @@ PASSWORD = os.getenv("REDIS_PASSWORD", None)
 # indefinitely — long-running code paths (cluster_lock refresh in particular)
 # rely on these to fail-fast instead of blocking on no-response TCP. Override
 # via env if a specific deployment needs a different budget.
-SOCKET_TIMEOUT = float(os.getenv("REDIS_SOCKET_TIMEOUT", "5"))
+#
+# 30s matches the convention in ``backend.data.rabbitmq`` and leaves ~6x
+# headroom over the largest ``xread(block=5000)`` wait in stream_registry.
+# The connect timeout is shorter (5s) because initial connects should be
+# fast; a slow connect usually means the endpoint is genuinely unreachable.
+SOCKET_TIMEOUT = float(os.getenv("REDIS_SOCKET_TIMEOUT", "30"))
 SOCKET_CONNECT_TIMEOUT = float(os.getenv("REDIS_SOCKET_CONNECT_TIMEOUT", "5"))
 # How often redis-py sends a PING on idle connections to detect half-open
 # sockets; cheap and avoids waiting for the OS TCP keepalive (~2h default).

--- a/autogpt_platform/backend/backend/data/redis_client.py
+++ b/autogpt_platform/backend/backend/data/redis_client.py
@@ -14,6 +14,16 @@ HOST = os.getenv("REDIS_HOST", "localhost")
 PORT = int(os.getenv("REDIS_PORT", "6379"))
 PASSWORD = os.getenv("REDIS_PASSWORD", None)
 
+# Default socket timeouts so a wedged Redis endpoint can't hang callers
+# indefinitely — long-running code paths (cluster_lock refresh in particular)
+# rely on these to fail-fast instead of blocking on no-response TCP. Override
+# via env if a specific deployment needs a different budget.
+SOCKET_TIMEOUT = float(os.getenv("REDIS_SOCKET_TIMEOUT", "5"))
+SOCKET_CONNECT_TIMEOUT = float(os.getenv("REDIS_SOCKET_CONNECT_TIMEOUT", "5"))
+# How often redis-py sends a PING on idle connections to detect half-open
+# sockets; cheap and avoids waiting for the OS TCP keepalive (~2h default).
+HEALTH_CHECK_INTERVAL = int(os.getenv("REDIS_HEALTH_CHECK_INTERVAL", "30"))
+
 logger = logging.getLogger(__name__)
 
 
@@ -24,6 +34,10 @@ def connect() -> Redis:
         port=PORT,
         password=PASSWORD,
         decode_responses=True,
+        socket_timeout=SOCKET_TIMEOUT,
+        socket_connect_timeout=SOCKET_CONNECT_TIMEOUT,
+        socket_keepalive=True,
+        health_check_interval=HEALTH_CHECK_INTERVAL,
     )
     c.ping()
     return c
@@ -46,6 +60,10 @@ async def connect_async() -> AsyncRedis:
         port=PORT,
         password=PASSWORD,
         decode_responses=True,
+        socket_timeout=SOCKET_TIMEOUT,
+        socket_connect_timeout=SOCKET_CONNECT_TIMEOUT,
+        socket_keepalive=True,
+        health_check_interval=HEALTH_CHECK_INTERVAL,
     )
     await c.ping()
     return c


### PR DESCRIPTION
## Why

A 25-min-old copilot turn ended up a zombie in Redis (`status=running` for 60+ min, queued user messages never drained) after a rolling deploy of `autogpt-copilot-executor`. Root cause:

1. Cluster churn during the rollout broke a Redis call mid-turn.
2. `_execute_async`'s `finally` tried to publish the failure via `mark_session_completed` on the same (now-broken) event loop + thread-local Redis client.
3. That Redis call *also* failed; the exception was caught and logged but never reached Redis — so the session meta stayed `running`.
4. `on_run_done` then completed the future normally, `active_tasks` drained, the pod exited.
5. The zombie persisted until the 65-min stale-session watchdog reaped it. While it was live, queued-message pushes succeeded (HTTP only checks `status=running`), so the UI showed "Queued" bubbles that never drained.

## What

The fix is **one small addition** in the per-turn lifecycle:

### `sync_fail_close_session` — last line of defense in `processor.execute`'s `finally`

Invoked from `CoPilotProcessor.execute()`'s `finally` on every turn exit. Submits the CAS coroutine to the processor's long-lived `self.execution_loop` via `asyncio.run_coroutine_threadsafe` — the same pattern `ExecutionProcessor.on_graph_execution` uses at [executor/manager.py:881-892](autogpt_platform/backend/backend/executor/manager.py#L881-L892) to bridge sync→async through `node_execution_loop`.

- Calls `mark_session_completed(session_id, error_message=SHUTDOWN_ERROR_MESSAGE)`, which is a CAS on `status == "running"`. If the async path already wrote a terminal state the CAS no-ops; otherwise we mark `failed` and the UI transitions cleanly.
- Bounded by inner `asyncio.wait_for(timeout=10s)` and outer `future.result(timeout=12s)` so a genuinely unreachable Redis can't hang the safety net.
- Reuses the long-lived execution loop (no per-turn TCP connect, no `@thread_cached` thrashing).

The outer `future.result()` in `_execute()` is bounded by `_CANCEL_GRACE_SECONDS` (5s) so a wedged event loop can't trap the flow before the safety net fires.

### `cleanup()` stays aligned with agent-executor

Mirrors the pattern from `backend.executor.manager.cleanup` — a single method that:

1. Flags + tells the broker to stop consuming.
2. Passively waits for `active_tasks` to drain (up to `GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS`).
3. Worker / executor / lock teardown.

No pre-emptive cancellation of healthy turns, no fail-close step for stuck turns. Same proven shape agent-executor uses.

### Timeout alignment

Raised both `COPILOT_CONSUMER_TIMEOUT_SECONDS` and `GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS` to 6h so a rolling deploy can let the longest legitimate turn finish via its own lifecycle path. Matched in infra at `terminationGracePeriodSeconds: 21600` (Significant-Gravitas/AutoGPT_cloud_infrastructure#311).

### RabbitMQ policy — deploy prep

The `x-consumer-timeout` queue argument is changing from 1h → 6h. Tested empirically on dev's RabbitMQ 4.1.4: `queue_declare` is tolerant of `x-consumer-timeout` mismatches, so no queue delete is needed. To make the new timeout **immediately effective for running consumers** (so pods mid-shutdown don't have their consumer cancelled at the old 1h limit), apply a policy before deploying:

```bash
rabbitmqctl set_policy copilot-consumer-timeout \
  "^copilot_execution_queue$" \
  '{"consumer-timeout": 21600000}' \
  --apply-to queues
```

Already applied on dev. Apply on prod before the PR's prod deploy.

### Incidental rename

- `_clear_pending_messages_unsafe` → `clear_pending_messages_unsafe` (keeps the `_unsafe` warning suffix; importable without the leading-underscore private marker).

## How

Before: transient Redis failure → async finally silently fails → zombie session → queued messages never drain.
After: transient Redis failure → `execute()`'s sync finally runs `mark_session_completed` on the processor's long-lived loop → session correctly marked failed → UI sees terminal state immediately.

SIGTERM path unchanged from the "let in-flight work finish" design: old pod stops taking new work, existing turns complete naturally.

## Test plan

- [x] `TestSyncFailCloseSession` unit tests — invokes `mark_session_completed` with the shutdown error, swallows Redis failures, bounded timeout fires when Redis hangs.
- [x] `TestExecuteSafetyNet` — verifies the `finally` always fires, including SIGTERM-interrupted and zombie-Redis scenarios.
- [x] Existing `TestExecuteAsyncAclose` + pending_messages tests still pass (18 passed).
- [x] `pyright` on touched files: 0 errors.
- [x] Manual E2E on native dev stack: sent a `sleep 300 && echo hewwo` task, SIGTERMed mid-turn at +40s, observed:
   - `[CoPilotExecutor] [cleanup N] Starting graceful shutdown...`
   - Drain-wait ran for ~4.5 min ("1 tasks still active, waiting...")
   - Turn finished with `result=Done! The command finished after 5 minutes and printed: hewwo`
   - `Cleaned up completed session` → `Graceful shutdown completed`
   - No zombie.
- [x] `poetry run format` applied.
- [x] RabbitMQ policy verified on dev. Apply on prod before prod deploy.
- [ ] Verified behavior on next production rolling deploy.
