### PR TITLE
fix(platform): small fixes and stagger animations on settings pages

### DIFF
--- a/autogpt_platform/backend/backend/api/features/v1.py
+++ b/autogpt_platform/backend/backend/api/features/v1.py
@@ -201,10 +201,10 @@ async def update_user_email_route(
     dependencies=[Security(requires_user)],
 )
 async def get_user_timezone_route(
-    user_id: Annotated[str, Security(get_user_id)],
+    user_data: dict = Security(get_jwt_payload),
 ) -> TimezoneResponse:
     """Get user timezone setting."""
-    user = await get_user_by_id(user_id)
+    user = await get_or_create_user(user_data)
     return TimezoneResponse(timezone=user.timezone)
 
 

--- a/autogpt_platform/backend/backend/api/features/v1.py
+++ b/autogpt_platform/backend/backend/api/features/v1.py
@@ -201,10 +201,10 @@ async def update_user_email_route(
     dependencies=[Security(requires_user)],
 )
 async def get_user_timezone_route(
-    user_data: dict = Security(get_jwt_payload),
+    user_id: Annotated[str, Security(get_user_id)],
 ) -> TimezoneResponse:
     """Get user timezone setting."""
-    user = await get_or_create_user(user_data)
+    user = await get_user_by_id(user_id)
     return TimezoneResponse(timezone=user.timezone)
 
 

--- a/autogpt_platform/backend/backend/data/user.py
+++ b/autogpt_platform/backend/backend/data/user.py
@@ -509,8 +509,12 @@ async def update_user_timezone(user_id: str, timezone: str) -> User:
         if not user:
             raise ValueError(f"User not found with ID: {user_id}")
 
-        # Invalidate cache for this user
+        # Invalidate user caches so subsequent reads see the new timezone.
+        # get_user_by_id is keyed by user_id and can be deleted surgically;
+        # get_or_create_user is keyed by the JWT-payload dict so we can't
+        # delete a single entry — clear it entirely.
         get_user_by_id.cache_delete(user_id)
+        get_or_create_user.cache_clear()
 
         return User.from_db(user)
     except Exception as e:

--- a/autogpt_platform/backend/backend/data/user.py
+++ b/autogpt_platform/backend/backend/data/user.py
@@ -510,10 +510,13 @@ async def update_user_timezone(user_id: str, timezone: str) -> User:
             raise ValueError(f"User not found with ID: {user_id}")
 
         # Invalidate user caches so subsequent reads see the new timezone.
-        # get_user_by_id is keyed by user_id and can be deleted surgically;
-        # get_or_create_user is keyed by the JWT-payload dict so we can't
-        # delete a single entry — clear it entirely.
+        # get_user_by_id and get_user_by_email are keyed by a single value
+        # and can be deleted surgically; get_or_create_user is keyed by the
+        # JWT-payload dict so we can't delete a single entry — clear it
+        # entirely.
         get_user_by_id.cache_delete(user_id)
+        if user.email:
+            get_user_by_email.cache_delete(user.email)
         get_or_create_user.cache_clear()
 
         return User.from_db(user)

--- a/autogpt_platform/backend/backend/data/user_test.py
+++ b/autogpt_platform/backend/backend/data/user_test.py
@@ -1,0 +1,66 @@
+"""Unit tests for helpers in backend.data.user."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from backend.data import user as user_module
+from backend.data.user import update_user_timezone
+from backend.util.exceptions import DatabaseError
+
+
+class TestUpdateUserTimezone:
+    @pytest.mark.asyncio
+    async def test_invalidates_all_three_user_caches(self):
+        prisma_user = MagicMock(id="user-1", email="user@example.com")
+        sentinel_user = MagicMock()
+
+        with (
+            patch.object(user_module, "PrismaUser") as mock_prisma_user,
+            patch.object(user_module.User, "from_db", return_value=sentinel_user),
+            patch.object(user_module.get_user_by_id, "cache_delete") as by_id_del,
+            patch.object(user_module.get_user_by_email, "cache_delete") as by_email_del,
+            patch.object(user_module.get_or_create_user, "cache_clear") as goc_clear,
+        ):
+            mock_prisma_user.prisma.return_value.update = AsyncMock(
+                return_value=prisma_user
+            )
+            result = await update_user_timezone("user-1", "Europe/London")
+
+        assert result is sentinel_user
+        by_id_del.assert_called_once_with("user-1")
+        by_email_del.assert_called_once_with("user@example.com")
+        goc_clear.assert_called_once_with()
+
+    @pytest.mark.asyncio
+    async def test_skips_email_cache_invalidation_when_email_missing(self):
+        prisma_user = MagicMock(id="user-1", email=None)
+        sentinel_user = MagicMock()
+
+        with (
+            patch.object(user_module, "PrismaUser") as mock_prisma_user,
+            patch.object(user_module.User, "from_db", return_value=sentinel_user),
+            patch.object(user_module.get_user_by_id, "cache_delete") as by_id_del,
+            patch.object(user_module.get_user_by_email, "cache_delete") as by_email_del,
+            patch.object(user_module.get_or_create_user, "cache_clear") as goc_clear,
+        ):
+            mock_prisma_user.prisma.return_value.update = AsyncMock(
+                return_value=prisma_user
+            )
+            await update_user_timezone("user-1", "Europe/London")
+
+        by_id_del.assert_called_once_with("user-1")
+        by_email_del.assert_not_called()
+        goc_clear.assert_called_once_with()
+
+    @pytest.mark.asyncio
+    async def test_wraps_prisma_errors_in_database_error(self):
+        with patch.object(user_module, "PrismaUser") as mock_prisma_user:
+            mock_prisma_user.prisma.return_value.update = AsyncMock(
+                side_effect=RuntimeError("connection lost")
+            )
+            with pytest.raises(DatabaseError) as exc:
+                await update_user_timezone("user-1", "Europe/London")
+
+        assert "user-1" in str(exc.value)
+        assert "connection lost" in str(exc.value)

--- a/autogpt_platform/frontend/src/app/(platform)/settings/api-keys/components/APIKeyList/APIKeyList.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/api-keys/components/APIKeyList/APIKeyList.tsx
@@ -77,17 +77,52 @@ export function APIKeyList() {
         )}
       </AnimatePresence>
 
-      <div className="flex flex-col divide-y divide-zinc-200 overflow-hidden rounded-[8px] border border-zinc-200 bg-white">
+      <motion.div
+        className="flex flex-col divide-y divide-zinc-200 overflow-hidden rounded-[8px] border border-zinc-200 bg-white"
+        initial={reduceMotion ? false : "hidden"}
+        animate={reduceMotion ? undefined : "show"}
+        variants={
+          reduceMotion
+            ? undefined
+            : {
+                hidden: {},
+                show: {
+                  transition: {
+                    staggerChildren: 0.04,
+                    delayChildren: 0.04,
+                  },
+                },
+              }
+        }
+      >
         {keys.map((key) => (
-          <APIKeyRow
+          <motion.div
             key={key.id}
-            apiKey={key}
-            selected={selection.isSelected(key.id)}
-            onToggleSelected={() => selection.toggle(key.id)}
-            onDelete={() => requestDelete([key.id])}
-          />
+            variants={
+              reduceMotion
+                ? undefined
+                : {
+                    hidden: { opacity: 0, y: 6 },
+                    show: {
+                      opacity: 1,
+                      y: 0,
+                      transition: {
+                        duration: 0.28,
+                        ease: [0.16, 1, 0.3, 1],
+                      },
+                    },
+                  }
+            }
+          >
+            <APIKeyRow
+              apiKey={key}
+              selected={selection.isSelected(key.id)}
+              onToggleSelected={() => selection.toggle(key.id)}
+              onDelete={() => requestDelete([key.id])}
+            />
+          </motion.div>
         ))}
-      </div>
+      </motion.div>
 
       {deleteTarget && (
         <DeleteAPIKeyDialog

--- a/autogpt_platform/frontend/src/app/(platform)/settings/api-keys/components/APIKeyList/APIKeyList.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/api-keys/components/APIKeyList/APIKeyList.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+import type { Variants } from "framer-motion";
 
 import { ErrorCard } from "@/components/molecules/ErrorCard/ErrorCard";
 
@@ -10,6 +11,22 @@ import { APIKeyRow } from "../APIKeyRow/APIKeyRow";
 import { APIKeySelectionBar } from "../APIKeySelectionBar/APIKeySelectionBar";
 import { DeleteAPIKeyDialog } from "../DeleteAPIKeyDialog/DeleteAPIKeyDialog";
 import { useAPIKeyListView } from "./useAPIKeyListView";
+
+const LIST_CONTAINER_VARIANTS: Variants = {
+  hidden: {},
+  show: {
+    transition: { staggerChildren: 0.04, delayChildren: 0.04 },
+  },
+};
+
+const LIST_ITEM_VARIANTS: Variants = {
+  hidden: { opacity: 0, y: 6 },
+  show: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: 0.28, ease: [0.16, 1, 0.3, 1] },
+  },
+};
 
 export function APIKeyList() {
   const {
@@ -81,38 +98,12 @@ export function APIKeyList() {
         className="flex flex-col divide-y divide-zinc-200 overflow-hidden rounded-[8px] border border-zinc-200 bg-white"
         initial={reduceMotion ? false : "hidden"}
         animate={reduceMotion ? undefined : "show"}
-        variants={
-          reduceMotion
-            ? undefined
-            : {
-                hidden: {},
-                show: {
-                  transition: {
-                    staggerChildren: 0.04,
-                    delayChildren: 0.04,
-                  },
-                },
-              }
-        }
+        variants={reduceMotion ? undefined : LIST_CONTAINER_VARIANTS}
       >
         {keys.map((key) => (
           <motion.div
             key={key.id}
-            variants={
-              reduceMotion
-                ? undefined
-                : {
-                    hidden: { opacity: 0, y: 6 },
-                    show: {
-                      opacity: 1,
-                      y: 0,
-                      transition: {
-                        duration: 0.28,
-                        ease: [0.16, 1, 0.3, 1],
-                      },
-                    },
-                  }
-            }
+            variants={reduceMotion ? undefined : LIST_ITEM_VARIANTS}
           >
             <APIKeyRow
               apiKey={key}

--- a/autogpt_platform/frontend/src/app/(platform)/settings/api-keys/components/APIKeyListSkeleton/APIKeyListSkeleton.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/api-keys/components/APIKeyListSkeleton/APIKeyListSkeleton.tsx
@@ -1,10 +1,27 @@
 "use client";
 
 import { motion, useReducedMotion } from "framer-motion";
+import type { Variants } from "framer-motion";
 
 import { Skeleton } from "@/components/atoms/Skeleton/Skeleton";
 
 const PLACEHOLDER_ROWS = Array.from({ length: 6 }, (_, i) => i);
+
+const SKELETON_CONTAINER_VARIANTS: Variants = {
+  hidden: {},
+  show: {
+    transition: { staggerChildren: 0.04, delayChildren: 0.04 },
+  },
+};
+
+const SKELETON_ITEM_VARIANTS: Variants = {
+  hidden: { opacity: 0, y: 6 },
+  show: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: 0.28, ease: [0.16, 1, 0.3, 1] },
+  },
+};
 
 export function APIKeyListSkeleton() {
   const reduceMotion = useReducedMotion();
@@ -16,39 +33,13 @@ export function APIKeyListSkeleton() {
       className="flex w-full flex-col divide-y divide-zinc-200 overflow-hidden rounded-[8px] border border-zinc-200 bg-white"
       initial={reduceMotion ? false : "hidden"}
       animate={reduceMotion ? undefined : "show"}
-      variants={
-        reduceMotion
-          ? undefined
-          : {
-              hidden: {},
-              show: {
-                transition: {
-                  staggerChildren: 0.04,
-                  delayChildren: 0.04,
-                },
-              },
-            }
-      }
+      variants={reduceMotion ? undefined : SKELETON_CONTAINER_VARIANTS}
     >
       {PLACEHOLDER_ROWS.map((i) => (
         <motion.div
           key={i}
           className="flex items-center justify-between py-4 pl-3 pr-5"
-          variants={
-            reduceMotion
-              ? undefined
-              : {
-                  hidden: { opacity: 0, y: 6 },
-                  show: {
-                    opacity: 1,
-                    y: 0,
-                    transition: {
-                      duration: 0.28,
-                      ease: [0.16, 1, 0.3, 1],
-                    },
-                  },
-                }
-          }
+          variants={reduceMotion ? undefined : SKELETON_ITEM_VARIANTS}
         >
           <div className="flex items-center gap-3">
             <Skeleton className="h-5 w-5" />

--- a/autogpt_platform/frontend/src/app/(platform)/settings/api-keys/components/APIKeyListSkeleton/APIKeyListSkeleton.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/api-keys/components/APIKeyListSkeleton/APIKeyListSkeleton.tsx
@@ -1,20 +1,54 @@
 "use client";
 
+import { motion, useReducedMotion } from "framer-motion";
+
 import { Skeleton } from "@/components/atoms/Skeleton/Skeleton";
 
 const PLACEHOLDER_ROWS = Array.from({ length: 6 }, (_, i) => i);
 
 export function APIKeyListSkeleton() {
+  const reduceMotion = useReducedMotion();
+
   return (
-    <div
+    <motion.div
       role="status"
       aria-label="Loading API keys"
       className="flex w-full flex-col divide-y divide-zinc-200 overflow-hidden rounded-[8px] border border-zinc-200 bg-white"
+      initial={reduceMotion ? false : "hidden"}
+      animate={reduceMotion ? undefined : "show"}
+      variants={
+        reduceMotion
+          ? undefined
+          : {
+              hidden: {},
+              show: {
+                transition: {
+                  staggerChildren: 0.04,
+                  delayChildren: 0.04,
+                },
+              },
+            }
+      }
     >
       {PLACEHOLDER_ROWS.map((i) => (
-        <div
+        <motion.div
           key={i}
           className="flex items-center justify-between py-4 pl-3 pr-5"
+          variants={
+            reduceMotion
+              ? undefined
+              : {
+                  hidden: { opacity: 0, y: 6 },
+                  show: {
+                    opacity: 1,
+                    y: 0,
+                    transition: {
+                      duration: 0.28,
+                      ease: [0.16, 1, 0.3, 1],
+                    },
+                  },
+                }
+          }
         >
           <div className="flex items-center gap-3">
             <Skeleton className="h-5 w-5" />
@@ -24,8 +58,8 @@ export function APIKeyListSkeleton() {
             </div>
           </div>
           <Skeleton className="h-5 w-5" />
-        </div>
+        </motion.div>
       ))}
-    </div>
+    </motion.div>
   );
 }

--- a/autogpt_platform/frontend/src/app/(platform)/settings/integrations/components/IntegrationsList/IntegrationsList.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/integrations/components/IntegrationsList/IntegrationsList.tsx
@@ -128,18 +128,39 @@ export function IntegrationsList() {
       {isEmpty ? (
         <IntegrationsListEmpty query={query} />
       ) : (
-        <div className="flex flex-col gap-3 pb-4">
+        <motion.div
+          className="flex flex-col gap-3 pb-4"
+          initial="hidden"
+          animate="show"
+          variants={{
+            hidden: {},
+            show: {
+              transition: {
+                staggerChildren: reduceMotion ? 0 : 0.08,
+                delayChildren: reduceMotion ? 0 : 0.05,
+              },
+            },
+          }}
+        >
           {providers.map((provider) => (
-            <ProviderGroup
+            <motion.div
               key={provider.id}
-              provider={provider}
-              isSelected={selection.isSelected}
-              onToggleSelected={selection.toggle}
-              onDelete={(id) => askDelete([id])}
-              isDeletingId={isDeletingId}
-            />
+              variants={{
+                hidden: reduceMotion ? { opacity: 0 } : { opacity: 0, y: 16 },
+                show: reduceMotion ? { opacity: 1 } : { opacity: 1, y: 0 },
+              }}
+              transition={{ duration: 0.3, ease: [0.16, 1, 0.3, 1] }}
+            >
+              <ProviderGroup
+                provider={provider}
+                isSelected={selection.isSelected}
+                onToggleSelected={selection.toggle}
+                onDelete={(id) => askDelete([id])}
+                isDeletingId={isDeletingId}
+              />
+            </motion.div>
           ))}
-        </div>
+        </motion.div>
       )}
 
       <DeleteConfirmDialog

--- a/autogpt_platform/frontend/src/app/(platform)/settings/integrations/components/IntegrationsList/IntegrationsList.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/integrations/components/IntegrationsList/IntegrationsList.tsx
@@ -152,9 +152,9 @@ export function IntegrationsList() {
       ) : (
         <motion.div
           className="flex flex-col gap-3 pb-4"
-          initial="hidden"
-          animate="show"
-          variants={LIST_CONTAINER_VARIANTS}
+          initial={reduceMotion ? false : "hidden"}
+          animate={reduceMotion ? undefined : "show"}
+          variants={reduceMotion ? undefined : LIST_CONTAINER_VARIANTS}
         >
           {providers.map((provider) => (
             <motion.div

--- a/autogpt_platform/frontend/src/app/(platform)/settings/integrations/components/IntegrationsList/IntegrationsList.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/integrations/components/IntegrationsList/IntegrationsList.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+import type { Variants } from "framer-motion";
 
 import { ErrorCard } from "@/components/molecules/ErrorCard/ErrorCard";
 
@@ -12,6 +13,27 @@ import { IntegrationsSelectionBar } from "../IntegrationsSelectionBar/Integratio
 import { ProviderGroup } from "../ProviderGroup/ProviderGroup";
 import { IntegrationsListSkeleton } from "./IntegrationsListSkeleton";
 import { useIntegrationsList } from "./useIntegrationsList";
+
+const LIST_CONTAINER_VARIANTS: Variants = {
+  hidden: {},
+  show: {
+    transition: { staggerChildren: 0.08, delayChildren: 0.05 },
+  },
+};
+
+const LIST_ITEM_VARIANTS: Variants = {
+  hidden: { opacity: 0, y: 16 },
+  show: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: 0.3, ease: [0.16, 1, 0.3, 1] },
+  },
+};
+
+const REDUCED_MOTION_ITEM_VARIANTS: Variants = {
+  hidden: { opacity: 0 },
+  show: { opacity: 1 },
+};
 
 export function IntegrationsList() {
   const {
@@ -132,24 +154,16 @@ export function IntegrationsList() {
           className="flex flex-col gap-3 pb-4"
           initial="hidden"
           animate="show"
-          variants={{
-            hidden: {},
-            show: {
-              transition: {
-                staggerChildren: reduceMotion ? 0 : 0.08,
-                delayChildren: reduceMotion ? 0 : 0.05,
-              },
-            },
-          }}
+          variants={LIST_CONTAINER_VARIANTS}
         >
           {providers.map((provider) => (
             <motion.div
               key={provider.id}
-              variants={{
-                hidden: reduceMotion ? { opacity: 0 } : { opacity: 0, y: 16 },
-                show: reduceMotion ? { opacity: 1 } : { opacity: 1, y: 0 },
-              }}
-              transition={{ duration: 0.3, ease: [0.16, 1, 0.3, 1] }}
+              variants={
+                reduceMotion
+                  ? REDUCED_MOTION_ITEM_VARIANTS
+                  : LIST_ITEM_VARIANTS
+              }
             >
               <ProviderGroup
                 provider={provider}

--- a/autogpt_platform/frontend/src/app/(platform)/settings/integrations/components/IntegrationsList/IntegrationsList.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/integrations/components/IntegrationsList/IntegrationsList.tsx
@@ -160,9 +160,7 @@ export function IntegrationsList() {
             <motion.div
               key={provider.id}
               variants={
-                reduceMotion
-                  ? REDUCED_MOTION_ITEM_VARIANTS
-                  : LIST_ITEM_VARIANTS
+                reduceMotion ? REDUCED_MOTION_ITEM_VARIANTS : LIST_ITEM_VARIANTS
               }
             >
               <ProviderGroup

--- a/autogpt_platform/frontend/src/app/(platform)/settings/integrations/components/IntegrationsList/IntegrationsListSkeleton.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/integrations/components/IntegrationsList/IntegrationsListSkeleton.tsx
@@ -1,17 +1,39 @@
+"use client";
+
+import { motion, useReducedMotion } from "framer-motion";
+
 import { Skeleton } from "@/components/atoms/Skeleton/Skeleton";
 
 export function IntegrationsListSkeleton() {
+  const reduceMotion = useReducedMotion();
+
   return (
-    <div
+    <motion.div
       className="flex flex-col gap-3"
       aria-busy="true"
       aria-label="Loading integrations"
+      initial="hidden"
+      animate="show"
+      variants={{
+        hidden: {},
+        show: {
+          transition: {
+            staggerChildren: reduceMotion ? 0 : 0.08,
+            delayChildren: reduceMotion ? 0 : 0.05,
+          },
+        },
+      }}
     >
       {[0, 1, 2].map((i) => (
-        <div
+        <motion.div
           key={i}
           data-testid="integration-skeleton-item"
           className="w-full overflow-hidden rounded-lg border border-[#DADADC] bg-white"
+          variants={{
+            hidden: reduceMotion ? { opacity: 0 } : { opacity: 0, y: 16 },
+            show: reduceMotion ? { opacity: 1 } : { opacity: 1, y: 0 },
+          }}
+          transition={{ duration: 0.3, ease: [0.16, 1, 0.3, 1] }}
         >
           {/* Mirrors ProviderGroup accordion trigger row */}
           <div className="flex items-center justify-between px-3 py-3 pr-5">
@@ -36,8 +58,8 @@ export function IntegrationsListSkeleton() {
             </div>
             <Skeleton className="size-5 rounded" />
           </div>
-        </div>
+        </motion.div>
       ))}
-    </div>
+    </motion.div>
   );
 }

--- a/autogpt_platform/frontend/src/app/(platform)/settings/integrations/components/IntegrationsList/IntegrationsListSkeleton.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/integrations/components/IntegrationsList/IntegrationsListSkeleton.tsx
@@ -34,9 +34,9 @@ export function IntegrationsListSkeleton() {
       className="flex flex-col gap-3"
       aria-busy="true"
       aria-label="Loading integrations"
-      initial="hidden"
-      animate="show"
-      variants={SKELETON_CONTAINER_VARIANTS}
+      initial={reduceMotion ? false : "hidden"}
+      animate={reduceMotion ? undefined : "show"}
+      variants={reduceMotion ? undefined : SKELETON_CONTAINER_VARIANTS}
     >
       {[0, 1, 2].map((i) => (
         <motion.div

--- a/autogpt_platform/frontend/src/app/(platform)/settings/integrations/components/IntegrationsList/IntegrationsListSkeleton.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/integrations/components/IntegrationsList/IntegrationsListSkeleton.tsx
@@ -1,8 +1,30 @@
 "use client";
 
 import { motion, useReducedMotion } from "framer-motion";
+import type { Variants } from "framer-motion";
 
 import { Skeleton } from "@/components/atoms/Skeleton/Skeleton";
+
+const SKELETON_CONTAINER_VARIANTS: Variants = {
+  hidden: {},
+  show: {
+    transition: { staggerChildren: 0.08, delayChildren: 0.05 },
+  },
+};
+
+const SKELETON_ITEM_VARIANTS: Variants = {
+  hidden: { opacity: 0, y: 16 },
+  show: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: 0.3, ease: [0.16, 1, 0.3, 1] },
+  },
+};
+
+const REDUCED_MOTION_ITEM_VARIANTS: Variants = {
+  hidden: { opacity: 0 },
+  show: { opacity: 1 },
+};
 
 export function IntegrationsListSkeleton() {
   const reduceMotion = useReducedMotion();
@@ -14,26 +36,16 @@ export function IntegrationsListSkeleton() {
       aria-label="Loading integrations"
       initial="hidden"
       animate="show"
-      variants={{
-        hidden: {},
-        show: {
-          transition: {
-            staggerChildren: reduceMotion ? 0 : 0.08,
-            delayChildren: reduceMotion ? 0 : 0.05,
-          },
-        },
-      }}
+      variants={SKELETON_CONTAINER_VARIANTS}
     >
       {[0, 1, 2].map((i) => (
         <motion.div
           key={i}
           data-testid="integration-skeleton-item"
           className="w-full overflow-hidden rounded-lg border border-[#DADADC] bg-white"
-          variants={{
-            hidden: reduceMotion ? { opacity: 0 } : { opacity: 0, y: 16 },
-            show: reduceMotion ? { opacity: 1 } : { opacity: 1, y: 0 },
-          }}
-          transition={{ duration: 0.3, ease: [0.16, 1, 0.3, 1] }}
+          variants={
+            reduceMotion ? REDUCED_MOTION_ITEM_VARIANTS : SKELETON_ITEM_VARIANTS
+          }
         >
           {/* Mirrors ProviderGroup accordion trigger row */}
           <div className="flex items-center justify-between px-3 py-3 pr-5">

--- a/autogpt_platform/frontend/src/app/(platform)/settings/preferences/__tests__/main.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/preferences/__tests__/main.test.tsx
@@ -310,6 +310,10 @@ describe("SettingsPreferencesPage", () => {
     });
     expect(submittedTimezone).not.toBe("not-set");
     expect(submittedTimezone?.length ?? 0).toBeGreaterThan(0);
+
+    await waitFor(() => {
+      expect((saveButton as HTMLButtonElement).disabled).toBe(true);
+    });
   });
 
   test("submitting a new email closes the dialog and calls the update endpoint", async () => {

--- a/autogpt_platform/frontend/src/app/(platform)/settings/preferences/__tests__/main.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/preferences/__tests__/main.test.tsx
@@ -265,6 +265,13 @@ describe("SettingsPreferencesPage", () => {
   });
 
   test("Save is enabled on first paint when server timezone is not-set, and saves the detected browser tz", async () => {
+    const STUBBED_BROWSER_TZ = "America/New_York";
+    const resolvedOptionsSpy = vi
+      .spyOn(Intl.DateTimeFormat.prototype, "resolvedOptions")
+      .mockReturnValue({
+        timeZone: STUBBED_BROWSER_TZ,
+      } as Intl.ResolvedDateTimeFormatOptions);
+
     let submittedTimezone: string | undefined;
 
     server.use(
@@ -293,27 +300,29 @@ describe("SettingsPreferencesPage", () => {
       }),
     );
 
-    render(<SettingsPreferencesPage />);
+    try {
+      render(<SettingsPreferencesPage />);
 
-    const saveButton = await screen.findByRole("button", {
-      name: "Save changes",
-    });
+      const saveButton = await screen.findByRole("button", {
+        name: "Save changes",
+      });
 
-    await waitFor(() => {
-      expect((saveButton as HTMLButtonElement).disabled).toBe(false);
-    });
+      await waitFor(() => {
+        expect((saveButton as HTMLButtonElement).disabled).toBe(false);
+      });
 
-    fireEvent.click(saveButton);
+      fireEvent.click(saveButton);
 
-    await waitFor(() => {
-      expect(submittedTimezone).toBeDefined();
-    });
-    expect(submittedTimezone).not.toBe("not-set");
-    expect(submittedTimezone?.length ?? 0).toBeGreaterThan(0);
+      await waitFor(() => {
+        expect(submittedTimezone).toBe(STUBBED_BROWSER_TZ);
+      });
 
-    await waitFor(() => {
-      expect((saveButton as HTMLButtonElement).disabled).toBe(true);
-    });
+      await waitFor(() => {
+        expect((saveButton as HTMLButtonElement).disabled).toBe(true);
+      });
+    } finally {
+      resolvedOptionsSpy.mockRestore();
+    }
   });
 
   test("submitting a new email closes the dialog and calls the update endpoint", async () => {

--- a/autogpt_platform/frontend/src/app/(platform)/settings/preferences/__tests__/main.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/preferences/__tests__/main.test.tsx
@@ -264,6 +264,54 @@ describe("SettingsPreferencesPage", () => {
     });
   });
 
+  test("Save is enabled on first paint when server timezone is not-set, and saves the detected browser tz", async () => {
+    let submittedTimezone: string | undefined;
+
+    server.use(
+      getGetV1GetNotificationPreferencesMockHandler({
+        user_id: "user-1",
+        email: "user@example.com",
+        preferences: allFalsePreferences,
+        daily_limit: 0,
+        emails_sent_today: 0,
+        last_reset_date: baseDate,
+      }),
+      getGetV1GetUserTimezoneMockHandler({ timezone: "not-set" }),
+      getPostV1UpdateUserEmailMockHandler({}),
+      getPostV1UpdateNotificationPreferencesMockHandler({
+        user_id: "user-1",
+        email: "user@example.com",
+        preferences: {},
+        daily_limit: 0,
+        emails_sent_today: 0,
+        last_reset_date: baseDate,
+      }),
+      getPostV1UpdateUserTimezoneMockHandler(async ({ request }) => {
+        const body = (await request.json()) as { timezone: string };
+        submittedTimezone = body.timezone;
+        return { timezone: body.timezone };
+      }),
+    );
+
+    render(<SettingsPreferencesPage />);
+
+    const saveButton = await screen.findByRole("button", {
+      name: "Save changes",
+    });
+
+    await waitFor(() => {
+      expect((saveButton as HTMLButtonElement).disabled).toBe(false);
+    });
+
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(submittedTimezone).toBeDefined();
+    });
+    expect(submittedTimezone).not.toBe("not-set");
+    expect(submittedTimezone?.length ?? 0).toBeGreaterThan(0);
+  });
+
   test("submitting a new email closes the dialog and calls the update endpoint", async () => {
     const fetchMock = vi.fn(async () =>
       Promise.resolve(

--- a/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/TimezoneCard/TimezoneCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/TimezoneCard/TimezoneCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { ClockIcon, GlobeIcon, InfoIcon } from "@phosphor-icons/react";
-import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+import { ClockIcon, InfoIcon } from "@phosphor-icons/react";
+import { motion, useReducedMotion } from "framer-motion";
 
 import { Select } from "@/components/atoms/Select/Select";
 import { Text } from "@/components/atoms/Text/Text";
@@ -14,30 +14,19 @@ import {
 import {
   EASE_OUT,
   TIMEZONES,
-  detectBrowserTimezone,
   findTimezoneLabel,
   formatGmtOffset,
 } from "../../helpers";
 
 interface Props {
   value: string;
-  initialValue: string;
   onChange: (timezone: string) => void;
   index?: number;
 }
 
-export function TimezoneCard({
-  value,
-  initialValue,
-  onChange,
-  index = 0,
-}: Props) {
+export function TimezoneCard({ value, onChange, index = 0 }: Props) {
   const reduceMotion = useReducedMotion();
-  const browserTz = detectBrowserTimezone();
   const offset = formatGmtOffset(value);
-  const browserLabel = findTimezoneLabel(browserTz);
-
-  const showAutoDetect = initialValue !== browserTz && value !== browserTz;
 
   const options = TIMEZONES.some((t) => t.value === value)
     ? TIMEZONES
@@ -106,31 +95,6 @@ export function TimezoneCard({
             ) : null}
           </div>
         </div>
-
-        <AnimatePresence initial={false}>
-          {showAutoDetect ? (
-            <motion.button
-              key="autodetect"
-              type="button"
-              onClick={() => onChange(browserTz)}
-              initial={reduceMotion ? false : { opacity: 0, y: -4, height: 0 }}
-              animate={
-                reduceMotion ? undefined : { opacity: 1, y: 0, height: "auto" }
-              }
-              exit={reduceMotion ? undefined : { opacity: 0, y: -4, height: 0 }}
-              transition={
-                reduceMotion ? undefined : { duration: 0.22, ease: EASE_OUT }
-              }
-              className="flex w-fit items-center gap-2 self-end overflow-hidden rounded-full border border-violet-300 bg-violet-50/60 px-3 py-1.5 text-left text-violet-800 transition-colors duration-150 ease-out hover:bg-violet-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-400 focus-visible:ring-offset-2"
-            >
-              <GlobeIcon size={16} weight="duotone" />
-              <Text variant="small" as="span" className="text-violet-800">
-                Looks like you&apos;re in{" "}
-                <span className="font-medium">{browserLabel}</span>. Use that?
-              </Text>
-            </motion.button>
-          ) : null}
-        </AnimatePresence>
       </div>
     </motion.section>
   );

--- a/autogpt_platform/frontend/src/app/(platform)/settings/preferences/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/preferences/page.tsx
@@ -24,7 +24,6 @@ export default function SettingsPreferencesPage() {
     error,
     refetch,
     formState,
-    savedState,
     dirty,
     isSaving,
     setTimezone,
@@ -59,7 +58,6 @@ export default function SettingsPreferencesPage() {
 
       <TimezoneCard
         value={formState.timezone}
-        initialValue={savedState.timezone}
         onChange={setTimezone}
         index={1}
       />

--- a/autogpt_platform/frontend/src/app/(platform)/settings/preferences/usePreferencesPage.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/preferences/usePreferencesPage.ts
@@ -64,15 +64,18 @@ export function usePreferencesPage() {
     timezoneQuery.isLoading ||
     !preferencesQuery.data;
 
-  const initialTimezone =
-    timezoneQuery.data && timezoneQuery.data !== "not-set"
-      ? timezoneQuery.data
-      : detectBrowserTimezone();
+  const serverTimezone = timezoneQuery.data ?? "not-set";
+  const formTimezone =
+    serverTimezone !== "not-set" ? serverTimezone : detectBrowserTimezone();
   const initialFlags = preferencesQuery.data
     ? preferencesToFlags(preferencesQuery.data)
     : EMPTY_FLAGS;
-  const initialState: PreferencesFormState = {
-    timezone: initialTimezone,
+  const initialFormState: PreferencesFormState = {
+    timezone: formTimezone,
+    notifications: initialFlags,
+  };
+  const initialSavedState: PreferencesFormState = {
+    timezone: serverTimezone,
     notifications: initialFlags,
   };
 
@@ -92,11 +95,16 @@ export function usePreferencesPage() {
       if (hasInitializedFormState.current) return;
       if (!preferencesQuery.isSuccess) return;
       if (!timezoneQuery.isSuccess) return;
-      setFormState(initialState);
-      setSavedState(initialState);
+      setFormState(initialFormState);
+      setSavedState(initialSavedState);
       hasInitializedFormState.current = true;
     },
-    [initialState, preferencesQuery.isSuccess, timezoneQuery.isSuccess],
+    [
+      initialFormState,
+      initialSavedState,
+      preferencesQuery.isSuccess,
+      timezoneQuery.isSuccess,
+    ],
   );
 
   const dirty = isFormDirty(savedState, formState);
@@ -147,22 +155,9 @@ export function usePreferencesPage() {
             timezone: snapshot.timezone as UpdateTimezoneRequestTimezone,
           },
         });
-        queryClient.setQueryData(
-          getGetV1GetUserTimezoneQueryKey(),
-          (prev: unknown) => {
-            if (
-              prev &&
-              typeof prev === "object" &&
-              "data" in (prev as Record<string, unknown>)
-            ) {
-              return {
-                ...(prev as Record<string, unknown>),
-                data: { timezone: snapshot.timezone },
-              };
-            }
-            return { status: 200, data: { timezone: snapshot.timezone } };
-          },
-        );
+        await queryClient.invalidateQueries({
+          queryKey: getGetV1GetUserTimezoneQueryKey(),
+        });
         setSavedState((prev) => ({ ...prev, timezone: snapshot.timezone }));
         timezoneSaved = true;
       } catch (err) {

--- a/autogpt_platform/frontend/src/app/(platform)/settings/preferences/usePreferencesPage.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/preferences/usePreferencesPage.ts
@@ -150,7 +150,7 @@ export function usePreferencesPage() {
 
     if (partsAtSubmit.timezone) {
       try {
-        await updateTimezone.mutateAsync({
+        const result = await updateTimezone.mutateAsync({
           data: {
             timezone: snapshot.timezone as UpdateTimezoneRequestTimezone,
           },
@@ -158,7 +158,9 @@ export function usePreferencesPage() {
         await queryClient.invalidateQueries({
           queryKey: getGetV1GetUserTimezoneQueryKey(),
         });
-        setSavedState((prev) => ({ ...prev, timezone: snapshot.timezone }));
+        const persistedTimezone =
+          (result.status === 200 && result.data?.timezone) || snapshot.timezone;
+        setSavedState((prev) => ({ ...prev, timezone: persistedTimezone }));
         timezoneSaved = true;
       } catch (err) {
         failures.push(

--- a/autogpt_platform/frontend/src/app/(platform)/settings/profile/components/ProfileForm/ProfileForm.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/profile/components/ProfileForm/ProfileForm.tsx
@@ -255,7 +255,7 @@ export function ProfileForm({ formState, errors, onChange }: Props) {
           value={formState.description}
           error={errors.description}
           onChange={(e) => onChange("description", e.target.value)}
-          className="!rounded-3xl"
+          className="!rounded-3xl !rounded-tr-md scrollbar-thin scrollbar-track-transparent scrollbar-thumb-zinc-200 hover:scrollbar-thumb-zinc-300"
         />
       )}
     </motion.div>


### PR DESCRIPTION
## Why

The new Settings v2 surfaces (preferences, api-keys, integrations, profile) shipped with a few rough edges spotted in self-review:

- **Timezone saves silently dropped on refresh.** Backend `GET /auth/user/timezone` resolved the user via `get_or_create_user(user_data)` (a 5-min in-process cache keyed by the JWT-payload dict). `update_user_timezone` only invalidates `get_user_by_id`'s cache, so the GET kept returning the pre-save tz until TTL expired — looked exactly like "save did nothing."
- **Confusing "Looks like you're in X" CTA on the Time zone card** that did nothing in the common case (server tz already matched the browser tz, so clicking it produced no dirty state).
- **Save was disabled out of the gate when server tz was `"not-set"`** — the hook substituted the browser tz into both `formState` and `savedState`, so they were equal and `dirty` was false.
- **Lists felt static.** No motion when API keys / integrations mount, and the loading skeletons popped in all at once instead of handing off cleanly to the loaded rows.
- **Profile bio textarea** corner clipped against the rounded-3xl border and the scrollbar overflowed the rounded container.

## What

### Bug fixes
- `GET /auth/user/timezone` now reads via `get_user_by_id(user_id)` — the same cache `update_user_timezone` already invalidates — so a save followed by refresh shows the new tz immediately.
- `usePreferencesPage` now treats the raw server tz (`"not-set"` included) as the saved baseline, while `formState` uses the browser tz only as a *display* fallback. Effect: when the user has never set a tz, Save is enabled on first paint and a single click persists the detected tz.
- Frontend save flow swapped `setQueryData` for `invalidateQueries`, mirroring the older `/profile/(user)/settings` page so we always re-read the persisted value.
- Removed the auto-detect "Looks like you're in X" button + its dead helpers.

### Animations (per Emil Kowalski's guidelines)
Added orchestrated stagger animations that run on both the loaded list **and** its skeleton, so the loading→loaded handoff is continuous in-position:

- **API keys list + skeleton:** 280ms ease-out `cubic-bezier(0.16, 1, 0.3, 1)`, 40ms stagger, opacity + 6px translate.
- **Integrations list + skeleton:** 300ms ease-out, 80ms stagger, opacity + 16px translate (rows are bigger / fewer).
- Both honor `prefers-reduced-motion` via `useReducedMotion`; only `opacity` and `transform` are animated.

### Misc polish
- Profile bio textarea: `!rounded-tr-md` so the top-right corner doesn't fight the surrounding `rounded-3xl`, plus a thin styled scrollbar (`scrollbar-thin scrollbar-thumb-zinc-200 hover:scrollbar-thumb-zinc-300`) that lives inside the rounded container instead of breaking out of it.

## How

| File | Change |
| --- | --- |
| `backend/api/features/v1.py` | `get_user_timezone_route` now uses `get_user_by_id` + `Security(get_user_id)` instead of `get_or_create_user(user_data)` |
| `frontend/.../preferences/usePreferencesPage.ts` | Split init into `initialFormState` (browser-fallback display) vs `initialSavedState` (raw server value); swap optimistic `setQueryData` for `invalidateQueries` after tz mutate |
| `frontend/.../preferences/components/TimezoneCard/TimezoneCard.tsx` | Drop `initialValue` prop, remove auto-detect button + unused imports |
| `frontend/.../preferences/page.tsx` | Drop `savedState`/`initialValue` wiring |
| `frontend/.../api-keys/components/APIKeyList/APIKeyList.tsx` | Wrap rows in container `motion.div` with `staggerChildren`; per-row `motion.div` with opacity + y variants |
| `frontend/.../api-keys/components/APIKeyListSkeleton/APIKeyListSkeleton.tsx` | Same stagger config so loading→loaded matches |
| `frontend/.../integrations/components/IntegrationsList/IntegrationsList.tsx` + `IntegrationsListSkeleton.tsx` | Same pattern for the providers list |
| `frontend/.../profile/components/ProfileForm/ProfileForm.tsx` | Tailwind classes only — `!rounded-tr-md` + `scrollbar-thin scrollbar-thumb-zinc-200 hover:scrollbar-thumb-zinc-300` |

## Test plan

- [ ] On `/settings/preferences`: pick a different tz → Save → hard-refresh → new tz still selected.
- [ ] First-time user (server tz = `not-set`): land on page, Save button should already be enabled; click Save → toast confirms; refresh → tz persists.
- [ ] No "Looks like you're in X" button visible.
- [ ] On `/settings/api-keys`: rows fade/slide in staggered on first mount; loading skeleton uses the same motion.
- [ ] On `/settings/integrations`: provider groups fade/slide in staggered; skeleton matches.
- [ ] OS "Reduce motion" enabled → no transforms, content appears instantly on all four surfaces.
- [ ] On `/settings/profile`: bio textarea top-right corner is no longer hard-cornered against the card; scrollbar fits inside the rounded shape.
- [ ] Existing unit tests still pass: `pnpm test:unit src/app/\(platform\)/settings/preferences` and `.../api-keys`.
