### PR TITLE
feat(frontend): vary daily-limit popup CTA by plan (SECRT-2314)

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/RateLimitResetDialog/RateLimitGate.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/RateLimitResetDialog/RateLimitGate.tsx
@@ -1,7 +1,10 @@
 "use client";
 
-import type { CoPilotUsagePublic } from "@/app/api/__generated__/models/coPilotUsagePublic";
 import { useGetV2GetCopilotUsage } from "@/app/api/__generated__/endpoints/chat/chat";
+import { useGetSubscriptionStatus } from "@/app/api/__generated__/endpoints/credits/credits";
+import type { CoPilotUsagePublic } from "@/app/api/__generated__/models/coPilotUsagePublic";
+import type { SubscriptionStatusResponse } from "@/app/api/__generated__/models/subscriptionStatusResponse";
+import type { SubscriptionTier } from "@/app/api/__generated__/models/subscriptionTier";
 import { toast } from "@/components/molecules/Toast/use-toast";
 import { useEffect } from "react";
 import { RateLimitResetDialog } from "./RateLimitResetDialog";
@@ -29,6 +32,19 @@ export function RateLimitGate({ rateLimitMessage, onDismiss }: Props) {
     },
   });
 
+  // Pulls the user's current tier so the dialog can branch the CTA between
+  // "Upgrade plan" (route to /settings/billing) and "Contact us" (top-tier
+  // users have no higher self-serve plan to upgrade to).
+  const { data: tier } = useGetSubscriptionStatus({
+    query: {
+      enabled: !!rateLimitMessage,
+      select: (res) =>
+        res.status === 200
+          ? ((res.data as SubscriptionStatusResponse).tier as SubscriptionTier)
+          : null,
+    },
+  });
+
   useEffect(() => {
     if (!rateLimitMessage) return;
     if (!usageError) return;
@@ -47,6 +63,7 @@ export function RateLimitGate({ rateLimitMessage, onDismiss }: Props) {
       isOpen={isOpen}
       onClose={onDismiss}
       resetsAt={usage?.daily?.resets_at ?? usage?.weekly?.resets_at ?? null}
+      tier={tier ?? null}
     />
   );
 }

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/RateLimitResetDialog/RateLimitResetDialog.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/RateLimitResetDialog/RateLimitResetDialog.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { SubscriptionTier } from "@/app/api/__generated__/models/subscriptionTier";
 import { Button } from "@/components/atoms/Button/Button";
 import { Text } from "@/components/atoms/Text/Text";
 import { Dialog } from "@/components/molecules/Dialog/Dialog";
@@ -10,11 +11,43 @@ interface Props {
   isOpen: boolean;
   onClose: () => void;
   resetsAt?: string | Date | null;
+  tier?: SubscriptionTier | null;
 }
 
-export function RateLimitResetDialog({ isOpen, onClose, resetsAt }: Props) {
+const CONTACT_US_URL = "mailto:contact@agpt.co";
+const BILLING_PATH = "/settings/billing";
+
+// Tiers that have no higher self-serve plan to upgrade to — direct these
+// users to support instead of the billing page.
+const TOP_TIERS: ReadonlySet<SubscriptionTier> = new Set([
+  "MAX",
+  "BUSINESS",
+  "ENTERPRISE",
+]);
+
+export function RateLimitResetDialog({
+  isOpen,
+  onClose,
+  resetsAt,
+  tier,
+}: Props) {
   const router = useRouter();
   const resetTimeLabel = resetsAt ? formatResetTime(resetsAt) : null;
+  const isTopTier = !!tier && TOP_TIERS.has(tier);
+
+  const ctaLabel = isTopTier ? "Contact us" : "Upgrade plan";
+  const bodyTrailer = isTopTier
+    ? "or contact us if you need more capacity."
+    : "or upgrade your plan.";
+
+  function handleCtaClick() {
+    onClose();
+    if (isTopTier) {
+      window.open(CONTACT_US_URL, "_blank", "noopener,noreferrer");
+      return;
+    }
+    router.push(BILLING_PATH);
+  }
 
   return (
     <Dialog
@@ -33,21 +66,15 @@ export function RateLimitResetDialog({ isOpen, onClose, resetsAt }: Props) {
           {resetTimeLabel && resetTimeLabel !== "now"
             ? ` Resets ${resetTimeLabel}.`
             : ""}{" "}
-          You can still browse, edit agents, and view results &mdash; or upgrade
-          your plan.
+          You can still browse, edit agents, and view results &mdash;{" "}
+          {bodyTrailer}
         </Text>
         <Dialog.Footer className="!justify-center">
           <Button variant="secondary" onClick={onClose}>
             Wait for reset
           </Button>
-          <Button
-            variant="primary"
-            onClick={() => {
-              onClose();
-              router.push("/settings/billing");
-            }}
-          >
-            Go to billing
+          <Button variant="primary" onClick={handleCtaClick}>
+            {ctaLabel}
           </Button>
         </Dialog.Footer>
       </Dialog.Content>

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/RateLimitResetDialog/__tests__/RateLimitGate.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/RateLimitResetDialog/__tests__/RateLimitGate.test.tsx
@@ -19,6 +19,12 @@ vi.mock("@/app/api/__generated__/endpoints/chat/chat", () => ({
     mockUseGetV2GetCopilotUsage(...args),
 }));
 
+const mockUseGetSubscriptionStatus = vi.fn();
+vi.mock("@/app/api/__generated__/endpoints/credits/credits", () => ({
+  useGetSubscriptionStatus: (...args: unknown[]) =>
+    mockUseGetSubscriptionStatus(...args),
+}));
+
 // Capture props the dialog was rendered with so we can assert on them.
 const dialogSpy = vi.fn();
 vi.mock("../RateLimitResetDialog", () => ({
@@ -26,6 +32,7 @@ vi.mock("../RateLimitResetDialog", () => ({
     isOpen: boolean;
     onClose: () => void;
     resetsAt?: string | Date | null;
+    tier?: string | null;
   }) => {
     dialogSpy(props);
     return <div data-testid="reset-dialog" data-open={String(props.isOpen)} />;
@@ -38,8 +45,17 @@ afterEach(() => {
   cleanup();
   mockToast.mockReset();
   mockUseGetV2GetCopilotUsage.mockReset();
+  mockUseGetSubscriptionStatus.mockReset();
   dialogSpy.mockReset();
 });
+
+function setSubscription(tier: string | null = null) {
+  mockUseGetSubscriptionStatus.mockReturnValue({
+    data: tier,
+    isSuccess: tier !== null,
+    isError: false,
+  });
+}
 
 describe("RateLimitGate", () => {
   it("disables the usage query when no rate-limit message is present", () => {
@@ -48,6 +64,7 @@ describe("RateLimitGate", () => {
       isSuccess: false,
       isError: false,
     });
+    setSubscription();
 
     render(<RateLimitGate rateLimitMessage={null} onDismiss={vi.fn()} />);
 
@@ -64,6 +81,7 @@ describe("RateLimitGate", () => {
       isSuccess: false,
       isError: false,
     });
+    setSubscription();
 
     render(
       <RateLimitGate
@@ -78,6 +96,23 @@ describe("RateLimitGate", () => {
     expect(config?.query?.enabled).toBe(true);
   });
 
+  it("disables the subscription query when no rate-limit message is present", () => {
+    mockUseGetV2GetCopilotUsage.mockReturnValue({
+      data: undefined,
+      isSuccess: false,
+      isError: false,
+    });
+    setSubscription();
+
+    render(<RateLimitGate rateLimitMessage={null} onDismiss={vi.fn()} />);
+
+    expect(mockUseGetSubscriptionStatus).toHaveBeenCalled();
+    const [config] = mockUseGetSubscriptionStatus.mock.calls[0] as [
+      { query?: { enabled?: boolean } },
+    ];
+    expect(config?.query?.enabled).toBe(false);
+  });
+
   it("opens the reset dialog when usage data is available", () => {
     const future = new Date(Date.now() + 4 * 60 * 60 * 1000).toISOString();
     mockUseGetV2GetCopilotUsage.mockReturnValue({
@@ -85,6 +120,7 @@ describe("RateLimitGate", () => {
       isSuccess: true,
       isError: false,
     });
+    setSubscription("PRO");
 
     render(
       <RateLimitGate rateLimitMessage="limit reached" onDismiss={vi.fn()} />,
@@ -96,6 +132,40 @@ describe("RateLimitGate", () => {
     expect(mockToast).not.toHaveBeenCalled();
   });
 
+  it("forwards the user's subscription tier to the dialog", () => {
+    const future = new Date(Date.now() + 4 * 60 * 60 * 1000).toISOString();
+    mockUseGetV2GetCopilotUsage.mockReturnValue({
+      data: { daily: { percent_used: 100, resets_at: future }, weekly: null },
+      isSuccess: true,
+      isError: false,
+    });
+    setSubscription("MAX");
+
+    render(
+      <RateLimitGate rateLimitMessage="limit reached" onDismiss={vi.fn()} />,
+    );
+
+    const lastProps = dialogSpy.mock.calls.at(-1)?.[0];
+    expect(lastProps.tier).toBe("MAX");
+  });
+
+  it("passes null tier when subscription status is unavailable", () => {
+    const future = new Date(Date.now() + 4 * 60 * 60 * 1000).toISOString();
+    mockUseGetV2GetCopilotUsage.mockReturnValue({
+      data: { daily: { percent_used: 100, resets_at: future }, weekly: null },
+      isSuccess: true,
+      isError: false,
+    });
+    setSubscription(null);
+
+    render(
+      <RateLimitGate rateLimitMessage="limit reached" onDismiss={vi.fn()} />,
+    );
+
+    const lastProps = dialogSpy.mock.calls.at(-1)?.[0];
+    expect(lastProps.tier).toBeNull();
+  });
+
   it("falls back to a toast when usage query errors", () => {
     const onDismiss = vi.fn();
     mockUseGetV2GetCopilotUsage.mockReturnValue({
@@ -103,6 +173,7 @@ describe("RateLimitGate", () => {
       isSuccess: false,
       isError: true,
     });
+    setSubscription();
 
     render(
       <RateLimitGate
@@ -130,6 +201,7 @@ describe("RateLimitGate", () => {
       isSuccess: false,
       isError: true,
     });
+    setSubscription();
 
     render(<RateLimitGate rateLimitMessage={null} onDismiss={vi.fn()} />);
 
@@ -142,6 +214,7 @@ describe("RateLimitGate", () => {
       isSuccess: false,
       isError: false,
     });
+    setSubscription();
 
     render(
       <RateLimitGate rateLimitMessage="limit reached" onDismiss={vi.fn()} />,
@@ -159,6 +232,7 @@ describe("RateLimitGate", () => {
       isSuccess: true,
       isError: false,
     });
+    setSubscription();
 
     render(
       <RateLimitGate rateLimitMessage="limit reached" onDismiss={vi.fn()} />,
@@ -180,6 +254,7 @@ describe("RateLimitGate", () => {
       isSuccess: true,
       isError: false,
     });
+    setSubscription();
 
     render(
       <RateLimitGate rateLimitMessage="limit reached" onDismiss={vi.fn()} />,
@@ -196,6 +271,7 @@ describe("RateLimitGate", () => {
       isSuccess: true,
       isError: false,
     });
+    setSubscription();
 
     render(
       <RateLimitGate rateLimitMessage="limit reached" onDismiss={vi.fn()} />,
@@ -219,6 +295,7 @@ describe("RateLimitGate", () => {
       isSuccess: true,
       isError: false,
     });
+    setSubscription();
 
     render(
       <RateLimitGate rateLimitMessage="limit reached" onDismiss={vi.fn()} />,

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/RateLimitResetDialog/__tests__/RateLimitResetDialog.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/RateLimitResetDialog/__tests__/RateLimitResetDialog.test.tsx
@@ -4,7 +4,7 @@ import {
   screen,
   fireEvent,
 } from "@/tests/integrations/test-utils";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockPush = vi.fn();
 vi.mock("next/navigation", () => ({
@@ -23,9 +23,21 @@ vi.mock("next/navigation", () => ({
 
 import { RateLimitResetDialog } from "../RateLimitResetDialog";
 
+const mockWindowOpen = vi.fn();
+
+beforeEach(() => {
+  // jsdom's window.open returns null and pollutes the test output; spy and
+  // suppress so we can assert the URL the dialog tries to open.
+  vi.spyOn(window, "open").mockImplementation(
+    mockWindowOpen as unknown as typeof window.open,
+  );
+});
+
 afterEach(() => {
   cleanup();
   mockPush.mockReset();
+  mockWindowOpen.mockReset();
+  vi.restoreAllMocks();
 });
 
 describe("RateLimitResetDialog", () => {
@@ -62,13 +74,14 @@ describe("RateLimitResetDialog", () => {
     expect(bodyText.textContent).not.toContain("Resets in");
   });
 
-  it("renders Wait for reset and Go to billing buttons", () => {
+  it("renders Wait for reset and Upgrade plan buttons by default", () => {
     render(
       <RateLimitResetDialog isOpen={true} onClose={vi.fn()} resetsAt={null} />,
     );
 
     expect(screen.getByText("Wait for reset")).toBeDefined();
-    expect(screen.getByText("Go to billing")).toBeDefined();
+    expect(screen.getByText("Upgrade plan")).toBeDefined();
+    expect(screen.queryByText("Contact us")).toBeNull();
   });
 
   it("calls onClose when Wait for reset is clicked", () => {
@@ -81,16 +94,65 @@ describe("RateLimitResetDialog", () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  it("navigates to /settings/billing when Go to billing is clicked", () => {
+  it("navigates to /settings/billing when Upgrade plan is clicked (no tier)", () => {
     const onClose = vi.fn();
     render(
       <RateLimitResetDialog isOpen={true} onClose={onClose} resetsAt={null} />,
     );
 
-    fireEvent.click(screen.getByText("Go to billing"));
+    fireEvent.click(screen.getByText("Upgrade plan"));
     expect(onClose).toHaveBeenCalledTimes(1);
     expect(mockPush).toHaveBeenCalledWith("/settings/billing");
+    expect(mockWindowOpen).not.toHaveBeenCalled();
   });
+
+  it.each(["NO_TIER", "BASIC", "PRO"] as const)(
+    "shows Upgrade plan and routes to /settings/billing for tier=%s",
+    (tier) => {
+      const onClose = vi.fn();
+      render(
+        <RateLimitResetDialog
+          isOpen={true}
+          onClose={onClose}
+          resetsAt={null}
+          tier={tier}
+        />,
+      );
+
+      expect(screen.getByText("Upgrade plan")).toBeDefined();
+      fireEvent.click(screen.getByText("Upgrade plan"));
+      expect(onClose).toHaveBeenCalledTimes(1);
+      expect(mockPush).toHaveBeenCalledWith("/settings/billing");
+      expect(mockWindowOpen).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(["MAX", "BUSINESS", "ENTERPRISE"] as const)(
+    "shows Contact us and opens mailto for top-tier plan=%s",
+    (tier) => {
+      const onClose = vi.fn();
+      render(
+        <RateLimitResetDialog
+          isOpen={true}
+          onClose={onClose}
+          resetsAt={null}
+          tier={tier}
+        />,
+      );
+
+      expect(screen.getByText("Contact us")).toBeDefined();
+      expect(screen.queryByText("Upgrade plan")).toBeNull();
+
+      fireEvent.click(screen.getByText("Contact us"));
+      expect(onClose).toHaveBeenCalledTimes(1);
+      expect(mockWindowOpen).toHaveBeenCalledWith(
+        "mailto:contact@agpt.co",
+        "_blank",
+        "noopener,noreferrer",
+      );
+      expect(mockPush).not.toHaveBeenCalled();
+    },
+  );
 
   it("does not render dialog content when closed", () => {
     render(


### PR DESCRIPTION
### Why / What / How

**Why:** [SECRT-2314](https://linear.app/autogpt/issue/SECRT-2314). When a user hits their daily AutoPilot limit, the popup currently shows a single "Go to billing" CTA regardless of their plan. For users on the highest self-serve tier (MAX) — and the contact-sales tiers above it — there's no higher plan they can upgrade to from the billing page, so routing them there is a dead end. Reported by John in #breakage on 2026-04-27 as a follow-up to SECRT-2294.

**What:** Branch the daily-limit popup CTA on the user's current subscription tier:
- `NO_TIER` / `BASIC` / `PRO` (or unknown) → **"Upgrade plan"** → routes to `/settings/billing` (drives conversion).
- `MAX` / `BUSINESS` / `ENTERPRISE` → **"Contact us"** → opens `mailto:contact@agpt.co` in a new tab (no higher self-serve plan).

**How:**
- `RateLimitResetDialog` gains an optional `tier?: SubscriptionTier | null` prop and decides label + click handler from a small `TOP_TIERS` set. The body copy adapts in the same branch ("upgrade your plan" vs "contact us if you need more capacity").
- `RateLimitGate` fetches `useGetSubscriptionStatus` (same hook `useYourPlanCard` uses) gated on `rateLimitMessage` being present, and forwards `tier`. The query is disabled when no rate-limit dialog is needed, so this adds zero extra requests on the happy path.
- `mailto:contact@agpt.co` is the same address used by `WaitlistErrorContent` — kept the convention rather than introducing a new constant.

### Changes 🏗️

- `RateLimitResetDialog.tsx` — accept `tier`, branch CTA label/handler/body trailer between Upgrade plan and Contact us.
- `RateLimitGate.tsx` — pull subscription status (gated on `rateLimitMessage`), forward `tier` to the dialog.
- Tests:
  - `RateLimitResetDialog.test.tsx` — parameterised over `NO_TIER`/`BASIC`/`PRO` (Upgrade plan + router push) and `MAX`/`BUSINESS`/`ENTERPRISE` (Contact us + `window.open`).
  - `RateLimitGate.test.tsx` — added `useGetSubscriptionStatus` mock; verified tier forwarding (MAX → "MAX", null → null) and that the subscription query is also disabled when no rate-limit message is present.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [x] `pnpm format && pnpm lint && pnpm types` clean
  - [x] `pnpm test:unit` against `RateLimitResetDialog/` — 26/26 passing
  - [ ] Manual: hit daily limit on dev as a `PRO` user → popup shows **"Upgrade plan"**, click routes to `/settings/billing`
  - [ ] Manual: hit daily limit on dev as a `MAX` user → popup shows **"Contact us"**, click opens `mailto:contact@agpt.co` in a new tab
  - [ ] Manual: hit daily limit on dev as a `NO_TIER` user → popup shows **"Upgrade plan"**, routes to `/settings/billing`
  - [ ] Manual: subscription-status request fails / returns no tier → popup falls back to **"Upgrade plan"** (safe default)

cc @lluis-agusti — flagging for review per request. Draft until manual QA on dev is done.
