### PR TITLE
fix(frontend): respect Monthly/Yearly toggle in onboarding step 4

### DIFF
--- a/autogpt_platform/backend/backend/api/features/v1.py
+++ b/autogpt_platform/backend/backend/api/features/v1.py
@@ -705,6 +705,10 @@ class SubscriptionTierRequest(BaseModel):
     tier: Literal["NO_TIER", "BASIC", "PRO", "MAX", "BUSINESS"]
     success_url: str = ""
     cancel_url: str = ""
+    # Billing cycle for paid upgrades. Defaults to "monthly" so existing
+    # clients keep working; the onboarding + settings UIs send this
+    # explicitly based on the user's Monthly/Yearly toggle selection.
+    billing_cycle: Literal["monthly", "yearly"] = "monthly"
 
 
 class SubscriptionStatusResponse(BaseModel):
@@ -953,7 +957,7 @@ async def update_subscription_tier(
         Flag.ENABLE_PLATFORM_PAYMENT, user_id, default=False
     )
 
-    target_price_id = await get_subscription_price_id(tier)
+    target_price_id = await get_subscription_price_id(tier, request.billing_cycle)
 
     # Cancel: target NO_TIER. Schedule Stripe cancellation at period end;
     # cancel_at_period_end=True lets the webhook flip the DB tier. No active
@@ -990,15 +994,23 @@ async def update_subscription_tier(
         )
 
     # Target has no LD price — not provisionable (matches the GET hiding).
+    # Yearly is a separate price ID in LD; when only monthly is configured,
+    # a yearly request lands here and fails fast rather than silently billing
+    # monthly (the bug this fix addresses).
     if target_price_id is None:
         raise HTTPException(
             status_code=422,
-            detail=f"Subscription not available for tier {tier.value}",
+            detail=(
+                f"Subscription not available for tier {tier.value} "
+                f"on {request.billing_cycle} billing"
+            ),
         )
 
     # Modify in place if there's a sub; else fall through to Checkout below.
     try:
-        modified = await modify_stripe_subscription_for_tier(user_id, tier)
+        modified = await modify_stripe_subscription_for_tier(
+            user_id, tier, request.billing_cycle
+        )
         if modified:
             return await get_subscription_status(user_id)
     except ValueError as e:
@@ -1084,6 +1096,7 @@ async def update_subscription_tier(
             tier=tier,
             success_url=request.success_url,
             cancel_url=request.cancel_url,
+            billing_cycle=request.billing_cycle,
         )
     except ValueError as e:
         raise HTTPException(status_code=422, detail=str(e))

--- a/autogpt_platform/backend/backend/data/credit.py
+++ b/autogpt_platform/backend/backend/data/credit.py
@@ -4,7 +4,7 @@ import time
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 import stripe
 from fastapi.concurrency import run_in_threadpool
