### PR TITLE
fix(export): coerce week_start to datetime in copilot weekly usage

### DIFF
--- a/autogpt_platform/backend/backend/data/platform_cost.py
+++ b/autogpt_platform/backend/backend/data/platform_cost.py
@@ -818,7 +818,14 @@ async def get_copilot_weekly_usage_for_export(
 
     out: list[CopilotWeeklyUsageRow] = []
     for r in rows:
-        week_start: datetime = r["week_start"]
+        # query_raw_with_schema returns timestamptz columns as ISO strings on
+        # some Prisma builds, so coerce defensively before stamping UTC.
+        raw_week_start = r["week_start"]
+        week_start: datetime = (
+            datetime.fromisoformat(raw_week_start)
+            if isinstance(raw_week_start, str)
+            else raw_week_start
+        )
         if week_start.tzinfo is None:
             week_start = week_start.replace(tzinfo=timezone.utc)
         # Inclusive end-of-week (Sunday 23:59:59.999999 UTC) — matches finance


### PR DESCRIPTION
## Why

The `/api/credits/admin/copilot-usage/export` endpoint shipped in #12958 returns **HTTP 500 on every call** in deployed dev: `'str' object has no attribute 'tzinfo'`.

Caught by the post-merge dev-environment test on commit \`09cb340ac\`:
```
GET /api/credits/admin/copilot-usage/export?start=2026-04-01T00:00:00Z&end=2026-04-30T00:00:00Z
→ 500 Internal Server Error
```

## Root cause

[platform_cost.py:821](autogpt_platform/backend/backend/data/platform_cost.py#L821) annotates `week_start: datetime = r["week_start"]`, but Prisma's `query_raw_with_schema` returns the `date_trunc('week', ...)` column as an ISO string on the deployed Prisma build. So `week_start.tzinfo` raises `AttributeError`. Local pr-test happened to get a `datetime` back from the same call (Prisma version drift), so the bug didn't surface there.

## Fix

Coerce defensively before the existing tz-aware check — if Prisma hands us a string, parse via `datetime.fromisoformat`; otherwise pass the value through.

## Test

The credit-transactions export was unaffected (uses Prisma's typed `find_many`, not raw SQL). Verified by the same post-merge dev test:
- `/api/credits/admin/transactions/export` → 200 with 9046 rows
- `/api/credits/admin/copilot-usage/export` → 500 (this PR fixes it)

## Checklist
- [x] Defensive parse only on the affected hot-path
- [x] No schema or contract change