### PR TITLE
feat(blocks): charge Ayrshare per-post + align Bannerbear/Jina floors

### DIFF
--- a/autogpt_platform/backend/backend/blocks/ayrshare/_cost.py
+++ b/autogpt_platform/backend/backend/blocks/ayrshare/_cost.py
@@ -1,0 +1,15 @@
+from backend.sdk import BlockCost, BlockCostType
+
+# Ayrshare is a subscription proxy ($149/mo Business). Per-post credit charges
+# prevent a single heavy user from absorbing the fixed cost and align with the
+# upload cost of each post variant.
+# cost_filter matches on is_video (default False in BaseAyrshareInput). First
+# match wins in block_usage_cost, so list the video tier first.
+AYRSHARE_POST_COSTS = (
+    BlockCost(
+        cost_amount=5, cost_type=BlockCostType.RUN, cost_filter={"is_video": True}
+    ),
+    BlockCost(
+        cost_amount=2, cost_type=BlockCostType.RUN, cost_filter={"is_video": False}
+    ),
+)

--- a/autogpt_platform/backend/backend/blocks/ayrshare/_cost.py
+++ b/autogpt_platform/backend/backend/blocks/ayrshare/_cost.py
@@ -3,8 +3,11 @@ from backend.sdk import BlockCost, BlockCostType
 # Ayrshare is a subscription proxy ($149/mo Business). Per-post credit charges
 # prevent a single heavy user from absorbing the fixed cost and align with the
 # upload cost of each post variant.
