### PR TITLE
fix(frontend): redirect www to non-www with 308 to preserve request method (#9188)

### DIFF
--- a/autogpt_platform/frontend/src/middleware.test.ts
+++ b/autogpt_platform/frontend/src/middleware.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const updateSessionMock = vi.fn();
+
+vi.mock("@/lib/supabase/middleware", () => ({
+  updateSession: (...args: unknown[]) => updateSessionMock(...args),
+}));
+
+import { middleware } from "./middleware";
+
+describe("middleware www→non-www redirect", () => {
+  it("redirects www host to non-www with 308", async () => {
+    const request = new NextRequest("https://www.example.com/dashboard");
+
+    const response = await middleware(request);
+
+    expect(response).toBeDefined();
+    expect(response.status).toBe(308);
+    expect(response.headers.get("location")).toBe(
+      "https://example.com/dashboard",
+    );
+    expect(updateSessionMock).not.toHaveBeenCalled();
+  });
+
+  it("treats uppercase WWW host as case-insensitive (URL API normalizes)", async () => {
+    const request = new NextRequest("https://WWW.example.com/path?x=1");
+
+    const response = await middleware(request);
+
+    expect(response.status).toBe(308);
+    expect(response.headers.get("location")).toBe(
+      "https://example.com/path?x=1",
+    );
+  });
+
+  it("falls through to updateSession when host is non-www", async () => {
+    const passthrough = new Response("ok");
+    updateSessionMock.mockResolvedValueOnce(passthrough);
+
+    const request = new NextRequest("https://example.com/dashboard");
+    const response = await middleware(request);
+
+    expect(updateSessionMock).toHaveBeenCalledTimes(1);
+    expect(response).toBe(passthrough);
+  });
+});

--- a/autogpt_platform/frontend/src/middleware.ts
+++ b/autogpt_platform/frontend/src/middleware.ts
@@ -2,11 +2,13 @@ import { updateSession } from "@/lib/supabase/middleware";
 import { NextResponse, type NextRequest } from "next/server";
 
 export async function middleware(request: NextRequest) {
-  // Redirect www to non-www to prevent cookie/auth domain mismatch (#9188)
-  const host = request.headers.get("host") || "";
-  if (host.startsWith("www.")) {
-    const url = request.nextUrl.clone();
-    url.host = host.replace(/^www\./, "");
+  // Redirect www to non-www so Supabase cookies are issued against a single,
+  // canonical host and avoid the auth/cookie domain mismatch (#9188).
+  // Use url.hostname (already lowercase-normalized by the URL parser) instead
+  // of the raw Host header, which RFC 7230 treats as case-insensitive.
+  const url = request.nextUrl.clone();
+  if (url.hostname.startsWith("www.")) {
+    url.hostname = url.hostname.slice(4);
     return NextResponse.redirect(url, 308);
   }
 

--- a/autogpt_platform/frontend/src/middleware.ts
+++ b/autogpt_platform/frontend/src/middleware.ts
@@ -1,7 +1,15 @@
 import { updateSession } from "@/lib/supabase/middleware";
-import { type NextRequest } from "next/server";
+import { NextResponse, type NextRequest } from "next/server";
 
 export async function middleware(request: NextRequest) {
+  // Redirect www to non-www to prevent cookie/auth domain mismatch (#9188)
+  const host = request.headers.get("host") || "";
+  if (host.startsWith("www.")) {
+    const url = request.nextUrl.clone();
+    url.host = host.replace(/^www\./, "");
+    return NextResponse.redirect(url, 308);
+  }
+
   return await updateSession(request);
 }
 


### PR DESCRIPTION
## Summary
Fixes #9188 — redirects `www.` to non-www to prevent cookie/auth domain mismatch.

Uses **308** (Permanent Redirect) instead of 301, which preserves the HTTP method and request body. This is important because the middleware matcher runs on `/auth/authorize` and `/auth/integrations/*`, where OAuth callbacks may use POST.

Split from #12895 per reviewer request.

## Changes
- Added www→non-www redirect in Next.js middleware using `NextResponse.redirect(url, 308)`