### PR TITLE
dx: use $REPO_ROOT in pr-test skill instead of hardcoded absolute path

### DIFF
--- a/.claude/skills/pr-test/SKILL.md
+++ b/.claude/skills/pr-test/SKILL.md
@@ -186,7 +186,7 @@ Multiple worktrees share the same host — Docker infra (postgres, redis, clamav
 
 ### Lock file contract
 
-Path (**always** the root worktree so all siblings see it): `/Users/majdyz/Code/AutoGPT/.ign.testing.lock`
+Path (**always** the root worktree so all siblings see it): `$REPO_ROOT/.ign.testing.lock`
 
 Body (one `key=value` per line):
 ```
@@ -202,7 +202,7 @@ intent=<one-line description + rough duration>
 ### Claim
 
 ```bash
-LOCK=/Users/majdyz/Code/AutoGPT/.ign.testing.lock
+LOCK=$REPO_ROOT/.ign.testing.lock
 NOW=$(date -u +%Y-%m-%dT%H:%MZ)
 STALE_AFTER_MIN=5
 
@@ -252,7 +252,7 @@ echo "$HEARTBEAT_PID" > /tmp/pr-test-heartbeat.pid
 kill "$HEARTBEAT_PID" 2>/dev/null
 rm -f "$LOCK" /tmp/pr-test-heartbeat.pid
 echo "$(date -u +%Y-%m-%dT%H:%MZ) [pr-${PR_NUMBER}] released lock" \
-    >> /Users/majdyz/Code/AutoGPT/.ign.testing.log
+    >> $REPO_ROOT/.ign.testing.log
 ```
 
 Use a `trap` so release runs even on `exit 1`:
@@ -278,7 +278,7 @@ Concretely, the sequence at the end of every `/pr-test` run (success or failure)
 kill "$HEARTBEAT_PID" 2>/dev/null
 rm -f "$LOCK" /tmp/pr-test-heartbeat.pid
 echo "$(date -u +%Y-%m-%dT%H:%MZ) [pr-${PR_NUMBER}] released lock (app may still be running)" \
-    >> /Users/majdyz/Code/AutoGPT/.ign.testing.log
+    >> $REPO_ROOT/.ign.testing.log
 # 3. Optionally leave the app running and note it so the user knows:
 echo "Native stack still running on :3000 / :8006 for manual poking. Kill with:"
 echo "  pkill -9 -f 'poetry run app'; pkill -9 -f 'next-server|next dev'"
@@ -288,10 +288,10 @@ If a sibling agent's `/pr-test` needs to take over, it'll do the kill+rebuild da
 
 ### Shared status log
 
-`/Users/majdyz/Code/AutoGPT/.ign.testing.log` is an append-only channel any agent can read/write. Use it for "I'm waiting", "I'm done, resources free", or post-run notes:
+`$REPO_ROOT/.ign.testing.log` is an append-only channel any agent can read/write. Use it for "I'm waiting", "I'm done, resources free", or post-run notes:
 ```bash
 echo "$(date -u +%Y-%m-%dT%H:%MZ) [pr-${PR_NUMBER}] <message>" \
-    >> /Users/majdyz/Code/AutoGPT/.ign.testing.log
+    >> $REPO_ROOT/.ign.testing.log
 ```
 
 ## Step 3: Environment setup


### PR DESCRIPTION
## Summary
- `.claude/skills/pr-test/SKILL.md` referenced `/Users/majdyz/Code/AutoGPT/.ign.testing.{lock,log}` in 5 places, which breaks the skill for anyone else who clones the repo.
- Replaced with `$REPO_ROOT`, which is already defined in Step 0 as `git -C "$WORKTREE_PATH" worktree list | head -1 | awk '{print $1}'`. That resolves to the main/primary worktree from any sibling worktree, preserving the original "always pin the lock to the root checkout so all siblings see the same file" semantics.
- No behavior change for the existing user; repo becomes portable for everyone else.

## Test plan
- [x] `grep -n "/Users/majdyz" .claude/skills/pr-test/SKILL.md` returns only the two intentional mentions in the "never paste absolute paths into PR comments" warning.
- [x] `$REPO_ROOT` is defined in Step 0 before any Step 3.0 usage.