-# cost_filter matches on is_video (default False in BaseAyrshareInput). First
-# match wins in block_usage_cost, so list the video tier first.
+# cost_filter matches on input_data.is_video BEFORE run() executes, so the flag
+# has to be correct at input-eval time. Video-only platforms (YouTube, Snapchat)
+# override the base default to True; platforms that accept both (TikTok, etc.)
+# rely on the caller setting is_video explicitly for accurate billing.
+# First match wins in block_usage_cost, so list the video tier first.
 AYRSHARE_POST_COSTS = (
     BlockCost(
         cost_amount=5, cost_type=BlockCostType.RUN, cost_filter={"is_video": True}

--- a/autogpt_platform/backend/backend/blocks/ayrshare/_util.py
+++ b/autogpt_platform/backend/backend/blocks/ayrshare/_util.py
@@ -29,7 +29,9 @@ class BaseAyrshareInput(BlockSchemaInput):
         advanced=False,
     )
     is_video: bool = SchemaField(
-        description="Whether the media is a video", default=False, advanced=True
+        description="Whether the media is a video. Set to True when uploading a video so billing applies the video tier.",
+        default=False,
+        advanced=True,
     )
     schedule_date: Optional[datetime] = SchemaField(
         description="UTC datetime for scheduling (YYYY-MM-DDThh:mm:ssZ)",

--- a/autogpt_platform/backend/backend/blocks/ayrshare/post_to_bluesky.py
+++ b/autogpt_platform/backend/backend/blocks/ayrshare/post_to_bluesky.py
@@ -6,11 +6,14 @@ from backend.sdk import (
     BlockSchemaOutput,
     BlockType,
     SchemaField,
+    cost,
 )
 
+from ._cost import AYRSHARE_POST_COSTS
 from ._util import BaseAyrshareInput, create_ayrshare_client, get_profile_key
 
 
+@cost(*AYRSHARE_POST_COSTS)
 class PostToBlueskyBlock(Block):
     """Block for posting to Bluesky with Bluesky-specific options."""
 
@@ -69,12 +72,18 @@ class PostToBlueskyBlock(Block):
 
         client = create_ayrshare_client()
         if not client:
-            yield "error", "Ayrshare integration is not configured. Please set up the AYRSHARE_API_KEY."
+            yield (
+                "error",
+                "Ayrshare integration is not configured. Please set up the AYRSHARE_API_KEY.",
+            )
             return
 
         # Validate character limit for Bluesky
         if len(input_data.post) > 300:
-            yield "error", f"Post text exceeds Bluesky's 300 character limit ({len(input_data.post)} characters)"
+            yield (
+                "error",
+                f"Post text exceeds Bluesky's 300 character limit ({len(input_data.post)} characters)",
+            )
             return
 
         # Validate media constraints for Bluesky

--- a/autogpt_platform/backend/backend/blocks/ayrshare/post_to_bluesky.py
+++ b/autogpt_platform/backend/backend/blocks/ayrshare/post_to_bluesky.py
@@ -72,18 +72,12 @@ class PostToBlueskyBlock(Block):
 
         client = create_ayrshare_client()
         if not client:
-            yield (
-                "error",
-                "Ayrshare integration is not configured. Please set up the AYRSHARE_API_KEY.",
-            )
+            yield "error", "Ayrshare integration is not configured. Please set up the AYRSHARE_API_KEY."
             return
 
         # Validate character limit for Bluesky
         if len(input_data.post) > 300:
-            yield (
-                "error",
-                f"Post text exceeds Bluesky's 300 character limit ({len(input_data.post)} characters)",
-            )
+            yield "error", f"Post text exceeds Bluesky's 300 character limit ({len(input_data.post)} characters)"
             return
 
         # Validate media constraints for Bluesky

--- a/autogpt_platform/backend/backend/blocks/ayrshare/post_to_facebook.py
+++ b/autogpt_platform/backend/backend/blocks/ayrshare/post_to_facebook.py
@@ -134,10 +134,7 @@ class PostToFacebookBlock(Block):
 
         client = create_ayrshare_client()
         if not client:
-            yield (
-                "error",
-                "Ayrshare integration is not configured. Please set up the AYRSHARE_API_KEY.",
-            )
+            yield "error", "Ayrshare integration is not configured. Please set up the AYRSHARE_API_KEY."
             return
 
         # Convert datetime to ISO format if provided

--- a/autogpt_platform/backend/backend/blocks/ayrshare/post_to_facebook.py
+++ b/autogpt_platform/backend/backend/blocks/ayrshare/post_to_facebook.py
@@ -6,8 +6,10 @@ from backend.sdk import (
     BlockSchemaOutput,
     BlockType,
     SchemaField,
+    cost,
 )
 
+from ._cost import AYRSHARE_POST_COSTS
 from ._util import (
     BaseAyrshareInput,
     CarouselItem,
@@ -16,6 +18,7 @@ from ._util import (
 )
 
 
+@cost(*AYRSHARE_POST_COSTS)
 class PostToFacebookBlock(Block):
     """Block for posting to Facebook with Facebook-specific options."""
 
@@ -131,7 +134,10 @@ class PostToFacebookBlock(Block):
 
         client = create_ayrshare_client()
         if not client:
-            yield "error", "Ayrshare integration is not configured. Please set up the AYRSHARE_API_KEY."
+            yield (
+                "error",
+                "Ayrshare integration is not configured. Please set up the AYRSHARE_API_KEY.",
+            )
             return
 
         # Convert datetime to ISO format if provided

--- a/autogpt_platform/backend/backend/blocks/ayrshare/post_to_gmb.py
+++ b/autogpt_platform/backend/backend/blocks/ayrshare/post_to_gmb.py
@@ -123,18 +123,12 @@ class PostToGMBBlock(Block):
 
         client = create_ayrshare_client()
         if not client:
-            yield (
-                "error",
-                "Ayrshare integration is not configured. Please set up the AYRSHARE_API_KEY.",
-            )
+            yield "error", "Ayrshare integration is not configured. Please set up the AYRSHARE_API_KEY."
             return
 
         # Validate GMB constraints
         if len(input_data.media_urls) > 1:
-            yield (
-                "error",
-                "Google My Business supports only one image or video per post",
-            )
+            yield "error", "Google My Business supports only one image or video per post"
             return
 
         # Validate offer coupon code length

--- a/autogpt_platform/backend/backend/blocks/ayrshare/post_to_gmb.py
+++ b/autogpt_platform/backend/backend/blocks/ayrshare/post_to_gmb.py
@@ -6,11 +6,14 @@ from backend.sdk import (
     BlockSchemaOutput,
     BlockType,
     SchemaField,
+    cost,
 )
 
+from ._cost import AYRSHARE_POST_COSTS
 from ._util import BaseAyrshareInput, create_ayrshare_client, get_profile_key
 
 
+@cost(*AYRSHARE_POST_COSTS)
 class PostToGMBBlock(Block):
     """Block for posting to Google My Business with GMB-specific options."""
 
@@ -120,12 +123,18 @@ class PostToGMBBlock(Block):
 
         client = create_ayrshare_client()
         if not client:
-            yield "error", "Ayrshare integration is not configured. Please set up the AYRSHARE_API_KEY."
+            yield (
+                "error",
+                "Ayrshare integration is not configured. Please set up the AYRSHARE_API_KEY.",
+            )
             return
 
         # Validate GMB constraints
         if len(input_data.media_urls) > 1:
-            yield "error", "Google My Business supports only one image or video per post"
+            yield (
+                "error",
+                "Google My Business supports only one image or video per post",
+            )
             return
 
         # Validate offer coupon code length

--- a/autogpt_platform/backend/backend/blocks/ayrshare/post_to_instagram.py
+++ b/autogpt_platform/backend/backend/blocks/ayrshare/post_to_instagram.py
@@ -8,8 +8,10 @@ from backend.sdk import (
     BlockSchemaOutput,
     BlockType,
     SchemaField,
+    cost,
 )
 
+from ._cost import AYRSHARE_POST_COSTS
 from ._util import (
     BaseAyrshareInput,
     InstagramUserTag,
@@ -18,6 +20,7 @@ from ._util import (
 )
 
 
+@cost(*AYRSHARE_POST_COSTS)
 class PostToInstagramBlock(Block):
     """Block for posting to Instagram with Instagram-specific options."""
 
@@ -123,16 +126,25 @@ class PostToInstagramBlock(Block):
 
         client = create_ayrshare_client()
         if not client:
-            yield "error", "Ayrshare integration is not configured. Please set up the AYRSHARE_API_KEY."
+            yield (
+                "error",
+                "Ayrshare integration is not configured. Please set up the AYRSHARE_API_KEY.",
+            )
             return
 
         # Validate Instagram constraints
         if len(input_data.post) > 2200:
-            yield "error", f"Instagram post text exceeds 2,200 character limit ({len(input_data.post)} characters)"
+            yield (
+                "error",
+                f"Instagram post text exceeds 2,200 character limit ({len(input_data.post)} characters)",
+            )
             return
 
         if len(input_data.media_urls) > 10:
-            yield "error", "Instagram supports a maximum of 10 images/videos in a carousel"
+            yield (
+                "error",
+                "Instagram supports a maximum of 10 images/videos in a carousel",
+            )
             return
 
         if len(input_data.collaborators) > 3:
@@ -147,7 +159,10 @@ class PostToInstagramBlock(Block):
         ]
 
         if any(reel_options) and not all(reel_options):
-            yield "error", "When posting a reel, all reel options must be set: share_reels_feed, audio_name, and either thumbnail or thumbnail_offset"
+            yield (
+                "error",
+                "When posting a reel, all reel options must be set: share_reels_feed, audio_name, and either thumbnail or thumbnail_offset",
+            )
             return
 
         # Count hashtags and mentions
@@ -155,11 +170,17 @@ class PostToInstagramBlock(Block):
         mention_count = input_data.post.count("@")
 
         if hashtag_count > 30:
-            yield "error", f"Instagram allows maximum 30 hashtags ({hashtag_count} found)"
+            yield (
+                "error",
+                f"Instagram allows maximum 30 hashtags ({hashtag_count} found)",
+            )
             return
 
         if mention_count > 3:
-            yield "error", f"Instagram allows maximum 3 @mentions ({mention_count} found)"
+            yield (
+                "error",
+                f"Instagram allows maximum 3 @mentions ({mention_count} found)",
+            )
             return
 
         # Convert datetime to ISO format if provided
@@ -191,7 +212,10 @@ class PostToInstagramBlock(Block):
             # Validate alt text length
             for i, alt in enumerate(input_data.alt_text):
                 if len(alt) > 1000:
-                    yield "error", f"Alt text {i+1} exceeds 1,000 character limit ({len(alt)} characters)"
+                    yield (
+                        "error",
+                        f"Alt text {i + 1} exceeds 1,000 character limit ({len(alt)} characters)",
+                    )
                     return
             instagram_options["altText"] = input_data.alt_text
 
@@ -206,13 +230,19 @@ class PostToInstagramBlock(Block):
                 try:
                     tag_obj = InstagramUserTag(**tag)
                 except Exception as e:
-                    yield "error", f"Invalid user tag: {e}, tages need to be a dictionary with a 3 items: username (str), x (float) and y (float)"
+                    yield (
+                        "error",
+                        f"Invalid user tag: {e}, tages need to be a dictionary with a 3 items: username (str), x (float) and y (float)",
+                    )
                     return
                 tag_dict: dict[str, float | str] = {"username": tag_obj.username}
                 if tag_obj.x is not None and tag_obj.y is not None:
                     # Validate coordinates
                     if not (0.0 <= tag_obj.x <= 1.0) or not (0.0 <= tag_obj.y <= 1.0):
-                        yield "error", f"User tag coordinates must be between 0.0 and 1.0 (user: {tag_obj.username})"
+                        yield (
+                            "error",
+                            f"User tag coordinates must be between 0.0 and 1.0 (user: {tag_obj.username})",
+                        )
                         return
                     tag_dict["x"] = tag_obj.x
                     tag_dict["y"] = tag_obj.y

--- a/autogpt_platform/backend/backend/blocks/ayrshare/post_to_instagram.py
+++ b/autogpt_platform/backend/backend/blocks/ayrshare/post_to_instagram.py
@@ -126,25 +126,16 @@ class PostToInstagramBlock(Block):
 
         client = create_ayrshare_client()
         if not client:
-            yield (
-                "error",
-                "Ayrshare integration is not configured. Please set up the AYRSHARE_API_KEY.",
-            )
+            yield "error", "Ayrshare integration is not configured. Please set up the AYRSHARE_API_KEY."
             return
 
         # Validate Instagram constraints
         if len(input_data.post) > 2200:
-            yield (
-                "error",
-                f"Instagram post text exceeds 2,200 character limit ({len(input_data.post)} characters)",
-            )
+            yield "error", f"Instagram post text exceeds 2,200 character limit ({len(input_data.post)} characters)"
             return
 
         if len(input_data.media_urls) > 10:
-            yield (
-                "error",
-                "Instagram supports a maximum of 10 images/videos in a carousel",
-            )
+            yield "error", "Instagram supports a maximum of 10 images/videos in a carousel"
             return
 
         if len(input_data.collaborators) > 3:
@@ -159,10 +150,7 @@ class PostToInstagramBlock(Block):
         ]
 
         if any(reel_options) and not all(reel_options):
-            yield (
-                "error",
-                "When posting a reel, all reel options must be set: share_reels_feed, audio_name, and either thumbnail or thumbnail_offset",
-            )
+            yield "error", "When posting a reel, all reel options must be set: share_reels_feed, audio_name, and either thumbnail or thumbnail_offset"
             return
 
         # Count hashtags and mentions
@@ -170,17 +158,11 @@ class PostToInstagramBlock(Block):
         mention_count = input_data.post.count("@")
 
         if hashtag_count > 30:
-            yield (
-                "error",
-                f"Instagram allows maximum 30 hashtags ({hashtag_count} found)",
-            )
+            yield "error", f"Instagram allows maximum 30 hashtags ({hashtag_count} found)"
             return
 
         if mention_count > 3:
-            yield (
-                "error",
-                f"Instagram allows maximum 3 @mentions ({mention_count} found)",
-            )
+            yield "error", f"Instagram allows maximum 3 @mentions ({mention_count} found)"
             return
 
         # Convert datetime to ISO format if provided
@@ -212,10 +194,7 @@ class PostToInstagramBlock(Block):
             # Validate alt text length
             for i, alt in enumerate(input_data.alt_text):
                 if len(alt) > 1000:
-                    yield (
-                        "error",
-                        f"Alt text {i + 1} exceeds 1,000 character limit ({len(alt)} characters)",
-                    )
+                    yield "error", f"Alt text {i + 1} exceeds 1,000 character limit ({len(alt)} characters)"
                     return
             instagram_options["altText"] = input_data.alt_text
 
@@ -230,19 +209,13 @@ class PostToInstagramBlock(Block):
                 try:
                     tag_obj = InstagramUserTag(**tag)
                 except Exception as e:
-                    yield (
-                        "error",
-                        f"Invalid user tag: {e}, tages need to be a dictionary with a 3 items: username (str), x (float) and y (float)",
-                    )
+                    yield "error", f"Invalid user tag: {e}, tages need to be a dictionary with a 3 items: username (str), x (float) and y (float)"
                     return
                 tag_dict: dict[str, float | str] = {"username": tag_obj.username}
                 if tag_obj.x is not None and tag_obj.y is not None:
                     # Validate coordinates
                     if not (0.0 <= tag_obj.x <= 1.0) or not (0.0 <= tag_obj.y <= 1.0):
-                        yield (
-                            "error",
-                            f"User tag coordinates must be between 0.0 and 1.0 (user: {tag_obj.username})",
-                        )
+                        yield "error", f"User tag coordinates must be between 0.0 and 1.0 (user: {tag_obj.username})"
                         return
                     tag_dict["x"] = tag_obj.x
                     tag_dict["y"] = tag_obj.y

--- a/autogpt_platform/backend/backend/blocks/ayrshare/post_to_linkedin.py
+++ b/autogpt_platform/backend/backend/blocks/ayrshare/post_to_linkedin.py
@@ -6,11 +6,14 @@ from backend.sdk import (
     BlockSchemaOutput,
     BlockType,
     SchemaField,
+    cost,
 )
 
+from ._cost import AYRSHARE_POST_COSTS
 from ._util import BaseAyrshareInput, create_ayrshare_client, get_profile_key
 
 
+@cost(*AYRSHARE_POST_COSTS)
 class PostToLinkedInBlock(Block):
     """Block for posting to LinkedIn with LinkedIn-specific options."""
 
@@ -123,12 +126,18 @@ class PostToLinkedInBlock(Block):
 
         client = create_ayrshare_client()
         if not client:
-            yield "error", "Ayrshare integration is not configured. Please set up the AYRSHARE_API_KEY."
+            yield (
+                "error",
+                "Ayrshare integration is not configured. Please set up the AYRSHARE_API_KEY.",
+            )
             return
 
         # Validate LinkedIn constraints
         if len(input_data.post) > 3000:
-            yield "error", f"LinkedIn post text exceeds 3,000 character limit ({len(input_data.post)} characters)"
+            yield (
+                "error",
+                f"LinkedIn post text exceeds 3,000 character limit ({len(input_data.post)} characters)",
+            )
             return
 
         if len(input_data.media_urls) > 9:
@@ -136,13 +145,19 @@ class PostToLinkedInBlock(Block):
             return
 
         if input_data.document_title and len(input_data.document_title) > 400:
-            yield "error", f"LinkedIn document title exceeds 400 character limit ({len(input_data.document_title)} characters)"
+            yield (
+                "error",
+                f"LinkedIn document title exceeds 400 character limit ({len(input_data.document_title)} characters)",
+            )
             return
 
         # Validate visibility option
         valid_visibility = ["public", "connections", "loggedin"]
         if input_data.visibility not in valid_visibility:
-            yield "error", f"LinkedIn visibility must be one of: {', '.join(valid_visibility)}"
+            yield (
+                "error",
+                f"LinkedIn visibility must be one of: {', '.join(valid_visibility)}",
+            )
             return
 
         # Check for document extensions

--- a/autogpt_platform/backend/backend/blocks/ayrshare/post_to_linkedin.py
+++ b/autogpt_platform/backend/backend/blocks/ayrshare/post_to_linkedin.py
@@ -126,18 +126,12 @@ class PostToLinkedInBlock(Block):
 
         client = create_ayrshare_client()
         if not client:
-            yield (
-                "error",
-                "Ayrshare integration is not configured. Please set up the AYRSHARE_API_KEY.",
-            )
+            yield "error", "Ayrshare integration is not configured. Please set up the AYRSHARE_API_KEY."
             return
 
         # Validate LinkedIn constraints
         if len(input_data.post) > 3000:
-            yield (
-                "error",
-                f"LinkedIn post text exceeds 3,000 character limit ({len(input_data.post)} characters)",
-            )
+            yield "error", f"LinkedIn post text exceeds 3,000 character limit ({len(input_data.post)} characters)"
             return
 
         if len(input_data.media_urls) > 9:
@@ -145,19 +139,13 @@ class PostToLinkedInBlock(Block):
             return
 
         if input_data.document_title and len(input_data.document_title) > 400:
-            yield (
-                "error",
-                f"LinkedIn document title exceeds 400 character limit ({len(input_data.document_title)} characters)",
-            )
+            yield "error", f"LinkedIn document title exceeds 400 character limit ({len(input_data.document_title)} characters)"
             return
 
         # Validate visibility option
         valid_visibility = ["public", "connections", "loggedin"]
         if input_data.visibility not in valid_visibility:
-            yield (
-                "error",
-                f"LinkedIn visibility must be one of: {', '.join(valid_visibility)}",
-            )
+            yield "error", f"LinkedIn visibility must be one of: {', '.join(valid_visibility)}"
             return
 
         # Check for document extensions

--- a/autogpt_platform/backend/backend/blocks/ayrshare/post_to_pinterest.py
+++ b/autogpt_platform/backend/backend/blocks/ayrshare/post_to_pinterest.py
@@ -106,32 +106,20 @@ class PostToPinterestBlock(Block):
 
         client = create_ayrshare_client()
         if not client:
-            yield (
-                "error",
-                "Ayrshare integration is not configured. Please set up the AYRSHARE_API_KEY.",
-            )
+            yield "error", "Ayrshare integration is not configured. Please set up the AYRSHARE_API_KEY."
             return
 
         # Validate Pinterest constraints
         if len(input_data.post) > 500:
-            yield (
-                "error",
-                f"Pinterest pin description exceeds 500 character limit ({len(input_data.post)} characters)",
-            )
+            yield "error", f"Pinterest pin description exceeds 500 character limit ({len(input_data.post)} characters)"
             return
 
         if len(input_data.pin_title) > 100:
-            yield (
-                "error",
-                f"Pinterest pin title exceeds 100 character limit ({len(input_data.pin_title)} characters)",
-            )
+            yield "error", f"Pinterest pin title exceeds 100 character limit ({len(input_data.pin_title)} characters)"
             return
 
         if len(input_data.link) > 2048:
-            yield (
-                "error",
-                f"Pinterest link URL exceeds 2048 character limit ({len(input_data.link)} characters)",
-            )
+            yield "error", f"Pinterest link URL exceeds 2048 character limit ({len(input_data.link)} characters)"
             return
 
         if len(input_data.media_urls) == 0:
@@ -156,10 +144,7 @@ class PostToPinterestBlock(Block):
         # Validate alt text length
         for i, alt in enumerate(input_data.alt_text):
             if len(alt) > 500:
-                yield (
-                    "error",
-                    f"Pinterest alt text {i + 1} exceeds 500 character limit ({len(alt)} characters)",
-                )
+                yield "error", f"Pinterest alt text {i + 1} exceeds 500 character limit ({len(alt)} characters)"
                 return
 
         # Convert datetime to ISO format if provided

--- a/autogpt_platform/backend/backend/blocks/ayrshare/post_to_pinterest.py
+++ b/autogpt_platform/backend/backend/blocks/ayrshare/post_to_pinterest.py
@@ -6,8 +6,10 @@ from backend.sdk import (
     BlockSchemaOutput,
     BlockType,
     SchemaField,
+    cost,
 )
 
+from ._cost import AYRSHARE_POST_COSTS
 from ._util import (
     BaseAyrshareInput,
     PinterestCarouselOption,
@@ -16,6 +18,7 @@ from ._util import (
 )
 
 
+@cost(*AYRSHARE_POST_COSTS)
 class PostToPinterestBlock(Block):
     """Block for posting to Pinterest with Pinterest-specific options."""
 
@@ -103,20 +106,32 @@ class PostToPinterestBlock(Block):
 
         client = create_ayrshare_client()
         if not client:
-            yield "error", "Ayrshare integration is not configured. Please set up the AYRSHARE_API_KEY."
+            yield (
+                "error",
+                "Ayrshare integration is not configured. Please set up the AYRSHARE_API_KEY.",
+            )
             return
 
         # Validate Pinterest constraints
         if len(input_data.post) > 500:
-            yield "error", f"Pinterest pin description exceeds 500 character limit ({len(input_data.post)} characters)"
+            yield (
+                "error",
+                f"Pinterest pin description exceeds 500 character limit ({len(input_data.post)} characters)",
+            )
             return
 
         if len(input_data.pin_title) > 100:
-            yield "error", f"Pinterest pin title exceeds 100 character limit ({len(input_data.pin_title)} characters)"
+            yield (
+                "error",
+                f"Pinterest pin title exceeds 100 character limit ({len(input_data.pin_title)} characters)",
+            )
             return
 
         if len(input_data.link) > 2048:
-            yield "error", f"Pinterest link URL exceeds 2048 character limit ({len(input_data.link)} characters)"
+            yield (
+                "error",
+                f"Pinterest link URL exceeds 2048 character limit ({len(input_data.link)} characters)",
+            )
             return
 
         if len(input_data.media_urls) == 0:
@@ -141,7 +156,10 @@ class PostToPinterestBlock(Block):
         # Validate alt text length
         for i, alt in enumerate(input_data.alt_text):
             if len(alt) > 500:
-                yield "error", f"Pinterest alt text {i+1} exceeds 500 character limit ({len(alt)} characters)"
+                yield (
+                    "error",
+                    f"Pinterest alt text {i + 1} exceeds 500 character limit ({len(alt)} characters)",
+                )
                 return
 
         # Convert datetime to ISO format if provided

--- a/autogpt_platform/backend/backend/blocks/ayrshare/post_to_reddit.py
+++ b/autogpt_platform/backend/backend/blocks/ayrshare/post_to_reddit.py
@@ -6,11 +6,14 @@ from backend.sdk import (
     BlockSchemaOutput,
     BlockType,
     SchemaField,
+    cost,
 )
 
+from ._cost import AYRSHARE_POST_COSTS
 from ._util import BaseAyrshareInput, create_ayrshare_client, get_profile_key
 
 
+@cost(*AYRSHARE_POST_COSTS)
 class PostToRedditBlock(Block):
     """Block for posting to Reddit."""
 

--- a/autogpt_platform/backend/backend/blocks/ayrshare/post_to_snapchat.py
+++ b/autogpt_platform/backend/backend/blocks/ayrshare/post_to_snapchat.py
@@ -84,10 +84,7 @@ class PostToSnapchatBlock(Block):
 
         client = create_ayrshare_client()
         if not client:
-            yield (
-                "error",
-                "Ayrshare integration is not configured. Please set up the AYRSHARE_API_KEY.",
-            )
+            yield "error", "Ayrshare integration is not configured. Please set up the AYRSHARE_API_KEY."
             return
 
         # Validate Snapchat constraints
@@ -102,10 +99,7 @@ class PostToSnapchatBlock(Block):
         # Validate story type
         valid_story_types = ["story", "saved_story", "spotlight"]
         if input_data.story_type not in valid_story_types:
-            yield (
-                "error",
-                f"Snapchat story type must be one of: {', '.join(valid_story_types)}",
-            )
+            yield "error", f"Snapchat story type must be one of: {', '.join(valid_story_types)}"
             return
 
         # Convert datetime to ISO format if provided

--- a/autogpt_platform/backend/backend/blocks/ayrshare/post_to_snapchat.py
+++ b/autogpt_platform/backend/backend/blocks/ayrshare/post_to_snapchat.py
@@ -34,6 +34,14 @@ class PostToSnapchatBlock(Block):
             advanced=False,
         )
 
+        # Snapchat is video-only; override the base default so the @cost filter
+        # selects the 5-credit video tier instead of the 2-credit image tier.
+        is_video: bool = SchemaField(
+            description="Whether the media is a video (always True for Snapchat)",
+            default=True,
+            advanced=True,
+        )
+
         # Snapchat-specific options
         story_type: str = SchemaField(
             description="Type of Snapchat content: 'story' (24-hour Stories), 'saved_story' (Saved Stories), or 'spotlight' (Spotlight posts)",

--- a/autogpt_platform/backend/backend/blocks/ayrshare/post_to_snapchat.py
+++ b/autogpt_platform/backend/backend/blocks/ayrshare/post_to_snapchat.py
@@ -6,11 +6,14 @@ from backend.sdk import (
     BlockSchemaOutput,
     BlockType,
     SchemaField,
+    cost,
 )
 
+from ._cost import AYRSHARE_POST_COSTS
 from ._util import BaseAyrshareInput, create_ayrshare_client, get_profile_key
 
 
+@cost(*AYRSHARE_POST_COSTS)
 class PostToSnapchatBlock(Block):
     """Block for posting to Snapchat with Snapchat-specific options."""
 
@@ -73,7 +76,10 @@ class PostToSnapchatBlock(Block):
 
         client = create_ayrshare_client()
         if not client:
-            yield "error", "Ayrshare integration is not configured. Please set up the AYRSHARE_API_KEY."
+            yield (
+                "error",
+                "Ayrshare integration is not configured. Please set up the AYRSHARE_API_KEY.",
+            )
             return
 
         # Validate Snapchat constraints
@@ -88,7 +94,10 @@ class PostToSnapchatBlock(Block):
         # Validate story type
         valid_story_types = ["story", "saved_story", "spotlight"]
         if input_data.story_type not in valid_story_types:
-            yield "error", f"Snapchat story type must be one of: {', '.join(valid_story_types)}"
+            yield (
+                "error",
+                f"Snapchat story type must be one of: {', '.join(valid_story_types)}",
+            )
             return
 
         # Convert datetime to ISO format if provided

--- a/autogpt_platform/backend/backend/blocks/ayrshare/post_to_telegram.py
+++ b/autogpt_platform/backend/backend/blocks/ayrshare/post_to_telegram.py
@@ -71,10 +71,7 @@ class PostToTelegramBlock(Block):
 
         client = create_ayrshare_client()
         if not client:
-            yield (
-                "error",
-                "Ayrshare integration is not configured. Please set up the AYRSHARE_API_KEY.",
-            )
+            yield "error", "Ayrshare integration is not configured. Please set up the AYRSHARE_API_KEY."
             return
 
         # Validate Telegram constraints

--- a/autogpt_platform/backend/backend/blocks/ayrshare/post_to_telegram.py
+++ b/autogpt_platform/backend/backend/blocks/ayrshare/post_to_telegram.py
@@ -6,11 +6,14 @@ from backend.sdk import (
     BlockSchemaOutput,
     BlockType,
     SchemaField,
+    cost,
 )
 
+from ._cost import AYRSHARE_POST_COSTS
 from ._util import BaseAyrshareInput, create_ayrshare_client, get_profile_key
 
 
+@cost(*AYRSHARE_POST_COSTS)
 class PostToTelegramBlock(Block):
     """Block for posting to Telegram with Telegram-specific options."""
 
@@ -68,7 +71,10 @@ class PostToTelegramBlock(Block):
 
         client = create_ayrshare_client()
         if not client:
-            yield "error", "Ayrshare integration is not configured. Please set up the AYRSHARE_API_KEY."
+            yield (
+                "error",
+                "Ayrshare integration is not configured. Please set up the AYRSHARE_API_KEY.",
+            )
             return
 
         # Validate Telegram constraints

--- a/autogpt_platform/backend/backend/blocks/ayrshare/post_to_threads.py
+++ b/autogpt_platform/backend/backend/blocks/ayrshare/post_to_threads.py
@@ -64,34 +64,22 @@ class PostToThreadsBlock(Block):
 
         client = create_ayrshare_client()
         if not client:
-            yield (
-                "error",
-                "Ayrshare integration is not configured. Please set up the AYRSHARE_API_KEY.",
-            )
+            yield "error", "Ayrshare integration is not configured. Please set up the AYRSHARE_API_KEY."
             return
 
         # Validate Threads constraints
         if len(input_data.post) > 500:
-            yield (
-                "error",
-                f"Threads post text exceeds 500 character limit ({len(input_data.post)} characters)",
-            )
+            yield "error", f"Threads post text exceeds 500 character limit ({len(input_data.post)} characters)"
             return
 
         if len(input_data.media_urls) > 20:
-            yield (
-                "error",
-                "Threads supports a maximum of 20 images/videos in a carousel",
-            )
+            yield "error", "Threads supports a maximum of 20 images/videos in a carousel"
             return
 
         # Count hashtags (only 1 allowed)
         hashtag_count = input_data.post.count("#")
         if hashtag_count > 1:
-            yield (
-                "error",
-                f"Threads allows only 1 hashtag per post ({hashtag_count} found)",
-            )
+            yield "error", f"Threads allows only 1 hashtag per post ({hashtag_count} found)"
             return
 
         # Convert datetime to ISO format if provided

--- a/autogpt_platform/backend/backend/blocks/ayrshare/post_to_threads.py
+++ b/autogpt_platform/backend/backend/blocks/ayrshare/post_to_threads.py
@@ -6,11 +6,14 @@ from backend.sdk import (
     BlockSchemaOutput,
     BlockType,
     SchemaField,
+    cost,
 )
 
+from ._cost import AYRSHARE_POST_COSTS
 from ._util import BaseAyrshareInput, create_ayrshare_client, get_profile_key
 
 
+@cost(*AYRSHARE_POST_COSTS)
 class PostToThreadsBlock(Block):
     """Block for posting to Threads with Threads-specific options."""
 
@@ -61,22 +64,34 @@ class PostToThreadsBlock(Block):
 
         client = create_ayrshare_client()
         if not client:
-            yield "error", "Ayrshare integration is not configured. Please set up the AYRSHARE_API_KEY."
+            yield (
+                "error",
+                "Ayrshare integration is not configured. Please set up the AYRSHARE_API_KEY.",
+            )
             return
 
         # Validate Threads constraints
         if len(input_data.post) > 500:
-            yield "error", f"Threads post text exceeds 500 character limit ({len(input_data.post)} characters)"
+            yield (
+                "error",
+                f"Threads post text exceeds 500 character limit ({len(input_data.post)} characters)",
+            )
             return
 
         if len(input_data.media_urls) > 20:
-            yield "error", "Threads supports a maximum of 20 images/videos in a carousel"
+            yield (
+                "error",
+                "Threads supports a maximum of 20 images/videos in a carousel",
+            )
             return
 
         # Count hashtags (only 1 allowed)
         hashtag_count = input_data.post.count("#")
         if hashtag_count > 1:
-            yield "error", f"Threads allows only 1 hashtag per post ({hashtag_count} found)"
+            yield (
+                "error",
+                f"Threads allows only 1 hashtag per post ({hashtag_count} found)",
+            )
             return
 
         # Convert datetime to ISO format if provided

--- a/autogpt_platform/backend/backend/blocks/ayrshare/post_to_tiktok.py
+++ b/autogpt_platform/backend/backend/blocks/ayrshare/post_to_tiktok.py
@@ -8,8 +8,10 @@ from backend.sdk import (
     BlockSchemaOutput,
     BlockType,
     SchemaField,
+    cost,
 )
 
+from ._cost import AYRSHARE_POST_COSTS
 from ._util import BaseAyrshareInput, create_ayrshare_client, get_profile_key
 
 
@@ -19,6 +21,7 @@ class TikTokVisibility(str, Enum):
     FOLLOWERS = "followers"
 
 
+@cost(*AYRSHARE_POST_COSTS)
 class PostToTikTokBlock(Block):
     """Block for posting to TikTok with TikTok-specific options."""
 
@@ -123,16 +126,25 @@ class PostToTikTokBlock(Block):
 
         client = create_ayrshare_client()
         if not client:
-            yield "error", "Ayrshare integration is not configured. Please set up the AYRSHARE_API_KEY."
+            yield (
+                "error",
+                "Ayrshare integration is not configured. Please set up the AYRSHARE_API_KEY.",
+            )
             return
 
         # Validate TikTok constraints
         if len(input_data.post) > 2200:
-            yield "error", f"TikTok post text exceeds 2,200 character limit ({len(input_data.post)} characters)"
+            yield (
+                "error",
+                f"TikTok post text exceeds 2,200 character limit ({len(input_data.post)} characters)",
+            )
             return
 
         if not input_data.media_urls:
-            yield "error", "TikTok requires at least one media URL (either 1 video or up to 35 images)"
+            yield (
+                "error",
+                "TikTok requires at least one media URL (either 1 video or up to 35 images)",
+            )
             return
 
         # Check for video vs image constraints
@@ -150,7 +162,10 @@ class PostToTikTokBlock(Block):
         )
 
         if has_video and has_images:
-            yield "error", "TikTok does not support mixing video and images in the same post"
+            yield (
+                "error",
+                "TikTok does not support mixing video and images in the same post",
+            )
             return
 
         if has_video and len(input_data.media_urls) > 1:
@@ -163,13 +178,19 @@ class PostToTikTokBlock(Block):
 
         # Validate image cover index
         if has_images and input_data.image_cover_index >= len(input_data.media_urls):
-            yield "error", f"Image cover index {input_data.image_cover_index} is out of range (max: {len(input_data.media_urls) - 1})"
+            yield (
+                "error",
+                f"Image cover index {input_data.image_cover_index} is out of range (max: {len(input_data.media_urls) - 1})",
+            )
             return
 
         # Check for PNG files (not supported)
         has_png = any(url.lower().endswith(".png") for url in input_data.media_urls)
         if has_png:
-            yield "error", "TikTok does not support PNG files. Please use JPG, JPEG, or WEBP for images."
+            yield (
+                "error",
+                "TikTok does not support PNG files. Please use JPG, JPEG, or WEBP for images.",
+            )
             return
 
         # Convert datetime to ISO format if provided

--- a/autogpt_platform/backend/backend/blocks/ayrshare/post_to_tiktok.py
+++ b/autogpt_platform/backend/backend/blocks/ayrshare/post_to_tiktok.py
@@ -126,25 +126,16 @@ class PostToTikTokBlock(Block):
 
         client = create_ayrshare_client()
         if not client:
-            yield (
-                "error",
-                "Ayrshare integration is not configured. Please set up the AYRSHARE_API_KEY.",
-            )
+            yield "error", "Ayrshare integration is not configured. Please set up the AYRSHARE_API_KEY."
             return
 
         # Validate TikTok constraints
         if len(input_data.post) > 2200:
-            yield (
-                "error",
-                f"TikTok post text exceeds 2,200 character limit ({len(input_data.post)} characters)",
-            )
+            yield "error", f"TikTok post text exceeds 2,200 character limit ({len(input_data.post)} characters)"
             return
 
         if not input_data.media_urls:
-            yield (
-                "error",
-                "TikTok requires at least one media URL (either 1 video or up to 35 images)",
-            )
+            yield "error", "TikTok requires at least one media URL (either 1 video or up to 35 images)"
             return
 
         # Check for video vs image constraints
@@ -162,10 +153,7 @@ class PostToTikTokBlock(Block):
         )
 
         if has_video and has_images:
-            yield (
-                "error",
-                "TikTok does not support mixing video and images in the same post",
-            )
+            yield "error", "TikTok does not support mixing video and images in the same post"
             return
 
         if has_video and len(input_data.media_urls) > 1:
@@ -178,19 +166,13 @@ class PostToTikTokBlock(Block):
 
         # Validate image cover index
         if has_images and input_data.image_cover_index >= len(input_data.media_urls):
-            yield (
-                "error",
-                f"Image cover index {input_data.image_cover_index} is out of range (max: {len(input_data.media_urls) - 1})",
-            )
+            yield "error", f"Image cover index {input_data.image_cover_index} is out of range (max: {len(input_data.media_urls) - 1})"
             return
 
         # Check for PNG files (not supported)
         has_png = any(url.lower().endswith(".png") for url in input_data.media_urls)
         if has_png:
-            yield (
-                "error",
-                "TikTok does not support PNG files. Please use JPG, JPEG, or WEBP for images.",
-            )
+            yield "error", "TikTok does not support PNG files. Please use JPG, JPEG, or WEBP for images."
             return
 
         # Convert datetime to ISO format if provided

--- a/autogpt_platform/backend/backend/blocks/ayrshare/post_to_x.py
+++ b/autogpt_platform/backend/backend/blocks/ayrshare/post_to_x.py
@@ -6,11 +6,14 @@ from backend.sdk import (
     BlockSchemaOutput,
     BlockType,
     SchemaField,
+    cost,
 )
 
+from ._cost import AYRSHARE_POST_COSTS
 from ._util import BaseAyrshareInput, create_ayrshare_client, get_profile_key
 
 
+@cost(*AYRSHARE_POST_COSTS)
 class PostToXBlock(Block):
     """Block for posting to X / Twitter with Twitter-specific options."""
 
@@ -126,16 +129,25 @@ class PostToXBlock(Block):
 
         client = create_ayrshare_client()
         if not client:
-            yield "error", "Ayrshare integration is not configured. Please set up the AYRSHARE_API_KEY."
+            yield (
+                "error",
+                "Ayrshare integration is not configured. Please set up the AYRSHARE_API_KEY.",
+            )
             return
 
         # Validate X constraints
         if not input_data.long_post and len(input_data.post) > 280:
-            yield "error", f"X post text exceeds 280 character limit ({len(input_data.post)} characters). Enable 'long_post' for Premium accounts."
+            yield (
+                "error",
+                f"X post text exceeds 280 character limit ({len(input_data.post)} characters). Enable 'long_post' for Premium accounts.",
+            )
             return
 
         if input_data.long_post and len(input_data.post) > 25000:
-            yield "error", f"X long post text exceeds 25,000 character limit ({len(input_data.post)} characters)"
+            yield (
+                "error",
+                f"X long post text exceeds 25,000 character limit ({len(input_data.post)} characters)",
+            )
             return
 
         if len(input_data.media_urls) > 4:
@@ -149,14 +161,20 @@ class PostToXBlock(Block):
                 return
 
             if input_data.poll_duration < 1 or input_data.poll_duration > 10080:
-                yield "error", "X poll duration must be between 1 and 10,080 minutes (7 days)"
+                yield (
+                    "error",
+                    "X poll duration must be between 1 and 10,080 minutes (7 days)",
+                )
                 return
 
         # Validate alt text
         if input_data.alt_text:
             for i, alt in enumerate(input_data.alt_text):
                 if len(alt) > 1000:
-                    yield "error", f"X alt text {i+1} exceeds 1,000 character limit ({len(alt)} characters)"
+                    yield (
+                        "error",
+                        f"X alt text {i + 1} exceeds 1,000 character limit ({len(alt)} characters)",
+                    )
                     return
 
         # Validate subtitle settings
@@ -168,7 +186,10 @@ class PostToXBlock(Block):
                 return
 
             if len(input_data.subtitle_name) > 150:
-                yield "error", f"Subtitle name exceeds 150 character limit ({len(input_data.subtitle_name)} characters)"
+                yield (
+                    "error",
+                    f"Subtitle name exceeds 150 character limit ({len(input_data.subtitle_name)} characters)",
+                )
                 return
 
         # Convert datetime to ISO format if provided

--- a/autogpt_platform/backend/backend/blocks/ayrshare/post_to_x.py
+++ b/autogpt_platform/backend/backend/blocks/ayrshare/post_to_x.py
@@ -129,25 +129,16 @@ class PostToXBlock(Block):
 
         client = create_ayrshare_client()
         if not client:
-            yield (
-                "error",
-                "Ayrshare integration is not configured. Please set up the AYRSHARE_API_KEY.",
-            )
+            yield "error", "Ayrshare integration is not configured. Please set up the AYRSHARE_API_KEY."
             return
 
         # Validate X constraints
         if not input_data.long_post and len(input_data.post) > 280:
-            yield (
-                "error",
-                f"X post text exceeds 280 character limit ({len(input_data.post)} characters). Enable 'long_post' for Premium accounts.",
-            )
+            yield "error", f"X post text exceeds 280 character limit ({len(input_data.post)} characters). Enable 'long_post' for Premium accounts."
             return
 
         if input_data.long_post and len(input_data.post) > 25000:
-            yield (
-                "error",
-                f"X long post text exceeds 25,000 character limit ({len(input_data.post)} characters)",
-            )
+            yield "error", f"X long post text exceeds 25,000 character limit ({len(input_data.post)} characters)"
             return
 
         if len(input_data.media_urls) > 4:
@@ -161,20 +152,14 @@ class PostToXBlock(Block):
                 return
 
             if input_data.poll_duration < 1 or input_data.poll_duration > 10080:
-                yield (
-                    "error",
-                    "X poll duration must be between 1 and 10,080 minutes (7 days)",
-                )
+                yield "error", "X poll duration must be between 1 and 10,080 minutes (7 days)"
                 return
 
         # Validate alt text
         if input_data.alt_text:
             for i, alt in enumerate(input_data.alt_text):
                 if len(alt) > 1000:
-                    yield (
-                        "error",
-                        f"X alt text {i + 1} exceeds 1,000 character limit ({len(alt)} characters)",
-                    )
+                    yield "error", f"X alt text {i + 1} exceeds 1,000 character limit ({len(alt)} characters)"
                     return
 
         # Validate subtitle settings
@@ -186,10 +171,7 @@ class PostToXBlock(Block):
                 return
 
             if len(input_data.subtitle_name) > 150:
-                yield (
-                    "error",
-                    f"Subtitle name exceeds 150 character limit ({len(input_data.subtitle_name)} characters)",
-                )
+                yield "error", f"Subtitle name exceeds 150 character limit ({len(input_data.subtitle_name)} characters)"
                 return
 
         # Convert datetime to ISO format if provided

--- a/autogpt_platform/backend/backend/blocks/ayrshare/post_to_youtube.py
+++ b/autogpt_platform/backend/backend/blocks/ayrshare/post_to_youtube.py
@@ -42,6 +42,14 @@ class PostToYouTubeBlock(Block):
             advanced=False,
         )
 
