### PR TITLE
fix(backend/copilot): disable ask_question tool pending UX rework

### DIFF
--- a/autogpt_platform/backend/backend/copilot/permissions.py
+++ b/autogpt_platform/backend/backend/copilot/permissions.py
@@ -71,7 +71,6 @@ if TYPE_CHECKING:
 ToolName = Literal[
     # Platform tools (must match keys in TOOL_REGISTRY)
     "add_understanding",
-    "ask_question",
     "bash_exec",
     "browser_act",
     "browser_navigate",

--- a/autogpt_platform/backend/backend/copilot/prompting_test.py
+++ b/autogpt_platform/backend/backend/copilot/prompting_test.py
@@ -1,7 +1,6 @@
-"""Tests for agent generation guide — verifies clarification section."""
+"""Tests for prompting helpers."""
 
 import importlib
-from pathlib import Path
 
 from backend.copilot import prompting
 
@@ -31,28 +30,3 @@ class TestGetSdkSupplementStaticPlaceholder:
     def test_e2b_mode_has_no_session_placeholder(self):
         result = prompting.get_sdk_supplement(use_e2b=True)
         assert "<session-id>" not in result
-
-
-class TestAgentGenerationGuideContainsClarifySection:
-    """The agent generation guide must include the clarification section."""
-
-    def test_guide_includes_clarify_section(self):
-        guide_path = Path(__file__).parent / "sdk" / "agent_generation_guide.md"
-        content = guide_path.read_text(encoding="utf-8")
-        assert "Before or During Building" in content
-
-    def test_guide_mentions_find_block_for_clarification(self):
-        guide_path = Path(__file__).parent / "sdk" / "agent_generation_guide.md"
-        content = guide_path.read_text(encoding="utf-8")
-        clarify_section = content.split("Before or During Building")[1].split(
-            "### Workflow"
-        )[0]
-        assert "find_block" in clarify_section
-
-    def test_guide_mentions_ask_question_tool(self):
-        guide_path = Path(__file__).parent / "sdk" / "agent_generation_guide.md"
-        content = guide_path.read_text(encoding="utf-8")
-        clarify_section = content.split("Before or During Building")[1].split(
-            "### Workflow"
-        )[0]
-        assert "ask_question" in clarify_section

--- a/autogpt_platform/backend/backend/copilot/sdk/agent_generation_guide.md
+++ b/autogpt_platform/backend/backend/copilot/sdk/agent_generation_guide.md
@@ -3,29 +3,6 @@
 You can create, edit, and customize agents directly. You ARE the brain —
 generate the agent JSON yourself using block schemas, then validate and save.
 
-### Clarifying — Before or During Building
-
-Use `ask_question` whenever the user's intent is ambiguous — whether
-that's before starting or midway through the workflow. Common moments:
-
-- **Before building**: output format, delivery channel, data source, or
-  trigger is unspecified.
-- **During block discovery**: multiple blocks could fit and the user
-  should choose.
-- **During JSON generation**: a wiring decision depends on user
-  preference.
-
-Steps:
-1. Call `find_block` (or another discovery tool) to learn what the
-   platform actually supports for the ambiguous dimension.
-2. Call `ask_question` with a concrete question listing the discovered
-   options (e.g. "The platform supports Gmail, Slack, and Google Docs —
-   which should the agent use for delivery?").
-3. **Wait for the user's answer** before continuing.
-
-**Skip this** when the goal already specifies all dimensions (e.g.
-"scrape prices from Amazon and email me daily").
-
 ### Workflow for Creating/Editing Agents
 
 1. **If editing**: First narrow to the specific agent by UUID, then fetch its

--- a/autogpt_platform/backend/backend/copilot/tools/__init__.py
+++ b/autogpt_platform/backend/backend/copilot/tools/__init__.py
@@ -11,7 +11,6 @@ from backend.copilot.tracking import track_tool_called
 from .add_understanding import AddUnderstandingTool
 from .agent_browser import BrowserActTool, BrowserNavigateTool, BrowserScreenshotTool
 from .agent_output import AgentOutputTool
-from .ask_question import AskQuestionTool
 from .base import BaseTool
 from .bash_exec import BashExecTool
 from .connect_integration import ConnectIntegrationTool
@@ -64,7 +63,6 @@ logger = logging.getLogger(__name__)
 # Single source of truth for all tools
 TOOL_REGISTRY: dict[str, BaseTool] = {
     "add_understanding": AddUnderstandingTool(),
-    "ask_question": AskQuestionTool(),
     "create_agent": CreateAgentTool(),
     "customize_agent": CustomizeAgentTool(),
     "edit_agent": EditAgentTool(),


### PR DESCRIPTION
### Why / What / How

**Why:** The in-conversation Question GUI is unreliable in production — users submitting answers can get their messages dropped and the agent gets stuck on the auto-generated "please proceed" step with no way to make progress. Discord report: https://discord.com/channels/1126875755960336515/1496474512966029472/1496537943287005365 (see attached video). Pause/queue semantics still need a rework; until then, the right call is to stop the model from reaching for this tool.

**What:** Removes `ask_question` from the copilot tool registry so the model never sees or calls it. Historical sessions that already contain `ask_question` tool calls still render (frontend renderers + response model untouched), so this is non-destructive to existing chats. Re-enabling once UX is reworked is a small revert.

**How:**
- Drop the `AskQuestionTool` import + registry entry from `backend/copilot/tools/__init__.py`.
- Drop `"ask_question"` from the `ToolName` literal in `backend/copilot/permissions.py` — required because a runtime consistency check asserts the literal matches `TOOL_REGISTRY.keys()`.
- Delete the "Clarifying — Before or During Building" section from `backend/copilot/sdk/agent_generation_guide.md` so the SDK-mode system prompt no longer instructs the model to call `ask_question`.
- Drop the three `prompting_test.py` tests that asserted the guide mentions that section.
- Keep `ask_question.py`, its unit test, `ClarificationNeededResponse`, and the frontend `AskQuestion`/`ClarificationQuestionsCard` components untouched so old sessions still render and re-enabling is a small revert.

### Changes 🏗️

- `backend/copilot/tools/__init__.py` — remove `AskQuestionTool` import and `"ask_question"` entry in `TOOL_REGISTRY`.
- `backend/copilot/permissions.py` — remove `"ask_question"` from the `ToolName` literal.
- `backend/copilot/sdk/agent_generation_guide.md` — remove the "Clarifying — Before or During Building" section.
- `backend/copilot/prompting_test.py` — remove `TestAgentGenerationGuideContainsClarifySection` and the now-unused `Path` import.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [x] `poetry run pytest backend/copilot/tools/ backend/copilot/permissions_test.py backend/copilot/prompting_test.py` — 805+78 tests pass, consistency check between `ToolName` literal and `TOOL_REGISTRY` still holds.
  - [ ] Smoke-test in dev: start a copilot session and confirm the model no longer lists/calls `ask_question` (its OpenAI tool schema is gone from `get_available_tools()` and from the SDK `allowed_tools`).
  - [ ] Load a historical session that contains an `ask_question` tool call in its transcript — confirm the frontend still renders the question card (no regression on legacy sessions).

