### PR TITLE
cleanup(backend/data): drop pre-cluster REDIS_HOST/RABBITMQ_HOST env fallbacks

### DIFF
--- a/.github/workflows/platform-backend-ci.yml
+++ b/.github/workflows/platform-backend-ci.yml
@@ -349,8 +349,8 @@ jobs:
           SUPABASE_URL: ${{ steps.supabase.outputs.API_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ steps.supabase.outputs.SERVICE_ROLE_KEY }}
           JWT_VERIFY_KEY: ${{ steps.supabase.outputs.JWT_SECRET }}
-          REDIS_HOST: "localhost"
-          REDIS_PORT: "17000"
+          REDIS_CLUSTER_HOST: "localhost"
+          REDIS_CLUSTER_PORT: "17000"
           ENCRYPTION_KEY: "dvziYgz0KSK8FENhju0ZYi8-fRTfAdlz6YLhdB_jhNw=" # DO NOT USE IN PRODUCTION!!
           # Opt-in: lets backend/data/e2e_redis_restart_test.py spin up its
           # own isolated 3-shard cluster (ports 27110–27112) and exercise

--- a/autogpt_platform/backend/.env.default
+++ b/autogpt_platform/backend/.env.default
@@ -19,8 +19,8 @@ PRISMA_SCHEMA="postgres/schema.prisma"
 
 ## ===== REQUIRED SERVICE CREDENTIALS ===== ##
 # Redis Configuration
-REDIS_HOST=localhost
-REDIS_PORT=6379
+REDIS_CLUSTER_HOST=localhost
+REDIS_CLUSTER_PORT=6379
 # REDIS_PASSWORD=
 
 # RabbitMQ Credentials

--- a/autogpt_platform/backend/backend/copilot/bot/README.md
+++ b/autogpt_platform/backend/backend/copilot/bot/README.md
@@ -20,7 +20,7 @@ See `backend/.env.default` for the full list with documentation. Minimum setup:
 |----------|---------|
 | `AUTOPILOT_BOT_DISCORD_TOKEN` | Discord bot token — enables the Discord adapter |
 | `FRONTEND_BASE_URL` | Frontend base URL for link confirmation pages (shared with the rest of the backend) |
-| `REDIS_HOST` / `REDIS_PORT` | Session + thread subscription state + copilot stream subscription (inherited from the shared backend config) |
+| `REDIS_CLUSTER_HOST` / `REDIS_CLUSTER_PORT` | Session + thread subscription state + copilot stream subscription (inherited from the shared backend config) |
 | `PLATFORMLINKINGMANAGER_HOST` | DNS name of the `PlatformLinkingManager` service pod (cluster-internal RPC) |
 
 ## Architecture

--- a/autogpt_platform/backend/backend/data/e2e_redis_restart_test.py
+++ b/autogpt_platform/backend/backend/data/e2e_redis_restart_test.py
@@ -190,10 +190,8 @@ async def test_subscriber_survives_shard_restart(isolated_cluster, monkeypatch) 
     """Subscriber must receive a post-`docker restart` SPUBLISH after
     reopening the sharded-pubsub client (the broker drops the socket on
     restart; production's `with_pubsub` loop reconnects the same way)."""
-    # Must override REDIS_CLUSTER_HOST/PORT too — those take precedence
-    # over REDIS_HOST/PORT and a stray .env would point us at the dev cluster.
-    monkeypatch.setenv("REDIS_HOST", "127.0.0.1")
-    monkeypatch.setenv("REDIS_PORT", str(ISOLATED_PORTS[0]))
+    # Override REDIS_CLUSTER_HOST/PORT — a stray .env would otherwise point
+    # us at the dev cluster.
     monkeypatch.setenv("REDIS_CLUSTER_HOST", "127.0.0.1")
     monkeypatch.setenv("REDIS_CLUSTER_PORT", str(ISOLATED_PORTS[0]))
     monkeypatch.setenv("REDIS_USE_ANNOUNCED_ADDRESS", "false")
