### PR TITLE
fix(backend/copilot): stop bot setup prompts in unrelated threads

### DIFF
--- a/autogpt_platform/backend/backend/copilot/bot/handler.py
+++ b/autogpt_platform/backend/backend/copilot/bot/handler.py
@@ -54,6 +54,11 @@ class MessageHandler:
                 )
             return
 
+        if ctx.channel_type == "thread" and not await threads.is_subscribed(
+            ctx.platform, ctx.channel_id
+        ):
+            return
+
         if not await self._ensure_linked(ctx, adapter):
             return
 
@@ -72,9 +77,7 @@ class MessageHandler:
             return ctx.channel_id
 
         if ctx.channel_type == "thread":
-            if await threads.is_subscribed(ctx.platform, ctx.channel_id):
-                return ctx.channel_id
-            return None
+            return ctx.channel_id
 
         # channel_type == "channel" — create a thread and subscribe
         thread_name = f"{ctx.username} × AutoPilot"

--- a/autogpt_platform/backend/backend/copilot/bot/handler_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/handler_test.py
@@ -94,6 +94,20 @@ class TestEnsureLinked:
         assert "/setup" in call_args[1]
 
     @pytest.mark.asyncio
+    async def test_unlinked_unsubscribed_thread_is_ignored(self):
+        api = _api(server_linked=False)
+        handler = MessageHandler(api)
+        adapter = _adapter()
+        with patch(
+            "backend.copilot.bot.handler.threads.is_subscribed",
+            new=AsyncMock(return_value=False),
+        ):
+            await handler.handle(_ctx(channel_type="thread"), adapter)
+
+        api.resolve_server.assert_not_awaited()
+        adapter.send_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_unlinked_dm_prompts_link_flow(self):
         handler = MessageHandler(_api(user_linked=False))
         adapter = _adapter()
@@ -133,26 +147,18 @@ class TestResolveTarget:
         assert result == "dm-42"
 
     @pytest.mark.asyncio
-    async def test_unsubscribed_thread_returns_none(self):
+    async def test_resolve_target_reuses_thread_after_subscription_gate(self):
         handler = MessageHandler(_api())
         adapter = _adapter()
         ctx = _ctx(channel_type="thread", channel_id="thread-old")
-        with patch(
-            "backend.copilot.bot.handler.threads.is_subscribed",
-            new=AsyncMock(return_value=False),
-        ):
-            assert await handler._resolve_target(ctx, adapter) is None
+        assert await handler._resolve_target(ctx, adapter) == "thread-old"
 
     @pytest.mark.asyncio
     async def test_subscribed_thread_keeps_channel(self):
         handler = MessageHandler(_api())
         adapter = _adapter()
         ctx = _ctx(channel_type="thread", channel_id="thread-ok")
-        with patch(
-            "backend.copilot.bot.handler.threads.is_subscribed",
-            new=AsyncMock(return_value=True),
-        ):
-            assert await handler._resolve_target(ctx, adapter) == "thread-ok"
+        assert await handler._resolve_target(ctx, adapter) == "thread-ok"
 
     @pytest.mark.asyncio
     async def test_channel_creates_and_subscribes_thread(self):


### PR DESCRIPTION
### Why / What / How

The Discord bot can currently send the unlinked-server setup prompt from unrelated thread messages. That is noisy in servers where the bot is installed but setup has not been completed yet.

This PR keeps the intended server behavior: regular channel messages are only handled after an explicit bot mention, and bot-created threads continue working after they are subscribed. Thread messages that do not belong to a bot-created/subscribed thread are ignored silently.

The handler now checks the thread subscription gate before checking server link status. Once a thread passes that gate, target resolution can reuse the thread directly.

### Changes

- Ignore unsubscribed Discord thread messages before resolving server link status.
- Keep the /setup prompt behavior for explicit bot mentions in regular server channels.
- Update bot handler tests to cover the thread subscription gate.
- No configuration changes.

### Checklist

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [x] poetry run python -m py_compile backend/copilot/bot/handler.py backend/copilot/bot/handler_test.py
  - [x] git diff --check
  - [ ] Deploy to dev and verify unrelated server/thread messages do not receive the setup prompt

#### For configuration changes:

- [x] .env.default is updated or already compatible with my changes
- [x] docker-compose.yml is updated or already compatible with my changes
- [x] I have included a list of my configuration changes in the PR description (under Changes)