### PR TITLE
fix(backend/copilot): preserve interrupted SDK partial work on final-failure exit

### DIFF
--- a/autogpt_platform/backend/backend/copilot/sdk/interrupted_partial_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/interrupted_partial_test.py
@@ -22,6 +22,8 @@ from backend.copilot.model import ChatMessage, ChatSession
 from backend.copilot.response_model import StreamToolOutputAvailable
 
 from .service import (
+    _classify_final_failure,
+    _FinalFailure,
     _flush_orphan_tool_uses_to_session,
     _HandledErrorInfo,
     _InterruptedAttempt,
@@ -49,7 +51,7 @@ def _adapter_with_unresolved(responses: list[StreamToolOutputAvailable]):
         out.extend(responses)
         adapter.has_unresolved_tool_calls = False
 
-    adapter._flush_unresolved_tool_calls.side_effect = _flush
+    adapter.flush_unresolved_tool_calls.side_effect = _flush
     state = MagicMock()
     state.adapter = adapter
     return state
@@ -147,8 +149,8 @@ class TestInterruptedAttemptFinalize:
         attempt = _InterruptedAttempt(
             partial=[ChatMessage(role="assistant", content="x")]
         )
-        attempt.finalize(None, state=None, display_msg="Boom", retryable=False)
-        # no raise = pass
+        events = attempt.finalize(None, state=None, display_msg="Boom", retryable=False)
+        assert events == []
 
     def test_flushes_unresolved_tools_between_partial_and_marker(self):
         session = _make_session([ChatMessage(role="user", content="hi")])
@@ -167,12 +169,20 @@ class TestInterruptedAttemptFinalize:
                 ),
             ]
         )
-        state = _adapter_with_unresolved([_tool_output("t1", "interrupted")])
-        attempt.finalize(session, state=state, display_msg="Boom", retryable=False)
+        flushed = [_tool_output("t1", "interrupted")]
+        state = _adapter_with_unresolved(flushed)
+        events = attempt.finalize(
+            session, state=state, display_msg="Boom", retryable=False
+        )
         roles = [m.role for m in session.messages]
         assert roles == ["user", "assistant", "tool", "assistant"]
         assert session.messages[2].tool_call_id == "t1"
         assert session.messages[2].content == "interrupted"