@@ -306,7 +304,7 @@ async def test_subscriber_survives_shard_restart(isolated_cluster, monkeypatch) 
             pass
         await rc.disconnect_async()
         # Undo monkeypatched env BEFORE reloading so subsequent tests see the
-        # original REDIS_HOST/PORT — otherwise the module captures the
+        # original REDIS_CLUSTER_HOST/PORT — otherwise the module captures the
         # isolated cluster's port (27110) which is torn down right after this
         # test, and any later test that touches redis hangs on conn_retry.
         monkeypatch.undo()

--- a/autogpt_platform/backend/backend/data/redis_client.py
+++ b/autogpt_platform/backend/backend/data/redis_client.py
@@ -14,10 +14,8 @@ from backend.util.retry import conn_retry
 
 load_dotenv()
 
-# Prefer the cluster env vars so the cluster-only image can co-exist with
-# old-image pods still reading REDIS_HOST during a rollout.
-HOST = os.getenv("REDIS_CLUSTER_HOST") or os.getenv("REDIS_HOST", "localhost")
-PORT = int(os.getenv("REDIS_CLUSTER_PORT") or os.getenv("REDIS_PORT", "6379"))
+HOST = os.getenv("REDIS_CLUSTER_HOST", "localhost")
+PORT = int(os.getenv("REDIS_CLUSTER_PORT", "6379"))
 PASSWORD = os.getenv("REDIS_PASSWORD", None)
 
 # Fail-fast on a wedged endpoint instead of blocking on no-response TCP.

--- a/autogpt_platform/backend/backend/util/settings.py
+++ b/autogpt_platform/backend/backend/util/settings.py
@@ -5,7 +5,6 @@ from enum import Enum
 from typing import Any, Dict, Generic, List, Set, Tuple, Type, TypeVar
 
 from pydantic import (
-    AliasChoices,
     BaseModel,
     Field,
     PrivateAttr,
@@ -315,18 +314,16 @@ class Config(UpdateTrackingModel["Config"], BaseSettings):
         description="The pool size for the scheduler database connection pool",
     )
 
-    # Prefer the cluster env var so the new image can co-exist with old-image
-    # pods still reading the unsuffixed RABBITMQ_HOST during a rollout.
     rabbitmq_host: str = Field(
         default="localhost",
         description="The host for the RabbitMQ server",
-        validation_alias=AliasChoices("RABBITMQ_CLUSTER_HOST", "RABBITMQ_HOST"),
+        validation_alias="RABBITMQ_CLUSTER_HOST",
     )
 
     rabbitmq_port: int = Field(
         default=5672,
         description="The port for the RabbitMQ server",
-        validation_alias=AliasChoices("RABBITMQ_CLUSTER_PORT", "RABBITMQ_PORT"),
+        validation_alias="RABBITMQ_CLUSTER_PORT",
     )
 
     rabbitmq_vhost: str = Field(
@@ -334,19 +331,16 @@ class Config(UpdateTrackingModel["Config"], BaseSettings):
         description="The vhost for the RabbitMQ server",
     )
 
