### PR TITLE
hotfix(backend): remove $5 VISIT_COPILOT signup grant

### DIFF
--- a/autogpt_platform/backend/backend/data/onboarding.py
+++ b/autogpt_platform/backend/backend/data/onboarding.py
@@ -123,9 +123,6 @@ async def update_user_onboarding(user_id: str, data: UserOnboardingUpdate):
 async def _reward_user(user_id: str, onboarding: UserOnboarding, step: OnboardingStep):
     reward = 0
     match step:
-        # Welcome bonus for visiting copilot ($5 = 500 credits)
-        case OnboardingStep.VISIT_COPILOT:
-            reward = 500
         # Reward user when they clicked New Run during onboarding
         # This is because they need credits before scheduling a run (next step)
         # This is seen as a reward for the GET_RESULTS step in the wallet

--- a/autogpt_platform/backend/backend/data/onboarding_test.py
+++ b/autogpt_platform/backend/backend/data/onboarding_test.py
@@ -1,4 +1,9 @@
-from backend.data.onboarding import format_onboarding_for_extraction
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from prisma.enums import OnboardingStep
+
+from backend.data.onboarding import _reward_user, format_onboarding_for_extraction
 
 
 def test_format_onboarding_for_extraction_basic():
@@ -25,3 +30,22 @@ def test_format_onboarding_for_extraction_with_other():
     assert "A: Jane" in result
     assert "A: Data Scientist" in result
     assert "Research, Building dashboards" in result
+
+
+@pytest.mark.asyncio
+async def test_visit_copilot_grants_no_reward():
+    # The $5 signup bonus tied to VISIT_COPILOT (PR #11862) has been retired.
+    # The step still completes for redirect/analytics purposes, but must not
+    # mint credits.
+    onboarding = MagicMock(rewardedFor=[])
+
+    with patch(
+        "backend.data.onboarding.get_user_credit_model", new=AsyncMock()
+    ) as get_credit_model:
+        await _reward_user(
+            user_id="test-user-id",
+            onboarding=onboarding,
+            step=OnboardingStep.VISIT_COPILOT,
+        )
+
+    get_credit_model.assert_not_called()

--- a/autogpt_platform/backend/backend/data/onboarding_test.py
+++ b/autogpt_platform/backend/backend/data/onboarding_test.py
@@ -49,3 +49,4 @@ async def test_visit_copilot_grants_no_reward():
         )
 
     get_credit_model.assert_not_called()
+    assert onboarding.rewardedFor == []


### PR DESCRIPTION
> Hotfix mirror of #12965 — targeting `master` directly so the grant stops minting credits in prod without waiting for the next dev → master promotion. Branch is named `hotfix/...` to bypass the `repo-pr-enforce-base-branch` auto-redirect.

### Why / What / How

**Why:** PR #11862 added a 500-credit ($5) reward that fired the first time a user completed the `VISIT_COPILOT` onboarding step — effectively a signup bonus, since every user who finishes the onboarding wizard hits it once. We're turning that grant off.

**What:** Removes only the `VISIT_COPILOT` arm of `_reward_user`'s `match` block. The `VISIT_COPILOT` enum value, the `complete_onboarding_step` call, the websocket notification, and every consumer that reads `completedSteps` (frontend redirect, playwright skip helper, `is_onboarding_completed` API, analytics funnel) stay exactly as they are.

**How:** With the `case` removed, `_reward_user` falls through with `reward = 0` and returns early before fetching the credit model — so no `CreditTransaction` row is ever created for this step. Existing users who already received the bonus keep their credits; no clawback, no DB migration.

### Changes 🏗️

- `backend/data/onboarding.py` — delete the `case OnboardingStep.VISIT_COPILOT: reward = 500` arm from `_reward_user`.
- `backend/data/onboarding_test.py` — add `test_visit_copilot_grants_no_reward` that patches `get_user_credit_model` and asserts it is never called when `_reward_user` runs with `VISIT_COPILOT`.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [x] Unit test: `test_visit_copilot_grants_no_reward` proves `_reward_user` returns early for `VISIT_COPILOT` and never fetches the credit model.
  - [ ] Manual: sign up a fresh user, complete the onboarding wizard, confirm `is_onboarding_completed` returns `true`, confirm wallet does not gain 500 credits, and confirm no `CreditTransaction` row exists with `transactionKey = "REWARD-<user_id>-VISIT_COPILOT"`.
  - [ ] Manual regression: trigger `MARKETPLACE_VISIT` (or any other rewarded step) and confirm that reward still lands — the change must not break the other `match` arms.

#### For configuration changes:

- [x] `.env.default` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes
- [x] I have included a list of my configuration changes in the PR description (under **Changes**)