### PR TITLE
refactor(backend): remove BetaUserCredit monthly credit refill

### DIFF
--- a/autogpt_platform/backend/backend/data/credit.py
+++ b/autogpt_platform/backend/backend/data/credit.py
@@ -36,7 +36,7 @@ from backend.data.user import get_user_by_id, get_user_email_by_id
 from backend.notifications.notifications import queue_notification_async
 from backend.util.cache import cached
 from backend.util.exceptions import InsufficientBalanceError
-from backend.util.feature_flag import Flag, get_feature_flag_value, is_feature_enabled
+from backend.util.feature_flag import Flag, get_feature_flag_value
 from backend.util.json import SafeJson, dumps
 from backend.util.models import Pagination
 from backend.util.retry import func_retry
@@ -1232,37 +1232,6 @@ class UserCredit(UserCreditBase):
         ]
 
 
-class BetaUserCredit(UserCredit):
-    """
-    This is a temporary class to handle the test user utilizing monthly credit refill.
-    TODO: Remove this class & its feature toggle.
-    """
-
-    def __init__(self, num_user_credits_refill: int):
-        self.num_user_credits_refill = num_user_credits_refill
-
-    async def get_credits(self, user_id: str) -> int:
-        cur_time = self.time_now().date()
-        balance, snapshot_time = await self._get_credits(user_id)
-        if (snapshot_time.year, snapshot_time.month) == (cur_time.year, cur_time.month):
-            return balance
-
-        target = self.num_user_credits_refill
-
-        try:
-            balance, _ = await self._add_transaction(
-                user_id=user_id,
-                amount=max(target - balance, 0),
-                transaction_type=CreditTransactionType.GRANT,
-                transaction_key=f"MONTHLY-CREDIT-TOP-UP-{cur_time}",
-                metadata=SafeJson({"reason": "Monthly credit refill"}),
-            )
-            return balance
-        except UniqueViolationError:
-            # Already refilled this month
-            return (await self._get_credits(user_id))[0]
-
-
 class DisabledUserCredit(UserCreditBase):
     async def get_credits(self, *args, **kwargs) -> int:
         return 100
@@ -1299,30 +1268,16 @@ class DisabledUserCredit(UserCreditBase):
 
 
 async def get_user_credit_model(user_id: str) -> UserCreditBase:
-    """
-    Get the credit model for a user, considering LaunchDarkly flags.
+    """Return the credit model for a user.
 
-    Args:
-        user_id (str): The user ID to check flags for.
-
-    Returns:
-        UserCreditBase: The appropriate credit model for the user
+    The ``user_id`` parameter is currently unused but retained for ABI
+    stability — many callers already pass it, and the function may need to
+    branch on user identity again in the future.
     """
+    _ = user_id
     if not settings.config.enable_credit:
         return DisabledUserCredit()
-
-    # Check LaunchDarkly flag for payment pilot users
-    # Default to False (beta monthly credit behavior) to maintain current behavior
-    is_payment_enabled = await is_feature_enabled(
-        Flag.ENABLE_PLATFORM_PAYMENT, user_id, default=False
-    )
-
-    if is_payment_enabled:
-        # Payment enabled users get UserCredit (no monthly refills, enable payments)
-        return UserCredit()
-    else:
-        # Default behavior: users get beta monthly credits
-        return BetaUserCredit(settings.config.num_user_credits_refill)
+    return UserCredit()
 
 
 def get_block_costs() -> dict[str, list["BlockCost"]]:

--- a/autogpt_platform/backend/backend/data/credit_concurrency_test.py
+++ b/autogpt_platform/backend/backend/data/credit_concurrency_test.py
@@ -20,7 +20,6 @@ from backend.util.exceptions import InsufficientBalanceError
 from backend.util.json import SafeJson
 from backend.util.test import SpinTestServer
 
-# Test with both UserCredit and BetaUserCredit if needed
 credit_system = UserCredit()
 
 

--- a/autogpt_platform/backend/backend/data/credit_integration_test.py
+++ b/autogpt_platform/backend/backend/data/credit_integration_test.py
@@ -11,9 +11,11 @@ from prisma.models import CreditTransaction, User, UserBalance
 
 from backend.data.credit import (
     AutoTopUpConfig,
-    BetaUserCredit,
+    DisabledUserCredit,
     UsageTransactionMetadata,
+    UserCredit,
     get_auto_top_up,
+    get_user_credit_model,
     set_auto_top_up,
 )
 from backend.util.json import SafeJson
@@ -61,7 +63,7 @@ async def test_credit_transaction_enum_casting_integration(cleanup_test_user):
     platform."CreditTransactionType" but got "CreditTransactionType".
     """
     user_id = cleanup_test_user
