### PR TITLE
feat(frontend): gate onboarding SubscriptionStep behind ENABLE_PLATFORM_PAYMENT

### DIFF
--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/__tests__/page.test.tsx
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/__tests__/page.test.tsx
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@/tests/integrations/test-utils";
+import OnboardingPage from "../page";
+import { useOnboardingWizardStore } from "../store";
+
+vi.mock("../steps/WelcomeStep", () => ({
+  WelcomeStep: () => <div data-testid="step-welcome" />,
+}));
+vi.mock("../steps/RoleStep", () => ({
+  RoleStep: () => <div data-testid="step-role" />,
+}));
+vi.mock("../steps/PainPointsStep", () => ({
+  PainPointsStep: () => <div data-testid="step-painpoints" />,
+}));
+vi.mock("../steps/SubscriptionStep/SubscriptionStep", () => ({
+  SubscriptionStep: () => <div data-testid="step-subscription" />,
+}));
+vi.mock("../steps/PreparingStep", () => ({
+  PreparingStep: ({ onComplete: _onComplete }: { onComplete: () => void }) => (
+    <div data-testid="step-preparing" />
+  ),
+}));
+
+let currentSearchParams = new URLSearchParams();
+const routerReplace = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    replace: routerReplace,
+    push: vi.fn(),
+    refresh: vi.fn(),
+  }),
+  useSearchParams: () => currentSearchParams,
+  usePathname: () => "/onboarding",
+}));
+
+vi.mock("@/lib/supabase/hooks/useSupabase", () => ({
+  useSupabase: () => ({ isLoggedIn: true, isUserLoading: false, user: null }),
+}));
+
+vi.mock("@/app/api/__generated__/endpoints/onboarding/onboarding", () => ({
+  getV1OnboardingState: () =>
+    Promise.resolve({ status: 200, data: { completedSteps: [] } }),
+  getV1CheckIfOnboardingIsCompleted: () =>
+    Promise.resolve({ status: 200, data: false }),
+  patchV1UpdateOnboardingState: () => Promise.resolve({ status: 200 }),
+  postV1CompleteOnboardingStep: () => Promise.resolve({ status: 200 }),
+  postV1SubmitOnboardingProfile: () => Promise.resolve({ status: 200 }),
+}));
+
+vi.mock("@/app/api/helpers", () => ({
+  resolveResponse: (p: Promise<{ data: unknown }>) => p.then((r) => r.data),
+}));
+
+let mockFlagValue = false;
+vi.mock("@/services/feature-flags/use-get-flag", () => ({
+  Flag: { ENABLE_PLATFORM_PAYMENT: "ENABLE_PLATFORM_PAYMENT" },
+  useGetFlag: () => mockFlagValue,
+}));
+
+vi.mock("launchdarkly-react-client-sdk", () => ({
+  useLDClient: () => ({
+    waitForInitialization: () => Promise.resolve(),
+  }),
+}));
+
+beforeEach(() => {
+  currentSearchParams = new URLSearchParams();
+  mockFlagValue = false;
+  routerReplace.mockClear();
+  useOnboardingWizardStore.getState().reset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("OnboardingPage — flag-gated SubscriptionStep", () => {
+  it("renders Welcome at step 1 by default in flag-off mode", async () => {
+    mockFlagValue = false;
+    render(<OnboardingPage />);
+    expect(await screen.findByTestId("step-welcome")).toBeDefined();
+    expect(screen.queryByTestId("step-subscription")).toBeNull();
+  });
+
+  it("clamps ?step=5 to step 1 when payments are gated off", async () => {
+    mockFlagValue = false;
+    currentSearchParams = new URLSearchParams("step=5");
+    render(<OnboardingPage />);
+    expect(await screen.findByTestId("step-welcome")).toBeDefined();
+    expect(screen.queryByTestId("step-preparing")).toBeNull();
+  });
+
+  it("treats step 4 as Preparing when payments are gated off", async () => {
+    mockFlagValue = false;
+    currentSearchParams = new URLSearchParams("step=4");
+    render(<OnboardingPage />);
+    expect(await screen.findByTestId("step-preparing")).toBeDefined();
+    expect(screen.queryByTestId("step-subscription")).toBeNull();
+  });
+
+  it("renders SubscriptionStep at step 4 when payments are enabled", async () => {
+    mockFlagValue = true;
+    currentSearchParams = new URLSearchParams("step=4");
+    render(<OnboardingPage />);
+    expect(await screen.findByTestId("step-subscription")).toBeDefined();
+    expect(screen.queryByTestId("step-preparing")).toBeNull();
+  });
+
+  it("treats step 5 as Preparing when payments are enabled", async () => {
+    mockFlagValue = true;
+    currentSearchParams = new URLSearchParams("step=5");
+    render(<OnboardingPage />);
+    expect(await screen.findByTestId("step-preparing")).toBeDefined();
+    expect(screen.queryByTestId("step-subscription")).toBeNull();
+  });
+
+  it("rejects decimal step values and falls back to step 1", async () => {
+    mockFlagValue = true;
+    currentSearchParams = new URLSearchParams("step=2.5");
+    render(<OnboardingPage />);
+    expect(await screen.findByTestId("step-welcome")).toBeDefined();
+    expect(screen.queryByTestId("step-role")).toBeNull();
+  });
+
+  it("rejects non-numeric step values and falls back to step 1", async () => {
+    mockFlagValue = true;
+    currentSearchParams = new URLSearchParams("step=foo");
+    render(<OnboardingPage />);
+    expect(await screen.findByTestId("step-welcome")).toBeDefined();
+  });
+});

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/page.tsx
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { CaretLeft } from "@phosphor-icons/react";
+import { Flag, useGetFlag } from "@/services/feature-flags/use-get-flag";
 import { ProgressBar } from "./components/ProgressBar";
 import { StepIndicator } from "./components/StepIndicator";
 import { PainPointsStep } from "./steps/PainPointsStep";
@@ -15,12 +16,15 @@ export default function OnboardingPage() {
   const { currentStep, isLoading, handlePreparingComplete } =
     useOnboardingPage();
   const prevStep = useOnboardingWizardStore((s) => s.prevStep);
+  const isPaymentEnabled = useGetFlag(Flag.ENABLE_PLATFORM_PAYMENT);
 
   if (isLoading) return null;
 
-  // ProgressBar + StepIndicator track only the user-interactive steps (1-4).
-  // Step 5 (PreparingStep) is a transition view that hides both indicators.
-  const totalSteps = 4;
+  // ProgressBar + StepIndicator track only the user-interactive steps. When
+  // payments are gated off, SubscriptionStep is skipped and PreparingStep
+  // takes its slot, shrinking the visible step count by one.
+  const totalSteps = isPaymentEnabled ? 4 : 3;
+  const preparingStep = isPaymentEnabled ? 5 : 4;
   const showDots = currentStep <= totalSteps;
   const showBack = currentStep > 1 && currentStep <= totalSteps;
   const showProgressBar = currentStep <= totalSteps;
@@ -46,8 +50,8 @@ export default function OnboardingPage() {
         {currentStep === 1 && <WelcomeStep />}
         {currentStep === 2 && <RoleStep />}
         {currentStep === 3 && <PainPointsStep />}
-        {currentStep === 4 && <SubscriptionStep />}
-        {currentStep === 5 && (
+        {isPaymentEnabled && currentStep === 4 && <SubscriptionStep />}
+        {currentStep === preparingStep && (
           <PreparingStep onComplete={handlePreparingComplete} />
         )}
       </div>

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/page.tsx
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { CaretLeft } from "@phosphor-icons/react";
-import { Flag, useGetFlag } from "@/services/feature-flags/use-get-flag";
 import { ProgressBar } from "./components/ProgressBar";
 import { StepIndicator } from "./components/StepIndicator";
 import { PainPointsStep } from "./steps/PainPointsStep";
@@ -13,18 +12,20 @@ import { useOnboardingWizardStore } from "./store";
 import { useOnboardingPage } from "./useOnboardingPage";
 
 export default function OnboardingPage() {
-  const { currentStep, isLoading, handlePreparingComplete } =
-    useOnboardingPage();
+  const {
+    currentStep,
+    isLoading,
+    handlePreparingComplete,
+    isPaymentEnabled,
+    preparingStep,
+    totalSteps,
+  } = useOnboardingPage();
   const prevStep = useOnboardingWizardStore((s) => s.prevStep);
-  const isPaymentEnabled = useGetFlag(Flag.ENABLE_PLATFORM_PAYMENT);
 
   if (isLoading) return null;
 
-  // ProgressBar + StepIndicator track only the user-interactive steps. When
-  // payments are gated off, SubscriptionStep is skipped and PreparingStep
-  // takes its slot, shrinking the visible step count by one.
-  const totalSteps = isPaymentEnabled ? 4 : 3;
-  const preparingStep = isPaymentEnabled ? 5 : 4;
+  // ProgressBar + StepIndicator track only the user-interactive steps.
+  // PreparingStep is a transition view that hides both indicators.
   const showDots = currentStep <= totalSteps;
   const showBack = currentStep > 1 && currentStep <= totalSteps;
   const showProgressBar = currentStep <= totalSteps;

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/useOnboardingPage.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/useOnboardingPage.ts
@@ -12,6 +12,8 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { Step, useOnboardingWizardStore } from "./store";
 
+const LD_INIT_TIMEOUT_SECONDS = 5;
+
 function parseStep(value: string | null, maxStep: number): Step {
   const n = Number(value);
   if (Number.isInteger(n) && n >= 1 && n <= maxStep) return n as Step;
@@ -37,8 +39,11 @@ export function useOnboardingPage() {
   useEffect(() => {
     if (!ldEnabled || !ldClient || areFlagsReady) return;
     let cancelled = false;
+    // Use the same 5s timeout as LDProvider so the wizard never hangs
+    // when LaunchDarkly is unreachable; on timeout we fall back to the
+    // default flag values that useGetFlag already returns.
     ldClient
-      .waitForInitialization()
+      .waitForInitialization(LD_INIT_TIMEOUT_SECONDS)
       .catch(() => undefined)
       .finally(() => {
         if (!cancelled) setAreFlagsReady(true);

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/useOnboardingPage.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/useOnboardingPage.ts
@@ -53,7 +53,15 @@ export function useOnboardingPage() {
     };
   }, [ldClient, ldEnabled, areFlagsReady]);
 
-  const isPaymentEnabled = useGetFlag(Flag.ENABLE_PLATFORM_PAYMENT);
+  // Snapshot the flag once LaunchDarkly resolves so an admin toggling
+  // ENABLE_PLATFORM_PAYMENT mid-session can't shuffle steps under a user
+  // who is already inside the wizard.
+  const livePaymentEnabled = useGetFlag(Flag.ENABLE_PLATFORM_PAYMENT);
+  const paymentEnabledSnapshot = useRef<boolean | null>(null);
+  if (paymentEnabledSnapshot.current === null && areFlagsReady) {
+    paymentEnabledSnapshot.current = livePaymentEnabled;
+  }
+  const isPaymentEnabled = paymentEnabledSnapshot.current ?? false;
   const preparingStep: Step = isPaymentEnabled ? 5 : 4;
   const totalSteps = isPaymentEnabled ? 4 : 3;
 

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/useOnboardingPage.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/useOnboardingPage.ts
@@ -5,13 +5,14 @@ import {
 } from "@/app/api/__generated__/endpoints/onboarding/onboarding";
 import { resolveResponse } from "@/app/api/helpers";
 import { useSupabase } from "@/lib/supabase/hooks/useSupabase";
+import { Flag, useGetFlag } from "@/services/feature-flags/use-get-flag";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { Step, useOnboardingWizardStore } from "./store";
 
-function parseStep(value: string | null): Step {
+function parseStep(value: string | null, maxStep: number): Step {
   const n = Number(value);
-  if (n >= 1 && n <= 5) return n as Step;
+  if (n >= 1 && n <= maxStep) return n as Step;
   return 1;
 }
 
@@ -22,6 +23,8 @@ export function useOnboardingPage() {
   const currentStep = useOnboardingWizardStore((s) => s.currentStep);
   const goToStep = useOnboardingWizardStore((s) => s.goToStep);
   const reset = useOnboardingWizardStore((s) => s.reset);
+  const isPaymentEnabled = useGetFlag(Flag.ENABLE_PLATFORM_PAYMENT);
+  const preparingStep = isPaymentEnabled ? 5 : 4;
   const [isLoading, setIsLoading] = useState(true);
   const hasSubmitted = useRef(false);
   const hasInitialized = useRef(false);
@@ -30,18 +33,18 @@ export function useOnboardingPage() {
   useEffect(() => {
     if (hasInitialized.current) return;
     hasInitialized.current = true;
-    const urlStep = parseStep(searchParams.get("step"));
+    const urlStep = parseStep(searchParams.get("step"), preparingStep);
     reset();
     goToStep(urlStep);
-  }, [searchParams, reset, goToStep]);
+  }, [searchParams, reset, goToStep, preparingStep]);
 
   // Sync store → URL when step changes
   useEffect(() => {
-    const urlStep = parseStep(searchParams.get("step"));
+    const urlStep = parseStep(searchParams.get("step"), preparingStep);
     if (currentStep !== urlStep) {
       router.replace(`/onboarding?step=${currentStep}`, { scroll: false });
     }
-  }, [currentStep, router, searchParams]);
+  }, [currentStep, router, searchParams, preparingStep]);
 
   // Check if onboarding already completed
   useEffect(() => {
@@ -63,9 +66,9 @@ export function useOnboardingPage() {
     checkCompletion();
   }, [isLoggedIn, router]);
 
-  // Submit profile when entering step 5 (Preparing)
+  // Submit profile when entering the Preparing step
   useEffect(() => {
-    if (currentStep !== 5 || hasSubmitted.current) return;
+    if (currentStep !== preparingStep || hasSubmitted.current) return;
     hasSubmitted.current = true;
 
     const { name, role, otherRole, painPoints, otherPainPoint } =
@@ -86,7 +89,7 @@ export function useOnboardingPage() {
     }).catch(() => {
       // Best effort — profile data is non-critical for accessing copilot
     });
-  }, [currentStep]);
+  }, [currentStep, preparingStep]);
 
   async function handlePreparingComplete() {
     for (let attempt = 0; attempt < 3; attempt++) {

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/useOnboardingPage.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/useOnboardingPage.ts
@@ -5,14 +5,16 @@ import {
 } from "@/app/api/__generated__/endpoints/onboarding/onboarding";
 import { resolveResponse } from "@/app/api/helpers";
 import { useSupabase } from "@/lib/supabase/hooks/useSupabase";
+import { environment } from "@/services/environment";
 import { Flag, useGetFlag } from "@/services/feature-flags/use-get-flag";
+import { useLDClient } from "launchdarkly-react-client-sdk";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { Step, useOnboardingWizardStore } from "./store";
 
 function parseStep(value: string | null, maxStep: number): Step {
   const n = Number(value);
-  if (n >= 1 && n <= maxStep) return n as Step;
+  if (Number.isInteger(n) && n >= 1 && n <= maxStep) return n as Step;
   return 1;
 }
 
@@ -23,28 +25,55 @@ export function useOnboardingPage() {
   const currentStep = useOnboardingWizardStore((s) => s.currentStep);
   const goToStep = useOnboardingWizardStore((s) => s.goToStep);
   const reset = useOnboardingWizardStore((s) => s.reset);
+
+  // Wait for LaunchDarkly before initialising the wizard from the URL.
+  // Without this, the init effect runs against the default flag value
+  // (false) on first render and clamps e.g. ?step=5 down to step 1; once
+  // the flag resolves to true, the hasInitialized guard blocks re-init
+  // and the user is stuck on step 1.
+  const ldClient = useLDClient();
+  const ldEnabled = environment.areFeatureFlagsEnabled();
+  const [areFlagsReady, setAreFlagsReady] = useState(!ldEnabled);
+  useEffect(() => {
+    if (!ldEnabled || !ldClient || areFlagsReady) return;
+    let cancelled = false;
+    ldClient
+      .waitForInitialization()
+      .catch(() => undefined)
+      .finally(() => {
+        if (!cancelled) setAreFlagsReady(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [ldClient, ldEnabled, areFlagsReady]);
+
   const isPaymentEnabled = useGetFlag(Flag.ENABLE_PLATFORM_PAYMENT);
-  const preparingStep = isPaymentEnabled ? 5 : 4;
-  const [isLoading, setIsLoading] = useState(true);
+  const preparingStep: Step = isPaymentEnabled ? 5 : 4;
+  const totalSteps = isPaymentEnabled ? 4 : 3;
+
+  const [isOnboardingStateLoading, setIsOnboardingStateLoading] =
+    useState(true);
   const hasSubmitted = useRef(false);
   const hasInitialized = useRef(false);
 
   // Initialise store from URL on mount, reset form data
   useEffect(() => {
-    if (hasInitialized.current) return;
+    if (!areFlagsReady || hasInitialized.current) return;
     hasInitialized.current = true;
     const urlStep = parseStep(searchParams.get("step"), preparingStep);
     reset();
     goToStep(urlStep);
-  }, [searchParams, reset, goToStep, preparingStep]);
+  }, [areFlagsReady, searchParams, reset, goToStep, preparingStep]);
 
   // Sync store → URL when step changes
   useEffect(() => {
+    if (!areFlagsReady) return;
     const urlStep = parseStep(searchParams.get("step"), preparingStep);
     if (currentStep !== urlStep) {
       router.replace(`/onboarding?step=${currentStep}`, { scroll: false });
     }
-  }, [currentStep, router, searchParams, preparingStep]);
+  }, [areFlagsReady, currentStep, router, searchParams, preparingStep]);
 
   // Check if onboarding already completed
   useEffect(() => {
@@ -60,7 +89,7 @@ export function useOnboardingPage() {
       } catch {
         // If we can't check, show onboarding anyway
       }
-      setIsLoading(false);
+      setIsOnboardingStateLoading(false);
     }
 
     checkCompletion();
@@ -106,7 +135,10 @@ export function useOnboardingPage() {
 
   return {
     currentStep,
-    isLoading,
+    isLoading: isOnboardingStateLoading || !areFlagsReady,
     handlePreparingComplete,
+    isPaymentEnabled,
+    preparingStep,
+    totalSteps,
   };
 }

--- a/autogpt_platform/frontend/src/playwright/utils/onboarding.ts
+++ b/autogpt_platform/frontend/src/playwright/utils/onboarding.ts
@@ -87,23 +87,30 @@ export async function completeOnboardingWizard(
 
   // Subscription step (only when ENABLE_PLATFORM_PAYMENT is on) — pick a
   // plan to advance. The "Team" CTA opens an external intake form and does
-  // not advance, so we don't exercise it here.
+  // not advance, so we don't exercise it here. Race the Subscription header
+  // against the Preparing header so the helper works in both flag states
+  // without a fixed timeout that flakes under slow renders.
   const subscriptionHeader = page.getByText(/choose the plan that.s right/i);
-  const subscriptionShown = await subscriptionHeader
-    .waitFor({ state: "visible", timeout: 2000 })
-    .then(() => true)
-    .catch(() => false);
+  const preparingHeader = page.getByText("Preparing your workspace...", {
+    exact: false,
+  });
+  const nextState = await Promise.race([
+    subscriptionHeader
+      .waitFor({ state: "visible", timeout: 10000 })
+      .then(() => "subscription" as const),
+    preparingHeader
+      .waitFor({ state: "visible", timeout: 10000 })
+      .then(() => "preparing" as const),
+  ]);
 
-  if (subscriptionShown) {
+  if (nextState === "subscription") {
     const planCta = plan === "max" ? "Upgrade to Max" : "Get Pro";
     await page.getByRole("button", { name: planCta }).click();
   }
 
   // Final step: Preparing — require the real transition state to appear first,
   // then wait for the app shell on /copilot rather than racing the redirect.
-  await expect(
-    page.getByText("Preparing your workspace...", { exact: false }),
-  ).toBeVisible({ timeout: 10000 });
+  await expect(preparingHeader).toBeVisible({ timeout: 10000 });
   await page.waitForURL(/\/copilot/, { timeout: 30000 });
   await expect(page.getByTestId("profile-popout-menu-trigger")).toBeVisible({
     timeout: 15000,

--- a/autogpt_platform/frontend/src/playwright/utils/onboarding.ts
+++ b/autogpt_platform/frontend/src/playwright/utils/onboarding.ts
@@ -45,7 +45,8 @@ export async function skipOnboardingIfPresent(
 }
 
 /**
- * Walk through the full 5-step onboarding wizard in the browser.
+ * Walk through the onboarding wizard in the browser. The Subscription step
+ * is gated behind ENABLE_PLATFORM_PAYMENT and only walked when present.
  * Returns the data that was entered so tests can verify it was submitted.
  */
 export async function completeOnboardingWizard(
@@ -84,15 +85,21 @@ export async function completeOnboardingWizard(
   }
   await page.getByRole("button", { name: "Continue" }).click();
 
-  // Step 4: Subscription — pick a plan to advance.
-  // (The "Team" CTA opens an external intake form and does not advance.)
-  await expect(page.getByText(/choose the plan that.s right/i)).toBeVisible({
-    timeout: 5000,
-  });
-  const planCta = plan === "max" ? "Upgrade to Max" : "Get Pro";
-  await page.getByRole("button", { name: planCta }).click();
+  // Subscription step (only when ENABLE_PLATFORM_PAYMENT is on) — pick a
+  // plan to advance. The "Team" CTA opens an external intake form and does
+  // not advance, so we don't exercise it here.
+  const subscriptionHeader = page.getByText(/choose the plan that.s right/i);
+  const subscriptionShown = await subscriptionHeader
+    .waitFor({ state: "visible", timeout: 2000 })
+    .then(() => true)
+    .catch(() => false);
 
-  // Step 5: Preparing — require the real transition state to appear first,
+  if (subscriptionShown) {
+    const planCta = plan === "max" ? "Upgrade to Max" : "Get Pro";
+    await page.getByRole("button", { name: planCta }).click();
+  }
+
+  // Final step: Preparing — require the real transition state to appear first,
   // then wait for the app shell on /copilot rather than racing the redirect.
   await expect(
     page.getByText("Preparing your workspace...", { exact: false }),


### PR DESCRIPTION
### Why / What / How

**Why:** The onboarding `SubscriptionStep` (added in #12935) is currently shown to every new user, but the platform payment system is rolled out behind the `ENABLE_PLATFORM_PAYMENT` LaunchDarkly flag. We need the onboarding plan-selection step to honor the same flag so users in flag-off cohorts don't hit a payment surface that the rest of the product won't support.

**What:** Conditionally render the `SubscriptionStep` based on `ENABLE_PLATFORM_PAYMENT`. When the flag is off the wizard runs `Welcome → Role → PainPoints → Preparing` (3 user-interactive steps + transition); when on, behavior is unchanged (`Welcome → Role → PainPoints → Subscription → Preparing`).

**How:**
- `page.tsx` reads the flag, computes `totalSteps` (3 vs. 4) and `preparingStep` (4 vs. 5), and only renders `SubscriptionStep` when the flag is on.
- `useOnboardingPage.ts` threads the same `preparingStep` into the URL `parseStep` clamp and into the "submit profile when entering Preparing" effect, so both adapt to the flag state.
- The Zustand store is left unchanged — its hard `Math.min(5, …)` clamp is unreachable in flag-off flow because PainPointsStep advances 3 → 4 (Preparing) and that's the terminal step.
- `playwright/utils/onboarding.ts`: with `NEXT_PUBLIC_PW_TEST=true` LaunchDarkly returns `defaultFlags` (`ENABLE_PLATFORM_PAYMENT: false`), so the helper now waits up to 2s for the Subscription header and only clicks a plan CTA if the step is actually rendered.

### Changes 🏗️

- `autogpt_platform/frontend/src/app/(no-navbar)/onboarding/page.tsx` — gate `SubscriptionStep` on `ENABLE_PLATFORM_PAYMENT`; derive `totalSteps`/`preparingStep` from the flag.
- `autogpt_platform/frontend/src/app/(no-navbar)/onboarding/useOnboardingPage.ts` — make `parseStep` and the profile-submission effect respect the flag-derived `preparingStep`.
- `autogpt_platform/frontend/src/playwright/utils/onboarding.ts` — make the Subscription step optional in `completeOnboardingWizard` so E2E works in both flag states.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [x] Existing onboarding unit tests pass (`pnpm test:unit` — 2447 passed, including `PainPointsStep`, `RoleStep`, `SubscriptionStep`, store)
  - [x] `pnpm format`, `pnpm lint`, `pnpm types` clean
  - [ ] Manual: with flag **off**, walk onboarding and confirm wizard goes Welcome → Role → PainPoints → Preparing → /copilot, progress bar shows 3 steps
  - [ ] Manual: with flag **on** (LD or `NEXT_PUBLIC_FORCE_FLAG_ENABLE_PLATFORM_PAYMENT=true`), walk onboarding and confirm SubscriptionStep is present at step 4, progress bar shows 4 steps
  - [ ] Manual: with flag **off**, hit `/onboarding?step=5` directly and confirm it clamps back to step 1 (no orphan Subscription state)
  - [ ] Playwright: `completeOnboardingWizard` E2E flow continues to pass under default `NEXT_PUBLIC_PW_TEST=true` (flag off path)

#### For configuration changes:
- [x] `.env.default` is updated or already compatible with my changes (no config changes — flag already exists in LaunchDarkly + `defaultFlags`)
- [x] `docker-compose.yml` is updated or already compatible with my changes
- [x] I have included a list of my configuration changes in the PR description (none needed)
