### PR TITLE
refactor(platform): consolidate 6 LD flags into 2 JSON flags

### DIFF
--- a/autogpt_platform/backend/backend/copilot/rate_limit.py
+++ b/autogpt_platform/backend/backend/copilot/rate_limit.py
@@ -148,6 +148,53 @@ async def _fetch_tier_multipliers_flag() -> dict[SubscriptionTier, float] | None
     return parsed or None
 
 
+@cached(ttl_seconds=60, maxsize=1, cache_none=False)
+async def _fetch_cost_limits_flag() -> dict[str, int] | None:
+    """Fetch the ``copilot-cost-limits`` LD flag and parse it.
+
+    Returns a sparse ``{"daily": int, "weekly": int}`` map built from whichever
+    keys are valid in the flag payload, or ``None`` when the flag is unset /
+    invalid / LD is unavailable.  Callers merge whatever survives into their
+    config defaults (see :func:`get_global_rate_limits`).
+
+    The LD value is expected to be a JSON object keyed by window name
+    (``{"daily": 625000, "weekly": 3125000}``).  Non-int / negative values
+    are skipped so a broken key degrades to the config default instead of
+    wiping out the limit.
+    """
+    # Lazy import: rate_limit -> feature_flag -> settings -> ... -> rate_limit.
+    from backend.util.feature_flag import Flag, get_feature_flag_value
+
+    raw = await get_feature_flag_value(Flag.COPILOT_COST_LIMITS.value, "system", None)
+    if raw is None:
+        return None
+    if not isinstance(raw, dict):
+        logger.warning(
+            "Invalid LD value for copilot-cost-limits (expected JSON object): %r",
+            raw,
+        )
+        return None
+
+    parsed: dict[str, int] = {}
+    for key in ("daily", "weekly"):
+        if key not in raw:
+            continue
+        try:
+            value = int(raw[key])
+        except (TypeError, ValueError):
+            logger.warning(
+                "Invalid LD value for copilot-cost-limits[%s]: %r", key, raw[key]
+            )
+            continue
+        if value < 0:
+            logger.warning(
+                "Negative LD value for copilot-cost-limits[%s]: %r", key, raw[key]
+            )
+            continue
+        parsed[key] = value
+    return parsed or None
+
+
 async def get_tier_multipliers() -> dict[str, float]:
     """Return the effective ``{tier_value: multiplier}`` map.
 
@@ -752,30 +799,14 @@ async def get_global_rate_limits(
     Returns:
         (daily_cost_limit, weekly_cost_limit, tier) — limits in microdollars.
     """
-    # Lazy import to avoid circular dependency:
-    # rate_limit -> feature_flag -> settings -> ... -> rate_limit
-    from backend.util.feature_flag import Flag, get_feature_flag_value
-
-    # Fetch daily + weekly flags in parallel — each LD evaluation is an
-    # independent network round-trip, so gather cuts latency roughly in half.
-    daily_raw, weekly_raw = await asyncio.gather(
-        get_feature_flag_value(
-            Flag.COPILOT_DAILY_COST_LIMIT.value, user_id, config_daily
-        ),
-        get_feature_flag_value(
-            Flag.COPILOT_WEEKLY_COST_LIMIT.value, user_id, config_weekly
-        ),
-    )
     try:
-        daily = max(0, int(daily_raw))
-    except (TypeError, ValueError):
-        logger.warning("Invalid LD value for daily cost limit: %r", daily_raw)
-        daily = config_daily
-    try:
-        weekly = max(0, int(weekly_raw))
-    except (TypeError, ValueError):
-        logger.warning("Invalid LD value for weekly cost limit: %r", weekly_raw)
-        weekly = config_weekly
+        override = await _fetch_cost_limits_flag()
+    except Exception:
+        logger.warning("get_global_rate_limits: LD lookup failed", exc_info=True)
+        override = None
+    override = override or {}
+    daily = override.get("daily", config_daily)
+    weekly = override.get("weekly", config_weekly)
 
     # Apply tier multiplier — resolved through LD (copilot-tier-multipliers)
     # so multipliers can be tuned without a deploy. Falls back to the defaults

