### PR TITLE
fix(util/truncate): keep output within size_limit and stop leaking originals at limit=1

### DIFF
--- a/autogpt_platform/backend/backend/util/truncate.py
+++ b/autogpt_platform/backend/backend/util/truncate.py
@@ -7,15 +7,35 @@ from typing import Any
 
 
 def _truncate_string_middle(value: str, limit: int) -> str:
-    """Shorten *value* to *limit* chars by removing the **middle** portion."""
+    """Shorten *value* to at most *limit* chars by removing the **middle** portion.
+
+    The returned string (head + sentinel + tail) is guaranteed to be no longer
+    than *limit*. The sentinel ``"… (omitted N chars)…"`` itself counts toward
+    the budget — previously it was added on top, so callers always overshot
+    the limit by ~22 chars and ``truncate(value, N)`` violated its own
+    docstring contract. For very small *limit* values where the sentinel
+    alone wouldn't fit, we degrade gracefully to a head-only slice.
+    """
 
     if len(value) <= limit:
         return value
 
-    head_len = max(1, limit // 2)
-    tail_len = limit - head_len  # ensures total == limit
+    # Reserve room for the sentinel inside the budget. Worst-case sentinel
+    # length is "… (omitted <len(value)> chars)…" — bounded by the input.
+    sentinel_template = "… (omitted {n} chars)…"
+    sentinel_len = len(sentinel_template.format(n=len(value)))
+
+    if limit <= sentinel_len:
+        # Not enough room for any kept content alongside the sentinel.
+        # Fall back to a hard slice that respects the limit exactly.
+        return value[:limit]
+
+    keep_budget = limit - sentinel_len
+    head_len = max(1, keep_budget // 2)
+    tail_len = keep_budget - head_len  # may be 0 for very tight budgets
     omitted = len(value) - (head_len + tail_len)
-    return f"{value[:head_len]}… (omitted {omitted} chars)…{value[-tail_len:]}"
+    tail = value[-tail_len:] if tail_len > 0 else ""
+    return f"{value[:head_len]}{sentinel_template.format(n=omitted)}{tail}"
 
 
 # ---------------------------------------------------------------------------

--- a/autogpt_platform/backend/backend/util/truncate_test.py
+++ b/autogpt_platform/backend/backend/util/truncate_test.py
@@ -1,0 +1,80 @@
+"""Tests for backend.util.truncate.
+
+These tests pin down the contract of :func:`truncate` — its docstring promises
+that the returned value's string representation does not exceed ``size_limit``
+characters. Historically ``_truncate_string_middle`` reserved the entire
+``limit`` budget for kept content and then *appended* the
+``"… (omitted N chars)…"`` sentinel on top, so truncated strings always
+overshot the limit by ~22 chars. This file locks in the corrected behaviour.
+"""
+
+import pytest
+
+from backend.util.truncate import truncate
+
+SENTINEL_CHARS_OVERHEAD = 24  # generous upper bound for "… (omitted N chars)…"
+
+
+class TestTruncateString:
+    @pytest.mark.parametrize("size_limit", [50, 100, 200, 500])
+    def test_truncated_string_respects_size_limit(self, size_limit):
+        # GIVEN a string much larger than the requested limit
+        big = "a" * 5000
+
+        # WHEN we truncate it
+        out = truncate(big, size_limit)
+
+        # THEN the string representation must fit within the limit (the
+        # whole point of the function is to bound output size).
+        assert isinstance(out, str)
+        assert len(str(out)) <= size_limit, (
+            f"truncate(string, {size_limit}) returned {len(str(out))} chars; "
+            f"output: {out!r}"
+        )
+
+    def test_short_string_returned_unchanged(self):
+        # Strings already within the limit should pass through untouched.
+        s = "hello world"
+        assert truncate(s, 100) == s
+        assert truncate(s, len(s)) == s
+
+    def test_truncated_string_preserves_head_and_tail(self):
+        # We still want to show the start and end of the original — that is
+        # the whole purpose of "middle" truncation.
+        s = "START_" + ("x" * 1000) + "_END"
+        out = truncate(s, 80)
+        assert isinstance(out, str)
+        assert out.startswith("S")
+        assert out.endswith("D")
+        assert "omitted" in out
+        assert len(out) <= 80
+
+    def test_truncate_string_with_small_limit_is_safe(self):
+        # Edge case: previously limit=1 produced ``head + sentinel + entire
+        # original tail`` because ``value[-0:]`` returns the whole string.
+        s = "abcdefghijklmnopqrstuvwxyz"
+        out = truncate(s, 1)
+        # We don't require it to be <= 1 (the sentinel itself is longer than
+        # 1 char), but we *do* require the original string is no longer
+        # smuggled in unredacted.
+        assert s not in str(out)
+
+
+class TestTruncateContainers:
+    def test_dict_with_long_string_value_respects_limit(self):
+        big = "z" * 5000
+        out = truncate({"key": big}, 200)
+        assert len(str(out)) <= 200 + SENTINEL_CHARS_OVERHEAD
+
+    def test_list_with_long_string_respects_limit(self):
+        big_items = ["q" * 1000 for _ in range(20)]
+        out = truncate(big_items, 300)
+        # Container truncation goes through the binary-search path which is
+        # already bounded; the leaf string truncator was the bug.
+        assert len(str(out)) <= 300 + SENTINEL_CHARS_OVERHEAD
+
+    def test_non_string_non_container_passthrough(self):
+        # Numbers, booleans, None should be returned as-is regardless of limit.
+        assert truncate(42, 5) == 42
+        assert truncate(True, 5) is True
+        assert truncate(None, 5) is None


### PR DESCRIPTION
## Summary

`autogpt_platform/backend/backend/util/truncate.py::_truncate_string_middle` reserved the entire `limit` budget for kept content (`head_len = limit//2`, `tail_len = limit - head_len`) and then *appended* the `"… (omitted N chars)…"` sentinel on top — so `truncate("a"*1000, 50)` returned 72 chars, a ~22-char overshoot every call. The fast path in `truncate()` for plain strings exposes this directly.

Secondary bug: when `limit == 1`, `tail_len == 0` and `value[-0:]` returns the entire original string unredacted, defeating truncation entirely.

## Fix

Compute the worst-case sentinel length `len("… (omitted <len(value)> chars)…")` and subtract it from the budget *before* splitting head/tail. When `limit <= sentinel_len`, fall back to a hard `value[:limit]` slice. Guard `tail = value[-tail_len:] if tail_len > 0 else ""` to avoid the `[-0:]` smuggling.

24/-4 production change.

## Test

`autogpt_platform/backend/backend/util/truncate_test.py` (10 parametrized tests). Asserts:
- `len(str(out)) <= size_limit` for plain strings;
- head/tail preserved;
- small-limit no longer leaks original;
- container truncation stays within `limit + sentinel_overhead`;
- scalars passthrough.

RED 6/10 on unfixed code → GREEN 10/10 after. `ruff` clean.

## Risk notes

- Output is now strictly tighter — head/tail get `limit - sentinel_len` characters instead of `limit/2` each. All in-tree call sites use this for log/UI truncation where the contract was "fits in N chars", so the new behaviour matches the contract.
- For very large `len(value)` the sentinel grows logarithmically; still bounded.