### PR TITLE
fix(backend): hide orphaned inactive top-ups from admin spending + handle checkout.session.expired

### DIFF
--- a/autogpt_platform/backend/backend/api/features/subscription_routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/subscription_routes_test.py
@@ -933,6 +933,72 @@ def test_stripe_webhook_dispatches_invoice_payment_failed(
     failure_mock.assert_awaited_once_with(invoice_obj)
 
 
+def test_stripe_webhook_dispatches_checkout_session_expired(
+    client: fastapi.testclient.TestClient,
+    mocker: pytest_mock.MockFixture,
+) -> None:
+    """POST /credits/stripe_webhook routes checkout.session.expired to the cleanup handler."""
+    event = {
+        "type": "checkout.session.expired",
+        "data": {"object": {"id": "cs_expired_test"}},
+    }
+
+    mocker.patch(
+        "backend.api.features.v1.settings.secrets.stripe_webhook_secret",
+        new="whsec_test",
+    )
+    mocker.patch(
+        "backend.api.features.v1.stripe.Webhook.construct_event",
+        return_value=event,
+    )
+    expire_mock = mocker.patch(
+        "backend.api.features.v1.UserCredit.expire_checkout",
+        new_callable=AsyncMock,
+    )
+
+    response = client.post(
+        "/credits/stripe_webhook",
+        content=b"{}",
+        headers={"stripe-signature": "t=1,v1=abc"},
+    )
+
+    assert response.status_code == 200
+    expire_mock.assert_awaited_once_with(session_id="cs_expired_test")
+
+
+def test_stripe_webhook_checkout_session_expired_missing_id_ignored(
+    client: fastapi.testclient.TestClient,
+    mocker: pytest_mock.MockFixture,
+) -> None:
+    """A malformed checkout.session.expired payload returns 200 without invoking the handler."""
+    event = {
+        "type": "checkout.session.expired",
+        "data": {"object": {}},
+    }
+
+    mocker.patch(
+        "backend.api.features.v1.settings.secrets.stripe_webhook_secret",
+        new="whsec_test",
+    )
+    mocker.patch(
+        "backend.api.features.v1.stripe.Webhook.construct_event",
+        return_value=event,
+    )
+    expire_mock = mocker.patch(
+        "backend.api.features.v1.UserCredit.expire_checkout",
+        new_callable=AsyncMock,
+    )
+
+    response = client.post(
+        "/credits/stripe_webhook",
+        content=b"{}",
+        headers={"stripe-signature": "t=1,v1=abc"},
+    )
+
+    assert response.status_code == 200
+    expire_mock.assert_not_awaited()
+
+
 def test_update_subscription_tier_paid_to_paid_modifies_subscription(
     client: fastapi.testclient.TestClient,
     mocker: pytest_mock.MockFixture,

--- a/autogpt_platform/backend/backend/api/features/v1.py
+++ b/autogpt_platform/backend/backend/api/features/v1.py
@@ -1160,6 +1160,15 @@ async def stripe_webhook(request: Request):
             return Response(status_code=200)
         await UserCredit().fulfill_checkout(session_id=session_id)
 
+    if event_type == "checkout.session.expired":
+        session_id = data_object.get("id")
+        if not session_id:
+            logger.warning(
+                "stripe_webhook: %s missing data.object.id; ignoring", event_type
+            )
+            return Response(status_code=200)
+        await UserCredit().expire_checkout(session_id=session_id)
+
     if event_type in (
         "customer.subscription.created",
         "customer.subscription.updated",

--- a/autogpt_platform/backend/backend/data/credit.py
+++ b/autogpt_platform/backend/backend/data/credit.py
@@ -1098,6 +1098,30 @@ class UserCredit(UserCreditBase):
                 metadata=SafeJson(checkout_session),
             )
 
+    async def expire_checkout(self, *, session_id: str) -> None:
+        """Drop the inactive TOP_UP placeholder for an expired Checkout session.
+
+        Stripe sends ``checkout.session.expired`` ~24h after an unredeemed
+        session; no payment is taken on that path, so a hard delete is correct.
+        Filtering ``isActive=False`` makes the operation safe against
+        out-of-order webhook delivery — a late ``expired`` event can never
+        delete a row that ``fulfill_checkout`` already activated.
+        """
+        if not session_id.startswith("cs_"):
+            return
+        deleted = await CreditTransaction.prisma().delete_many(
+            where={
+                "transactionKey": session_id,
+                "type": CreditTransactionType.TOP_UP,
+                "isActive": False,
+            },
+        )
+        if deleted:
+            logger.info(
+                f"expire_checkout: removed {deleted} inactive TOP_UP row(s) "
+                f"for session {session_id}"
+            )
+
     async def get_credits(self, user_id: str) -> int:
         balance, _ = await self._get_credits(user_id)
         return balance
@@ -2588,7 +2612,12 @@ async def admin_get_user_history(
     if page < 1 or page_size < 1:
         raise ValueError("Invalid pagination input")
 
-    where_clause: CreditTransactionWhereInput = {}
+    # Mirror the user-facing get_transaction_history filter: only ledger-applied
+    # rows. Inactive rows are pre-Stripe placeholders whose runningBalance is
+    # the unchanged current balance — surfacing them here makes the admin UI
+    # render phantom "before balance" gaps (running_balance - amount) for
+    # transactions that never moved any credits.
+    where_clause: CreditTransactionWhereInput = {"isActive": True}
     if transaction_filter:
         where_clause["type"] = transaction_filter
     if search:

--- a/autogpt_platform/backend/backend/data/credit_integration_test.py
+++ b/autogpt_platform/backend/backend/data/credit_integration_test.py
@@ -13,6 +13,8 @@ from backend.data.credit import (
     AutoTopUpConfig,
     BetaUserCredit,
     UsageTransactionMetadata,
+    UserCredit,
+    admin_get_user_history,
     get_auto_top_up,
     set_auto_top_up,
 )
@@ -275,3 +277,118 @@ async def test_auto_top_up_configuration_storage(cleanup_test_user, monkeypatch)
     # Should only have the initial GRANT transaction
     assert len(transactions) == 1
     assert transactions[0].type == CreditTransactionType.GRANT
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_admin_get_user_history_filters_inactive(cleanup_test_user):
+    """Admin spending UI must hide inactive (pre-Stripe placeholder) rows.
+
+    Inactive top-ups store ``runningBalance = current_balance`` (unchanged) and
+    ``amount = $X``. The admin frontend renders ``before = running_balance -
+    amount``, which produces a fake "$X drop" preceding a "$X restore" — the
+    silent-drop bug observed in production. Surface only ledger-applied rows.
+    """
+    user_id = cleanup_test_user
+
+    await CreditTransaction.prisma().create(
+        data={
+            "userId": user_id,
+            "amount": 1000,
+            "type": CreditTransactionType.TOP_UP,
+            "transactionKey": f"cs_test_active_{user_id}",
+            "isActive": True,
+            "runningBalance": 1000,
+        }
+    )
+    await CreditTransaction.prisma().create(
+        data={
+            "userId": user_id,
+            "amount": 500,
+            "type": CreditTransactionType.TOP_UP,
+            "transactionKey": f"cs_test_orphan_{user_id}",
+            "isActive": False,
+            "runningBalance": 1000,
+        }
+    )
+
+    resp = await admin_get_user_history(search=user_id)
+
+    keys = {tx.transaction_key for tx in resp.history}
+    assert f"cs_test_active_{user_id}" in keys
+    assert f"cs_test_orphan_{user_id}" not in keys
+    assert resp.pagination.total_items == 1
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_expire_checkout_deletes_inactive_then_idempotent(cleanup_test_user):
+    user_id = cleanup_test_user
+    sid = f"cs_test_expire_{user_id}"
+
+    await CreditTransaction.prisma().create(
+        data={
+            "userId": user_id,
+            "amount": 500,
+            "type": CreditTransactionType.TOP_UP,
+            "transactionKey": sid,
+            "isActive": False,
+            "runningBalance": 0,
+        }
+    )
+
+    await UserCredit().expire_checkout(session_id=sid)
+    assert (
+        await CreditTransaction.prisma().find_first(where={"transactionKey": sid})
+        is None
+    )
+
+    # Second call must be a no-op, not an error.
+    await UserCredit().expire_checkout(session_id=sid)
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_expire_checkout_skips_active_row(cleanup_test_user):
+    """Out-of-order webhook delivery must not delete a fulfilled top-up."""
+    user_id = cleanup_test_user
+    sid = f"cs_test_active_skip_{user_id}"
+
+    await CreditTransaction.prisma().create(
+        data={
+            "userId": user_id,
+            "amount": 500,
+            "type": CreditTransactionType.TOP_UP,
+            "transactionKey": sid,
+            "isActive": True,
+            "runningBalance": 500,
+        }
+    )
+
+    await UserCredit().expire_checkout(session_id=sid)
+
+    row = await CreditTransaction.prisma().find_first(where={"transactionKey": sid})
+    assert row is not None
+    assert row.isActive is True
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_expire_checkout_ignores_non_checkout_keys(cleanup_test_user):
+    """Guard against accidentally deleting non-Checkout inactive rows."""
+    user_id = cleanup_test_user
+    non_cs_key = f"pi_test_{user_id}"
+
+    await CreditTransaction.prisma().create(
+        data={
+            "userId": user_id,
+            "amount": 500,
+            "type": CreditTransactionType.TOP_UP,
+            "transactionKey": non_cs_key,
+            "isActive": False,
+            "runningBalance": 0,
+        }
+    )
+
+    await UserCredit().expire_checkout(session_id=non_cs_key)
+
+    row = await CreditTransaction.prisma().find_first(
+        where={"transactionKey": non_cs_key}
+    )
+    assert row is not None


### PR DESCRIPTION
### Why / What / How

#### Why

The admin spending UI (`/admin/spending`) is rendering phantom "silent drops" in users' credit ledgers, immediately followed by "do-nothing" `TOP_UP` rows that just restore the bogus drop.

This was reported as a real ledger inconsistency. It isn't — `UserBalance` reconciles cleanly with the active-only history. A direct DB query against an affected user (`f6f8dec6-6a89-4f9e-8fc3-a46aab3281f6`) confirmed the root cause:

- `top_up_intent` (`credit.py`) writes an `isActive=false` placeholder `CreditTransaction` keyed by the Stripe Checkout session id (`cs_…`) **before** redirecting the user to Stripe. The placeholder stores `runningBalance = current_balance` (unchanged) and `amount = $X`. Balance is not moved.
- If the user abandons the Checkout, `fulfill_checkout` never runs (it only fires on `checkout.session.completed`). The placeholder lingers — there is no `checkout.session.expired` handler and no cleanup job.
- `admin_get_user_history` does **not** filter `isActive`, while the user-facing `get_transaction_history` does. So orphans surface in admin only.
- The admin frontend (`AdminUserGrantHistory.tsx`) computes `before = running_balance - amount`. Applied to an inactive row whose `runningBalance` was the unchanged current balance, this yields `current_balance - amount` — a value the balance never actually held. Reads as a $X silent drop followed by a $X compensating top-up.

The reporting user had **3 orphaned `cs_live_…` rows in a single day** ($15 of phantom drops); the pattern compounds over time across the user base.

#### What

1. `admin_get_user_history` now filters `isActive=true` (mirrors `get_transaction_history`). One-line behavioural change; response shape is unchanged.
2. New `UserCredit.expire_checkout(session_id=...)` hard-deletes the inactive placeholder for an expired Checkout session. Filters `isActive=false` so a late-arriving `expired` event can never delete a row that `fulfill_checkout` already activated.
3. The Stripe webhook router (`v1.py`) now dispatches `checkout.session.expired` to the new method.
4. Tests: 4 real-DB integration tests in `credit_integration_test.py` (filter behaviour, delete + idempotency, active-row protection, non-`cs_` key guard) and 2 webhook dispatch tests in `subscription_routes_test.py` (happy path + missing-id guard).

#### How

- **Filter consistency.** The user-facing endpoint already filters `isActive=true`; the admin endpoint was the only outlier. Bringing it in line is the smallest possible diff that fixes the rendered artifact.
- **Race safety on the new webhook.** Stripe's `expired` and `completed` are mutually exclusive at source, but `expire_checkout` still defends against out-of-order delivery: filtering `isActive=false` in the `delete_many` means `completed`-then-`expired` is a no-op (row is already active), and `expired`-then-`completed` is also a no-op (row is gone, and `fulfill_checkout`/`_enable_transaction`'s own `isActive=false` filter finds nothing to enable). No double-fulfillment, no negative balance, no advisory locks needed.
- **Hard delete.** No payment is taken on an expired session, so the placeholder represents nothing and can be removed. Soft-deletion would leave it visible to any future query that doesn't filter `isActive`.
- **Test placement.** Existing admin-routes tests (`credit_admin_routes_test.py`) are 100% mocked and would not catch this regression — the bug is in the actual SQL filter. New tests live in `credit_integration_test.py` (real Postgres, reuses the `cleanup_test_user` fixture) and `subscription_routes_test.py` (mocks the webhook target on `backend.api.features.v1.UserCredit.expire_checkout`, mirroring the existing `test_stripe_webhook_dispatches_subscription_events` pattern).

#### Out of scope (deliberate)

- **No sweep of the historical orphan backlog.** The display filter masks them; `expire_checkout` catches new expirations going forward. A backfill is a separate concern.
- **No `include_inactive=true` admin opt-in.** Admin view exactly mirrors user view. Direct-DB inspection covers the rare debugging case.

### Changes 🏗️

- `autogpt_platform/backend/backend/data/credit.py`
  - `admin_get_user_history`: add `isActive=true` to `where_clause`.
  - `UserCredit`: new `expire_checkout(session_id=...)` method.
- `autogpt_platform/backend/backend/api/features/v1.py`
  - Stripe webhook: dispatch `checkout.session.expired` → `UserCredit().expire_checkout(...)`.
- `autogpt_platform/backend/backend/data/credit_integration_test.py`
  - `test_admin_get_user_history_filters_inactive`
  - `test_expire_checkout_deletes_inactive_then_idempotent`
  - `test_expire_checkout_skips_active_row`
  - `test_expire_checkout_ignores_non_checkout_keys`
- `autogpt_platform/backend/backend/api/features/subscription_routes_test.py`
  - `test_stripe_webhook_dispatches_checkout_session_expired`
  - `test_stripe_webhook_checkout_session_expired_missing_id_ignored`

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [ ] CI: `poetry run pytest backend/data/credit_integration_test.py -k "admin_get_user_history_filters_inactive or expire_checkout"`
  - [ ] CI: `poetry run pytest backend/api/features/subscription_routes_test.py -k "checkout_session_expired"`
  - [ ] CI: full backend test suite must remain green
  - [ ] Manual (post-merge, dev DB): admin spending page for the affected user no longer shows phantom drops
  - [ ] Manual (post-merge, dev DB): `stripe trigger checkout.session.expired` removes the corresponding inactive `cs_…` row

#### For configuration changes:
- [x] `.env.default` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes
- [x] I have included a list of my configuration changes in the PR description (under **Changes**) — none

#### Note on local test execution

The reporter's local Windows env has a `poetry install` blocker on the `stagehand` wheel (`[Errno 22]` extracting from poetry's artifact cache) that is unrelated to these changes — it predates this branch and reproduces on `dev` HEAD. All four edited files pass `python -m ast` parse, the test patterns mirror the existing passing `test_stripe_webhook_dispatches_subscription_events` / `test_stripe_webhook_dispatches_invoice_payment_failed` shape, and the integration tests reuse the existing `cleanup_test_user` fixture. CI is the source of truth here.
