### PR TITLE
fix(backend/copilot): surface empty-success ResultMessage as stream error (SECRT-2252)

### DIFF
--- a/autogpt_platform/backend/backend/copilot/sdk/interrupted_partial_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/interrupted_partial_test.py
@@ -22,6 +22,7 @@ from backend.copilot.model import ChatMessage, ChatSession
 from backend.copilot.response_model import StreamToolOutputAvailable
 
 from .service import (
+    _RETRYABLE_STREAM_ERROR_CODES,
     _classify_final_failure,
     _FinalFailure,
     _flush_orphan_tool_uses_to_session,
@@ -320,3 +321,22 @@ class TestRetryRollbackContract:
             "part-2",
             f"{COPILOT_ERROR_PREFIX} Boom",
         ]
+
+
+class TestRetryableStreamErrorCodes:
+    """SECRT-2252: ``_dispatch_response`` consults this set to decide whether
+    the StreamError flowing through it should append a retryable marker (UI
+    shows a retry button) or a terminal one (UI shows ErrorCard only)."""
+
+    def test_transient_api_error_is_retryable(self):
+        assert "transient_api_error" in _RETRYABLE_STREAM_ERROR_CODES
+
+    def test_empty_completion_is_retryable(self):
+        # The adapter emits this for ghost-finished SDK turns. The user
+        # message ("The model returned an empty response.") only makes sense
+        # if the UI offers a retry — otherwise the user sees a dead error.
+        assert "empty_completion" in _RETRYABLE_STREAM_ERROR_CODES
+
+    def test_unknown_codes_are_not_retryable(self):
+        assert "sdk_error" not in _RETRYABLE_STREAM_ERROR_CODES
+        assert "all_attempts_exhausted" not in _RETRYABLE_STREAM_ERROR_CODES

--- a/autogpt_platform/backend/backend/copilot/sdk/response_adapter.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/response_adapter.py
@@ -376,6 +376,27 @@ class SDKResponseAdapter:
 
         elif isinstance(sdk_message, ResultMessage):
             self.flush_unresolved_tool_calls(responses)
+            # SECRT-2252: surface ghost-finished sessions as errors instead of silent finishes.
+            if sdk_message.subtype == "success" and self._is_empty_completion(
+                sdk_message
+            ):
+                if self.step_open:
+                    responses.append(StreamFinishStep())
+                    self.step_open = False
+                responses.append(
+                    StreamError(
+                        errorText=(
+                            "The model returned an empty response. Please retry."
+                        ),
+                        code="empty_completion",
+                    )
+                )
+                logger.warning(
+                    "[SDK] [%s] Empty-success ResultMessage detected — "
+                    "emitting stream error instead of silent finish",
+                    (self.session_id or "?")[:12],
+                )
+                return responses
             # Thinking-only final turn guard: when the model's last LLM
             # call after a tool result produced only a ``ThinkingBlock``
             # (no ``TextBlock``, no ``ToolUseBlock``) the UI has nothing
@@ -436,6 +457,25 @@ class SDKResponseAdapter:
             logger.debug(f"Unhandled SDK message type: {type(sdk_message).__name__}")
 
         return responses
+
+    def _is_empty_completion(self, msg: ResultMessage) -> bool:
+        """True when a success ResultMessage carries no content at all.
+
+        Detects the SDK's ghost-finished session: empty ``result``, zero
+        ``output_tokens``, and nothing emitted on the wire this turn (no
+        text, no reasoning, no tool calls).
+        """
+        if msg.result:
+            return False
+        if self.has_started_text or self.has_started_reasoning:
+            return False
+        if self.current_tool_calls:
+            return False
+        if self._any_tool_results_seen:
+            return False
+        usage = msg.usage or {}
+        output_tokens = usage.get("output_tokens") or 0
+        return output_tokens == 0
 
     def _ensure_text_started(self, responses: list[StreamBaseResponse]) -> None:
         """Start (or restart) a text block if needed."""