-    # Same rollover pattern as rabbitmq_host; REDIS_CLUSTER_HOST must win so
-    # cache.py's RedisCluster client reaches the sharded cluster, not the
-    # pre-migration standalone Redis.
     redis_host: str = Field(
         default="localhost",
         description="The host for the Redis server",
-        validation_alias=AliasChoices("REDIS_CLUSTER_HOST", "REDIS_HOST"),
+        validation_alias="REDIS_CLUSTER_HOST",
     )
 
     redis_port: int = Field(
         default=6379,
         description="The port for the Redis server",
-        validation_alias=AliasChoices("REDIS_CLUSTER_PORT", "REDIS_PORT"),
+        validation_alias="REDIS_CLUSTER_PORT",
     )
 
     redis_password: str = Field(

--- a/autogpt_platform/backend/backend/util/settings.py
+++ b/autogpt_platform/backend/backend/util/settings.py
@@ -4,13 +4,7 @@ import re
 from enum import Enum
 from typing import Any, Dict, Generic, List, Set, Tuple, Type, TypeVar
 
-from pydantic import (
-    BaseModel,
-    Field,
-    PrivateAttr,
-    ValidationInfo,
-    field_validator,
-)
+from pydantic import BaseModel, Field, PrivateAttr, ValidationInfo, field_validator
 from pydantic_settings import (
     BaseSettings,
     JsonConfigSettingsSource,

--- a/autogpt_platform/docker-compose.platform.yml
+++ b/autogpt_platform/docker-compose.platform.yml
@@ -16,14 +16,14 @@ x-backend-env:
   NOTIFICATIONMANAGER_HOST: notification_server
   CLAMAV_SERVICE_HOST: clamav
   DB_HOST: db
-  REDIS_HOST: redis-0
-  REDIS_PORT: "17000"
+  REDIS_CLUSTER_HOST: redis-0
+  REDIS_CLUSTER_PORT: "17000"
   # The 3-container local cluster announces distinct compose hostnames per
   # shard (redis-0/1/2), each resolvable via Docker DNS inside the compose
   # network. Bypass the HOST-pinning address_remap so CLUSTER SLOTS uses the
   # announced addresses directly — see ``backend.data.redis_client``.
   REDIS_USE_ANNOUNCED_ADDRESS: "true"
-  RABBITMQ_HOST: rabbitmq
+  RABBITMQ_CLUSTER_HOST: rabbitmq
   GRAPHITI_FALKORDB_HOST: falkordb
   GRAPHITI_FALKORDB_PORT: "6379"
   # Override Supabase URL for Docker network


### PR DESCRIPTION
## Background

The Redis Cluster migration (#12900) shipped dual-read fallbacks so old-image pods could keep reading the unsuffixed `REDIS_HOST` / `RABBITMQ_HOST` while we rolled out the cluster-image. That rolling-deploy window has long closed:

- shared-config no longer exposes `REDIS_HOST` / `RABBITMQ_HOST` (see related infra PR #316),
- every pod is on the cluster image and reads `*_CLUSTER_HOST` exclusively.

The fallback path is dead surface — kept around it would just rot and confuse future readers (and trip the next `address_remap` change, since it can silently grab a stale `REDIS_HOST` if something puts one back).

## Changes

- `backend/data/redis_client.py` — drop the `os.getenv("REDIS_CLUSTER_HOST") or os.getenv("REDIS_HOST", ...)` chain; cluster envs only.
- `backend/util/settings.py` — replace `AliasChoices("RABBITMQ_CLUSTER_HOST", "RABBITMQ_HOST")` (and the redis equivalent) with single-string aliases on `rabbitmq_host/port` and `redis_host/port`. `AliasChoices` import removed (no other call sites).
- `backend/.env.default` — `REDIS_HOST` / `REDIS_PORT` -> `REDIS_CLUSTER_HOST` / `REDIS_CLUSTER_PORT` so contributors set the canonical name.
- `docker-compose.platform.yml` — same rename in the shared `x-backend-env` block (`REDIS_HOST: redis-0` -> `REDIS_CLUSTER_HOST: redis-0`, `RABBITMQ_HOST: rabbitmq` -> `RABBITMQ_CLUSTER_HOST: rabbitmq`).
- `.github/workflows/platform-backend-ci.yml` — same rename in the unit-test job env block.
- `backend/data/e2e_redis_restart_test.py` — `monkeypatch.setenv` only sets the cluster envs now.
- `backend/copilot/bot/README.md` — env-var docs updated to `REDIS_CLUSTER_HOST` / `REDIS_CLUSTER_PORT`.

## Behaviour

No production behaviour change. Every caller already reads `*_CLUSTER_HOST` first; this PR just deletes the never-hit fallback.

## Test plan

- [x] `poetry run ruff check` + `ruff format --check` clean on all touched `.py` files.
- [ ] CI: `platform-backend-ci` runs the focused redis/rabbit unit tests + `e2e_redis_restart_test` against the new env names. (Local `pytest` collection currently blocked by sibling agents holding the shared `.venv`; relying on CI here.)
- [ ] Dev preview deploy lands on a cluster-image stack and the rest_server connects to redis-cluster + rabbit-cluster via `*_CLUSTER_HOST` only.