### PR TITLE
fix(backend/push): skip OS push for onboarding payloads

### DIFF
--- a/autogpt_platform/backend/backend/data/notification_bus.py
+++ b/autogpt_platform/backend/backend/data/notification_bus.py
@@ -18,6 +18,12 @@ _settings = Settings()
 # to tasks, so a fire-and-forget create_task can be GC'd mid-run.
 _push_tasks: set[asyncio.Task] = set()
 
+# Allowlist of payload types that should trigger an OS-level web push.
+# The notification bus is also used by in-page-only producers (e.g. onboarding
+# step toasts) that we don't want surfacing as system notifications. Add new
+# types here only when they're meant to reach users with the tab closed.
+_PUSH_ENABLED_TYPES: frozenset[str] = frozenset({"copilot_completion"})
+
 
 class NotificationEvent(BaseModel):
     """Generic notification event destined for websocket delivery."""
@@ -48,9 +54,14 @@ class AsyncRedisNotificationEventBus(AsyncRedisEventBus[NotificationEvent]):
 
     async def publish(self, event: NotificationEvent) -> None:
         await self.publish_event(event, event.user_id)
-        # Fan out to web push subscriptions in parallel. Fire-and-forget so
-        # publishers never wait on the push service; held in _push_tasks so
-        # the task survives until completion.
+        # Fan out to web push only for payload types we've opted in. The bus
+        # also carries in-page-only events (onboarding step toasts, etc.) that
+        # shouldn't surface as OS notifications. Fire-and-forget so publishers
+        # never wait on the push service; held in _push_tasks so the task
+        # survives until completion.
+        payload_type = event.payload.model_dump().get("type")
+        if payload_type not in _PUSH_ENABLED_TYPES:
+            return
         task = asyncio.create_task(_safe_send_push(event.user_id, event.payload))
         _push_tasks.add(task)
         task.add_done_callback(_push_tasks.discard)

--- a/autogpt_platform/backend/backend/data/notification_bus.py
+++ b/autogpt_platform/backend/backend/data/notification_bus.py
@@ -18,12 +18,6 @@ _settings = Settings()
 # to tasks, so a fire-and-forget create_task can be GC'd mid-run.
 _push_tasks: set[asyncio.Task] = set()
 
-# Allowlist of payload types that should trigger an OS-level web push.
-# The notification bus is also used by in-page-only producers (e.g. onboarding
-# step toasts) that we don't want surfacing as system notifications. Add new
-# types here only when they're meant to reach users with the tab closed.
-_PUSH_ENABLED_TYPES: frozenset[str] = frozenset({"copilot_completion"})
-
 
 class NotificationEvent(BaseModel):
     """Generic notification event destined for websocket delivery."""
@@ -54,14 +48,14 @@ class AsyncRedisNotificationEventBus(AsyncRedisEventBus[NotificationEvent]):
 
     async def publish(self, event: NotificationEvent) -> None:
         await self.publish_event(event, event.user_id)
-        # Fan out to web push only for payload types we've opted in. The bus
-        # also carries in-page-only events (onboarding step toasts, etc.) that
-        # shouldn't surface as OS notifications. Fire-and-forget so publishers
-        # never wait on the push service; held in _push_tasks so the task
-        # survives until completion.
-        payload_type = event.payload.model_dump().get("type")
-        if payload_type not in _PUSH_ENABLED_TYPES:
+        # Skip OS push for onboarding step toasts — those are in-page only.
+        # TODO: remove once the onboarding/wallet rework lands and decides
+        # per-event whether a system notification is desired.
+        if event.payload.model_dump().get("type") == "onboarding":
             return
+        # Fan out to web push subscriptions in parallel. Fire-and-forget so
+        # publishers never wait on the push service; held in _push_tasks so
+        # the task survives until completion.
         task = asyncio.create_task(_safe_send_push(event.user_id, event.payload))
         _push_tasks.add(task)
         task.add_done_callback(_push_tasks.discard)

--- a/autogpt_platform/backend/backend/data/notification_bus_test.py
+++ b/autogpt_platform/backend/backend/data/notification_bus_test.py
@@ -73,14 +73,11 @@ def test_event_bus_name_is_configured() -> None:
 
 
 @pytest.mark.asyncio
