### PR TITLE
Add PaperClaw — Community Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,3 +236,5 @@ To maintain a uniform standard and ensure seamless compatibility with many curre
 <a href="https://github.com/Significant-Gravitas/AutoGPT/graphs/contributors" alt="View Contributors">
   <img src="https://contrib.rocks/image?repo=Significant-Gravitas/AutoGPT&max=1000&columns=10" alt="Contributors" />
 </a>
+
+- [PaperClaw](https://github.com/Agnuxo1/PaperClaw) — IDE extension for one-click peer-reviewed paper generation from code with AI Tribunal


### PR DESCRIPTION
Adding [PaperClaw](https://github.com/Agnuxo1/PaperClaw) to the Community Projects section.

IDE extension for one-click peer-reviewed paper generation from code with AI Tribunal.

Open source (MIT/Apache 2.0).