### PR TITLE
refactor(frontend): remove Compare plans link from billing YourPlanCard

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/SubscriptionTab/YourPlanCard/YourPlanCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/SubscriptionTab/YourPlanCard/YourPlanCard.tsx
@@ -15,8 +15,6 @@ import {
 } from "../../../helpers";
 import { useYourPlanCard } from "./useYourPlanCard";
 
-const PRICING_PAGE_URL = "https://agpt.co/pricing";
-
 interface Props {
   index?: number;
 }
@@ -53,18 +51,6 @@ export function YourPlanCard({ index = 0 }: Props) {
         <Text variant="body-medium" as="span" className="text-textBlack">
           Your plan
         </Text>
-        <a
-          href={PRICING_PAGE_URL}
-          target="_blank"
-          rel="noopener noreferrer"
-          aria-label="Compare plans on the AutoGPT pricing page"
-          className="inline-flex items-center gap-1 text-zinc-500 hover:text-violet-700"
-        >
-          <Text variant="small" as="span">
-            Compare plans
-          </Text>
-          <ArrowSquareOutIcon size={14} aria-hidden="true" />
-        </a>
       </div>
 
       <div className="flex flex-wrap items-center justify-between gap-4 rounded-[18px] border border-zinc-200 bg-white p-5 shadow-[0_1px_2px_rgba(15,15,20,0.04)]">


### PR DESCRIPTION
## Why

The "Compare plans" link on the billing settings page (next to "Your plan" in the SubscriptionTab > YourPlanCard) was redundant — users already see their current plan and can upgrade/downgrade directly from the same card. The external link to `agpt.co/pricing` added noise without adding value.

## What

- Removed the "Compare plans" anchor link (and accompanying external-link icon) from the `Your plan` header inside `YourPlanCard`.
- Removed the now-unused `PRICING_PAGE_URL` constant.
- Kept the `ArrowSquareOutIcon` import — still used by the "Talk to sales" upgrade button.

## How

Single-file change in `autogpt_platform/frontend/src/app/(platform)/settings/billing/components/SubscriptionTab/YourPlanCard/YourPlanCard.tsx`:

- Dropped the `<a>` element that wrapped "Compare plans" + the external icon.
- The header `<div>` now contains only the "Your plan" label.

## Test plan

- [ ] Navigate to `/settings/billing` and confirm the "Compare plans" link no longer renders next to "Your plan".
- [ ] Verify the rest of `YourPlanCard` (plan label, badge, manage/upgrade/downgrade buttons) still renders correctly for free, paid, pending-cancel, and pending-downgrade states.
- [ ] `pnpm types` / `pnpm lint` clean.