@@ -1776,7 +1776,9 @@ async def _schedule_downgrade_at_period_end(
 
 
 async def modify_stripe_subscription_for_tier(
-    user_id: str, tier: SubscriptionTier
+    user_id: str,
+    tier: SubscriptionTier,
+    billing_cycle: BillingCycle = "monthly",
 ) -> bool:
     """Change a Stripe subscription to a new paid tier.
 
@@ -1799,9 +1801,11 @@ async def modify_stripe_subscription_for_tier(
     Raises stripe.StripeError on API failures so callers can propagate a 502.
     Raises ValueError when no Stripe price ID is configured for the tier.
     """
-    price_id = await get_subscription_price_id(tier)
+    price_id = await get_subscription_price_id(tier, billing_cycle)
     if not price_id:
-        raise ValueError(f"No Stripe price ID configured for tier {tier}")
+        raise ValueError(
+            f"No Stripe price ID configured for tier {tier} on {billing_cycle} billing"
+        )
 
     user = await get_user_by_id(user_id)
     if not user.stripe_customer_id:
@@ -2076,17 +2080,29 @@ async def get_auto_top_up(user_id: str) -> AutoTopUpConfig:
     return AutoTopUpConfig.model_validate(user.top_up_config)
 
 
-@cached(ttl_seconds=60, maxsize=8, cache_none=False)
-async def get_subscription_price_id(tier: SubscriptionTier) -> str | None:
-    """Return Stripe Price ID for a tier from LaunchDarkly, cached for 60 seconds.
+BillingCycle = Literal["monthly", "yearly"]
 
-    Reads the ``copilot-tier-stripe-prices`` JSON flag once and looks up the
-    requested tier. The flag is a JSON object keyed by tier enum value
-    (``{"PRO": "price_xxx", "MAX": "price_yyy"}``); tiers missing from the
-    payload resolve to ``None`` ("not offered").
 
-    ``cache_none=False`` prevents a transient LD failure from caching ``None``
-    and blocking subscription upgrades for the full 60-second TTL window.
+@cached(ttl_seconds=60, maxsize=16, cache_none=False)
+async def get_subscription_price_id(
+    tier: SubscriptionTier, billing_cycle: BillingCycle = "monthly"
+) -> str | None:
+    """Return Stripe Price ID for a tier + billing cycle from LaunchDarkly.
+
+    Reads the ``copilot-tier-stripe-prices`` JSON flag and looks up the
+    requested tier. Two shapes are supported:
+
+    - Flat (legacy, monthly-only):
+      ``{"PRO": "price_xxx", "MAX": "price_yyy"}``
+    - Nested (per-cycle):
+      ``{"PRO": {"monthly": "price_xxx", "yearly": "price_zzz"}, ...}``
+
+    With the flat shape, ``billing_cycle="yearly"`` resolves to ``None`` —
+    yearly must be explicitly configured in LD before it's offered, so we
+    fail closed (422 at the API) rather than silently billing monthly.
+
+    ``cache_none=False`` prevents a transient LD failure from caching
+    ``None`` and blocking subscription upgrades for the full TTL window.
     """
     raw = await get_feature_flag_value(
         Flag.COPILOT_TIER_STRIPE_PRICES.value, user_id="system", default=None
@@ -2099,8 +2115,16 @@ async def get_subscription_price_id(tier: SubscriptionTier) -> str | None:
             raw,
         )
         return None
-    price_id = raw.get(tier.value)
-    return price_id if isinstance(price_id, str) and price_id else None
+    entry = raw.get(tier.value)
+    if isinstance(entry, str):
+        # Flat shape — monthly only. Yearly requests fail closed.
+        if billing_cycle == "monthly" and entry:
+            return entry
+        return None
+    if isinstance(entry, dict):
+        price_id = entry.get(billing_cycle)
+        return price_id if isinstance(price_id, str) and price_id else None
+    return None
 
 
 async def create_subscription_checkout(
@@ -2108,11 +2132,14 @@ async def create_subscription_checkout(
     tier: SubscriptionTier,
     success_url: str,
     cancel_url: str,
+    billing_cycle: BillingCycle = "monthly",
 ) -> str:
     """Create a Stripe Checkout Session for a subscription. Returns the redirect URL."""
-    price_id = await get_subscription_price_id(tier)
+    price_id = await get_subscription_price_id(tier, billing_cycle)
     if not price_id:
-        raise ValueError(f"Subscription not available for tier {tier.value}")
+        raise ValueError(
+            f"Subscription not available for tier {tier.value} on {billing_cycle} billing"
+        )
     customer_id = await get_stripe_customer_id(user_id)
     session = await run_in_threadpool(
         stripe.checkout.Session.create,
@@ -2121,7 +2148,13 @@ async def create_subscription_checkout(
         line_items=[{"price": price_id, "quantity": 1}],
         success_url=success_url,
         cancel_url=cancel_url,
-        subscription_data={"metadata": {"user_id": user_id, "tier": tier.value}},
+        subscription_data={
+            "metadata": {
+                "user_id": user_id,
+                "tier": tier.value,
+                "billing_cycle": billing_cycle,
+            }
+        },
         allow_promotion_codes=True,
     )
     if not session.url:

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/useSubscriptionStep.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/useSubscriptionStep.ts
@@ -95,9 +95,14 @@ export function useSubscriptionStep() {
       });
 
       const baseUrl = `${window.location.origin}/onboarding`;
+      // Send billing_cycle explicitly so the backend picks the correct
+      // Stripe price ID. Without this, the API silently defaults to the
+      // monthly price even when the user has the "Yearly billing" toggle
+      // enabled on the plan card.
       const result = await updateTier({
         data: {
           tier,
+          billing_cycle: isYearly ? "yearly" : "monthly",
           success_url: `${baseUrl}?step=5&subscription=success`,
           cancel_url: `${baseUrl}?step=4&subscription=cancelled`,
         },


### PR DESCRIPTION
### Why / What / How

**Why:** Reported via page feedback on `/onboarding?step=4` — the `Monthly / Yearly` billing toggle above the plan cards was purely cosmetic. Once the user hit **Upgrade to Pro / Max**, the backend always billed the monthly price regardless of the toggle state, which is a silent overcharge for yearly-intending users.

Original page feedback:
> The Monthly/Yearly switch (`.flex > div > .-mt-[2rem] > .inline-flex`, source `_next/static/chunks/8852ab3f.65af6b160609bfb1.js:189:6079`) has no effect — once *Upgrade to Max* or *Upgrade to Pro* is pressed the API always bills the user monthly regardless of the toggle.

**What:** Plumb `billing_cycle` end-to-end so the toggle actually drives the Stripe price ID selection.

**How:**
- Frontend reads `isYearly` from the onboarding Zustand store and forwards it as `billing_cycle: "monthly" | "yearly"` in the `updateTier` request.
- Backend `SubscriptionTierRequest` gains `billing_cycle: Literal["monthly","yearly"]` defaulting to `"monthly"` (back-compat for the settings billing tab).
- `get_subscription_price_id(tier, billing_cycle)` accepts the new arg and supports both LD JSON shapes:
  - Legacy flat: `{"PRO": "price_xxx"}` — monthly only
  - Nested: `{"PRO": {"monthly": "price_m", "yearly": "price_y"}}`
  - Legacy-flat + yearly → returns `None` so we fail closed (422) instead of silently billing monthly.
- `create_subscription_checkout` and `modify_stripe_subscription_for_tier` forward the cycle to the price lookup and tag the Stripe subscription metadata with `billing_cycle` for observability.

### Changes 🏗️

- `frontend/.../SubscriptionStep/useSubscriptionStep.ts` — send `billing_cycle` based on `isYearly`.
- `backend/api/features/v1.py` — `SubscriptionTierRequest.billing_cycle`; endpoint forwards it to price lookup + checkout + modify.
- `backend/data/credit.py` — `BillingCycle` type alias, `get_subscription_price_id(tier, billing_cycle)` with dual-shape LD support, cycle threaded through `create_subscription_checkout` and `modify_stripe_subscription_for_tier`, cycle written to Stripe subscription metadata.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [ ] Start the platform locally with a LD flag value `{"PRO": {"monthly": "<price_m>", "yearly": "<price_y>"}}`
  - [ ] In a fresh onboarding flow, reach step 4, toggle to **Yearly**, click **Upgrade to Pro**, and confirm the resulting Stripe Checkout session uses the yearly price ID
  - [ ] Repeat with **Monthly** and confirm the monthly price ID is used
  - [ ] With the legacy flat LD shape `{"PRO": "price_m"}`, confirm yearly selection returns a 422 (fail-closed) rather than silently charging monthly
  - [ ] Confirm the settings billing tab (which does not send `billing_cycle`) continues to default to monthly

#### For configuration changes:

- [x] `.env.default` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes
- [ ] LaunchDarkly flag `copilot-tier-stripe-prices` should be migrated to the nested `{tier: {monthly, yearly}}` shape for any tier that should support yearly billing. The legacy flat shape continues to work for monthly-only tiers.
