### PR TITLE
chore: update subscription screen plan copy

### DIFF
--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/helpers.ts
@@ -48,7 +48,7 @@ export const PLANS: PlanDef[] = [
   {
     key: PLAN_KEYS.MAX,
     name: "Max",
-    usage: "7x",
+    usage: "8.5x",
     usdMonthly: MAX_USD_MONTHLY,
     description: "For users who are serious about getting more work done.",
     features: [

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/helpers.ts
@@ -5,85 +5,84 @@ export const YEARLY_PRICE_FACTOR = 0.85;
 export const TEAM_INTAKE_FORM_URL = "https://tally.so/r/2Eb9zj";
 
 export const PLAN_KEYS = {
-    PRO: "PRO",
-    MAX: "MAX",
-    TEAM: "TEAM",
+  PRO: "PRO",
+  MAX: "MAX",
+  TEAM: "TEAM",
 } as const;
 export type PlanKey = (typeof PLAN_KEYS)[keyof typeof PLAN_KEYS];
 
-  export interface PlanDef {
+export interface PlanDef {
   key: PlanKey;
-    name: string;
-    usage: string | null;
-    usdMonthly: number | null;
-    description: string;
-    features: string[];
-    cta: string;
-    highlighted: boolean;
-    badge: string | null;
-    buttonVariant: "primary" | "secondary";
+  name: string;
+  usage: string | null;
+  usdMonthly: number | null;
+  description: string;
+  features: string[];
+  cta: string;
+  highlighted: boolean;
+  badge: string | null;
+  buttonVariant: "primary" | "secondary";
 }
 
 export const PLANS: PlanDef[] = [
   {
-        key: PLAN_KEYS.PRO,
-        name: "Pro",
-        usage: "1x",
-        usdMonthly: PRO_USD_MONTHLY,
-        description:
-                "For individuals getting started with dependable everyday automation.",
-        features: [
-                "Access to virtually any leading AI model",
-                "Agents work non-stop in the background",
-                "Visual agent builder and chat-based agent creation",
-                "File-aware agents that can work with your documents",
-                "End-to-end agent management and run visibility",
-                "Scheduled and event-based triggers",
-              ],
-        cta: "Get Pro",
-        highlighted: false,
-        badge: null,
-        buttonVariant: "secondary",
+    key: PLAN_KEYS.PRO,
+    name: "Pro",
+    usage: "1x",
+    usdMonthly: PRO_USD_MONTHLY,
+    description:
+      "For individuals getting started with dependable everyday automation.",
+    features: [
+      "Access to virtually any leading AI model",
+      "Agents work non-stop in the background",
+      "Visual agent builder and chat-based agent creation",
+      "File-aware agents that can work with your documents",
+      "End-to-end agent management and run visibility",
+      "Scheduled and event-based triggers",
+    ],
+    cta: "Get Pro",
+    highlighted: false,
+    badge: null,
+    buttonVariant: "secondary",
   },
   {
-        key: PLAN_KEYS.MAX,
-        name: "Max",
-        usage: "7x",
-        usdMonthly: MAX_USD_MONTHLY,
-        description:
-                "For users who are serious about getting more work done.",
-        features: [
-                "Includes everything in Pro",
-                "8.5x Pro usage",
-                "5x file storage",
-                "Early access to features before anyone else",
-                "Expand our extensive integration library",
-                "Priority support",
-                "Help drive the roadmap for new features",
-              ],
-        cta: "Upgrade to Max",
-        highlighted: true,
-        badge: "Best value",
-        buttonVariant: "primary",
+    key: PLAN_KEYS.MAX,
+    name: "Max",
+    usage: "7x",
+    usdMonthly: MAX_USD_MONTHLY,
+    description: "For users who are serious about getting more work done.",
+    features: [
+      "Includes everything in Pro",
+      "8.5x Pro usage",
+      "5x file storage",
+      "Early access to features before anyone else",
+      "Expand our extensive integration library",
+      "Priority support",
+      "Help drive the roadmap for new features",
+    ],
+    cta: "Upgrade to Max",
+    highlighted: true,
+    badge: "Best value",
+    buttonVariant: "primary",
   },
   {
-        key: PLAN_KEYS.TEAM,
-        name: "Team",
-        usage: null,
-        usdMonthly: null,
-        description:
-                "For teams that need collaboration, controls, and custom usage.",
-        features: [
-                "Multi-user workspaces",
-                "Admin controls & roles",
-                "Centralized billing & seat management",
-                "Collaboration & approvals",
-                "Security & compliance options",
-                "Secure access for shared integrations",
-              ],
-        cta: "Contact sales",
-        highlighted: false,
-        badge: "Coming soon",
-        buttonVariant: "secondary",
+    key: PLAN_KEYS.TEAM,
+    name: "Team",
+    usage: null,
+    usdMonthly: null,
+    description:
+      "For teams that need collaboration, controls, and custom usage.",
+    features: [
+      "Multi-user workspaces",
+      "Admin controls & roles",
+      "Centralized billing & seat management",
+      "Collaboration & approvals",
+      "Security & compliance options",
+      "Secure access for shared integrations",
+    ],
+    cta: "Contact sales",
+    highlighted: false,
+    badge: "Coming soon",
+    buttonVariant: "secondary",
   },
-  ];
+];

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/helpers.ts
@@ -5,84 +5,85 @@ export const YEARLY_PRICE_FACTOR = 0.85;
 export const TEAM_INTAKE_FORM_URL = "https://tally.so/r/2Eb9zj";
 
 export const PLAN_KEYS = {
-  PRO: "PRO",
-  MAX: "MAX",
-  TEAM: "TEAM",
+    PRO: "PRO",
+    MAX: "MAX",
+    TEAM: "TEAM",
 } as const;
 export type PlanKey = (typeof PLAN_KEYS)[keyof typeof PLAN_KEYS];
 
-export interface PlanDef {
+  export interface PlanDef {
   key: PlanKey;
-  name: string;
-  usage: string | null;
-  usdMonthly: number | null;
-  description: string;
-  features: string[];
-  cta: string;
-  highlighted: boolean;
-  badge: string | null;
-  buttonVariant: "primary" | "secondary";
+    name: string;
+    usage: string | null;
+    usdMonthly: number | null;
+    description: string;
+    features: string[];
+    cta: string;
+    highlighted: boolean;
+    badge: string | null;
+    buttonVariant: "primary" | "secondary";
 }
 
 export const PLANS: PlanDef[] = [
   {
-    key: PLAN_KEYS.PRO,
-    name: "Pro",
-    usage: "1x",
-    usdMonthly: PRO_USD_MONTHLY,
-    description:
-      "For individuals getting started with dependable everyday automation.",
-    features: [
-      "1x usage allowance",
-      "Up to 1,000 agent runs / month",
-      "Access to core models",
-      "Core agent library",
-      "Standard support",
-    ],
-    cta: "Get Pro",
-    highlighted: false,
-    badge: null,
-    buttonVariant: "secondary",
+        key: PLAN_KEYS.PRO,
+        name: "Pro",
+        usage: "1x",
+        usdMonthly: PRO_USD_MONTHLY,
+        description:
+                "For individuals getting started with dependable everyday automation.",
+        features: [
+                "Access to virtually any leading AI model",
+                "Agents work non-stop in the background",
+                "Visual agent builder and chat-based agent creation",
+                "File-aware agents that can work with your documents",
+                "End-to-end agent management and run visibility",
+                "Scheduled and event-based triggers",
+              ],
+        cta: "Get Pro",
+        highlighted: false,
+        badge: null,
+        buttonVariant: "secondary",
   },
   {
-    key: PLAN_KEYS.MAX,
-    name: "Max",
-    usage: "7x",
-    usdMonthly: MAX_USD_MONTHLY,
-    description:
-      "For power users running more workflows and higher-volume automations.",
-    features: [
-      "7x usage allowance",
-      "Up to 10,000 agent runs / month",
-      "Access to premium models",
-      "Advanced workflows & tools",
-      "Priority processing",
-      "Faster support",
-      "Custom integrations (beta)",
-    ],
-    cta: "Upgrade to Max",
-    highlighted: true,
-    badge: "Best value",
-    buttonVariant: "primary",
+        key: PLAN_KEYS.MAX,
+        name: "Max",
+        usage: "7x",
+        usdMonthly: MAX_USD_MONTHLY,
+        description:
+                "For users who are serious about getting more work done.",
+        features: [
+                "Includes everything in Pro",
+                "8.5x Pro usage",
+                "5x file storage",
+                "Early access to features before anyone else",
+                "Expand our extensive integration library",
+                "Priority support",
+                "Help drive the roadmap for new features",
+              ],
+        cta: "Upgrade to Max",
+        highlighted: true,
+        badge: "Best value",
+        buttonVariant: "primary",
   },
   {
-    key: PLAN_KEYS.TEAM,
-    name: "Team",
-    usage: null,
-    usdMonthly: null,
-    description:
-      "For teams that need collaboration, controls, and custom usage.",
-    features: [
-      "Multi-user workspaces",
-      "Admin controls & roles",
-      "Shared billing & usage pools",
-      "Collaboration & approvals",
-      "Security & compliance options",
-      "Premium support",
-    ],
-    cta: "Contact sales",
-    highlighted: false,
-    badge: "Coming soon",
-    buttonVariant: "secondary",
+        key: PLAN_KEYS.TEAM,
+        name: "Team",
+        usage: null,
+        usdMonthly: null,
+        description:
+                "For teams that need collaboration, controls, and custom usage.",
+        features: [
+                "Multi-user workspaces",
+                "Admin controls & roles",
+                "Centralized billing & seat management",
+                "Collaboration & approvals",
+                "Security & compliance options",
+                "Secure access for shared integrations",
+              ],
+        cta: "Contact sales",
+        highlighted: false,
+        badge: "Coming soon",
+        buttonVariant: "secondary",
   },
-];
+  ];


### PR DESCRIPTION
Updates placeholder copy on Pro, Max, and Team plan cards in the subscription step. Copy only — no layout or component changes.

### Why / What / How

The subscription screen (merged in PR #12935) shipped with placeholder bullet copy. This PR updates the features lists and descriptions to match the finalized plan positioning before the paid pilot launch.

### Changes

- **Pro**: Replaced 5 placeholder bullets with 6 final feature bullets (AI models, background agents, visual builder, file-aware agents, run visibility, triggers)
- - **Max**: Updated subtitle from "For power users..." to "For users who are serious about getting more work done." Replaced 7 placeholder bullets with final copy (everything in Pro, 8.5x usage, 5x file storage, early access, integrations, priority support, roadmap influence)
- - **Team**: Changed bullet 3 from "Shared billing & usage pools" to "Centralized billing & seat management" and bullet 6 from "Premium support" to "Secure access for shared integrations"
### Checklist

- [x] I have clearly listed my changes in the PR description
- [ ] - [x] Copy only — no layout, component, or logic changes
- [ ] - [x] No new dependencies