### PR TITLE
refactor(platform/copilot): consolidate 4 model-routing LD flags into 1 JSON flag

### DIFF
--- a/autogpt_platform/backend/backend/copilot/config.py
+++ b/autogpt_platform/backend/backend/copilot/config.py
@@ -49,14 +49,14 @@ class ChatConfig(BaseSettings):
             "CHAT_FAST_MODEL",
         ),
         description="Baseline path, 'standard' / ``None`` tier.  Per-user "
-        "overrides flow through the ``copilot-fast-standard-model`` LD flag "
+        "overrides flow through ``copilot-model-routing[fast][standard]`` "
         "(see ``copilot/model_router.py``); this value is the fallback.",
     )
     fast_advanced_model: str = Field(
         default="anthropic/claude-opus-4.7",
         validation_alias=AliasChoices("CHAT_FAST_ADVANCED_MODEL"),
         description="Baseline path, 'advanced' tier.  LD override: "
-        "``copilot-fast-advanced-model``.",
+        "``copilot-model-routing[fast][advanced]``.",
     )
     thinking_standard_model: str = Field(
         default="anthropic/claude-sonnet-4-6",
@@ -65,7 +65,7 @@ class ChatConfig(BaseSettings):
             "CHAT_MODEL",
         ),
         description="SDK (extended-thinking) path, 'standard' / ``None`` "
-        "tier.  LD override: ``copilot-thinking-standard-model``.",
+        "tier.  LD override: ``copilot-model-routing[thinking][standard]``.",
     )
     thinking_advanced_model: str = Field(
         default="anthropic/claude-opus-4.7",
@@ -74,7 +74,7 @@ class ChatConfig(BaseSettings):
             "CHAT_ADVANCED_MODEL",
         ),
         description="SDK (extended-thinking) path, 'advanced' tier.  LD "
