### PR TITLE
dx(pr-polish): use --json bucket instead of awk text-column parsing

### DIFF
--- a/.claude/skills/pr-polish/SKILL.md
+++ b/.claude/skills/pr-polish/SKILL.md
@@ -166,7 +166,7 @@ The `fetch_check_runs(PR)` step above must use `--json`, not the default text ou
 
 ```bash
 # Reliable: use --json so columns are unambiguous.
-ci_json=$(gh pr checks $PR --repo $REPO --json name,state,bucket)
+ci_json=$(gh pr checks $PR --repo Significant-Gravitas/AutoGPT --json name,state,bucket)
 pending=$(echo "$ci_json" | jq '[.[] | select(.bucket == "pending")] | length')
 failed=$(echo "$ci_json" | jq '[.[] | select(.bucket == "fail" or .bucket == "cancel")] | length')
 

--- a/.claude/skills/pr-polish/SKILL.md
+++ b/.claude/skills/pr-polish/SKILL.md
@@ -160,6 +160,24 @@ while clean_polls < required_clean:
 
 Only after `clean_polls == 2` do you report `ORCHESTRATOR:DONE`.
 
+### Concrete CI fetch (don't parse `gh pr checks` text columns)
+
+The `fetch_check_runs(PR)` step above must use `--json`, not the default text output. Job names can contain spaces and parentheses (e.g. `test (3.11)`, `Analyze (python)`), so `gh pr checks $PR | awk '{print $2}'` extracts `(3.11)` instead of the status — leading to a clean-poll firing while jobs are still pending.
+
+```bash
+# Reliable: use --json so columns are unambiguous.
+ci_json=$(gh pr checks $PR --repo $REPO --json name,state,bucket)
+pending=$(echo "$ci_json" | jq '[.[] | select(.bucket == "pending")] | length')
+failed=$(echo "$ci_json" | jq '[.[] | select(.bucket == "fail" or .bucket == "cancel")] | length')
+
+# Buckets are: pass | fail | pending | cancel | skipping
+# (NOTE: gh pr checks does NOT expose `conclusion` as a JSON field —
+# only `bucket`. Don't confuse with the GitHub REST API's check_runs
+# endpoint, which DOES use conclusion.)
+```
+
+Map back to the pseudocode above: `bucket == "pending"` is `ci.conclusion is None (still in_progress)`; `bucket in {"fail", "cancel"}` is `ci.conclusion in NON_SUCCESS_TERMINAL`; `bucket in {"pass", "skipping"}` is clean.
+
 ### Why 2 clean polls, not 1
 
 A single green snapshot can be misleading — the final CI check often completes ~30s before a bot posts its delayed review. One quiet cycle does not prove the PR is stable; two consecutive cycles with no new threads, reviews, or issue comments arriving gives high confidence nothing else is incoming.

--- a/.claude/skills/pr-polish/SKILL.md
+++ b/.claude/skills/pr-polish/SKILL.md
@@ -214,6 +214,18 @@ The child skill returning is a **loop iteration boundary**, not a conversation t
 
 If the user needs to approve a risky action mid-loop (e.g., a force-push or a destructive git operation), pause there — but not at the routine "round N finished, round N+1 needed" boundary. Those are silent transitions.
 
+### **Run /pr-polish in the foreground — never in a background agent**
+
+Spawning `/pr-polish` inside an `Agent(subagent_type="general-purpose")` background task **does not work**. Background agents don't inherit the parent's slash-command registry, so `Skill(skill="pr-review")` and `Skill(skill="pr-address")` calls aren't available — the agent has to manually replicate the child skills' logic, which is fragile and tends to stall on the first network or rate-limit hiccup. Symptom: the background task reports `stalled: no progress for 600s` mid-review.
+
+Run `/pr-polish` inline in the foreground conversation. If the user asks for "/pr-polish + /pr-test in parallel", split them: foreground `/pr-polish`, and ONLY then can the test step go to a background agent (because `/pr-test` doesn't itself need to invoke skills).
+
+### **You MUST invoke `Skill(pr-review)` every round — even when bot reviews already exist**
+
+A common failure mode: CodeRabbit / autogpt-reviewer / Sentry have already posted findings on the PR, and the orchestrator skips the `Skill(pr-review)` step on the assumption that "review has been done." That's wrong — the outer loop's purpose is to layer **the agent's own review** on top of the bot reviews, catching issues the bots miss (architecture, naming, cross-file invariants, hidden coupling). If the orchestrator only addresses bot findings without ever running its own review, the loop converges to "bot-clean" but not "agent-reviewed-clean," and the user reasonably asks "did /pr-polish even read the diff?"
+
+**Self-check before reporting `ORCHESTRATOR:DONE`:** confirm at least one `Skill(skill="pr-review")` call appears in the current orchestration. If none, the loop is incomplete — go back and run one round.
+
 ## GitHub rate limits
 
 This skill issues many GraphQL calls (one review-thread query per outer iteration plus per-poll queries inside polish polling). Expect the GraphQL budget to be tight on large PRs. When `gh api rate_limit --jq .resources.graphql.remaining` drops below ~200, back off:


### PR DESCRIPTION
## Why

`/pr-polish` was prematurely emitting `CLEAN-POLL` while CI was still pending, because the polish-polling loop's CI gate parsed `gh pr checks $PR` text columns with `awk '{print $2}'`. That works fine for plain job names, but breaks on jobs with spaces or parens like `test (3.11)`, `Analyze (python)`, where column 2 is the version `(3.11)` — so `grep -q "pending"` matched on column 2 of OTHER rows but missed the actual pending entries. Real symptom on PR #12948: the orchestrator reported `ORCHESTRATOR:DONE` while `test (3.11/3.12/3.13)` and `Check PR Status` were still running.

## What

Add a "Concrete CI fetch" subsection right after the polish-polling pseudocode block, showing the `--json bucket` shape that bypasses the column-parsing trap entirely. Also flag the `bucket` vs `conclusion` gotcha (the REST API uses `conclusion`; `gh pr checks --json` only exposes `bucket`).

## How

Surgical additive edit — the existing pseudocode + state machine is preserved; the new subsection just translates the abstract `fetch_check_runs(PR)` into a concrete one-liner so the next implementer doesn't reach for `awk` again.

## Test plan

- [x] Verified the regression against PR #12948: bucket-based polling correctly identified 4 pending checks the awk path missed
- [x] Confirmed `gh pr checks {N} --json conclusion` errors with `Unknown JSON field: "conclusion"` (this gotcha is now noted in the skill)
