### PR TITLE
fix(frontend): settings v2 QA pass — dialog padding, billing tab restore, auto-refill defaults

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/settings/account/components/TimezoneCard/TimezoneCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/account/components/TimezoneCard/TimezoneCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ClockIcon, InfoIcon } from "@phosphor-icons/react";
+import { InfoIcon } from "@phosphor-icons/react";
 import { motion, useReducedMotion } from "framer-motion";
 
 import { Select } from "@/components/atoms/Select/Select";
@@ -11,12 +11,7 @@ import {
   TooltipTrigger,
 } from "@/components/atoms/Tooltip/BaseTooltip";
 
-import {
-  EASE_OUT,
-  TIMEZONES,
-  findTimezoneLabel,
-  formatGmtOffset,
-} from "../../helpers";
+import { EASE_OUT, TIMEZONES, findTimezoneLabel } from "../../helpers";
 
 interface Props {
   value: string;
@@ -26,7 +21,6 @@ interface Props {
 
 export function TimezoneCard({ value, onChange, index = 0 }: Props) {
   const reduceMotion = useReducedMotion();
-  const offset = formatGmtOffset(value);
 
   const options = TIMEZONES.some((t) => t.value === value)
     ? TIMEZONES
@@ -69,31 +63,17 @@ export function TimezoneCard({ value, onChange, index = 0 }: Props) {
             </Tooltip>
           </div>
 
-          <div className="flex h-fit items-center gap-2">
-            <Select
-              id="timezone"
-              label="Timezone"
-              hideLabel
-              value={value}
-              onValueChange={onChange}
-              options={options}
-              placeholder="Select your timezone"
-              size="small"
-              wrapperClassName="!mb-0 w-fit"
-            />
-            {offset ? (
-              <div className="flex h-fit shrink-0 items-center gap-1.5 rounded-full border border-zinc-200 bg-zinc-50 px-3 py-1.5 tabular-nums text-zinc-600">
-                <ClockIcon size={14} weight="duotone" />
-                <Text
-                  variant="small-medium"
-                  as="span"
-                  className="text-zinc-600"
-                >
-                  {offset}
-                </Text>
-              </div>
-            ) : null}
-          </div>
+          <Select
+            id="timezone"
+            label="Timezone"
+            hideLabel
+            value={value}
+            onValueChange={onChange}
+            options={options}
+            placeholder="Select your timezone"
+            size="small"
+            wrapperClassName="!mb-0 w-fit"
+          />
         </div>
       </div>
     </motion.section>

--- a/autogpt_platform/frontend/src/app/(platform)/settings/account/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/account/helpers.ts
@@ -273,17 +273,3 @@ export const TIMEZONES = TIMEZONE_LIST;
 export function findTimezoneLabel(value: string): string {
   return TIMEZONES.find((t) => t.value === value)?.label ?? value;
 }
-
-export function formatGmtOffset(timezone: string): string | null {
-  try {
-    const formatter = new Intl.DateTimeFormat("en-US", {
-      timeZone: timezone,
-      timeZoneName: "shortOffset",
-    });
-    const parts = formatter.formatToParts(new Date());
-    const offset = parts.find((p) => p.type === "timeZoneName")?.value;
-    return offset ?? null;
-  } catch {
-    return null;
-  }
-}

--- a/autogpt_platform/frontend/src/app/(platform)/settings/billing/__tests__/billing-hooks.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/billing/__tests__/billing-hooks.test.tsx
@@ -323,6 +323,85 @@ describe("useAutoRefillCard", () => {
     // Mutation never started.
     expect(result.current.isSaving).toBe(false);
   });
+
+  it("opening the dialog with no saved config pre-fills $5/$5 so the form is valid by default", async () => {
+    server.use(
+      jsonHandler("get", "/api/credits/auto-top-up", {
+        amount: 0,
+        threshold: 0,
+      }),
+    );
+
+    const { result } = renderHook(() => useAutoRefillCard(), {
+      wrapper: makeWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => result.current.setOpen(true));
+
+    // Empty-state copy in the dialog says "min $5"; defaults must match.
+    await waitFor(() => {
+      expect(result.current.threshold).toBe("5");
+      expect(result.current.refillAmount).toBe("5");
+      expect(result.current.isValid).toBe(true);
+    });
+  });
+
+  it("opening the dialog with saved config pre-fills the saved threshold and refill amount", async () => {
+    server.use(
+      jsonHandler("get", "/api/credits/auto-top-up", {
+        amount: 2000,
+        threshold: 750,
+      }),
+    );
+
+    const { result } = renderHook(() => useAutoRefillCard(), {
+      wrapper: makeWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => result.current.setOpen(true));
+
+    await waitFor(() => {
+      // 750 cents → $7.50; 2000 cents → $20.
+      expect(result.current.threshold).toBe("7.5");
+      expect(result.current.refillAmount).toBe("20");
+    });
+  });
+
+  it("does not clobber in-progress edits if the dialog is re-opened without first closing", async () => {
+    server.use(
+      jsonHandler("get", "/api/credits/auto-top-up", {
+        amount: 0,
+        threshold: 0,
+      }),
+    );
+
+    const { result } = renderHook(() => useAutoRefillCard(), {
+      wrapper: makeWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => result.current.setOpen(true));
+    await waitFor(() => expect(result.current.threshold).toBe("5"));
+
+    // User starts editing — increases the threshold beyond the default.
+    act(() => {
+      result.current.setThreshold("25");
+      result.current.setRefillAmount("50");
+    });
+
+    // Re-trigger the open=true effect by toggling open again WITHOUT closing
+    // (e.g. another effect fires while open). Defaults must NOT overwrite
+    // the user's in-progress edits.
+    act(() => result.current.setOpen(true));
+
+    expect(result.current.threshold).toBe("25");
+    expect(result.current.refillAmount).toBe("50");
+  });
 });
 
 describe("usePaymentMethodCard", () => {

--- a/autogpt_platform/frontend/src/app/(platform)/settings/billing/__tests__/billing-page.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/billing/__tests__/billing-page.test.tsx
@@ -160,6 +160,51 @@ describe("Settings billing page (integration)", () => {
     );
   });
 
+  it("activates the Automation Credits tab when a Stripe topup redirect lands on the page", async () => {
+    useDefaultBillingHandlers();
+    server.use(
+      http.patch("*/api/credits/fulfill_checkout", () =>
+        HttpResponse.json({}, { status: 200 }),
+      ),
+    );
+    // Topup flow originates from the Automation Credits tab; the redirect
+    // back from Stripe must NOT bounce the user to Subscription.
+    mockSearchParams.current = new URLSearchParams({ topup: "success" });
+
+    render(<SettingsBillingPage />);
+
+    const automationCreditsTab = await screen.findByRole("tab", {
+      name: /automation credits/i,
+    });
+    expect(automationCreditsTab.getAttribute("data-state")).toBe("active");
+  });
+
+  it("activates the requested tab when ?tab=automation-credits is present (deep-link)", async () => {
+    useDefaultBillingHandlers();
+    mockSearchParams.current = new URLSearchParams({
+      tab: "automation-credits",
+    });
+
+    render(<SettingsBillingPage />);
+
+    const automationCreditsTab = await screen.findByRole("tab", {
+      name: /automation credits/i,
+    });
+    expect(automationCreditsTab.getAttribute("data-state")).toBe("active");
+  });
+
+  it("ignores an unknown ?tab= value and falls back to the Subscription default", async () => {
+    useDefaultBillingHandlers();
+    mockSearchParams.current = new URLSearchParams({ tab: "bogus" });
+
+    render(<SettingsBillingPage />);
+
+    const subscriptionTab = await screen.findByRole("tab", {
+      name: "Subscription",
+    });
+    expect(subscriptionTab.getAttribute("data-state")).toBe("active");
+  });
+
   it("AutomationCreditsTab renders the ErrorCard when the balance fetch fails", async () => {
     server.use(
       jsonHandler("get", "/api/credits/subscription", SUBSCRIPTION_RESPONSE),

--- a/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/AutomationCreditsTab/AutoRefillCard/AutoRefillDialog.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/AutomationCreditsTab/AutoRefillCard/AutoRefillDialog.tsx
@@ -60,10 +60,15 @@ export function AutoRefillDialog({
             onChange={setRefillAmount}
           />
 
-          <div className="flex items-center gap-2 rounded-[12px] bg-amber-50 px-3 py-2">
-            <WarningIcon size={18} className="shrink-0 text-amber-600" />
+          <div className="flex items-start gap-2 rounded-[12px] bg-amber-50 px-3 py-2">
+            <WarningIcon
+              size={18}
+              className="mt-0.5 shrink-0 text-amber-600"
+            />
             <Text variant="small" as="span" className="text-amber-700">
-              Auto-refill triggers at most once per agent execution.
+              A single agent run can only trigger one auto-refill. Set a refill
+              amount that covers your typical usage so agents don&apos;t pause
+              mid-run.
             </Text>
           </div>
         </div>

--- a/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/AutomationCreditsTab/AutoRefillCard/AutoRefillDialog.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/AutomationCreditsTab/AutoRefillCard/AutoRefillDialog.tsx
@@ -61,10 +61,7 @@ export function AutoRefillDialog({
           />
 
           <div className="flex items-start gap-2 rounded-[12px] bg-amber-50 px-3 py-2">
-            <WarningIcon
-              size={18}
-              className="mt-0.5 shrink-0 text-amber-600"
-            />
+            <WarningIcon size={18} className="mt-0.5 shrink-0 text-amber-600" />
             <Text variant="small" as="span" className="text-amber-700">
               A single agent run can only trigger one auto-refill. Set a refill
               amount that covers your typical usage so agents don&apos;t pause

--- a/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/AutomationCreditsTab/AutoRefillCard/useAutoRefillCard.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/AutomationCreditsTab/AutoRefillCard/useAutoRefillCard.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import {
   useGetV1GetAutoTopUp,
@@ -33,16 +33,23 @@ export function useAutoRefillCard() {
   const [open, setOpen] = useState(false);
   const [threshold, setThreshold] = useState("");
   const [refillAmount, setRefillAmount] = useState("");
+  const initializedForOpenRef = useRef(false);
 
   useEffect(() => {
-    if (open) {
-      // Backend minimum is $5 — pre-fill with the floor so the form is valid
-      // by default and matches the "$5 minimum" copy in the empty state.
-      setThreshold(
-        config?.threshold ? (config.threshold / 100).toString() : "5",
-      );
-      setRefillAmount(config?.amount ? (config.amount / 100).toString() : "5");
+    if (!open) {
+      initializedForOpenRef.current = false;
+      return;
     }
+    // Initialize once per open transition so background refetches (e.g. on
+    // window focus) don't clobber the user's in-progress edits.
+    if (initializedForOpenRef.current) return;
+    initializedForOpenRef.current = true;
+    // Backend minimum is $5 — pre-fill with the floor so the form is valid
+    // by default and matches the "$5 minimum" copy in the empty state.
+    setThreshold(
+      config?.threshold ? (config.threshold / 100).toString() : "5",
+    );
+    setRefillAmount(config?.amount ? (config.amount / 100).toString() : "5");
   }, [open, config]);
 
   const thresholdValue = Number.parseFloat(threshold);

--- a/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/AutomationCreditsTab/AutoRefillCard/useAutoRefillCard.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/AutomationCreditsTab/AutoRefillCard/useAutoRefillCard.ts
@@ -40,6 +40,10 @@ export function useAutoRefillCard() {
       initializedForOpenRef.current = false;
       return;
     }
+    // Wait for the config fetch to settle before locking in defaults —
+    // otherwise opening the dialog mid-load would seed "5/5" and skip
+    // re-hydration when saved config arrives moments later.
+    if (isLoading) return;
     // Initialize once per open transition so background refetches (e.g. on
     // window focus) don't clobber the user's in-progress edits.
     if (initializedForOpenRef.current) return;
@@ -48,7 +52,7 @@ export function useAutoRefillCard() {
     // by default and matches the "$5 minimum" copy in the empty state.
     setThreshold(config?.threshold ? (config.threshold / 100).toString() : "5");
     setRefillAmount(config?.amount ? (config.amount / 100).toString() : "5");
-  }, [open, config]);
+  }, [open, config, isLoading]);
 
   const thresholdValue = Number.parseFloat(threshold);
   const refillValue = Number.parseFloat(refillAmount);

--- a/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/AutomationCreditsTab/AutoRefillCard/useAutoRefillCard.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/AutomationCreditsTab/AutoRefillCard/useAutoRefillCard.ts
@@ -46,9 +46,7 @@ export function useAutoRefillCard() {
     initializedForOpenRef.current = true;
     // Backend minimum is $5 — pre-fill with the floor so the form is valid
     // by default and matches the "$5 minimum" copy in the empty state.
-    setThreshold(
-      config?.threshold ? (config.threshold / 100).toString() : "5",
-    );
+    setThreshold(config?.threshold ? (config.threshold / 100).toString() : "5");
     setRefillAmount(config?.amount ? (config.amount / 100).toString() : "5");
   }, [open, config]);
 

--- a/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/AutomationCreditsTab/AutoRefillCard/useAutoRefillCard.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/AutomationCreditsTab/AutoRefillCard/useAutoRefillCard.ts
@@ -36,10 +36,12 @@ export function useAutoRefillCard() {
 
   useEffect(() => {
     if (open) {
+      // Backend minimum is $5 — pre-fill with the floor so the form is valid
+      // by default and matches the "$5 minimum" copy in the empty state.
       setThreshold(
-        config?.threshold ? (config.threshold / 100).toString() : "",
+        config?.threshold ? (config.threshold / 100).toString() : "5",
       );
-      setRefillAmount(config?.amount ? (config.amount / 100).toString() : "");
+      setRefillAmount(config?.amount ? (config.amount / 100).toString() : "5");
     }
   }, [open, config]);
 

--- a/autogpt_platform/frontend/src/app/(platform)/settings/billing/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/billing/page.tsx
@@ -22,11 +22,13 @@ import { SubscriptionTab } from "./components/SubscriptionTab/SubscriptionTab";
 
 type BillingTab = "subscription" | "automation-credits";
 
+function isBillingTab(value: string): value is BillingTab {
+  return value === "subscription" || value === "automation-credits";
+}
+
 function resolveInitialTab(searchParams: URLSearchParams): BillingTab {
   const tabParam = searchParams.get("tab");
-  if (tabParam === "automation-credits" || tabParam === "subscription") {
-    return tabParam;
-  }
+  if (tabParam && isBillingTab(tabParam)) return tabParam;
   // Topup flow only originates from the Automation Credits tab — when Stripe
   // redirects back, return the user to where they started instead of the
   // Subscription default.
@@ -46,6 +48,10 @@ export default function SettingsBillingPage() {
   const [activeTab, setActiveTab] = useState<BillingTab>(() =>
     resolveInitialTab(searchParams),
   );
+
+  function handleTabChange(value: string) {
+    if (isBillingTab(value)) setActiveTab(value);
+  }
 
   useEffect(function setBillingDocumentTitle() {
     document.title = "Billing – AutoGPT Platform";
@@ -116,10 +122,7 @@ export default function SettingsBillingPage() {
         Billing
       </Text>
 
-      <TabsLine
-        value={activeTab}
-        onValueChange={(value) => setActiveTab(value as BillingTab)}
-      >
+      <TabsLine value={activeTab} onValueChange={handleTabChange}>
         <TabsLineList flush className="ml-4 overflow-x-auto">
           <TabsLineTrigger value="subscription">Subscription</TabsLineTrigger>
           <TabsLineTrigger value="automation-credits">

--- a/autogpt_platform/frontend/src/app/(platform)/settings/billing/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/billing/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useQueryClient } from "@tanstack/react-query";
 
@@ -20,6 +20,20 @@ import {
 import { AutomationCreditsTab } from "./components/AutomationCreditsTab/AutomationCreditsTab";
 import { SubscriptionTab } from "./components/SubscriptionTab/SubscriptionTab";
 
+type BillingTab = "subscription" | "automation-credits";
+
+function resolveInitialTab(searchParams: URLSearchParams): BillingTab {
+  const tabParam = searchParams.get("tab");
+  if (tabParam === "automation-credits" || tabParam === "subscription") {
+    return tabParam;
+  }
+  // Topup flow only originates from the Automation Credits tab — when Stripe
+  // redirects back, return the user to where they started instead of the
+  // Subscription default.
+  if (searchParams.get("topup")) return "automation-credits";
+  return "subscription";
+}
+
 export default function SettingsBillingPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -29,6 +43,9 @@ export default function SettingsBillingPage() {
   const { mutateAsync: fulfillCheckout } = usePatchV1FulfillCheckoutSession();
   const handledTopupRef = useRef<string | null>(null);
   const handledSubscriptionRef = useRef<string | null>(null);
+  const [activeTab, setActiveTab] = useState<BillingTab>(() =>
+    resolveInitialTab(searchParams),
+  );
 
   useEffect(function setBillingDocumentTitle() {
     document.title = "Billing – AutoGPT Platform";
@@ -99,7 +116,10 @@ export default function SettingsBillingPage() {
         Billing
       </Text>
 
-      <TabsLine defaultValue="subscription">
+      <TabsLine
+        value={activeTab}
+        onValueChange={(value) => setActiveTab(value as BillingTab)}
+      >
         <TabsLineList flush className="ml-4 overflow-x-auto">
           <TabsLineTrigger value="subscription">Subscription</TabsLineTrigger>
           <TabsLineTrigger value="automation-credits">

--- a/autogpt_platform/frontend/src/app/(platform)/settings/integrations/components/ConnectServiceDialog/ConnectServiceDialog.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/integrations/components/ConnectServiceDialog/ConnectServiceDialog.tsx
@@ -71,7 +71,7 @@ export function ConnectServiceDialog({ open, onOpenChange }: Props) {
       <Dialog.Content>
         <MotionConfig transition={TRANSITION}>
           <motion.div
-            className="relative overflow-hidden"
+            className="relative overflow-hidden px-2"
             animate={{ height: contentHeight ?? "auto" }}
             transition={reduceMotion ? { duration: 0 } : HEIGHT_TRANSITION}
           >

--- a/autogpt_platform/frontend/src/app/(platform)/settings/integrations/components/IntegrationsHeader/IntegrationsHeader.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/integrations/components/IntegrationsHeader/IntegrationsHeader.tsx
@@ -18,7 +18,7 @@ export function IntegrationsHeader({ onConnect }: Props) {
         <Text variant="body" className="mt-4 max-w-[600px] text-[#505057]">
           Manage the 3rd party accounts you&apos;ve connected to AutoGPT. These
           are services that can be used by your agents — like Gmail for sending
-          emails, GitHub for code, or Figma for designs.
+          emails, GitHub for code, or Notion for documents.
         </Text>
       </div>
 

--- a/autogpt_platform/frontend/src/app/(platform)/settings/profile/__tests__/main.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/profile/__tests__/main.test.tsx
@@ -479,6 +479,34 @@ describe("SettingsProfilePage - save & discard", () => {
     });
   });
 
+  test("background refetch with unchanged server data does not clobber in-progress link edits", async () => {
+    server.use(getGetV2GetUserProfileMockHandler200(makeProfile()));
+
+    render(<SettingsProfilePage />);
+
+    const link = (await screen.findByLabelText(
+      /^link 1$/i,
+    )) as HTMLInputElement;
+
+    // User edits a link.
+    fireEvent.change(link, { target: { value: "https://edited.dev" } });
+    expect(link.value).toBe("https://edited.dev");
+
+    // Simulate a background refetch returning the SAME server data — this
+    // used to regenerate LinkRow IDs and replace state, wiping the edit
+    // and triggering a row exit/enter flash.
+    server.use(getGetV2GetUserProfileMockHandler200(makeProfile()));
+    fireEvent(window, new Event("focus"));
+
+    // Wait a tick to let any refetch effect run, then assert the edit
+    // survived.
+    await waitFor(() => {
+      expect(
+        (screen.getByLabelText(/^link 1$/i) as HTMLInputElement).value,
+      ).toBe("https://edited.dev");
+    });
+  });
+
   test("Save shows a destructive toast on a 422", async () => {
     server.use(
       getGetV2GetUserProfileMockHandler200(makeProfile()),

--- a/autogpt_platform/frontend/src/app/(platform)/settings/profile/__tests__/main.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/profile/__tests__/main.test.tsx
@@ -479,6 +479,43 @@ describe("SettingsProfilePage - save & discard", () => {
     });
   });
 
+  test("Discard restores the row in place (no remount → no AnimatePresence flash)", async () => {
+    server.use(
+      getGetV2GetUserProfileMockHandler200(
+        makeProfile({ links: ["https://a.dev", "https://b.dev"] }),
+      ),
+    );
+
+    render(<SettingsProfilePage />);
+
+    const link1Before = (await screen.findByLabelText(
+      /^link 1$/i,
+    )) as HTMLInputElement;
+    // Capture the input element identity. If Discard re-keys the row,
+    // AnimatePresence remounts it and this reference becomes a stale node.
+    const link1Node = link1Before;
+
+    // Trigger a background refetch with the same data — this used to
+    // regenerate link IDs via makeLinkRow() and cause Discard to remount
+    // every row.
+    server.use(
+      getGetV2GetUserProfileMockHandler200(
+        makeProfile({ links: ["https://a.dev", "https://b.dev"] }),
+      ),
+    );
+    fireEvent(window, new Event("focus"));
+
+    fireEvent.change(link1Before, { target: { value: "https://edited.dev" } });
+    fireEvent.click(screen.getByRole("button", { name: /discard/i }));
+
+    await waitFor(() => {
+      expect(link1Node.value).toBe("https://a.dev");
+    });
+    // The original input node is still in the document — it was never
+    // unmounted/remounted by Discard.
+    expect(link1Node.isConnected).toBe(true);
+  });
+
   test("background refetch with unchanged server data does not clobber in-progress link edits", async () => {
     server.use(getGetV2GetUserProfileMockHandler200(makeProfile()));
 

--- a/autogpt_platform/frontend/src/app/(platform)/settings/profile/useProfilePage.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/profile/useProfilePage.ts
@@ -56,12 +56,20 @@ export function useProfilePage() {
 
   const [formState, setFormState] = useState<ProfileFormState>(EMPTY_FORM);
   const lastSyncedRef = useRef<ProfileFormState>(EMPTY_FORM);
+  const hasHydratedRef = useRef(false);
 
   useEffect(
     function syncFormStateOnDataLoad() {
       if (!profileQuery.data) return;
       const incoming = profileToFormState(profileQuery.data);
       setFormState((prev) => {
+        // First load always hydrates — even when the server returns an empty
+        // profile, we need the padded link slots in formState to render.
+        if (!hasHydratedRef.current) {
+          hasHydratedRef.current = true;
+          lastSyncedRef.current = incoming;
+          return incoming;
+        }
         if (!isFormDirty(incoming, prev)) {
           lastSyncedRef.current = incoming;
           return prev;

--- a/autogpt_platform/frontend/src/app/(platform)/settings/profile/useProfilePage.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/profile/useProfilePage.ts
@@ -58,9 +58,9 @@ export function useProfilePage() {
 
   useEffect(
     function syncFormStateOnDataLoad() {
-      if (profileQuery.data) {
-        setFormState(profileToFormState(profileQuery.data));
-      }
+      if (!profileQuery.data) return;
+      const incoming = profileToFormState(profileQuery.data);
+      setFormState((prev) => (isFormDirty(incoming, prev) ? incoming : prev));
     },
     [profileQuery.data],
   );

--- a/autogpt_platform/frontend/src/app/(platform)/settings/profile/useProfilePage.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/profile/useProfilePage.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 
 import {
@@ -55,12 +55,23 @@ export function useProfilePage() {
   );
 
   const [formState, setFormState] = useState<ProfileFormState>(EMPTY_FORM);
+  const lastSyncedRef = useRef<ProfileFormState>(EMPTY_FORM);
 
   useEffect(
     function syncFormStateOnDataLoad() {
       if (!profileQuery.data) return;
       const incoming = profileToFormState(profileQuery.data);
-      setFormState((prev) => (isFormDirty(incoming, prev) ? incoming : prev));
+      setFormState((prev) => {
+        if (!isFormDirty(incoming, prev)) {
+          lastSyncedRef.current = incoming;
+          return prev;
+        }
+        // Don't clobber unsaved edits on background refetches — only hydrate
+        // when the local form is still pristine relative to the last sync.
+        if (isFormDirty(lastSyncedRef.current, prev)) return prev;
+        lastSyncedRef.current = incoming;
+        return incoming;
+      });
     },
     [profileQuery.data],
   );

--- a/autogpt_platform/frontend/src/app/(platform)/settings/profile/useProfilePage.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/profile/useProfilePage.ts
@@ -55,31 +55,40 @@ export function useProfilePage() {
   );
 
   const [formState, setFormState] = useState<ProfileFormState>(EMPTY_FORM);
+  const formStateRef = useRef<ProfileFormState>(EMPTY_FORM);
   const lastSyncedRef = useRef<ProfileFormState>(EMPTY_FORM);
   const hasHydratedRef = useRef(false);
+
+  useEffect(() => {
+    formStateRef.current = formState;
+  }, [formState]);
 
   useEffect(
     function syncFormStateOnDataLoad() {
       if (!profileQuery.data) return;
       const incoming = profileToFormState(profileQuery.data);
-      setFormState((prev) => {
-        // First load always hydrates — even when the server returns an empty
-        // profile, we need the padded link slots in formState to render.
-        if (!hasHydratedRef.current) {
-          hasHydratedRef.current = true;
-          lastSyncedRef.current = incoming;
-          return incoming;
-        }
-        if (!isFormDirty(incoming, prev)) {
-          lastSyncedRef.current = incoming;
-          return prev;
-        }
-        // Don't clobber unsaved edits on background refetches — only hydrate
-        // when the local form is still pristine relative to the last sync.
-        if (isFormDirty(lastSyncedRef.current, prev)) return prev;
+      const prev = formStateRef.current;
+
+      // First load always hydrates — even when the server returns an empty
+      // profile, we need the padded link slots in formState to render.
+      if (!hasHydratedRef.current) {
+        hasHydratedRef.current = true;
         lastSyncedRef.current = incoming;
-        return incoming;
-      });
+        setFormState(incoming);
+        return;
+      }
+      // Refetch returned the same content as the local form — keep prev to
+      // preserve link IDs (avoids a row exit/enter flash) and refresh the
+      // synced snapshot so future dirty checks compare against the latest.
+      if (!isFormDirty(incoming, prev)) {
+        lastSyncedRef.current = incoming;
+        return;
+      }
+      // User has edits relative to the last synced snapshot — never clobber.
+      if (isFormDirty(lastSyncedRef.current, prev)) return;
+      // Form pristine, server data changed — hydrate with the new snapshot.
+      lastSyncedRef.current = incoming;
+      setFormState(incoming);
     },
     [profileQuery.data],
   );

--- a/autogpt_platform/frontend/src/app/(platform)/settings/profile/useProfilePage.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/profile/useProfilePage.ts
@@ -48,13 +48,13 @@ export function useProfilePage() {
     },
   });
 
-  const initialState: ProfileFormState = useMemo(
-    () =>
-      profileQuery.data ? profileToFormState(profileQuery.data) : EMPTY_FORM,
-    [profileQuery.data],
-  );
-
   const [formState, setFormState] = useState<ProfileFormState>(EMPTY_FORM);
+  // Pristine baseline for dirty detection + Discard. Held as state (not a
+  // ref) so dirty re-derives when it changes; pinned to the current
+  // formState's link IDs on every sync so Discard never swaps IDs and
+  // triggers an AnimatePresence flash.
+  const [pristineState, setPristineState] =
+    useState<ProfileFormState>(EMPTY_FORM);
   const formStateRef = useRef<ProfileFormState>(EMPTY_FORM);
   const lastSyncedRef = useRef<ProfileFormState>(EMPTY_FORM);
   const hasHydratedRef = useRef(false);
@@ -75,6 +75,7 @@ export function useProfilePage() {
         hasHydratedRef.current = true;
         lastSyncedRef.current = incoming;
         setFormState(incoming);
+        setPristineState(incoming);
         return;
       }
       // Refetch returned the same content as the local form — keep prev to
@@ -82,6 +83,10 @@ export function useProfilePage() {
       // synced snapshot so future dirty checks compare against the latest.
       if (!isFormDirty(incoming, prev)) {
         lastSyncedRef.current = incoming;
+        // Pin the pristine baseline to the current formState (with its
+        // existing link IDs) so a subsequent Discard restores the same
+        // rows — not freshly-keyed copies that would re-trigger animations.
+        setPristineState(prev);
         return;
       }
       // User has edits relative to the last synced snapshot — never clobber.
@@ -89,14 +94,15 @@ export function useProfilePage() {
       // Form pristine, server data changed — hydrate with the new snapshot.
       lastSyncedRef.current = incoming;
       setFormState(incoming);
+      setPristineState(incoming);
     },
     [profileQuery.data],
   );
 
   const validation = useMemo(() => validateForm(formState), [formState]);
   const dirty = useMemo(
-    () => isFormDirty(initialState, formState),
-    [initialState, formState],
+    () => isFormDirty(pristineState, formState),
+    [pristineState, formState],
   );
 
   function patchField<K extends keyof ProfileFormState>(
@@ -131,7 +137,7 @@ export function useProfilePage() {
   }
 
   function discardChanges() {
-    setFormState(initialState);
+    setFormState(pristineState);
   }
 
   const uploadMutation = usePostV2UploadSubmissionMedia({
@@ -200,7 +206,6 @@ export function useProfilePage() {
     error: profileQuery.error,
     refetch: profileQuery.refetch,
     formState,
-    initialState,
     patchField,
     setLink,
     addLink,

--- a/autogpt_platform/frontend/src/components/molecules/Dialog/components/DialogWrap.tsx
+++ b/autogpt_platform/frontend/src/components/molecules/Dialog/components/DialogWrap.tsx
@@ -102,7 +102,7 @@ export function DialogWrap({
         }}
       >
         <div
-          className={`flex items-center justify-between ${
+          className={`flex items-center justify-between px-2 ${
             title ? "pb-6" : "pb-0"
           }`}
         >
@@ -130,11 +130,11 @@ export function DialogWrap({
             </Button>
           )}
         </div>
-        <div className="flex min-h-0 flex-1 flex-col">
+        <div className="flex min-h-0 flex-1 flex-col ">
           <div
             ref={scrollRef}
             className={cn(
-              "flex-1 overflow-y-auto overflow-x-hidden",
+              "flex-1 overflow-y-auto overflow-x-hidden px-2",
               scrollbarStyles,
             )}
             style={{

--- a/autogpt_platform/frontend/src/components/molecules/Dialog/components/DialogWrap.tsx
+++ b/autogpt_platform/frontend/src/components/molecules/Dialog/components/DialogWrap.tsx
@@ -130,7 +130,7 @@ export function DialogWrap({
             </Button>
           )}
         </div>
-        <div className="flex min-h-0 flex-1 flex-col ">
+        <div className="flex min-h-0 flex-1 flex-col">
           <div
             ref={scrollRef}
             className={cn(


### PR DESCRIPTION
### Why / What / How

**Why:** A round of QA on the new Settings v2 surfaced several small but visible polish issues — input focus rings being clipped on the right edge of every dialog, the link rows in the Profile page flashing on save, the Billing page bouncing the user back to the Subscription tab after a Stripe topup, the Auto-refill dialog defaulting to an invalid empty state that contradicted its own "$5 minimum" copy, and the Integrations header recommending Figma even though it isn't a connectable provider.

**What:** Frontend-only fix pass that addresses each of those issues at the component level (and the dialog issue at the shared `DialogWrap` level so every dialog benefits).

**How:**

- **Profile save flash** — `useProfilePage` previously rebuilt the form state from scratch every time `useGetV2GetUserProfile` data changed. After save, the refetch generated brand-new `LinkRow` IDs via `makeLinkRow()`, which `<AnimatePresence>` keyed off of, causing every row to exit + re-enter (the "flash"). Now the post-fetch sync skips when the incoming profile is content-equivalent to current form state, preserving link identity and silencing the animation.
- **Dialog focus-ring clipping** — Inputs use `ring-1` (a 1 px box-shadow rendered outside the border). The dialog's scroll container had `overflow-x-hidden` flush against the input edge, chopping off the right side of every focus oval. Added `px-2` to both the dialog title row and the inner scroll container in `DialogWrap`, giving 8 px of horizontal breathing room across all dialogs.
- **ConnectServiceDialog inner clip** — That dialog has its own `overflow-hidden` wrapper (used for the height/slide animation between list and detail views), which clipped focus rings before the new `DialogWrap` padding could help. Added matching `px-2` there.
- **Billing tab restore after Stripe** — `<TabsLine>` was uncontrolled with `defaultValue="subscription"`, so a Stripe topup redirect (`?topup=success|cancel`) always landed users on the Subscription tab even though the topup flow originates from Automation Credits. Made the tab controlled with state initialized from URL params: explicit `?tab=` wins, else `?topup` implies Automation Credits, else fall back to Subscription. Adds deep-link support as a side benefit.
- **Auto-refill defaults + banner copy** — The dialog opened with empty fields (placeholder "min $5") but the form was invalid by default and the existing yellow banner ("Auto-refill triggers at most once per agent execution.") didn't tell users what to do about it. Pre-fill threshold and refill amount with `"5"` so the form is valid by default and matches the empty-state copy; rewrote the banner to: "A single agent run can only trigger one auto-refill. Set a refill amount that covers your typical usage so agents don't pause mid-run."
- **Integrations copy** — Replaced the Figma example in `IntegrationsHeader` with Notion (verified Notion is a real provider in `backend/integrations/providers.py`) so the copy doesn't reference an integration that isn't actually offered in Connect Service.

### Changes 🏗️

- `frontend/src/app/(platform)/settings/profile/useProfilePage.ts` — guard form re-sync on equivalent refetch.
- `frontend/src/components/molecules/Dialog/components/DialogWrap.tsx` — `px-2` on title row and scroll container.
- `frontend/src/app/(platform)/settings/integrations/components/ConnectServiceDialog/ConnectServiceDialog.tsx` — `px-2` on inner animation wrapper.
- `frontend/src/app/(platform)/settings/billing/page.tsx` — controlled tab state with URL-aware initial value.
- `frontend/src/app/(platform)/settings/billing/components/AutomationCreditsTab/AutoRefillCard/useAutoRefillCard.ts` — default to `"5"` when no saved config.
- `frontend/src/app/(platform)/settings/billing/components/AutomationCreditsTab/AutoRefillCard/AutoRefillDialog.tsx` — clearer warning banner, top-aligned icon for multi-line copy.
- `frontend/src/app/(platform)/settings/integrations/components/IntegrationsHeader/IntegrationsHeader.tsx` — "Figma for designs" → "Notion for documents".

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Open `/settings/profile`, edit a link, click Save → no flash on link rows
  - [x] Open Update email dialog, focus the email input → purple focus oval is fully closed on the right
  - [x] Open Connect a service dialog, focus the search input → purple focus oval is fully closed
  - [x] Open Add credits dialog and Auto-refill dialog → focus rings render fully
  - [x] Add credits via Stripe, get redirected back → land on the Automation Credits tab (not Subscription)
  - [x] Open Auto-refill dialog with no prior config → fields show $5 / $5, Save button is enabled
  - [x] Auto-refill dialog yellow banner reads as a clear, actionable instruction
  - [x] Visit `/settings/integrations` → header copy says "Notion for documents", not "Figma for designs"