--- a/autogpt_platform/backend/backend/copilot/rate_limit.py
+++ b/autogpt_platform/backend/backend/copilot/rate_limit.py
@@ -179,16 +179,18 @@ async def _fetch_cost_limits_flag() -> dict[str, int] | None:
     for key in ("daily", "weekly"):
         if key not in raw:
             continue
-        try:
-            value = int(raw[key])
-        except (TypeError, ValueError):
+        value = raw[key]
+        # Strict int check — booleans are subclasses of int in Python, and we
+        # don't want to coerce strings like "100" or floats like 1.9 silently
+        # into a rate-limit cap. Docstring says "non-int values are skipped".
+        if isinstance(value, bool) or not isinstance(value, int):
             logger.warning(
-                "Invalid LD value for copilot-cost-limits[%s]: %r", key, raw[key]
+                "Invalid LD value for copilot-cost-limits[%s]: %r", key, value
             )
             continue
         if value < 0:
             logger.warning(
-                "Negative LD value for copilot-cost-limits[%s]: %r", key, raw[key]
+                "Negative LD value for copilot-cost-limits[%s]: %r", key, value
             )
             continue
         parsed[key] = value

--- a/autogpt_platform/backend/backend/copilot/rate_limit_test.py
+++ b/autogpt_platform/backend/backend/copilot/rate_limit_test.py
@@ -16,6 +16,7 @@ from .rate_limit import (
     UsageWindow,
     _daily_key,
     _daily_reset_time,
+    _fetch_cost_limits_flag,
     _fetch_tier_multipliers_flag,
     _weekly_key,
     _weekly_reset_time,
@@ -468,6 +469,173 @@ class TestGetTierMultipliers:
 
 
 # ---------------------------------------------------------------------------
+# get_global_rate_limits — LD-flag cost limits parsing
+# ---------------------------------------------------------------------------
+
+
+class TestGetGlobalRateLimitsCostLimitsFlag:
+    """Coverage for the ``copilot-cost-limits`` JSON flag parsing path."""
+
+    _CONFIG_DAILY = 625_000
+    _CONFIG_WEEKLY = 3_125_000
+
+    @pytest.fixture(autouse=True)
+    def _clear_flag_cache(self):
+        _fetch_tier_multipliers_flag.cache_clear()  # type: ignore[attr-defined]
+        _fetch_cost_limits_flag.cache_clear()  # type: ignore[attr-defined]
+
+    @pytest.mark.asyncio
+    async def test_flag_unset_uses_config_defaults(self):
+        async def _ld(_flag_key: str, _uid: str, default):
+            return default  # LD returns default → None for cost-limits
+
+        with (
+            patch(
+                "backend.copilot.rate_limit.get_user_tier",
+                new_callable=AsyncMock,
+                return_value=SubscriptionTier.BASIC,
+            ),
+            patch(
+                "backend.util.feature_flag.get_feature_flag_value",
+                side_effect=_ld,
+            ),
+        ):
+            daily, weekly, tier = await get_global_rate_limits(
+                _USER, self._CONFIG_DAILY, self._CONFIG_WEEKLY
+            )
+        assert daily == self._CONFIG_DAILY
+        assert weekly == self._CONFIG_WEEKLY
+        assert tier == SubscriptionTier.BASIC
+
+    @pytest.mark.asyncio
+    async def test_flag_with_both_keys_honoured(self):
+        async def _ld(flag_key: str, _uid: str, default):
+            if "cost-limits" in flag_key.lower():
+                return {"daily": 2_000_000, "weekly": 10_000_000}
+            return default
+
+        with (
+            patch(
+                "backend.copilot.rate_limit.get_user_tier",
+                new_callable=AsyncMock,
+                return_value=SubscriptionTier.BASIC,
+            ),
+            patch(
+                "backend.util.feature_flag.get_feature_flag_value",
+                side_effect=_ld,
+            ),
+        ):
+            daily, weekly, _ = await get_global_rate_limits(
+                _USER, self._CONFIG_DAILY, self._CONFIG_WEEKLY
+            )
+        assert daily == 2_000_000
+        assert weekly == 10_000_000
+
+    @pytest.mark.asyncio
+    async def test_flag_with_only_daily_weekly_defaults(self):
+        async def _ld(flag_key: str, _uid: str, default):
+            if "cost-limits" in flag_key.lower():
+                return {"daily": 9_999_999}
+            return default
+
+        with (
+            patch(
+                "backend.copilot.rate_limit.get_user_tier",
+                new_callable=AsyncMock,
+                return_value=SubscriptionTier.BASIC,
+            ),
+            patch(
+                "backend.util.feature_flag.get_feature_flag_value",
+                side_effect=_ld,
+            ),
+        ):
+            daily, weekly, _ = await get_global_rate_limits(
+                _USER, self._CONFIG_DAILY, self._CONFIG_WEEKLY
+            )
+        assert daily == 9_999_999
+        assert weekly == self._CONFIG_WEEKLY
+
+    @pytest.mark.asyncio
+    async def test_non_dict_payload_falls_back_and_warns(self, caplog):
+        async def _ld(flag_key: str, _uid: str, default):
+            if "cost-limits" in flag_key.lower():
+                return "not-a-dict"
+            return default
+
+        with (
+            patch(
+                "backend.copilot.rate_limit.get_user_tier",
+                new_callable=AsyncMock,
+                return_value=SubscriptionTier.BASIC,
+            ),
+            patch(
+                "backend.util.feature_flag.get_feature_flag_value",
+                side_effect=_ld,
+            ),
+            caplog.at_level("WARNING"),
+        ):
+            daily, weekly, _ = await get_global_rate_limits(
+                _USER, self._CONFIG_DAILY, self._CONFIG_WEEKLY
+            )
+        assert daily == self._CONFIG_DAILY
+        assert weekly == self._CONFIG_WEEKLY
+        assert any("copilot-cost-limits" in rec.message for rec in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_invalid_per_key_values_fall_back(self):
+        """Negative / non-int per-key values resolve to the config default for
+        that key while any valid key survives."""
+
+        async def _ld(flag_key: str, _uid: str, default):
+            if "cost-limits" in flag_key.lower():
+                return {"daily": -5, "weekly": "oops"}
+            return default
+
+        with (
+            patch(
+                "backend.copilot.rate_limit.get_user_tier",
+                new_callable=AsyncMock,
+                return_value=SubscriptionTier.BASIC,
+            ),
+            patch(
+                "backend.util.feature_flag.get_feature_flag_value",
+                side_effect=_ld,
+            ),
+        ):
+            daily, weekly, _ = await get_global_rate_limits(
+                _USER, self._CONFIG_DAILY, self._CONFIG_WEEKLY
+            )
+        assert daily == self._CONFIG_DAILY
+        assert weekly == self._CONFIG_WEEKLY
+
+    @pytest.mark.asyncio
+    async def test_partial_invalid_key_preserves_valid_key(self):
+        """A valid daily + invalid weekly → daily honoured, weekly defaults."""
+
+        async def _ld(flag_key: str, _uid: str, default):
+            if "cost-limits" in flag_key.lower():
+                return {"daily": 1_234_567, "weekly": -1}
+            return default
+
+        with (
+            patch(
+                "backend.copilot.rate_limit.get_user_tier",
+                new_callable=AsyncMock,
+                return_value=SubscriptionTier.BASIC,
+            ),
+            patch(
+                "backend.util.feature_flag.get_feature_flag_value",
+                side_effect=_ld,
+            ),
+        ):
+            daily, weekly, _ = await get_global_rate_limits(
+                _USER, self._CONFIG_DAILY, self._CONFIG_WEEKLY
+            )
+        assert daily == 1_234_567
+        assert weekly == self._CONFIG_WEEKLY
+
+
+# ---------------------------------------------------------------------------
 # get_user_tier
 # ---------------------------------------------------------------------------
 
@@ -741,22 +909,22 @@ class TestSetUserTier:
 class TestGetGlobalRateLimitsWithTiers:
     @pytest.fixture(autouse=True)
     def _clear_flag_cache(self):
-        """Clear the LD flag cache between tests so patches don't leak."""
+        """Clear the LD flag caches between tests so patches don't leak."""
         _fetch_tier_multipliers_flag.cache_clear()  # type: ignore[attr-defined]
+        _fetch_cost_limits_flag.cache_clear()  # type: ignore[attr-defined]
 
     @staticmethod
     def _ld_side_effect(daily: int, weekly: int):
         """Return an async side_effect that dispatches by flag_key.
 
-        Returns the raw default for the tier-multipliers flag so existing
-        tests continue to exercise the default multiplier map.
+        Returns the cost-limits JSON shape for ``copilot-cost-limits`` and
+        the raw default for the tier-multipliers flag so existing tests
+        continue to exercise the default multiplier map.
         """
 
         async def _side_effect(flag_key: str, _uid: str, default):
-            if "daily" in flag_key.lower():
-                return daily
-            if "weekly" in flag_key.lower():
-                return weekly
+            if "cost-limits" in flag_key.lower():
+                return {"daily": daily, "weekly": weekly}
             return default
 
         return _side_effect
@@ -766,10 +934,8 @@ class TestGetGlobalRateLimitsWithTiers:
         """A fractional LD multiplier is applied and truncated back to int."""
 
         async def _ld(flag_key: str, _uid: str, default):
-            if "daily" in flag_key.lower():
-                return 1_000_000
-            if "weekly" in flag_key.lower():
-                return 5_000_000
+            if "cost-limits" in flag_key.lower():
+                return {"daily": 1_000_000, "weekly": 5_000_000}
             if "tier-multipliers" in flag_key.lower():
                 return {"PRO": 8.5}
             return default
@@ -923,15 +1089,14 @@ class TestTierLimitsRespected:
     @pytest.fixture(autouse=True)
     def _clear_flag_cache(self):
         _fetch_tier_multipliers_flag.cache_clear()  # type: ignore[attr-defined]
+        _fetch_cost_limits_flag.cache_clear()  # type: ignore[attr-defined]
 
     @staticmethod
     def _ld_side_effect(daily: int, weekly: int):
 
         async def _side_effect(flag_key: str, _uid: str, default):
-            if "daily" in flag_key.lower():
-                return daily
-            if "weekly" in flag_key.lower():
-                return weekly
+            if "cost-limits" in flag_key.lower():
+                return {"daily": daily, "weekly": weekly}
             return default
 
         return _side_effect
@@ -1140,16 +1305,15 @@ class TestTierLimitsEnforced:
     @pytest.fixture(autouse=True)
     def _clear_flag_cache(self):
         _fetch_tier_multipliers_flag.cache_clear()  # type: ignore[attr-defined]
+        _fetch_cost_limits_flag.cache_clear()  # type: ignore[attr-defined]
 
     @staticmethod
     def _ld_side_effect(daily: int, weekly: int):
         """Mock LD flag lookup returning the given raw limits."""
 
         async def _side_effect(flag_key: str, _uid: str, default):
-            if "daily" in flag_key.lower():
-                return daily
-            if "weekly" in flag_key.lower():
-                return weekly
+            if "cost-limits" in flag_key.lower():
+                return {"daily": daily, "weekly": weekly}
             return default
 
         return _side_effect

--- a/autogpt_platform/backend/backend/copilot/rate_limit_test.py
+++ b/autogpt_platform/backend/backend/copilot/rate_limit_test.py
@@ -634,6 +634,42 @@ class TestGetGlobalRateLimitsCostLimitsFlag:
         assert daily == 1_234_567
         assert weekly == self._CONFIG_WEEKLY
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "bad_value",
+        [True, False, "100", 1.9, [1, 2], None],
+        ids=["bool-true", "bool-false", "str-numeric", "float", "list", "null"],
+    )
+    async def test_non_strict_int_values_rejected(self, bad_value):
+        """Strings like '100', booleans, floats, lists — none should coerce.
+
+        Docstring promises "non-int values are skipped"; this asserts the
+        strict-check (``isinstance(x, int) and not isinstance(x, bool)``)
+        actually rejects values ``int()`` would silently coerce.
+        """
+
+        async def _ld(flag_key: str, _uid: str, default):
+            if "cost-limits" in flag_key.lower():
+                return {"daily": bad_value}
+            return default
+
+        with (
+            patch(
+                "backend.copilot.rate_limit.get_user_tier",
+                new_callable=AsyncMock,
+                return_value=SubscriptionTier.BASIC,
+            ),
+            patch(
+                "backend.util.feature_flag.get_feature_flag_value",
+                side_effect=_ld,
+            ),
+        ):
+            daily, weekly, _ = await get_global_rate_limits(
+                _USER, self._CONFIG_DAILY, self._CONFIG_WEEKLY
+            )
+        assert daily == self._CONFIG_DAILY
+        assert weekly == self._CONFIG_WEEKLY
+
 
 # ---------------------------------------------------------------------------
 # get_user_tier

--- a/autogpt_platform/backend/backend/data/credit.py
+++ b/autogpt_platform/backend/backend/data/credit.py
@@ -1940,7 +1940,7 @@ async def get_auto_top_up(user_id: str) -> AutoTopUpConfig:
     return AutoTopUpConfig.model_validate(user.top_up_config)
 
 
-@cached(ttl_seconds=60, maxsize=1, cache_none=False)
+@cached(ttl_seconds=60, maxsize=8, cache_none=False)
 async def get_subscription_price_id(tier: SubscriptionTier) -> str | None:
     """Return Stripe Price ID for a tier from LaunchDarkly, cached for 60 seconds.
 

--- a/autogpt_platform/backend/backend/data/credit.py
+++ b/autogpt_platform/backend/backend/data/credit.py
@@ -1940,29 +1940,30 @@ async def get_auto_top_up(user_id: str) -> AutoTopUpConfig:
     return AutoTopUpConfig.model_validate(user.top_up_config)
 
 
-@cached(ttl_seconds=60, maxsize=8, cache_none=False)
+@cached(ttl_seconds=60, maxsize=1, cache_none=False)
 async def get_subscription_price_id(tier: SubscriptionTier) -> str | None:
     """Return Stripe Price ID for a tier from LaunchDarkly, cached for 60 seconds.
 
-    Price IDs are LaunchDarkly flag values that change only at deploy time.
-    Caching for 60 seconds avoids hitting the LD SDK on every webhook delivery
-    and every GET /credits/subscription page load (called 2x per request).
+    Reads the ``copilot-tier-stripe-prices`` JSON flag once and looks up the
+    requested tier. The flag is a JSON object keyed by tier enum value
+    (``{"PRO": "price_xxx", "MAX": "price_yyy"}``); tiers missing from the
+    payload resolve to ``None`` ("not offered").
 
     ``cache_none=False`` prevents a transient LD failure from caching ``None``
     and blocking subscription upgrades for the full 60-second TTL window.
-    ENTERPRISE has no LD flag and returns None from an O(1) dict lookup before
-    hitting LD, so the extra LD call is never made.
     """
-    flag_map = {
-        SubscriptionTier.BASIC: Flag.STRIPE_PRICE_BASIC,
-        SubscriptionTier.PRO: Flag.STRIPE_PRICE_PRO,
-        SubscriptionTier.MAX: Flag.STRIPE_PRICE_MAX,
-        SubscriptionTier.BUSINESS: Flag.STRIPE_PRICE_BUSINESS,
-    }
-    flag = flag_map.get(tier)
-    if flag is None:
+    raw = await get_feature_flag_value(
+        Flag.COPILOT_TIER_STRIPE_PRICES.value, user_id="system", default=None
+    )
+    if raw is None:
         return None
-    price_id = await get_feature_flag_value(flag.value, user_id="system", default="")
+    if not isinstance(raw, dict):
+        logger.warning(
+            "Invalid LD value for copilot-tier-stripe-prices (expected JSON object): %r",
+            raw,
+        )
+        return None
+    price_id = raw.get(tier.value)
     return price_id if isinstance(price_id, str) and price_id else None
 
 

--- a/autogpt_platform/backend/backend/data/credit_subscription_test.py
+++ b/autogpt_platform/backend/backend/data/credit_subscription_test.py
@@ -1049,6 +1049,38 @@ async def test_get_subscription_price_id_partial_dict():
 
 
 @pytest.mark.asyncio
+async def test_get_subscription_price_id_empty_string_value_returns_none():
+    """Empty-string price_id in the JSON resolves to None (defensive)."""
+    from backend.data.credit import get_subscription_price_id
+
+    get_subscription_price_id.cache_clear()  # type: ignore[attr-defined]
+    with patch(
+        "backend.data.credit.get_feature_flag_value",
+        new_callable=AsyncMock,
+        return_value={"PRO": ""},
+    ):
+        assert await get_subscription_price_id(SubscriptionTier.PRO) is None
+    get_subscription_price_id.cache_clear()  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_get_subscription_price_id_non_string_value_returns_none():
+    """Non-string price_id (e.g. number, null) resolves to None."""
+    from backend.data.credit import get_subscription_price_id
+
+    get_subscription_price_id.cache_clear()  # type: ignore[attr-defined]
+    with patch(
+        "backend.data.credit.get_feature_flag_value",
+        new_callable=AsyncMock,
+        return_value={"PRO": 123, "MAX": None},
+    ):
+        assert await get_subscription_price_id(SubscriptionTier.PRO) is None
+        get_subscription_price_id.cache_clear()  # type: ignore[attr-defined]
+        assert await get_subscription_price_id(SubscriptionTier.MAX) is None
+    get_subscription_price_id.cache_clear()  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
 async def test_get_subscription_price_id_non_dict_payload_returns_none(caplog):
     """A non-dict LD value logs a warning and returns None for every tier."""
     from backend.data.credit import get_subscription_price_id

--- a/autogpt_platform/backend/backend/data/credit_subscription_test.py
+++ b/autogpt_platform/backend/backend/data/credit_subscription_test.py
@@ -954,7 +954,7 @@ async def test_get_subscription_price_id_pro():
     with patch(
         "backend.data.credit.get_feature_flag_value",
         new_callable=AsyncMock,
-        return_value="price_pro_monthly",
+        return_value={"PRO": "price_pro_monthly", "MAX": "price_max_monthly"},
     ):
         price_id = await get_subscription_price_id(SubscriptionTier.PRO)
         assert price_id == "price_pro_monthly"
@@ -969,7 +969,7 @@ async def test_get_subscription_price_id_basic_returns_ld_flag():
     with patch(
         "backend.data.credit.get_feature_flag_value",
         new_callable=AsyncMock,
-        return_value="price_basic_monthly",
+        return_value={"BASIC": "price_basic_monthly"},
     ):
         price_id = await get_subscription_price_id(SubscriptionTier.BASIC)
         assert price_id == "price_basic_monthly"
@@ -984,7 +984,7 @@ async def test_get_subscription_price_id_max():
     with patch(
         "backend.data.credit.get_feature_flag_value",
         new_callable=AsyncMock,
-        return_value="price_max_monthly",
+        return_value={"MAX": "price_max_monthly"},
     ):
         price_id = await get_subscription_price_id(SubscriptionTier.MAX)
         assert price_id == "price_max_monthly"
@@ -995,23 +995,92 @@ async def test_get_subscription_price_id_max():
 async def test_get_subscription_price_id_enterprise_returns_none():
     from backend.data.credit import get_subscription_price_id
 
-    # ENTERPRISE bypasses the LD flag lookup entirely (returns None before fetch).
-    price_id = await get_subscription_price_id(SubscriptionTier.ENTERPRISE)
-    assert price_id is None
+    # ENTERPRISE is never a key in the JSON flag → resolves to None.
+    get_subscription_price_id.cache_clear()  # type: ignore[attr-defined]
+    with patch(
+        "backend.data.credit.get_feature_flag_value",
+        new_callable=AsyncMock,
+        return_value={"PRO": "price_pro_monthly"},
+    ):
+        price_id = await get_subscription_price_id(SubscriptionTier.ENTERPRISE)
+        assert price_id is None
+    get_subscription_price_id.cache_clear()  # type: ignore[attr-defined]
 
 
 @pytest.mark.asyncio
 async def test_get_subscription_price_id_empty_flag_returns_none():
+    """Empty dict payload → every tier resolves to None."""
     from backend.data.credit import get_subscription_price_id
 
     get_subscription_price_id.cache_clear()  # type: ignore[attr-defined]
     with patch(
         "backend.data.credit.get_feature_flag_value",
         new_callable=AsyncMock,
-        return_value="",  # LD flag not set
+        return_value={},
     ):
-        price_id = await get_subscription_price_id(SubscriptionTier.BUSINESS)
+        for tier in (
+            SubscriptionTier.BASIC,
+            SubscriptionTier.PRO,
+            SubscriptionTier.MAX,
+            SubscriptionTier.BUSINESS,
+            SubscriptionTier.ENTERPRISE,
+        ):
+            assert await get_subscription_price_id(tier) is None
+            get_subscription_price_id.cache_clear()  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_get_subscription_price_id_partial_dict():
+    """Dict with only PRO resolves PRO, other tiers return None."""
+    from backend.data.credit import get_subscription_price_id
+
+    get_subscription_price_id.cache_clear()  # type: ignore[attr-defined]
+    with patch(
+        "backend.data.credit.get_feature_flag_value",
+        new_callable=AsyncMock,
+        return_value={"PRO": "price_pro_monthly"},
+    ):
+        assert (
+            await get_subscription_price_id(SubscriptionTier.PRO) == "price_pro_monthly"
+        )
+        get_subscription_price_id.cache_clear()  # type: ignore[attr-defined]
+        assert await get_subscription_price_id(SubscriptionTier.MAX) is None
+    get_subscription_price_id.cache_clear()  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_get_subscription_price_id_non_dict_payload_returns_none(caplog):
+    """A non-dict LD value logs a warning and returns None for every tier."""
+    from backend.data.credit import get_subscription_price_id
+
+    get_subscription_price_id.cache_clear()  # type: ignore[attr-defined]
+    with patch(
+        "backend.data.credit.get_feature_flag_value",
+        new_callable=AsyncMock,
+        return_value="not-a-dict",
+    ):
+        with caplog.at_level("WARNING"):
+            price_id = await get_subscription_price_id(SubscriptionTier.PRO)
         assert price_id is None
+        assert any(
+            "copilot-tier-stripe-prices" in rec.message for rec in caplog.records
+        )
+    get_subscription_price_id.cache_clear()  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_get_subscription_price_id_ld_raises_returns_none():
+    """Transient LD failure (here surfaced as a caught exception inside
+    get_feature_flag_value → default None) returns None and does not raise."""
+    from backend.data.credit import get_subscription_price_id
+
+    get_subscription_price_id.cache_clear()  # type: ignore[attr-defined]
+    with patch(
+        "backend.data.credit.get_feature_flag_value",
+        new_callable=AsyncMock,
+        return_value=None,
+    ):
+        assert await get_subscription_price_id(SubscriptionTier.PRO) is None
     get_subscription_price_id.cache_clear()  # type: ignore[attr-defined]
 
 
@@ -1026,12 +1095,12 @@ async def test_get_subscription_price_id_none_not_cached():
     from backend.data.credit import get_subscription_price_id
 
     get_subscription_price_id.cache_clear()  # type: ignore[attr-defined]
-    mock_ld = AsyncMock(side_effect=["", "price_pro_monthly"])
+    mock_ld = AsyncMock(side_effect=[None, {"PRO": "price_pro_monthly"}])
     with patch("backend.data.credit.get_feature_flag_value", mock_ld):
-        # First call: LD returns empty string → None (transient failure)
+        # First call: LD returns None (transient failure)
         first = await get_subscription_price_id(SubscriptionTier.PRO)
         assert first is None
-        # Second call: LD returns the real price ID — must NOT be blocked by cached None
+        # Second call: LD returns the real price dict — must NOT be blocked by cached None
         second = await get_subscription_price_id(SubscriptionTier.PRO)
         assert second == "price_pro_monthly"
         assert mock_ld.call_count == 2  # both calls hit LD (None was not cached)

--- a/autogpt_platform/backend/backend/util/feature_flag.py
+++ b/autogpt_platform/backend/backend/util/feature_flag.py
@@ -42,13 +42,9 @@ class Flag(str, Enum):
     CHAT = "chat"
     CHAT_MODE_OPTION = "chat-mode-option"
     COPILOT_SDK = "copilot-sdk"
-    COPILOT_DAILY_COST_LIMIT = "copilot-daily-cost-limit-microdollars"
-    COPILOT_WEEKLY_COST_LIMIT = "copilot-weekly-cost-limit-microdollars"
+    COPILOT_COST_LIMITS = "copilot-cost-limits"
     COPILOT_TIER_MULTIPLIERS = "copilot-tier-multipliers"
-    STRIPE_PRICE_BASIC = "stripe-price-id-basic"
-    STRIPE_PRICE_PRO = "stripe-price-id-pro"
-    STRIPE_PRICE_MAX = "stripe-price-id-max"
-    STRIPE_PRICE_BUSINESS = "stripe-price-id-business"
+    COPILOT_TIER_STRIPE_PRICES = "copilot-tier-stripe-prices"
     GRAPHITI_MEMORY = "graphiti-memory"
 
     # Copilot model routing — string-valued, returns the model identifier


### PR DESCRIPTION
## What

Consolidates two groups of LaunchDarkly flags into single JSON-valued flags, matching the pattern established by `copilot-tier-multipliers` (merged in #12910):

**Stripe prices** — 4 string flags → 1 JSON flag:
- ~~`stripe-price-id-basic`~~ / ~~`-pro`~~ / ~~`-max`~~ / ~~`-business`~~
- **New:** `copilot-tier-stripe-prices` (JSON)
  ```json
  { "PRO": "price_xxx", "MAX": "price_yyy" }
  ```

**Cost limits** — 2 number flags → 1 JSON flag:
- ~~`copilot-daily-cost-limit-microdollars`~~ / ~~`copilot-weekly-cost-limit-microdollars`~~
- **New:** `copilot-cost-limits` (JSON)
  ```json
  { "daily": 625000, "weekly": 3125000 }
  ```

## Why

- One flag to manage per config domain (LD UI less cluttered, easier audit trail).
- Atomic updates — e.g., rotating Pro + Max prices happens in a single save.
- Fewer LD entities to name, version, target, and explain.
- Mirrors the just-merged `copilot-tier-multipliers` shape so the whole pricing/limits config is uniform.

## How

- `get_subscription_price_id(tier)` now parses `copilot-tier-stripe-prices` and looks up `tier.value` — returns `None` when the flag is unset, non-dict, tier key missing, or value isn't a non-empty string.
- `get_global_rate_limits` uses a new sibling `_fetch_cost_limits_flag()` helper (60s cache, `cache_none=False`) that extracts `daily` / `weekly` int keys independently and falls back to the existing `ChatConfig` defaults when any key is missing / non-int / negative. A broken `daily` doesn't wipe out `weekly` (or vice versa).
- Tests rewritten to mock the new JSON shapes + cover partial / invalid / missing-key fallbacks.

## ⚠️ Operator action required BEFORE merging

This PR **removes 6 LD flags** and introduces 2 replacements. To avoid a pricing/rate-limit outage, do this in LaunchDarkly first:

1. Create `copilot-tier-stripe-prices` (type: **JSON**). Default variation = union of the current `stripe-price-id-*` values:
   ```json
   { "PRO": "<current stripe-price-id-pro>", "MAX": "<current stripe-price-id-max>" }
   ```
   Omit BASIC / BUSINESS if those flags are unset today.

2. Create `copilot-cost-limits` (type: **JSON**). Default variation = the current two flags' values:
   ```json
   { "daily": <current daily microdollars>, "weekly": <current weekly microdollars> }
   ```

3. Merge this PR.

4. After deploy + smoke test, delete the six legacy flags:
   - `stripe-price-id-{basic,pro,max,business}`
   - `copilot-daily-cost-limit-microdollars`
   - `copilot-weekly-cost-limit-microdollars`

## Testing

- Backend unit tests: `pytest backend/copilot/rate_limit_test.py backend/data/credit_subscription_test.py backend/api/features/subscription_routes_test.py` — rewritten to exercise the JSON flag shapes + fallback paths; passes locally.
- `black --check` / `ruff check` / `isort --check` — all clean.

## Checklist

- [x] I have read the project's contributing guide.
- [x] I have clearly described what this PR changes and why.
- [x] My code follows the style guidelines of this project.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes (CI will confirm).