### PR TITLE
fix(frontend/copilot): gate credits-add pop-up behind ENABLE_PLATFORM_PAYMENT

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/RateLimitResetDialog/RateLimitGate.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/RateLimitResetDialog/RateLimitGate.tsx
@@ -40,20 +40,32 @@ export function RateLimitGate({ rateLimitMessage, onDismiss }: Props) {
   const hasInsufficientCredits =
     credits !== null && resetCost != null && credits < resetCost;
 
-  // When the credit-based reset is unavailable (feature disabled or the query
-  // failed), fall back to a toast so the user still gets feedback.
+  // Fall back to a toast when the credit-based reset isn't a real option:
+  // billing is off (no way to top up), the usage query failed, or reset_cost
+  // is non-positive. Without billing the dialog's "Add credits" CTA is dead,
+  // so showing it would just dangle a useless reset offer.
   useEffect(() => {
     if (!rateLimitMessage) return;
-    if (!usageError && !(hasUsage && (resetCost ?? 0) <= 0)) return;
+    const creditResetUnavailable =
+      !isBillingEnabled || usageError || (hasUsage && (resetCost ?? 0) <= 0);
+    if (!creditResetUnavailable) return;
     toast({
       title: "Usage limit reached",
       description: rateLimitMessage,
       variant: "destructive",
     });
     onDismiss();
-  }, [rateLimitMessage, resetCost, hasUsage, usageError, onDismiss]);
+  }, [
+    rateLimitMessage,
+    resetCost,
+    hasUsage,
+    usageError,
+    onDismiss,
+    isBillingEnabled,
+  ]);
 
-  const canShowDialog = !!rateLimitMessage && hasUsage && (resetCost ?? 0) > 0;
+  const canShowDialog =
+    isBillingEnabled && !!rateLimitMessage && hasUsage && (resetCost ?? 0) > 0;
 
   return (
     <RateLimitResetDialog

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/RateLimitResetDialog/__tests__/RateLimitGate.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/RateLimitResetDialog/__tests__/RateLimitGate.test.tsx
@@ -23,9 +23,10 @@ vi.mock("@/hooks/useCredits", () => ({
   default: () => ({ credits: 1000, fetchCredits: vi.fn() }),
 }));
 
+const mockUseGetFlag = vi.fn(() => true);
 vi.mock("@/services/feature-flags/use-get-flag", () => ({
   Flag: { ENABLE_PLATFORM_PAYMENT: "ENABLE_PLATFORM_PAYMENT" },
-  useGetFlag: () => false,
+  useGetFlag: () => mockUseGetFlag(),
 }));
 
 // Capture props the dialog was rendered with so we can assert on them.
@@ -44,6 +45,8 @@ afterEach(() => {
   mockToast.mockReset();
   mockUseGetV2GetCopilotUsage.mockReset();
   dialogSpy.mockReset();
+  mockUseGetFlag.mockReset();
+  mockUseGetFlag.mockReturnValue(true);
 });
 
 describe("RateLimitGate", () => {
@@ -144,6 +147,25 @@ describe("RateLimitGate", () => {
     expect(mockToast).toHaveBeenCalledTimes(1);
     expect(onDismiss).toHaveBeenCalledTimes(1);
 
+    const lastProps = dialogSpy.mock.calls.at(-1)?.[0];
+    expect(lastProps.isOpen).toBe(false);
+  });
+
+  it("falls back to a toast when ENABLE_PLATFORM_PAYMENT is off, even with a positive reset cost", () => {
+    mockUseGetFlag.mockReturnValue(false);
+    const onDismiss = vi.fn();
+    mockUseGetV2GetCopilotUsage.mockReturnValue({
+      data: { reset_cost: 50, weekly: { percent_used: 10 } },
+      isSuccess: true,
+      isError: false,
+    });
+
+    render(
+      <RateLimitGate rateLimitMessage="limit reached" onDismiss={onDismiss} />,
+    );
+
+    expect(mockToast).toHaveBeenCalledTimes(1);
+    expect(onDismiss).toHaveBeenCalledTimes(1);
     const lastProps = dialogSpy.mock.calls.at(-1)?.[0];
     expect(lastProps.isOpen).toBe(false);
   });


### PR DESCRIPTION
### Why / What / How

**Why:** On an active CoPilot chat session, when the user runs out of credits we show a pop-up (`RateLimitResetDialog`) hinting them to add more credits. While the "Add credits" copy and CTA were already gated behind `ENABLE_PLATFORM_PAYMENT`, the dialog itself still rendered when billing was off — leaving users in the no-billing cohort staring at a credit-reset offer they can't act on.

**What:** Gate the entire credits pop-up behind `ENABLE_PLATFORM_PAYMENT`. When the flag is off, fall back to the existing destructive toast (same path used today when usage data is unavailable). When the flag is on, behaviour is unchanged.

**How:** In `RateLimitGate.tsx`, fold `!isBillingEnabled` into both the toast-fallback condition and `canShowDialog` so it joins the existing "credit reset unavailable" branch. Treating it as just another flavour of "credit reset unavailable" keeps the fallback logic in one place rather than introducing a parallel control flow.

### Changes 🏗️

- `RateLimitGate.tsx`: dialog no longer opens when `ENABLE_PLATFORM_PAYMENT` is off; toast fires instead.
- `RateLimitGate.test.tsx`: converted the `useGetFlag` mock into a configurable `vi.fn()` defaulting to `true` (so existing assertions still cover the billing-on path) and added a new test confirming the dialog stays closed and the toast fires when billing is off, even with a positive `reset_cost`.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Unit tests pass: `pnpm vitest run src/app/(platform)/copilot/components/RateLimitResetDialog/__tests__/RateLimitGate.test.tsx` (7/7).
  - [x] With `ENABLE_PLATFORM_PAYMENT` off: hitting a usage limit surfaces the destructive toast and no dialog renders.
  - [x] With `ENABLE_PLATFORM_PAYMENT` on: existing dialog flows (sufficient credits / insufficient credits / weekly exhausted / reset_cost = 0) all behave as before.