-    credit_system = BetaUserCredit(1000)
+    credit_system = UserCredit()
 
     # Test each transaction type to ensure enum casting works
     test_cases = [
@@ -111,11 +113,9 @@ async def test_auto_top_up_integration(cleanup_test_user, monkeypatch):
     from backend.data.credit import settings
 
     monkeypatch.setattr(settings.config, "enable_credit", True)
-    monkeypatch.setattr(settings.config, "enable_beta_monthly_credit", True)
-    monkeypatch.setattr(settings.config, "num_user_credits_refill", 1000)
 
     user_id = cleanup_test_user
-    credit_system = BetaUserCredit(1000)
+    credit_system = UserCredit()
 
     # First add some initial credits so we can test the configuration and subsequent behavior
     balance, _ = await credit_system._add_transaction(
@@ -177,7 +177,7 @@ async def test_enable_transaction_enum_casting_integration(cleanup_test_user):
     involves SQL queries with CreditTransactionType enum casting.
     """
     user_id = cleanup_test_user
-    credit_system = BetaUserCredit(1000)
+    credit_system = UserCredit()
 
     # Create an inactive transaction
     balance, tx_key = await credit_system._add_transaction(
@@ -238,11 +238,9 @@ async def test_auto_top_up_configuration_storage(cleanup_test_user, monkeypatch)
     from backend.data.credit import settings
 
     monkeypatch.setattr(settings.config, "enable_credit", True)
-    monkeypatch.setattr(settings.config, "enable_beta_monthly_credit", True)
-    monkeypatch.setattr(settings.config, "num_user_credits_refill", 1000)
 
     user_id = cleanup_test_user
-    credit_system = BetaUserCredit(1000)
+    credit_system = UserCredit()
 
     # Set initial balance
     balance, _ = await credit_system._add_transaction(
@@ -275,3 +273,24 @@ async def test_auto_top_up_configuration_storage(cleanup_test_user, monkeypatch)
     # Should only have the initial GRANT transaction
     assert len(transactions) == 1
     assert transactions[0].type == CreditTransactionType.GRANT
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_get_user_credit_model_returns_usercredit_unconditionally(
+    cleanup_test_user, monkeypatch
+):
+    """Regression guard: the factory must never branch back to a beta-cohort class.
+
+    Uses ``__class__ is UserCredit`` (not ``isinstance``) so that any future
+    ``class BetaFoo(UserCredit)`` resurrection trips this test instead of
+    silently passing.
+    """
+    from backend.data.credit import settings
+
+    monkeypatch.setattr(settings.config, "enable_credit", True)
+    model = await get_user_credit_model(cleanup_test_user)
+    assert model.__class__ is UserCredit
+
+    monkeypatch.setattr(settings.config, "enable_credit", False)
+    model_disabled = await get_user_credit_model(cleanup_test_user)
+    assert model_disabled.__class__ is DisabledUserCredit

--- a/autogpt_platform/backend/backend/data/credit_metadata_test.py
+++ b/autogpt_platform/backend/backend/data/credit_metadata_test.py
@@ -13,7 +13,7 @@ import pytest
 from prisma.enums import CreditTransactionType
 from prisma.models import CreditTransaction, UserBalance
 
-from backend.data.credit import BetaUserCredit
+from backend.data.credit import UserCredit
 from backend.data.user import DEFAULT_USER_ID
 from backend.util.json import SafeJson
 
@@ -38,7 +38,7 @@ async def setup_test_user():
 async def test_metadata_json_serialization(setup_test_user):
     """Test that metadata is properly serialized for JSONB column in raw SQL."""
     user_id = setup_test_user
-    credit_system = BetaUserCredit(1000)
+    credit_system = UserCredit()
 
     # Test with complex metadata that would fail if not properly serialized
     complex_metadata = SafeJson(
@@ -90,7 +90,7 @@ async def test_metadata_json_serialization(setup_test_user):
 async def test_enable_transaction_metadata_serialization(setup_test_user):
     """Test that _enable_transaction also handles metadata JSON serialization correctly."""
     user_id = setup_test_user
-    credit_system = BetaUserCredit(1000)
+    credit_system = UserCredit()
 
     # First create an inactive transaction
     balance, tx_key = await credit_system._add_transaction(

--- a/autogpt_platform/backend/backend/data/credit_test.py
+++ b/autogpt_platform/backend/backend/data/credit_test.py
@@ -1,31 +1,26 @@
-from datetime import datetime, timedelta, timezone
-
 import pytest
 from prisma.enums import CreditTransactionType
 from prisma.models import CreditTransaction, UserBalance
 
 from backend.blocks import get_block
 from backend.blocks.llm import AITextGeneratorBlock
-from backend.data.credit import BetaUserCredit, UsageTransactionMetadata
+from backend.data.credit import UsageTransactionMetadata, UserCredit
 from backend.data.execution import ExecutionContext, NodeExecutionEntry
 from backend.data.user import DEFAULT_USER_ID
 from backend.executor.utils import block_usage_cost
 from backend.integrations.credentials_store import openai_credentials
 from backend.util.test import SpinTestServer
 
-REFILL_VALUE = 1000
-user_credit = BetaUserCredit(REFILL_VALUE)
+user_credit = UserCredit()
 
 
 async def disable_test_user_transactions():
     await CreditTransaction.prisma().delete_many(where={"userId": DEFAULT_USER_ID})
-    # Also reset the balance to 0 and set updatedAt to old date to trigger monthly refill
-    old_date = datetime.now(timezone.utc) - timedelta(days=35)  # More than a month ago
     await UserBalance.prisma().upsert(
         where={"userId": DEFAULT_USER_ID},
         data={
             "create": {"userId": DEFAULT_USER_ID, "balance": 0},
-            "update": {"balance": 0, "updatedAt": old_date},
+            "update": {"balance": 0},
         },
     )
 
@@ -119,112 +114,3 @@ async def test_block_credit_top_up(server: SpinTestServer):
 
     new_credit = await user_credit.get_credits(DEFAULT_USER_ID)
     assert new_credit == current_credit + 100
-
-
-@pytest.mark.asyncio(loop_scope="session")
-async def test_block_credit_reset(server: SpinTestServer):
-    """Test that BetaUserCredit provides monthly refills correctly."""
-    await disable_test_user_transactions()
-
-    # Save original time_now function for restoration
-    original_time_now = user_credit.time_now
-
-    try:
-        # Test month 1 behavior
-        month1 = datetime.now(timezone.utc).replace(month=1, day=1)
-        user_credit.time_now = lambda: month1
-
-        # IMPORTANT: Set updatedAt to December of previous year to ensure it's
-        # in a different month than month1 (January). This fixes a timing bug
-        # where if the test runs in early February, 35 days ago would be January,
-        # matching the mocked month1 and preventing the refill from triggering.
-        dec_previous_year = month1.replace(year=month1.year - 1, month=12, day=15)
-        await UserBalance.prisma().update(
-            where={"userId": DEFAULT_USER_ID},
-            data={"updatedAt": dec_previous_year},
-        )
-
-        # First call in month 1 should trigger refill
-        balance = await user_credit.get_credits(DEFAULT_USER_ID)
-        assert balance == REFILL_VALUE  # Should get 1000 credits
-
-        # Manually create a transaction with month 1 timestamp to establish history
-        await CreditTransaction.prisma().create(
-            data={
-                "userId": DEFAULT_USER_ID,
-                "amount": 100,
-                "type": CreditTransactionType.TOP_UP,
-                "runningBalance": 1100,
-                "isActive": True,
-                "createdAt": month1,  # Set specific timestamp
-            }
-        )
-
-        # Update user balance to match
-        await UserBalance.prisma().upsert(
-            where={"userId": DEFAULT_USER_ID},
-            data={
-                "create": {"userId": DEFAULT_USER_ID, "balance": 1100},
-                "update": {"balance": 1100},
-            },
-        )
-
-        # Now test month 2 behavior
-        month2 = datetime.now(timezone.utc).replace(month=2, day=1)
-        user_credit.time_now = lambda: month2
-
-        # In month 2, since balance (1100) > refill (1000), no refill should happen
-        month2_balance = await user_credit.get_credits(DEFAULT_USER_ID)
-        assert month2_balance == 1100  # Balance persists, no reset
-
-        # Now test the refill behavior when balance is low
-        # Set balance below refill threshold and backdate updatedAt to month2 so
-        # the month3 refill check sees a different (month2 → month3) transition.
-        # Without the explicit updatedAt, Prisma sets it to real-world NOW which
-        # may share the same calendar month as the mocked month3, suppressing refill.
-        await UserBalance.prisma().update(
-            where={"userId": DEFAULT_USER_ID},
-            data={"balance": 400, "updatedAt": month2},
-        )
-
-        # Create a month 2 transaction to update the last transaction time
-        await CreditTransaction.prisma().create(
-            data={
-                "userId": DEFAULT_USER_ID,
-                "amount": -700,  # Spent 700 to get to 400
-                "type": CreditTransactionType.USAGE,
-                "runningBalance": 400,
-                "isActive": True,
-                "createdAt": month2,
-            }
-        )
-
-        # Move to month 3
-        month3 = datetime.now(timezone.utc).replace(month=3, day=1)
-        user_credit.time_now = lambda: month3
-
-        # Should get refilled since balance (400) < refill value (1000)
-        month3_balance = await user_credit.get_credits(DEFAULT_USER_ID)
-        assert month3_balance == REFILL_VALUE  # Should be refilled to 1000
-
-        # Verify the refill transaction was created
-        refill_tx = await CreditTransaction.prisma().find_first(
-            where={
-                "userId": DEFAULT_USER_ID,
-                "type": CreditTransactionType.GRANT,
-                "transactionKey": {"contains": "MONTHLY-CREDIT-TOP-UP"},
-            },
-            order={"createdAt": "desc"},
-        )
-        assert refill_tx is not None, "Monthly refill transaction should be created"
-        assert refill_tx.amount == 600, "Refill should be 600 (1000 - 400)"
-    finally:
-        # Restore original time_now function
-        user_credit.time_now = original_time_now
-
-
-@pytest.mark.asyncio(loop_scope="session")
-async def test_credit_refill(server: SpinTestServer):
-    await disable_test_user_transactions()
-    balance = await user_credit.get_credits(DEFAULT_USER_ID)
-    assert balance == REFILL_VALUE

--- a/autogpt_platform/backend/backend/util/settings.py
+++ b/autogpt_platform/backend/backend/util/settings.py
@@ -128,14 +128,6 @@ class Config(UpdateTrackingModel["Config"], BaseSettings):
         default=False,
         description="If user credit system is enabled or not",
     )
-    enable_beta_monthly_credit: bool = Field(
-        default=True,
-        description="If beta monthly credits accounting is enabled or not",
-    )
-    num_user_credits_refill: int = Field(
-        default=1500,
-        description="Number of credits to refill for each user",
-    )
     refund_credit_tolerance_threshold: int = Field(
         default=500,
         description="Maximum number of credits above the balance to be auto-approved.",


### PR DESCRIPTION
### Why / What / How

#### Why

Beta-cohort users have been receiving $15 of free credits at the start of every calendar month via a `MONTHLY-CREDIT-TOP-UP-{date}` `GRANT` transaction. The `BetaUserCredit` class that implemented this perk was always documented as temporary — its own docstring at `credit.py:1235-1239` reads:

> This is a temporary class to handle the test user utilizing monthly credit refill.
> TODO: Remove this class & its feature toggle.

The free-credit perk is being retired. Removing it also removes a quiet bifurcation in the credit system that has accumulated downstream branches (paywall, onboarding, rate-limits) — the cleanest path forward is to close out the beta cohort.

#### What

This PR is **intentionally surgical** — it removes the monthly-refill mechanism only:

- Deletes `BetaUserCredit` (`credit.py:1235-1263`).
- Simplifies `get_user_credit_model()` (`credit.py:1301-1325`) to always return `UserCredit` (or `DisabledUserCredit` when credits are disabled).
- Drops two now-unused settings fields: `enable_beta_monthly_credit` (never read in production code, only by two test monkeypatches) and `num_user_credits_refill` (only consumed by the deleted class's `__init__`).
- Drops a now-unused import of `is_feature_enabled` from `credit.py`.
- Updates tests:
  - Deletes the two tests that exercised monthly-refill behavior specifically (`test_block_credit_reset` and `test_credit_refill` in `credit_test.py`).
  - Cleans the dead `updatedAt = 35-days-ago` setup from `disable_test_user_transactions()` (it was specifically there to trigger the now-gone monthly check).
  - Swaps `BetaUserCredit(1000)` → `UserCredit()` in `credit_test.py`, `credit_integration_test.py` (4 sites), and `credit_metadata_test.py` (2 sites). All swapped tests exercise behavior that lived on the parent class — class choice was incidental.
  - Drops the four stale `enable_beta_monthly_credit` / `num_user_credits_refill` monkeypatches from `credit_integration_test.py`.
  - Removes a stale comment in `credit_concurrency_test.py`.
  - Adds `test_get_user_credit_model_returns_usercredit_unconditionally` — a regression guard that asserts the factory returns exactly `UserCredit` (using `__class__ is UserCredit`, not `isinstance`, so any future `class BetaFoo(UserCredit)` resurrection trips the test instead of silently passing).

#### How

`Flag.ENABLE_PLATFORM_PAYMENT` and its three remaining downstream consumers (`backend/copilot/rate_limit.py:800-809`, `backend/api/features/v1.py:954-955`, `frontend/src/app/(platform)/PaywallGate/PaywallGate.tsx`, `frontend/src/app/(no-navbar)/onboarding/useOnboardingPage.ts`) are **deliberately left in place**. A user who currently has the flag off will, post-merge, get `UserCredit` from the factory but no longer see the paywall engage on `NO_TIER` (because `rate_limit.py` still falls back to `BASIC` multipliers when the flag is off, and `PaywallGate` skips when the flag is off). The soft-brick risk this creates for flag-off users without payment configured is being addressed by other moving parts in flight — out of scope for this PR by design.

A follow-up PR can clean up the flag and its gates once that parallel work lands.

**Existing data**: `MONTHLY-CREDIT-TOP-UP-*` `GRANT` rows already in the database are unaffected. They remain valid historical ledger entries; nothing depends on them and nothing cleans them up. No migration needed.

**Rollback**: pure code change. `git revert` of the squash commit fully restores prior behavior.

### Changes 🏗️

- `autogpt_platform/backend/backend/data/credit.py`
  - Delete `BetaUserCredit` class.
  - Simplify `get_user_credit_model()` to `UserCredit` / `DisabledUserCredit` only.
  - Drop unused `is_feature_enabled` import.
- `autogpt_platform/backend/backend/util/settings.py`
  - Delete `enable_beta_monthly_credit` and `num_user_credits_refill` fields.
- `autogpt_platform/backend/backend/data/credit_test.py`
  - Swap module-level `BetaUserCredit(REFILL_VALUE)` → `UserCredit()`. Drop `REFILL_VALUE` constant. Clean dead `updatedAt` reset in `disable_test_user_transactions`.
  - Delete `test_block_credit_reset` (monthly-refill behavioral test).
  - Delete `test_credit_refill` (asserted post-reset balance equals refill value).
  - Drop now-unused `datetime` / `timedelta` / `timezone` imports.
- `autogpt_platform/backend/backend/data/credit_integration_test.py`
  - Swap 4 instances of `BetaUserCredit(1000)` → `UserCredit()`.
  - Drop 4 monkeypatches of `enable_beta_monthly_credit` / `num_user_credits_refill`.
  - Add `test_get_user_credit_model_returns_usercredit_unconditionally` regression test.
- `autogpt_platform/backend/backend/data/credit_metadata_test.py`
  - Swap 2 instances of `BetaUserCredit(1000)` → `UserCredit()`.
- `autogpt_platform/backend/backend/data/credit_concurrency_test.py`
  - Delete stale comment referencing `BetaUserCredit`.

Net: −149 LoC across 6 files.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [ ] CI: `poetry run pytest backend/data/credit_test.py backend/data/credit_integration_test.py backend/data/credit_metadata_test.py backend/data/credit_concurrency_test.py -v`
  - [ ] CI: `poetry run pytest backend/data/credit_integration_test.py::test_get_user_credit_model_returns_usercredit_unconditionally -v` (new regression test)
  - [ ] CI: full backend test suite remains green
  - [ ] Manual (post-merge, dev DB): existing beta users no longer see new `MONTHLY-CREDIT-TOP-UP-*` rows on the 1st of next month
  - [ ] Manual: `grep -rn "BetaUserCredit\|num_user_credits_refill\|enable_beta_monthly_credit" autogpt_platform/backend/` returns zero hits

#### For configuration changes:
- [x] `.env.default` is updated or already compatible with my changes — neither removed setting was in `.env.default` (they were Pydantic defaults only)
- [x] `docker-compose.yml` is updated or already compatible — no references
- [x] I have included a list of my configuration changes in the PR description (under **Changes**) — `enable_beta_monthly_credit` and `num_user_credits_refill` removed from `Settings`

#### Note on local test execution

The reporter's local Windows env has a `poetry install` blocker on the `stagehand` wheel (`[Errno 22]` extracting from poetry's artifact cache) that is unrelated to this branch and reproduces on `dev` HEAD. All 6 edited files pass `python -m ast` parse, and `grep` confirms zero residual references to `BetaUserCredit`, `num_user_credits_refill`, `enable_beta_monthly_credit`, `MONTHLY-CREDIT-TOP-UP`, or `REFILL_VALUE` anywhere in `autogpt_platform/backend/`. CI is the source of truth for the test runs.

#### Out of scope (deliberate)

- `Flag.ENABLE_PLATFORM_PAYMENT` and its 3 downstream consumers — soft-brick risk handled separately.
- Backfill / cleanup of historical `MONTHLY-CREDIT-TOP-UP-*` ledger rows.
- LaunchDarkly-side flag deletion.
- User-facing announcement copy.
