### PR TITLE
fix(frontend): persist onboarding store + skip Stripe on LOCAL

### DIFF
--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/__tests__/page.test.tsx
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/__tests__/page.test.tsx
@@ -175,4 +175,24 @@ describe("OnboardingPage — flag-gated SubscriptionStep", () => {
     expect(await screen.findByTestId("step-subscription")).toBeDefined();
     expect(useOnboardingWizardStore.getState().selectedPlan).toBeNull();
   });
+
+  it("preserves form data on mount (zustand persist; no reset-on-init)", async () => {
+    // Regression test for the 422 caused by init's old `reset()` wiping
+    // name/role on every mount. With zustand persist, refreshing mid-wizard
+    // must preserve what the user already typed.
+    mockFlagValue = true;
+    window.sessionStorage.setItem(STEP_STORAGE_KEY, "4");
+    useOnboardingWizardStore.setState({
+      name: "Alice",
+      role: "Engineering",
+      painPoints: ["slow builds"],
+    });
+    currentSearchParams = new URLSearchParams("step=4");
+    render(<OnboardingPage />);
+    expect(await screen.findByTestId("step-subscription")).toBeDefined();
+    const state = useOnboardingWizardStore.getState();
+    expect(state.name).toBe("Alice");
+    expect(state.role).toBe("Engineering");
+    expect(state.painPoints).toEqual(["slow builds"]);
+  });
 });

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/page.tsx
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { CaretLeft } from "@phosphor-icons/react";
+import { CaretLeft, SignOutIcon } from "@phosphor-icons/react";
+import Link from "next/link";
 import { ProgressBar } from "./components/ProgressBar";
 import { StepIndicator } from "./components/StepIndicator";
 import { PainPointsStep } from "./steps/PainPointsStep";
@@ -29,6 +30,7 @@ export default function OnboardingPage() {
   const showDots = currentStep <= totalSteps;
   const showBack = currentStep > 1 && currentStep <= totalSteps;
   const showProgressBar = currentStep <= totalSteps;
+  const showLogout = currentStep <= totalSteps;
 
   return (
     <div className="flex min-h-screen w-full flex-col items-center">
@@ -61,6 +63,16 @@ export default function OnboardingPage() {
         <div className="pb-8">
           <StepIndicator totalSteps={totalSteps} currentStep={currentStep} />
         </div>
+      )}
+
+      {showLogout && (
+        <Link
+          href="/logout"
+          className="text-md absolute bottom-6 left-6 flex items-center gap-1 text-zinc-500 transition-colors duration-200 hover:text-zinc-900"
+        >
+          <SignOutIcon size={16} />
+          Log out
+        </Link>
       )}
     </div>
   );

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/page.tsx
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { CaretLeft, SignOutIcon } from "@phosphor-icons/react";
+import { CaretLeftIcon, SignOutIcon } from "@phosphor-icons/react";
 import Link from "next/link";
 import { ProgressBar } from "./components/ProgressBar";
 import { StepIndicator } from "./components/StepIndicator";
