### PR TITLE
refactor(platform): normalize earn-credits checklist rewards to $1

### DIFF
--- a/autogpt_platform/backend/backend/data/onboarding.py
+++ b/autogpt_platform/backend/backend/data/onboarding.py
@@ -150,9 +150,9 @@ async def _reward_user(user_id: str, onboarding: UserOnboarding, step: Onboardin
         case OnboardingStep.TRIGGER_WEBHOOK:
             reward = 100
         case OnboardingStep.RUN_14_DAYS:
-            reward = 300
+            reward = 100
         case OnboardingStep.RUN_AGENTS_100:
-            reward = 300
+            reward = 100
 
     if reward == 0:
         return

--- a/autogpt_platform/backend/backend/data/onboarding_test.py
+++ b/autogpt_platform/backend/backend/data/onboarding_test.py
@@ -1,4 +1,10 @@
-from backend.data.onboarding import format_onboarding_for_extraction
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+import pytest_mock
+from prisma.enums import OnboardingStep
+
+from backend.data.onboarding import _reward_user, format_onboarding_for_extraction
 
 
 def test_format_onboarding_for_extraction_basic():
@@ -25,3 +31,61 @@ def test_format_onboarding_for_extraction_with_other():
     assert "A: Jane" in result
     assert "A: Data Scientist" in result
     assert "Research, Building dashboards" in result
+
+
+@pytest.mark.asyncio(loop_scope="function")
+@pytest.mark.parametrize(
+    "step,expected_reward",
+    [
+        (OnboardingStep.VISIT_COPILOT, 500),
+        (OnboardingStep.AGENT_NEW_RUN, 300),
+        (OnboardingStep.MARKETPLACE_ADD_AGENT, 100),
+        (OnboardingStep.MARKETPLACE_RUN_AGENT, 100),
+        (OnboardingStep.SCHEDULE_AGENT, 100),
+        (OnboardingStep.RUN_3_DAYS, 100),
+        (OnboardingStep.TRIGGER_WEBHOOK, 100),
+        (OnboardingStep.RUN_14_DAYS, 100),
+        (OnboardingStep.RUN_AGENTS_100, 100),
+    ],
+)
+async def test_reward_user_grants_expected_amount(
+    mocker: pytest_mock.MockFixture,
+    step: OnboardingStep,
+    expected_reward: int,
+):
+    onboarding = Mock()
+    onboarding.rewardedFor = []
+
+    credit_model = Mock()
+    credit_model.onboarding_reward = AsyncMock()
+    mocker.patch(
+        "backend.data.onboarding.get_user_credit_model",
+        AsyncMock(return_value=credit_model),
+    )
+    mock_prisma = mocker.patch("backend.data.onboarding.UserOnboarding.prisma")
+    mock_prisma.return_value.update = AsyncMock()
+
+    await _reward_user("user-1", onboarding, step)
+
+    credit_model.onboarding_reward.assert_called_once_with(
+        "user-1", expected_reward, step
+    )
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_reward_user_skips_if_already_rewarded(
+    mocker: pytest_mock.MockFixture,
+):
+    onboarding = Mock()
+    onboarding.rewardedFor = [OnboardingStep.RUN_14_DAYS]
+
+    credit_model = Mock()
+    credit_model.onboarding_reward = AsyncMock()
+    mocker.patch(
+        "backend.data.onboarding.get_user_credit_model",
+        AsyncMock(return_value=credit_model),
+    )
+
+    await _reward_user("user-1", onboarding, OnboardingStep.RUN_14_DAYS)
+
+    credit_model.onboarding_reward.assert_not_called()

--- a/autogpt_platform/frontend/src/components/layout/Navbar/components/Wallet/Wallet.tsx
+++ b/autogpt_platform/frontend/src/components/layout/Navbar/components/Wallet/Wallet.tsx
@@ -144,7 +144,7 @@ export function Wallet() {
           {
             id: "RUN_14_DAYS",
             name: "Run agents 14 days in a row",
-            amount: 3,
+            amount: 1,
             details:
               "Run any agents from the Library or Builder for 10 days in a row",
             progress: {
@@ -155,7 +155,7 @@ export function Wallet() {
           {
             id: "RUN_AGENTS_100",
             name: "Complete 100 agent runs",
-            amount: 3,
+            amount: 1,
             details: "Let your agents run and complete 100 tasks in total",
             progress: {
               current: state?.agentRuns || 0,


### PR DESCRIPTION
### Why / What / How

**Why:** The "Earn Credits" wallet (gamified secondary onboarding) currently has inconsistent reward values: most checklist items grant $1, but two outliers (`RUN_14_DAYS`, `RUN_AGENTS_100`) grant $3, which makes the credit economy uneven and harder to communicate. We want a flat $1 across the board, with the only exception being the $3 onboarding-completion line.

**What:** Drops `RUN_14_DAYS` and `RUN_AGENTS_100` rewards from $3 to $1 — both in the wallet UI display and in the backend credit grant.

**How:** Two-line change in `Wallet.tsx` (UI `amount`) and two-line change in `_reward_user` (`onboarding.py`). Keeping the UI display in sync with the actual credit grant prevents the "advertised vs received" mismatch.

> Note: this PR targets `master` because it's a hotfix. Branch is named `hotfix/...` to skip the dev auto-redirect, mirroring #12968.

### Changes 🏗️

**Frontend** — `autogpt_platform/frontend/src/components/layout/Navbar/components/Wallet/Wallet.tsx`
- `RUN_14_DAYS` task: `amount: 3` → `amount: 1`
- `RUN_AGENTS_100` task: `amount: 3` → `amount: 1`

**Backend** — `autogpt_platform/backend/backend/data/onboarding.py`
- `_reward_user`: `RUN_14_DAYS` reward `300` → `100`
- `_reward_user`: `RUN_AGENTS_100` reward `300` → `100`

**Intentionally not changed**
- `GET_RESULTS` — the $3 onboarding-completion line (the wallet displays $3 backed by the `AGENT_NEW_RUN` server reward of 300; both stay).
- `VISIT_COPILOT` (500) — hidden server-side-only welcome bonus, out of scope per the task.
- All other already-$1 visible items (`MARKETPLACE_ADD_AGENT`, `MARKETPLACE_RUN_AGENT`, `SCHEDULE_AGENT`, `RUN_3_DAYS`, `TRIGGER_WEBHOOK`).

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [ ] Open the Wallet popover — confirm "Run agents 14 days in a row" and "Complete 100 agent runs" each display `$1.00`. The "First Wins" group total should still be `$5.00` (3+1+1), "Consistency Challenge" `$2.00` (1+1), "The Pro Playground" `$3.00` (1+1+1).
  - [ ] As a new user who has not yet hit those milestones: trigger `RUN_14_DAYS` (or `RUN_AGENTS_100` in a test env) and confirm the user receives 100 credits ($1), not 300.
  - [ ] As a user already in `rewardedFor` for these steps: confirm no extra credits are granted (gated by `if step in onboarding.rewardedFor: return`).
  - [ ] Confirm `GET_RESULTS` still shows $3.00 in the wallet and the onboarding completion still grants 300 credits via `AGENT_NEW_RUN`.
