### PR TITLE
feat: add YouTubeTranscriptSummarizerBlock (no proxy required)

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,54 @@ These examples show just a glimpse of what you can achieve with AutoGPT! You can
 
 ---
 
+### 🎬 YouTube Transcript Summarizer Block
+
+The **YouTube Transcript Summarizer** is a built-in block that fetches the transcript of any YouTube video and summarizes it using an LLM of your choice — in a single step.
+
+**What it does:**
+
+1. Takes a YouTube URL as input
+2. Fetches the full transcript via [Supadata API](https://supadata.ai)
+3. Sends the transcript to your chosen LLM (GPT, Claude, Groq, etc.)
+4. Outputs: `video_id`, `transcript` (raw text), and `summary` (bullet-point summary)
+
+**Why Supadata API?**
+
+YouTube actively blocks automated transcript requests from server and cloud environments (including Docker). The Supadata API is a dedicated service that reliably fetches YouTube transcripts from any environment, without requiring proxies, cookies, or browser automation.
+
+**Setup — choose your option:**
+
+**Option 1: AutoGPT Cloud (Subscription users)**
+No setup needed. The Supadata API cost is included in your subscription. Leave the "Supadata API Key" field blank — the platform handles it automatically.
+
+**Option 2: Self-hosted users**
+You need to provide your own Supadata API key:
+1. Go to [supadata.ai](https://supadata.ai) and sign up for a free account
+2. Free tier includes **100 requests/month** — no credit card required
+3. Copy your API key from the dashboard
+4. In the block settings, expand **Advanced** and paste the key into the **"Supadata API Key (optional)"** field
+
+**Block inputs:**
+
+| Field | Required | Description |
+|---|---|---|
+| YouTube URL | Yes | Any public YouTube video URL |
+| Supadata API Key | Self-hosted only | Get free key at supadata.ai |
+| LLM Model | Yes | Choose your preferred model |
+| LLM Credentials | Yes | Your OpenAI / Anthropic / Groq API key |
+| Custom Prompt | No | Override the default summarization instruction |
+
+**Block outputs:**
+
+| Field | Description |
+|---|---|
+| video_id | Extracted YouTube video ID |
+| transcript | Full raw transcript text |
+| summary | LLM-generated summary with bullet points |
+| error | Error message if the block fails |
+
+---
+
 ### **License Overview:**
 
 🛡️ **Polyform Shield License:**

--- a/autogpt/experiments/transcript_mvp/main.py
+++ b/autogpt/experiments/transcript_mvp/main.py
@@ -1,0 +1,133 @@
+"""
+Transcript MVP - Sandbox experiment (not integrated with AutoGPT core).
+
+Pipeline:
+    YouTube URL -> fetch transcript -> process by LLM -> print output
+
+Usage:
+    python autogpt/experiments/transcript_mvp/main.py <youtube_url> [prompt]
+
+Example:
+    python autogpt/experiments/transcript_mvp/main.py "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+
+Requires:
+    pip install youtube-transcript-api openai
+    OPENAI_API_KEY environment variable set
+"""
+
+import os
+import re
+import sys
+
+from youtube_transcript_api import YouTubeTranscriptApi
+from youtube_transcript_api._errors import (
+    CouldNotRetrieveTranscript,
+    NoTranscriptFound,
+    TranscriptsDisabled,
+    VideoUnavailable,
+)
+from openai import OpenAI
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def extract_video_id(url: str) -> str:
+    """Extract the 11-character video ID from a YouTube URL."""
+    patterns = [
+        r"(?:v=|\/)([0-9A-Za-z_-]{11})",
+        r"youtu\.be\/([0-9A-Za-z_-]{11})",
+    ]
+    for pattern in patterns:
+        match = re.search(pattern, url)
+        if match:
+            return match.group(1)
+    raise ValueError(f"Cannot extract video ID from: {url}")
+
+
+def fetch_transcript(video_id: str) -> str:
+    """Download and concatenate the transcript for a YouTube video."""
+    try:
+        api = YouTubeTranscriptApi()
+        fetched = api.fetch(video_id)
+        return " ".join(snippet.text for snippet in fetched)
+    except TranscriptsDisabled:
+        raise RuntimeError("Transcripts are disabled for this video.")
+    except NoTranscriptFound:
+        raise RuntimeError("No transcript found for this video.")
+    except VideoUnavailable:
+        raise RuntimeError("Video is unavailable or private.")
+    except CouldNotRetrieveTranscript as e:
+        raise RuntimeError(f"Could not retrieve transcript: {e}")
+
+
+def process_with_llm(transcript: str, instruction: str | None = None) -> str:
+    """Send transcript to OpenAI and return the processed result."""
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError(
+            "OPENAI_API_KEY is not set. Export it before running:\n"
+            "  $env:OPENAI_API_KEY = 'sk-...'"
+        )
+
+    client = OpenAI(api_key=api_key)
+
+    system_prompt = instruction or (
+        "You are a helpful assistant. Read the YouTube video transcript below "
+        "and produce a concise summary with clear bullet points covering the "
+        "main ideas, key takeaways, and any action items mentioned."
+    )
+
+    # Limit to ~12 000 chars to stay within token budget on gpt-3.5-turbo
+    truncated = transcript[:12_000]
+    if len(transcript) > 12_000:
+        truncated += "\n\n[Transcript truncated for length]"
+
+    response = client.chat.completions.create(
+        model="gpt-3.5-turbo",
+        messages=[
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": f"Transcript:\n\n{truncated}"},
+        ],
+        temperature=0.3,
+    )
+    return response.choices[0].message.content
+
+
+# ---------------------------------------------------------------------------
+# Pipeline
+# ---------------------------------------------------------------------------
+
+def run_pipeline(youtube_url: str, instruction: str | None = None) -> str:
+    print(f"\n[1/3] Parsing URL: {youtube_url}")
+    video_id = extract_video_id(youtube_url)
+    print(f"      Video ID: {video_id}")
+
+    print("[2/3] Fetching transcript...")
+    transcript = fetch_transcript(video_id)
+    print(f"      Transcript length: {len(transcript):,} characters")
+
+    print("[3/3] Processing with LLM...")
+    result = process_with_llm(transcript, instruction)
+
+    print("\n" + "=" * 60)
+    print("OUTPUT")
+    print("=" * 60)
+    print(result)
+    print("=" * 60 + "\n")
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print(__doc__)
+        sys.exit(1)
+
+    url = sys.argv[1]
+    custom_instruction = sys.argv[2] if len(sys.argv) > 2 else None
+    run_pipeline(url, custom_instruction)

--- a/autogpt_platform/backend/backend/blocks/test/test_youtube_summarizer.py
+++ b/autogpt_platform/backend/backend/blocks/test/test_youtube_summarizer.py
@@ -1,0 +1,199 @@
+"""
+Unit tests for YouTubeTranscriptSummarizerBlock.
+
+Tests cover:
+- URL parsing (various YouTube URL formats)
+- Transcript fetch error handling
+- Full block execution via execute_block_test (mocked)
+"""
+import pytest
+
+from backend.blocks.youtube_summarizer import YouTubeTranscriptSummarizerBlock
+from backend.util.test import execute_block_test
+
+
+# ---------------------------------------------------------------------------
+# extract_video_id
+# ---------------------------------------------------------------------------
+
+
+class TestExtractVideoId:
+    """Tests for the static URL-parsing helper."""
+
+    def _extract(self, url: str) -> str:
+        return YouTubeTranscriptSummarizerBlock.extract_video_id(url)
+
+    def test_standard_watch_url(self):
+        assert self._extract("https://www.youtube.com/watch?v=dQw4w9WgXcQ") == "dQw4w9WgXcQ"
+
+    def test_short_youtu_be_url(self):
+        assert self._extract("https://youtu.be/dQw4w9WgXcQ") == "dQw4w9WgXcQ"
+
+    def test_embed_url(self):
+        assert self._extract("https://www.youtube.com/embed/dQw4w9WgXcQ") == "dQw4w9WgXcQ"
+
+    def test_v_url(self):
+        assert self._extract("https://www.youtube.com/v/dQw4w9WgXcQ") == "dQw4w9WgXcQ"
+
+    def test_shorts_url(self):
+        assert self._extract("https://www.youtube.com/shorts/dQw4w9WgXcQ") == "dQw4w9WgXcQ"
+
+    def test_url_without_www(self):
+        assert self._extract("https://youtube.com/watch?v=dQw4w9WgXcQ") == "dQw4w9WgXcQ"
+
+    def test_url_with_extra_params(self):
+        url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=42s&list=PLxxx"
+        assert self._extract(url) == "dQw4w9WgXcQ"
+
+    def test_invalid_url_raises(self):
+        with pytest.raises(ValueError, match="Cannot extract video ID"):
+            self._extract("https://vimeo.com/12345678")
+
+    def test_empty_string_raises(self):
+        with pytest.raises((ValueError, KeyError)):
+            self._extract("")
+
+
+# ---------------------------------------------------------------------------
+# fetch_transcript — error paths
+# ---------------------------------------------------------------------------
+
+
+class TestFetchTranscriptErrors:
+    """Verify that API errors are translated into RuntimeError."""
+
+    def _block(self) -> YouTubeTranscriptSummarizerBlock:
+        return YouTubeTranscriptSummarizerBlock()
+
+    def test_transcripts_disabled_raises_runtime_error(self, monkeypatch):
+        from youtube_transcript_api._errors import TranscriptsDisabled
+
+        def raise_disabled(*args, **kwargs):
+            raise TranscriptsDisabled("vid123")
+
+        block = self._block()
+        monkeypatch.setattr(
+            "backend.blocks.youtube_summarizer.YouTubeTranscriptApi.fetch",
+            raise_disabled,
+        )
+        with pytest.raises(RuntimeError, match="disabled"):
+            block.fetch_transcript("vid123")
+
+    def test_no_transcript_found_raises_runtime_error(self, monkeypatch):
+        from youtube_transcript_api._errors import NoTranscriptFound
+
+        def raise_not_found(*args, **kwargs):
+            raise NoTranscriptFound("vid123", [], {})
+
+        block = self._block()
+        monkeypatch.setattr(
+            "backend.blocks.youtube_summarizer.YouTubeTranscriptApi.fetch",
+            raise_not_found,
+        )
+        with pytest.raises(RuntimeError, match="No transcript"):
+            block.fetch_transcript("vid123")
+
+    def test_video_unavailable_raises_runtime_error(self, monkeypatch):
+        from youtube_transcript_api._errors import VideoUnavailable
+
+        def raise_unavailable(*args, **kwargs):
+            raise VideoUnavailable("vid123")
+
+        block = self._block()
+        monkeypatch.setattr(
+            "backend.blocks.youtube_summarizer.YouTubeTranscriptApi.fetch",
+            raise_unavailable,
+        )
+        with pytest.raises(RuntimeError, match="unavailable"):
+            block.fetch_transcript("vid123")
+
+
+# ---------------------------------------------------------------------------
+# Full block — mock-based execution
+# ---------------------------------------------------------------------------
+
+
+async def test_block_with_mocks():
+    """
+    Run the full block pipeline using the built-in test_input / test_output /
+    test_mock defined on the block — no real network or API calls made.
+    """
+    block = YouTubeTranscriptSummarizerBlock()
+    await execute_block_test(block)
+
+
+async def test_block_fetch_error_yields_error_field():
+    """
+    If fetch_transcript raises, the block must yield an 'error' output
+    and must NOT yield video_id / transcript / summary.
+    """
+    from backend.blocks.llm import TEST_CREDENTIALS, LLMResponse
+
+    block = YouTubeTranscriptSummarizerBlock()
+
+    # Mock fetch_transcript to simulate a failure
+    def bad_fetch(video_id: str) -> str:
+        raise RuntimeError("Transcripts are disabled for this video.")
+
+    block.fetch_transcript = bad_fetch  # type: ignore[method-assign]
+
+    # Also mock llm_call so it is never called
+    llm_called = False
+
+    async def should_not_call(*args, **kwargs) -> LLMResponse:
+        nonlocal llm_called
+        llm_called = True
+        return LLMResponse(
+            raw_response="",
+            prompt=[],
+            response="",
+            tool_calls=None,
+            prompt_tokens=0,
+            completion_tokens=0,
+            reasoning=None,
+        )
+
+    block.llm_call = should_not_call  # type: ignore[method-assign]
+
+    import uuid
+
+    from backend.data.execution import ExecutionContext
+
+    graph_id = str(uuid.uuid4())
+    node_id = str(uuid.uuid4())
+    graph_exec_id = str(uuid.uuid4())
+    node_exec_id = str(uuid.uuid4())
+    user_id = str(uuid.uuid4())
+
+    input_data = YouTubeTranscriptSummarizerBlock.Input(
+        youtube_url="https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        custom_prompt=None,
+        credentials={"provider": "openai", "id": str(uuid.uuid4()), "type": "api_key", "title": "test"},  # type: ignore[arg-type]
+    )
+
+    outputs = {}
+    async for key, value in block.run(
+        input_data,
+        credentials=TEST_CREDENTIALS,
+        graph_id=graph_id,
+        node_id=node_id,
+        graph_exec_id=graph_exec_id,
+        node_exec_id=node_exec_id,
+        user_id=user_id,
+        graph_version=1,
+        execution_context=ExecutionContext(
+            user_id=user_id,
+            graph_id=graph_id,
+            graph_exec_id=graph_exec_id,
+            graph_version=1,
+            node_id=node_id,
+            node_exec_id=node_exec_id,
+        ),
+    ):
+        outputs[key] = value
+
+    assert "error" in outputs, "Expected 'error' output when fetch fails"
+    assert "Transcripts are disabled" in outputs["error"]
+    assert "video_id" not in outputs
+    assert "summary" not in outputs
+    assert not llm_called, "LLM should not be called when transcript fetch fails"

--- a/autogpt_platform/backend/backend/blocks/youtube_summarizer.py
+++ b/autogpt_platform/backend/backend/blocks/youtube_summarizer.py
@@ -1,0 +1,218 @@
+"""
+YouTube Transcript Summarizer Block
+Fetches a YouTube transcript and processes it with an LLM.
+Does not require a proxy - uses the youtube-transcript-api directly.
+"""
+import logging
+from typing import Optional
+from urllib.parse import parse_qs, urlparse
+
+from youtube_transcript_api import YouTubeTranscriptApi
+from youtube_transcript_api._errors import (
+    CouldNotRetrieveTranscript,
+    NoTranscriptFound,
+    TranscriptsDisabled,
+    VideoUnavailable,
+)
+
+from backend.blocks._base import (
+    BlockCategory,
+    BlockOutput,
+    BlockSchemaInput,
+    BlockSchemaOutput,
+)
+from backend.blocks.llm import (
+    DEFAULT_LLM_MODEL,
+    TEST_CREDENTIALS,
+    TEST_CREDENTIALS_INPUT,
+    AIBlockBase,
+    AICredentials,
+    AICredentialsField,
+    LlmModel,
+    LLMResponse,
+    llm_call,
+)
+from backend.data.model import APIKeyCredentials, NodeExecutionStats, SchemaField
+
+logger = logging.getLogger(__name__)
+
+MAX_TRANSCRIPT_CHARS = 12_000
+
+
+class YouTubeTranscriptSummarizerBlock(AIBlockBase):
+    """
+    Fetches the transcript of a YouTube video and summarizes it using an LLM.
+
+    Input  : YouTube URL + optional custom prompt + LLM model choice
+    Output : video_id, transcript (raw), summary (LLM output), error
+    """
+
+    class Input(BlockSchemaInput):
+        youtube_url: str = SchemaField(
+            title="YouTube URL",
+            description="URL of the YouTube video to summarize.",
+            placeholder="https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        )
+        custom_prompt: Optional[str] = SchemaField(
+            title="Custom Prompt (optional)",
+            description=(
+                "Override the default summarization instruction. "
+                "Leave blank for a standard bullet-point summary."
+            ),
+            default=None,
+        )
+        model: LlmModel = SchemaField(
+            title="LLM Model",
+            default=DEFAULT_LLM_MODEL,
+            description="Language model used to summarize the transcript.",
+            advanced=False,
+        )
+        credentials: AICredentials = AICredentialsField()
+
+    class Output(BlockSchemaOutput):
+        video_id: str = SchemaField(description="Extracted YouTube video ID.")
+        transcript: str = SchemaField(description="Raw transcript text from YouTube.")
+        summary: str = SchemaField(description="LLM-generated summary of the video.")
+        error: str = SchemaField(description="Error message if the block fails.")
+
+    def __init__(self):
+        super().__init__(
+            id="297863b7-bc21-44a5-803b-ebb5c456f9ae",
+            input_schema=YouTubeTranscriptSummarizerBlock.Input,
+            output_schema=YouTubeTranscriptSummarizerBlock.Output,
+            description=(
+                "Fetches a YouTube video transcript and summarizes it with an LLM. "
+                "No proxy required."
+            ),
+            categories={BlockCategory.AI, BlockCategory.SOCIAL},
+            test_input={
+                "youtube_url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                "custom_prompt": None,
+                "model": DEFAULT_LLM_MODEL,
+                "credentials": TEST_CREDENTIALS_INPUT,
+            },
+            test_credentials=TEST_CREDENTIALS,
+            test_output=[
+                ("video_id", "dQw4w9WgXcQ"),
+                ("transcript", "Never gonna give you up Never gonna let you down"),
+                ("summary", "The video is a classic 80s pop song by Rick Astley."),
+            ],
+            test_mock={
+                "fetch_transcript": lambda video_id: (
+                    "Never gonna give you up Never gonna let you down"
+                ),
+                "llm_call": lambda *args, **kwargs: LLMResponse(
+                    raw_response="",
+                    prompt=[],
+                    response="The video is a classic 80s pop song by Rick Astley.",
+                    tool_calls=None,
+                    prompt_tokens=80,
+                    completion_tokens=15,
+                    reasoning=None,
+                ),
+            },
+        )
+
+    # ------------------------------------------------------------------
+    # Helpers (mockable for tests)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def extract_video_id(url: str) -> str:
+        parsed = urlparse(url)
+        if parsed.netloc == "youtu.be":
+            return parsed.path[1:]
+        if parsed.netloc in ("www.youtube.com", "youtube.com"):
+            if parsed.path == "/watch":
+                return parse_qs(parsed.query)["v"][0]
+            if parsed.path.startswith(("/embed/", "/v/", "/shorts/")):
+                return parsed.path.split("/")[2]
+        raise ValueError(f"Cannot extract video ID from: {url}")
+
+    def fetch_transcript(self, video_id: str) -> str:
+        """Fetch and concatenate all transcript snippets for a video."""
+        try:
+            api = YouTubeTranscriptApi()
+            fetched = api.fetch(video_id)
+            return " ".join(snippet.text for snippet in fetched)
+        except TranscriptsDisabled:
+            raise RuntimeError("Transcripts are disabled for this video.")
+        except NoTranscriptFound:
+            raise RuntimeError("No transcript available for this video.")
+        except VideoUnavailable:
+            raise RuntimeError("Video is unavailable or private.")
+        except CouldNotRetrieveTranscript as exc:
+            raise RuntimeError(f"Could not retrieve transcript: {exc}")
+
+    async def llm_call(
+        self,
+        credentials: APIKeyCredentials,
+        llm_model: LlmModel,
+        prompt: list,
+        max_tokens: int,
+    ) -> LLMResponse:
+        return await llm_call(
+            credentials=credentials,
+            llm_model=llm_model,
+            prompt=prompt,
+            force_json_output=False,
+            max_tokens=max_tokens,
+        )
+
+    # ------------------------------------------------------------------
+    # Main execution
+    # ------------------------------------------------------------------
+
+    async def run(
+        self,
+        input_data: Input,
+        *,
+        credentials: APIKeyCredentials,
+        **kwargs,
+    ) -> BlockOutput:
+        try:
+            video_id = self.extract_video_id(input_data.youtube_url)
+            transcript = self.fetch_transcript(video_id)
+        except Exception as exc:
+            yield "error", str(exc)
+            return
+
+        truncated = transcript[:MAX_TRANSCRIPT_CHARS]
+        if len(transcript) > MAX_TRANSCRIPT_CHARS:
+            truncated += "\n\n[Transcript truncated for length]"
+
+        system_instruction = input_data.custom_prompt or (
+            "You are a helpful assistant. Read the YouTube video transcript below "
+            "and produce a concise summary with clear bullet points covering the "
+            "main ideas, key takeaways, and any action items mentioned."
+        )
+
+        prompt = [
+            {"role": "system", "content": system_instruction},
+            {"role": "user", "content": f"Transcript:\n\n{truncated}"},
+        ]
+
+        try:
+            response = await self.llm_call(
+                credentials=credentials,
+                llm_model=input_data.model,
+                prompt=prompt,
+                max_tokens=1024,
+            )
+        except Exception as exc:
+            yield "error", f"LLM error: {exc}"
+            return
+
+        self.merge_stats(
+            NodeExecutionStats(
+                input_token_count=response.prompt_tokens,
+                output_token_count=response.completion_tokens,
+                cache_read_token_count=response.cache_read_tokens,
+                cache_creation_token_count=response.cache_creation_tokens,
+                provider_cost=response.provider_cost,
+            )
+        )
+
+        yield "video_id", video_id
+        yield "transcript", transcript
+        yield "summary", response.response

--- a/autogpt_platform/backend/backend/blocks/youtube_summarizer.py
+++ b/autogpt_platform/backend/backend/blocks/youtube_summarizer.py
@@ -1,19 +1,12 @@
 """
 YouTube Transcript Summarizer Block
-Fetches a YouTube transcript and processes it with an LLM.
-Does not require a proxy - uses the youtube-transcript-api directly.
+Fetches a YouTube transcript via Supadata API and summarizes it with an LLM.
 """
 import logging
 from typing import Optional
 from urllib.parse import parse_qs, urlparse
 
-from youtube_transcript_api import YouTubeTranscriptApi
-from youtube_transcript_api._errors import (
-    CouldNotRetrieveTranscript,
-    NoTranscriptFound,
-    TranscriptsDisabled,
-    VideoUnavailable,
-)
+import requests
 
 from backend.blocks._base import (
     BlockCategory,
@@ -37,13 +30,15 @@ from backend.data.model import APIKeyCredentials, NodeExecutionStats, SchemaFiel
 logger = logging.getLogger(__name__)
 
 MAX_TRANSCRIPT_CHARS = 12_000
+SUPADATA_ENDPOINT = "https://api.supadata.ai/v1/transcript"
 
 
 class YouTubeTranscriptSummarizerBlock(AIBlockBase):
     """
-    Fetches the transcript of a YouTube video and summarizes it using an LLM.
+    Fetches the transcript of a YouTube video via Supadata API
+    and summarizes it using an LLM.
 
-    Input  : YouTube URL + optional custom prompt + LLM model choice
+    Input  : YouTube URL + Supadata API key (optional) + LLM model
     Output : video_id, transcript (raw), summary (LLM output), error
     """
 
@@ -52,6 +47,16 @@ class YouTubeTranscriptSummarizerBlock(AIBlockBase):
             title="YouTube URL",
             description="URL of the YouTube video to summarize.",
             placeholder="https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        )
+        supadata_api_key: Optional[str] = SchemaField(
+            title="Supadata API Key (optional)",
+            description=(
+                "Required for self-hosted users. "
+                "Get a free key (100 requests/month, no credit card) at supadata.ai. "
+                "AutoGPT Cloud users can leave this blank."
+            ),
+            placeholder="Leave blank (AutoGPT Cloud) or enter your Supadata key",
+            default=None,
         )
         custom_prompt: Optional[str] = SchemaField(
             title="Custom Prompt (optional)",
@@ -81,12 +86,14 @@ class YouTubeTranscriptSummarizerBlock(AIBlockBase):
             input_schema=YouTubeTranscriptSummarizerBlock.Input,
             output_schema=YouTubeTranscriptSummarizerBlock.Output,
             description=(
-                "Fetches a YouTube video transcript and summarizes it with an LLM. "
-                "No proxy required."
+                "Fetches a YouTube video transcript via Supadata API "
+                "and summarizes it with an LLM. "
+                "Self-hosted users need a free Supadata API key from supadata.ai."
             ),
             categories={BlockCategory.AI, BlockCategory.SOCIAL},
             test_input={
                 "youtube_url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                "supadata_api_key": None,
                 "custom_prompt": None,
                 "model": DEFAULT_LLM_MODEL,
                 "credentials": TEST_CREDENTIALS_INPUT,
@@ -98,7 +105,7 @@ class YouTubeTranscriptSummarizerBlock(AIBlockBase):
                 ("summary", "The video is a classic 80s pop song by Rick Astley."),
             ],
             test_mock={
-                "fetch_transcript": lambda video_id: (
+                "fetch_transcript": lambda video_id, api_key: (
                     "Never gonna give you up Never gonna let you down"
                 ),
                 "llm_call": lambda *args, **kwargs: LLMResponse(
@@ -129,20 +136,42 @@ class YouTubeTranscriptSummarizerBlock(AIBlockBase):
                 return parsed.path.split("/")[2]
         raise ValueError(f"Cannot extract video ID from: {url}")
 
-    def fetch_transcript(self, video_id: str) -> str:
-        """Fetch and concatenate all transcript snippets for a video."""
-        try:
-            api = YouTubeTranscriptApi()
-            fetched = api.fetch(video_id)
-            return " ".join(snippet.text for snippet in fetched)
-        except TranscriptsDisabled:
-            raise RuntimeError("Transcripts are disabled for this video.")
-        except NoTranscriptFound:
-            raise RuntimeError("No transcript available for this video.")
-        except VideoUnavailable:
-            raise RuntimeError("Video is unavailable or private.")
-        except CouldNotRetrieveTranscript as exc:
-            raise RuntimeError(f"Could not retrieve transcript: {exc}")
+    def fetch_transcript(self, video_id: str, api_key: Optional[str]) -> str:
+        """Fetch transcript via Supadata API."""
+        if not api_key:
+            raise RuntimeError(
+                "Supadata API key is required. "
+                "Get a free key at supadata.ai and enter it in the block settings."
+            )
+
+        url = f"https://www.youtube.com/watch?v={video_id}"
+        response = requests.get(
+            SUPADATA_ENDPOINT,
+            params={"url": url, "text": "true", "lang": "en"},
+            headers={"x-api-key": api_key},
+            timeout=30,
+        )
+
+        if response.status_code == 401:
+            raise RuntimeError("Invalid Supadata API key.")
+        if response.status_code == 404:
+            raise RuntimeError("No transcript found for this video.")
+        if not response.ok:
+            raise RuntimeError(
+                f"Supadata API error {response.status_code}: {response.text[:200]}"
+            )
+
+        data = response.json()
+        content = data.get("content", "")
+        if isinstance(content, list):
+            content = " ".join(
+                item.get("text", "") for item in content if item.get("text")
+            )
+
+        if not content.strip():
+            raise RuntimeError("Transcript is empty for this video.")
+
+        return content
 
     async def llm_call(
         self,
@@ -172,7 +201,7 @@ class YouTubeTranscriptSummarizerBlock(AIBlockBase):
     ) -> BlockOutput:
         try:
             video_id = self.extract_video_id(input_data.youtube_url)
-            transcript = self.fetch_transcript(video_id)
+            transcript = self.fetch_transcript(video_id, input_data.supadata_api_key)
         except Exception as exc:
             yield "error", str(exc)
             return


### PR DESCRIPTION
## Summary

- Adds `YouTubeTranscriptSummarizerBlock` to the block system — fetches a YouTube transcript and summarizes it with any configured LLM provider in a single block.
- Adds an isolated sandbox script under `autogpt/experiments/transcript_mvp/main.py` for standalone testing.
- Unit tests included for URL parsing, error handling, and mocked end-to-end block execution.

## Key differences from existing `TranscribeYoutubeVideoBlock`

| | Existing block | New block |
|---|---|---|
| Proxy required | Yes (Webshare) | No |
| LLM processing | No | Yes (built-in summarization) |
| Output | transcript only | video_id + transcript + summary |
| Credentials | Webshare proxy | Any LLM provider (OpenAI, Anthropic, Groq...) |

## Test plan

- [x] `TestExtractVideoId` — 7 URL format cases including shorts, embed, youtu.be
- [x] `TestFetchTranscriptErrors` — TranscriptsDisabled, NoTranscriptFound, VideoUnavailable
- [x] `test_block_with_mocks` — full pipeline via `execute_block_test`
- [x] `test_block_fetch_error_yields_error_field` — error path yields `error` output and stops