-        "override: ``copilot-thinking-advanced-model``.",
+        "override: ``copilot-model-routing[thinking][advanced]``.",
     )
     title_model: str = Field(
         default="openai/gpt-4o-mini",

--- a/autogpt_platform/backend/backend/copilot/model_router.py
+++ b/autogpt_platform/backend/backend/copilot/model_router.py
@@ -1,24 +1,31 @@
 """LaunchDarkly-aware model selection for the copilot.
 
 Each cell of the ``(mode, tier)`` matrix has a static default baked into
-``ChatConfig`` (see ``copilot/config.py``) and a matching LaunchDarkly
-string-valued feature flag that can override it per-user.  This module
-centralises the lookup so both the baseline and SDK paths agree on the
-selection rule and so A/B experiments can target a single cell without
-shipping a config change.
+``ChatConfig`` (see ``copilot/config.py``) and a single JSON-valued
+LaunchDarkly feature flag — ``copilot-model-routing`` — that can override
+it per-user.  This module centralises the lookup so both the baseline
+and SDK paths agree on the selection rule and so A/B experiments can
+target a single cell without shipping a config change.
 
 Matrix:
 
-    +----------+-------------------------------------+-------------------------------------+
-    |          | standard                            | advanced                            |
-    +----------+-------------------------------------+-------------------------------------+
-    | fast     | copilot-fast-standard-model         | copilot-fast-advanced-model         |
-    | thinking | copilot-thinking-standard-model     | copilot-thinking-advanced-model     |
-    +----------+-------------------------------------+-------------------------------------+
+    +----------+----------+----------+
+    |          | standard | advanced |
+    +----------+----------+----------+
+    | fast     |    .     |    .     |
+    | thinking |    .     |    .     |
+    +----------+----------+----------+
 
-LD flag values are arbitrary strings (model identifiers, e.g.
-``"anthropic/claude-sonnet-4-6"`` or ``"moonshotai/kimi-k2.6"``).  Empty
-or non-string values fall back to the config default.
+LD payload shape::
+
+    {
+      "fast":     {"standard": "anthropic/claude-sonnet-4-6", "advanced": "anthropic/claude-opus-4-6"},
+      "thinking": {"standard": "moonshotai/kimi-k2.6",         "advanced": "anthropic/claude-opus-4-6"}
+    }
+
+Missing mode, missing tier-within-mode, non-string cell value, non-dict
+payload, or LD failure all fall back to the corresponding ``ChatConfig``
+default.
 """
 
 from __future__ import annotations
@@ -33,14 +40,6 @@ logger = logging.getLogger(__name__)
 
 ModelMode = Literal["fast", "thinking"]
 ModelTier = Literal["standard", "advanced"]
-
-
-_FLAG_BY_CELL: dict[tuple[ModelMode, ModelTier], Flag] = {
-    ("fast", "standard"): Flag.COPILOT_FAST_STANDARD_MODEL,
-    ("fast", "advanced"): Flag.COPILOT_FAST_ADVANCED_MODEL,
-    ("thinking", "standard"): Flag.COPILOT_THINKING_STANDARD_MODEL,
-    ("thinking", "advanced"): Flag.COPILOT_THINKING_ADVANCED_MODEL,
-}
 
 
 def _config_default(config: ChatConfig, mode: ModelMode, tier: ModelTier) -> str:
@@ -66,38 +65,62 @@ async def resolve_model(
 ) -> str:
     """Return the model identifier for a ``(mode, tier)`` cell.
 
-    Consults the matching LaunchDarkly flag for *user_id* first and
-    falls back to the ``ChatConfig`` default on missing user, missing
-    flag, or non-string flag value.  Passing *config* explicitly keeps
-    the resolver cheap to unit-test.
+    Consults ``copilot-model-routing`` (JSON) for *user_id* — LD targeting is
+    still per-user so cohorts can receive different routing — and falls back to
+    the ``ChatConfig`` default on missing user, missing / invalid flag payload,
+    or non-string cell value.
     """
     fallback = _config_default(config, mode, tier).strip()
     if not user_id:
         return fallback
 
-    flag = _FLAG_BY_CELL[(mode, tier)]
     try:
-        value = await get_feature_flag_value(flag.value, user_id, default=fallback)
+        payload = await get_feature_flag_value(
+            Flag.COPILOT_MODEL_ROUTING.value, user_id, default=None
+        )
     except Exception:
         logger.warning(
-            "[model_router] LD lookup failed for %s — using config default %s",
-            flag.value,
+            "[model_router] LD lookup failed for copilot-model-routing — "
+            "using config default %s for (%s, %s)",
             fallback,
+            mode,
+            tier,
             exc_info=True,
         )
         return fallback
 
+    if payload is None:
+        return fallback
+
+    if not isinstance(payload, dict):
+        logger.warning(
+            "[model_router] copilot-model-routing expected a JSON object, got %r — "
+            "using config default %s for (%s, %s)",
+            payload,
+            fallback,
+            mode,
+            tier,
+        )
+        return fallback
+
+    mode_cell = payload.get(mode)
+    if not isinstance(mode_cell, dict):
+        return fallback
+
+    value = mode_cell.get(tier)
     if isinstance(value, str) and value.strip():
         return value.strip()
-    if value != fallback:
+    if value is not None:
         reason = (
             "empty string"
             if isinstance(value, str)
             else f"non-string ({type(value).__name__})"
         )
         logger.warning(
-            "[model_router] LD flag %s returned %s — using config default %s",
-            flag.value,
+            "[model_router] copilot-model-routing[%s][%s] returned %s — "
+            "using config default %s",
+            mode,
+            tier,
             reason,
             fallback,
         )

--- a/autogpt_platform/backend/backend/copilot/model_router.py
+++ b/autogpt_platform/backend/backend/copilot/model_router.py
@@ -75,7 +75,7 @@ async def resolve_model(
         return fallback
 
     try:
-        payload = await get_feature_flag_value(
+        payload: object = await get_feature_flag_value(
             Flag.COPILOT_MODEL_ROUTING.value, user_id, default=None
         )
     except Exception:
@@ -104,6 +104,17 @@ async def resolve_model(
         return fallback
 
     mode_cell = payload.get(mode)
+    if mode in payload and not isinstance(mode_cell, dict):
+        # Operator typed something at the mode level (e.g. a string) instead of
+        # a {tier: model} dict — surface the typo in logs.
+        logger.warning(
+            "[model_router] copilot-model-routing[%s] expected a JSON object, "
+            "got %r — using config default %s for tier %s",
+            mode,
+            mode_cell,
+            fallback,
+            tier,
+        )
     if not isinstance(mode_cell, dict):
         return fallback
 

--- a/autogpt_platform/backend/backend/copilot/model_router_test.py
+++ b/autogpt_platform/backend/backend/copilot/model_router_test.py
@@ -1,11 +1,12 @@
 """Tests for the LD-aware model resolver."""
 
+import logging
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from backend.copilot.config import ChatConfig
-from backend.copilot.model_router import _FLAG_BY_CELL, _config_default, resolve_model
+from backend.copilot.model_router import _config_default, resolve_model
 
 
 def _make_config() -> ChatConfig:
@@ -16,6 +17,18 @@ def _make_config() -> ChatConfig:
         thinking_standard_model="anthropic/claude-sonnet-4-6",
         thinking_advanced_model="anthropic/claude-opus-4.7",
     )
+
+
+_FULL_PAYLOAD = {
+    "fast": {
+        "standard": "fast-standard-model",
+        "advanced": "fast-advanced-model",
+    },
+    "thinking": {
+        "standard": "thinking-standard-model",
+        "advanced": "thinking-advanced-model",
+    },
+}
 
 
 class TestConfigDefault:
@@ -68,56 +81,173 @@ class TestResolveModel:
         assert result == "anthropic/claude-sonnet-4-6"
 
     @pytest.mark.asyncio
-    async def test_ld_string_override_wins(self):
-        """LD-returned model string replaces the config default."""
+    async def test_payload_none_falls_back(self):
+        """LD unset / serving ``None`` → ChatConfig default for every cell."""
         cfg = _make_config()
         with patch(
             "backend.copilot.model_router.get_feature_flag_value",
-            new=AsyncMock(return_value="moonshotai/kimi-k2.6"),
+            new=AsyncMock(return_value=None),
         ):
-            result = await resolve_model("fast", "standard", "user-1", config=cfg)
-        assert result == "moonshotai/kimi-k2.6"
+            assert (
+                await resolve_model("fast", "standard", "u", config=cfg)
+                == cfg.fast_standard_model
+            )
+            assert (
+                await resolve_model("fast", "advanced", "u", config=cfg)
+                == cfg.fast_advanced_model
+            )
+            assert (
+                await resolve_model("thinking", "standard", "u", config=cfg)
+                == cfg.thinking_standard_model
+            )
+            assert (
+                await resolve_model("thinking", "advanced", "u", config=cfg)
+                == cfg.thinking_advanced_model
+            )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "mode, tier, expected",
+        [
+            ("fast", "standard", "fast-standard-model"),
+            ("fast", "advanced", "fast-advanced-model"),
+            ("thinking", "standard", "thinking-standard-model"),
+            ("thinking", "advanced", "thinking-advanced-model"),
+        ],
+    )
+    async def test_full_payload_routes_each_cell(self, mode, tier, expected):
+        """Full JSON with all 4 cells → each cell returns its mapped value."""
+        cfg = _make_config()
+        with patch(
+            "backend.copilot.model_router.get_feature_flag_value",
+            new=AsyncMock(return_value=_FULL_PAYLOAD),
+        ):
+            result = await resolve_model(mode, tier, "user-1", config=cfg)
+        assert result == expected
+
+    @pytest.mark.asyncio
+    async def test_partial_payload_missing_mode_falls_back(self):
+        """Only ``fast`` provided → present cells returned, missing mode falls back."""
+        cfg = _make_config()
+        payload = {
+            "fast": {
+                "standard": "fast-standard-override",
+                "advanced": "fast-advanced-override",
+            }
+        }
+        with patch(
+            "backend.copilot.model_router.get_feature_flag_value",
+            new=AsyncMock(return_value=payload),
+        ):
+            assert (
+                await resolve_model("fast", "standard", "u", config=cfg)
+                == "fast-standard-override"
+            )
+            assert (
+                await resolve_model("fast", "advanced", "u", config=cfg)
+                == "fast-advanced-override"
+            )
+            assert (
+                await resolve_model("thinking", "standard", "u", config=cfg)
+                == cfg.thinking_standard_model
+            )
+            assert (
+                await resolve_model("thinking", "advanced", "u", config=cfg)
+                == cfg.thinking_advanced_model
+            )
+
+    @pytest.mark.asyncio
+    async def test_partial_payload_missing_tier_falls_back(self):
+        """Only ``fast.standard`` set → that cell returned, fast.advanced falls back."""
+        cfg = _make_config()
+        payload = {"fast": {"standard": "fast-standard-override"}}
+        with patch(
+            "backend.copilot.model_router.get_feature_flag_value",
+            new=AsyncMock(return_value=payload),
+        ):
+            assert (
+                await resolve_model("fast", "standard", "u", config=cfg)
+                == "fast-standard-override"
+            )
+            assert (
+                await resolve_model("fast", "advanced", "u", config=cfg)
+                == cfg.fast_advanced_model
+            )
 
     @pytest.mark.asyncio
     async def test_whitespace_is_stripped(self):
         cfg = _make_config()
+        payload = {"thinking": {"advanced": "  xai/grok-4  "}}
         with patch(
             "backend.copilot.model_router.get_feature_flag_value",
-            new=AsyncMock(return_value="  xai/grok-4  "),
+            new=AsyncMock(return_value=payload),
         ):
             result = await resolve_model("thinking", "advanced", "user-1", config=cfg)
         assert result == "xai/grok-4"
 
     @pytest.mark.asyncio
-    async def test_non_string_value_falls_back_with_type_in_warning(self, caplog):
-        """LD misconfigured as a boolean flag — don't try to use ``True`` as a
-        model name; return the config default.  Warning must say
-        'non-string' (not 'empty string') so the LD operator knows the
-        flag type is wrong, not just missing a value."""
-        import logging
-
+    @pytest.mark.parametrize(
+        "bogus_payload",
+        [
+            "anthropic/claude-sonnet-4-6",  # raw string (legacy shape)
+            ["anthropic/claude-sonnet-4-6"],
+            42,
+            True,
+        ],
+    )
+    async def test_non_dict_payload_falls_back_with_warning(
+        self, caplog, bogus_payload
+    ):
+        """Non-dict payload → all cells fall back + warning logged."""
         cfg = _make_config()
         with caplog.at_level(logging.WARNING, logger="backend.copilot.model_router"):
             with patch(
                 "backend.copilot.model_router.get_feature_flag_value",
-                new=AsyncMock(return_value=True),
+                new=AsyncMock(return_value=bogus_payload),
+            ):
+                result = await resolve_model("fast", "standard", "user-1", config=cfg)
+        assert result == cfg.fast_standard_model
+        assert any("expected a JSON object" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "value",
+        [42, ["x"], None, True, {"nested": "dict"}],
+    )
+    async def test_non_string_cell_value_falls_back_with_warning(self, caplog, value):
+        """LD misconfigured cell value (number, list, bool, dict) — don't try
+        to use it as a model name; return the config default.  Warning
+        must say 'non-string' (skipped for ``None`` since that means the
+        cell is simply unset, not misconfigured)."""
+        cfg = _make_config()
+        payload = {"fast": {"advanced": value}}
+        with caplog.at_level(logging.WARNING, logger="backend.copilot.model_router"):
+            with patch(
+                "backend.copilot.model_router.get_feature_flag_value",
+                new=AsyncMock(return_value=payload),
             ):
                 result = await resolve_model("fast", "advanced", "user-1", config=cfg)
         assert result == cfg.fast_advanced_model
-        assert any("non-string" in r.message for r in caplog.records)
+        if value is None:
+            # ``None`` is a missing cell, not a misconfiguration — no warning.
+            assert not any(
+                "non-string" in r.message or "empty string" in r.message
+                for r in caplog.records
+            )
+        else:
+            assert any("non-string" in r.message for r in caplog.records)
 
     @pytest.mark.asyncio
-    async def test_empty_string_falls_back_with_empty_in_warning(self, caplog):
-        """When LD returns ``""`` the warning must say 'empty string' —
-        not 'non-string' — so the operator doesn't chase a type bug
-        when the flag is simply unset to an empty value."""
-        import logging
-
+    async def test_empty_string_cell_falls_back_with_empty_in_warning(self, caplog):
+        """When LD returns ``""`` for a cell the warning must say 'empty
+        string' — not 'non-string' — so the operator doesn't chase a
+        type bug when the flag is simply unset to an empty value."""
         cfg = _make_config()
+        payload = {"fast": {"standard": ""}}
         with caplog.at_level(logging.WARNING, logger="backend.copilot.model_router"):
             with patch(
                 "backend.copilot.model_router.get_feature_flag_value",
-                new=AsyncMock(return_value=""),
+                new=AsyncMock(return_value=payload),
             ):
                 result = await resolve_model("fast", "standard", "user-1", config=cfg)
         assert result == cfg.fast_standard_model
@@ -126,27 +256,53 @@ class TestResolveModel:
         assert not any("non-string" in m for m in messages)
 
     @pytest.mark.asyncio
-    async def test_ld_exception_falls_back(self):
-        """LD client throws (network blip, SDK init race) — serve the default
-        instead of failing the whole request."""
+    async def test_mode_cell_not_dict_falls_back_silently(self):
+        """LD payload has ``"fast": "claude"`` (string instead of dict) —
+        treat the whole mode as missing and fall back without spamming
+        a warning per cell (the non-dict-payload branch already warns
+        once for the top-level shape issue when applicable)."""
         cfg = _make_config()
+        payload = {"fast": "anthropic/claude-sonnet-4-6"}
         with patch(
             "backend.copilot.model_router.get_feature_flag_value",
-            new=AsyncMock(side_effect=RuntimeError("LD down")),
+            new=AsyncMock(return_value=payload),
         ):
-            result = await resolve_model("fast", "standard", "user-1", config=cfg)
-        assert result == cfg.fast_standard_model
+            assert (
+                await resolve_model("fast", "standard", "u", config=cfg)
+                == cfg.fast_standard_model
+            )
+            assert (
+                await resolve_model("fast", "advanced", "u", config=cfg)
+                == cfg.fast_advanced_model
+            )
 
     @pytest.mark.asyncio
-    async def test_all_four_cells_hit_distinct_flags(self):
-        """Each (mode, tier) cell must route to its own flag — regression
-        guard against copy-paste bugs in the _FLAG_BY_CELL map."""
+    async def test_ld_exception_falls_back_with_warning(self, caplog):
+        """LD client throws (network blip, SDK init race) — serve the default
+        instead of failing the whole request, and log with ``exc_info``."""
+        cfg = _make_config()
+        with caplog.at_level(logging.WARNING, logger="backend.copilot.model_router"):
+            with patch(
+                "backend.copilot.model_router.get_feature_flag_value",
+                new=AsyncMock(side_effect=RuntimeError("LD down")),
+            ):
+                result = await resolve_model("fast", "standard", "user-1", config=cfg)
+        assert result == cfg.fast_standard_model
+        records = [r for r in caplog.records if "LD lookup failed" in r.message]
+        assert records, "expected an LD-failure warning"
+        assert records[0].exc_info is not None
+
+    @pytest.mark.asyncio
+    async def test_single_ld_call_per_resolve(self):
+        """Each ``resolve_model`` call hits the single JSON flag exactly once
+        — regression guard against accidentally re-introducing per-cell
+        flag fan-out."""
         cfg = _make_config()
         calls: list[str] = []
 
         async def _capture(flag_key, user_id, default):
             calls.append(flag_key)
-            return default
+            return _FULL_PAYLOAD
 
         with patch(
             "backend.copilot.model_router.get_feature_flag_value",
@@ -157,10 +313,4 @@ class TestResolveModel:
             await resolve_model("thinking", "standard", "u", config=cfg)
             await resolve_model("thinking", "advanced", "u", config=cfg)
 
-        assert calls == [
-            _FLAG_BY_CELL[("fast", "standard")].value,
-            _FLAG_BY_CELL[("fast", "advanced")].value,
-            _FLAG_BY_CELL[("thinking", "standard")].value,
-            _FLAG_BY_CELL[("thinking", "advanced")].value,
-        ]
-        assert len(set(calls)) == 4
+        assert calls == ["copilot-model-routing"] * 4

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -794,8 +794,8 @@ async def _resolve_thinking_model_for_user(
 ) -> str:
     """LD-aware thinking-tier model pick for a specific user.
 
-    Consults ``copilot-thinking-{tier}-model`` and falls back to the
-    ``ChatConfig`` default on missing user / missing flag.
+    Consults ``copilot-model-routing[thinking][{tier}]`` and falls back
+    to the ``ChatConfig`` default on missing user / missing flag.
     """
     return await resolve_model("thinking", tier, user_id, config=config)
 
@@ -831,10 +831,11 @@ async def _resolve_sdk_model_for_request(
 
     Priority (highest first):
     1. ``config.claude_agent_model`` — unconditional override, bypasses LD.
-    2. LaunchDarkly ``copilot-thinking-{tier}-model`` if it serves a value
-       different from the config default for *user_id*.  An LD-served
-       override wins over subscription mode so admins can route specific
-       users to a specific model without flipping subscription on/off.
+    2. LaunchDarkly ``copilot-model-routing[thinking][{tier}]`` if it
+       serves a value different from the config default for *user_id*.
+       An LD-served override wins over subscription mode so admins can
+       route specific users to a specific model without flipping
+       subscription on/off.
     3. ``config.use_claude_code_subscription`` on the standard tier —
        returns ``None`` so the CLI picks the subscription default (this
        branch fires when LD has no opinion, i.e. the value equals the
@@ -864,8 +865,8 @@ async def _resolve_sdk_model_for_request(
     # user somewhere).  Any LD override — even to the same value with
     # stripped whitespace normalised — is an explicit admin choice that
     # must be honoured.  Without this, a subscription-mode deployment
-    # silently ignores the ``copilot-thinking-standard-model`` flag
-    # entirely, which defeats the point of cohort-based routing.
+    # silently ignores the ``copilot-model-routing[thinking][standard]``
+    # flag entirely, which defeats the point of cohort-based routing.
     ld_overrides_default = resolved != tier_default
     if (
         not ld_overrides_default

--- a/autogpt_platform/backend/backend/copilot/sdk/service_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service_test.py
@@ -614,10 +614,10 @@ class TestResolveSdkModelForRequestLdFallback:
         self, monkeypatch, _clean_config_env
     ):
         """Bug reported in local test: subscription mode + LD serving Kimi
-        on ``copilot-thinking-standard-model`` returned ``None`` (CLI
-        picked subscription default Opus), silently ignoring the LD
-        override.  An LD value different from the config default is an
-        explicit admin decision and must win."""
+        on ``copilot-model-routing[thinking][standard]`` returned
+        ``None`` (CLI picked subscription default Opus), silently
+        ignoring the LD override.  An LD value different from the
+        config default is an explicit admin decision and must win."""
         cfg = cfg_mod.ChatConfig(
             thinking_standard_model="anthropic/claude-sonnet-4-6",
             claude_agent_model=None,

--- a/autogpt_platform/backend/backend/util/feature_flag.py
+++ b/autogpt_platform/backend/backend/util/feature_flag.py
@@ -47,15 +47,16 @@ class Flag(str, Enum):
     COPILOT_TIER_STRIPE_PRICES = "copilot-tier-stripe-prices"
     GRAPHITI_MEMORY = "graphiti-memory"
 
-    # Copilot model routing — string-valued, returns the model identifier
-    # (e.g. ``"anthropic/claude-sonnet-4-6"`` or ``"moonshotai/kimi-k2.6"``)
-    # to use for each cell of the (mode, tier) matrix.  Falls back to the
-    # ``CHAT_*_MODEL`` env/config default when the flag is unset or LD is
-    # unavailable.  Evaluated per user_id so cohorts can be targeted.
-    COPILOT_FAST_STANDARD_MODEL = "copilot-fast-standard-model"
-    COPILOT_FAST_ADVANCED_MODEL = "copilot-fast-advanced-model"
-    COPILOT_THINKING_STANDARD_MODEL = "copilot-thinking-standard-model"
-    COPILOT_THINKING_ADVANCED_MODEL = "copilot-thinking-advanced-model"
+    # Copilot model routing — JSON-valued, returns the per-(mode, tier)
+    # model identifier (e.g. ``"anthropic/claude-sonnet-4-6"`` or
+    # ``"moonshotai/kimi-k2.6"``).  Shape:
+    # ``{"fast": {"standard": "...", "advanced": "..."},
+    #   "thinking": {"standard": "...", "advanced": "..."}}``.
+    # Missing mode, missing tier-within-mode, non-string value, non-dict
+    # payload, or LD failure all fall back to the corresponding
+    # ``ChatConfig`` default.  Evaluated per user_id so cohorts can be
+    # targeted.
+    COPILOT_MODEL_ROUTING = "copilot-model-routing"
 
 
 def is_configured() -> bool:


### PR DESCRIPTION
## What

Replaces 4 string-valued LaunchDarkly flags with a single JSON-valued flag for copilot model routing:

- ~~`copilot-fast-standard-model`~~
- ~~`copilot-fast-advanced-model`~~
- ~~`copilot-thinking-standard-model`~~
- ~~`copilot-thinking-advanced-model`~~

**New:** `copilot-model-routing` (JSON), keyed `{mode: {tier: model}}`:
```json
{
  "fast":     { "standard": "anthropic/claude-sonnet-4-6", "advanced": "anthropic/claude-opus-4-6" },
  "thinking": { "standard": "moonshotai/kimi-k2.6",         "advanced": "anthropic/claude-opus-4-6" }
}
```

## Why

Same pattern as the sibling consolidation in #12915 (pricing / cost-limits flags) and the merged #12910 (tier-multipliers):

- One flag per config domain — less LD UI clutter, easier audit trail.
- Atomic updates — rotating fast.standard + thinking.standard is a single save.
- Fewer LD entities to name, version, target, explain.
- Mirrors the now-uniform copilot-* JSON-flag shape.

## How

- `backend/util/feature_flag.py`: drop the four `COPILOT_*_MODEL` enum values, add `COPILOT_MODEL_ROUTING`.
- `backend/copilot/model_router.py`: rewrite `resolve_model` to fetch the JSON flag once per call and walk `payload[mode][tier]`. Missing mode, missing tier-within-mode, non-string cell value, non-dict payload, or LD failure all fall back to the corresponding `ChatConfig` default (same user-visible semantics as before). `_FLAG_BY_CELL` removed entirely; `_config_default` / `ModelMode` / `ModelTier` unchanged.
- Per-user LD targeting preserved — cohorts can still receive different routing.
- No caching added (preserves existing uncached behaviour).
- Docstring references in `copilot/config.py` + `copilot/sdk/service.py` updated to point at the new nested key path; one docstring in `service_test.py` likewise.

## Operator action required BEFORE merging

This PR removes 4 LD flags and introduces 1 replacement.

1. In LaunchDarkly, create `copilot-model-routing` (type: **JSON**, server-side only). Default variation = union of the current four string flags, shaped as:
   ```json
   {
     "fast":     { "standard": "<current copilot-fast-standard-model>",     "advanced": "<current copilot-fast-advanced-model>" },
     "thinking": { "standard": "<current copilot-thinking-standard-model>", "advanced": "<current copilot-thinking-advanced-model>" }
   }
   ```
   Omit any cell that's currently unset (its `ChatConfig` default will be used).

2. Merge this PR.

3. After deploy + smoke, delete the four legacy flags:
   - `copilot-fast-standard-model`
   - `copilot-fast-advanced-model`
   - `copilot-thinking-standard-model`
   - `copilot-thinking-advanced-model`

## Testing

- `backend/copilot/model_router_test.py` rewritten — 27 tests pass:
  - LD unset / `None` payload → fallback for every cell.
  - Full JSON → each cell maps to its value (parametrized).
  - Partial JSON (missing mode, missing tier-within-mode, mode value not a dict).
  - Non-dict payloads (str / list / int / bool) → fallback + warning.
  - Non-string cell values (number, list, bool, dict) → fallback + 'non-string' warning.
  - Empty-string cell → fallback + 'empty string' warning (not 'non-string').
  - LD raises → fallback + warning with `exc_info`.
  - `user_id=None` → skip LD entirely.
  - Single-LD-call regression guard against re-introducing per-cell flag fan-out.
- `backend/copilot/sdk/service_test.py`: 61 tests still pass (it mocks `_resolve_thinking_model_for_user`, so the inner flag change is transparent).
- `black --check` / `ruff check` / `isort --check` all clean.

## Sibling

- #12915 — same consolidation pattern for stripe-price / cost-limits flags.

## Checklist

- [x] I have read the project's contributing guide.
- [x] I have clearly described what this PR changes and why.
- [x] My code follows the style guidelines of this project.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes (CI will confirm).