### PR TITLE
fix(backend): default new users to NO_TIER instead of PRO

### DIFF
--- a/autogpt_platform/backend/backend/data/model.py
+++ b/autogpt_platform/backend/backend/data/model.py
@@ -72,7 +72,7 @@ class User(BaseModel):
         None, description="Top up configuration"
     )
     subscription_tier: SubscriptionTier = Field(
-        default=SubscriptionTier.BASIC, description="User subscription tier"
+        default=SubscriptionTier.NO_TIER, description="User subscription tier"
     )
 
     # Notification preferences
@@ -148,7 +148,7 @@ class User(BaseModel):
             integrations=prisma_user.integrations or "",
             stripe_customer_id=prisma_user.stripeCustomerId,
             top_up_config=top_up_config,
-            subscription_tier=prisma_user.subscriptionTier or SubscriptionTier.BASIC,
+            subscription_tier=prisma_user.subscriptionTier or SubscriptionTier.NO_TIER,
             max_emails_per_day=prisma_user.maxEmailsPerDay or 3,
             notify_on_agent_run=prisma_user.notifyOnAgentRun or True,
             notify_on_zero_balance=prisma_user.notifyOnZeroBalance or True,

--- a/autogpt_platform/backend/migrations/20260501172500_default_new_users_to_no_tier/migration.sql
+++ b/autogpt_platform/backend/migrations/20260501172500_default_new_users_to_no_tier/migration.sql
@@ -1,0 +1,3 @@
+-- Change the column default for new user rows from PRO to NO_TIER.
+-- Existing rows are NOT modified — all historical PRO rows remain untouched.
+ALTER TABLE "User" ALTER COLUMN "subscriptionTier" SET DEFAULT 'NO_TIER';

--- a/autogpt_platform/backend/schema.prisma
+++ b/autogpt_platform/backend/schema.prisma
@@ -40,14 +40,7 @@ model User {
 
   timezone String @default("not-set")
 
-  // CoPilot subscription tier — controls rate-limit multipliers.
-  // Multipliers applied in get_global_rate_limits(): BASIC=1x, PRO=5x, MAX=20x, BUSINESS=60x, ENTERPRISE=60x.
-  // NOTE: @default(PRO) is intentional for the beta period — all existing and new
-  // users receive PRO-level (5x) rate limits by default. The Python-level constant
-  // DEFAULT_TIER=BASIC (in copilot/rate_limit.py) acts as a code-level fallback when
-  // the DB value is NULL or unrecognised. At GA, a migration will flip the column
-  // default to BASIC and batch-update users to their billing-derived tiers.
-  subscriptionTier SubscriptionTier @default(PRO)
+  subscriptionTier SubscriptionTier @default(NO_TIER)
 
   // Relations
 


### PR DESCRIPTION
### Why / What / How

**Why:** New users signing up on the platform currently receive a `PRO` subscription tier by default — a holdover from the beta period. This gives free, unrestricted access to all platform features without ever hitting a paywall. SECRT-2295 requires closing this gap so new signups land on `NO_TIER` and are prompted to subscribe.

**What:** Changes the default subscription tier for newly created users from `PRO` to `NO_TIER` across the database schema, migration, and Python model fallbacks. Existing users are **not** affected — their tier remains whatever it already is.

**How:**
- Updates the Prisma schema `@default(PRO)` → `@default(NO_TIER)` on the `User.subscriptionTier` column
- Adds a DDL-only migration (`ALTER COLUMN SET DEFAULT 'NO_TIER'`) that touches zero rows and acquires only a microsecond metadata lock
- Updates two Python-side fallback defaults in `model.py` from `BASIC` → `NO_TIER` to stay consistent with the DB
- The existing beta fallback in `rate_limit.py` already handles `NO_TIER` users gracefully (maps to `BASIC` multiplier when `ENABLE_PLATFORM_PAYMENT` flag is off)

### Changes 🏗️

- **`schema.prisma`**: Removed stale 7-line beta comment block, changed `@default(PRO)` → `@default(NO_TIER)` on `subscriptionTier`
- **`migrations/20260501172500_default_new_users_to_no_tier/migration.sql`**: New DDL-only migration — `ALTER TABLE "User" ALTER COLUMN "subscriptionTier" SET DEFAULT 'NO_TIER'`
- **`backend/data/model.py`**: Updated two fallback defaults from `SubscriptionTier.BASIC` → `SubscriptionTier.NO_TIER` (field default on line 75, `from_db()` fallback on line 151)

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Signed up a new user (`horses@ntindle.com`) on local dev stack and confirmed `subscriptionTier = NO_TIER` in the database
  - [x] Verified existing users retain their current tier (no row-level changes in migration)
  - [x] Confirmed rate_limit.py beta fallback maps NO_TIER → BASIC multiplier when payment flag is off
  - [x] CI pipeline validation (backend tests, lint, type checks)

#### For configuration changes:

- [x] `.env.default` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes
- [x] I have included a list of my configuration changes in the PR description (under **Changes**)

No configuration changes required — this is a schema default + Python fallback change only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the default `User.subscriptionTier` at both DB and application layers, which can affect entitlement/rate-limit behavior for all newly created accounts. Low implementation complexity, but it touches subscription gating assumptions and signup flows.
> 
> **Overview**
> Newly created users now default to `SubscriptionTier.NO_TIER` instead of a paid tier.
> 
> This updates the Prisma schema default for `User.subscriptionTier`, adds a DDL-only migration to set the Postgres column default to `'NO_TIER'` without modifying existing rows, and aligns Python-side fallbacks in `backend/data/model.py` (field default + `from_db()` fallback) to `NO_TIER`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3764e8f94de0702c6684a81089f7797b5fd02cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->