### PR TITLE
refactor(platform): remove 4 earn-credits onboarding checklist items

### DIFF
--- a/autogpt_platform/backend/backend/api/features/v1.py
+++ b/autogpt_platform/backend/backend/api/features/v1.py
@@ -80,7 +80,6 @@ from backend.data.onboarding import (
     OnboardingStep,
     UserOnboardingUpdate,
     complete_onboarding_step,
-    complete_re_run_agent,
     format_onboarding_for_extraction,
     get_recommended_agents,
     get_user_onboarding,
@@ -1310,9 +1309,6 @@ async def create_new_graph(
     await library_db.create_library_agent(graph, user_id)
     activated_graph = await on_graph_activate(graph, user_id=user_id)
 
-    if create_graph.source == "builder":
-        await complete_onboarding_step(user_id, OnboardingStep.BUILDER_SAVE_AGENT)
-
     return activated_graph
 
 
@@ -1491,7 +1487,6 @@ async def execute_graph(
         # Record successful graph execution
         record_graph_execution(graph_id=graph_id, status="success", user_id=user_id)
         record_graph_operation(operation="execute", status="success")
-        await complete_re_run_agent(user_id, graph_id)
         if source == "library":
             await complete_onboarding_step(
                 user_id, OnboardingStep.MARKETPLACE_RUN_AGENT

--- a/autogpt_platform/backend/backend/data/onboarding.py
+++ b/autogpt_platform/backend/backend/data/onboarding.py
@@ -11,7 +11,6 @@ from prisma.types import UserOnboardingCreateInput, UserOnboardingUpdateInput
 
 from backend.api.features.store.model import StoreAgentDetails
 from backend.api.model import OnboardingNotificationPayload
-from backend.data import execution as execution_db
 from backend.data.credit import get_user_credit_model
 from backend.data.notification_bus import (
     AsyncRedisNotificationEventBus,
@@ -42,7 +41,6 @@ FrontendOnboardingStep = Literal[
     OnboardingStep.AGENT_INPUT,
     OnboardingStep.CONGRATS,
     OnboardingStep.VISIT_COPILOT,
-    OnboardingStep.MARKETPLACE_VISIT,
     OnboardingStep.BUILDER_OPEN,
 ]
 
@@ -131,20 +129,12 @@ async def _reward_user(user_id: str, onboarding: UserOnboarding, step: Onboardin
         # This is seen as a reward for the GET_RESULTS step in the wallet
         case OnboardingStep.AGENT_NEW_RUN:
             reward = 300
-        case OnboardingStep.MARKETPLACE_VISIT:
-            reward = 100
         case OnboardingStep.MARKETPLACE_ADD_AGENT:
             reward = 100
         case OnboardingStep.MARKETPLACE_RUN_AGENT:
             reward = 100
-        case OnboardingStep.BUILDER_SAVE_AGENT:
-            reward = 100
-        case OnboardingStep.RE_RUN_AGENT:
-            reward = 100
         case OnboardingStep.SCHEDULE_AGENT:
             reward = 100
-        case OnboardingStep.RUN_AGENTS:
-            reward = 300
         case OnboardingStep.RUN_3_DAYS:
             reward = 100
         case OnboardingStep.TRIGGER_WEBHOOK:
@@ -201,23 +191,6 @@ async def _send_onboarding_notification(
     await AsyncRedisNotificationEventBus().publish(
         NotificationEvent(user_id=user_id, payload=payload)
     )
-
-
-async def complete_re_run_agent(user_id: str, graph_id: str) -> None:
-    """
-    Complete RE_RUN_AGENT step when a user runs a graph they've run before.
-    Keeps overhead low by only counting executions if the step is still pending.
-    """
-    onboarding = await get_user_onboarding(user_id)
-    if OnboardingStep.RE_RUN_AGENT in onboarding.completedSteps:
-        return
-
-    # Includes current execution, so count > 1 means there was at least one prior run.
-    previous_exec_count = await execution_db.get_graph_executions_count(
-        user_id=user_id, graph_id=graph_id
-    )
-    if previous_exec_count > 1:
-        await complete_onboarding_step(user_id, OnboardingStep.RE_RUN_AGENT)
 
 
 def _clean_and_split(text: str) -> list[str]:
@@ -325,8 +298,6 @@ def _get_run_milestone_steps(
     new_run_count: int, consecutive_days: int
 ) -> list[OnboardingStep]:
     milestones: list[OnboardingStep] = []
-    if new_run_count >= 10:
-        milestones.append(OnboardingStep.RUN_AGENTS)
     if new_run_count >= 100:
         milestones.append(OnboardingStep.RUN_AGENTS_100)
     if consecutive_days >= 3:

--- a/autogpt_platform/frontend/src/app/(platform)/marketplace/components/HeroSection/useHeroSection.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/marketplace/components/HeroSection/useHeroSection.ts
@@ -1,18 +1,10 @@
-import { useOnboarding } from "@/providers/onboarding/onboarding-provider";
 import { Flag, useGetFlag } from "@/services/feature-flags/use-get-flag";
 import { useRouter } from "next/navigation";
-import { useEffect } from "react";
 import { DEFAULT_SEARCH_TERMS } from "./helpers";
 
 export const useHeroSection = () => {
   const router = useRouter();
-  const { completeStep } = useOnboarding();
   const searchTerms = useGetFlag(Flag.MARKETPLACE_SEARCH_TERMS);
-
-  // Mark marketplace visit task as completed
-  useEffect(() => {
-    completeStep("MARKETPLACE_VISIT");
-  }, [completeStep]);
 
   function onFilterChange(selectedFilters: string[]) {
     const encodedTerm = encodeURIComponent(selectedFilters.join(", "));

--- a/autogpt_platform/frontend/src/app/api/openapi.json
+++ b/autogpt_platform/frontend/src/app/api/openapi.json
@@ -6970,7 +6970,6 @@
                 "AGENT_INPUT",
                 "CONGRATS",
                 "VISIT_COPILOT",
-                "MARKETPLACE_VISIT",
                 "BUILDER_OPEN"
               ],
               "type": "string",

--- a/autogpt_platform/frontend/src/components/__legacy__/composite/HeroSection.tsx
+++ b/autogpt_platform/frontend/src/components/__legacy__/composite/HeroSection.tsx
@@ -4,16 +4,9 @@ import * as React from "react";
 import { SearchBar } from "@/components/__legacy__/SearchBar";
 import { FilterChips } from "@/components/__legacy__/FilterChips";
 import { useRouter } from "next/navigation";
-import { useOnboarding } from "@/providers/onboarding/onboarding-provider";
 
 export const HeroSection: React.FC = () => {
   const router = useRouter();
-  const onboarding = useOnboarding();
-
-  // Mark marketplace visit task as completed
-  React.useEffect(() => {
-    onboarding?.completeStep("MARKETPLACE_VISIT");
-  }, [onboarding?.completeStep]);
 
   function onFilterChange(selectedFilters: string[]) {
     const encodedTerm = encodeURIComponent(selectedFilters.join(", "));

--- a/autogpt_platform/frontend/src/components/layout/Navbar/components/Wallet/Wallet.tsx
+++ b/autogpt_platform/frontend/src/components/layout/Navbar/components/Wallet/Wallet.tsx
@@ -60,13 +60,6 @@ export function Wallet() {
             details: "",
           },
           {
-            id: "MARKETPLACE_VISIT",
-            name: "Go to Marketplace",
-            amount: 1,
-            details: "Click Marketplace in the top navigation",
-            video: "/onboarding/marketplace-visit.mp4",
-          },
-          {
             id: "MARKETPLACE_ADD_AGENT",
             name: "Find and add an agent",
             amount: 1,
@@ -81,14 +74,6 @@ export function Wallet() {
             details: "Go to the Library, open an agent you want, and run it",
             video: "/onboarding/marketplace-run.mp4",
           },
-          {
-            id: "BUILDER_SAVE_AGENT",
-            name: "Place your first blocks and save your agent",
-            amount: 1,
-            details:
-              "Open block library on the left and add a block to the canvas then save your agent",
-            video: "/onboarding/builder-save.mp4",
-          },
         ],
       },
       {
@@ -96,26 +81,10 @@ export function Wallet() {
         details: "Build your rhythm and make agents part of your routine.",
         tasks: [
           {
-            id: "RE_RUN_AGENT",
-            name: "Re-run an agent",
-            amount: 1,
-            details: "Re-run an agent from the Library",
-          },
-          {
             id: "SCHEDULE_AGENT",
             name: "Schedule your first agent",
             amount: 1,
             details: "Schedule an agent to run on a recurring basis",
-          },
-          {
-            id: "RUN_AGENTS",
-            name: "Run 10 agents",
-            amount: 3,
-            details: "Run agents from Library or Builder 10 times",
-            progress: {
-              current: state?.agentRuns || 0,
-              target: 10,
-            },
           },
           {
             id: "RUN_3_DAYS",

--- a/autogpt_platform/frontend/src/providers/onboarding/onboarding-provider.tsx
+++ b/autogpt_platform/frontend/src/providers/onboarding/onboarding-provider.tsx
@@ -7,15 +7,6 @@ import {
 } from "@/app/api/__generated__/endpoints/onboarding/onboarding";
 import { PostV1CompleteOnboardingStepStep } from "@/app/api/__generated__/models/postV1CompleteOnboardingStepStep";
 import { resolveResponse } from "@/app/api/helpers";
-import { Button } from "@/components/__legacy__/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/__legacy__/ui/dialog";
 import { useToast } from "@/components/molecules/Toast/use-toast";
 import { useOnboardingTimezoneDetection } from "@/hooks/useOnboardingTimezoneDetection";
 import {
@@ -25,7 +16,6 @@ import {
 } from "@/lib/autogpt-server-api";
 import { useBackendAPI } from "@/lib/autogpt-server-api/context";
 import { useSupabase } from "@/lib/supabase/hooks/useSupabase";
-import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import {
   createContext,
@@ -93,7 +83,6 @@ export default function OnboardingProvider({
 }) {
   const [state, setState] = useState<UserOnboarding | null>(null);
   const [step, setStep] = useState(1);
-  const [npsDialogOpen, setNpsDialogOpen] = useState(false);
   const hasInitialized = useRef(false);
   const isMounted = useRef(true);
   const pendingUpdatesRef = useRef<Set<Promise<void>>>(new Set());
@@ -188,10 +177,6 @@ export default function OnboardingProvider({
     (notification: WebSocketNotification) => {
       if (!isLoggedIn || notification.type !== "onboarding") {
         return;
-      }
-
-      if (notification.step === "RUN_AGENTS") {
-        setNpsDialogOpen(true);
       }
 
       fetchOnboarding().catch((error) => {
@@ -290,33 +275,6 @@ export default function OnboardingProvider({
         completeStep,
       }}
     >
-      <Dialog onOpenChange={setNpsDialogOpen} open={npsDialogOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>We&apos;d love your feedback</DialogTitle>
-            <DialogDescription>
-              You&apos;ve run 10 agents — amazing! We&apos;re constantly
-              improving the platform, and your thoughts help shape what we build
-              next. This 1-minute form is just a few quick questions to share
-              how things are going.
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter className="justify-end">
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => setNpsDialogOpen(false)}
-            >
-              Cancel
-            </Button>
-            <Link href="https://tally.so/r/w4El0b" target="_blank">
-              <Button type="button" onClick={() => setNpsDialogOpen(false)}>
-                Give Feedback
-              </Button>
-            </Link>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
       {children}
     </OnboardingContext.Provider>
   );


### PR DESCRIPTION
### Why / What / How

**Why:** The "earn credits" gamified secondary onboarding (the Wallet) currently lists 4 checklist items that we want to retire. Each was granting credits to users on completion, so simply hiding them in the UI isn't enough — the reward and trigger logic needs to be removed too.

**What:** Removes 4 checklist items end-to-end:
- "Go to Marketplace" (`MARKETPLACE_VISIT`)
- "Place your first blocks and save your agent" (`BUILDER_SAVE_AGENT`)
- "Re-run an agent" (`RE_RUN_AGENT`)
- "Run 10 agents" (`RUN_AGENTS`)

**How:** Surgical removal across UI, reward logic, and trigger sites. The Prisma `OnboardingStep` enum and the TypeScript `OnboardingStep` union are intentionally left intact so users with these values already in `completedSteps`/`rewardedFor`/`notified` keep working — a destructive enum migration would be unfit for a hotfix.

> Note: this PR targets `master` because it's a hotfix. Branch is named `hotfix/...` to skip the dev auto-redirect.

### Changes 🏗️

**Frontend**
- `Wallet.tsx` — remove the 4 task entries from the "First Wins" and "Consistency Challenge" groups.
- `marketplace/components/HeroSection/useHeroSection.ts` — remove `completeStep("MARKETPLACE_VISIT")` effect (and the now-unused `useOnboarding`/`useEffect` imports).
- `__legacy__/composite/HeroSection.tsx` — remove `completeStep("MARKETPLACE_VISIT")` effect (and the now-unused `useOnboarding` import).
- `onboarding-provider.tsx` — remove the NPS feedback dialog (only triggered on `RUN_AGENTS`) and unused imports/state.
- `openapi.json` — remove `MARKETPLACE_VISIT` from the `/onboarding/step` query enum to match backend.

**Backend**
- `data/onboarding.py` — remove the 4 reward cases from `_reward_user`, drop `MARKETPLACE_VISIT` from `FrontendOnboardingStep`, delete the `complete_re_run_agent` helper, drop the `RUN_AGENTS` 10-run milestone in `_get_run_milestone_steps`, remove the now-unused `execution_db` import.
- `api/features/v1.py` — remove the `complete_re_run_agent` import + call site (graph execute), remove the `complete_onboarding_step(..., BUILDER_SAVE_AGENT)` call site (graph create from builder).

**Intentionally not changed**
- `schema.prisma` `OnboardingStep` enum — kept (existing user data references these).
- Migrations under `backend/migrations/` — immutable history.
- `frontend/src/lib/autogpt-server-api/types.ts` `OnboardingStep` union — kept for backward compat with DB values.
- The full `OnboardingStep` schema in `openapi.json` — same reason.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [ ] Open the Wallet popover as a new user — confirm the 4 removed tasks no longer appear in "First Wins" or "Consistency Challenge" groups, and that the totals/percentages render correctly.
  - [ ] Visit the Marketplace as a new user — confirm no `POST /onboarding/step { step: "MARKETPLACE_VISIT" }` request fires (Network tab), and no credits are granted.
  - [ ] Save an agent from the Builder — confirm no `BUILDER_SAVE_AGENT` step is recorded and no credits are granted; agent save still works end-to-end.
  - [ ] Run the same agent twice from Library — confirm `RE_RUN_AGENT` is not recorded and no credits are granted; run still succeeds.
  - [ ] Run 10 agents — confirm `RUN_AGENTS` is not recorded, no credits are granted, and the NPS feedback dialog does not appear.
  - [ ] Run an agent for 3 / 14 days in a row, or hit 100 total runs — confirm the remaining `RUN_3_DAYS` / `RUN_14_DAYS` / `RUN_AGENTS_100` milestones still trigger and grant credits as before.
  - [ ] Existing user with the removed steps already in `completedSteps`/`rewardedFor` — confirm the app loads without errors and no extra credits are granted retroactively.