-async def test_publish_fans_out_to_web_push_for_allowlisted_type():
-    """publish() must kick off web-push fanout for opted-in payload types."""
+async def test_publish_fans_out_to_web_push():
+    """publish() must also kick off web-push fanout for the user."""
     bus = AsyncRedisNotificationEventBus()
     event = NotificationEvent(
-        user_id="user-42",
-        payload=NotificationPayload(
-            type="copilot_completion", event="session_completed"
-        ),
+        user_id="user-42", payload=NotificationPayload(type="info", event="hi")
     )
 
     with (
@@ -101,8 +98,8 @@ async def test_publish_fans_out_to_web_push_for_allowlisted_type():
 
 
 @pytest.mark.asyncio
-async def test_publish_skips_web_push_for_non_allowlisted_type():
-    """In-page-only payload types (e.g. onboarding) must NOT trigger OS push."""
+async def test_publish_skips_web_push_for_onboarding():
+    """Onboarding step toasts are in-page only and must NOT trigger OS push."""
     bus = AsyncRedisNotificationEventBus()
     event = NotificationEvent(
         user_id="user-42",
@@ -130,10 +127,7 @@ async def test_publish_swallows_push_errors():
     """A failing push must not propagate or fail the publish."""
     bus = AsyncRedisNotificationEventBus()
     event = NotificationEvent(
-        user_id="user-42",
-        payload=NotificationPayload(
-            type="copilot_completion", event="session_completed"
-        ),
+        user_id="user-42", payload=NotificationPayload(type="info", event="hi")
     )
 
     with (

--- a/autogpt_platform/backend/backend/data/notification_bus_test.py
+++ b/autogpt_platform/backend/backend/data/notification_bus_test.py
@@ -73,11 +73,14 @@ def test_event_bus_name_is_configured() -> None:
 
 
 @pytest.mark.asyncio
-async def test_publish_fans_out_to_web_push():
-    """publish() must also kick off web-push fanout for the user."""
+async def test_publish_fans_out_to_web_push_for_allowlisted_type():
+    """publish() must kick off web-push fanout for opted-in payload types."""
     bus = AsyncRedisNotificationEventBus()
     event = NotificationEvent(
-        user_id="user-42", payload=NotificationPayload(type="info", event="hi")
+        user_id="user-42",
+        payload=NotificationPayload(
+            type="copilot_completion", event="session_completed"
+        ),
     )
 
     with (
@@ -98,11 +101,39 @@ async def test_publish_fans_out_to_web_push():
 
 
 @pytest.mark.asyncio
+async def test_publish_skips_web_push_for_non_allowlisted_type():
+    """In-page-only payload types (e.g. onboarding) must NOT trigger OS push."""
+    bus = AsyncRedisNotificationEventBus()
+    event = NotificationEvent(
+        user_id="user-42",
+        payload=NotificationPayload(type="onboarding", event="step_completed"),
+    )
+
+    with (
+        patch.object(AsyncRedisNotificationEventBus, "publish_event", AsyncMock()),
+        patch(
+            "backend.data.notification_bus.send_push_for_user",
+            new_callable=AsyncMock,
+        ) as mock_push,
+    ):
+        await bus.publish(event)
+        import asyncio
+
+        for _ in range(3):
+            await asyncio.sleep(0)
+
+    mock_push.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_publish_swallows_push_errors():
     """A failing push must not propagate or fail the publish."""
     bus = AsyncRedisNotificationEventBus()
     event = NotificationEvent(
-        user_id="user-42", payload=NotificationPayload(type="info", event="hi")
+        user_id="user-42",
+        payload=NotificationPayload(
+            type="copilot_completion", event="session_completed"
+        ),
     )
 
     with (


### PR DESCRIPTION
## Why

[#12723](https://github.com/Significant-Gravitas/AutoGPT/pull/12723) wired Web Push fanout into `AsyncRedisNotificationEventBus.publish()` so copilot completion events reach users with the tab closed. But the bus is also used by `data/onboarding.py` for in-page step toasts, and those started firing OS-level system notifications (`increment_runs`, `step_completed`, etc.) — unwanted noise.

## What

Smallest possible patch: skip the OS push fanout when `payload.type == "onboarding"`. WebSocket delivery is unchanged.

## How

```python
async def publish(self, event: NotificationEvent) -> None:
    await self.publish_event(event, event.user_id)
    # Skip OS push for onboarding step toasts — those are in-page only.
    # TODO: remove once the onboarding/wallet rework lands.
    if event.payload.model_dump().get("type") == "onboarding":
        return
    ...
```

Five-line addition in `backend/data/notification_bus.py`. Marked `TODO` to remove once the upcoming onboarding/wallet rework decides per-event whether a system notification is desired.

Tests: added `test_publish_skips_web_push_for_onboarding`; existing fanout tests continue to validate the happy path with non-onboarding payloads.

## Test plan

- [x] `poetry run format` (ruff + isort + black + pyright)
- [ ] CI: `poetry run pytest backend/data/notification_bus_test.py`
- [ ] Manual on dev: trigger onboarding step → confirm no OS notification; finish copilot session → confirm OS notification still fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
