### PR TITLE
fix(backend/copilot): surface non-zero E2B exits as real results, not sandbox errors

### DIFF
--- a/autogpt_platform/backend/backend/copilot/tools/bash_exec.py
+++ b/autogpt_platform/backend/backend/copilot/tools/bash_exec.py
@@ -35,7 +35,7 @@ from .sandbox import get_workspace_dir, has_full_sandbox, run_sandboxed
 logger = logging.getLogger(__name__)
 
 
-def _build_response(
+def _build_completion_response(
     stdout: str | None,
     stderr: str | None,
     exit_code: int,
@@ -197,7 +197,7 @@ class BashExecTool(BaseTool):
                 timeout=timeout,
                 envs=envs,
             )
-            return _build_response(
+            return _build_completion_response(
                 result.stdout,
                 result.stderr,
                 result.exit_code,
@@ -205,7 +205,7 @@ class BashExecTool(BaseTool):
                 session_id,
             )
         except CommandExitException as exc:
-            return _build_response(
+            return _build_completion_response(
                 exc.stdout, exc.stderr, exc.exit_code, secret_values, session_id
             )
         except TimeoutException:

--- a/autogpt_platform/backend/backend/copilot/tools/bash_exec.py
+++ b/autogpt_platform/backend/backend/copilot/tools/bash_exec.py
@@ -18,7 +18,7 @@ import logging
 import shlex
 from typing import Any
 
-from e2b import AsyncSandbox
+from e2b import AsyncSandbox, CommandExitException
 from e2b.exceptions import TimeoutException
 
 from backend.copilot.context import E2B_WORKDIR, get_current_sandbox
@@ -33,6 +33,28 @@ from .models import BashExecResponse, ErrorResponse, ToolResponseBase
 from .sandbox import get_workspace_dir, has_full_sandbox, run_sandboxed
 
 logger = logging.getLogger(__name__)
+
+
+def _build_response(
+    stdout: str | None,
+    stderr: str | None,
+    exit_code: int,
+    secret_values: list[str],
+    session_id: str | None,
+) -> BashExecResponse:
+    out = stdout or ""
+    err = stderr or ""
+    for secret in secret_values:
+        out = out.replace(secret, "[REDACTED]")
+        err = err.replace(secret, "[REDACTED]")
+    return BashExecResponse(
+        message=f"Command executed with status code {exit_code}",
+        stdout=out,
+        stderr=err,
+        exit_code=exit_code,
+        timed_out=False,
+        session_id=session_id,
+    )
 
 
 class BashExecTool(BaseTool):
@@ -175,31 +197,27 @@ class BashExecTool(BaseTool):
                 timeout=timeout,
                 envs=envs,
             )
-            stdout = result.stdout or ""
-            stderr = result.stderr or ""
-            # Scrub injected tokens from command output to prevent exfiltration
-            # via `echo $GH_TOKEN`, `env`, `printenv`, etc.
-            for secret in secret_values:
-                stdout = stdout.replace(secret, "[REDACTED]")
-                stderr = stderr.replace(secret, "[REDACTED]")
+            return _build_response(
+                result.stdout,
+                result.stderr,
+                result.exit_code,
+                secret_values,
+                session_id,
+            )
+        except CommandExitException as exc:
+            return _build_response(
+                exc.stdout, exc.stderr, exc.exit_code, secret_values, session_id
+            )
+        except TimeoutException:
             return BashExecResponse(
-                message=f"Command executed with status code {result.exit_code}",
-                stdout=stdout,
-                stderr=stderr,
-                exit_code=result.exit_code,
-                timed_out=False,
+                message="Execution timed out",
+                stdout="",
+                stderr=f"Timed out after {timeout}s",
+                exit_code=-1,
+                timed_out=True,
                 session_id=session_id,
             )
         except Exception as exc:
-            if isinstance(exc, TimeoutException):
-                return BashExecResponse(
-                    message="Execution timed out",
-                    stdout="",
-                    stderr=f"Timed out after {timeout}s",
-                    exit_code=-1,
-                    timed_out=True,
-                    session_id=session_id,
-                )
             logger.error("[E2B] bash_exec failed: %s", exc, exc_info=True)
             return ErrorResponse(
                 message=f"E2B execution failed: {exc}",

--- a/autogpt_platform/backend/backend/copilot/tools/bash_exec_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/bash_exec_test.py
@@ -3,6 +3,7 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from e2b import CommandExitException
 
 from ._test_data import make_session
 from .bash_exec import BashExecTool
@@ -124,6 +125,47 @@ class TestBashExecE2BTokenInjection:
         call_kwargs = sandbox.commands.run.call_args[1]
         assert "GIT_AUTHOR_NAME" not in call_kwargs["envs"]
         assert "GIT_COMMITTER_EMAIL" not in call_kwargs["envs"]
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_nonzero_exit_returned_as_bash_exec_response(self):
+        """CommandExitException (non-zero exit) must become a BashExecResponse with scrubbed output."""
+        tool = _make_tool()
+        session = make_session(user_id=_USER)
+
+        sandbox = MagicMock()
+        sandbox.commands.run = AsyncMock(
+            side_effect=CommandExitException(
+                stdout="not logged in gh-secret",
+                stderr="oops gh-secret",
+                exit_code=1,
+                error=None,
+            )
+        )
+
+        with (
+            patch(
+                "backend.copilot.tools.bash_exec.get_integration_env_vars",
+                new=AsyncMock(return_value={"GH_TOKEN": "gh-secret"}),
+            ),
+            patch(
+                "backend.copilot.tools.bash_exec.get_github_user_git_identity",
+                new=AsyncMock(return_value=None),
+            ),
+        ):
+            result = await tool._execute_on_e2b(
+                sandbox=sandbox,
+                command="gh auth status 2>&1",
+                timeout=10,
+                session_id=session.session_id,
+                user_id=_USER,
+            )
+
+        assert isinstance(result, BashExecResponse)
+        assert result.exit_code == 1
+        assert result.timed_out is False
+        assert result.stdout == "not logged in [REDACTED]"
+        assert result.stderr == "oops [REDACTED]"
+        assert result.message == "Command executed with status code 1"
 
     @pytest.mark.asyncio(loop_scope="session")
     async def test_no_token_injection_when_user_id_is_none(self):


### PR DESCRIPTION
## Why

`gh auth status` looked flaky in the E2B sandbox. Not actually flaky: it fails deterministically when the user has not connected GitHub (or the token is missing/expired), and our wrapper disguises that legitimate exit-1 as a sandbox infrastructure failure.

Root cause: E2B's `sandbox.commands.run()` raises `CommandExitException` for **any** non-zero exit. We caught it as a generic `Exception` and returned an `ErrorResponse` with message:

```
E2B execution failed: Command exited with code 1 and error:
{stderr}
```

When the model runs `gh auth status 2>&1`, stderr is redirected to stdout — so `exc.stderr` is empty **and** `exc.stdout` (which carries the real info, e.g. "You are not logged into any GitHub hosts") is discarded. The model sees a generic infra failure, can't tell it's an auth-check signal, and prompts the user with broken-looking errors instead of calling `connect_integration(provider="github")`.

Compare: the local bubblewrap path already handles non-zero exits correctly by returning a `BashExecResponse` with `exit_code` set. The E2B path was asymmetric.

## What

- Import `CommandExitException` and catch it explicitly in `_execute_on_e2b` before the generic handler.
- Return a `BashExecResponse` with the real `exit_code`, `stdout`, and `stderr` from the exception (scrubbed of injected secret values, same as the success path).
- Extract shared scrub/build logic into `_build_response` to avoid duplicating it across the success and exit-exception branches.
- Keep `TimeoutException` and the catch-all `except Exception` for real infra failures.

## How

Result shape now matches bubblewrap: non-zero exit is a valid result, not an error. The model sees:

```
message: "Command executed with status code 1"
exit_code: 1
stdout: "You are not logged into any GitHub hosts. ..."
stderr: ""
```

instead of the prior cryptic "E2B execution failed" message.

## Test plan

- [x] New unit test `test_nonzero_exit_returned_as_bash_exec_response` in `bash_exec_test.py` — mocks `sandbox.commands.run` to raise `CommandExitException`, asserts `BashExecResponse` with correct `exit_code`, and verifies secret scrubbing on both `stdout` and `stderr`.
- [x] `poetry run pytest backend/copilot/tools/bash_exec_test.py` — 5 passed.
- [x] `poetry run pyright` on changed files — 0 errors.
- [x] `poetry run ruff` — clean.