@@ -44,7 +44,7 @@ export default function OnboardingPage() {
           onClick={prevStep}
           className="text-md absolute left-6 top-6 flex items-center gap-1 text-zinc-500 transition-colors duration-200 hover:text-zinc-900"
         >
-          <CaretLeft size={16} />
+          <CaretLeftIcon size={16} />
           Back
         </button>
       )}

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/useSubscriptionStep.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/useSubscriptionStep.ts
@@ -78,18 +78,17 @@ export function useSubscriptionStep() {
     setSelectedPlan(planKey);
     const tier = PLAN_TO_TIER[planKey];
 
-    // Profile data lives in an in-memory zustand store, so persist it before
-    // Stripe takes the user off-page — otherwise the user's name/role/pain
-    // points are lost on the post-checkout redirect.
     const { name, role, painPoints } = normalizeOnboardingProfile(
       useOnboardingWizardStore.getState(),
     );
 
     try {
-      // Profile must be persisted before Stripe takes over — the zustand
-      // store is in-memory and the post-checkout return is a full page
-      // navigation. Abort on failure rather than silently losing the user's
-      // name / role / pain points.
+      // POST the profile pre-redirect as defence in depth: zustand persist
+      // (sessionStorage) keeps the store across the Stripe round-trip, but
+      // submitting now also covers the case where the user closes the tab
+      // mid-checkout — the backend still has their name / role / pain
+      // points. Abort on failure rather than starting a Checkout session
+      // we'd have to reconcile with a missing profile after success.
       await postV1SubmitOnboardingProfile({
         user_name: name,
         user_role: role,

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/useSubscriptionStep.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/useSubscriptionStep.ts
@@ -63,6 +63,7 @@ export function useSubscriptionStep() {
       return;
     }
     if (isProcessing) return;
+    setIsSubmitting(true);
 
     // Local dev: backend has no Stripe wiring, so skip the checkout
     // round-trip and advance straight to Preparing. The profile still
@@ -72,8 +73,6 @@ export function useSubscriptionStep() {
       nextStep();
       return;
     }
-
-    setIsSubmitting(true);
 
     setSelectedPlan(planKey);
     const tier = PLAN_TO_TIER[planKey];

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/useSubscriptionStep.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/useSubscriptionStep.ts
@@ -2,6 +2,7 @@ import { useUpdateSubscriptionTier } from "@/app/api/__generated__/endpoints/cre
 import { postV1SubmitOnboardingProfile } from "@/app/api/__generated__/endpoints/onboarding/onboarding";
 import type { SubscriptionTierRequestTier } from "@/app/api/__generated__/models/subscriptionTierRequestTier";
 import { toast } from "@/components/molecules/Toast/use-toast";
+import { environment } from "@/services/environment";
 import { useState } from "react";
 import { normalizeOnboardingProfile } from "../../helpers";
 import { useOnboardingWizardStore } from "../../store";
@@ -62,6 +63,16 @@ export function useSubscriptionStep() {
       return;
     }
     if (isProcessing) return;
+
+    // Local dev: backend has no Stripe wiring, so skip the checkout
+    // round-trip and advance straight to Preparing. The profile still
+    // gets POSTed there via useOnboardingPage's submission effect.
+    if (environment.isLocal()) {
+      setSelectedPlan(planKey);
+      nextStep();
+      return;
+    }
+
     setIsSubmitting(true);
 
     setSelectedPlan(planKey);

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/__tests__/SubscriptionStep.test.tsx
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/__tests__/SubscriptionStep.test.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/tests/integrations/test-utils";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { server } from "@/mocks/mock-server";
+import { environment } from "@/services/environment";
 import { useOnboardingWizardStore } from "../../store";
 import { SubscriptionStep } from "../SubscriptionStep/SubscriptionStep";
 
@@ -26,6 +27,9 @@ afterEach(cleanup);
 beforeEach(() => {
   useOnboardingWizardStore.getState().reset();
   useOnboardingWizardStore.getState().goToStep(4);
+  // Default tests to cloud mode so they exercise the Stripe Checkout path.
+  // The local-bypass test below opts back into LOCAL.
+  vi.spyOn(environment, "isLocal").mockReturnValue(false);
 });
 
 describe("SubscriptionStep", () => {
@@ -146,6 +150,35 @@ describe("SubscriptionStep", () => {
     fireEvent.click(screen.getByRole("button", { name: /United States/i }));
     fireEvent.click(screen.getByRole("button", { name: /European Union/i }));
     expect(useOnboardingWizardStore.getState().selectedCountryCode).toBe("EU");
+  });
+
+  test("local dev: clicking Pro skips Stripe and advances to the next step", async () => {
+    vi.spyOn(environment, "isLocal").mockReturnValue(true);
+
+    let stripeCalled = false;
+    let profileCalledSync = false;
+    server.use(
+      http.post("*/api/credits/subscription", () => {
+        stripeCalled = true;
+        return HttpResponse.json({ url: null });
+      }),
+      http.post("*/api/onboarding/profile", () => {
+        profileCalledSync = true;
+        return HttpResponse.json({}, { status: 200 });
+      }),
+    );
+
+    render(<SubscriptionStep />);
+    fireEvent.click(screen.getByRole("button", { name: /Get Pro/i }));
+
+    await waitFor(() => {
+      expect(useOnboardingWizardStore.getState().selectedPlan).toBe("PRO");
+    });
+    // Local short-circuit: no Stripe Checkout, no pre-redirect profile POST
+    // (the Preparing step handles submission via useOnboardingPage).
+    expect(stripeCalled).toBe(false);
+    expect(profileCalledSync).toBe(false);
+    expect(useOnboardingWizardStore.getState().currentStep).toBe(5);
   });
 
   test("clicking a plan keeps the request in flight: clicked card spins, others lock", async () => {

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/store.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/store.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
 
 export const MAX_PAIN_POINT_SELECTIONS = 3;
 export type Step = 1 | 2 | 3 | 4 | 5;
@@ -27,75 +28,104 @@ interface OnboardingWizardState {
   reset(): void;
 }
 
-export const useOnboardingWizardStore = create<OnboardingWizardState>(
-  (set) => ({
-    currentStep: 1,
-    name: "",
-    role: "",
-    otherRole: "",
-    painPoints: [],
-    otherPainPoint: "",
-    selectedPlan: null,
-    selectedBilling: "monthly",
-    selectedCountryCode: "US",
-    setName(name) {
-      set({ name });
+export const useOnboardingWizardStore = create<OnboardingWizardState>()(
+  persist(
+    (set) => ({
+      currentStep: 1,
+      name: "",
+      role: "",
+      otherRole: "",
+      painPoints: [],
+      otherPainPoint: "",
+      selectedPlan: null,
+      selectedBilling: "monthly",
+      selectedCountryCode: "US",
+      setName(name) {
+        set({ name });
+      },
+      setRole(role) {
+        set({ role });
+      },
+      setOtherRole(otherRole) {
+        set({ otherRole });
+      },
+      togglePainPoint(painPoint) {
+        set((state) => {
+          const exists = state.painPoints.includes(painPoint);
+          if (!exists && state.painPoints.length >= MAX_PAIN_POINT_SELECTIONS)
+            return state;
+          return {
+            painPoints: exists
+              ? state.painPoints.filter((p) => p !== painPoint)
+              : [...state.painPoints, painPoint],
+          };
+        });
+      },
+      setOtherPainPoint(otherPainPoint) {
+        set({ otherPainPoint });
+      },
+      setSelectedPlan(plan) {
+        set({ selectedPlan: plan });
+      },
+      setSelectedBilling(billing) {
+        set({ selectedBilling: billing });
+      },
+      setSelectedCountryCode(code) {
+        set({ selectedCountryCode: code });
+      },
+      nextStep() {
+        set((state) => ({
+          currentStep: Math.min(5, state.currentStep + 1) as Step,
+        }));
+      },
+      prevStep() {
+        set((state) => ({
+          currentStep: Math.max(1, state.currentStep - 1) as Step,
+        }));
+      },
+      goToStep(step) {
+        set({ currentStep: step });
+      },
+      reset() {
+        set({
+          currentStep: 1,
+          name: "",
+          role: "",
+          otherRole: "",
+          painPoints: [],
+          otherPainPoint: "",
+          selectedPlan: null,
+          selectedBilling: "monthly",
+          selectedCountryCode: "US",
+        });
+      },
+    }),
+    {
+      name: "onboarding-wizard",
+      version: 1,
+      // sessionStorage (not localStorage) so abandoning the wizard and
+      // closing the tab gives a clean slate next time, matching the
+      // STEP_STORAGE_KEY ceiling in useOnboardingPage. SSR-safe: a no-op
+      // stub runs during Next.js SSR / vitest where window is undefined —
+      // returning undefined would make zustand throw on first getItem.
+      storage: createJSONStorage(() =>
+        typeof window !== "undefined" && window.sessionStorage
+          ? window.sessionStorage
+          : { getItem: () => null, setItem: () => {}, removeItem: () => {} },
+      ),
+      // currentStep is intentionally excluded — the URL is the source of
+      // truth for which step the user is on, and the page hook syncs the
+      // store from the URL on mount.
+      partialize: (state) => ({
+        name: state.name,
+        role: state.role,
+        otherRole: state.otherRole,
+        painPoints: state.painPoints,
+        otherPainPoint: state.otherPainPoint,
+        selectedPlan: state.selectedPlan,
+        selectedBilling: state.selectedBilling,
+        selectedCountryCode: state.selectedCountryCode,
+      }),
     },
-    setRole(role) {
-      set({ role });
-    },
-    setOtherRole(otherRole) {
-      set({ otherRole });
-    },
-    togglePainPoint(painPoint) {
-      set((state) => {
-        const exists = state.painPoints.includes(painPoint);
-        if (!exists && state.painPoints.length >= MAX_PAIN_POINT_SELECTIONS)
-          return state;
-        return {
-          painPoints: exists
-            ? state.painPoints.filter((p) => p !== painPoint)
-            : [...state.painPoints, painPoint],
-        };
-      });
-    },
-    setOtherPainPoint(otherPainPoint) {
-      set({ otherPainPoint });
-    },
-    setSelectedPlan(plan) {
-      set({ selectedPlan: plan });
-    },
-    setSelectedBilling(billing) {
-      set({ selectedBilling: billing });
-    },
-    setSelectedCountryCode(code) {
-      set({ selectedCountryCode: code });
-    },
-    nextStep() {
-      set((state) => ({
-        currentStep: Math.min(5, state.currentStep + 1) as Step,
-      }));
-    },
-    prevStep() {
-      set((state) => ({
-        currentStep: Math.max(1, state.currentStep - 1) as Step,
-      }));
-    },
-    goToStep(step) {
-      set({ currentStep: step });
-    },
-    reset() {
-      set({
-        currentStep: 1,
-        name: "",
-        role: "",
-        otherRole: "",
-        painPoints: [],
-        otherPainPoint: "",
-        selectedPlan: null,
-        selectedBilling: "monthly",
-        selectedCountryCode: "US",
-      });
-    },
-  }),
+  ),
 );

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/store.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/store.ts
@@ -116,13 +116,17 @@ export const useOnboardingWizardStore = create<OnboardingWizardState>()(
       // currentStep is intentionally excluded — the URL is the source of
       // truth for which step the user is on, and the page hook syncs the
       // store from the URL on mount.
+      // selectedPlan is also excluded — it's only meaningful while a
+      // Stripe Checkout request is in flight (gated by isUpdatingTier in
+      // SubscriptionStep). The full-page Stripe redirect doesn't survive
+      // in-memory state anyway, so persisting it serves no purpose and
+      // would resurface a stale "selected" plan after cancel-and-return.
       partialize: (state) => ({
         name: state.name,
         role: state.role,
         otherRole: state.otherRole,
         painPoints: state.painPoints,
         otherPainPoint: state.otherPainPoint,
-        selectedPlan: state.selectedPlan,
         selectedBilling: state.selectedBilling,
         selectedCountryCode: state.selectedCountryCode,
       }),

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/useOnboardingPage.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/useOnboardingPage.ts
@@ -50,7 +50,6 @@ export function useOnboardingPage() {
   const { isLoggedIn } = useSupabase();
   const currentStep = useOnboardingWizardStore((s) => s.currentStep);
   const goToStep = useOnboardingWizardStore((s) => s.goToStep);
-  const reset = useOnboardingWizardStore((s) => s.reset);
 
   // Wait for LaunchDarkly before initialising the wizard from the URL.
   // Without this, the init effect runs against the default flag value
@@ -94,9 +93,12 @@ export function useOnboardingPage() {
   const hasSubmitted = useRef(false);
   const hasInitialized = useRef(false);
 
-  // Initialise store from URL on mount, reset form data, clamp ?step= to
-  // the highest step the user has actually reached. No-step URL resumes from
-  // the highest reached so refreshes don't drop the user back to step 1.
+  // Initialise store from URL on mount, clamp ?step= to the highest step
+  // the user has actually reached. No-step URL resumes from the highest
+  // reached so refreshes don't drop the user back to step 1. Form data is
+  // persisted (zustand persist), so we no longer reset on mount — that
+  // would defeat the point of persistence by wiping the user's name/role
+  // every time they refresh mid-wizard.
   useEffect(() => {
     if (!areFlagsReady || hasInitialized.current) return;
     hasInitialized.current = true;
@@ -112,9 +114,8 @@ export function useOnboardingPage() {
     const target = (
       urlStep === null ? ceiling : Math.min(urlStep, ceiling)
     ) as Step;
-    reset();
     goToStep(target);
-  }, [areFlagsReady, searchParams, reset, goToStep, preparingStep]);
+  }, [areFlagsReady, searchParams, goToStep, preparingStep]);
 
   // Sync store → URL when step changes; record the new ceiling.
   useEffect(() => {
@@ -137,6 +138,12 @@ export function useOnboardingPage() {
         const onboarding = await resolveResponse(getV1OnboardingState());
         if (onboarding.completedSteps.includes("VISIT_COPILOT")) {
           clearHighestStep();
+          // Clear the persisted form data without touching in-memory state.
+          // `reset()` would set currentStep=1 and trip the URL-sync effect
+          // into racing with the /copilot redirect (the spurious
+          // /onboarding?step=1 replace wins, stranding the user on Welcome
+          // until they refresh).
+          useOnboardingWizardStore.persist.clearStorage();
           router.replace("/copilot");
           return;
         }
@@ -158,12 +165,14 @@ export function useOnboardingPage() {
       useOnboardingWizardStore.getState(),
     );
 
-    // Profile is submitted before the Stripe Checkout redirect (the wizard
-    // store is in-memory and doesn't survive the round-trip). Skip the
-    // resubmit on return to avoid overwriting saved data with empties —
-    // belt-and-suspenders: also skip when `name` is empty so that even if
-    // the success query param gets stripped (manual edit, share link,
-    // upstream proxy normalising URLs), we don't blank the saved profile.
+    // Profile is submitted before the Stripe Checkout redirect (defence in
+    // depth: persist keeps the store across the round-trip, but submitting
+    // pre-redirect ensures the backend has the data even if the user
+    // closes the tab during checkout). Skip the resubmit on return to
+    // avoid overwriting saved data with empties — belt-and-suspenders:
+    // also skip when `name` is empty so that even if the success query
+    // param gets stripped (manual edit, share link, upstream proxy
+    // normalising URLs), we don't blank the saved profile.
     if (searchParams.get("subscription") === "success" || !name.trim()) return;
 
     postV1SubmitOnboardingProfile({
@@ -180,6 +189,7 @@ export function useOnboardingPage() {
       try {
         await postV1CompleteOnboardingStep({ step: "VISIT_COPILOT" });
         clearHighestStep();
+        useOnboardingWizardStore.persist.clearStorage();
         router.replace("/copilot");
         return;
       } catch {
@@ -187,6 +197,7 @@ export function useOnboardingPage() {
       }
     }
     clearHighestStep();
+    useOnboardingWizardStore.persist.clearStorage();
     router.replace("/copilot");
   }
 

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/UsageLimits/UsageLimitReachedCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/UsageLimits/UsageLimitReachedCard.tsx
@@ -69,7 +69,7 @@ export function UsageLimitReachedCard() {
             </Badge>
           )}
         </div>
-        <Link href="/profile/credits" className="shrink-0 hover:underline">
+        <Link href="/settings/billing" className="shrink-0 hover:underline">
           <Text as="span" variant="small" className="text-blue-600">
             Learn more about usage limits
           </Text>

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/UsageLimits/UsagePanelContent.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/UsageLimits/UsagePanelContent.tsx
@@ -252,16 +252,16 @@ export function UsagePanelContent({
         isBillingEnabled && (
           <Button
             as="NextLink"
-            href="/profile/credits"
+            href="/settings/billing"
             variant="primary"
             size="small"
             className="mt-1 w-full"
           >
-            Add credits to reset
+            Go to billing
           </Button>
         )}
       {showBillingLink && (
-        <Link href="/profile/credits" className="hover:underline">
+        <Link href="/settings/billing" className="hover:underline">
           <Text as="span" variant="small" className="text-blue-600">
             Learn more about usage limits
           </Text>

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/UsageLimits/__tests__/UsageLimits.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/UsageLimits/__tests__/UsageLimits.test.tsx
@@ -132,7 +132,7 @@ describe("UsageLimits", () => {
     expect(screen.getByText("Pro plan")).toBeDefined();
   });
 
-  it("shows learn more link to credits page", () => {
+  it("shows learn more link to billing page", () => {
     mockUseGetV2GetCopilotUsage.mockReturnValue({
       data: makeUsage(),
       isSuccess: true,
@@ -141,6 +141,6 @@ describe("UsageLimits", () => {
 
     const link = screen.getByText("Learn more about usage limits");
     expect(link).toBeDefined();
-    expect(link.closest("a")?.getAttribute("href")).toBe("/profile/credits");
+    expect(link.closest("a")?.getAttribute("href")).toBe("/settings/billing");
   });
 });

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/UsageLimits/__tests__/UsagePanelContentRender.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/UsageLimits/__tests__/UsagePanelContentRender.test.tsx
@@ -139,7 +139,7 @@ describe("UsagePanelContent", () => {
     expect(mockResetUsage).toHaveBeenCalled();
   });
 
-  it("renders 'Add credits' link when insufficient credits", () => {
+  it("renders 'Go to billing' link when insufficient credits", () => {
     render(
       <UsagePanelContent
         usage={makeUsage({ dailyPercent: 100, resetCost: 50 })}
@@ -147,7 +147,7 @@ describe("UsagePanelContent", () => {
         isBillingEnabled={true}
       />,
     );
-    expect(screen.getByText("Add credits to reset")).toBeDefined();
+    expect(screen.getByText("Go to billing")).toBeDefined();
   });
 
   it("renders percent used in the usage bar", () => {

--- a/autogpt_platform/frontend/src/app/(platform)/library/components/AgentBriefingPanel/BriefingTabContent.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/components/AgentBriefingPanel/BriefingTabContent.tsx
@@ -73,7 +73,7 @@ function UsageSection() {
         <div className="flex-1" />
         {isBillingEnabled && (
           <Link
-            href="/profile/credits"
+            href="/settings/billing"
             className="text-sm text-blue-600 hover:underline"
           >
             Manage billing
@@ -279,7 +279,7 @@ function UsageFooter({
       )}
       {showAddCredits && (
         <Link
-          href="/profile/credits"
+          href="/settings/billing"
           className="inline-flex items-center justify-center rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90"
         >
           Add credits to reset


### PR DESCRIPTION
### Why / What / How

**Why.** Three bugs, one PR — all rooted in the onboarding wizard's lack of persistence:

1. **422 on `/api/onboarding/profile` mid-wizard.** The wizard store was in-memory and `useOnboardingPage`'s init effect called `reset()` on every mount. A user who refreshed mid-flow (or navigated to `?step=4` directly) hit the SubscriptionStep with empty `name` / `role`; clicking *Get Pro* / *Upgrade to Max* advanced to Preparing, which POSTed empty `user_name` / `user_role` and got rejected with `string_too_short`.
2. **LOCAL crash on plan select.** The Stripe checkout path is unconditional. On `BEHAVE_AS=LOCAL` the backend has no Stripe wiring, so plan selection blew up trying to start a Checkout session.
3. **Welcome detour after completion.** `handlePreparingComplete` and `checkCompletion` called `reset()`, which set `currentStep=1` after `router.replace("/copilot")` had already been queued. The URL-sync effect then fired a second `router.replace("/onboarding?step=1")` that won, stranding the user on Welcome until they refreshed.

**What.**
- Wrap the wizard store with `zustand/middleware`'s `persist` (sessionStorage, matches the existing `STEP_STORAGE_KEY` ceiling). `partialize` excludes `currentStep` — the URL stays the source of truth for which step the user is on.
- Drop the unconditional `reset()` from the init effect so persisted form data survives refreshes.
- Replace `reset()` with `useOnboardingWizardStore.persist.clearStorage()` on completion paths to clean storage without mutating in-memory state (no spurious re-render, no URL-sync race).
- Short-circuit `handlePlanSelect` on `environment.isLocal()` to skip the profile POST + Stripe Checkout and advance straight to Preparing; cloud path is unchanged.

**How.**
- `store.ts` — `persist(...)` with SSR-safe `createJSONStorage` (no-op stub during SSR/vitest), `partialize` exposing only the form fields. `version: 1` so future schema changes have a migration anchor.
- `useOnboardingPage.ts` — remove `reset()` from init effect; swap completion-path `reset()` calls for `persist.clearStorage()`. Comment block explains the URL-sync race so the next reader doesn't reintroduce it.
- `useSubscriptionStep.ts` — early-return on `environment.isLocal()` after the TEAM/inflight guards, before any Stripe code.
- Tests:
  - `page.test.tsx` — regression test that pre-set form data isn't wiped on mount (the bug the persist change fixes).
  - `SubscriptionStep.test.tsx` — `vi.spyOn(environment, "isLocal").mockReturnValue(false)` in `beforeEach` so existing Stripe-path tests stay in cloud mode; new test flips it `true` and asserts no Stripe / profile request fires and `currentStep` advances to 5.

### Changes 🏗️

- `autogpt_platform/frontend/src/app/(no-navbar)/onboarding/store.ts` — `zustand/middleware`'s `persist` with sessionStorage + `partialize` excluding `currentStep`.
- `autogpt_platform/frontend/src/app/(no-navbar)/onboarding/useOnboardingPage.ts` — drop `reset()` from init; switch completion `reset()` to `persist.clearStorage()`.
- `autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/useSubscriptionStep.ts` — early-return on `environment.isLocal()` to skip Stripe.
- `autogpt_platform/frontend/src/app/(no-navbar)/onboarding/__tests__/page.test.tsx` — new "preserves form data on mount" regression test.
- `autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/__tests__/SubscriptionStep.test.tsx` — force cloud mode in `beforeEach`; add LOCAL bypass test.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [ ] On `BEHAVE_AS=LOCAL`: complete onboarding through Welcome → Role → PainPoints → Subscription, click *Get Pro* → no Stripe Checkout, lands on Preparing, then `/copilot` (no Welcome bounce, no refresh needed). Repeat with *Upgrade to Max*.
  - [ ] On `BEHAVE_AS=LOCAL`: click *Contact sales* (Team) → Tally form opens in new tab; wizard stays on step 4.
  - [ ] On `BEHAVE_AS=CLOUD`: existing Stripe Checkout flow unchanged — *Get Pro* / *Upgrade to Max* redirect to Stripe with the right `success_url` / `cancel_url`; success returns to `?step=5&subscription=success` and lands on `/copilot`; cancel returns to `?step=4&subscription=cancelled`.
  - [ ] Mid-wizard refresh on step 4 with `payments` flag enabled: name / role / pain points stay filled in (no 422, no re-fill required).
  - [ ] Direct nav to `/onboarding?step=4` without prior data: clamps back to the highest reached step (or step 1 on a fresh session) — no fast-forward into Subscription.
  - [ ] Returning user with `VISIT_COPILOT` already complete: redirects to `/copilot` cleanly with no Welcome flash.

#### For configuration changes:

- [x] `.env.default` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes
