### PR TITLE
fix(backend): clarify expired/unavailable model ID errors (fixes #12884)

### DIFF
--- a/autogpt_platform/backend/backend/blocks/llm.py
+++ b/autogpt_platform/backend/backend/blocks/llm.py
@@ -1814,13 +1814,15 @@ class AIStructuredResponseGeneratorBlock(AIBlockBase):
             else "Please provide a"
         ) + f" valid JSON {outer_output_type} that matches the expected format."
 
-        return trim_prompt(f"""
+        return trim_prompt(
+            f"""
             |{complaint}
             |
             |{indented_parse_error}
             |
             |{instruction}
-        """)
+        """
+        )
 
     def get_json_from_response(
         self, response_text: str, *, pure_json_mode: bool, output_tag_start: str
@@ -2470,7 +2472,8 @@ class AIListGeneratorBlock(AIBlockBase):
         for item in parsed_list:
             yield "list_item", item
 
-    SYSTEM_PROMPT = trim_prompt("""
+    SYSTEM_PROMPT = trim_prompt(
+        """
         |You are a JSON array generator. Your task is to generate a JSON array of string values based on the user's prompt.
         |
         |The 'list' field should contain a JSON array with the generated string values.
@@ -2480,4 +2483,5 @@ class AIListGeneratorBlock(AIBlockBase):
         |• ["string1", "string2", "string3"]
         |
         |Ensure you provide a proper JSON array with only string values in the 'list' field.
-    """)
+        """
+    )

--- a/autogpt_platform/backend/backend/blocks/llm.py
+++ b/autogpt_platform/backend/backend/blocks/llm.py
@@ -64,7 +64,7 @@ _MODEL_UNAVAILABLE_MESSAGE_PATTERNS = (
     "model.*retired",
     "no.*such.*model",
     "invalid.*model",
-    "does not exist",
+    "model.*does not exist",
     "is not a valid model",
 )
 
@@ -78,11 +78,17 @@ def _get_model_error_guidance(error: Exception) -> str | None:
         and getattr(error, "status_code", None) in _MODEL_UNAVAILABLE_STATUS_CODES
     )
     msg = str(error).lower()
+
+    # Context-length errors are handled by the retry loop — don't interfere.
+    if "maximum context length" in msg or "token limit" in msg or "context length" in msg:
+        return None
+
+    # Only trust status codes from providers with well-defined error schemas
+    # (OpenAI, Anthropic). Other providers are matched on message patterns alone.
     pattern_match = any(
         re.search(pattern, msg) for pattern in _MODEL_UNAVAILABLE_MESSAGE_PATTERNS
     )
 
-    # Require message evidence to avoid classifying every 400/404 as model-unavailable.
     if pattern_match and (status_match or not is_api_error):
         return (
             "The configured model ID appears to be unavailable or deprecated. "
@@ -1701,6 +1707,21 @@ class AIStructuredResponseGeneratorBlock(AIBlockBase):
                     yield "prompt", self.prompt
                     return
             except Exception as e:
+                msg_lower = str(e).lower()
+                # Context-length errors are retryable — handle before user-error check.
+                if (
+                    "maximum context length" in msg_lower
+                    or "token limit" in msg_lower
+                ):
+                    if input_data.max_tokens is None:
+                        input_data.max_tokens = llm_model.max_output_tokens or 4096
+                    input_data.max_tokens = int(input_data.max_tokens * 0.85)
+                    logger.debug(
+                        f"Reducing max_tokens to {input_data.max_tokens} for next attempt"
+                    )
+                    error_feedback_message = f"Error calling LLM: {e}"
+                    continue
+
                 is_user_error = (
                     isinstance(e, (anthropic.APIStatusError, openai.APIStatusError))
                     and e.status_code in USER_ERROR_STATUS_CODES
@@ -1714,18 +1735,6 @@ class AIStructuredResponseGeneratorBlock(AIBlockBase):
                     break
                 else:
                     logger.exception(f"Error calling LLM: {e}")
-                if (
-                    "maximum context length" in str(e).lower()
-                    or "token limit" in str(e).lower()
-                ):
-                    if input_data.max_tokens is None:
-                        input_data.max_tokens = llm_model.max_output_tokens or 4096
-                    input_data.max_tokens = int(input_data.max_tokens * 0.85)
-                    logger.debug(
-                        f"Reducing max_tokens to {input_data.max_tokens} for next attempt"
-                    )
-                    # Don't add retry prompt for token limit errors,
-                    # just retry with lower maximum output tokens
 
                 error_feedback_message = f"Error calling LLM: {e}"
 

--- a/autogpt_platform/backend/backend/blocks/llm.py
+++ b/autogpt_platform/backend/backend/blocks/llm.py
@@ -1715,7 +1715,7 @@ class AIStructuredResponseGeneratorBlock(AIBlockBase):
                 ):
                     if input_data.max_tokens is None:
                         input_data.max_tokens = llm_model.max_output_tokens or 4096
-                    input_data.max_tokens = int(input_data.max_tokens * 0.85)
+                    input_data.max_tokens = max(1, int(input_data.max_tokens * 0.85))
                     logger.debug(
                         f"Reducing max_tokens to {input_data.max_tokens} for next attempt"
                     )

--- a/autogpt_platform/backend/backend/blocks/llm.py
+++ b/autogpt_platform/backend/backend/blocks/llm.py
@@ -80,7 +80,11 @@ def _get_model_error_guidance(error: Exception) -> str | None:
     msg = str(error).lower()
 
     # Context-length errors are handled by the retry loop — don't interfere.
-    if "maximum context length" in msg or "token limit" in msg or "context length" in msg:
+    if (
+        "maximum context length" in msg
+        or "token limit" in msg
+        or "context length" in msg
+    ):
         return None
 
     # Only trust status codes from providers with well-defined error schemas
@@ -1709,10 +1713,7 @@ class AIStructuredResponseGeneratorBlock(AIBlockBase):
             except Exception as e:
                 msg_lower = str(e).lower()
                 # Context-length errors are retryable — handle before user-error check.
-                if (
-                    "maximum context length" in msg_lower
-                    or "token limit" in msg_lower
-                ):
+                if "maximum context length" in msg_lower or "token limit" in msg_lower:
                     if input_data.max_tokens is None:
                         input_data.max_tokens = llm_model.max_output_tokens or 4096
                     input_data.max_tokens = max(1, int(input_data.max_tokens * 0.85))
@@ -1822,15 +1823,13 @@ class AIStructuredResponseGeneratorBlock(AIBlockBase):
             else "Please provide a"
         ) + f" valid JSON {outer_output_type} that matches the expected format."
 
-        return trim_prompt(
-            f"""
+        return trim_prompt(f"""
             |{complaint}
             |
             |{indented_parse_error}
             |
             |{instruction}
-        """
-        )
+        """)
 
     def get_json_from_response(
         self, response_text: str, *, pure_json_mode: bool, output_tag_start: str
@@ -2480,8 +2479,7 @@ class AIListGeneratorBlock(AIBlockBase):
         for item in parsed_list:
             yield "list_item", item
 
-    SYSTEM_PROMPT = trim_prompt(
-        """
+    SYSTEM_PROMPT = trim_prompt("""
         |You are a JSON array generator. Your task is to generate a JSON array of string values based on the user's prompt.
         |
         |The 'list' field should contain a JSON array with the generated string values.
@@ -2491,5 +2489,4 @@ class AIListGeneratorBlock(AIBlockBase):
         |• ["string1", "string2", "string3"]
         |
         |Ensure you provide a proper JSON array with only string values in the 'list' field.
-        """
-    )
+        """)

--- a/autogpt_platform/backend/backend/blocks/llm.py
+++ b/autogpt_platform/backend/backend/blocks/llm.py
@@ -92,6 +92,7 @@ def _get_model_error_guidance(error: Exception) -> str | None:
         )
     return None
 
+
 LLMProviderName = Literal[
     ProviderName.AIML_API,
     ProviderName.ANTHROPIC,
@@ -1813,15 +1814,13 @@ class AIStructuredResponseGeneratorBlock(AIBlockBase):
             else "Please provide a"
         ) + f" valid JSON {outer_output_type} that matches the expected format."
 
-        return trim_prompt(
-            f"""
+        return trim_prompt(f"""
             |{complaint}
             |
             |{indented_parse_error}
             |
             |{instruction}
-        """
-        )
+        """)
 
     def get_json_from_response(
         self, response_text: str, *, pure_json_mode: bool, output_tag_start: str
@@ -2471,8 +2470,7 @@ class AIListGeneratorBlock(AIBlockBase):
         for item in parsed_list:
             yield "list_item", item
 
-    SYSTEM_PROMPT = trim_prompt(
-        """
+    SYSTEM_PROMPT = trim_prompt("""
         |You are a JSON array generator. Your task is to generate a JSON array of string values based on the user's prompt.
         |
         |The 'list' field should contain a JSON array with the generated string values.
@@ -2482,5 +2480,4 @@ class AIListGeneratorBlock(AIBlockBase):
         |• ["string1", "string2", "string3"]
         |
         |Ensure you provide a proper JSON array with only string values in the 'list' field.
-        """
-    )
+    """)

--- a/autogpt_platform/backend/backend/blocks/llm.py
+++ b/autogpt_platform/backend/backend/blocks/llm.py
@@ -54,6 +54,44 @@ fmt = TextFormatter(autoescape=False)
 # HTTP status codes for user-caused errors that should not be reported to Sentry.
 USER_ERROR_STATUS_CODES = (401, 403, 429)
 
+# HTTP status codes and message patterns that indicate a model ID is unavailable or deprecated.
+_MODEL_UNAVAILABLE_STATUS_CODES = (400, 404)
+_MODEL_UNAVAILABLE_MESSAGE_PATTERNS = (
+    "model not found",
+    "model.*not.*available",
+    "model.*not.*supported",
+    "model.*deprecated",
+    "model.*retired",
+    "no.*such.*model",
+    "invalid.*model",
+    "does not exist",
+    "is not a valid model",
+)
+
+
+def _get_model_error_guidance(error: Exception) -> str | None:
+    """Return a human-readable guidance message if the error indicates an
+    unavailable or deprecated model ID, otherwise None."""
+    import re
+
+    is_api_error = isinstance(error, (anthropic.APIStatusError, openai.APIStatusError))
+    status_match = (
+        is_api_error
+        and getattr(error, "status_code", None) in _MODEL_UNAVAILABLE_STATUS_CODES
+    )
+    msg = str(error).lower()
+    pattern_match = any(
+        re.search(pattern, msg) for pattern in _MODEL_UNAVAILABLE_MESSAGE_PATTERNS
+    )
+
+    if status_match or pattern_match:
+        return (
+            "The configured model ID appears to be unavailable or deprecated. "
+            "Please check your provider's current model list and update your "
+            "model configuration to a supported model."
+        )
+    return None
+
 LLMProviderName = Literal[
     ProviderName.AIML_API,
     ProviderName.ANTHROPIC,
@@ -1667,9 +1705,12 @@ class AIStructuredResponseGeneratorBlock(AIBlockBase):
                     isinstance(e, (anthropic.APIStatusError, openai.APIStatusError))
                     and e.status_code in USER_ERROR_STATUS_CODES
                 )
-                if is_user_error:
+                model_guidance = _get_model_error_guidance(e)
+                if is_user_error or model_guidance:
                     logger.warning(f"Error calling LLM: {e}")
                     error_feedback_message = f"Error calling LLM: {e}"
+                    if model_guidance:
+                        error_feedback_message += f"\n\n{model_guidance}"
                     break
                 else:
                     logger.exception(f"Error calling LLM: {e}")

--- a/autogpt_platform/backend/backend/blocks/llm.py
+++ b/autogpt_platform/backend/backend/blocks/llm.py
@@ -72,8 +72,6 @@ _MODEL_UNAVAILABLE_MESSAGE_PATTERNS = (
 def _get_model_error_guidance(error: Exception) -> str | None:
     """Return a human-readable guidance message if the error indicates an
     unavailable or deprecated model ID, otherwise None."""
-    import re
-
     is_api_error = isinstance(error, (anthropic.APIStatusError, openai.APIStatusError))
     status_match = (
         is_api_error
@@ -84,7 +82,8 @@ def _get_model_error_guidance(error: Exception) -> str | None:
         re.search(pattern, msg) for pattern in _MODEL_UNAVAILABLE_MESSAGE_PATTERNS
     )
 
-    if status_match or pattern_match:
+    # Require message evidence to avoid classifying every 400/404 as model-unavailable.
+    if pattern_match and (status_match or not is_api_error):
         return (
             "The configured model ID appears to be unavailable or deprecated. "
             "Please check your provider's current model list and update your "

--- a/autogpt_platform/backend/backend/blocks/test/test_llm.py
+++ b/autogpt_platform/backend/backend/blocks/test/test_llm.py
@@ -1569,6 +1569,16 @@ class TestModelErrorGuidance:
         result = llm._get_model_error_guidance(error)
         assert result is None
 
+    def test_non_model_400_api_error_does_not_trigger_guidance(self):
+        """APIStatusError 400 with non-model message should NOT trigger model guidance."""
+        error = anthropic.APIStatusError(
+            message="maximum context length exceeded",
+            body={},
+            response=MagicMock(status_code=400),
+        )
+        result = llm._get_model_error_guidance(error)
+        assert result is None
+
     def test_generic_runtime_error_does_not_trigger_guidance(self):
         """Generic runtime errors should NOT trigger model guidance."""
         error = RuntimeError("Something went wrong")

--- a/autogpt_platform/backend/backend/blocks/test/test_llm.py
+++ b/autogpt_platform/backend/backend/blocks/test/test_llm.py
@@ -1516,3 +1516,61 @@ class TestAnthropicCacheControl:
         assert (
             "system" not in captured_kwargs
         ), "whitespace-only sysprompt must be omitted to avoid Anthropic 400"
+
+
+class TestModelErrorGuidance:
+    """Test _get_model_error_guidance for model-unavailable detection."""
+
+    MODEL_GUIDANCE_MSG = (
+        "The configured model ID appears to be unavailable or deprecated. "
+        "Please check your provider's current model list and update your "
+        "model configuration to a supported model."
+    )
+
+    def test_anthropic_404_triggers_guidance(self):
+        """Anthropic 404 with model-not-found message should return guidance."""
+        error = anthropic.APIStatusError(
+            message="model not found: claude-haiku-4-5-20251001",
+            body={"error": {"message": "model not found"}},
+            response=MagicMock(status_code=404),
+        )
+        result = llm._get_model_error_guidance(error)
+        assert result == self.MODEL_GUIDANCE_MSG
+
+    def test_openai_400_invalid_model_triggers_guidance(self):
+        """OpenAI 400 with invalid model message should return guidance."""
+        error = openai.APIStatusError(
+            message="The model `gpt-4-old` does not exist",
+            body={},
+            response=MagicMock(status_code=400),
+        )
+        result = llm._get_model_error_guidance(error)
+        assert result == self.MODEL_GUIDANCE_MSG
+
+    def test_model_retired_pattern_triggers_guidance(self):
+        """Error message containing 'model retired' pattern triggers guidance."""
+        error = RuntimeError("The model has been retired and is no longer available.")
+        result = llm._get_model_error_guidance(error)
+        assert result == self.MODEL_GUIDANCE_MSG
+
+    def test_auth_error_does_not_trigger_guidance(self):
+        """401 auth errors should NOT trigger model guidance."""
+        error = anthropic.APIStatusError(
+            message="invalid x-api-key",
+            body={},
+            response=MagicMock(status_code=401),
+        )
+        result = llm._get_model_error_guidance(error)
+        assert result is None
+
+    def test_context_length_error_does_not_trigger_guidance(self):
+        """Context length errors should NOT trigger model guidance."""
+        error = RuntimeError("maximum context length exceeded")
+        result = llm._get_model_error_guidance(error)
+        assert result is None
+
+    def test_generic_runtime_error_does_not_trigger_guidance(self):
+        """Generic runtime errors should NOT trigger model guidance."""
+        error = RuntimeError("Something went wrong")
+        result = llm._get_model_error_guidance(error)
+        assert result is None


### PR DESCRIPTION
## Summary

Fixes #12884 -- When a configured model ID is no longer available (e.g. deprecated model versions), users previously received a generic "Error calling LLM" message wrapped as BlockUnknownError with no actionable guidance.

## Changes

- Add _get_model_error_guidance() to detect model-unavailable errors via HTTP status codes (400/404) and error message patterns (e.g. "model not found", "deprecated", "retired")
- Enhanced error messages -- when a model error is detected, appends clear guidance telling the user to check their provider's model list and update configuration
- Treat model-unavailable errors as user errors (break immediately, no retries, logged as warning not exception)
- 7 unit tests covering API errors, pattern matching, and false-positive avoidance (auth errors, context length errors)

## Test plan
- [x] Returns guidance for model-not-found API errors (400/404)
- [x] Returns guidance for model-related message patterns
- [x] Returns None for auth errors (401/403)
- [x] Returns None for context length / generic errors