### PR TITLE
fix(backend): run copilot executor in foreground

### DIFF
--- a/autogpt_platform/backend/backend/app.py
+++ b/autogpt_platform/backend/backend/app.py
@@ -53,8 +53,8 @@ def main(**kwargs):
         WebsocketServer(),
         AgentServer(),
         ExecutionManager(),
-        CoPilotExecutor(),
         CoPilotChatBridge(),
+        CoPilotExecutor(),
         **kwargs,
     )
 


### PR DESCRIPTION
## Changes
- Move CoPilotChatBridge before CoPilotExecutor in backend process startup.
- Restore CoPilotExecutor as the last process, so it runs in the foreground under run_processes.

## Why
PR #12618 added CoPilotChatBridge after CoPilotExecutor, which made CoPilotExecutor start as a background multiprocessing process. On macOS forkserver, that path pickles the process object and fails on the executor threading.Lock with TypeError: cannot pickle _thread.lock object.

Keeping CoPilotExecutor last restores the intended local startup topology: the chat bridge runs in the background, and the copilot executor remains the foreground process.

## Testing
- poetry run ruff check backend/app.py