+        # The same events that were persisted to history are returned to the
+        # caller so the caller can yield them to the client — without this
+        # the frontend's spinner widgets stay open until refresh because the
+        # adapter's has_unresolved_tool_calls flag is already flipped to False.
+        assert events == flushed
 
     def test_clear_drops_both_partial_and_handled_error(self):
         attempt = _InterruptedAttempt(
@@ -189,27 +199,101 @@ class TestInterruptedAttemptFinalize:
 class TestFlushOrphanToolUses:
     def test_appends_synthetic_tool_results_for_unresolved(self):
         session = _make_session()
-        state = _adapter_with_unresolved(
-            [_tool_output("t1", "r1"), _tool_output("t2", {"ok": False})]
-        )
-        _flush_orphan_tool_uses_to_session(session, state)
+        flushed = [_tool_output("t1", "r1"), _tool_output("t2", {"ok": False})]
+        state = _adapter_with_unresolved(flushed)
+        events = _flush_orphan_tool_uses_to_session(session, state)
         assert [m.tool_call_id for m in session.messages] == ["t1", "t2"]
         # Dict outputs are JSON-encoded so structure survives the str-only
         # ChatMessage content field for the next-turn LLM read.
         assert session.messages[1].content == '{"ok": false}'
+        assert events == flushed
 
     def test_noop_when_state_is_none(self):
         session = _make_session()
-        _flush_orphan_tool_uses_to_session(session, None)
+        events = _flush_orphan_tool_uses_to_session(session, None)
         assert session.messages == []
+        assert events == []
 
     def test_noop_when_no_unresolved(self):
         adapter = MagicMock()
         adapter.has_unresolved_tool_calls = False
         state = MagicMock()
         state.adapter = adapter
-        _flush_orphan_tool_uses_to_session(_make_session(), state)
-        adapter._flush_unresolved_tool_calls.assert_not_called()
+        events = _flush_orphan_tool_uses_to_session(_make_session(), state)
+        adapter.flush_unresolved_tool_calls.assert_not_called()
+        assert events == []
+
+
+class TestClassifyFinalFailure:
+    """Ensures the history marker (via finalize) and the SSE StreamError yield
+    share one source of truth for display message + stream code — any drift
+    would let the chat bubble and the SSE event show different copy for the
+    same failure."""
+
+    def test_handled_error_wins(self):
+        interrupted = _InterruptedAttempt(
+            handled_error=_HandledErrorInfo(
+                error_msg="circuit tripped",
+                code="circuit_breaker",
+                retryable=False,
+                already_yielded=True,
+            )
+        )
+        result = _classify_final_failure(
+            interrupted,
+            attempts_exhausted=False,
+            transient_exhausted=False,
+            stream_err=RuntimeError("ignored"),
+        )
+        assert result == _FinalFailure(
+            display_msg="circuit tripped",
+            code="circuit_breaker",
+            retryable=False,
+        )
+
+    def test_attempts_exhausted(self):
+        result = _classify_final_failure(
+            _InterruptedAttempt(),
+            attempts_exhausted=True,
+            transient_exhausted=False,
+            stream_err=RuntimeError("x"),
+        )
+        assert result is not None
+        assert result.code == "all_attempts_exhausted"
+        assert result.retryable is False
+
+    def test_transient_exhausted(self):
+        result = _classify_final_failure(
+            _InterruptedAttempt(),
+            attempts_exhausted=False,
+            transient_exhausted=True,
+            stream_err=RuntimeError("x"),
+        )
+        assert result is not None
+        assert result.code == "transient_api_error"
+        assert result.retryable is True
+
+    def test_stream_err_fallback(self):
+        result = _classify_final_failure(
+            _InterruptedAttempt(),
+            attempts_exhausted=False,
+            transient_exhausted=False,
+            stream_err=RuntimeError("some sdk error"),
+        )
+        assert result is not None
+        assert result.code == "sdk_stream_error"
+        assert result.retryable is False
+
+    def test_returns_none_when_no_failure_recorded(self):
+        assert (
+            _classify_final_failure(
+                _InterruptedAttempt(),
+                attempts_exhausted=False,
+                transient_exhausted=False,
+                stream_err=None,
+            )
+            is None
+        )
 
 
 class TestRetryRollbackContract:

--- a/autogpt_platform/backend/backend/copilot/sdk/interrupted_partial_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/interrupted_partial_test.py
@@ -1,14 +1,13 @@
 """Tests for partial-work preservation when an SDK turn is interrupted.
 
-Covers the regression path SECRT-2275 surfaced: when the SDK retry loop
-rolls back ``session.messages`` for a failed attempt (correct behavior so a
-successful retry doesn't duplicate content) it MUST re-attach the rolled-back
-work on final-failure exit. Otherwise the user's UI streamed tokens live but
+Covers the regression SECRT-2275 surfaced: when the SDK retry loop rolls
+back ``session.messages`` for a failed attempt (correct so a successful
+retry doesn't duplicate content) it MUST re-attach the rolled-back work on
+final-failure exit. Without that, the user's UI streamed tokens live then
 a refresh shows an empty turn — described by users as "the turn is gone".
 
-Tests target the helper functions directly (unit) plus the rollback-then-
-restore contract (state-driven). Full end-to-end coverage of the retry loop
-lives in retry_scenarios_test.py.
+Tests target the ``_InterruptedAttempt`` dataclass + the orphan-tool flush
+directly. Full retry-loop coverage lives in ``retry_scenarios_test.py``.
 """
 
 from __future__ import annotations
@@ -24,8 +23,8 @@ from backend.copilot.response_model import StreamToolOutputAvailable
 
 from .service import (
     _flush_orphan_tool_uses_to_session,
-    _restore_partial_with_error_marker,
-    _rollback_attempt_capturing_partial,
+    _HandledErrorInfo,
+    _InterruptedAttempt,
 )
 
 
@@ -35,21 +34,19 @@ def _make_session(messages: list[ChatMessage] | None = None) -> ChatSession:
     return session
 
 
-def _make_tool_output(tool_call_id: str, output) -> StreamToolOutputAvailable:
+def _tool_output(tool_call_id: str, output) -> StreamToolOutputAvailable:
     return StreamToolOutputAvailable(
-        toolCallId=tool_call_id,
-        toolName="t",
-        output=output,
+        toolCallId=tool_call_id, toolName="t", output=output
     )
 
 
-def _adapter_with_unresolved(unresolved_responses: list[StreamToolOutputAvailable]):
-    """Build a stub _RetryState whose adapter flushes the given responses."""
+def _adapter_with_unresolved(responses: list[StreamToolOutputAvailable]):
+    """Stub _RetryState whose adapter flushes the given responses."""
     adapter = MagicMock()
-    adapter.has_unresolved_tool_calls = bool(unresolved_responses)
+    adapter.has_unresolved_tool_calls = bool(responses)
 
-    def _flush(responses: list) -> None:
-        responses.extend(unresolved_responses)
+    def _flush(out: list) -> None:
+        out.extend(responses)
         adapter.has_unresolved_tool_calls = False
 
     adapter._flush_unresolved_tool_calls.side_effect = _flush
@@ -58,145 +55,29 @@ def _adapter_with_unresolved(unresolved_responses: list[StreamToolOutputAvailabl
     return state
 
 
-class TestRestorePartialWithErrorMarker:
-    def test_appends_partial_then_marker_when_partial_present(self):
-        session = _make_session([ChatMessage(role="user", content="hi")])
-        partial = [
-            ChatMessage(role="assistant", content="I was working on "),
-            ChatMessage(role="tool", content="result-1", tool_call_id="t1"),
-        ]
-        _restore_partial_with_error_marker(
-            session,
-            state=None,
-            partial=partial,
-            display_msg="Boom",
-            retryable=False,
-        )
-        # Pre-existing user msg + 2 partial msgs + error marker
-        assert len(session.messages) == 4
-        assert session.messages[1].content == "I was working on "
-        assert session.messages[2].role == "tool"
-        assert session.messages[3].content.startswith(COPILOT_ERROR_PREFIX)
-        # Partial list is consumed (cleared) so a stray follow-up call won't
-        # double-attach the same content.
-        assert partial == []
-
-    def test_only_marker_when_partial_empty(self):
-        session = _make_session([ChatMessage(role="user", content="hi")])
-        _restore_partial_with_error_marker(
-            session,
-            state=None,
-            partial=[],
-            display_msg="Boom",
-            retryable=True,
-        )
-        assert len(session.messages) == 2
-        assert session.messages[-1].content.startswith(COPILOT_RETRYABLE_ERROR_PREFIX)
-
-    def test_noop_when_session_is_none(self):
-        # Signature accepts None — must not raise.
-        _restore_partial_with_error_marker(
-            None,
-            state=None,
-            partial=[ChatMessage(role="assistant", content="x")],
-            display_msg="Boom",
-            retryable=False,
-        )
-
-    def test_flushes_unresolved_tools_between_partial_and_marker(self):
-        session = _make_session([ChatMessage(role="user", content="hi")])
-        partial = [
-            ChatMessage(
-                role="assistant",
-                content="calling tool",
-                tool_calls=[
-                    {
-                        "id": "t1",
-                        "type": "function",
-                        "function": {"name": "lookup", "arguments": "{}"},
-                    }
-                ],
-            ),
-        ]
-        state = _adapter_with_unresolved([_make_tool_output("t1", "interrupted")])
-        _restore_partial_with_error_marker(
-            session,
-            state=state,
-            partial=partial,
-            display_msg="Boom",
-            retryable=False,
-        )
-        roles = [m.role for m in session.messages]
-        # user, assistant(partial), tool(synthetic), assistant(error marker)
-        assert roles == ["user", "assistant", "tool", "assistant"]
-        synthetic_tool = session.messages[2]
-        assert synthetic_tool.tool_call_id == "t1"
-        assert synthetic_tool.content == "interrupted"
+def _builder_stub() -> MagicMock:
+    builder = MagicMock()
+    builder.restore = MagicMock()
+    return builder
 
 
-class TestFlushOrphanToolUses:
-    def test_appends_synthetic_tool_results_for_unresolved(self):
-        session = _make_session()
-        state = _adapter_with_unresolved(
-            [
-                _make_tool_output("t1", "r1"),
-                _make_tool_output("t2", {"ok": False}),
-            ]
-        )
-        _flush_orphan_tool_uses_to_session(session, state)
-        assert [m.tool_call_id for m in session.messages] == ["t1", "t2"]
-        # Dict outputs are JSON-encoded so they survive the str-only ChatMessage
-        # content field without losing structure for the next-turn LLM read.
-        assert session.messages[1].content == '{"ok": false}'
-
-    def test_noop_when_state_is_none(self):
-        session = _make_session()
-        _flush_orphan_tool_uses_to_session(session, None)
-        assert session.messages == []
-
-    def test_noop_when_no_unresolved(self):
-        session = _make_session()
-        adapter = MagicMock()
-        adapter.has_unresolved_tool_calls = False
-        state = MagicMock()
-        state.adapter = adapter
-        _flush_orphan_tool_uses_to_session(session, state)
-        adapter._flush_unresolved_tool_calls.assert_not_called()
-
-
-class TestRollbackCapturingPartial:
-    """Direct tests of `_rollback_attempt_capturing_partial`.
-
-    The retry loop relies on this helper not to leak error markers that
-    `_run_stream_attempt` already appended to `session.messages` — otherwise
-    the post-loop restore replays a stale marker before adding its own,
-    leaving duplicate error bubbles.
-    """
-
-    def _builder_with_snap(self):
-        builder = MagicMock()
-        builder.restore = MagicMock()
-        return builder
-
-    def test_returns_partial_when_no_marker_present(self):
+class TestInterruptedAttemptCapture:
+    def test_keeps_partial_when_no_marker_present(self):
         session = _make_session(
             [
                 ChatMessage(role="user", content="hi"),
                 ChatMessage(role="assistant", content="part-1"),
             ]
         )
-        builder = self._builder_with_snap()
-        captured = _rollback_attempt_capturing_partial(
-            session, builder, transcript_snap=object(), pre_attempt_msg_count=1
-        )
-        assert [m.content for m in captured] == ["part-1"]
-        assert session.messages == [ChatMessage(role="user", content="hi")]
+        attempt = _InterruptedAttempt()
+        attempt.capture(session, _builder_stub(), object(), pre_attempt_msg_count=1)
+        assert [m.content for m in attempt.partial] == ["part-1"]
+        assert [m.content for m in session.messages] == ["hi"]
 
     def test_strips_trailing_error_marker(self):
-        # _run_stream_attempt appended a marker via _append_error_marker
-        # (e.g. idle timeout, circuit breaker) before raising
-        # _HandledStreamError. The rollback must NOT carry it forward, or
-        # the post-loop restore will replay the stale marker + add its own.
+        # _run_stream_attempt may append a marker (idle timeout, circuit
+        # breaker) before raising _HandledStreamError. Carrying it forward
+        # would let finalize() replay it and then add its own.
         marker = (
             f"{COPILOT_RETRYABLE_ERROR_PREFIX} The session has been idle "
             "for too long. Please try again."
@@ -208,66 +89,136 @@ class TestRollbackCapturingPartial:
                 ChatMessage(role="assistant", content=marker),
             ]
         )
-        captured = _rollback_attempt_capturing_partial(
-            session,
-            self._builder_with_snap(),
-            transcript_snap=object(),
-            pre_attempt_msg_count=1,
-        )
-        assert [m.content for m in captured] == ["part-1"]
+        attempt = _InterruptedAttempt()
+        attempt.capture(session, _builder_stub(), object(), pre_attempt_msg_count=1)
+        assert [m.content for m in attempt.partial] == ["part-1"]
 
     def test_strips_consecutive_error_markers(self):
-        # Defensive: if more than one marker landed back-to-back (legacy
-        # path or future regression), strip them all.
         session = _make_session(
             [
                 ChatMessage(role="user", content="hi"),
                 ChatMessage(role="assistant", content="part-1"),
                 ChatMessage(role="assistant", content=f"{COPILOT_ERROR_PREFIX} a"),
                 ChatMessage(
-                    role="assistant",
-                    content=f"{COPILOT_RETRYABLE_ERROR_PREFIX} b",
+                    role="assistant", content=f"{COPILOT_RETRYABLE_ERROR_PREFIX} b"
                 ),
             ]
         )
-        captured = _rollback_attempt_capturing_partial(
-            session,
-            self._builder_with_snap(),
-            transcript_snap=object(),
-            pre_attempt_msg_count=1,
-        )
-        assert [m.content for m in captured] == ["part-1"]
+        attempt = _InterruptedAttempt()
+        attempt.capture(session, _builder_stub(), object(), pre_attempt_msg_count=1)
+        assert [m.content for m in attempt.partial] == ["part-1"]
 
-    def test_does_not_strip_non_marker_assistant(self):
-        # Regular assistant text starting with similar-but-not-prefix
-        # content must be preserved — only the canonical error markers
-        # should be filtered.
+    def test_preserves_non_marker_assistant(self):
         session = _make_session(
             [
                 ChatMessage(role="user", content="hi"),
                 ChatMessage(role="assistant", content="Important note"),
             ]
         )
-        captured = _rollback_attempt_capturing_partial(
-            session,
-            self._builder_with_snap(),
-            transcript_snap=object(),
-            pre_attempt_msg_count=1,
+        attempt = _InterruptedAttempt()
+        attempt.capture(session, _builder_stub(), object(), pre_attempt_msg_count=1)
+        assert [m.content for m in attempt.partial] == ["Important note"]
+
+
+class TestInterruptedAttemptFinalize:
+    def test_appends_partial_then_marker(self):
+        session = _make_session([ChatMessage(role="user", content="hi")])
+        attempt = _InterruptedAttempt(
+            partial=[
+                ChatMessage(role="assistant", content="working"),
+                ChatMessage(role="tool", content="result", tool_call_id="t1"),
+            ]
         )
-        assert [m.content for m in captured] == ["Important note"]
+        attempt.finalize(session, state=None, display_msg="Boom", retryable=False)
+        roles = [m.role for m in session.messages]
+        assert roles == ["user", "assistant", "tool", "assistant"]
+        assert session.messages[-1].content.startswith(COPILOT_ERROR_PREFIX)
+        # partial consumed so a follow-up finalize() is a no-op for partial.
+        assert attempt.partial == []
+
+    def test_only_marker_when_partial_empty(self):
+        session = _make_session([ChatMessage(role="user", content="hi")])
+        attempt = _InterruptedAttempt()
+        attempt.finalize(session, state=None, display_msg="Boom", retryable=True)
+        assert len(session.messages) == 2
+        assert session.messages[-1].content.startswith(COPILOT_RETRYABLE_ERROR_PREFIX)
+
+    def test_noop_when_session_is_none(self):
+        attempt = _InterruptedAttempt(
+            partial=[ChatMessage(role="assistant", content="x")]
+        )
+        attempt.finalize(None, state=None, display_msg="Boom", retryable=False)
+        # no raise = pass
+
+    def test_flushes_unresolved_tools_between_partial_and_marker(self):
+        session = _make_session([ChatMessage(role="user", content="hi")])
+        attempt = _InterruptedAttempt(
+            partial=[
+                ChatMessage(
+                    role="assistant",
+                    content="calling",
+                    tool_calls=[
+                        {
+                            "id": "t1",
+                            "type": "function",
+                            "function": {"name": "lookup", "arguments": "{}"},
+                        }
+                    ],
+                ),
+            ]
+        )
+        state = _adapter_with_unresolved([_tool_output("t1", "interrupted")])
+        attempt.finalize(session, state=state, display_msg="Boom", retryable=False)
+        roles = [m.role for m in session.messages]
+        assert roles == ["user", "assistant", "tool", "assistant"]
+        assert session.messages[2].tool_call_id == "t1"
+        assert session.messages[2].content == "interrupted"
+
+    def test_clear_drops_both_partial_and_handled_error(self):
+        attempt = _InterruptedAttempt(
+            partial=[ChatMessage(role="assistant", content="x")],
+            handled_error=_HandledErrorInfo(
+                error_msg="m", code="c", retryable=True, already_yielded=False
+            ),
+        )
+        attempt.clear()
+        assert attempt.partial == []
+        assert attempt.handled_error is None
+
+
+class TestFlushOrphanToolUses:
+    def test_appends_synthetic_tool_results_for_unresolved(self):
+        session = _make_session()
+        state = _adapter_with_unresolved(
+            [_tool_output("t1", "r1"), _tool_output("t2", {"ok": False})]
+        )
+        _flush_orphan_tool_uses_to_session(session, state)
+        assert [m.tool_call_id for m in session.messages] == ["t1", "t2"]
+        # Dict outputs are JSON-encoded so structure survives the str-only
+        # ChatMessage content field for the next-turn LLM read.
+        assert session.messages[1].content == '{"ok": false}'
+
+    def test_noop_when_state_is_none(self):
+        session = _make_session()
+        _flush_orphan_tool_uses_to_session(session, None)
+        assert session.messages == []
+
+    def test_noop_when_no_unresolved(self):
+        adapter = MagicMock()
+        adapter.has_unresolved_tool_calls = False
+        state = MagicMock()
+        state.adapter = adapter
+        _flush_orphan_tool_uses_to_session(_make_session(), state)
+        adapter._flush_unresolved_tool_calls.assert_not_called()
 
 
 class TestRetryRollbackContract:
-    """Property-style: a rolled-back attempt must be recoverable on final exit.
+    """End-to-end contract: capture on a rolled-back attempt + finalize yields
+    the exact content the user saw streaming live, plus the error marker."""
 
-    Simulates the retry loop's rollback by mirroring the exact slicing and
-    captured-list shape used in stream_chat_completion_sdk so that any drift
-    in that contract is caught here without needing the full SDK fixture.
-    """
-
-    def test_capture_slice_matches_rollback(self):
+    def test_capture_then_finalize_matches_streamed_sequence(self):
         session = _make_session([ChatMessage(role="user", content="hi")])
-        pre_attempt_msg_count = len(session.messages)
+        pre = len(session.messages)
         # Simulate incremental SDK appends during the attempt.
         session.messages.extend(
             [
@@ -275,18 +226,11 @@ class TestRetryRollbackContract:
                 ChatMessage(role="assistant", content="part-2"),
             ]
         )
-        captured = list(session.messages[pre_attempt_msg_count:])
-        session.messages = session.messages[:pre_attempt_msg_count]
-        # Final-failure restore.
-        _restore_partial_with_error_marker(
-            session,
-            state=None,
-            partial=captured,
-            display_msg="Boom",
-            retryable=False,
-        )
-        contents = [m.content for m in session.messages]
-        assert contents == [
+        attempt = _InterruptedAttempt()
+        attempt.capture(session, _builder_stub(), object(), pre)
+        # Final-failure path — no retry, no success clear().
+        attempt.finalize(session, state=None, display_msg="Boom", retryable=False)
+        assert [m.content for m in session.messages] == [
             "hi",
             "part-1",
             "part-2",

--- a/autogpt_platform/backend/backend/copilot/sdk/interrupted_partial_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/interrupted_partial_test.py
@@ -1,0 +1,200 @@
+"""Tests for partial-work preservation when an SDK turn is interrupted.
+
+Covers the regression path SECRT-2275 surfaced: when the SDK retry loop
+rolls back ``session.messages`` for a failed attempt (correct behavior so a
+successful retry doesn't duplicate content) it MUST re-attach the rolled-back
+work on final-failure exit. Otherwise the user's UI streamed tokens live but
+a refresh shows an empty turn — described by users as "the turn is gone".
+
+Tests target the helper functions directly (unit) plus the rollback-then-
+restore contract (state-driven). Full end-to-end coverage of the retry loop
+lives in retry_scenarios_test.py.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from backend.copilot.constants import (
+    COPILOT_ERROR_PREFIX,
+    COPILOT_RETRYABLE_ERROR_PREFIX,
+)
+from backend.copilot.model import ChatMessage, ChatSession
+from backend.copilot.response_model import StreamToolOutputAvailable
+
+from .service import (
+    _flush_orphan_tool_uses_to_session,
+    _restore_partial_with_error_marker,
+)
+
+
+def _make_session(messages: list[ChatMessage] | None = None) -> ChatSession:
+    session = ChatSession.new(user_id="user-1", dry_run=False)
+    session.messages = list(messages or [])
+    return session
+
+
+def _make_tool_output(tool_call_id: str, output) -> StreamToolOutputAvailable:
+    return StreamToolOutputAvailable(
+        toolCallId=tool_call_id,
+        toolName="t",
+        output=output,
+    )
+
+
+def _adapter_with_unresolved(unresolved_responses: list[StreamToolOutputAvailable]):
+    """Build a stub _RetryState whose adapter flushes the given responses."""
+    adapter = MagicMock()
+    adapter.has_unresolved_tool_calls = bool(unresolved_responses)
+
+    def _flush(responses: list) -> None:
+        responses.extend(unresolved_responses)
+        adapter.has_unresolved_tool_calls = False
+
+    adapter._flush_unresolved_tool_calls.side_effect = _flush
+    state = MagicMock()
+    state.adapter = adapter
+    return state
+
+
+class TestRestorePartialWithErrorMarker:
+    def test_appends_partial_then_marker_when_partial_present(self):
+        session = _make_session([ChatMessage(role="user", content="hi")])
+        partial = [
+            ChatMessage(role="assistant", content="I was working on "),
+            ChatMessage(role="tool", content="result-1", tool_call_id="t1"),
+        ]
+        _restore_partial_with_error_marker(
+            session,
+            state=None,
+            partial=partial,
+            display_msg="Boom",
+            retryable=False,
+        )
+        # Pre-existing user msg + 2 partial msgs + error marker
+        assert len(session.messages) == 4
+        assert session.messages[1].content == "I was working on "
+        assert session.messages[2].role == "tool"
+        assert session.messages[3].content.startswith(COPILOT_ERROR_PREFIX)
+        # Partial list is consumed (cleared) so a stray follow-up call won't
+        # double-attach the same content.
+        assert partial == []
+
+    def test_only_marker_when_partial_empty(self):
+        session = _make_session([ChatMessage(role="user", content="hi")])
+        _restore_partial_with_error_marker(
+            session,
+            state=None,
+            partial=[],
+            display_msg="Boom",
+            retryable=True,
+        )
+        assert len(session.messages) == 2
+        assert session.messages[-1].content.startswith(COPILOT_RETRYABLE_ERROR_PREFIX)
+
+    def test_noop_when_session_is_none(self):
+        # Signature accepts None — must not raise.
+        _restore_partial_with_error_marker(
+            None,
+            state=None,
+            partial=[ChatMessage(role="assistant", content="x")],
+            display_msg="Boom",
+            retryable=False,
+        )
+
+    def test_flushes_unresolved_tools_between_partial_and_marker(self):
+        session = _make_session([ChatMessage(role="user", content="hi")])
+        partial = [
+            ChatMessage(
+                role="assistant",
+                content="calling tool",
+                tool_calls=[
+                    {
+                        "id": "t1",
+                        "type": "function",
+                        "function": {"name": "lookup", "arguments": "{}"},
+                    }
+                ],
+            ),
+        ]
+        state = _adapter_with_unresolved([_make_tool_output("t1", "interrupted")])
+        _restore_partial_with_error_marker(
+            session,
+            state=state,
+            partial=partial,
+            display_msg="Boom",
+            retryable=False,
+        )
+        roles = [m.role for m in session.messages]
+        # user, assistant(partial), tool(synthetic), assistant(error marker)
+        assert roles == ["user", "assistant", "tool", "assistant"]
+        synthetic_tool = session.messages[2]
+        assert synthetic_tool.tool_call_id == "t1"
+        assert synthetic_tool.content == "interrupted"
+
+
+class TestFlushOrphanToolUses:
+    def test_appends_synthetic_tool_results_for_unresolved(self):
+        session = _make_session()
+        state = _adapter_with_unresolved(
+            [
+                _make_tool_output("t1", "r1"),
+                _make_tool_output("t2", {"ok": False}),
+            ]
+        )
+        _flush_orphan_tool_uses_to_session(session, state)
+        assert [m.tool_call_id for m in session.messages] == ["t1", "t2"]
+        # Dict outputs are JSON-encoded so they survive the str-only ChatMessage
+        # content field without losing structure for the next-turn LLM read.
+        assert session.messages[1].content == '{"ok": false}'
+
+    def test_noop_when_state_is_none(self):
+        session = _make_session()
+        _flush_orphan_tool_uses_to_session(session, None)
+        assert session.messages == []
+
+    def test_noop_when_no_unresolved(self):
+        session = _make_session()
+        adapter = MagicMock()
+        adapter.has_unresolved_tool_calls = False
+        state = MagicMock()
+        state.adapter = adapter
+        _flush_orphan_tool_uses_to_session(session, state)
+        adapter._flush_unresolved_tool_calls.assert_not_called()
+
+
+class TestRetryRollbackContract:
+    """Property-style: a rolled-back attempt must be recoverable on final exit.
+
+    Simulates the retry loop's rollback by mirroring the exact slicing and
+    captured-list shape used in stream_chat_completion_sdk so that any drift
+    in that contract is caught here without needing the full SDK fixture.
+    """
+
+    def test_capture_slice_matches_rollback(self):
+        session = _make_session([ChatMessage(role="user", content="hi")])
+        pre_attempt_msg_count = len(session.messages)
+        # Simulate incremental SDK appends during the attempt.
+        session.messages.extend(
+            [
+                ChatMessage(role="assistant", content="part-1"),
+                ChatMessage(role="assistant", content="part-2"),
+            ]
+        )
+        captured = list(session.messages[pre_attempt_msg_count:])
+        session.messages = session.messages[:pre_attempt_msg_count]
+        # Final-failure restore.
+        _restore_partial_with_error_marker(
+            session,
+            state=None,
+            partial=captured,
+            display_msg="Boom",
+            retryable=False,
+        )
+        contents = [m.content for m in session.messages]
+        assert contents == [
+            "hi",
+            "part-1",
+            "part-2",
+            f"{COPILOT_ERROR_PREFIX} Boom",
+        ]

--- a/autogpt_platform/backend/backend/copilot/sdk/interrupted_partial_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/interrupted_partial_test.py
@@ -25,6 +25,7 @@ from backend.copilot.response_model import StreamToolOutputAvailable
 from .service import (
     _flush_orphan_tool_uses_to_session,
     _restore_partial_with_error_marker,
+    _rollback_attempt_capturing_partial,
 )
 
 
@@ -161,6 +162,99 @@ class TestFlushOrphanToolUses:
         state.adapter = adapter
         _flush_orphan_tool_uses_to_session(session, state)
         adapter._flush_unresolved_tool_calls.assert_not_called()
+
+
+class TestRollbackCapturingPartial:
+    """Direct tests of `_rollback_attempt_capturing_partial`.
+
+    The retry loop relies on this helper not to leak error markers that
+    `_run_stream_attempt` already appended to `session.messages` — otherwise
+    the post-loop restore replays a stale marker before adding its own,
+    leaving duplicate error bubbles.
+    """
+
+    def _builder_with_snap(self):
+        builder = MagicMock()
+        builder.restore = MagicMock()
+        return builder
+
+    def test_returns_partial_when_no_marker_present(self):
+        session = _make_session(
+            [
+                ChatMessage(role="user", content="hi"),
+                ChatMessage(role="assistant", content="part-1"),
+            ]
+        )
+        builder = self._builder_with_snap()
+        captured = _rollback_attempt_capturing_partial(
+            session, builder, transcript_snap=object(), pre_attempt_msg_count=1
+        )
+        assert [m.content for m in captured] == ["part-1"]
+        assert session.messages == [ChatMessage(role="user", content="hi")]
+
+    def test_strips_trailing_error_marker(self):
+        # _run_stream_attempt appended a marker via _append_error_marker
+        # (e.g. idle timeout, circuit breaker) before raising
+        # _HandledStreamError. The rollback must NOT carry it forward, or
+        # the post-loop restore will replay the stale marker + add its own.
+        marker = (
+            f"{COPILOT_RETRYABLE_ERROR_PREFIX} The session has been idle "
+            "for too long. Please try again."
+        )
+        session = _make_session(
+            [
+                ChatMessage(role="user", content="hi"),
+                ChatMessage(role="assistant", content="part-1"),
+                ChatMessage(role="assistant", content=marker),
+            ]
+        )
+        captured = _rollback_attempt_capturing_partial(
+            session,
+            self._builder_with_snap(),
+            transcript_snap=object(),
+            pre_attempt_msg_count=1,
+        )
+        assert [m.content for m in captured] == ["part-1"]
+
+    def test_strips_consecutive_error_markers(self):
+        # Defensive: if more than one marker landed back-to-back (legacy
+        # path or future regression), strip them all.
+        session = _make_session(
+            [
+                ChatMessage(role="user", content="hi"),
+                ChatMessage(role="assistant", content="part-1"),
+                ChatMessage(role="assistant", content=f"{COPILOT_ERROR_PREFIX} a"),
+                ChatMessage(
+                    role="assistant",
+                    content=f"{COPILOT_RETRYABLE_ERROR_PREFIX} b",
+                ),
+            ]
+        )
+        captured = _rollback_attempt_capturing_partial(
+            session,
+            self._builder_with_snap(),
+            transcript_snap=object(),
+            pre_attempt_msg_count=1,
+        )
+        assert [m.content for m in captured] == ["part-1"]
+
+    def test_does_not_strip_non_marker_assistant(self):
+        # Regular assistant text starting with similar-but-not-prefix
+        # content must be preserved — only the canonical error markers
+        # should be filtered.
+        session = _make_session(
+            [
+                ChatMessage(role="user", content="hi"),
+                ChatMessage(role="assistant", content="Important note"),
+            ]
+        )
+        captured = _rollback_attempt_capturing_partial(
+            session,
+            self._builder_with_snap(),
+            transcript_snap=object(),
+            pre_attempt_msg_count=1,
+        )
+        assert [m.content for m in captured] == ["Important note"]
 
 
 class TestRetryRollbackContract:

--- a/autogpt_platform/backend/backend/copilot/sdk/response_adapter.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/response_adapter.py
@@ -166,7 +166,7 @@ class SDKResponseAdapter:
             # are still executing concurrently and haven't finished yet.
             is_tool_only = all(isinstance(b, ToolUseBlock) for b in sdk_message.content)
             if not is_tool_only:
-                self._flush_unresolved_tool_calls(responses)
+                self.flush_unresolved_tool_calls(responses)
 
             # After tool results, the SDK sends a new AssistantMessage for the
             # next LLM turn. Open a new step if the previous one was closed.
@@ -375,7 +375,7 @@ class SDKResponseAdapter:
                 self.step_open = False
 
         elif isinstance(sdk_message, ResultMessage):
-            self._flush_unresolved_tool_calls(responses)
+            self.flush_unresolved_tool_calls(responses)
             # Thinking-only final turn guard: when the model's last LLM
             # call after a tool result produced only a ``ThinkingBlock``
             # (no ``TextBlock``, no ``ToolUseBlock``) the UI has nothing
@@ -703,7 +703,7 @@ class SDKResponseAdapter:
         self._pending_thinking_delta = ""
         self._pending_thinking_index = None
 
-    def _flush_unresolved_tool_calls(self, responses: list[StreamBaseResponse]) -> None:
+    def flush_unresolved_tool_calls(self, responses: list[StreamBaseResponse]) -> None:
         """Emit outputs for tool calls that didn't receive a UserMessage result.
 
         SDK built-in tools (WebSearch, Read, etc.) may be executed by the CLI
@@ -711,6 +711,12 @@ class SDKResponseAdapter:
         ``ToolResultBlock`` content.  The ``PostToolUse`` hook stashes their
         output, which we pop and emit here before the next ``AssistantMessage``
         starts.
+
+        Callers that need to both record synthetic tool_results in history AND
+        yield the same events to the client should call this exactly once and
+        share the resulting list — the method mutates ``resolved_tool_calls``,
+        so a second call returns nothing and ``has_unresolved_tool_calls``
+        flips to ``False`` after the first invocation.
         """
         unresolved = [
             (tid, info.get("name", "unknown"))

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -3067,7 +3067,7 @@ async def _maybe_prepend_builder_context(
     return block + query_message if block else query_message
 
 
-async def stream_chat_completion_sdk(
+async def stream_chat_completion_sdk(  # pyright: ignore[reportGeneralTypeIssues]
     session_id: str,
     message: str | None = None,
     is_user_message: bool = True,
@@ -3080,6 +3080,12 @@ async def stream_chat_completion_sdk(
     request_arrival_at: float = 0.0,
     **_kwargs: Any,
 ) -> AsyncGenerator[StreamBaseResponse, None]:
+    # Pyright's complexity heuristic bails on this function (~1500 LoC, retry
+    # loop with context-overflow fallback + transient backoff + partial-work
+    # preservation). Splitting further would hurt readability — the branches
+    # share state (session, adapter, transcript builder, token accumulators)
+    # that's hard to pass cleanly through helpers. Suppress the bailout; real
+    # type errors elsewhere in the file remain surfaced.
     """Stream chat completion using Claude Agent SDK.
 
     Args:
@@ -3247,6 +3253,11 @@ async def stream_chat_completion_sdk(
     # failed attempt. On final-failure exit we re-attach these so the user sees
     # what the assistant produced before the error rather than an empty chat.
     last_attempt_partial: list[ChatMessage] = []
+    # Populated by the _HandledStreamError branch with (display_msg, code,
+    # already_yielded). Consumed once after the retry loop to re-attach the
+    # partial and, if the inner handler hadn't already emitted one, yield a
+    # single StreamError to the client.
+    handled_error_info: tuple[str, str, bool] | None = None
     # Defaults ensure the finally block can always reference these safely even when
     # an early return (e.g. sdk_cwd error) skips their normal assignment below.
     sdk_model: str | None = None
@@ -3965,28 +3976,12 @@ async def stream_chat_completion_sdk(
                 # attempt that no longer match session.messages.  Skip upload
                 # so a future --resume doesn't replay rolled-back content.
                 skip_transcript_upload = True
-                # Re-attach the rolled-back partial work + add error marker.
-                # Without partial restoration the user's UI streamed tokens
-                # live but a refresh shows nothing happened.
-                _restore_partial_with_error_marker(
-                    session,
-                    state,
-                    last_attempt_partial,
+                handled_error_info = (
                     exc.error_msg or FRIENDLY_TRANSIENT_MSG,
-                    retryable=True,
+                    exc.code or "transient_api_error",
+                    exc.already_yielded,
                 )
                 ended_with_stream_error = True
-                # For transient errors the StreamError was deliberately NOT
-                # yielded inside _run_stream_attempt (already_yielded=False)
-                # so the client didn't see a premature error flash.  Yield it
-                # now that we know retries are exhausted.
-                # For non-transient errors (circuit breaker, idle timeout)
-                # already_yielded=True — do NOT yield again.
-                if not exc.already_yielded:
-                    yield StreamError(
-                        errorText=exc.error_msg or FRIENDLY_TRANSIENT_MSG,
-                        code=exc.code or "transient_api_error",
-                    )
                 break
             except Exception as e:
                 stream_err = e
@@ -4020,19 +4015,6 @@ async def stream_chat_completion_sdk(
                         events_yielded,
                     )
                     skip_transcript_upload = True
-                    # Restore the streamed partial + add error marker — without
-                    # this the frontend would briefly show streamed text live
-                    # then a refresh would show an empty turn.
-                    safe_err = (
-                        str(stream_err).replace("\n", " ").replace("\r", "")[:500]
-                    )
-                    _restore_partial_with_error_marker(
-                        session,
-                        state,
-                        last_attempt_partial,
-                        _friendly_error_text(safe_err),
-                        retryable=False,
-                    )
                     ended_with_stream_error = True
                     break
                 # Transient API errors (ECONNRESET, 429, 5xx) — retry
@@ -4060,13 +4042,6 @@ async def stream_chat_completion_sdk(
                     # at line ~2310.
                     transient_exhausted = True
                     skip_transcript_upload = True
-                    _restore_partial_with_error_marker(
-                        session,
-                        state,
-                        last_attempt_partial,
-                        FRIENDLY_TRANSIENT_MSG,
-                        retryable=True,
-                    )
                     ended_with_stream_error = True
                     break
 
@@ -4074,16 +4049,6 @@ async def stream_chat_completion_sdk(
                     # Non-context, non-transient errors (auth, fatal)
                     # should not trigger compaction — surface immediately.
                     skip_transcript_upload = True
-                    safe_err = (
-                        str(stream_err).replace("\n", " ").replace("\r", "")[:500]
-                    )
-                    _restore_partial_with_error_marker(
-                        session,
-                        state,
-                        last_attempt_partial,
-                        _friendly_error_text(safe_err),
-                        retryable=False,
-                    )
                     ended_with_stream_error = True
                     break
                 attempt += 1  # advance to next context-level attempt
@@ -4100,17 +4065,39 @@ async def stream_chat_completion_sdk(
                 _MAX_STREAM_ATTEMPTS,
                 stream_err,
             )
-            # Restore the last attempt's partial work (rolled back by the
-            # exhausted context-level retry) so the user sees what was
-            # produced before the conversation hit the context ceiling.
-            _restore_partial_with_error_marker(
-                session,
-                state,
-                last_attempt_partial,
-                "Your conversation is too long. "
-                "Please start a new chat or clear some history.",
-                retryable=False,
-            )
+        # Restore the rolled-back partial work + add error marker exactly once
+        # per failure mode. Earlier revisions did this inline in each retry-loop
+        # branch; consolidating here keeps the retry loop itself simple enough
+        # for pyright to type-check.
+        if ended_with_stream_error:
+            if handled_error_info is not None:
+                final_msg, _, _ = handled_error_info
+                final_retryable = True
+            elif attempts_exhausted:
+                final_msg = (
+                    "Your conversation is too long. "
+                    "Please start a new chat or clear some history."
+                )
+                final_retryable = False
+            elif transient_exhausted:
+                final_msg = FRIENDLY_TRANSIENT_MSG
+                final_retryable = True
+            elif stream_err is not None:
+                final_msg = _friendly_error_text(
+                    str(stream_err).replace("\n", " ").replace("\r", "")[:500]
+                )
+                final_retryable = False
+            else:
+                final_msg = None
+                final_retryable = False
+            if final_msg is not None:
+                _restore_partial_with_error_marker(
+                    session,
+                    state,
+                    last_attempt_partial,
+                    final_msg,
+                    retryable=final_retryable,
+                )
 
         if ended_with_stream_error and state is not None:
             # Flush any unresolved tool calls so the frontend can close
@@ -4148,6 +4135,16 @@ async def stream_chat_completion_sdk(
                 error_text = _friendly_error_text(safe_err)
                 error_code = "sdk_stream_error"
             yield StreamError(errorText=error_text, code=error_code)
+
+        # _HandledStreamError exits the retry loop with stream_err unset, so
+        # the previous block doesn't fire. Emit the client-facing StreamError
+        # here when the inner handler chose not to (transient errors suppress
+        # the early flash so the client only sees the final error after all
+        # retries are exhausted).
+        if handled_error_info is not None:
+            handled_msg, handled_code, already_yielded = handled_error_info
+            if not already_yielded:
+                yield StreamError(errorText=handled_msg, code=handled_code)
 
         # Copy token usage from retry state to outer-scope accumulators
         # so the finally block can persist them.

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -541,14 +541,7 @@ def _append_error_marker(
     *,
     retryable: bool = False,
 ) -> None:
-    """Append a copilot error marker to *session* so it persists across refresh.
-
-    Args:
-        session: The chat session to append to (no-op if `None`).
-        display_msg: User-visible error text.
-        retryable: If `True`, use the retryable prefix so the frontend
-            shows a "Try Again" button.
-    """
+    """Append a copilot error marker to *session* so it persists across refresh."""
     if session is None:
         return
     prefix = COPILOT_RETRYABLE_ERROR_PREFIX if retryable else COPILOT_ERROR_PREFIX
@@ -557,17 +550,97 @@ def _append_error_marker(
     )
 
 
+def _is_error_marker(msg: ChatMessage) -> bool:
+    """True if *msg* is an error marker emitted by ``_append_error_marker``."""
+    if msg.role != "assistant" or not msg.content:
+        return False
+    return msg.content.startswith(COPILOT_ERROR_PREFIX) or msg.content.startswith(
+        COPILOT_RETRYABLE_ERROR_PREFIX
+    )
+
+
+@dataclass
+class _InterruptedAttempt:
+    """Captured state of a failed SDK attempt, carried across the retry loop.
+
+    The SDK always rolls back ``session.messages`` before deciding whether
+    to retry (so attempt #2 starts clean). That rollback would otherwise
+    discard everything the assistant produced — the user sees tokens stream
+    live, then a refresh shows nothing. This dataclass holds the rolled-back
+    messages plus the ``_HandledStreamError`` info needed to emit a final
+    ``StreamError`` once the loop decides not to retry.
+
+    The retry loop calls ``capture()`` on every failed attempt, ``clear()``
+    on a successful retry (so prior rolled-back content is not replayed),
+    and ``finalize()`` exactly once after the loop on final failure.
+    """
+
+    partial: list[ChatMessage] = dataclass_field(default_factory=list)
+    # Populated by the ``except _HandledStreamError`` branch so the post-loop
+    # block can restore the partial and (when the inner handler didn't) emit
+    # the client-facing StreamError. Transient errors deliberately suppress
+    # the early StreamError flash and rely on this post-loop emit.
+    handled_error: "_HandledErrorInfo | None" = None
+
+    def capture(
+        self,
+        session: ChatSession,
+        transcript_builder: "TranscriptBuilder",
+        transcript_snap: object,
+        pre_attempt_msg_count: int,
+    ) -> None:
+        """Roll back ``session.messages`` + transcript, keeping the partial.
+
+        Trailing error markers appended inside ``_run_stream_attempt`` (idle
+        timeout, circuit breaker) are stripped: re-attaching them would make
+        the post-loop restore replay a stale marker before adding its own,
+        leaving duplicate error bubbles.
+        """
+        tail = list(session.messages[pre_attempt_msg_count:])
+        while tail and _is_error_marker(tail[-1]):
+            tail.pop()
+        self.partial = tail
+        session.messages = session.messages[:pre_attempt_msg_count]
+        transcript_builder.restore(transcript_snap)  # type: ignore[arg-type]
+
+    def clear(self) -> None:
+        """Drop captured state — used on successful retry."""
+        self.partial = []
+        self.handled_error = None
+
+    def finalize(
+        self,
+        session: ChatSession | None,
+        state: "_RetryState | None",
+        display_msg: str,
+        *,
+        retryable: bool,
+    ) -> None:
+        """Re-attach partial + synthetic tool_result rows + error marker.
+
+        Called exactly once after the retry loop on final-failure exit.
+        Idempotent on empty state, so it's safe to call on paths where no
+        rollback happened.
+        """
+        if session is None:
+            return
+        if self.partial:
+            session.messages.extend(self.partial)
+            self.partial = []
+        _flush_orphan_tool_uses_to_session(session, state)
+        _append_error_marker(session, display_msg, retryable=retryable)
+
+
 def _flush_orphan_tool_uses_to_session(
     session: "ChatSession | None",
     state: "_RetryState | None",
 ) -> None:
-    """Synthesize tool_result rows for tool_use blocks that never resolved.
+    """Synthesize ``tool_result`` rows for ``tool_use`` blocks that never resolved.
 
-    Without this, partial assistant work re-attached after a final failure
-    would carry orphan tool_use blocks. The next turn's LLM call would error
-    with ``tool_use_id without tool_result`` — and any baseline replay would
-    surface the same broken history. Flushing produces interrupted-marker
-    tool_results that satisfy the API contract.
+    Re-attached partial work may carry orphan ``tool_use`` blocks; without
+    matching ``tool_result`` rows the next turn's LLM call would error with
+    ``tool_use_id without tool_result``. The adapter's safety-flush produces
+    interrupted-marker results that satisfy the API contract.
     """
     if session is None or state is None:
         return
@@ -587,65 +660,30 @@ def _flush_orphan_tool_uses_to_session(
             )
 
 
-def _restore_partial_with_error_marker(
-    session: "ChatSession | None",
-    state: "_RetryState | None",
-    partial: list[ChatMessage],
-    display_msg: str,
-    *,
-    retryable: bool,
-) -> None:
-    """Re-attach a rolled-back attempt's partial work, then add the error marker.
+def _classify_final_failure(
+    interrupted: _InterruptedAttempt,
+    attempts_exhausted: bool,
+    transient_exhausted: bool,
+    stream_err: BaseException | None,
+) -> tuple[str | None, bool]:
+    """Pick the display message + retryable flag for the post-loop restore.
 
-    Called when retries are exhausted or no retry is attempted. Without this,
-    the SDK retry loop's pre-decision rollback would discard everything the
-    assistant produced in the failed attempt (text, tool calls, reasoning),
-    leaving the user with a chat that looks like nothing happened — even
-    though the events were already streamed live to their UI.
+    Mirrors the error-code selection used for the client-facing ``StreamError``
+    yield so the in-history marker and the SSE event stay consistent.
     """
-    if session is None:
-        return
-    if partial:
-        session.messages.extend(partial)
-        partial.clear()
-    _flush_orphan_tool_uses_to_session(session, state)
-    _append_error_marker(session, display_msg, retryable=retryable)
-
-
-def _rollback_attempt_capturing_partial(
-    session: "ChatSession",
-    transcript_builder: "TranscriptBuilder",
-    transcript_snap: object,
-    pre_attempt_msg_count: int,
-) -> list[ChatMessage]:
-    """Roll back an attempt's session.messages + transcript, capturing the partial.
-
-    The returned list holds the assistant work that was incrementally appended
-    during the failed attempt. The caller passes it to
-    ``_restore_partial_with_error_marker`` on final-failure exit and discards
-    it on a successful retry.
-
-    Trailing error markers appended inside ``_run_stream_attempt`` (idle
-    timeout, circuit breaker) are stripped: re-attaching them would let the
-    post-loop restore replay a stale marker before adding its own, leaving
-    duplicate error bubbles and pushing any synthetic ``tool_result`` after
-    an assistant(error) turn that has no matching ``tool_use``.
-    """
-    captured = list(session.messages[pre_attempt_msg_count:])
-    while captured and _is_error_marker(captured[-1]):
-        captured.pop()
-    session.messages = session.messages[:pre_attempt_msg_count]
-    transcript_builder.restore(transcript_snap)  # type: ignore[arg-type]
-    return captured
-
-
-def _is_error_marker(msg: ChatMessage) -> bool:
-    """True if *msg* is an error marker emitted by ``_append_error_marker``."""
-    if msg.role != "assistant" or not msg.content:
-        return False
-    return msg.content.startswith(COPILOT_ERROR_PREFIX) or msg.content.startswith(
-        COPILOT_RETRYABLE_ERROR_PREFIX
-    )
+    if interrupted.handled_error is not None:
+        return interrupted.handled_error.error_msg, interrupted.handled_error.retryable
+    if attempts_exhausted:
+        return (
+            "Your conversation is too long. "
+            "Please start a new chat or clear some history."
+        ), False
+    if transient_exhausted:
+        return FRIENDLY_TRANSIENT_MSG, True
+    if stream_err is not None:
+        safe_err = str(stream_err).replace("\n", " ").replace("\r", "")[:500]
+        return _friendly_error_text(safe_err), False
+    return None, False
 
 
 def _setup_langfuse_otel() -> None:
@@ -3112,12 +3150,13 @@ async def stream_chat_completion_sdk(  # pyright: ignore[reportGeneralTypeIssues
     request_arrival_at: float = 0.0,
     **_kwargs: Any,
 ) -> AsyncGenerator[StreamBaseResponse, None]:
-    # Pyright's complexity heuristic bails on this function (~1500 LoC, retry
+    # Pyright's complexity heuristic bails on this ~1500 LoC function (retry
     # loop with context-overflow fallback + transient backoff + partial-work
-    # preservation). Splitting further would hurt readability — the branches
-    # share state (session, adapter, transcript builder, token accumulators)
-    # that's hard to pass cleanly through helpers. Suppress the bailout; real
-    # type errors elsewhere in the file remain surfaced.
+    # preservation). Splitting the retry loop further hurts readability —
+    # branches share mutable state (session, adapter, transcript builder,
+    # usage accumulators) that doesn't pass cleanly through helpers. The
+    # suppression only silences the complexity bailout; real type errors in
+    # the function body still surface.
     """Stream chat completion using Claude Agent SDK.
 
     Args:
@@ -3281,14 +3320,11 @@ async def stream_chat_completion_sdk(  # pyright: ignore[reportGeneralTypeIssues
     turn_cost_usd: float | None = None
     graphiti_enabled = False
     pre_attempt_msg_count = 0
-    # Holds messages that the retry loop rolls back from session.messages on a
-    # failed attempt. On final-failure exit we re-attach these so the user sees
-    # what the assistant produced before the error rather than an empty chat.
-    last_attempt_partial: list[ChatMessage] = []
-    # Populated by the _HandledStreamError branch. Consumed once after the
-    # retry loop to re-attach the partial and, if the inner handler hadn't
-    # already emitted one, yield a single StreamError to the client.
-    handled_error_info: _HandledErrorInfo | None = None
+    # State of the latest failed attempt: rolled-back messages + any
+    # _HandledStreamError info to emit on final-failure exit. The retry loop
+    # mutates this via capture()/clear(); the post-loop block calls
+    # finalize() once.
+    interrupted = _InterruptedAttempt()
     # Defaults ensure the finally block can always reference these safely even when
     # an early return (e.g. sdk_cwd error) skips their normal assignment below.
     sdk_model: str | None = None
@@ -3949,10 +3985,9 @@ async def stream_chat_completion_sdk(  # pyright: ignore[reportGeneralTypeIssues
                             "using fallback model for this request"
                         )
                     yield event
-                # Drop any stale partial captured from prior failed attempts
-                # so the outer cleanup paths don't re-attach pre-retry content
-                # the successful attempt already replaced.
-                last_attempt_partial.clear()
+                # Discard any state captured from prior failed attempts so
+                # outer cleanup paths don't replay pre-retry content.
+                interrupted.clear()
                 break  # Stream completed — exit retry loop
             except asyncio.CancelledError:
                 logger.warning(
@@ -3968,7 +4003,7 @@ async def stream_chat_completion_sdk(  # pyright: ignore[reportGeneralTypeIssues
                 # session messages and set the error flag — do NOT set
                 # stream_err so the post-loop code won't emit a
                 # duplicate StreamError.
-                last_attempt_partial = _rollback_attempt_capturing_partial(
+                interrupted.capture(
                     session,
                     state.transcript_builder,
                     transcript_snap,
@@ -4007,7 +4042,7 @@ async def stream_chat_completion_sdk(  # pyright: ignore[reportGeneralTypeIssues
                 # attempt that no longer match session.messages.  Skip upload
                 # so a future --resume doesn't replay rolled-back content.
                 skip_transcript_upload = True
-                handled_error_info = _HandledErrorInfo(
+                interrupted.handled_error = _HandledErrorInfo(
                     error_msg=exc.error_msg or FRIENDLY_TRANSIENT_MSG,
                     code=exc.code or "transient_api_error",
                     retryable=exc.retryable,
@@ -4031,7 +4066,7 @@ async def stream_chat_completion_sdk(  # pyright: ignore[reportGeneralTypeIssues
                     stream_err,
                     exc_info=True,
                 )
-                last_attempt_partial = _rollback_attempt_capturing_partial(
+                interrupted.capture(
                     session,
                     state.transcript_builder,
                     transcript_snap,
@@ -4097,38 +4132,15 @@ async def stream_chat_completion_sdk(  # pyright: ignore[reportGeneralTypeIssues
                 _MAX_STREAM_ATTEMPTS,
                 stream_err,
             )
-        # Restore the rolled-back partial work + add error marker exactly once
-        # per failure mode. Earlier revisions did this inline in each retry-loop
-        # branch; consolidating here keeps the retry loop itself simple enough
-        # for pyright to type-check.
+        # Restore the rolled-back partial + add error marker exactly once per
+        # failure mode. See _InterruptedAttempt for the carry-state contract.
         if ended_with_stream_error:
-            if handled_error_info is not None:
-                final_msg = handled_error_info.error_msg
-                final_retryable = handled_error_info.retryable
-            elif attempts_exhausted:
-                final_msg = (
-                    "Your conversation is too long. "
-                    "Please start a new chat or clear some history."
-                )
-                final_retryable = False
-            elif transient_exhausted:
-                final_msg = FRIENDLY_TRANSIENT_MSG
-                final_retryable = True
-            elif stream_err is not None:
-                final_msg = _friendly_error_text(
-                    str(stream_err).replace("\n", " ").replace("\r", "")[:500]
-                )
-                final_retryable = False
-            else:
-                final_msg = None
-                final_retryable = False
+            final_msg, final_retryable = _classify_final_failure(
+                interrupted, attempts_exhausted, transient_exhausted, stream_err
+            )
             if final_msg is not None:
-                _restore_partial_with_error_marker(
-                    session,
-                    state,
-                    last_attempt_partial,
-                    final_msg,
-                    retryable=final_retryable,
+                interrupted.finalize(
+                    session, state, final_msg, retryable=final_retryable
                 )
 
         if ended_with_stream_error and state is not None:
@@ -4173,10 +4185,13 @@ async def stream_chat_completion_sdk(  # pyright: ignore[reportGeneralTypeIssues
         # here when the inner handler chose not to (transient errors suppress
         # the early flash so the client only sees the final error after all
         # retries are exhausted).
-        if handled_error_info is not None and not handled_error_info.already_yielded:
+        if (
+            interrupted.handled_error is not None
+            and not interrupted.handled_error.already_yielded
+        ):
             yield StreamError(
-                errorText=handled_error_info.error_msg,
-                code=handled_error_info.code,
+                errorText=interrupted.handled_error.error_msg,
+                code=interrupted.handled_error.code,
             )
 
         # Copy token usage from retry state to outer-scope accumulators
@@ -4259,24 +4274,13 @@ async def stream_chat_completion_sdk(  # pyright: ignore[reportGeneralTypeIssues
         else:
             display_msg, code = error_msg, "sdk_error"
 
-        # Append error marker to session (non-invasive text parsing approach).
-        # The finally block will persist the session with this error marker.
-        # Skip if a marker was already appended inside the stream loop
-        # (ended_with_stream_error) to avoid duplicate stale markers.
+        # Append error marker + restore any rolled-back partial when the retry
+        # loop didn't already finalize. ``interrupted`` is empty on success and
+        # on paths where the retry loop's own post-loop finalize() already ran,
+        # so this is a no-op for those and only kicks in for unhandled errors
+        # that bypass the retry-loop handlers entirely.
         if not ended_with_stream_error:
-            # Restore any rolled-back partial work the retry loop captured —
-            # last_attempt_partial is empty on success / final-failure-handled
-            # paths (cleared on success break, consumed inside the retry loop
-            # by _restore_partial_with_error_marker), so this is a no-op for
-            # those cases and only kicks in when an unhandled exception bypassed
-            # the retry loop's own restoration.
-            _restore_partial_with_error_marker(
-                session,
-                state,
-                last_attempt_partial,
-                display_msg,
-                retryable=is_transient,
-            )
+            interrupted.finalize(session, state, display_msg, retryable=is_transient)
             logger.debug(
                 "%s Appended error marker, will be persisted in finally",
                 log_prefix,

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -615,39 +615,48 @@ class _InterruptedAttempt:
         display_msg: str,
         *,
         retryable: bool,
-    ) -> None:
+    ) -> list[StreamBaseResponse]:
         """Re-attach partial + synthetic tool_result rows + error marker.
 
         Called exactly once after the retry loop on final-failure exit.
         Idempotent on empty state, so it's safe to call on paths where no
         rollback happened.
+
+        Returns the ``StreamBaseResponse`` events produced by the safety
+        flush so the caller can yield them to the client (the flush mutates
+        adapter state, so a second flush elsewhere would return nothing and
+        stale UI elements like spinners would stay open).
         """
         if session is None:
-            return
+            return []
         if self.partial:
             session.messages.extend(self.partial)
             self.partial = []
-        _flush_orphan_tool_uses_to_session(session, state)
+        events = _flush_orphan_tool_uses_to_session(session, state)
         _append_error_marker(session, display_msg, retryable=retryable)
+        return events
 
 
 def _flush_orphan_tool_uses_to_session(
     session: "ChatSession | None",
     state: "_RetryState | None",
-) -> None:
+) -> list[StreamBaseResponse]:
     """Synthesize ``tool_result`` rows for ``tool_use`` blocks that never resolved.
 
     Re-attached partial work may carry orphan ``tool_use`` blocks; without
     matching ``tool_result`` rows the next turn's LLM call would error with
     ``tool_use_id without tool_result``. The adapter's safety-flush produces
     interrupted-marker results that satisfy the API contract.
+
+    Returns the flushed events so callers can yield them to the client
+    alongside persisting the synthetic rows in session history.
     """
     if session is None or state is None:
-        return
+        return []
     if not state.adapter.has_unresolved_tool_calls:
-        return
+        return []
     safety: list[StreamBaseResponse] = []
-    state.adapter._flush_unresolved_tool_calls(safety)  # noqa: SLF001
+    state.adapter.flush_unresolved_tool_calls(safety)
     for resp in safety:
         if isinstance(resp, StreamToolOutputAvailable):
             content = (
@@ -658,6 +667,20 @@ def _flush_orphan_tool_uses_to_session(
             session.messages.append(
                 ChatMessage(role="tool", content=content, tool_call_id=resp.toolCallId)
             )
+    return safety
+
+
+@dataclass(frozen=True)
+class _FinalFailure:
+    """Display message + stream code + retryable flag for a final-failure exit.
+
+    Shared by the in-history error marker (via ``_InterruptedAttempt.finalize``)
+    and the client-facing ``StreamError`` SSE yield so the two stay in sync.
+    """
+
+    display_msg: str
+    code: str
+    retryable: bool
 
 
 def _classify_final_failure(
@@ -665,25 +688,41 @@ def _classify_final_failure(
     attempts_exhausted: bool,
     transient_exhausted: bool,
     stream_err: BaseException | None,
-) -> tuple[str | None, bool]:
-    """Pick the display message + retryable flag for the post-loop restore.
+) -> _FinalFailure | None:
+    """Pick the display message, stream code, and retryable flag for the exit.
 
-    Mirrors the error-code selection used for the client-facing ``StreamError``
-    yield so the in-history marker and the SSE event stay consistent.
+    Returns ``None`` when no failure was recorded (success path) — the caller
+    should skip both the history marker and the SSE yield in that case.
     """
     if interrupted.handled_error is not None:
-        return interrupted.handled_error.error_msg, interrupted.handled_error.retryable
+        return _FinalFailure(
+            display_msg=interrupted.handled_error.error_msg,
+            code=interrupted.handled_error.code,
+            retryable=interrupted.handled_error.retryable,
+        )
     if attempts_exhausted:
-        return (
-            "Your conversation is too long. "
-            "Please start a new chat or clear some history."
-        ), False
+        return _FinalFailure(
+            display_msg=(
+                "Your conversation is too long. "
+                "Please start a new chat or clear some history."
+            ),
+            code="all_attempts_exhausted",
+            retryable=False,
+        )
     if transient_exhausted:
-        return FRIENDLY_TRANSIENT_MSG, True
+        return _FinalFailure(
+            display_msg=FRIENDLY_TRANSIENT_MSG,
+            code="transient_api_error",
+            retryable=True,
+        )
     if stream_err is not None:
         safe_err = str(stream_err).replace("\n", " ").replace("\r", "")[:500]
-        return _friendly_error_text(safe_err), False
-    return None, False
+        return _FinalFailure(
+            display_msg=_friendly_error_text(safe_err),
+            code="sdk_stream_error",
+            retryable=False,
+        )
+    return None
 
 
 def _setup_langfuse_otel() -> None:
@@ -2868,7 +2907,7 @@ async def _run_stream_attempt(
             - len(state.adapter.resolved_tool_calls),
         )
         safety_responses: list[StreamBaseResponse] = []
-        state.adapter._flush_unresolved_tool_calls(safety_responses)
+        state.adapter.flush_unresolved_tool_calls(safety_responses)
         for response in safety_responses:
             if isinstance(
                 response,
@@ -4132,67 +4171,38 @@ async def stream_chat_completion_sdk(  # pyright: ignore[reportGeneralTypeIssues
                 _MAX_STREAM_ATTEMPTS,
                 stream_err,
             )
-        # Restore the rolled-back partial + add error marker exactly once per
-        # failure mode. See _InterruptedAttempt for the carry-state contract.
+        # Consolidated final-failure handling. _classify_final_failure picks
+        # the display message + stream code + retryable flag, finalize() adds
+        # the history marker and produces the safety-flush events that close
+        # stale UI widgets on the client, and the StreamError yield below
+        # surfaces the same message over SSE. The _HandledStreamError path
+        # sets ``already_yielded=True`` for non-transient errors (circuit
+        # breaker, idle timeout) whose inner handler already yielded — skip
+        # the re-yield in that case.
         if ended_with_stream_error:
-            final_msg, final_retryable = _classify_final_failure(
+            failure = _classify_final_failure(
                 interrupted, attempts_exhausted, transient_exhausted, stream_err
             )
-            if final_msg is not None:
-                interrupted.finalize(
-                    session, state, final_msg, retryable=final_retryable
+            if failure is not None:
+                cleanup_events: list[StreamBaseResponse] = []
+                if state is not None:
+                    state.adapter._end_text_if_open(cleanup_events)
+                cleanup_events.extend(
+                    interrupted.finalize(
+                        session,
+                        state,
+                        failure.display_msg,
+                        retryable=failure.retryable,
+                    )
                 )
-
-        if ended_with_stream_error and state is not None:
-            # Flush any unresolved tool calls so the frontend can close
-            # stale UI elements (e.g. spinners) that were started before
-            # the exception interrupted the stream.
-            error_flush: list[StreamBaseResponse] = []
-            state.adapter._end_text_if_open(error_flush)
-            if state.adapter.has_unresolved_tool_calls:
-                logger.warning(
-                    "%s Flushing %d unresolved tool(s) after stream error",
-                    log_prefix,
-                    len(state.adapter.current_tool_calls)
-                    - len(state.adapter.resolved_tool_calls),
+                for response in cleanup_events:
+                    yield response
+                already_yielded = (
+                    interrupted.handled_error is not None
+                    and interrupted.handled_error.already_yielded
                 )
-                state.adapter._flush_unresolved_tool_calls(error_flush)
-            for response in error_flush:
-                yield response
-
-        if ended_with_stream_error and stream_err is not None:
-            # Use distinct error codes depending on how the loop ended:
-            # • "all_attempts_exhausted" — context compaction ran out of room
-            # • "transient_api_error" — 429/5xx/ECONNRESET retries exhausted
-            # • "sdk_stream_error" — non-context, non-transient fatal error
-            safe_err = str(stream_err).replace("\n", " ").replace("\r", "")[:500]
-            if attempts_exhausted:
-                error_text = (
-                    "Your conversation is too long. "
-                    "Please start a new chat or clear some history."
-                )
-                error_code = "all_attempts_exhausted"
-            elif transient_exhausted:
-                error_text = FRIENDLY_TRANSIENT_MSG
-                error_code = "transient_api_error"
-            else:
-                error_text = _friendly_error_text(safe_err)
-                error_code = "sdk_stream_error"
-            yield StreamError(errorText=error_text, code=error_code)
-
-        # _HandledStreamError exits the retry loop with stream_err unset, so
-        # the previous block doesn't fire. Emit the client-facing StreamError
-        # here when the inner handler chose not to (transient errors suppress
-        # the early flash so the client only sees the final error after all
-        # retries are exhausted).
-        if (
-            interrupted.handled_error is not None
-            and not interrupted.handled_error.already_yielded
-        ):
-            yield StreamError(
-                errorText=interrupted.handled_error.error_msg,
-                code=interrupted.handled_error.code,
-            )
+                if not already_yielded:
+                    yield StreamError(errorText=failure.display_msg, code=failure.code)
 
         # Copy token usage from retry state to outer-scope accumulators
         # so the finally block can persist them.

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -624,11 +624,28 @@ def _rollback_attempt_capturing_partial(
     during the failed attempt. The caller passes it to
     ``_restore_partial_with_error_marker`` on final-failure exit and discards
     it on a successful retry.
+
+    Trailing error markers appended inside ``_run_stream_attempt`` (idle
+    timeout, circuit breaker) are stripped: re-attaching them would let the
+    post-loop restore replay a stale marker before adding its own, leaving
+    duplicate error bubbles and pushing any synthetic ``tool_result`` after
+    an assistant(error) turn that has no matching ``tool_use``.
     """
     captured = list(session.messages[pre_attempt_msg_count:])
+    while captured and _is_error_marker(captured[-1]):
+        captured.pop()
     session.messages = session.messages[:pre_attempt_msg_count]
     transcript_builder.restore(transcript_snap)  # type: ignore[arg-type]
     return captured
+
+
+def _is_error_marker(msg: ChatMessage) -> bool:
+    """True if *msg* is an error marker emitted by ``_append_error_marker``."""
+    if msg.role != "assistant" or not msg.content:
+        return False
+    return msg.content.startswith(COPILOT_ERROR_PREFIX) or msg.content.startswith(
+        COPILOT_RETRYABLE_ERROR_PREFIX
+    )
 
 
 def _setup_langfuse_otel() -> None:
@@ -2079,6 +2096,21 @@ class _HandledStreamError(Exception):
         self.already_yielded = already_yielded
 
 
+@dataclass(frozen=True)
+class _HandledErrorInfo:
+    """Carries a `_HandledStreamError`'s decisions out of the retry loop.
+
+    Set inside the `except _HandledStreamError` branch and consumed by the
+    post-loop block, which restores the partial and (if the inner handler
+    didn't already do it) yields the client-facing StreamError.
+    """
+
+    error_msg: str
+    code: str
+    retryable: bool
+    already_yielded: bool
+
+
 @dataclass
 class _EmptyToolBreakResult:
     """Result of checking for empty tool calls in a single AssistantMessage."""
@@ -3253,11 +3285,10 @@ async def stream_chat_completion_sdk(  # pyright: ignore[reportGeneralTypeIssues
     # failed attempt. On final-failure exit we re-attach these so the user sees
     # what the assistant produced before the error rather than an empty chat.
     last_attempt_partial: list[ChatMessage] = []
-    # Populated by the _HandledStreamError branch with (display_msg, code,
-    # already_yielded). Consumed once after the retry loop to re-attach the
-    # partial and, if the inner handler hadn't already emitted one, yield a
-    # single StreamError to the client.
-    handled_error_info: tuple[str, str, bool] | None = None
+    # Populated by the _HandledStreamError branch. Consumed once after the
+    # retry loop to re-attach the partial and, if the inner handler hadn't
+    # already emitted one, yield a single StreamError to the client.
+    handled_error_info: _HandledErrorInfo | None = None
     # Defaults ensure the finally block can always reference these safely even when
     # an early return (e.g. sdk_cwd error) skips their normal assignment below.
     sdk_model: str | None = None
@@ -3976,10 +4007,11 @@ async def stream_chat_completion_sdk(  # pyright: ignore[reportGeneralTypeIssues
                 # attempt that no longer match session.messages.  Skip upload
                 # so a future --resume doesn't replay rolled-back content.
                 skip_transcript_upload = True
-                handled_error_info = (
-                    exc.error_msg or FRIENDLY_TRANSIENT_MSG,
-                    exc.code or "transient_api_error",
-                    exc.already_yielded,
+                handled_error_info = _HandledErrorInfo(
+                    error_msg=exc.error_msg or FRIENDLY_TRANSIENT_MSG,
+                    code=exc.code or "transient_api_error",
+                    retryable=exc.retryable,
+                    already_yielded=exc.already_yielded,
                 )
                 ended_with_stream_error = True
                 break
@@ -4071,8 +4103,8 @@ async def stream_chat_completion_sdk(  # pyright: ignore[reportGeneralTypeIssues
         # for pyright to type-check.
         if ended_with_stream_error:
             if handled_error_info is not None:
-                final_msg, _, _ = handled_error_info
-                final_retryable = True
+                final_msg = handled_error_info.error_msg
+                final_retryable = handled_error_info.retryable
             elif attempts_exhausted:
                 final_msg = (
                     "Your conversation is too long. "
@@ -4141,10 +4173,11 @@ async def stream_chat_completion_sdk(  # pyright: ignore[reportGeneralTypeIssues
         # here when the inner handler chose not to (transient errors suppress
         # the early flash so the client only sees the final error after all
         # retries are exhausted).
-        if handled_error_info is not None:
-            handled_msg, handled_code, already_yielded = handled_error_info
-            if not already_yielded:
-                yield StreamError(errorText=handled_msg, code=handled_code)
+        if handled_error_info is not None and not handled_error_info.already_yielded:
+            yield StreamError(
+                errorText=handled_error_info.error_msg,
+                code=handled_error_info.code,
+            )
 
         # Copy token usage from retry state to outer-scope accumulators
         # so the finally block can persist them.

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -557,6 +557,80 @@ def _append_error_marker(
     )
 
 
+def _flush_orphan_tool_uses_to_session(
+    session: "ChatSession | None",
+    state: "_RetryState | None",
+) -> None:
+    """Synthesize tool_result rows for tool_use blocks that never resolved.
+
+    Without this, partial assistant work re-attached after a final failure
+    would carry orphan tool_use blocks. The next turn's LLM call would error
+    with ``tool_use_id without tool_result`` — and any baseline replay would
+    surface the same broken history. Flushing produces interrupted-marker
+    tool_results that satisfy the API contract.
+    """
+    if session is None or state is None:
+        return
+    if not state.adapter.has_unresolved_tool_calls:
+        return
+    safety: list[StreamBaseResponse] = []
+    state.adapter._flush_unresolved_tool_calls(safety)  # noqa: SLF001
+    for resp in safety:
+        if isinstance(resp, StreamToolOutputAvailable):
+            content = (
+                resp.output
+                if isinstance(resp.output, str)
+                else json.dumps(resp.output, ensure_ascii=False)
+            )
+            session.messages.append(
+                ChatMessage(role="tool", content=content, tool_call_id=resp.toolCallId)
+            )
+
+
+def _restore_partial_with_error_marker(
+    session: "ChatSession | None",
+    state: "_RetryState | None",
+    partial: list[ChatMessage],
+    display_msg: str,
+    *,
+    retryable: bool,
+) -> None:
+    """Re-attach a rolled-back attempt's partial work, then add the error marker.
+
+    Called when retries are exhausted or no retry is attempted. Without this,
+    the SDK retry loop's pre-decision rollback would discard everything the
+    assistant produced in the failed attempt (text, tool calls, reasoning),
+    leaving the user with a chat that looks like nothing happened — even
+    though the events were already streamed live to their UI.
+    """
+    if session is None:
+        return
+    if partial:
+        session.messages.extend(partial)
+        partial.clear()
+    _flush_orphan_tool_uses_to_session(session, state)
+    _append_error_marker(session, display_msg, retryable=retryable)
+
+
+def _rollback_attempt_capturing_partial(
+    session: "ChatSession",
+    transcript_builder: "TranscriptBuilder",
+    transcript_snap: object,
+    pre_attempt_msg_count: int,
+) -> list[ChatMessage]:
+    """Roll back an attempt's session.messages + transcript, capturing the partial.
+
+    The returned list holds the assistant work that was incrementally appended
+    during the failed attempt. The caller passes it to
+    ``_restore_partial_with_error_marker`` on final-failure exit and discards
+    it on a successful retry.
+    """
+    captured = list(session.messages[pre_attempt_msg_count:])
+    session.messages = session.messages[:pre_attempt_msg_count]
+    transcript_builder.restore(transcript_snap)  # type: ignore[arg-type]
+    return captured
+
+
 def _setup_langfuse_otel() -> None:
     """Configure OTEL tracing for the Claude Agent SDK → Langfuse.
 
@@ -3169,6 +3243,10 @@ async def stream_chat_completion_sdk(
     turn_cost_usd: float | None = None
     graphiti_enabled = False
     pre_attempt_msg_count = 0
+    # Holds messages that the retry loop rolls back from session.messages on a
+    # failed attempt. On final-failure exit we re-attach these so the user sees
+    # what the assistant produced before the error rather than an empty chat.
+    last_attempt_partial: list[ChatMessage] = []
     # Defaults ensure the finally block can always reference these safely even when
     # an early return (e.g. sdk_cwd error) skips their normal assignment below.
     sdk_model: str | None = None
@@ -3829,6 +3907,10 @@ async def stream_chat_completion_sdk(
                             "using fallback model for this request"
                         )
                     yield event
+                # Drop any stale partial captured from prior failed attempts
+                # so the outer cleanup paths don't re-attach pre-retry content
+                # the successful attempt already replaced.
+                last_attempt_partial.clear()
                 break  # Stream completed — exit retry loop
             except asyncio.CancelledError:
                 logger.warning(
@@ -3844,8 +3926,12 @@ async def stream_chat_completion_sdk(
                 # session messages and set the error flag — do NOT set
                 # stream_err so the post-loop code won't emit a
                 # duplicate StreamError.
-                session.messages = session.messages[:pre_attempt_msg_count]
-                state.transcript_builder.restore(transcript_snap)
+                last_attempt_partial = _rollback_attempt_capturing_partial(
+                    session,
+                    state.transcript_builder,
+                    transcript_snap,
+                    pre_attempt_msg_count,
+                )
                 # Check if this is a transient error we can retry with backoff.
                 # exc.code is the only reliable signal — str(exc) is always the
                 # static "Stream error handled — StreamError already yielded" message.
@@ -3879,12 +3965,13 @@ async def stream_chat_completion_sdk(
                 # attempt that no longer match session.messages.  Skip upload
                 # so a future --resume doesn't replay rolled-back content.
                 skip_transcript_upload = True
-                # Re-append the error marker so it survives the rollback
-                # and is persisted by the finally block (see #2947655365).
-                # Use the specific error message from the attempt (e.g.
-                # circuit breaker msg) rather than always the generic one.
-                _append_error_marker(
+                # Re-attach the rolled-back partial work + add error marker.
+                # Without partial restoration the user's UI streamed tokens
+                # live but a refresh shows nothing happened.
+                _restore_partial_with_error_marker(
                     session,
+                    state,
+                    last_attempt_partial,
                     exc.error_msg or FRIENDLY_TRANSIENT_MSG,
                     retryable=True,
                 )
@@ -3917,8 +4004,12 @@ async def stream_chat_completion_sdk(
                     stream_err,
                     exc_info=True,
                 )
-                session.messages = session.messages[:pre_attempt_msg_count]
-                state.transcript_builder.restore(transcript_snap)
+                last_attempt_partial = _rollback_attempt_capturing_partial(
+                    session,
+                    state.transcript_builder,
+                    transcript_snap,
+                    pre_attempt_msg_count,
+                )
                 if events_yielded > 0:
                     # Events were already sent to the frontend and cannot be
                     # unsent.  Retrying would produce duplicate/inconsistent
@@ -3929,6 +4020,19 @@ async def stream_chat_completion_sdk(
                         events_yielded,
                     )
                     skip_transcript_upload = True
+                    # Restore the streamed partial + add error marker — without
+                    # this the frontend would briefly show streamed text live
+                    # then a refresh would show an empty turn.
+                    safe_err = (
+                        str(stream_err).replace("\n", " ").replace("\r", "")[:500]
+                    )
+                    _restore_partial_with_error_marker(
+                        session,
+                        state,
+                        last_attempt_partial,
+                        _friendly_error_text(safe_err),
+                        retryable=False,
+                    )
                     ended_with_stream_error = True
                     break
                 # Transient API errors (ECONNRESET, 429, 5xx) — retry
@@ -3956,8 +4060,12 @@ async def stream_chat_completion_sdk(
                     # at line ~2310.
                     transient_exhausted = True
                     skip_transcript_upload = True
-                    _append_error_marker(
-                        session, FRIENDLY_TRANSIENT_MSG, retryable=True
+                    _restore_partial_with_error_marker(
+                        session,
+                        state,
+                        last_attempt_partial,
+                        FRIENDLY_TRANSIENT_MSG,
+                        retryable=True,
                     )
                     ended_with_stream_error = True
                     break
@@ -3966,6 +4074,16 @@ async def stream_chat_completion_sdk(
                     # Non-context, non-transient errors (auth, fatal)
                     # should not trigger compaction — surface immediately.
                     skip_transcript_upload = True
+                    safe_err = (
+                        str(stream_err).replace("\n", " ").replace("\r", "")[:500]
+                    )
+                    _restore_partial_with_error_marker(
+                        session,
+                        state,
+                        last_attempt_partial,
+                        _friendly_error_text(safe_err),
+                        retryable=False,
+                    )
                     ended_with_stream_error = True
                     break
                 attempt += 1  # advance to next context-level attempt
@@ -3981,6 +4099,17 @@ async def stream_chat_completion_sdk(
                 log_prefix,
                 _MAX_STREAM_ATTEMPTS,
                 stream_err,
+            )
+            # Restore the last attempt's partial work (rolled back by the
+            # exhausted context-level retry) so the user sees what was
+            # produced before the conversation hit the context ceiling.
+            _restore_partial_with_error_marker(
+                session,
+                state,
+                last_attempt_partial,
+                "Your conversation is too long. "
+                "Please start a new chat or clear some history.",
+                retryable=False,
             )
 
         if ended_with_stream_error and state is not None:
@@ -4105,7 +4234,19 @@ async def stream_chat_completion_sdk(
         # Skip if a marker was already appended inside the stream loop
         # (ended_with_stream_error) to avoid duplicate stale markers.
         if not ended_with_stream_error:
-            _append_error_marker(session, display_msg, retryable=is_transient)
+            # Restore any rolled-back partial work the retry loop captured —
+            # last_attempt_partial is empty on success / final-failure-handled
+            # paths (cleared on success break, consumed inside the retry loop
+            # by _restore_partial_with_error_marker), so this is a no-op for
+            # those cases and only kicks in when an unhandled exception bypassed
+            # the retry loop's own restoration.
+            _restore_partial_with_error_marker(
+                session,
+                state,
+                last_attempt_partial,
+                display_msg,
+                retryable=is_transient,
+            )
             logger.debug(
                 "%s Appended error marker, will be persisted in finally",
                 log_prefix,

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -133,7 +133,7 @@ from ..transcript import (
     upload_transcript,
     validate_transcript,
 )
-from ..transcript_builder import TranscriptBuilder
+from ..transcript_builder import TranscriptBuilder, TranscriptSnapshot
 from .compaction import CompactionTracker, filter_compaction_messages
 from .env import build_sdk_env  # noqa: F401 — re-export for backward compat
 from .openrouter_cost import record_turn_cost_from_openrouter
@@ -586,7 +586,7 @@ class _InterruptedAttempt:
         self,
         session: ChatSession,
         transcript_builder: "TranscriptBuilder",
-        transcript_snap: object,
+        transcript_snap: TranscriptSnapshot,
         pre_attempt_msg_count: int,
     ) -> None:
         """Roll back ``session.messages`` + transcript, keeping the partial.
@@ -601,7 +601,7 @@ class _InterruptedAttempt:
             tail.pop()
         self.partial = tail
         session.messages = session.messages[:pre_attempt_msg_count]
-        transcript_builder.restore(transcript_snap)  # type: ignore[arg-type]
+        transcript_builder.restore(transcript_snap)
 
     def clear(self) -> None:
         """Drop captured state — used on successful retry."""

--- a/autogpt_platform/backend/backend/copilot/transcript_builder.py
+++ b/autogpt_platform/backend/backend/copilot/transcript_builder.py
@@ -34,6 +34,9 @@ class TranscriptEntry(BaseModel):
     message: dict[str, Any]
 
 
+TranscriptSnapshot = tuple[list[TranscriptEntry], str | None]
+
+
 class TranscriptBuilder:
     """Build complete JSONL transcript from SDK messages.
 
@@ -224,7 +227,7 @@ class TranscriptBuilder:
         lines = [entry.model_dump_json(exclude_none=True) for entry in self._entries]
         return "\n".join(lines) + "\n"
 
-    def snapshot(self) -> tuple[list[TranscriptEntry], str | None]:
+    def snapshot(self) -> TranscriptSnapshot:
         """Return a shallow snapshot of the current builder state.
 
         Use with :meth:`restore` to roll back transcript mutations from a
@@ -235,7 +238,7 @@ class TranscriptBuilder:
         """
         return list(self._entries), self._last_uuid
 
-    def restore(self, snap: tuple[list[TranscriptEntry], str | None]) -> None:
+    def restore(self, snap: TranscriptSnapshot) -> None:
         """Restore builder state from a :meth:`snapshot`.
 
         Replaces ``_entries`` and ``_last_uuid`` atomically so the builder

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/__tests__/useCopilotStream.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/__tests__/useCopilotStream.test.ts
@@ -180,6 +180,47 @@ describe("useCopilotStream — reconnect debounce", () => {
       return next.length === 0;
     });
     expect(dropCall).toBeTruthy();
+
+    // Branch: when the trailing message is NOT a user bubble (e.g. an
+    // assistant turn already landed), the rollback updater must leave the
+    // list untouched so we don't clobber the assistant reply.
+    const updater = setMessagesMock.mock.calls
+      .map(([arg]) => arg)
+      .find(
+        (arg): arg is (p: UIMessage[]) => UIMessage[] =>
+          typeof arg === "function",
+      );
+    expect(updater).toBeDefined();
+    const assistantOnly: UIMessage[] = [
+      {
+        id: "a1",
+        role: "assistant",
+        parts: [{ type: "text", text: "ok" }],
+      } as unknown as UIMessage,
+    ];
+    expect(updater!(assistantOnly)).toBe(assistantOnly);
+    expect(updater!([])).toEqual([]);
+  });
+
+  it("skips composer restore on 429 when there is no captured unsent text", async () => {
+    useCopilotUIStore.getState().setInitialPrompt(null);
+    renderStream();
+
+    await act(async () => {
+      lastUseChatArgs!.onError!(
+        new Error(JSON.stringify({ detail: "Daily usage limit exceeded" })),
+      );
+    });
+
+    // No sendMessage was called → lastSubmittedMsgRef stays null → restore
+    // branch must be skipped. The store stays untouched and setMessages is
+    // NOT invoked with a rollback updater.
+    expect(useCopilotUIStore.getState().initialPrompt).toBeNull();
+    expect(sdkSendMessageMock).not.toHaveBeenCalled();
+    const rollbackUpdaterCall = setMessagesMock.mock.calls.find(
+      ([arg]) => typeof arg === "function",
+    );
+    expect(rollbackUpdaterCall).toBeUndefined();
   });
 
   it("does not debounce a reconnect that arrives after the window closes", async () => {

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/__tests__/useCopilotStream.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/__tests__/useCopilotStream.test.ts
@@ -2,6 +2,7 @@ import { act, renderHook } from "@testing-library/react";
 import type { UIMessage } from "ai";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { useCopilotUIStore } from "../store";
 import { useCopilotStream } from "../useCopilotStream";
 
 // Capture the args passed to ``useChat`` so tests can invoke onFinish/onError
@@ -67,6 +68,7 @@ vi.mock("@/components/molecules/Toast/use-toast", () => ({
 vi.mock("@/services/environment", () => ({
   environment: {
     getAGPTServerBaseUrl: () => "http://localhost",
+    isServerSide: () => false,
   },
 }));
 
@@ -145,6 +147,39 @@ describe("useCopilotStream — reconnect debounce", () => {
       await vi.advanceTimersByTimeAsync(2_000);
     });
     expect(resumeStreamMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("restores the unsent text and drops the optimistic user bubble on 429 usage-limit", async () => {
+    useCopilotUIStore.getState().setInitialPrompt(null);
+    const { result } = renderStream();
+
+    await act(async () => {
+      await result.current.sendMessage({ text: "recover me" });
+    });
+    expect(sdkSendMessageMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      lastUseChatArgs!.onError!(
+        new Error(JSON.stringify({ detail: "Daily usage limit exceeded" })),
+      );
+    });
+
+    expect(useCopilotUIStore.getState().initialPrompt).toBe("recover me");
+    expect(result.current.rateLimitMessage).toContain("Daily usage limit");
+
+    const dropCall = setMessagesMock.mock.calls.find(([arg]) => {
+      if (typeof arg !== "function") return false;
+      const prev: UIMessage[] = [
+        {
+          id: "u1",
+          role: "user",
+          parts: [{ type: "text", text: "recover me" }],
+        } as unknown as UIMessage,
+      ];
+      const next = (arg as (p: UIMessage[]) => UIMessage[])(prev);
+      return next.length === 0;
+    });
+    expect(dropCall).toBeTruthy();
   });
 
   it("does not debounce a reconnect that arrives after the window closes", async () => {

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/useCopilotStream.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/useCopilotStream.ts
@@ -20,6 +20,7 @@ import {
   disconnectSessionStream,
   shouldDebounceReconnect,
 } from "./helpers";
+import { useCopilotUIStore } from "./store";
 import type { CopilotLlmModel, CopilotMode } from "./store";
 import { useHydrateOnStreamEnd } from "./useHydrateOnStreamEnd";
 
@@ -62,6 +63,7 @@ export function useCopilotStream({
   copilotModel,
 }: UseCopilotStreamArgs) {
   const queryClient = useQueryClient();
+  const setInitialPrompt = useCopilotUIStore((s) => s.setInitialPrompt);
   const [rateLimitMessage, setRateLimitMessage] = useState<string | null>(null);
   function dismissRateLimit() {
     setRateLimitMessage(null);
@@ -269,6 +271,20 @@ export function useCopilotStream({
       }
       const isRateLimited = errorDetail.toLowerCase().includes("usage limit");
       if (isRateLimited) {
+        // Backend raises 429 BEFORE persisting the user message, so the
+        // optimistic user bubble added by useChat is a lie. Restore the text
+        // into the composer (via the same store slot URL pre-fills use) and
+        // drop the unsent bubble so the user can edit/resend after reset.
+        const unsentText = lastSubmittedMsgRef.current;
+        if (unsentText) {
+          setInitialPrompt(unsentText);
+          lastSubmittedMsgRef.current = null;
+          setMessages((prev) => {
+            const last = prev[prev.length - 1];
+            if (last?.role === "user") return prev.slice(0, -1);
+            return prev;
+          });
+        }
         setRateLimitMessage(
           errorDetail ||
             "You've reached your usage limit. Please try again later.",


### PR DESCRIPTION
## Background

[SECRT-2275](https://linear.app/autogpt/issue/SECRT-2275). User report: when a copilot ("autopilot") turn is interrupted by a usage-limit, tool-call-limit, or other run interruption, the user's recent work disappears. User described it as: "my initial message was lost 3 times and it disappeared, then when I would say 'continue' it would do a random old task."

Investigation surfaced two distinct failure modes. This PR addresses both.

- **Mode 1** — rate-limit (or other pre-stream rejection) at turn start: the user's text only ever lives in the optimistic `useChat` bubble; the backend rejects before the message is persisted, so the bubble is a lie and a refresh / retry would lose the text.
- **Mode 2** — long-running turn interrupted mid-stream: the entire turn's progress (assistant text, tool calls, reasoning) vanishes on interruption — what users describe as "the turn is gone."

## Mode 1 — frontend: restore unsent text on 429

Backend can't recover this on its own: `check_rate_limit` raises before `append_and_save_message`, so by the time the 429 surfaces there is no DB row to roll forward. See `autogpt_platform/backend/backend/api/features/chat/routes.py:916-922` (rate-limit check) and `routes.py:945` (later append-and-save).

Frontend fix in `autogpt_platform/frontend/src/app/(platform)/copilot/useCopilotStream.ts`: when `useChat`'s `onError` reports a usage-limit error, we

- drop the optimistic user bubble (DB has no record of it, so leaving it would be a phantom),
- push `lastSubmittedMsgRef.current` back into the composer via the existing `setInitialPrompt` slot — the same slot URL pre-fills use, so `useChatInput`'s `consumeInitialPrompt` effect picks it up automatically,
- clear `lastSubmittedMsgRef` so the dedup guard doesn't block re-send.

In-memory only; surviving a hard refresh while rate-limited is a separate follow-up (would need localStorage persistence with TTL).

Test: `autogpt_platform/frontend/src/app/(platform)/copilot/__tests__/useCopilotStream.test.ts` — verifies the composer is repopulated and the optimistic bubble is dropped on a 429.

## Mode 2 — backend: preserve interrupted partial in DB

### Root cause

The SDK retry loop in `stream_chat_completion_sdk` always rolls back `session.messages` to the pre-attempt watermark on any exception. That rollback is correct **before a retry** so attempt #2 doesn't duplicate attempt #1's content. But it runs **before the retry decision is made**, so when retries are exhausted (or no retry is attempted) the partial work is discarded too.

Three branches of the retry loop ended in a final-failure state with side effects worse than just losing the partial:
- `_HandledStreamError` non-transient: rollback then add error marker — partial gone
- `Exception` with `events_yielded > 0`: rollback then break — **no error marker added either**, so on refresh the chat looks like nothing happened even though the user just watched tokens stream live
- `Exception` non-context-non-transient + the while-`else:` exhaustion path: same, no marker
- Outer except (cancellation, GeneratorExit cleanup): didn't restore captured partial

### Fix

`autogpt_platform/backend/backend/copilot/sdk/service.py`:

1. **`_InterruptedAttempt` dataclass** — holds the rolled-back `partial: list[ChatMessage]` + optional `handled_error: _HandledErrorInfo`. Three methods drive the contract:
   - `capture(session, transcript_builder, transcript_snap, pre_attempt_msg_count)` — slices `session.messages`, restores the transcript, strips trailing error markers to prevent duplicate markers after restore.
   - `clear()` — drops captured state on a successful retry so outer cleanup paths don't replay pre-retry content.
   - `finalize(session, state, display_msg, retryable=...) -> list[StreamBaseResponse]` — re-attaches partial, synthesizes `tool_result` rows for orphan `tool_use` blocks, appends the canonical error marker, and returns the flushed events so the caller can yield them to the client (no double-flush).
2. **`_flush_orphan_tool_uses_to_session(session, state) -> list[StreamBaseResponse]`** — synthesizes `tool_result` rows for any `tool_use` that never resolved before the error so the next turn's LLM context stays API-valid (Anthropic rejects orphan tool_use). Uses the public `adapter.flush_unresolved_tool_calls` and returns the events for the caller to yield.
3. **`_classify_final_failure(...) -> _FinalFailure | None`** — picks the display message + stream code + retryable flag for the final-failure exit. One source of truth for the in-history error marker and the client-facing `StreamError` SSE yield so they can't drift.
4. **Consolidated post-loop emit**: the former three scattered blocks (partial restore + redundant re-flush + two separate `yield StreamError` sites) collapsed to one block driven by `_classify_final_failure` → `_FinalFailure` → `finalize()` → yield events + single `StreamError`.
5. **Adapter `flush_unresolved_tool_calls`** (renamed from `_flush_unresolved_tool_calls` to drop the `# noqa: SLF001` suppressors on cross-module callers).

Each retry-loop rollback site calls `interrupted.capture(...)`; the success break calls `interrupted.clear()`; the post-loop failure block calls `interrupted.finalize(...)` exactly once.

The baseline service already preserves partial work via its existing finally block — no change needed there.

## Tests

Backend (`backend/copilot/sdk/interrupted_partial_test.py`, new, 18 tests):

- `TestInterruptedAttemptCapture` — slice semantics + stale-marker stripping
- `TestInterruptedAttemptFinalize` — appends partial then marker, handles empty partial, no-op on `None` session, flushes unresolved tools between partial and marker, returns flushed events for caller to yield
- `TestFlushOrphanToolUses` — synthesizes `tool_result` rows, returns events, no-op on None state / no unresolved
- `TestClassifyFinalFailure` — handled_error wins, attempts_exhausted, transient_exhausted, stream_err fallback, returns None on success path
- `TestRetryRollbackContract` — end-to-end: capture + finalize yields the exact content the user saw streaming live plus the error marker

1022 total SDK tests pass (baseline + new).

Frontend (`useCopilotStream.test.ts`): 1 new test — `restores the unsent text and drops the optimistic user bubble on 429 usage-limit`.

## Out of scope

- Frontend rendering tweaks for the interrupted-turn marker (existing error-marker rendering already works).
- Refresh-survival of the unsent text in Mode 1 (would require localStorage persistence with TTL) — separate follow-up.
- Hard process-kill / OOM where Python `finally` doesn't run — needs a different mechanism (pod-level checkpoint sweeper).

## Checklist

- [x] My code follows the style guidelines of this project (black/isort/ruff via `poetry run format`)
- [x] I have performed a self-review of my own code
- [x] I have added relevant unit tests
- [x] I have run lint and tests locally (1022 SDK tests pass)

## Test plan

- [ ] Verify a long-running turn that hits transient-retry exhaustion preserves partial assistant text + tool results in chat history after refresh
- [ ] Verify the next user message after an interrupted turn carries enough context that the model can continue the prior task instead of inventing a new one
- [ ] Verify a successful retry (attempt #1 fails, attempt #2 succeeds) shows ONLY attempt #2's content (no leaked partial from #1)
- [ ] Verify hitting daily usage limit at turn start re-populates the composer with the unsent text and removes the optimistic user bubble
