### PR TITLE
fix(frontend): filter null query params (#11237) and redirect www to non-www (#9188)

### DIFF
--- a/autogpt_platform/frontend/src/lib/autogpt-server-api/helpers.ts
+++ b/autogpt_platform/frontend/src/lib/autogpt-server-api/helpers.ts
@@ -68,10 +68,11 @@ export function buildUrlWithQuery(
 ): string {
   if (!query) return url;
 
-  // Filter out undefined values to prevent them from being included as "undefined" strings
+  // Filter out undefined and null values to prevent them from being included
+  // as "undefined" / "null" strings in query parameters (fixes #11237)
   const filteredQuery = Object.entries(query).reduce(
     (acc, [key, value]) => {
-      if (value !== undefined) {
+      if (value !== undefined && value !== null) {
         acc[key] = value;
       }
       return acc;

--- a/autogpt_platform/frontend/src/middleware.ts
+++ b/autogpt_platform/frontend/src/middleware.ts
@@ -1,7 +1,15 @@
 import { updateSession } from "@/lib/supabase/middleware";
-import { type NextRequest } from "next/server";
+import { NextResponse, type NextRequest } from "next/server";
 
 export async function middleware(request: NextRequest) {
+  // Redirect www to non-www to prevent cookie/auth domain mismatch (#9188)
+  const host = request.headers.get("host") || "";
+  if (host.startsWith("www.")) {
+    const url = request.nextUrl.clone();
+    url.host = host.replace(/^www\./, "");
+    return NextResponse.redirect(url, 301);
+  }
+
   return await updateSession(request);
 }
 


### PR DESCRIPTION
## Summary

Two frontend bug fixes:

### 1. Filter null values in query parameters (fixes #11237)

**Problem**: `buildUrlWithQuery()` in `helpers.ts` only filtered `undefined` values but not `null`. When `graphVersion` was `null`, the string `"null"` was sent as a query parameter, causing FastAPI to return a 422 validation error (expects `int`).

**Fix**: Added `value !== null` check alongside the existing `value !== undefined` filter in `buildUrlWithQuery()`.

### 2. Redirect www to non-www (fixes #9188)

**Problem**: Accessing the platform via `www.platform.agpt.co` breaks authentication because Supabase Auth cookies are bound to `platform.agpt.co`. The `www.` subdomain is a different origin, so cookies aren't sent → auth fails → white screen or redirect loop.

**Fix**: Added a 301 redirect in `middleware.ts` that strips the `www.` prefix before the Supabase session check runs.

## Changes

- `autogpt_platform/frontend/src/lib/autogpt-server-api/helpers.ts`: `buildUrlWithQuery` now filters both `undefined` and `null`
- `autogpt_platform/frontend/src/middleware.ts`: www → non-www 301 redirect

## Testing

- Verified `URLSearchParams` behavior: `null` values pass through as `"null"` strings while `undefined` is already filtered
- The www redirect is a standard pattern used in Next.js middleware