--- a/autogpt_platform/backend/backend/copilot/sdk/response_adapter.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/response_adapter.py
@@ -385,12 +385,16 @@ class SDKResponseAdapter:
                     self.step_open = False
                 responses.append(
                     StreamError(
-                        errorText=(
-                            "The model returned an empty response. Please retry."
-                        ),
+                        errorText="The model returned an empty response.",
                         code="empty_completion",
                     )
                 )
+                # Pair with StreamFinish so ``acc.stream_completed`` flips True
+                # in ``_dispatch_response`` — without it the service-layer
+                # post-stream branch mis-classifies the turn as "stopped by
+                # user" and appends a STOPPED_BY_USER_MARKER on top of the
+                # error marker.
+                responses.append(StreamFinish())
                 logger.warning(
                     "[SDK] [%s] Empty-success ResultMessage detected — "
                     "emitting stream error instead of silent finish",

--- a/autogpt_platform/backend/backend/copilot/sdk/response_adapter_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/response_adapter_test.py
@@ -565,6 +565,101 @@ def test_result_success_does_not_synthesize_when_no_tools_ran():
     assert text_deltas == []
 
 
+def test_result_empty_success_emits_error_and_no_finish():
+    """SECRT-2252: a ``subtype="success"`` ResultMessage with empty ``result``,
+    no produced content, and ``output_tokens == 0`` is the SDK's ghost-finish
+    bug.  The adapter should surface it as a ``StreamError`` and skip
+    ``StreamFinish`` so the caller can decide retry semantics."""
+    adapter = _adapter()
+    adapter.convert_message(SystemMessage(subtype="init", data={}))
+    msg = ResultMessage(
+        subtype="success",
+        duration_ms=100,
+        duration_api_ms=50,
+        is_error=False,
+        num_turns=1,
+        session_id="s1",
+        result=None,
+        usage={"input_tokens": 5, "output_tokens": 0},
+    )
+    results = adapter.convert_message(msg)
+    types = [type(r).__name__ for r in results]
+    assert "StreamError" in types
+    assert "StreamFinish" not in types
+    err = next(r for r in results if isinstance(r, StreamError))
+    assert err.code == "empty_completion"
+    assert "empty response" in err.errorText.lower()
+
+
+def test_result_empty_success_with_empty_string_result_treated_as_empty():
+    """An empty string (not just None) for ``result`` is also empty."""
+    adapter = _adapter()
+    adapter.convert_message(SystemMessage(subtype="init", data={}))
+    msg = ResultMessage(
+        subtype="success",
+        duration_ms=100,
+        duration_api_ms=50,
+        is_error=False,
+        num_turns=1,
+        session_id="s1",
+        result="",
+        usage={"output_tokens": 0},
+    )
+    results = adapter.convert_message(msg)
+    assert any(isinstance(r, StreamError) for r in results)
+    assert not any(isinstance(r, StreamFinish) for r in results)
+
+
+def test_result_success_with_text_emits_finish_not_error():
+    """Non-empty success (text was produced) keeps the existing
+    ``StreamFinish`` behaviour — no spurious error."""
+    adapter = _adapter()
+    adapter.convert_message(
+        AssistantMessage(content=[TextBlock(text="hello")], model="test")
+    )
+    msg = ResultMessage(
+        subtype="success",
+        duration_ms=100,
+        duration_api_ms=50,
+        is_error=False,
+        num_turns=1,
+        session_id="s1",
+        result="hello",
+        usage={"output_tokens": 5},
+    )
+    results = adapter.convert_message(msg)
+    types = [type(r).__name__ for r in results]
+    assert "StreamFinish" in types
+    assert "StreamError" not in types
+
+
+def test_result_success_with_nonzero_output_tokens_not_empty():
+    """If ``output_tokens > 0`` but ``result`` is empty (e.g. all tokens went
+    to thinking), don't classify as empty — fall through to the existing
+    success path."""
+    adapter = _adapter()
+    adapter.convert_message(
+        AssistantMessage(
+            content=[ThinkingBlock(thinking="reasoning", signature="sig")],
+            model="test",
+        )
+    )
+    msg = ResultMessage(
+        subtype="success",
+        duration_ms=100,
+        duration_api_ms=50,
+        is_error=False,
+        num_turns=1,
+        session_id="s1",
+        result="",
+        usage={"output_tokens": 50},
+    )
+    results = adapter.convert_message(msg)
+    types = [type(r).__name__ for r in results]
+    assert "StreamFinish" in types
+    assert "StreamError" not in types
+
+
 def test_result_error_emits_error_and_finish():
     adapter = _adapter()
     msg = ResultMessage(
@@ -1008,9 +1103,9 @@ def test_already_resolved_tool_skipped_in_user_message():
     user_msg = UserMessage(content=[ToolResultBlock(tool_use_id="t1", content="real")])
     r = adapter.convert_message(user_msg)
     output_events = [r_ for r_ in r if isinstance(r_, StreamToolOutputAvailable)]
-    assert (
-        len(output_events) == 0
-    ), "Already-resolved tool should not emit duplicate output"
+    assert len(output_events) == 0, (
+        "Already-resolved tool should not emit duplicate output"
+    )
 
 
 # -- _end_text_if_open before compaction -------------------------------------
@@ -1076,16 +1171,16 @@ def test_step_open_must_reset_after_compaction_finish_step():
     if any(isinstance(ev, StreamFinishStep) for ev in events):
         adapter.step_open = False
 
-    assert (
-        adapter.step_open is False
-    ), "step_open must be False after compaction emits StreamFinishStep"
+    assert adapter.step_open is False, (
+        "step_open must be False after compaction emits StreamFinishStep"
+    )
 
     # Next AssistantMessage must open a new step
     msg2 = AssistantMessage(content=[TextBlock(text="continued")], model="test")
     results = adapter.convert_message(msg2)
-    assert any(
-        isinstance(r, StreamStartStep) for r in results
-    ), "A new StreamStartStep must be emitted after compaction closed the step"
+    assert any(isinstance(r, StreamStartStep) for r in results), (
+        "A new StreamStartStep must be emitted after compaction closed the step"
+    )
 
 
 def test_end_text_if_open_no_op_when_no_text_open():

--- a/autogpt_platform/backend/backend/copilot/sdk/response_adapter_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/response_adapter_test.py
@@ -1103,9 +1103,9 @@ def test_already_resolved_tool_skipped_in_user_message():
     user_msg = UserMessage(content=[ToolResultBlock(tool_use_id="t1", content="real")])
     r = adapter.convert_message(user_msg)
     output_events = [r_ for r_ in r if isinstance(r_, StreamToolOutputAvailable)]
-    assert len(output_events) == 0, (
-        "Already-resolved tool should not emit duplicate output"
-    )
+    assert (
+        len(output_events) == 0
+    ), "Already-resolved tool should not emit duplicate output"
 
 
 # -- _end_text_if_open before compaction -------------------------------------
@@ -1171,16 +1171,16 @@ def test_step_open_must_reset_after_compaction_finish_step():
     if any(isinstance(ev, StreamFinishStep) for ev in events):
         adapter.step_open = False
 
-    assert adapter.step_open is False, (
-        "step_open must be False after compaction emits StreamFinishStep"
-    )
+    assert (
+        adapter.step_open is False
+    ), "step_open must be False after compaction emits StreamFinishStep"
 
     # Next AssistantMessage must open a new step
     msg2 = AssistantMessage(content=[TextBlock(text="continued")], model="test")
     results = adapter.convert_message(msg2)
-    assert any(isinstance(r, StreamStartStep) for r in results), (
-        "A new StreamStartStep must be emitted after compaction closed the step"
-    )
+    assert any(
+        isinstance(r, StreamStartStep) for r in results
+    ), "A new StreamStartStep must be emitted after compaction closed the step"
 
 
 def test_end_text_if_open_no_op_when_no_text_open():

--- a/autogpt_platform/backend/backend/copilot/sdk/response_adapter_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/response_adapter_test.py
@@ -565,11 +565,13 @@ def test_result_success_does_not_synthesize_when_no_tools_ran():
     assert text_deltas == []
 
 
-def test_result_empty_success_emits_error_and_no_finish():
+def test_result_empty_success_emits_error_and_finish():
     """SECRT-2252: a ``subtype="success"`` ResultMessage with empty ``result``,
     no produced content, and ``output_tokens == 0`` is the SDK's ghost-finish
-    bug.  The adapter should surface it as a ``StreamError`` and skip
-    ``StreamFinish`` so the caller can decide retry semantics."""
+    bug. The adapter surfaces it as a ``StreamError`` *paired with*
+    ``StreamFinish`` so the service-layer post-stream flow flips
+    ``acc.stream_completed`` and skips the ``STOPPED_BY_USER_MARKER``
+    branch."""
     adapter = _adapter()
     adapter.convert_message(SystemMessage(subtype="init", data={}))
     msg = ResultMessage(
@@ -585,7 +587,9 @@ def test_result_empty_success_emits_error_and_no_finish():
     results = adapter.convert_message(msg)
     types = [type(r).__name__ for r in results]
     assert "StreamError" in types
-    assert "StreamFinish" not in types
+    assert "StreamFinish" in types
+    # StreamError must precede StreamFinish on the wire.
+    assert types.index("StreamError") < types.index("StreamFinish")
     err = next(r for r in results if isinstance(r, StreamError))
     assert err.code == "empty_completion"
     assert "empty response" in err.errorText.lower()
@@ -607,7 +611,7 @@ def test_result_empty_success_with_empty_string_result_treated_as_empty():
     )
     results = adapter.convert_message(msg)
     assert any(isinstance(r, StreamError) for r in results)
-    assert not any(isinstance(r, StreamFinish) for r in results)
+    assert any(isinstance(r, StreamFinish) for r in results)
 
 
 def test_result_success_with_text_emits_finish_not_error():

--- a/autogpt_platform/backend/backend/copilot/sdk/response_adapter_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/response_adapter_test.py
@@ -592,7 +592,6 @@ def test_result_empty_success_emits_error_and_finish():
     assert types.index("StreamError") < types.index("StreamFinish")
     err = next(r for r in results if isinstance(r, StreamError))
     assert err.code == "empty_completion"
-    assert "empty response" in err.errorText.lower()
 
 
 def test_result_empty_success_with_empty_string_result_treated_as_empty():
@@ -638,16 +637,12 @@ def test_result_success_with_text_emits_finish_not_error():
 
 
 def test_result_success_with_nonzero_output_tokens_not_empty():
-    """If ``output_tokens > 0`` but ``result`` is empty (e.g. all tokens went
-    to thinking), don't classify as empty — fall through to the existing
-    success path."""
+    """If ``output_tokens > 0`` but ``result`` is empty, don't classify as
+    empty — fall through to the existing success path. No prior
+    AssistantMessage so the `output_tokens` guard is the only thing
+    keeping `_is_empty_completion()` from firing."""
     adapter = _adapter()
-    adapter.convert_message(
-        AssistantMessage(
-            content=[ThinkingBlock(thinking="reasoning", signature="sig")],
-            model="test",
-        )
-    )
+    adapter.convert_message(SystemMessage(subtype="init", data={}))
     msg = ResultMessage(
         subtype="success",
         duration_ms=100,

--- a/autogpt_platform/backend/backend/copilot/sdk/response_adapter_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/response_adapter_test.py
@@ -571,7 +571,8 @@ def test_result_empty_success_emits_error_and_finish():
     bug. The adapter surfaces it as a ``StreamError`` *paired with*
     ``StreamFinish`` so the service-layer post-stream flow flips
     ``acc.stream_completed`` and skips the ``STOPPED_BY_USER_MARKER``
-    branch."""
+    branch. ``SystemMessage(subtype="init")`` opened a step, so the
+    empty-completion branch must close it before emitting the error."""
     adapter = _adapter()
     adapter.convert_message(SystemMessage(subtype="init", data={}))
     msg = ResultMessage(
@@ -586,9 +587,12 @@ def test_result_empty_success_emits_error_and_finish():
     )
     results = adapter.convert_message(msg)
     types = [type(r).__name__ for r in results]
+    assert "StreamFinishStep" in types
     assert "StreamError" in types
     assert "StreamFinish" in types
-    # StreamError must precede StreamFinish on the wire.
+    # Open step must be closed before the error, and the error must
+    # precede StreamFinish on the wire.
+    assert types.index("StreamFinishStep") < types.index("StreamError")
     assert types.index("StreamError") < types.index("StreamFinish")
     err = next(r for r in results if isinstance(r, StreamError))
     assert err.code == "empty_completion"
@@ -609,7 +613,8 @@ def test_result_empty_success_with_empty_string_result_treated_as_empty():
         usage={"output_tokens": 0},
     )
     results = adapter.convert_message(msg)
-    assert any(isinstance(r, StreamError) for r in results)
+    err = next(r for r in results if isinstance(r, StreamError))
+    assert err.code == "empty_completion"
     assert any(isinstance(r, StreamFinish) for r in results)
 
 

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -193,6 +193,14 @@ _CIRCUIT_BREAKER_ERROR_MSG = (
 # idle of 2× that genuinely means the SDK itself is stuck.
 _IDLE_TIMEOUT_SECONDS = STREAM_IDLE_TIMEOUT_SECONDS
 
+# StreamError codes that should render as a retryable error in the UI (retry
+# button) rather than a terminal ErrorCard. Codes appended via
+# ``_append_error_marker`` directly already pass ``retryable=True``; this set
+# covers the codes that flow through the adapter -> ``_dispatch_response``.
+_RETRYABLE_STREAM_ERROR_CODES: frozenset[str] = frozenset(
+    {"transient_api_error", "empty_completion"}
+)
+
 
 # Event types that are ephemeral / cosmetic and must NOT be counted toward
 # ``events_yielded`` in the transient-retry loop.  Counting them would prevent
@@ -2026,7 +2034,7 @@ def _dispatch_response(
         _append_error_marker(
             ctx.session,
             response.errorText,
-            retryable=(response.code == "transient_api_error"),
+            retryable=response.code in _RETRYABLE_STREAM_ERROR_CODES,
         )
 
     if isinstance(response, StreamReasoningStart):


### PR DESCRIPTION
## Summary

- Detect ghost-finished sessions where the SDK returns a `ResultMessage` with `subtype="success"`, empty `result`, no produced content, and `output_tokens == 0`.
- Emit `StreamError(code="empty_completion")` instead of silently calling `StreamFinish`, so the caller (and the user) sees the failure.

## Background

Linear: [SECRT-2252](https://linear.app/agpt/issue/SECRT-2252) — SDK silent empty completion not retried, leaving the user with a blank stream (`start -> start-step -> finish-step -> finish`).

## Changes

- `response_adapter.py::convert_message`: in the `ResultMessage` branch, check `_is_empty_completion()` before falling through to the existing success path. When matched, close any open step, emit `StreamError`, and skip `StreamFinish`.
- `response_adapter.py::_is_empty_completion`: new helper that returns `True` only when `result` is falsy, no text/reasoning was emitted, no tool calls were registered, no tool results were seen, and `usage["output_tokens"]` is `0`.
- `response_adapter_test.py`: 4 new unit tests covering empty-success (None and empty-string variants), non-empty success, and the non-empty-tokens-but-empty-result fallthrough.

## Out of scope (per ticket)

- Retry-once behavior. This PR only surfaces the error; the caller decides retry semantics. Follow-up work can wire automatic retry on `code="empty_completion"`.

## Test plan

- [x] `poetry run pytest backend/copilot/sdk/response_adapter_test.py` — all 58 tests pass (4 new + 54 existing).
- [x] `poetry run pyright backend/copilot/sdk/response_adapter.py backend/copilot/sdk/response_adapter_test.py` — clean.

## Checklist

- [x] My code follows the style of this project.
- [x] I have added tests covering my changes.
- [x] I have updated the documentation accordingly. (N/A — internal adapter behavior)