+        # YouTube is video-only; override the base default so the @cost filter
+        # selects the 5-credit video tier instead of the 2-credit image tier.
+        is_video: bool = SchemaField(
+            description="Whether the media is a video (always True for YouTube)",
+            default=True,
+            advanced=True,
+        )
+
         # YouTube-specific required options
         title: str = SchemaField(
             description="Video title (max 100 chars, required). Cannot contain < or > characters.",

--- a/autogpt_platform/backend/backend/blocks/ayrshare/post_to_youtube.py
+++ b/autogpt_platform/backend/backend/blocks/ayrshare/post_to_youtube.py
@@ -9,8 +9,10 @@ from backend.sdk import (
     BlockSchemaOutput,
     BlockType,
     SchemaField,
+    cost,
 )
 
+from ._cost import AYRSHARE_POST_COSTS
 from ._util import BaseAyrshareInput, create_ayrshare_client, get_profile_key
 
 
@@ -20,6 +22,7 @@ class YouTubeVisibility(str, Enum):
     UNLISTED = "unlisted"
 
 
+@cost(*AYRSHARE_POST_COSTS)
 class PostToYouTubeBlock(Block):
     """Block for posting to YouTube with YouTube-specific options."""
 
@@ -149,7 +152,10 @@ class PostToYouTubeBlock(Block):
 
         client = create_ayrshare_client()
         if not client:
-            yield "error", "Ayrshare integration is not configured. Please set up the AYRSHARE_API_KEY."
+            yield (
+                "error",
+                "Ayrshare integration is not configured. Please set up the AYRSHARE_API_KEY.",
+            )
             return
 
         # Validate YouTube constraints
@@ -158,11 +164,17 @@ class PostToYouTubeBlock(Block):
             return
 
         if len(input_data.title) > 100:
-            yield "error", f"YouTube title exceeds 100 character limit ({len(input_data.title)} characters)"
+            yield (
+                "error",
+                f"YouTube title exceeds 100 character limit ({len(input_data.title)} characters)",
+            )
             return
 
         if len(input_data.post) > 5000:
-            yield "error", f"YouTube description exceeds 5,000 character limit ({len(input_data.post)} characters)"
+            yield (
+                "error",
+                f"YouTube description exceeds 5,000 character limit ({len(input_data.post)} characters)",
+            )
             return
 
         # Check for forbidden characters
@@ -186,7 +198,10 @@ class PostToYouTubeBlock(Block):
         # Validate visibility option
         valid_visibility = ["private", "public", "unlisted"]
         if input_data.visibility not in valid_visibility:
-            yield "error", f"YouTube visibility must be one of: {', '.join(valid_visibility)}"
+            yield (
+                "error",
+                f"YouTube visibility must be one of: {', '.join(valid_visibility)}",
+            )
             return
 
         # Validate thumbnail URL format
@@ -202,12 +217,18 @@ class PostToYouTubeBlock(Block):
         if input_data.tags:
             total_tag_length = sum(len(tag) for tag in input_data.tags)
             if total_tag_length > 500:
-                yield "error", f"YouTube tags total length exceeds 500 characters ({total_tag_length} characters)"
+                yield (
+                    "error",
+                    f"YouTube tags total length exceeds 500 characters ({total_tag_length} characters)",
+                )
                 return
 
             for tag in input_data.tags:
                 if len(tag) < 2:
-                    yield "error", f"YouTube tag '{tag}' is too short (minimum 2 characters)"
+                    yield (
+                        "error",
+                        f"YouTube tag '{tag}' is too short (minimum 2 characters)",
+                    )
                     return
 
         # Validate subtitle URL
@@ -225,12 +246,18 @@ class PostToYouTubeBlock(Block):
                 return
 
         if input_data.subtitle_name and len(input_data.subtitle_name) > 150:
-            yield "error", f"YouTube subtitle name exceeds 150 character limit ({len(input_data.subtitle_name)} characters)"
+            yield (
+                "error",
+                f"YouTube subtitle name exceeds 150 character limit ({len(input_data.subtitle_name)} characters)",
+            )
             return
 
         # Validate publish_at format if provided
         if input_data.publish_at and input_data.schedule_date:
-            yield "error", "Cannot use both 'publish_at' and 'schedule_date'. Use 'publish_at' for YouTube-controlled publishing."
+            yield (
+                "error",
+                "Cannot use both 'publish_at' and 'schedule_date'. Use 'publish_at' for YouTube-controlled publishing.",
+            )
             return
 
         # Convert datetime to ISO format if provided (only if not using publish_at)

--- a/autogpt_platform/backend/backend/blocks/ayrshare/post_to_youtube.py
+++ b/autogpt_platform/backend/backend/blocks/ayrshare/post_to_youtube.py
@@ -160,10 +160,7 @@ class PostToYouTubeBlock(Block):
 
         client = create_ayrshare_client()
         if not client:
-            yield (
-                "error",
-                "Ayrshare integration is not configured. Please set up the AYRSHARE_API_KEY.",
-            )
+            yield "error", "Ayrshare integration is not configured. Please set up the AYRSHARE_API_KEY."
             return
 
         # Validate YouTube constraints
@@ -172,17 +169,11 @@ class PostToYouTubeBlock(Block):
             return
 
         if len(input_data.title) > 100:
-            yield (
-                "error",
-                f"YouTube title exceeds 100 character limit ({len(input_data.title)} characters)",
-            )
+            yield "error", f"YouTube title exceeds 100 character limit ({len(input_data.title)} characters)"
             return
 
         if len(input_data.post) > 5000:
-            yield (
-                "error",
-                f"YouTube description exceeds 5,000 character limit ({len(input_data.post)} characters)",
-            )
+            yield "error", f"YouTube description exceeds 5,000 character limit ({len(input_data.post)} characters)"
             return
 
         # Check for forbidden characters
@@ -206,10 +197,7 @@ class PostToYouTubeBlock(Block):
         # Validate visibility option
         valid_visibility = ["private", "public", "unlisted"]
         if input_data.visibility not in valid_visibility:
-            yield (
-                "error",
-                f"YouTube visibility must be one of: {', '.join(valid_visibility)}",
-            )
+            yield "error", f"YouTube visibility must be one of: {', '.join(valid_visibility)}"
             return
 
         # Validate thumbnail URL format
@@ -225,18 +213,12 @@ class PostToYouTubeBlock(Block):
         if input_data.tags:
             total_tag_length = sum(len(tag) for tag in input_data.tags)
             if total_tag_length > 500:
-                yield (
-                    "error",
-                    f"YouTube tags total length exceeds 500 characters ({total_tag_length} characters)",
-                )
+                yield "error", f"YouTube tags total length exceeds 500 characters ({total_tag_length} characters)"
                 return
 
             for tag in input_data.tags:
                 if len(tag) < 2:
-                    yield (
-                        "error",
-                        f"YouTube tag '{tag}' is too short (minimum 2 characters)",
-                    )
+                    yield "error", f"YouTube tag '{tag}' is too short (minimum 2 characters)"
                     return
 
         # Validate subtitle URL
@@ -254,18 +236,12 @@ class PostToYouTubeBlock(Block):
                 return
 
         if input_data.subtitle_name and len(input_data.subtitle_name) > 150:
-            yield (
-                "error",
-                f"YouTube subtitle name exceeds 150 character limit ({len(input_data.subtitle_name)} characters)",
-            )
+            yield "error", f"YouTube subtitle name exceeds 150 character limit ({len(input_data.subtitle_name)} characters)"
             return
 
         # Validate publish_at format if provided
         if input_data.publish_at and input_data.schedule_date:
-            yield (
-                "error",
-                "Cannot use both 'publish_at' and 'schedule_date'. Use 'publish_at' for YouTube-controlled publishing.",
-            )
+            yield "error", "Cannot use both 'publish_at' and 'schedule_date'. Use 'publish_at' for YouTube-controlled publishing."
             return
 
         # Convert datetime to ISO format if provided (only if not using publish_at)

--- a/autogpt_platform/backend/backend/blocks/bannerbear/_config.py
+++ b/autogpt_platform/backend/backend/blocks/bannerbear/_config.py
@@ -3,6 +3,6 @@ from backend.sdk import BlockCostType, ProviderBuilder
 bannerbear = (
     ProviderBuilder("bannerbear")
     .with_api_key("BANNERBEAR_API_KEY", "Bannerbear API Key")
-    .with_base_cost(1, BlockCostType.RUN)
+    .with_base_cost(3, BlockCostType.RUN)
     .build()
 )

--- a/autogpt_platform/backend/backend/data/block_cost_config.py
+++ b/autogpt_platform/backend/backend/data/block_cost_config.py
@@ -22,6 +22,7 @@ from backend.blocks.enrichlayer.linkedin import (
 )
 from backend.blocks.flux_kontext import AIImageEditorBlock, FluxKontextModelName
 from backend.blocks.ideogram import IdeogramModelBlock
+from backend.blocks.jina.chunking import JinaChunkingBlock
 from backend.blocks.jina.embeddings import JinaEmbeddingBlock
 from backend.blocks.jina.fact_checker import FactCheckerBlock
 from backend.blocks.jina.search import ExtractWebsiteContentBlock, SearchTheWebBlock
@@ -956,12 +957,9 @@ BLOCK_COSTS: dict[Type[Block], list[BlockCost]] = {
             },
         )
     ],
