### PR TITLE
fix(frontend): change onboarding checklist labels

### DIFF
--- a/autogpt_platform/frontend/src/components/layout/Navbar/components/Wallet/Wallet.tsx
+++ b/autogpt_platform/frontend/src/components/layout/Navbar/components/Wallet/Wallet.tsx
@@ -55,7 +55,7 @@ export function Wallet() {
         tasks: [
           {
             id: "GET_RESULTS",
-            name: "Complete onboarding and see your first agent's results",
+            name: "Complete onboarding",
             amount: 3,
             details: "",
           },
@@ -68,7 +68,7 @@ export function Wallet() {
           },
           {
             id: "MARKETPLACE_ADD_AGENT",
-            name: "Find and add an agent",
+            name: "Get an agent from the marketplace",
             amount: 1,
             details:
               "Search for an agent in the Marketplace and add it to your Library",


### PR DESCRIPTION
### Why / What / How

**Why:** The two checklist items in the Wallet onboarding panel were unnecessarily wordy or didn't reflect intent. Shorter labels are easier to scan and align better with the actual user action.

**What:** Two `name` strings on tasks in `Wallet.tsx` are updated:
- `"Complete onboarding and see your first agent's results"` → `"Complete onboarding"`
- `"Find and add an agent"` → `"Get an agent from the marketplace"`

**How:** Pure copy change. Task `id`s (`GET_RESULTS`, `MARKETPLACE_ADD_AGENT`), reward `amount`s, `details`, and `video` fields are untouched, so backend reward wiring (`onboarding.py`) and progress tracking are unaffected. This is shipped as a `hotfix/...` branch directly against `master`.

### Changes 🏗️

- `autogpt_platform/frontend/src/components/layout/Navbar/components/Wallet/Wallet.tsx`: shortened the two checklist `name` strings noted above (+2 / -2).

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [x] `pnpm types` passes (in the new worktree, after `pnpm generate:api`)
  - [x] `next lint` and `prettier --check` pass on the modified file
  - [ ] Manual smoke: open the Wallet popover from the navbar and confirm the two checklist items now read "Complete onboarding" and "Get an agent from the marketplace" with no broken layout
  - [ ] Confirm reward flow still triggers — completing onboarding still grants the `GET_RESULTS` reward and adding a marketplace agent still grants the `MARKETPLACE_ADD_AGENT` reward (IDs unchanged, so this should be a no-op)

#### For configuration changes:

- [x] `.env.default` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes
- [x] I have included a list of my configuration changes in the PR description (under **Changes**) — n/a, no config changes
