### PR TITLE
copy(frontend): update auto-refill warning text on billing settings page

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/AutomationCreditsTab/AutoRefillCard/AutoRefillDialog.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/AutomationCreditsTab/AutoRefillCard/AutoRefillDialog.tsx
@@ -63,9 +63,9 @@ export function AutoRefillDialog({
           <div className="flex items-start gap-2 rounded-[12px] bg-amber-50 px-3 py-2">
             <WarningIcon size={18} className="mt-0.5 shrink-0 text-amber-600" />
             <Text variant="small" as="span" className="text-amber-700">
-              A single agent run can only trigger one auto-refill. Set a refill
-              amount that covers your typical usage so agents don&apos;t pause
-              mid-run.
+              As a safety mechanism, auto-refill will only trigger once per
+              task. Keep this in mind when budgeting to ensure your balance does
+              not hit zero and your tasks don&apos;t pause mid-run.
             </Text>
           </div>
         </div>

--- a/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/AutomationCreditsTab/AutoRefillCard/AutoRefillDialog.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/AutomationCreditsTab/AutoRefillCard/AutoRefillDialog.tsx
@@ -65,7 +65,7 @@ export function AutoRefillDialog({
             <Text variant="small" as="span" className="text-amber-700">
               As a safety mechanism, auto-refill will only trigger once per
               task. Keep this in mind when budgeting to ensure your balance does
-              not hit zero and your tasks don&apos;t pause mid-run.
+              not hit zero and your tasks don't pause mid-run.
             </Text>
           </div>
         </div>

--- a/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/AutomationCreditsTab/AutoRefillCard/AutoRefillDialog.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/AutomationCreditsTab/AutoRefillCard/AutoRefillDialog.tsx
@@ -65,7 +65,7 @@ export function AutoRefillDialog({
             <Text variant="small" as="span" className="text-amber-700">
               As a safety mechanism, auto-refill will only trigger once per
               task. Keep this in mind when budgeting to ensure your balance does
-              not hit zero and your tasks don't pause mid-run.
+              not hit zero and your tasks don&apos;t pause mid-run.
             </Text>
           </div>
         </div>


### PR DESCRIPTION
### Why / What / How

**Why:** The existing warning text was written from an implementation perspective. User feedback requested clearer, user-benefit-oriented copy that helps users budget appropriately.

**What:** Updated the warning text inside the auto-refill dialog on `/settings/billing` to use plain language that explains the safety mechanism and its budgeting implications.

**How:** Single string change in `AutoRefillDialog.tsx`.

### Changes 🏗️

- Updated warning copy in `AutoRefillCard/AutoRefillDialog.tsx` from:
  > "A single agent run can only trigger one auto-refill. Set a refill amount that covers your typical usage so agents don't pause mid-run."

  To:
  > "As a safety mechanism, auto-refill will only trigger once per task. Keep this in mind when budgeting to ensure your balance does not hit zero and your tasks don't pause mid-run."

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Navigate to `/settings/billing`, open the auto-refill dialog, verify new warning text is displayed correctly