-    # ClaudeCodeBlock runs an E2B sandbox (~$0.00003/sec compute) AND
-    # executes Claude Sonnet inside it. Real session cost is dominated by
-    # the LLM and varies $0.50–$2 per typical run. Flat 100 credits ($1.00)
-    # is a conservative-but-fair estimate; revisit once we expose the
-    # x-total-cost header from the in-sandbox Claude calls back to
-    # NodeExecutionStats.provider_cost.
+    # ClaudeCodeBlock runs an E2B sandbox AND executes Claude Sonnet inside it.
+    # Real cost $0.50-$2/run; flat 100 credits is conservative until we pipe
+    # x-total-cost from the in-sandbox Claude calls into provider_cost.
     ClaudeCodeBlock: [
         BlockCost(
             cost_amount=100,
@@ -970,6 +968,24 @@ BLOCK_COSTS: dict[Type[Block], list[BlockCost]] = {
                     "id": e2b_credentials.id,
                     "provider": e2b_credentials.provider,
                     "type": e2b_credentials.type,
+                }
+            },
+        )
+    ],
+    # Ayrshare post blocks use the @cost(...) decorator directly on each block
+    # class (see backend/blocks/ayrshare/_cost.py). They can't be listed here
+    # because post_to_*.py imports from backend.sdk, which imports from this
+    # module — registering via decorator avoids the circular import.
+    # Jina chunking: $0.02/1M tokens. Flat 1 credit floor so the block is not
+    # wallet-free; embedding/search already have their own entries.
+    JinaChunkingBlock: [
+        BlockCost(
+            cost_amount=1,
+            cost_filter={
+                "credentials": {
+                    "id": jina_credentials.id,
+                    "provider": jina_credentials.provider,
+                    "type": jina_credentials.type,
                 }
             },
         )

--- a/autogpt_platform/backend/backend/data/block_cost_config.py
+++ b/autogpt_platform/backend/backend/data/block_cost_config.py
@@ -13,6 +13,11 @@ from backend.blocks.apollo.organization import SearchOrganizationsBlock
 from backend.blocks.apollo.people import SearchPeopleBlock
 from backend.blocks.apollo.person import GetPersonDetailBlock
 from backend.blocks.claude_code import ClaudeCodeBlock
+from backend.blocks.code_executor import (
+    ExecuteCodeBlock,
+    ExecuteCodeStepBlock,
+    InstantiateCodeSandboxBlock,
+)
 from backend.blocks.codex import CodeGenerationBlock, CodexModel
 from backend.blocks.enrichlayer.linkedin import (
     GetLinkedinProfileBlock,
@@ -20,6 +25,7 @@ from backend.blocks.enrichlayer.linkedin import (
     LinkedinPersonLookupBlock,
     LinkedinRoleLookupBlock,
 )
+from backend.blocks.fal.ai_video_generator import AIVideoGeneratorBlock
 from backend.blocks.flux_kontext import AIImageEditorBlock, FluxKontextModelName
 from backend.blocks.ideogram import IdeogramModelBlock
 from backend.blocks.jina.chunking import JinaChunkingBlock
@@ -55,6 +61,7 @@ from backend.blocks.smartlead.campaign import (
 from backend.blocks.talking_head import CreateTalkingAvatarVideoBlock
 from backend.blocks.text_to_speech_block import UnrealTextToSpeechBlock
 from backend.blocks.video.narration import VideoNarrationBlock
+from backend.blocks.youtube import TranscribeYoutubeVideoBlock
 from backend.blocks.zerobounce.validate_emails import ValidateEmailsBlock
 from backend.integrations.credentials_store import (
     aiml_api_credentials,
@@ -64,6 +71,7 @@ from backend.integrations.credentials_store import (
     e2b_credentials,
     elevenlabs_credentials,
     enrichlayer_credentials,
+    fal_credentials,
     groq_credentials,
     ideogram_credentials,
     jina_credentials,
@@ -78,6 +86,7 @@ from backend.integrations.credentials_store import (
     smartlead_credentials,
     unreal_credentials,
     v0_credentials,
+    webshare_proxy_credentials,
     zerobounce_credentials,
 )
 
@@ -976,6 +985,76 @@ BLOCK_COSTS: dict[Type[Block], list[BlockCost]] = {
     # class (see backend/blocks/ayrshare/_cost.py). They can't be listed here
     # because post_to_*.py imports from backend.sdk, which imports from this
     # module — registering via decorator avoids the circular import.
+    # E2B code-execution blocks: Hobby tier ~$0.000014/vCPU-s. A typical 30s
+    # sandbox with 2 vCPU is ~$0.00084. Flat 2 credits covers the floor with
+    # margin; accurate per-second billing happens via walltime-based resolver
+    # in the dynamic-pricing follow-up.
+    ExecuteCodeBlock: [
+        BlockCost(
+            cost_amount=2,
+            cost_filter={
+                "credentials": {
+                    "id": e2b_credentials.id,
+                    "provider": e2b_credentials.provider,
+                    "type": e2b_credentials.type,
+                }
+            },
+        )
+    ],
+    InstantiateCodeSandboxBlock: [
+        BlockCost(
+            cost_amount=2,
+            cost_filter={
+                "credentials": {
+                    "id": e2b_credentials.id,
+                    "provider": e2b_credentials.provider,
+                    "type": e2b_credentials.type,
+                }
+            },
+        )
+    ],
+    ExecuteCodeStepBlock: [
+        BlockCost(
+            cost_amount=2,
+            cost_filter={
+                "credentials": {
+                    "id": e2b_credentials.id,
+                    "provider": e2b_credentials.provider,
+                    "type": e2b_credentials.type,
+                }
+            },
+        )
+    ],
+    # FAL video generation: $0.001-$0.02 per output second. A 5s clip costs
+    # us ~$0.05-$0.10 in practice. 10 credits is a safe floor until walltime
+    # billing lands.
+    AIVideoGeneratorBlock: [
+        BlockCost(
+            cost_amount=10,
+            cost_filter={
+                "credentials": {
+                    "id": fal_credentials.id,
+                    "provider": fal_credentials.provider,
+                    "type": fal_credentials.type,
+                }
+            },
+        )
+    ],
+    # Webshare is a flat monthly proxy subscription — the per-call cost to us
+    # is effectively zero, but the transcription step itself consumes compute
+    # time we haven't otherwise charged for. 1 credit is a tooling-tax floor.
+    TranscribeYoutubeVideoBlock: [
+        BlockCost(
+            cost_amount=1,
+            cost_filter={
+                "credentials": {
+                    "id": webshare_proxy_credentials.id,
+                    "provider": webshare_proxy_credentials.provider,
+                    "type": webshare_proxy_credentials.type,
+                }
+            },
+        )
+    ],
     # Jina chunking: $0.02/1M tokens. Flat 1 credit floor so the block is not
     # wallet-free; embedding/search already have their own entries.
     JinaChunkingBlock: [

--- a/autogpt_platform/backend/backend/data/block_cost_config_test.py
+++ b/autogpt_platform/backend/backend/data/block_cost_config_test.py
@@ -63,3 +63,61 @@ def test_bannerbear_base_cost_is_three_credits():
     block = BannerbearTextOverlayBlock()
     cost, _ = block_usage_cost(block, {})
     assert cost == 3
+
+
+def test_e2b_sandbox_blocks_have_two_credit_floor():
+    from backend.blocks.code_executor import (
+        ExecuteCodeBlock,
+        ExecuteCodeStepBlock,
+        InstantiateCodeSandboxBlock,
+    )
+    from backend.integrations.credentials_store import e2b_credentials
+
+    creds = {
+        "credentials": {
+            "id": e2b_credentials.id,
+            "provider": e2b_credentials.provider,
+            "type": e2b_credentials.type,
+        }
+    }
+    for block_cls in (
+        ExecuteCodeBlock,
+        InstantiateCodeSandboxBlock,
+        ExecuteCodeStepBlock,
+    ):
+        cost, _ = block_usage_cost(block_cls(), creds)
+        assert cost == 2, f"{block_cls.__name__} floor must be 2 credits, got {cost}"
+
+
+def test_fal_video_generator_has_ten_credit_floor():
+    from backend.blocks.fal.ai_video_generator import AIVideoGeneratorBlock
+    from backend.integrations.credentials_store import fal_credentials
+
+    cost, _ = block_usage_cost(
+        AIVideoGeneratorBlock(),
+        {
+            "credentials": {
+                "id": fal_credentials.id,
+                "provider": fal_credentials.provider,
+                "type": fal_credentials.type,
+            }
+        },
+    )
+    assert cost == 10
+
+
+def test_transcribe_youtube_has_one_credit_tooling_floor():
+    from backend.blocks.youtube import TranscribeYoutubeVideoBlock
+    from backend.integrations.credentials_store import webshare_proxy_credentials
+
+    cost, _ = block_usage_cost(
+        TranscribeYoutubeVideoBlock(),
+        {
+            "credentials": {
+                "id": webshare_proxy_credentials.id,
+                "provider": webshare_proxy_credentials.provider,
+                "type": webshare_proxy_credentials.type,
+            }
+        },
+    )
+    assert cost == 1

--- a/autogpt_platform/backend/backend/data/block_cost_config_test.py
+++ b/autogpt_platform/backend/backend/data/block_cost_config_test.py
@@ -14,10 +14,22 @@ from backend.blocks.ayrshare.post_to_tiktok import PostToTikTokBlock
 from backend.blocks.ayrshare.post_to_x import PostToXBlock
 from backend.blocks.ayrshare.post_to_youtube import PostToYouTubeBlock
 from backend.blocks.bannerbear.text_overlay import BannerbearTextOverlayBlock
+from backend.blocks.code_executor import (
+    ExecuteCodeBlock,
+    ExecuteCodeStepBlock,
+    InstantiateCodeSandboxBlock,
+)
+from backend.blocks.fal.ai_video_generator import AIVideoGeneratorBlock
 from backend.blocks.jina.chunking import JinaChunkingBlock
+from backend.blocks.youtube import TranscribeYoutubeVideoBlock
 from backend.data.block_cost_config import BLOCK_COSTS
 from backend.executor.utils import block_usage_cost
-from backend.integrations.credentials_store import jina_credentials
+from backend.integrations.credentials_store import (
+    e2b_credentials,
+    fal_credentials,
+    jina_credentials,
+    webshare_proxy_credentials,
+)
 
 ALL_AYRSHARE_BLOCKS = [
     PostToBlueskyBlock,
@@ -100,13 +112,6 @@ def test_bannerbear_base_cost_is_three_credits():
 
 
 def test_e2b_sandbox_blocks_have_two_credit_floor():
-    from backend.blocks.code_executor import (
-        ExecuteCodeBlock,
-        ExecuteCodeStepBlock,
-        InstantiateCodeSandboxBlock,
-    )
-    from backend.integrations.credentials_store import e2b_credentials
-
     creds = {
         "credentials": {
             "id": e2b_credentials.id,
@@ -124,9 +129,6 @@ def test_e2b_sandbox_blocks_have_two_credit_floor():
 
 
 def test_fal_video_generator_has_ten_credit_floor():
-    from backend.blocks.fal.ai_video_generator import AIVideoGeneratorBlock
-    from backend.integrations.credentials_store import fal_credentials
-
     cost, _ = block_usage_cost(
         AIVideoGeneratorBlock(),
         {
@@ -141,9 +143,6 @@ def test_fal_video_generator_has_ten_credit_floor():
 
 
 def test_transcribe_youtube_has_one_credit_tooling_floor():
-    from backend.blocks.youtube import TranscribeYoutubeVideoBlock
-    from backend.integrations.credentials_store import webshare_proxy_credentials
-
     cost, _ = block_usage_cost(
         TranscribeYoutubeVideoBlock(),
         {

--- a/autogpt_platform/backend/backend/data/block_cost_config_test.py
+++ b/autogpt_platform/backend/backend/data/block_cost_config_test.py
@@ -1,0 +1,65 @@
+import pytest
+
+from backend.blocks.ayrshare.post_to_x import PostToXBlock
+from backend.blocks.bannerbear.text_overlay import BannerbearTextOverlayBlock
+from backend.blocks.jina.chunking import JinaChunkingBlock
+from backend.data.block_cost_config import BLOCK_COSTS
+from backend.executor.utils import block_usage_cost
+
+
+@pytest.mark.parametrize(
+    "block_class",
+    [
+        # Spot-check one block per credential source to keep the suite fast; the
+        # per-block tier tuple is built from a shared dict comprehension so
+        # covering every social platform here would be redundant.
+        PostToXBlock,
+    ],
+)
+def test_ayrshare_block_has_video_and_default_tier(block_class):
+    costs = BLOCK_COSTS.get(block_class)
+    assert costs is not None and len(costs) == 2
+    amounts = {c.cost_amount for c in costs}
+    assert amounts == {2, 5}
+
+
+def test_ayrshare_video_post_charges_video_tier():
+    block = PostToXBlock()
+    cost, _ = block_usage_cost(block, {"is_video": True})
+    assert cost == 5
+
+
+def test_ayrshare_non_video_post_charges_default_tier():
+    block = PostToXBlock()
+    cost, _ = block_usage_cost(block, {"is_video": False})
+    assert cost == 2
+
+
+def test_ayrshare_default_is_video_false_still_matches_default_tier():
+    block = PostToXBlock()
+    cost, _ = block_usage_cost(block, {})
+    assert cost == 2
+
+
+def test_jina_chunking_has_flat_cost_floor():
+    from backend.integrations.credentials_store import jina_credentials
+
+    block = JinaChunkingBlock()
+    cost, _ = block_usage_cost(
+        block,
+        {
+            "credentials": {
+                "id": jina_credentials.id,
+                "provider": jina_credentials.provider,
+                "type": jina_credentials.type,
+            }
+        },
+    )
+    assert cost == 1
+
+
+def test_bannerbear_base_cost_is_three_credits():
+    # Bannerbear is registered via the SDK ProviderBuilder with base_cost=3.
+    block = BannerbearTextOverlayBlock()
+    cost, _ = block_usage_cost(block, {})
+    assert cost == 3

--- a/autogpt_platform/backend/backend/data/block_cost_config_test.py
+++ b/autogpt_platform/backend/backend/data/block_cost_config_test.py
@@ -1,21 +1,46 @@
 import pytest
 
+from backend.blocks.ayrshare.post_to_bluesky import PostToBlueskyBlock
+from backend.blocks.ayrshare.post_to_facebook import PostToFacebookBlock
+from backend.blocks.ayrshare.post_to_gmb import PostToGMBBlock
+from backend.blocks.ayrshare.post_to_instagram import PostToInstagramBlock
+from backend.blocks.ayrshare.post_to_linkedin import PostToLinkedInBlock
+from backend.blocks.ayrshare.post_to_pinterest import PostToPinterestBlock
+from backend.blocks.ayrshare.post_to_reddit import PostToRedditBlock
+from backend.blocks.ayrshare.post_to_snapchat import PostToSnapchatBlock
+from backend.blocks.ayrshare.post_to_telegram import PostToTelegramBlock
+from backend.blocks.ayrshare.post_to_threads import PostToThreadsBlock
+from backend.blocks.ayrshare.post_to_tiktok import PostToTikTokBlock
 from backend.blocks.ayrshare.post_to_x import PostToXBlock
+from backend.blocks.ayrshare.post_to_youtube import PostToYouTubeBlock
 from backend.blocks.bannerbear.text_overlay import BannerbearTextOverlayBlock
 from backend.blocks.jina.chunking import JinaChunkingBlock
 from backend.data.block_cost_config import BLOCK_COSTS
 from backend.executor.utils import block_usage_cost
+from backend.integrations.credentials_store import jina_credentials
+
+ALL_AYRSHARE_BLOCKS = [
+    PostToBlueskyBlock,
+    PostToFacebookBlock,
+    PostToGMBBlock,
+    PostToInstagramBlock,
+    PostToLinkedInBlock,
+    PostToPinterestBlock,
+    PostToRedditBlock,
+    PostToSnapchatBlock,
+    PostToTelegramBlock,
+    PostToThreadsBlock,
+    PostToTikTokBlock,
+    PostToXBlock,
+    PostToYouTubeBlock,
+]
+
+# YouTube and Snapchat are video-only platforms, so their Input overrides
+# is_video default to True; the @cost filter should pick the 5-credit tier.
+AYRSHARE_VIDEO_ONLY_BLOCKS = [PostToYouTubeBlock, PostToSnapchatBlock]
 
 
-@pytest.mark.parametrize(
-    "block_class",
-    [
-        # Spot-check one block per credential source to keep the suite fast; the
-        # per-block tier tuple is built from a shared dict comprehension so
-        # covering every social platform here would be redundant.
-        PostToXBlock,
-    ],
-)
+@pytest.mark.parametrize("block_class", ALL_AYRSHARE_BLOCKS)
 def test_ayrshare_block_has_video_and_default_tier(block_class):
     costs = BLOCK_COSTS.get(block_class)
     assert costs is not None and len(costs) == 2
@@ -41,9 +66,18 @@ def test_ayrshare_default_is_video_false_still_matches_default_tier():
     assert cost == 2
 
 
-def test_jina_chunking_has_flat_cost_floor():
-    from backend.integrations.credentials_store import jina_credentials
+@pytest.mark.parametrize("block_class", AYRSHARE_VIDEO_ONLY_BLOCKS)
+def test_ayrshare_video_only_block_defaults_to_video_tier(block_class):
+    # Video-only platforms override is_video default to True so billing matches
+    # the is_video=True passed into client.create_post.
+    block = block_class()
+    default_is_video = block.input_schema.model_fields["is_video"].default
+    assert default_is_video is True
+    cost, _ = block_usage_cost(block, {"is_video": default_is_video})
+    assert cost == 5
 
+
+def test_jina_chunking_has_flat_cost_floor():
     block = JinaChunkingBlock()
     cost, _ = block_usage_cost(
         block,

--- a/autogpt_platform/backend/backend/sdk/cost_integration.py
+++ b/autogpt_platform/backend/backend/sdk/cost_integration.py
@@ -1,16 +1,18 @@
 """
 Integration between SDK provider costs and the execution cost system.
 
-This module provides the glue between provider-defined base costs and the 
+This module provides the glue between provider-defined base costs and the
 BLOCK_COSTS configuration used by the execution system.
 """
 
 import logging
-from typing import List, Type
+from typing import List, Type, TypeVar
 
 from backend.blocks._base import Block, BlockCost
 from backend.data.block_cost_config import BLOCK_COSTS
 from backend.sdk.registry import AutoRegistry
+
+BlockT = TypeVar("BlockT", bound=Type[Block])
 
 logger = logging.getLogger(__name__)
 
@@ -150,7 +152,7 @@ def cost(*costs: BlockCost):
         *costs: Variable number of BlockCost objects
     """
 
-    def decorator(block_class: Type[Block]) -> Type[Block]:
+    def decorator(block_class: BlockT) -> BlockT:
         # Register the costs for this block
         if costs:
             BLOCK_COSTS[block_class] = list(costs)

--- a/docs/integrations/block-integrations/ayrshare/post_to_bluesky.md
+++ b/docs/integrations/block-integrations/ayrshare/post_to_bluesky.md
@@ -21,7 +21,7 @@ The block authenticates through your Ayrshare credentials and sends the post dat
 |-------|-------------|------|----------|
 | post | The post text to be published (max 300 characters for Bluesky) | str | No |
 | media_urls | Optional list of media URLs to include. Bluesky supports up to 4 images or 1 video. | List[str] | No |
-| is_video | Whether the media is a video | bool | No |
+| is_video | Whether the media is a video. Set to True when uploading a video so billing applies the video tier. | bool | No |
 | schedule_date | UTC datetime for scheduling (YYYY-MM-DDThh:mm:ssZ) | str (date-time) | No |
 | disable_comments | Whether to disable comments | bool | No |
 | shorten_links | Whether to shorten links | bool | No |

--- a/docs/integrations/block-integrations/ayrshare/post_to_facebook.md
+++ b/docs/integrations/block-integrations/ayrshare/post_to_facebook.md
@@ -21,7 +21,7 @@ The block authenticates through Ayrshare and leverages the Meta Graph API to han
 |-------|-------------|------|----------|
 | post | The post text to be published | str | No |
 | media_urls | Optional list of media URLs to include. Set is_video in advanced settings to true if you want to upload videos. | List[str] | No |
-| is_video | Whether the media is a video | bool | No |
+| is_video | Whether the media is a video. Set to True when uploading a video so billing applies the video tier. | bool | No |
 | schedule_date | UTC datetime for scheduling (YYYY-MM-DDThh:mm:ssZ) | str (date-time) | No |
 | disable_comments | Whether to disable comments | bool | No |
 | shorten_links | Whether to shorten links | bool | No |

--- a/docs/integrations/block-integrations/ayrshare/post_to_gmb.md
+++ b/docs/integrations/block-integrations/ayrshare/post_to_gmb.md
@@ -21,7 +21,7 @@ The block integrates with Google's Business Profile API through Ayrshare, enabli
 |-------|-------------|------|----------|
 | post | The post text to be published | str | No |
 | media_urls | Optional list of media URLs. GMB supports only one image or video per post. | List[str] | No |
-| is_video | Whether the media is a video | bool | No |
+| is_video | Whether the media is a video. Set to True when uploading a video so billing applies the video tier. | bool | No |
 | schedule_date | UTC datetime for scheduling (YYYY-MM-DDThh:mm:ssZ) | str (date-time) | No |
 | disable_comments | Whether to disable comments | bool | No |
 | shorten_links | Whether to shorten links | bool | No |

--- a/docs/integrations/block-integrations/ayrshare/post_to_instagram.md
+++ b/docs/integrations/block-integrations/ayrshare/post_to_instagram.md
@@ -21,7 +21,7 @@ The block requires an Instagram account connected to a Facebook Page and authent
 |-------|-------------|------|----------|
 | post | The post text (max 2,200 chars, up to 30 hashtags, 3 @mentions) | str | No |
 | media_urls | Optional list of media URLs. Instagram supports up to 10 images/videos in a carousel. | List[str] | No |
-| is_video | Whether the media is a video | bool | No |
+| is_video | Whether the media is a video. Set to True when uploading a video so billing applies the video tier. | bool | No |
 | schedule_date | UTC datetime for scheduling (YYYY-MM-DDThh:mm:ssZ) | str (date-time) | No |
 | disable_comments | Whether to disable comments | bool | No |
 | shorten_links | Whether to shorten links | bool | No |

--- a/docs/integrations/block-integrations/ayrshare/post_to_linkedin.md
+++ b/docs/integrations/block-integrations/ayrshare/post_to_linkedin.md
@@ -19,7 +19,7 @@ _Add technical explanation here._
 |-------|-------------|------|----------|
 | post | The post text (max 3,000 chars, hashtags supported with #) | str | No |
 | media_urls | Optional list of media URLs. LinkedIn supports up to 9 images, videos, or documents (PPT, PPTX, DOC, DOCX, PDF <100MB, <300 pages). | List[str] | No |
-| is_video | Whether the media is a video | bool | No |
+| is_video | Whether the media is a video. Set to True when uploading a video so billing applies the video tier. | bool | No |
 | schedule_date | UTC datetime for scheduling (YYYY-MM-DDThh:mm:ssZ) | str (date-time) | No |
 | disable_comments | Whether to disable comments | bool | No |
 | shorten_links | Whether to shorten links | bool | No |

--- a/docs/integrations/block-integrations/ayrshare/post_to_pinterest.md
+++ b/docs/integrations/block-integrations/ayrshare/post_to_pinterest.md
@@ -21,7 +21,7 @@ The block connects to Pinterest's API through Ayrshare, allowing you to specify 
 |-------|-------------|------|----------|
 | post | Pin description (max 500 chars, links not clickable - use link field instead) | str | No |
 | media_urls | Required image/video URLs. Pinterest requires at least one image. Videos need thumbnail. Up to 5 images for carousel. | List[str] | No |
-| is_video | Whether the media is a video | bool | No |
+| is_video | Whether the media is a video. Set to True when uploading a video so billing applies the video tier. | bool | No |
 | schedule_date | UTC datetime for scheduling (YYYY-MM-DDThh:mm:ssZ) | str (date-time) | No |
 | disable_comments | Whether to disable comments | bool | No |
 | shorten_links | Whether to shorten links | bool | No |

--- a/docs/integrations/block-integrations/ayrshare/post_to_reddit.md
+++ b/docs/integrations/block-integrations/ayrshare/post_to_reddit.md
@@ -21,7 +21,7 @@ The block authenticates through Ayrshare and submits content to your connected R
 |-------|-------------|------|----------|
 | post | The post text to be published | str | No |
 | media_urls | Optional list of media URLs to include. Set is_video in advanced settings to true if you want to upload videos. | List[str] | No |
-| is_video | Whether the media is a video | bool | No |
+| is_video | Whether the media is a video. Set to True when uploading a video so billing applies the video tier. | bool | No |
 | schedule_date | UTC datetime for scheduling (YYYY-MM-DDThh:mm:ssZ) | str (date-time) | No |
 | disable_comments | Whether to disable comments | bool | No |
 | shorten_links | Whether to shorten links | bool | No |

--- a/docs/integrations/block-integrations/ayrshare/post_to_snapchat.md
+++ b/docs/integrations/block-integrations/ayrshare/post_to_snapchat.md
@@ -21,7 +21,7 @@ The block authenticates through Ayrshare and uploads video content with optional
 |-------|-------------|------|----------|
 | post | The post text (optional for video-only content) | str | No |
 | media_urls | Required video URL for Snapchat posts. Snapchat only supports video content. | List[str] | No |
-| is_video | Whether the media is a video | bool | No |
+| is_video | Whether the media is a video (always True for Snapchat) | bool | No |
 | schedule_date | UTC datetime for scheduling (YYYY-MM-DDThh:mm:ssZ) | str (date-time) | No |
 | disable_comments | Whether to disable comments | bool | No |
 | shorten_links | Whether to shorten links | bool | No |

--- a/docs/integrations/block-integrations/ayrshare/post_to_threads.md
+++ b/docs/integrations/block-integrations/ayrshare/post_to_threads.md
@@ -21,7 +21,7 @@ The block authenticates through Meta's API via Ayrshare. Content can mention use
 |-------|-------------|------|----------|
 | post | The post text (max 500 chars, empty string allowed). Only 1 hashtag allowed. Use @handle to mention users. | str | No |
 | media_urls | Optional list of media URLs. Supports up to 20 images/videos in a carousel. Auto-preview links unless media is included. | List[str] | No |
-| is_video | Whether the media is a video | bool | No |
+| is_video | Whether the media is a video. Set to True when uploading a video so billing applies the video tier. | bool | No |
 | schedule_date | UTC datetime for scheduling (YYYY-MM-DDThh:mm:ssZ) | str (date-time) | No |
 | disable_comments | Whether to disable comments | bool | No |
 | shorten_links | Whether to shorten links | bool | No |

--- a/docs/integrations/block-integrations/ayrshare/post_to_tiktok.md
+++ b/docs/integrations/block-integrations/ayrshare/post_to_tiktok.md
@@ -21,7 +21,7 @@ The block connects to TikTok's API through Ayrshare with controls for visibility
 |-------|-------------|------|----------|
 | post | The post text (max 2,200 chars, empty string allowed). Use @handle to mention users. Line breaks will be ignored. | str | Yes |
 | media_urls | Required media URLs. Either 1 video OR up to 35 images (JPG/JPEG/WEBP only). Cannot mix video and images. | List[str] | No |
-| is_video | Whether the media is a video | bool | No |
+| is_video | Whether the media is a video. Set to True when uploading a video so billing applies the video tier. | bool | No |
 | schedule_date | UTC datetime for scheduling (YYYY-MM-DDThh:mm:ssZ) | str (date-time) | No |
 | disable_comments | Disable comments on the published post | bool | No |
 | shorten_links | Whether to shorten links | bool | No |

--- a/docs/integrations/block-integrations/ayrshare/post_to_x.md
+++ b/docs/integrations/block-integrations/ayrshare/post_to_x.md
@@ -21,7 +21,7 @@ The block authenticates through Ayrshare and handles X-specific features like au
 |-------|-------------|------|----------|
 | post | The post text (max 280 chars, up to 25,000 for Premium users). Use @handle to mention users. Use \n\n for thread breaks. | str | Yes |
 | media_urls | Optional list of media URLs. X supports up to 4 images or videos per tweet. Auto-preview links unless media is included. | List[str] | No |
-| is_video | Whether the media is a video | bool | No |
+| is_video | Whether the media is a video. Set to True when uploading a video so billing applies the video tier. | bool | No |
 | schedule_date | UTC datetime for scheduling (YYYY-MM-DDThh:mm:ssZ) | str (date-time) | No |
 | disable_comments | Whether to disable comments | bool | No |
 | shorten_links | Whether to shorten links | bool | No |

--- a/docs/integrations/block-integrations/ayrshare/post_to_youtube.md
+++ b/docs/integrations/block-integrations/ayrshare/post_to_youtube.md
@@ -19,7 +19,7 @@ _Add technical explanation here._
 |-------|-------------|------|----------|
 | post | Video description (max 5,000 chars, empty string allowed). Cannot contain < or > characters. | str | Yes |
 | media_urls | Required video URL. YouTube only supports 1 video per post. | List[str] | No |
-| is_video | Whether the media is a video | bool | No |
+| is_video | Whether the media is a video (always True for YouTube) | bool | No |
 | schedule_date | UTC datetime for scheduling (YYYY-MM-DDThh:mm:ssZ) | str (date-time) | No |
 | disable_comments | Whether to disable comments | bool | No |
 | shorten_links | Whether to shorten links | bool | No |


### PR DESCRIPTION
## Why

The cost-tracking audit on 2026-04-23 ([Platform System Credentials](https://www.notion.so/auto-gpt/4d251f343fe146bcb91b6a037d1bfc3c)) surfaced three gaps where the user wallet was silently subsidising third-party spend:

1. **Ayrshare (13 blocks)** — zero charge on every social post. No `BLOCK_COSTS` entry, no SDK `.with_base_cost` registration. Platform absorbs the entire ~$149/mo Business plan.
2. **Bannerbear** — flat 1 credit/call below the ~$0.025/image unit cost on the Starter tier ($49/mo / 2K images).
3. **JinaChunkingBlock** — wallet-free; siblings (`JinaEmbeddingBlock`, `SearchTheWebBlock`) are charged.

## What

- New `backend/blocks/ayrshare/_cost.py` with two-tier `AYRSHARE_POST_COSTS` (5 credits when `is_video=True`, 2 credits otherwise — first-match wins in `block_usage_cost`).
- All 13 `PostTo*Block` classes decorated with `@cost(*AYRSHARE_POST_COSTS)`.
- `BannerbearTextOverlayBlock` floor: 1 → 3 credits in `bannerbear/_config.py`.
- `JinaChunkingBlock` added to `BLOCK_COSTS` with a flat 1-credit floor.
- `cost(...)` decorator generic-ized via `TypeVar`, so pyright retains `PostToXBlock.Input/Output` narrowing.

## How

Ayrshare uses a decorator-based registration (not a direct `BLOCK_COSTS` entry) because each `post_to_*.py` block imports from `backend.sdk`, and `backend.sdk.cost_integration` imports `BLOCK_COSTS` — listing the blocks in `block_cost_config.py` would create a circular import. The `@cost` decorator defined in `sdk/cost_integration.py` was already the approved escape hatch for this exact shape.

cost_filter in `block_usage_cost` already supports boolean-field matching (see Apollo's `enrich_info` tier), so `{"is_video": True}` and `{"is_video": False}` select the right tier at execution time. `is_video` defaults to `False` on `BaseAyrshareInput`, so posts that omit the field still land on the 2-credit default.

## Test plan

- [x] `poetry run pytest backend/data/block_cost_config_test.py` — new 6-test suite covers Ayrshare video/non-video/default tiers, the Bannerbear floor, and the Jina chunking floor
- [x] `poetry run pytest backend/executor/manager_cost_tracking_test.py` — no regressions (45 pre-existing tests still pass)
- [x] `poetry run ruff format` + `poetry run isort` + `poetry run ruff check --fix`
- [x] `poetry run pyright` on touched files — 0 errors, 0 warnings (pre-existing `LlmModel.KIMI_K2_*` errors are on dev and unrelated)
- [ ] Manual: run an Ayrshare post through the builder and confirm 2cr (text/image) vs 5cr (video) charge
