### PR TITLE
fix(frontend): filter null query params in buildUrlWithQuery (#11237)

### DIFF
--- a/autogpt_platform/frontend/src/lib/autogpt-server-api/helpers.test.ts
+++ b/autogpt_platform/frontend/src/lib/autogpt-server-api/helpers.test.ts
@@ -12,7 +12,7 @@ vi.mock("@/services/environment", () => ({
   },
 }));
 
-import { createRequestHeaders } from "./helpers";
+import { buildUrlWithQuery, createRequestHeaders } from "./helpers";
 import {
   API_KEY_HEADER_NAME,
   IMPERSONATION_HEADER_NAME,
@@ -21,6 +21,37 @@ import {
 function makeRequest(headers: Record<string, string>): Request {
   return new Request("http://example.com/test", { headers });
 }
+
+describe("buildUrlWithQuery", () => {
+  const url = "http://example.com/api";
+
+  it("returns the URL unchanged when query is undefined", () => {
+    expect(buildUrlWithQuery(url)).toBe(url);
+  });
+
+  it("returns the URL unchanged when every value is null or undefined", () => {
+    expect(buildUrlWithQuery(url, { a: null, b: undefined })).toBe(url);
+  });
+
+  it("filters out null and undefined values but keeps falsy primitives", () => {
+    const result = buildUrlWithQuery(url, {
+      kept: "yes",
+      zero: 0,
+      empty: "",
+      flag: false,
+      missing: undefined,
+      blank: null,
+    });
+
+    const params = new URL(result).searchParams;
+    expect(params.get("kept")).toBe("yes");
+    expect(params.get("zero")).toBe("0");
+    expect(params.get("empty")).toBe("");
+    expect(params.get("flag")).toBe("false");
+    expect(params.has("missing")).toBe(false);
+    expect(params.has("blank")).toBe(false);
+  });
+});
 
 describe("createRequestHeaders — basics", () => {
   it("adds Content-Type when hasRequestBody is true", () => {

--- a/autogpt_platform/frontend/src/lib/autogpt-server-api/helpers.ts
+++ b/autogpt_platform/frontend/src/lib/autogpt-server-api/helpers.ts
@@ -68,11 +68,11 @@ export function buildUrlWithQuery(
 ): string {
   if (!query) return url;
 
-  // Filter out undefined and null values to prevent them from being included
-  // as "undefined" / "null" strings in query parameters (fixes #11237)
+  // Drop null/undefined so URLSearchParams doesn't serialize them as the
+  // strings "null" / "undefined".
   const filteredQuery = Object.entries(query).reduce(
     (acc, [key, value]) => {
-      if (value !== undefined && value !== null) {
+      if (value != null) {
         acc[key] = value;
       }
       return acc;

--- a/autogpt_platform/frontend/src/lib/autogpt-server-api/helpers.ts
+++ b/autogpt_platform/frontend/src/lib/autogpt-server-api/helpers.ts
@@ -68,10 +68,11 @@ export function buildUrlWithQuery(
 ): string {
   if (!query) return url;
 
-  // Filter out undefined values to prevent them from being included as "undefined" strings
+  // Filter out undefined and null values to prevent them from being included
+  // as "undefined" / "null" strings in query parameters (fixes #11237)
   const filteredQuery = Object.entries(query).reduce(
     (acc, [key, value]) => {
-      if (value !== undefined) {
+      if (value !== undefined && value !== null) {
         acc[key] = value;
       }
       return acc;


### PR DESCRIPTION
## Summary
Fixes #11237 — `buildUrlWithQuery` now filters out `null` values in addition to `undefined`, preventing them from being serialized as literal `"null"` strings in URL query parameters.

Split from #12895 per reviewer request.

## Changes
- Added `value !== null` check alongside existing `value !== undefined` in `buildUrlWithQuery`