### PR TITLE
fix(backend): use {schema_prefix} in raw SQL migrations instead of hardcoded 'platform.'

### DIFF
--- a/autogpt_platform/backend/backend/data/graph.py
+++ b/autogpt_platform/backend/backend/data/graph.py
@@ -36,9 +36,7 @@ from backend.util.models import Pagination
 from backend.util.request import parse_url
 
 from .block import BlockInput
-from .db import BaseDbModel
-from .db import prisma as db
-from .db import query_raw_with_schema, transaction
+from .db import BaseDbModel, execute_raw_with_schema, query_raw_with_schema, transaction
 from .dynamic_fields import is_tool_pin, sanitize_pin_name
 from .includes import AGENT_GRAPH_INCLUDE, AGENT_NODE_INCLUDE, MAX_GRAPH_VERSIONS_FETCH
 from .model import CredentialsFieldInfo, CredentialsMetaInput, is_credentials_field_name
@@ -1858,15 +1856,15 @@ async def migrate_llm_models(migrate_to: LlmModel):
     # Update each block
     for id, path in llm_model_fields.items():
         query = f"""
-            UPDATE platform."AgentNode"
+            UPDATE {{schema_prefix}}"AgentNode"
             SET "constantInput" = jsonb_set("constantInput", $1, to_jsonb($2), true)
             WHERE "agentBlockId" = $3
             AND "constantInput" ? ($4)::text
             AND "constantInput"->>($4)::text NOT IN {escaped_enum_values}
             """
 
-        await db.execute_raw(
-            query,  # type: ignore - is supposed to be LiteralString
+        await execute_raw_with_schema(
+            query,
             [path],
             migrate_to.value,
             id,

--- a/autogpt_platform/backend/backend/data/graph_test.py
+++ b/autogpt_platform/backend/backend/data/graph_test.py
@@ -2174,3 +2174,28 @@ def test_auto_credentials_non_str_non_dict_value_rejected(bad_value):
     msg = errors[graph.nodes[0].id]["spreadsheet"]
     # Must point the user at the correct fix (the Drive input block).
     assert "AgentGoogleDriveFileInputBlock" in msg
+
+
+@pytest.mark.asyncio
+async def test_migrate_llm_models_uses_schema_prefix_placeholder():
+    """Regression: migrate_llm_models must use the {schema_prefix} placeholder
+    so environments where the Prisma datasource lands in `public` (no
+    ?schema=platform on DATABASE_URL) don't blow up with
+    `relation "platform.AgentNode" does not exist`."""
+    from backend.blocks.llm import LlmModel
+    from backend.data.graph import migrate_llm_models
+
+    with patch(
+        "backend.data.graph.execute_raw_with_schema",
+        new_callable=AsyncMock,
+    ) as mock_execute:
+        await migrate_llm_models(next(iter(LlmModel)))
+
+    for call in mock_execute.await_args_list:
+        query_template = call.args[0]
+        assert "{schema_prefix}" in query_template, (
+            "migrate_llm_models must pass the {schema_prefix} placeholder "
+            "to execute_raw_with_schema; hardcoding 'platform.' breaks when "
+            "DATABASE_URL has no ?schema= param."
+        )
+        assert 'platform."AgentNode"' not in query_template


### PR DESCRIPTION
### Why / What / How

**Why.** Backend CI was failing at startup with `relation "platform.AgentNode" does not exist`. Prisma's `migrate deploy` uses the `schema.prisma` datasource, which doesn't declare a schema, so when `DATABASE_URL` has no `?schema=platform` query param (as in CI / raw Supabase), Prisma creates tables in `public` — but the lifespan migration `backend.data.graph.migrate_llm_models` hardcoded `platform."AgentNode"` in its raw SQL and crashed the boot.

**What.** Switched `migrate_llm_models` to use the `execute_raw_with_schema` helper and the `{schema_prefix}` placeholder — the same pattern already used by the sibling `fix_llm_provider_credentials` migration in the same file. The helper in `backend/data/db.py` reads the schema from `DATABASE_URL` at runtime and substitutes `"platform".` or an empty prefix, so the query works in both dev (schema=platform) and CI / raw Supabase (public).

**How.**
- Template change: `UPDATE platform."AgentNode"` → `UPDATE {{schema_prefix}}"AgentNode"` (f-string double-brace escape so `{schema_prefix}` survives to `.format()` inside `execute_raw_with_schema`).
- Replace `db.execute_raw(...)` with `execute_raw_with_schema(...)`; drop the now-unused `prisma as db` import.
- Regression test: mocks `execute_raw_with_schema` and asserts every emitted query contains `{schema_prefix}` and no longer contains `platform."AgentNode"`.

### Audit

Audited the other three lifespan migrations in `backend/api/rest_api.py::lifespan_context`:
- `backend.data.user.migrate_and_encrypt_user_integrations` — uses Prisma ORM, no raw SQL. OK.
- `backend.data.graph.fix_llm_provider_credentials` — already uses `query_raw_with_schema` + `{schema_prefix}`. OK.
- `backend.integrations.webhooks.utils.migrate_legacy_triggered_graphs` — uses Prisma ORM, no raw SQL. OK.

Also grepped the whole backend for `platform."` in Python files — `migrate_llm_models` was the only offender; the other hits were unrelated string content (docstrings, error messages, test data).

### Changes

- `autogpt_platform/backend/backend/data/graph.py`: `migrate_llm_models` now uses `execute_raw_with_schema` with the `{schema_prefix}` placeholder; unused `prisma as db` import dropped.
- `autogpt_platform/backend/backend/data/graph_test.py`: added `test_migrate_llm_models_uses_schema_prefix_placeholder` regression test.

### Checklist

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Ran `migrate_llm_models` under mocked `execute_raw_with_schema` — all 7 emitted UPDATE queries contain `{schema_prefix}` and none hardcode `platform."AgentNode"`.
  - [x] Verified the f-string double-brace escape by evaluating the template and running `.format(schema_prefix=...)` — substitution is correct for both `"platform".` and empty-prefix (public-schema) cases.
  - [x] `poetry run pyright backend/data/graph.py` clean (pre-existing pyright error on `backend/api/features/v1.py:834` on `origin/dev` is unrelated).
  - [x] Grepped the whole backend for other hardcoded `platform."..."` raw-SQL occurrences — none found.

#### For configuration changes:
- [x] `.env.default` is updated or already compatible with my changes (N/A — no config changes)
- [x] `docker-compose.yml` is updated or already compatible with my changes (N/A — no config changes)
