### PR TITLE
feat(frontend): redesign publish agent flow modal

### DIFF
--- a/autogpt_platform/backend/backend/api/features/store/db.py
+++ b/autogpt_platform/backend/backend/api/features/store/db.py
@@ -1194,9 +1194,13 @@ async def get_my_agents(
     user_id: str,
     page: int = 1,
     page_size: int = 20,
+    sort_by: store_model.MyAgentsSortBy = store_model.MyAgentsSortBy.MOST_RECENT,
 ) -> store_model.MyUnpublishedAgentsResponse:
     """Get the agents for the authenticated user"""
-    logger.debug(f"Getting my agents for user {user_id}, page={page}")
+    logger.debug(
+        f"Getting my agents for user {user_id}, page={page}, "
+        f"sort_by={sort_by.value}"
+    )
 
     try:
         search_filter: prisma.types.LibraryAgentWhereInput = {
@@ -1216,9 +1220,17 @@ async def get_my_agents(
             "isDeleted": False,
         }
 
+        if sort_by == store_model.MyAgentsSortBy.NAME:
+            order: list = [
+                {"AgentGraph": {"name": "asc"}},
+                {"updatedAt": "desc"},
+            ]
+        else:
+            order = [{"updatedAt": "desc"}]
+
         library_agents = await prisma.models.LibraryAgent.prisma().find_many(
             where=search_filter,
-            order=[{"updatedAt": "desc"}],
+            order=order,
             skip=(page - 1) * page_size,
             take=page_size,
             include={"AgentGraph": True},

--- a/autogpt_platform/backend/backend/api/features/store/db.py
+++ b/autogpt_platform/backend/backend/api/features/store/db.py
@@ -1190,23 +1190,79 @@ async def update_profile(
         raise DatabaseError("Failed to update profile") from e
 
 
+def _status_clause(status: store_model.MyAgentsStatusFilter) -> dict:
+    """Map a status filter to an AgentGraph where-clause (matches LibraryAgent.AgentGraph)."""
+    live_published = {
+        "isAvailable": True,
+        "submissionStatus": prisma.enums.SubmissionStatus.APPROVED,
+        "StoreListing": {"is": {"isDeleted": False}},
+    }
+    match status:
+        case store_model.MyAgentsStatusFilter.PUBLISHED:
+            return {"StoreListingVersions": {"some": live_published}}
+        case store_model.MyAgentsStatusFilter.SUBMITTED:
+            # Pending review and no version already live.
+            return {
+                "StoreListingVersions": {
+                    "some": {
+                        "submissionStatus": prisma.enums.SubmissionStatus.PENDING,
+                    }
+                },
+                "AND": [
+                    {"StoreListingVersions": {"none": live_published}},
+                ],
+            }
+        case store_model.MyAgentsStatusFilter.DRAFT:
+            # Has a draft listing version, nothing pending or live.
+            return {
+                "StoreListingVersions": {
+                    "some": {
+                        "submissionStatus": prisma.enums.SubmissionStatus.DRAFT,
+                    }
+                },
+                "AND": [
+                    {
+                        "StoreListingVersions": {
+                            "none": {
+                                "submissionStatus": prisma.enums.SubmissionStatus.PENDING,
+                            }
+                        }
+                    },
+                    {"StoreListingVersions": {"none": live_published}},
+                ],
+            }
+        case store_model.MyAgentsStatusFilter.NEVER_SUBMITTED:
+            return {"StoreListingVersions": {"none": {}}}
+
+
 async def get_my_agents(
     user_id: str,
     page: int = 1,
     page_size: int = 20,
     sort_by: store_model.MyAgentsSortBy = store_model.MyAgentsSortBy.MOST_RECENT,
+    statuses: list[store_model.MyAgentsStatusFilter] | None = None,
 ) -> store_model.MyUnpublishedAgentsResponse:
     """Get the agents for the authenticated user"""
     logger.debug(
         f"Getting my agents for user {user_id}, page={page}, "
-        f"sort_by={sort_by.value}"
+        f"sort_by={sort_by.value}, statuses={statuses}"
     )
 
     try:
         search_filter: prisma.types.LibraryAgentWhereInput = {
             "userId": user_id,
-            # Filter for unpublished agents only:
-            "AgentGraph": {
+            "isArchived": False,
+            "isDeleted": False,
+        }
+
+        if statuses:
+            search_filter["AgentGraph"] = {
+                "is": {"OR": [_status_clause(s) for s in statuses]}
+            }
+        else:
+            # No filter selected → preserve legacy behaviour: exclude
+            # agents that already have a live published listing.
+            search_filter["AgentGraph"] = {
                 "is": {
                     "StoreListingVersions": {
                         "none": {
@@ -1215,10 +1271,7 @@ async def get_my_agents(
                         }
                     }
                 }
-            },
-            "isArchived": False,
-            "isDeleted": False,
-        }
+            }
 
         if sort_by == store_model.MyAgentsSortBy.NAME:
             order: list = [

--- a/autogpt_platform/backend/backend/api/features/store/db.py
+++ b/autogpt_platform/backend/backend/api/features/store/db.py
@@ -1190,79 +1190,23 @@ async def update_profile(
         raise DatabaseError("Failed to update profile") from e
 
 
-def _status_clause(status: store_model.MyAgentsStatusFilter) -> dict:
-    """Map a status filter to an AgentGraph where-clause (matches LibraryAgent.AgentGraph)."""
-    live_published = {
-        "isAvailable": True,
-        "submissionStatus": prisma.enums.SubmissionStatus.APPROVED,
-        "StoreListing": {"is": {"isDeleted": False}},
-    }
-    match status:
-        case store_model.MyAgentsStatusFilter.PUBLISHED:
-            return {"StoreListingVersions": {"some": live_published}}
-        case store_model.MyAgentsStatusFilter.SUBMITTED:
-            # Pending review and no version already live.
-            return {
-                "StoreListingVersions": {
-                    "some": {
-                        "submissionStatus": prisma.enums.SubmissionStatus.PENDING,
-                    }
-                },
-                "AND": [
-                    {"StoreListingVersions": {"none": live_published}},
-                ],
-            }
-        case store_model.MyAgentsStatusFilter.DRAFT:
-            # Has a draft listing version, nothing pending or live.
-            return {
-                "StoreListingVersions": {
-                    "some": {
-                        "submissionStatus": prisma.enums.SubmissionStatus.DRAFT,
-                    }
-                },
-                "AND": [
-                    {
-                        "StoreListingVersions": {
-                            "none": {
-                                "submissionStatus": prisma.enums.SubmissionStatus.PENDING,
-                            }
-                        }
-                    },
-                    {"StoreListingVersions": {"none": live_published}},
-                ],
-            }
-        case store_model.MyAgentsStatusFilter.NEVER_SUBMITTED:
-            return {"StoreListingVersions": {"none": {}}}
-
-
 async def get_my_agents(
     user_id: str,
     page: int = 1,
     page_size: int = 20,
     sort_by: store_model.MyAgentsSortBy = store_model.MyAgentsSortBy.MOST_RECENT,
-    statuses: list[store_model.MyAgentsStatusFilter] | None = None,
 ) -> store_model.MyUnpublishedAgentsResponse:
     """Get the agents for the authenticated user"""
     logger.debug(
         f"Getting my agents for user {user_id}, page={page}, "
-        f"sort_by={sort_by.value}, statuses={statuses}"
+        f"sort_by={sort_by.value}"
     )
 
     try:
         search_filter: prisma.types.LibraryAgentWhereInput = {
             "userId": user_id,
-            "isArchived": False,
-            "isDeleted": False,
-        }
-
-        if statuses:
-            search_filter["AgentGraph"] = {
-                "is": {"OR": [_status_clause(s) for s in statuses]}
-            }
-        else:
-            # No filter selected → preserve legacy behaviour: exclude
-            # agents that already have a live published listing.
-            search_filter["AgentGraph"] = {
+            # Filter for unpublished agents only:
+            "AgentGraph": {
                 "is": {
                     "StoreListingVersions": {
                         "none": {
@@ -1271,7 +1215,10 @@ async def get_my_agents(
                         }
                     }
                 }
-            }
+            },
+            "isArchived": False,
+            "isDeleted": False,
+        }
 
         if sort_by == store_model.MyAgentsSortBy.NAME:
             order: list = [

--- a/autogpt_platform/backend/backend/api/features/store/db_test.py
+++ b/autogpt_platform/backend/backend/api/features/store/db_test.py
@@ -562,3 +562,108 @@ async def test_get_store_submissions_reuses_stats_total_for_pagination(mocker):
     assert result.stats.total == 7
     assert result.stats.average_rating == 3.9
     mock_store_sub.return_value.count.assert_not_called()
+
+
+def _make_library_agent(idx: int, now: datetime) -> prisma.models.LibraryAgent:
+    graph = prisma.models.AgentGraph(
+        id=f"graph-{idx}",
+        version=1,
+        userId="user-id",
+        createdAt=now,
+        updatedAt=now,
+        isActive=True,
+        name=f"Agent {idx}",
+        description=f"Description {idx}",
+    )
+    return prisma.models.LibraryAgent.model_construct(
+        id=f"library-{idx}",
+        userId="user-id",
+        agentGraphId=graph.id,
+        agentGraphVersion=graph.version,
+        createdAt=now,
+        updatedAt=now,
+        isArchived=False,
+        isDeleted=False,
+        isFavorite=False,
+        isCreatedByUser=True,
+        useGraphIsActiveVersion=True,
+        settings={},
+        imageUrl=None,
+        AgentGraph=graph,
+    )
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_get_my_agents_default_sort_most_recent(mocker):
+    """Default sort orders by updatedAt desc and returns mapped agents."""
+    now = datetime.now()
+    mock_agents = [_make_library_agent(i, now) for i in range(1, 4)]
+
+    find_many = AsyncMock(return_value=mock_agents)
+    count = AsyncMock(return_value=3)
+    mock_library = mocker.patch("prisma.models.LibraryAgent.prisma")
+    mock_library.return_value.find_many = find_many
+    mock_library.return_value.count = count
+
+    from .model import MyAgentsSortBy
+
+    result = await db.get_my_agents(user_id="user-id", page=1, page_size=10)
+
+    assert result.pagination.total_items == 3
+    assert result.pagination.total_pages == 1
+    assert [a.graph_id for a in result.agents] == [
+        "graph-1",
+        "graph-2",
+        "graph-3",
+    ]
+    # Default sort_by is MOST_RECENT → updatedAt desc only.
+    kwargs = find_many.call_args.kwargs
+    assert kwargs["order"] == [{"updatedAt": "desc"}]
+    assert kwargs["skip"] == 0
+    assert kwargs["take"] == 10
+
+    # Make sure the enum default is what we expect for callers.
+    assert MyAgentsSortBy.MOST_RECENT.value == "most_recent"
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_get_my_agents_sort_by_name(mocker):
+    """sort_by=NAME orders by AgentGraph.name asc then updatedAt desc."""
+    now = datetime.now()
+    mock_library = mocker.patch("prisma.models.LibraryAgent.prisma")
+    mock_library.return_value.find_many = AsyncMock(return_value=[])
+    mock_library.return_value.count = AsyncMock(return_value=0)
+
+    from .model import MyAgentsSortBy
+
+    result = await db.get_my_agents(
+        user_id="user-id",
+        page=1,
+        page_size=10,
+        sort_by=MyAgentsSortBy.NAME,
+    )
+
+    assert result.agents == []
+    assert result.pagination.total_pages == 0
+    kwargs = mock_library.return_value.find_many.call_args.kwargs
+    assert kwargs["order"] == [
+        {"AgentGraph": {"name": "asc"}},
+        {"updatedAt": "desc"},
+    ]
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_get_my_agents_pagination_window(mocker):
+    """skip/take honour the requested page so we hit the right offset."""
+    now = datetime.now()
+    mock_library = mocker.patch("prisma.models.LibraryAgent.prisma")
+    mock_library.return_value.find_many = AsyncMock(return_value=[])
+    mock_library.return_value.count = AsyncMock(return_value=47)
+
+    result = await db.get_my_agents(user_id="user-id", page=3, page_size=10)
+
+    assert result.pagination.total_pages == 5
+    assert result.pagination.current_page == 3
+    kwargs = mock_library.return_value.find_many.call_args.kwargs
+    assert kwargs["skip"] == 20
+    assert kwargs["take"] == 10

--- a/autogpt_platform/backend/backend/api/features/store/db_test.py
+++ b/autogpt_platform/backend/backend/api/features/store/db_test.py
@@ -8,7 +8,7 @@ import pytest
 from prisma import Prisma
 
 from . import db
-from .model import Profile, SubmissionStats
+from .model import MyAgentsSortBy, Profile, SubmissionStats
 
 
 @pytest.fixture(autouse=True)
@@ -605,8 +605,6 @@ async def test_get_my_agents_default_sort_most_recent(mocker):
     mock_library.return_value.find_many = find_many
     mock_library.return_value.count = count
 
-    from .model import MyAgentsSortBy
-
     result = await db.get_my_agents(user_id="user-id", page=1, page_size=10)
 
     assert result.pagination.total_items == 3
@@ -633,8 +631,6 @@ async def test_get_my_agents_sort_by_name(mocker):
     mock_library = mocker.patch("prisma.models.LibraryAgent.prisma")
     mock_library.return_value.find_many = AsyncMock(return_value=[])
     mock_library.return_value.count = AsyncMock(return_value=0)
-
-    from .model import MyAgentsSortBy
 
     result = await db.get_my_agents(
         user_id="user-id",

--- a/autogpt_platform/backend/backend/api/features/store/model.py
+++ b/autogpt_platform/backend/backend/api/features/store/model.py
@@ -1,4 +1,5 @@
 import datetime
+import enum
 from typing import TYPE_CHECKING, List, Self
 
 import prisma.enums
@@ -14,6 +15,11 @@ class ChangelogEntry(pydantic.BaseModel):
     version: str
     changes_summary: str
     date: datetime.datetime
+
+
+class MyAgentsSortBy(str, enum.Enum):
+    MOST_RECENT = "most_recent"
+    NAME = "name"
 
 
 class MyUnpublishedAgent(pydantic.BaseModel):

--- a/autogpt_platform/backend/backend/api/features/store/model.py
+++ b/autogpt_platform/backend/backend/api/features/store/model.py
@@ -22,6 +22,13 @@ class MyAgentsSortBy(str, enum.Enum):
     NAME = "name"
 
 
+class MyAgentsStatusFilter(str, enum.Enum):
+    DRAFT = "draft"
+    SUBMITTED = "submitted"
+    PUBLISHED = "published"
+    NEVER_SUBMITTED = "never_submitted"
+
+
 class MyUnpublishedAgent(pydantic.BaseModel):
     graph_id: str
     graph_version: int

--- a/autogpt_platform/backend/backend/api/features/store/model.py
+++ b/autogpt_platform/backend/backend/api/features/store/model.py
@@ -22,13 +22,6 @@ class MyAgentsSortBy(str, enum.Enum):
     NAME = "name"
 
 
-class MyAgentsStatusFilter(str, enum.Enum):
-    DRAFT = "draft"
-    SUBMITTED = "submitted"
-    PUBLISHED = "published"
-    NEVER_SUBMITTED = "never_submitted"
-
-
 class MyUnpublishedAgent(pydantic.BaseModel):
     graph_id: str
     graph_version: int

--- a/autogpt_platform/backend/backend/api/features/store/routes.py
+++ b/autogpt_platform/backend/backend/api/features/store/routes.py
@@ -331,9 +331,17 @@ async def get_my_unpublished_agents(
     user_id: str = Security(autogpt_libs.auth.get_user_id),
     page: int = Query(ge=1, default=1),
     page_size: int = Query(ge=1, default=20),
+    sort_by: store_model.MyAgentsSortBy = Query(
+        default=store_model.MyAgentsSortBy.MOST_RECENT
+    ),
 ) -> store_model.MyUnpublishedAgentsResponse:
     """List the authenticated user's unpublished agents"""
-    agents = await store_db.get_my_agents(user_id, page=page, page_size=page_size)
+    agents = await store_db.get_my_agents(
+        user_id,
+        page=page,
+        page_size=page_size,
+        sort_by=sort_by,
+    )
     return agents
 
 

--- a/autogpt_platform/backend/backend/api/features/store/routes.py
+++ b/autogpt_platform/backend/backend/api/features/store/routes.py
@@ -334,13 +334,22 @@ async def get_my_unpublished_agents(
     sort_by: store_model.MyAgentsSortBy = Query(
         default=store_model.MyAgentsSortBy.MOST_RECENT
     ),
+    status: list[store_model.MyAgentsStatusFilter] | None = Query(default=None),
 ) -> store_model.MyUnpublishedAgentsResponse:
-    """List the authenticated user's unpublished agents"""
+    """List the authenticated user's agents.
+
+    When `status` is supplied (any combination of draft / submitted /
+    published / never_submitted) the result is filtered to that union;
+    otherwise the legacy behaviour is preserved (already-published
+    agents are excluded so the publish-flow first step keeps working
+    out of the box).
+    """
     agents = await store_db.get_my_agents(
         user_id,
         page=page,
         page_size=page_size,
         sort_by=sort_by,
+        statuses=status,
     )
     return agents
 

--- a/autogpt_platform/backend/backend/api/features/store/routes.py
+++ b/autogpt_platform/backend/backend/api/features/store/routes.py
@@ -334,22 +334,13 @@ async def get_my_unpublished_agents(
     sort_by: store_model.MyAgentsSortBy = Query(
         default=store_model.MyAgentsSortBy.MOST_RECENT
     ),
-    status: list[store_model.MyAgentsStatusFilter] | None = Query(default=None),
 ) -> store_model.MyUnpublishedAgentsResponse:
-    """List the authenticated user's agents.
-
-    When `status` is supplied (any combination of draft / submitted /
-    published / never_submitted) the result is filtered to that union;
-    otherwise the legacy behaviour is preserved (already-published
-    agents are excluded so the publish-flow first step keeps working
-    out of the box).
-    """
+    """List the authenticated user's unpublished agents"""
     agents = await store_db.get_my_agents(
         user_id,
         page=page,
         page_size=page_size,
         sort_by=sort_by,
-        statuses=status,
     )
     return agents
 

--- a/autogpt_platform/frontend/src/app/api/openapi.json
+++ b/autogpt_platform/frontend/src/app/api/openapi.json
@@ -8592,7 +8592,7 @@
       "get": {
         "tags": ["v2", "store", "private"],
         "summary": "Get my agents",
-        "description": "List the authenticated user's unpublished agents",
+        "description": "List the authenticated user's agents.\n\nWhen `status` is supplied (any combination of draft / submitted /\npublished / never_submitted) the result is filtered to that union;\notherwise the legacy behaviour is preserved (already-published\nagents are excluded so the publish-flow first step keeps working\nout of the box).",
         "operationId": "getV2Get my agents",
         "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
@@ -8625,6 +8625,23 @@
             "schema": {
               "$ref": "#/components/schemas/MyAgentsSortBy",
               "default": "most_recent"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/MyAgentsStatusFilter"
+                  }
+                },
+                { "type": "null" }
+              ],
+              "title": "Status"
             }
           }
         ],
@@ -13596,6 +13613,11 @@
         "type": "string",
         "enum": ["most_recent", "name"],
         "title": "MyAgentsSortBy"
+      },
+      "MyAgentsStatusFilter": {
+        "type": "string",
+        "enum": ["draft", "submitted", "published", "never_submitted"],
+        "title": "MyAgentsStatusFilter"
       },
       "MyUnpublishedAgent": {
         "properties": {

--- a/autogpt_platform/frontend/src/app/api/openapi.json
+++ b/autogpt_platform/frontend/src/app/api/openapi.json
@@ -8617,6 +8617,15 @@
               "default": 20,
               "title": "Page Size"
             }
+          },
+          {
+            "name": "sort_by",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/MyAgentsSortBy",
+              "default": "most_recent"
+            }
           }
         ],
         "responses": {
@@ -13582,6 +13591,11 @@
         "type": "object",
         "required": ["value", "label", "provider"],
         "title": "ModelInfo"
+      },
+      "MyAgentsSortBy": {
+        "type": "string",
+        "enum": ["most_recent", "name"],
+        "title": "MyAgentsSortBy"
       },
       "MyUnpublishedAgent": {
         "properties": {

--- a/autogpt_platform/frontend/src/app/api/openapi.json
+++ b/autogpt_platform/frontend/src/app/api/openapi.json
@@ -8592,7 +8592,7 @@
       "get": {
         "tags": ["v2", "store", "private"],
         "summary": "Get my agents",
-        "description": "List the authenticated user's agents.\n\nWhen `status` is supplied (any combination of draft / submitted /\npublished / never_submitted) the result is filtered to that union;\notherwise the legacy behaviour is preserved (already-published\nagents are excluded so the publish-flow first step keeps working\nout of the box).",
+        "description": "List the authenticated user's unpublished agents",
         "operationId": "getV2Get my agents",
         "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
@@ -8625,23 +8625,6 @@
             "schema": {
               "$ref": "#/components/schemas/MyAgentsSortBy",
               "default": "most_recent"
-            }
-          },
-          {
-            "name": "status",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/MyAgentsStatusFilter"
-                  }
-                },
-                { "type": "null" }
-              ],
-              "title": "Status"
             }
           }
         ],
@@ -13613,11 +13596,6 @@
         "type": "string",
         "enum": ["most_recent", "name"],
         "title": "MyAgentsSortBy"
-      },
-      "MyAgentsStatusFilter": {
-        "type": "string",
-        "enum": ["draft", "submitted", "published", "never_submitted"],
-        "title": "MyAgentsStatusFilter"
       },
       "MyUnpublishedAgent": {
         "properties": {

--- a/autogpt_platform/frontend/src/components/atoms/Input/Input.tsx
+++ b/autogpt_platform/frontend/src/components/atoms/Input/Input.tsx
@@ -7,6 +7,8 @@ import { Eye, EyeSlash } from "@phosphor-icons/react";
 import { forwardRef, ReactNode, useState } from "react";
 import CurrencyInput from "react-currency-input-field";
 import { Text } from "../Text/Text";
+import type { Variant } from "../Text/helpers";
+import { InformationTooltip } from "@/components/molecules/InformationTooltip/InformationTooltip";
 import { useInput } from "./useInput";
 
 type InputElement = HTMLInputElement | HTMLTextAreaElement;
@@ -19,6 +21,9 @@ export interface TextFieldProps extends Omit<InputProps, "size"> {
   error?: string;
   hint?: ReactNode;
   size?: "small" | "medium";
+  labelVariant?: Variant;
+  labelClassName?: string;
+  labelTooltip?: string;
   wrapperClassName?: string;
   type?:
     | "text"
@@ -47,6 +52,9 @@ export const Input = forwardRef<InputElement, TextFieldProps>(function Input(
     hint,
     error,
     size = "medium",
+    labelVariant = "large-medium",
+    labelClassName,
+    labelTooltip,
     wrapperClassName,
     amountPrefix,
     amountSuffix,
@@ -79,7 +87,7 @@ export const Input = forwardRef<InputElement, TextFieldProps>(function Input(
 
   const baseStyles = cn(
     // Base styles
-    "rounded-3xl border border-zinc-200 bg-white px-4 shadow-none w-full",
+    "rounded-xl border border-zinc-200 bg-white px-4 shadow-none w-full",
     "font-normal text-black",
     "placeholder:font-normal placeholder:text-zinc-400",
     // Focus and hover states
@@ -233,10 +241,19 @@ export const Input = forwardRef<InputElement, TextFieldProps>(function Input(
     inputWithError
   ) : (
     <label htmlFor={props.id} className="flex w-full flex-col gap-2">
-      <div className="flex items-center justify-between">
-        <Text variant="large-medium" as="span" className="text-black">
-          {label}
-        </Text>
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-1">
+          <Text
+            variant={labelVariant}
+            as="span"
+            className={cn("text-black", labelClassName)}
+          >
+            {label}
+          </Text>
+          {labelTooltip ? (
+            <InformationTooltip description={labelTooltip} iconSize={20} />
+          ) : null}
+        </div>
         {hint ? (
           <Text variant="small" as="span" className="!text-zinc-400">
             {hint}

--- a/autogpt_platform/frontend/src/components/atoms/Select/Select.tsx
+++ b/autogpt_platform/frontend/src/components/atoms/Select/Select.tsx
@@ -12,6 +12,8 @@ import { cn } from "@/lib/utils";
 import * as React from "react";
 import { ReactNode } from "react";
 import { Text } from "../Text/Text";
+import type { Variant } from "../Text/helpers";
+import { InformationTooltip } from "@/components/molecules/InformationTooltip/InformationTooltip";
 
 export interface SelectOption {
   value: string;
@@ -35,6 +37,9 @@ export interface SelectFieldProps {
   onValueChange?: (value: string) => void;
   options: SelectOption[];
   size?: "small" | "medium";
+  labelVariant?: Variant;
+  labelClassName?: string;
+  labelTooltip?: string;
   renderItem?: (option: SelectOption) => React.ReactNode;
   wrapperClassName?: string;
 }
@@ -52,12 +57,15 @@ export function Select({
   onValueChange,
   options,
   size = "medium",
+  labelVariant = "large-medium",
+  labelClassName,
+  labelTooltip,
   renderItem,
   wrapperClassName,
 }: SelectFieldProps) {
   const triggerStyles = cn(
     // Base styles matching Input
-    "rounded-3xl border border-zinc-200 bg-white px-4 shadow-none",
+    "rounded-xl border border-zinc-200 bg-white px-4 shadow-none",
     "font-normal text-black w-full",
     "placeholder:font-normal !placeholder:text-zinc-400",
     // Focus and hover states
@@ -139,10 +147,19 @@ export function Select({
     selectWithError
   ) : (
     <label htmlFor={id} className="flex flex-col gap-2">
-      <div className="flex items-center justify-between">
-        <Text variant="large-medium" as="span" className="text-black">
-          {label}
-        </Text>
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-1">
+          <Text
+            variant={labelVariant}
+            as="span"
+            className={cn("text-black", labelClassName)}
+          >
+            {label}
+          </Text>
+          {labelTooltip ? (
+            <InformationTooltip description={labelTooltip} iconSize={20} />
+          ) : null}
+        </div>
         {hint}
       </div>
       {selectWithError}

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/PublishAgentModal.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/PublishAgentModal.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import * as React from "react";
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import { AgentSelectStep } from "./components/AgentSelectStep/AgentSelectStep";
 import { AgentInfoStep } from "./components/AgentInfoStep/AgentInfoStep";
 import { AgentReviewStep } from "./components/AgentReviewStep";
+import { StepStrip } from "./components/StepStrip";
 import { Dialog } from "@/components/molecules/Dialog/Dialog";
 import { Skeleton } from "@/components/__legacy__/ui/skeleton";
 import { Button } from "@/components/atoms/Button/Button";
@@ -45,6 +47,18 @@ export function PublishAgentModal({
   });
 
   const { user, isUserLoading } = useSupabase();
+  const shouldReduceMotion = useReducedMotion();
+
+  const stepOrder = React.useMemo(
+    () => ["select", "info", "review"] as const,
+    [],
+  );
+  const currentStepIndex = stepOrder.indexOf(currentState.step);
+  const previousStepIndexRef = React.useRef(currentStepIndex);
+  const direction = currentStepIndex >= previousStepIndexRef.current ? 1 : -1;
+  React.useEffect(() => {
+    previousStepIndexRef.current = currentStepIndex;
+  }, [currentStepIndex]);
 
   function renderContent() {
     if (isUserLoading) {
@@ -107,7 +121,7 @@ export function PublishAgentModal({
     <>
       <Dialog
         styling={{
-          maxWidth: "45rem",
+          maxWidth: "48rem",
         }}
         controlled={{
           isOpen: currentState.isOpen,
@@ -130,7 +144,58 @@ export function PublishAgentModal({
           </Dialog.Trigger>
         )}
         <Dialog.Content>
-          <div data-testid="publish-agent-modal">{renderContent()}</div>
+          <div data-testid="publish-agent-modal" className="min-h-0">
+            {user && currentState.step && currentState.step !== "review" ? (
+              <StepStrip currentStep={currentState.step} />
+            ) : null}
+            <motion.div
+              layout
+              transition={{
+                layout: shouldReduceMotion
+                  ? { duration: 0 }
+                  : { duration: 0.32, ease: [0.16, 1, 0.3, 1] },
+              }}
+              className="overflow-hidden"
+            >
+              <AnimatePresence
+                mode="wait"
+                initial={false}
+                custom={direction}
+              >
+                <motion.div
+                  key={user ? currentState.step : "auth"}
+                  custom={direction}
+                  variants={{
+                    enter: (dir: number) => ({
+                      opacity: 0,
+                      x: shouldReduceMotion ? 0 : dir * 40,
+                    }),
+                    center: {
+                      opacity: 1,
+                      x: 0,
+                      transition: {
+                        duration: shouldReduceMotion ? 0 : 0.24,
+                        ease: [0.16, 1, 0.3, 1],
+                      },
+                    },
+                    exit: (dir: number) => ({
+                      opacity: 0,
+                      x: shouldReduceMotion ? 0 : dir * -40,
+                      transition: {
+                        duration: shouldReduceMotion ? 0 : 0.16,
+                        ease: [0.4, 0, 1, 1],
+                      },
+                    }),
+                  }}
+                  initial="enter"
+                  animate="center"
+                  exit="exit"
+                >
+                  {renderContent()}
+                </motion.div>
+              </AnimatePresence>
+            </motion.div>
+          </div>
         </Dialog.Content>
       </Dialog>
     </>

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/PublishAgentModal.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/PublishAgentModal.tsx
@@ -157,11 +157,7 @@ export function PublishAgentModal({
               }}
               className="overflow-hidden"
             >
-              <AnimatePresence
-                mode="wait"
-                initial={false}
-                custom={direction}
-              >
+              <AnimatePresence mode="wait" initial={false} custom={direction}>
                 <motion.div
                   key={user ? currentState.step : "auth"}
                   custom={direction}

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentInfoStep/AgentInfoStep.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentInfoStep/AgentInfoStep.tsx
@@ -2,14 +2,31 @@
 
 import { CronExpressionDialog } from "@/components/contextual/CronScheduler/cron-scheduler-dialog";
 import { Form, FormField } from "@/components/__legacy__/ui/form";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/molecules/Accordion/Accordion";
 import { Button } from "@/components/atoms/Button/Button";
 import { Input } from "@/components/atoms/Input/Input";
 import { Select } from "@/components/atoms/Select/Select";
 import { Text } from "@/components/atoms/Text/Text";
 import { humanizeCronExpression } from "@/lib/cron-expression-utils";
-import { CalendarClockIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { InformationTooltip } from "@/components/molecules/InformationTooltip/InformationTooltip";
+import {
+  CalendarDotsIcon,
+  CheckCircleIcon,
+  ImagesIcon,
+  InfoIcon,
+  SparkleIcon,
+  StorefrontIcon,
+  WarningCircleIcon,
+} from "@phosphor-icons/react";
 import * as React from "react";
 import { StepHeader } from "../StepHeader";
+import { StepFooter } from "../StepFooter";
 import { ThumbnailImages } from "./components/ThumbnailImages";
 import { Props, useAgentInfoStep } from "./useAgentInfoStep";
 
@@ -24,6 +41,7 @@ export function AgentInfoStep({
   const {
     form,
     agentId,
+    images,
     initialImages,
     initialSelectedImage,
     handleImagesChange,
@@ -40,6 +58,11 @@ export function AgentInfoStep({
 
   const [cronScheduleDialogOpen, setCronScheduleDialogOpen] =
     React.useState(false);
+  const [openAccordion, setOpenAccordion] = React.useState("");
+  React.useEffect(() => {
+    const timer = window.setTimeout(() => setOpenAccordion("basics"), 320);
+    return () => window.clearTimeout(timer);
+  }, []);
 
   const handleScheduleChange = (cronExpression: string) => {
     form.setValue("recommendedScheduleCron", cronExpression);
@@ -58,223 +81,410 @@ export function AgentInfoStep({
     { value: "other", label: "Other" },
   ];
 
+  const isSubmitDisabled =
+    Object.keys(form.formState.errors).length > 0 || isSubmitting;
+
+  const watched = form.watch();
+  const errors = form.formState.errors;
+  const basicsHasError = !!(
+    errors.title ||
+    errors.slug ||
+    errors.subheader ||
+    errors.category
+  );
+  const experienceHasError = !!(
+    errors.description ||
+    errors.instructions ||
+    errors.youtubeLink ||
+    errors.agentOutputDemo
+  );
+  const thumbnailsHasError = !!errors.root;
+  const basicsComplete =
+    !basicsHasError &&
+    !!watched.title &&
+    !!watched.slug &&
+    !!watched.subheader &&
+    !!watched.category;
+  const thumbnailsComplete = !thumbnailsHasError && images.length > 0;
+  const experienceComplete =
+    !experienceHasError &&
+    !!watched.description &&
+    !!watched.youtubeLink &&
+    !!watched.agentOutputDemo;
+
+  const title = isMarketplaceUpdate
+    ? "Describe the update"
+    : "Build the store listing";
+  const description = isMarketplaceUpdate
+    ? "Explain what changed, then adjust any listing details that need to move with this version."
+    : "Write a bit of details about your agent so reviewers and users know what to expect.";
+
   return (
-    <div className="mx-auto flex w-full flex-col rounded-3xl">
-      <StepHeader
-        title="Publish Agent"
-        description="Write a bit of details about your agent"
-      />
+    <div className="mx-auto flex w-full flex-col">
+      <StepHeader title={title} description={description} currentStep="info" />
 
       <Form {...form}>
-        <form onSubmit={handleSubmit} className="flex-grow overflow-y-auto p-6">
-          {/* Changes summary field - only shown for updates */}
+        <form onSubmit={handleSubmit} className="flex flex-col gap-5 pb-5">
           {isMarketplaceUpdate && (
-            <FormField
-              control={form.control}
-              name="changesSummary"
-              render={({ field }) => (
-                <div className="mb-6">
+            <section className="rounded-[18px] border border-amber-200 bg-amber-50 p-4">
+              <div className="mb-4 flex items-start gap-3">
+                <div className="flex size-9 shrink-0 items-center justify-center rounded-full bg-white text-amber-700 shadow-[0_1px_2px_rgba(15,15,20,0.04)]">
+                  <InfoIcon size={18} weight="duotone" />
+                </div>
+                <div className="flex min-w-0 flex-col gap-1">
+                  <Text
+                    variant="body-medium"
+                    as="h3"
+                    className="text-amber-950"
+                  >
+                    Update note
+                  </Text>
+                  <Text variant="small" className="text-amber-800">
+                    Reviewers use this to understand why the marketplace listing
+                    needs a new version.
+                  </Text>
+                </div>
+              </div>
+              <FormField
+                control={form.control}
+                name="changesSummary"
+                render={({ field }) => (
                   <Input
                     id={field.name}
+                    labelVariant="body"
                     label="What changed?"
+                    labelTooltip="Summary of what's new or improved in this version. Reviewers see this first."
                     type="textarea"
+                    rows={1}
                     placeholder="Describe what's new or improved in this version..."
                     error={form.formState.errors.changesSummary?.message}
                     required
+                    wrapperClassName="!mb-0"
                     {...field}
                   />
-                  <Text variant="small" className="mt-1 text-gray-600">
-                    This is required to help users understand what&apos;s
-                    different in this update.
-                  </Text>
+                )}
+              />
+            </section>
+          )}
+
+          <Accordion
+            type="single"
+            collapsible
+            value={openAccordion}
+            onValueChange={setOpenAccordion}
+            className="overflow-hidden rounded-[14px] border border-zinc-200 bg-white shadow-[0_1px_2px_rgba(15,15,20,0.04)] [&>*+*]:border-t [&>*+*]:border-zinc-200"
+          >
+            <AccordionItem
+              value="basics"
+              className="border-0 px-4"
+            >
+              <AccordionTrigger className="hover:no-underline">
+                <span className="flex items-center gap-2 text-sm font-medium text-textBlack">
+                  <StorefrontIcon
+                    size={18}
+                    weight="duotone"
+                    className="text-zinc-500"
+                  />
+                  Listing basics
+                  {basicsHasError ? (
+                    <WarningCircleIcon
+                      size={16}
+                      weight="fill"
+                      className="text-rose-500"
+                    />
+                  ) : basicsComplete ? (
+                    <CheckCircleIcon
+                      size={16}
+                      weight="fill"
+                      className="text-purple-500"
+                    />
+                  ) : null}
+                </span>
+              </AccordionTrigger>
+              <AccordionContent className="px-1 pb-4 pt-0">
+                <div className="grid gap-x-4 sm:grid-cols-2">
+                  <FormField
+                    control={form.control}
+                    name="title"
+                    render={({ field }) => (
+                      <Input
+                        id={field.name}
+                        labelVariant="body"
+                        label="Title"
+                        labelTooltip="Public name shown on the marketplace listing."
+                        type="text"
+                        placeholder="Agent name"
+                        error={form.formState.errors.title?.message}
+                        {...field}
+                      />
+                    )}
+                  />
+
+                  <FormField
+                    control={form.control}
+                    name="subheader"
+                    render={({ field }) => (
+                      <Input
+                        id={field.name}
+                        labelVariant="body"
+                        label="Subheader"
+                        labelTooltip="One-sentence tagline displayed under the title."
+                        type="text"
+                        placeholder="A concise tagline for your agent"
+                        error={form.formState.errors.subheader?.message}
+                        {...field}
+                      />
+                    )}
+                  />
                 </div>
-              )}
-            />
-          )}
 
-          {/* Optional section label for updates */}
-          {isMarketplaceUpdate && (
-            <div className="mb-4">
-              <Text variant="body" className="font-medium text-gray-700">
-                Optional: Update any of the following details (or leave them
-                as-is)
-              </Text>
-            </div>
-          )}
+                <FormField
+                  control={form.control}
+                  name="slug"
+                  render={({ field }) => (
+                    <Input
+                      id={field.name}
+                      labelVariant="body"
+                      label="Slug"
+                      labelTooltip="URL-friendly identifier used in the marketplace path. Lowercase letters, numbers, hyphens only."
+                      type="text"
+                      placeholder="URL-friendly name"
+                      error={form.formState.errors.slug?.message}
+                      {...field}
+                    />
+                  )}
+                />
 
-          <FormField
-            control={form.control}
-            name="title"
-            render={({ field }) => (
-              <Input
-                id={field.name}
-                label="Title"
-                type="text"
-                placeholder="Agent name"
-                error={form.formState.errors.title?.message}
-                {...field}
-              />
-            )}
-          />
+                <FormField
+                  control={form.control}
+                  name="category"
+                  render={({ field }) => (
+                    <Select
+                      id={field.name}
+                      labelVariant="body"
+                      label="Category"
+                      labelTooltip="Primary category that helps users discover the agent."
+                      placeholder="Select a category"
+                      value={field.value}
+                      onValueChange={field.onChange}
+                      error={form.formState.errors.category?.message}
+                      options={categoryOptions}
+                    />
+                  )}
+                />
+              </AccordionContent>
+            </AccordionItem>
 
-          <FormField
-            control={form.control}
-            name="subheader"
-            render={({ field }) => (
-              <Input
-                id={field.name}
-                label="Subheader"
-                type="text"
-                placeholder="A tagline for your agent"
-                error={form.formState.errors.subheader?.message}
-                {...field}
-              />
-            )}
-          />
-
-          <FormField
-            control={form.control}
-            name="slug"
-            render={({ field }) => (
-              <Input
-                id={field.name}
-                label="Slug"
-                type="text"
-                placeholder="URL-friendly name for your agent"
-                error={form.formState.errors.slug?.message}
-                {...field}
-              />
-            )}
-          />
-
-          <ThumbnailImages
-            agentId={agentId}
-            onImagesChange={handleImagesChange}
-            initialImages={initialImages}
-            initialSelectedImage={initialSelectedImage}
-            errorMessage={form.formState.errors.root?.message}
-          />
-
-          <FormField
-            control={form.control}
-            name="youtubeLink"
-            render={({ field }) => (
-              <Input
-                id={field.name}
-                label="YouTube video link"
-                type="url"
-                placeholder="Paste a video link here"
-                error={form.formState.errors.youtubeLink?.message}
-                {...field}
-              />
-            )}
-          />
-
-          <FormField
-            control={form.control}
-            name="category"
-            render={({ field }) => (
-              <Select
-                id={field.name}
-                label="Category"
-                placeholder="Select a category for your agent"
-                value={field.value}
-                onValueChange={field.onChange}
-                error={form.formState.errors.category?.message}
-                options={categoryOptions}
-              />
-            )}
-          />
-
-          <FormField
-            control={form.control}
-            name="description"
-            render={({ field }) => (
-              <Input
-                id={field.name}
-                label="Description"
-                type="textarea"
-                placeholder="Describe your agent and what it does"
-                error={form.formState.errors.description?.message}
-                {...field}
-              />
-            )}
-          />
-
-          <FormField
-            control={form.control}
-            name="agentOutputDemo"
-            render={({ field }) => (
-              <Input
-                id={field.name}
-                label="Agent Output Demo"
-                type="url"
-                placeholder="Add a short video showing the agent's results in action."
-                error={form.formState.errors.agentOutputDemo?.message}
-                {...field}
-              />
-            )}
-          />
-
-          <FormField
-            control={form.control}
-            name="instructions"
-            render={({ field }) => (
-              <Input
-                id={field.name}
-                label="Instructions"
-                type="textarea"
-                placeholder="Explain to users how to run this agent and what to expect"
-                error={form.formState.errors.instructions?.message}
-                {...field}
-              />
-            )}
-          />
-
-          <FormField
-            control={form.control}
-            name="recommendedScheduleCron"
-            render={({ field }) => (
-              <div className="mb-8 flex flex-col space-y-2">
-                <Text variant="large-medium">Recommended Schedule</Text>
-                <p className="text-xs text-gray-600">
-                  Suggest when users should run this agent for best results
-                </p>
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={() => setCronScheduleDialogOpen(true)}
-                  className="w-full justify-start text-sm"
-                >
-                  <CalendarClockIcon className="mr-2 h-4 w-4" />
-                  {field.value
-                    ? humanizeCronExpression(field.value)
-                    : "Set schedule"}
-                </Button>
-              </div>
-            )}
-          />
-
-          <div className="flex justify-between gap-4 pt-6">
-            <Button
-              type="button"
-              onClick={onBack}
-              variant="secondary"
-              className="w-full"
+            <AccordionItem
+              value="thumbnails"
+              className="border-0 px-4"
             >
-              Back
-            </Button>
-            <Button
-              type="submit"
-              className="w-full"
-              disabled={
-                Object.keys(form.formState.errors).length > 0 || isSubmitting
-              }
-              loading={isSubmitting}
+              <AccordionTrigger className="hover:no-underline">
+                <span className="flex items-center gap-2 text-sm font-medium text-textBlack">
+                  <ImagesIcon
+                    size={18}
+                    weight="duotone"
+                    className="text-zinc-500"
+                  />
+                  Thumbnails
+                  {thumbnailsHasError ? (
+                    <WarningCircleIcon
+                      size={16}
+                      weight="fill"
+                      className="text-rose-500"
+                    />
+                  ) : thumbnailsComplete ? (
+                    <CheckCircleIcon
+                      size={16}
+                      weight="fill"
+                      className="text-purple-500"
+                    />
+                  ) : null}
+                </span>
+              </AccordionTrigger>
+              <AccordionContent className="px-1 pb-4 pt-0">
+                <ThumbnailImages
+                  agentId={agentId}
+                  onImagesChange={handleImagesChange}
+                  initialImages={initialImages}
+                  initialSelectedImage={initialSelectedImage}
+                  errorMessage={form.formState.errors.root?.message}
+                />
+              </AccordionContent>
+            </AccordionItem>
+
+            <AccordionItem
+              value="experience"
+              className="border-0 px-4"
             >
-              Submit for review
-            </Button>
-          </div>
+              <AccordionTrigger className="hover:no-underline">
+                <span className="flex items-center gap-2 text-sm font-medium text-textBlack">
+                  <SparkleIcon
+                    size={18}
+                    weight="duotone"
+                    className="text-zinc-500"
+                  />
+                  Experience details
+                  {experienceHasError ? (
+                    <WarningCircleIcon
+                      size={16}
+                      weight="fill"
+                      className="text-rose-500"
+                    />
+                  ) : experienceComplete ? (
+                    <CheckCircleIcon
+                      size={16}
+                      weight="fill"
+                      className="text-purple-500"
+                    />
+                  ) : null}
+                </span>
+              </AccordionTrigger>
+              <AccordionContent className="px-1 pb-4 pt-0">
+                <FormField
+                  control={form.control}
+                  name="description"
+                  render={({ field }) => (
+                    <Input
+                      id={field.name}
+                      labelVariant="body"
+                      label="Description"
+                      labelTooltip="What the agent does and the outcome users get."
+                      type="textarea"
+                      rows={1}
+                      placeholder="Describe the outcome this agent creates"
+                      error={form.formState.errors.description?.message}
+                      {...field}
+                    />
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="instructions"
+                  render={({ field }) => (
+                    <Input
+                      id={field.name}
+                      labelVariant="body"
+                      label="Instructions"
+                      labelTooltip="Steps users should follow to set up and run the agent."
+                      type="textarea"
+                      rows={1}
+                      placeholder="Explain inputs, setup, and what to expect after a run"
+                      error={form.formState.errors.instructions?.message}
+                      {...field}
+                    />
+                  )}
+                />
+
+                <div className="grid gap-x-4 sm:grid-cols-2">
+                  <FormField
+                    control={form.control}
+                    name="youtubeLink"
+                    render={({ field }) => (
+                      <Input
+                        id={field.name}
+                        labelVariant="body"
+                        label="YouTube video link"
+                        labelTooltip="Demo or walkthrough video hosted on YouTube."
+                        type="url"
+                        placeholder="https://youtube.com/watch?v=..."
+                        error={form.formState.errors.youtubeLink?.message}
+                        {...field}
+                      />
+                    )}
+                  />
+
+                  <FormField
+                    control={form.control}
+                    name="agentOutputDemo"
+                    render={({ field }) => (
+                      <Input
+                        id={field.name}
+                        labelVariant="body"
+                        label="Output demo"
+                        labelTooltip="Link showing example output the agent produces."
+                        type="url"
+                        placeholder="https://youtube.com/watch?v=..."
+                        error={form.formState.errors.agentOutputDemo?.message}
+                        {...field}
+                      />
+                    )}
+                  />
+                </div>
+
+                <FormField
+                  control={form.control}
+                  name="recommendedScheduleCron"
+                  render={({ field }) => (
+                    <div className="flex flex-col gap-2">
+                      <div className="flex items-center justify-between gap-3">
+                        <div className="flex items-center gap-1">
+                          <Text
+                            variant="body"
+                            as="span"
+                            className="text-black"
+                          >
+                            Recommended schedule
+                          </Text>
+                          <InformationTooltip
+                            description="Suggested cron schedule users can run the agent on. Sets a run cadence for recurring use cases."
+                            iconSize={20}
+                          />
+                        </div>
+                      </div>
+                      <button
+                        type="button"
+                        onClick={() => setCronScheduleDialogOpen(true)}
+                        className="flex h-[2.875rem] w-full items-center gap-2 rounded-xl border border-zinc-200 bg-white px-4 py-2.5 text-left text-sm font-normal text-black shadow-none transition-colors hover:border-zinc-300 focus:border-purple-400 focus:outline-none focus:ring-1 focus:ring-purple-400"
+                      >
+                        <CalendarDotsIcon
+                          size={16}
+                          weight="duotone"
+                          className="shrink-0 text-zinc-500"
+                        />
+                        <span
+                          className={cn(
+                            "truncate",
+                            !field.value && "text-zinc-400",
+                          )}
+                        >
+                          {field.value
+                            ? humanizeCronExpression(field.value)
+                            : "Set schedule"}
+                        </span>
+                      </button>
+                    </div>
+                  )}
+                />
+              </AccordionContent>
+            </AccordionItem>
+          </Accordion>
+
+          <StepFooter
+            secondary={
+              <Button
+                type="button"
+                onClick={onBack}
+                variant="secondary"
+                size="small"
+                className="w-full sm:w-auto"
+              >
+                Back
+              </Button>
+            }
+            primary={
+              <Button
+                type="submit"
+                size="small"
+                disabled={isSubmitDisabled}
+                loading={isSubmitting}
+                className="w-full sm:w-auto"
+              >
+                {isSubmitting ? "Submitting" : "Submit for review"}
+              </Button>
+            }
+          />
         </form>
       </Form>
 

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentInfoStep/AgentInfoStep.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentInfoStep/AgentInfoStep.tsx
@@ -30,6 +30,38 @@ import { StepFooter } from "../StepFooter";
 import { ThumbnailImages } from "./components/ThumbnailImages";
 import { Props, useAgentInfoStep } from "./useAgentInfoStep";
 
+const DESCRIPTION_MAX = 1000;
+const INSTRUCTIONS_MAX = 2000;
+
+interface CharCountedTextareaProps {
+  max: number;
+  value: string;
+  children: React.ReactNode;
+}
+
+function CharCountedTextarea({
+  max,
+  value,
+  children,
+}: CharCountedTextareaProps) {
+  const length = value.length;
+  const over = length > max;
+  return (
+    <div className="relative">
+      <span
+        aria-hidden
+        className={cn(
+          "pointer-events-none absolute right-0 top-0 z-10 text-xs tabular-nums",
+          over ? "text-rose-600" : "text-zinc-400",
+        )}
+      >
+        {length} / {max}
+      </span>
+      {children}
+    </div>
+  );
+}
+
 export function AgentInfoStep({
   onBack,
   onSuccess,
@@ -336,17 +368,22 @@ export function AgentInfoStep({
                   control={form.control}
                   name="description"
                   render={({ field }) => (
-                    <Input
-                      id={field.name}
-                      labelVariant="body"
-                      label="Description"
-                      labelTooltip="What the agent does and the outcome users get."
-                      type="textarea"
-                      rows={1}
-                      placeholder="Describe the outcome this agent creates"
-                      error={form.formState.errors.description?.message}
-                      {...field}
-                    />
+                    <CharCountedTextarea
+                      max={DESCRIPTION_MAX}
+                      value={field.value ?? ""}
+                    >
+                      <Input
+                        id={field.name}
+                        labelVariant="body"
+                        label="Description"
+                        labelTooltip="What the agent does and the outcome users get."
+                        type="textarea"
+                        rows={4}
+                        placeholder="Describe the outcome this agent creates"
+                        error={form.formState.errors.description?.message}
+                        {...field}
+                      />
+                    </CharCountedTextarea>
                   )}
                 />
 
@@ -354,17 +391,22 @@ export function AgentInfoStep({
                   control={form.control}
                   name="instructions"
                   render={({ field }) => (
-                    <Input
-                      id={field.name}
-                      labelVariant="body"
-                      label="Instructions"
-                      labelTooltip="Steps users should follow to set up and run the agent."
-                      type="textarea"
-                      rows={1}
-                      placeholder="Explain inputs, setup, and what to expect after a run"
-                      error={form.formState.errors.instructions?.message}
-                      {...field}
-                    />
+                    <CharCountedTextarea
+                      max={INSTRUCTIONS_MAX}
+                      value={field.value ?? ""}
+                    >
+                      <Input
+                        id={field.name}
+                        labelVariant="body"
+                        label="Instructions"
+                        labelTooltip="Steps users should follow to set up and run the agent."
+                        type="textarea"
+                        rows={4}
+                        placeholder="Explain inputs, setup, and what to expect after a run"
+                        error={form.formState.errors.instructions?.message}
+                        {...field}
+                      />
+                    </CharCountedTextarea>
                   )}
                 />
 

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentInfoStep/AgentInfoStep.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentInfoStep/AgentInfoStep.tsx
@@ -64,7 +64,9 @@ export function AgentInfoStep({
     React.useState(false);
   const [openAccordion, setOpenAccordion] = React.useState("");
   React.useEffect(() => {
-    const timer = window.setTimeout(() => setOpenAccordion("basics"), 320);
+    const timer = window.setTimeout(() => {
+      setOpenAccordion((current) => current || "basics");
+    }, 320);
     return () => window.clearTimeout(timer);
   }, []);
 

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentInfoStep/AgentInfoStep.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentInfoStep/AgentInfoStep.tsx
@@ -174,10 +174,7 @@ export function AgentInfoStep({
             onValueChange={setOpenAccordion}
             className="overflow-hidden rounded-[14px] border border-zinc-200 bg-white shadow-[0_1px_2px_rgba(15,15,20,0.04)] [&>*+*]:border-t [&>*+*]:border-zinc-200"
           >
-            <AccordionItem
-              value="basics"
-              className="border-0 px-4"
-            >
+            <AccordionItem value="basics" className="border-0 px-4">
               <AccordionTrigger className="hover:no-underline">
                 <span className="flex items-center gap-2 text-sm font-medium text-textBlack">
                   <StorefrontIcon
@@ -275,10 +272,7 @@ export function AgentInfoStep({
               </AccordionContent>
             </AccordionItem>
 
-            <AccordionItem
-              value="thumbnails"
-              className="border-0 px-4"
-            >
+            <AccordionItem value="thumbnails" className="border-0 px-4">
               <AccordionTrigger className="hover:no-underline">
                 <span className="flex items-center gap-2 text-sm font-medium text-textBlack">
                   <ImagesIcon
@@ -313,10 +307,7 @@ export function AgentInfoStep({
               </AccordionContent>
             </AccordionItem>
 
-            <AccordionItem
-              value="experience"
-              className="border-0 px-4"
-            >
+            <AccordionItem value="experience" className="border-0 px-4">
               <AccordionTrigger className="hover:no-underline">
                 <span className="flex items-center gap-2 text-sm font-medium text-textBlack">
                   <SparkleIcon
@@ -420,11 +411,7 @@ export function AgentInfoStep({
                     <div className="flex flex-col gap-2">
                       <div className="flex items-center justify-between gap-3">
                         <div className="flex items-center gap-1">
-                          <Text
-                            variant="body"
-                            as="span"
-                            className="text-black"
-                          >
+                          <Text variant="body" as="span" className="text-black">
                             Recommended schedule
                           </Text>
                           <InformationTooltip

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentInfoStep/AgentInfoStep.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentInfoStep/AgentInfoStep.tsx
@@ -28,39 +28,11 @@ import * as React from "react";
 import { StepHeader } from "../StepHeader";
 import { StepFooter } from "../StepFooter";
 import { ThumbnailImages } from "./components/ThumbnailImages";
+import { CharCountedTextarea } from "./components/CharCountedTextarea";
 import { Props, useAgentInfoStep } from "./useAgentInfoStep";
 
 const DESCRIPTION_MAX = 1000;
 const INSTRUCTIONS_MAX = 2000;
-
-interface CharCountedTextareaProps {
-  max: number;
-  value: string;
-  children: React.ReactNode;
-}
-
-function CharCountedTextarea({
-  max,
-  value,
-  children,
-}: CharCountedTextareaProps) {
-  const length = value.length;
-  const over = length > max;
-  return (
-    <div className="relative">
-      <span
-        aria-hidden
-        className={cn(
-          "pointer-events-none absolute right-0 top-0 z-10 text-xs tabular-nums",
-          over ? "text-rose-600" : "text-zinc-400",
-        )}
-      >
-        {length} / {max}
-      </span>
-      {children}
-    </div>
-  );
-}
 
 export function AgentInfoStep({
   onBack,

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentInfoStep/AgentInfoStep.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentInfoStep/AgentInfoStep.tsx
@@ -378,7 +378,7 @@ export function AgentInfoStep({
                         label="Description"
                         labelTooltip="What the agent does and the outcome users get."
                         type="textarea"
-                        rows={4}
+                        rows={2}
                         placeholder="Describe the outcome this agent creates"
                         error={form.formState.errors.description?.message}
                         {...field}
@@ -401,7 +401,7 @@ export function AgentInfoStep({
                         label="Instructions"
                         labelTooltip="Steps users should follow to set up and run the agent."
                         type="textarea"
-                        rows={4}
+                        rows={2}
                         placeholder="Explain inputs, setup, and what to expect after a run"
                         error={form.formState.errors.instructions?.message}
                         {...field}

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentInfoStep/__tests__/AgentInfoStep.test.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentInfoStep/__tests__/AgentInfoStep.test.tsx
@@ -8,12 +8,9 @@ vi.mock("@sentry/nextjs", () => ({
   captureException: vi.fn(),
 }));
 
-vi.mock(
-  "@/components/contextual/CronScheduler/cron-scheduler-dialog",
-  () => ({
-    CronExpressionDialog: () => null,
-  }),
-);
+vi.mock("@/components/contextual/CronScheduler/cron-scheduler-dialog", () => ({
+  CronExpressionDialog: () => null,
+}));
 
 vi.mock("./components/ThumbnailImages", () => ({
   ThumbnailImages: () => <div data-testid="thumbnail-images-mock" />,
@@ -58,9 +55,8 @@ describe("AgentInfoStep", () => {
 
   it("mounts cleanly when the submissions API would error (handler installed)", async () => {
     server.use(
-      http.post(
-        "http://localhost:3000/api/proxy/api/store/submissions",
-        () => HttpResponse.json({ detail: "boom" }, { status: 500 }),
+      http.post("http://localhost:3000/api/proxy/api/store/submissions", () =>
+        HttpResponse.json({ detail: "boom" }, { status: 500 }),
       ),
     );
     render(<AgentInfoStep {...baseProps} />);

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentInfoStep/__tests__/AgentInfoStep.test.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentInfoStep/__tests__/AgentInfoStep.test.tsx
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, screen } from "@testing-library/react";
+import { render } from "@/tests/integrations/test-utils";
+import { server } from "@/mocks/mock-server";
+import { http, HttpResponse } from "msw";
+
+vi.mock("@sentry/nextjs", () => ({
+  captureException: vi.fn(),
+}));
+
+vi.mock(
+  "@/components/contextual/CronScheduler/cron-scheduler-dialog",
+  () => ({
+    CronExpressionDialog: () => null,
+  }),
+);
+
+vi.mock("./components/ThumbnailImages", () => ({
+  ThumbnailImages: () => <div data-testid="thumbnail-images-mock" />,
+}));
+
+import { AgentInfoStep } from "../AgentInfoStep";
+
+describe("AgentInfoStep", () => {
+  const baseProps = {
+    onBack: vi.fn(),
+    onSuccess: vi.fn(),
+    selectedAgentId: "graph-1",
+    selectedAgentVersion: 1,
+    initialData: undefined,
+    isMarketplaceUpdate: false,
+  };
+
+  it("renders the listing form with the three accordion sections", async () => {
+    render(<AgentInfoStep {...baseProps} />);
+
+    expect(await screen.findByText("Build the store listing")).toBeDefined();
+    expect(screen.getByText("Listing basics")).toBeDefined();
+    expect(screen.getByText("Thumbnails")).toBeDefined();
+    expect(screen.getByText("Experience details")).toBeDefined();
+    expect(
+      screen.getByRole("button", { name: /submit for review/i }),
+    ).toBeDefined();
+  });
+
+  it("calls onBack when Back is clicked", async () => {
+    const onBack = vi.fn();
+    render(<AgentInfoStep {...baseProps} onBack={onBack} />);
+    await screen.findByText("Build the store listing");
+    fireEvent.click(screen.getByRole("button", { name: /back/i }));
+    expect(onBack).toHaveBeenCalled();
+  });
+
+  it("renders the marketplace-update copy when isMarketplaceUpdate is true", async () => {
+    render(<AgentInfoStep {...baseProps} isMarketplaceUpdate />);
+    expect(await screen.findByText("Describe the update")).toBeDefined();
+  });
+
+  it("mounts cleanly when the submissions API would error (handler installed)", async () => {
+    server.use(
+      http.post(
+        "http://localhost:3000/api/proxy/api/store/submissions",
+        () => HttpResponse.json({ detail: "boom" }, { status: 500 }),
+      ),
+    );
+    render(<AgentInfoStep {...baseProps} />);
+    expect(await screen.findByText("Build the store listing")).toBeDefined();
+  });
+});

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentInfoStep/__tests__/helpers.test.ts
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentInfoStep/__tests__/helpers.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { publishAgentSchemaFactory } from "../helpers";
+
+const validBase = {
+  title: "My Agent",
+  subheader: "A short tagline",
+  slug: "my-agent",
+  youtubeLink: "https://www.youtube.com/watch?v=abcdefghijk",
+  category: "automation",
+  description: "Does X for Y users.",
+  recommendedScheduleCron: "",
+  instructions: "",
+  agentOutputDemo: "https://www.youtube.com/watch?v=abcdefghijk",
+  changesSummary: "",
+};
+
+describe("publishAgentSchemaFactory", () => {
+  it("validates a happy-path submission for first-time publish", () => {
+    const result = publishAgentSchemaFactory(false).safeParse(validBase);
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an empty title for first-time publish", () => {
+    const result = publishAgentSchemaFactory(false).safeParse({
+      ...validBase,
+      title: "",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects slugs with disallowed characters", () => {
+    const result = publishAgentSchemaFactory(false).safeParse({
+      ...validBase,
+      slug: "Has Spaces",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a description over 1000 chars", () => {
+    const result = publishAgentSchemaFactory(false).safeParse({
+      ...validBase,
+      description: "a".repeat(1001),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects instructions over 2000 chars", () => {
+    const result = publishAgentSchemaFactory(false).safeParse({
+      ...validBase,
+      instructions: "a".repeat(2001),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an invalid YouTube link", () => {
+    const result = publishAgentSchemaFactory(false).safeParse({
+      ...validBase,
+      youtubeLink: "https://example.com/nope",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("requires changesSummary on marketplace updates", () => {
+    const result = publishAgentSchemaFactory(true).safeParse({
+      ...validBase,
+      changesSummary: "",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts an update with the changes summary filled in", () => {
+    const result = publishAgentSchemaFactory(true).safeParse({
+      ...validBase,
+      changesSummary: "Fixed bug in agent",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("treats title / subheader / category as optional on updates", () => {
+    const result = publishAgentSchemaFactory(true).safeParse({
+      ...validBase,
+      title: "",
+      subheader: "",
+      category: "",
+      changesSummary: "Refreshed copy",
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentInfoStep/components/CharCountedTextarea.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentInfoStep/components/CharCountedTextarea.tsx
@@ -1,0 +1,28 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+interface Props {
+  max: number;
+  value: string;
+  children: React.ReactNode;
+}
+
+export function CharCountedTextarea({ max, value, children }: Props) {
+  const length = value.length;
+  const over = length > max;
+  return (
+    <div className="relative">
+      <span
+        aria-hidden
+        data-testid="char-count"
+        className={cn(
+          "pointer-events-none absolute right-0 top-0 z-10 text-xs tabular-nums",
+          over ? "text-rose-600" : "text-zinc-400",
+        )}
+      >
+        {length} / {max}
+      </span>
+      {children}
+    </div>
+  );
+}

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentInfoStep/components/ThumbnailImages.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentInfoStep/components/ThumbnailImages.tsx
@@ -2,10 +2,10 @@
 
 import { Button } from "@/components/atoms/Button/Button";
 import { Text } from "@/components/atoms/Text/Text";
-import { MagicWand } from "@phosphor-icons/react";
+import { MagicWand, PlusIcon, XIcon } from "@phosphor-icons/react";
 import Image from "next/image";
-import { IconCross, IconPlus } from "../../../../../__legacy__/ui/icons";
 import { useThumbnailImages } from "./useThumbnailImages";
+import { cn } from "@/lib/utils";
 
 interface ThumbnailImagesProps {
   agentId: string | null;
@@ -40,40 +40,32 @@ export function ThumbnailImages({
   });
 
   return (
-    <div className="space-y-2.5">
-      <div className="flex flex-col items-start justify-start gap-1">
-        <Text variant="large-medium" className="leading-tight">
-          Thumbnail images
-        </Text>
-        <Text variant="body" className="!text-zinc-500">
-          The first image will be used as the thumbnail for your agent.
+    <div className="space-y-4">
+      <div className="flex flex-col gap-1">
+        <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+          <Text variant="body-medium" as="h3" className="text-textBlack">
+            Media
+          </Text>
+          <Text variant="small" as="span" className="text-zinc-500">
+            {images.length}/5 images
+          </Text>
+        </div>
+        <Text variant="small" className="text-zinc-500">
+          The selected image is submitted first and appears as the marketplace
+          thumbnail.
         </Text>
         {errorMessage && <p className="text-sm text-red-500">{errorMessage}</p>}
       </div>
-      <div className="relative flex aspect-video items-center justify-center overflow-hidden rounded-md border border-neutral-300 p-2.5">
-        {selectedImage !== null && selectedImage !== undefined ? (
-          <Image
-            src={selectedImage}
-            alt="Selected Thumbnail"
-            fill
-            style={{ objectFit: "cover" }}
-            className="rounded-md object-cover"
-          />
-        ) : (
-          <p className="font-sans text-sm font-normal text-neutral-600 dark:text-neutral-400">
-            No images yet
-          </p>
-        )}
-      </div>
+
       <div
         ref={thumbnailsContainerRef}
-        className="relative z-10 flex items-center space-x-2 pb-4"
+        className="relative z-10 flex flex-col gap-3"
       >
         {images.length === 0 ? (
-          <div className="flex w-full items-center justify-start gap-2 pl-2">
+          <div className="flex flex-col gap-2 sm:flex-row">
             <label
               htmlFor="image-upload"
-              className="inline-flex h-[2.50rem] cursor-pointer items-center justify-center gap-1.5 whitespace-nowrap rounded-full border border-zinc-700 bg-transparent px-3 py-2 font-sans text-sm font-medium leading-snug text-black transition-colors hover:border-zinc-700 hover:bg-zinc-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-neutral-950 disabled:pointer-events-none disabled:opacity-50"
+              className="inline-flex h-[2.25rem] min-w-[5.5rem] cursor-pointer items-center justify-center gap-1.5 whitespace-nowrap rounded-full border border-zinc-700 bg-transparent px-3 py-2 font-sans text-sm font-medium leading-snug text-black transition-colors hover:border-zinc-700 hover:bg-zinc-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-neutral-950"
             >
               <input
                 id="image-upload"
@@ -82,7 +74,7 @@ export function ThumbnailImages({
                 onChange={handleFileChange}
                 className="hidden"
               />
-              <IconPlus className="h-4 w-4" />
+              <PlusIcon size={16} weight="bold" />
               <span>Add image</span>
             </label>
             <Button
@@ -91,61 +83,82 @@ export function ThumbnailImages({
               size="small"
               onClick={handleGenerateImage}
               disabled={isGenerating || images.length >= 5}
+              loading={isGenerating}
+              leftIcon={<MagicWand className="h-4 w-4" />}
             >
-              <MagicWand className="h-4 w-4" />
-              {isGenerating
-                ? "Generating..."
-                : images.length >= 5
-                  ? "Max images reached"
-                  : "Generate"}
+              {isGenerating ? "Generating" : "Generate"}
             </Button>
           </div>
         ) : (
-          <>
-            {images.map((src, index) => (
-              <div
-                key={index}
-                className="relative flex-shrink-0 overflow-visible"
-              >
-                <button
-                  type="button"
-                  onClick={() => handleRemoveImage(index)}
-                  className="absolute -right-2 -top-2 z-50 inline-flex size-6 items-center justify-center rounded-full bg-slate-900"
-                  aria-label="Remove image"
-                >
-                  <IconCross className="h-2 w-2 text-white" />
-                </button>
-                <div
-                  className={`relative aspect-video h-16 w-24 overflow-hidden rounded-md border-2 transition-colors ${
-                    selectedImage === src
-                      ? "border-blue-500 shadow-md"
-                      : "border-transparent hover:border-gray-300"
-                  }`}
-                >
-                  <Image
-                    src={src}
-                    alt={`Thumbnail ${index + 1}`}
-                    fill
-                    style={{ objectFit: "cover" }}
-                    className="cursor-pointer"
+          <div className="flex flex-col gap-3">
+            <div className="flex gap-2 overflow-x-auto pb-1">
+              {images.map((src, index) => (
+                <div key={src} className="relative shrink-0">
+                  <button
+                    type="button"
                     onClick={() => handleImageSelect(src)}
-                  />
+                    className={cn(
+                      "relative aspect-video h-28 w-44 overflow-hidden rounded-[10px] border-2 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900 focus-visible:ring-offset-2",
+                      selectedImage === src
+                        ? "border-zinc-900"
+                        : "border-transparent hover:border-zinc-300",
+                    )}
+                    aria-pressed={selectedImage === src}
+                    aria-label={`Select thumbnail ${index + 1}`}
+                  >
+                    <Image
+                      src={src}
+                      alt={`Thumbnail ${index + 1}`}
+                      fill
+                      style={{ objectFit: "cover" }}
+                    />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => handleRemoveImage(index)}
+                    className="absolute right-1.5 top-1.5 z-20 inline-flex size-6 items-center justify-center rounded-full bg-zinc-900/80 text-white shadow-sm backdrop-blur-sm transition-colors hover:bg-zinc-900"
+                    aria-label="Remove image"
+                  >
+                    <XIcon size={12} weight="bold" />
+                  </button>
+                  {index === 0 ? (
+                    <span className="mt-1 block text-center text-[11px] font-medium text-zinc-500">
+                      Thumbnail
+                    </span>
+                  ) : null}
                 </div>
-              </div>
-            ))}
-            {images.length < 5 ? (
+              ))}
+            </div>
+
+            <div className="flex flex-col gap-2 sm:flex-row">
+              {images.length < 5 ? (
+                <Button
+                  type="button"
+                  onClick={handleAddImage}
+                  variant="outline"
+                  size="small"
+                  leftIcon={<PlusIcon size={16} weight="bold" />}
+                >
+                  Add image
+                </Button>
+              ) : null}
               <Button
                 type="button"
-                onClick={handleAddImage}
                 variant="outline"
                 size="small"
-                className="!ml-4"
+                onClick={handleGenerateImage}
+                disabled={isGenerating || images.length >= 5}
+                loading={isGenerating}
+                leftIcon={<MagicWand className="h-4 w-4" />}
               >
-                <IconPlus className="h-4 w-4" />
-                <span>Add image</span>
+                {isGenerating
+                  ? "Generating"
+                  : images.length >= 5
+                    ? "Max images reached"
+                    : "Generate"}
               </Button>
-            ) : null}
-          </>
+            </div>
+          </div>
         )}
       </div>
     </div>

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentInfoStep/components/__tests__/CharCountedTextarea.test.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentInfoStep/components/__tests__/CharCountedTextarea.test.tsx
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { CharCountedTextarea } from "../CharCountedTextarea";
+
+describe("CharCountedTextarea", () => {
+  it("renders the children and a length / max badge", () => {
+    render(
+      <CharCountedTextarea max={100} value="hello">
+        <textarea />
+      </CharCountedTextarea>,
+    );
+
+    const badge = screen.getByTestId("char-count");
+    expect(badge.textContent).toBe("5 / 100");
+    expect(badge.className).toMatch(/text-zinc-400/);
+    expect(screen.getByRole("textbox")).toBeDefined();
+  });
+
+  it("turns rose-600 when the value exceeds the max", () => {
+    render(
+      <CharCountedTextarea max={3} value="too long">
+        <textarea />
+      </CharCountedTextarea>,
+    );
+
+    const badge = screen.getByTestId("char-count");
+    expect(badge.textContent).toBe("8 / 3");
+    expect(badge.className).toMatch(/text-rose-600/);
+  });
+});

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentInfoStep/components/useThumbnailImages.ts
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentInfoStep/components/useThumbnailImages.ts
@@ -29,35 +29,31 @@ export function useThumbnailImages({
   const thumbnailsContainerRef = useRef<HTMLDivElement | null>(null);
   const { toast } = useToast();
 
-  // Memoize the stringified version to detect actual changes
   const initialImagesKey = JSON.stringify(initialImages);
 
-  // Update images when initialImages prop changes (by value, not reference)
   useEffect(() => {
     if (initialImages.length > 0) {
       setImages(initialImages);
       setSelectedImage(initialSelectedImage || initialImages[0]);
     }
-  }, [initialImagesKey, initialSelectedImage]); // Use stringified key instead of array reference
+  }, [initialImagesKey, initialSelectedImage]);
 
-  // Notify parent when images change
   useEffect(() => {
     onImagesChange(images);
   }, [images, onImagesChange]);
 
   const setImagesWithValidation = (newImages: string[]) => {
-    // Remove duplicates
     const uniqueImages = Array.from(new Set(newImages));
-    // Keep only first 5 images
     const limitedImages = uniqueImages.slice(0, 5);
     setImages(limitedImages);
   };
 
   function handleRemoveImage(indexToRemove: number) {
+    const removedImage = images[indexToRemove];
     const newImages = [...images];
     newImages.splice(indexToRemove, 1);
     setImagesWithValidation(newImages);
-    if (newImages[indexToRemove] === selectedImage) {
+    if (removedImage === selectedImage) {
       setSelectedImage(newImages[0] || null);
     }
     if (newImages.length === 0) {
@@ -72,7 +68,6 @@ export function useThumbnailImages({
     input.type = "file";
     input.accept = "image/*";
 
-    // Create a promise that resolves when file is selected
     const fileSelected = new Promise<File | null>((resolve) => {
       input.onchange = (e) => {
         const file = (e.target as HTMLInputElement).files?.[0];
@@ -80,10 +75,8 @@ export function useThumbnailImages({
       };
     });
 
-    // Trigger file selection
     input.click();
 
-    // Wait for file selection
     const file = await fileSelected;
     if (!file) return;
 
@@ -149,15 +142,17 @@ export function useThumbnailImages({
 
   function handleImageSelect(imageSrc: string) {
     setSelectedImage(imageSrc);
+    setImagesWithValidation([
+      imageSrc,
+      ...images.filter((src) => src !== imageSrc),
+    ]);
   }
 
   return {
-    // State
     images,
     selectedImage,
     isGenerating,
     thumbnailsContainerRef,
-    // Handlers
     handleRemoveImage,
     handleAddImage,
     handleFileChange,

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentInfoStep/components/useThumbnailImages.ts
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentInfoStep/components/useThumbnailImages.ts
@@ -32,10 +32,18 @@ export function useThumbnailImages({
   const initialImagesKey = JSON.stringify(initialImages);
 
   useEffect(() => {
-    if (initialImages.length > 0) {
-      setImages(initialImages);
-      setSelectedImage(initialSelectedImage || initialImages[0]);
+    if (initialImages.length === 0) {
+      setImages([]);
+      setSelectedImage(null);
+      return;
     }
+
+    const nextSelectedImage = initialSelectedImage || initialImages[0];
+    setImages([
+      nextSelectedImage,
+      ...initialImages.filter((image) => image !== nextSelectedImage),
+    ]);
+    setSelectedImage(nextSelectedImage);
   }, [initialImagesKey, initialSelectedImage]);
 
   useEffect(() => {

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentReviewStep.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentReviewStep.tsx
@@ -1,13 +1,27 @@
 "use client";
 
 import * as React from "react";
+import { createPortal } from "react-dom";
 
 import Image from "next/image";
-import { StepHeader } from "./StepHeader";
+import { motion, useReducedMotion } from "framer-motion";
+import { StepFooter } from "./StepFooter";
 import { Button } from "@/components/atoms/Button/Button";
 import { Text } from "@/components/atoms/Text/Text";
+import { Confetti } from "@/components/molecules/Confetti/Confetti";
 import { usePathname } from "next/navigation";
 import { SubmissionStatus } from "@/app/api/__generated__/models/submissionStatus";
+import {
+  ArrowRightIcon,
+  CheckIcon,
+  ClockIcon,
+  ImageBrokenIcon,
+  PaperPlaneTiltIcon,
+  RocketLaunchIcon,
+  WarningCircleIcon,
+  XIcon,
+} from "@phosphor-icons/react";
+import { cn } from "@/lib/utils";
 
 interface Props {
   agentName: string;
@@ -21,29 +35,38 @@ interface Props {
   reviewComments?: string | null;
 }
 
-function getStepHeaderContent(
+function getHeroContent(
   status: SubmissionStatus | undefined,
   isDashboardPage: boolean,
-): { title: string; description: string } {
+) {
   switch (status) {
     case SubmissionStatus.APPROVED:
       return {
         title: "Agent approved",
         description:
-          "Your agent has been approved and is now available in the AutoGPT marketplace.",
+          "Your agent has been approved and is now live on the AutoGPT marketplace.",
+        Icon: CheckIcon,
+        ringClass: "bg-emerald-50 ring-emerald-100",
+        iconClass: "bg-emerald-500 text-white",
       };
     case SubmissionStatus.REJECTED:
       return {
-        title: "Agent rejected",
+        title: "Agent needs changes",
         description:
-          "Your agent submission was not approved. Please review the feedback and resubmit.",
+          "Your submission was not approved. Review the feedback and resubmit.",
+        Icon: XIcon,
+        ringClass: "bg-rose-50 ring-rose-100",
+        iconClass: "bg-rose-500 text-white",
       };
     default:
       return {
-        title: "Agent is awaiting review",
+        title: "Submission received",
         description: isDashboardPage
-          ? "Once the agent is approved, it will be available in the AutoGPT marketplace."
-          : "In the meantime you can check your progress on your Creator Dashboard page",
+          ? "We'll notify you once review is complete. Approved agents go live on the marketplace."
+          : "We'll notify you once review is complete. Track progress from the Creator Dashboard.",
+        Icon: CheckIcon,
+        ringClass: "bg-purple-50 ring-purple-100",
+        iconClass: "bg-purple-500 text-white",
       };
   }
 }
@@ -51,7 +74,7 @@ function getStepHeaderContent(
 export function AgentReviewStep({
   agentName,
   subheader,
-  description,
+  description: _description,
   thumbnailSrc,
   onDone,
   onViewProgress,
@@ -60,97 +83,299 @@ export function AgentReviewStep({
 }: Props) {
   const pathname = usePathname();
   const isDashboardPage = pathname.includes("/settings/creator-dashboard");
-  const headerContent = getStepHeaderContent(status, isDashboardPage);
+  const hero = getHeroContent(status, isDashboardPage);
+  const HeroIcon = hero.Icon;
+  const shouldReduceMotion = useReducedMotion();
+  const isPending =
+    status !== SubmissionStatus.APPROVED && status !== SubmissionStatus.REJECTED;
+
+  const showCelebration = status !== SubmissionStatus.REJECTED;
+  const [portalTarget, setPortalTarget] = React.useState<HTMLElement | null>(
+    null,
+  );
+  React.useEffect(() => {
+    const target = document.querySelector(
+      "[data-dialog-content]",
+    ) as HTMLElement | null;
+    setPortalTarget(target);
+  }, []);
 
   return (
-    <div aria-labelledby="modal-title">
-      <StepHeader
-        title={headerContent.title}
-        description={headerContent.description}
-      />
+    <div
+      aria-labelledby="modal-title"
+      className="relative flex flex-col items-center pb-4 pt-10"
+    >
+      {portalTarget
+        ? createPortal(
+            <>
+              <div
+                aria-hidden
+                className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-48 rounded-t-2xlarge bg-gradient-to-b from-purple-200/70 via-purple-100/40 to-transparent"
+              />
+              <div
+                aria-hidden
+                className="pointer-events-none absolute -top-16 left-1/2 -z-10 size-64 -translate-x-1/2 rounded-full bg-purple-300/40 blur-3xl"
+              />
+            </>,
+            portalTarget,
+          )
+        : null}
+      {showCelebration ? (
+        <Confetti
+          options={{
+            particleCount: 80,
+            spread: 70,
+            startVelocity: 35,
+            origin: { y: 0.3 },
+          }}
+        />
+      ) : null}
 
-      <div className="flex flex-1 flex-col items-center gap-8 px-6 pt-6 sm:gap-6">
-        <div className="mt-4 flex w-full flex-col items-center gap-6 sm:mt-0 sm:gap-4">
-          <div className="gap- flex flex-col items-center">
-            <Text
-              variant="lead"
-              className="line-clamp-1 text-ellipsis text-center font-semibold"
-              data-testid="view-agent-name"
-            >
-              {agentName}
-            </Text>
-            <Text
-              variant="large"
-              className="line-clamp-1 text-ellipsis text-center text-neutral-500"
-            >
+      <div className="relative flex items-center justify-center">
+        {showCelebration && !shouldReduceMotion ? (
+          <>
+            <motion.span
+              aria-hidden
+              initial={{ opacity: 0.5, scale: 0.6 }}
+              animate={{ opacity: 0, scale: 1.6 }}
+              transition={{
+                duration: 1.6,
+                ease: "easeOut",
+                repeat: Infinity,
+                repeatDelay: 0.4,
+              }}
+              className={cn(
+                "absolute inline-block size-24 rounded-full",
+                hero.iconClass.includes("bg-emerald")
+                  ? "bg-emerald-400/40"
+                  : hero.iconClass.includes("bg-rose")
+                    ? "bg-rose-400/40"
+                    : "bg-purple-400/40",
+              )}
+            />
+            <motion.span
+              aria-hidden
+              initial={{ opacity: 0.4, scale: 0.7 }}
+              animate={{ opacity: 0, scale: 1.4 }}
+              transition={{
+                duration: 1.6,
+                ease: "easeOut",
+                repeat: Infinity,
+                repeatDelay: 0.4,
+                delay: 0.5,
+              }}
+              className={cn(
+                "absolute inline-block size-24 rounded-full",
+                hero.iconClass.includes("bg-emerald")
+                  ? "bg-emerald-400/40"
+                  : hero.iconClass.includes("bg-rose")
+                    ? "bg-rose-400/40"
+                    : "bg-purple-400/40",
+              )}
+            />
+          </>
+        ) : null}
+        <motion.div
+          initial={
+            shouldReduceMotion ? { opacity: 0 } : { opacity: 0, scale: 0.7 }
+          }
+          animate={{ opacity: 1, scale: 1 }}
+          transition={
+            shouldReduceMotion
+              ? { duration: 0 }
+              : { type: "spring", stiffness: 280, damping: 20, delay: 0.05 }
+          }
+          className={cn(
+            "relative flex size-20 items-center justify-center rounded-full shadow-[0_8px_24px_-8px_rgba(119,51,245,0.45)]",
+            hero.iconClass.includes("bg-emerald")
+              ? "bg-gradient-to-br from-emerald-400 to-emerald-600"
+              : hero.iconClass.includes("bg-rose")
+                ? "bg-gradient-to-br from-rose-400 to-rose-600"
+                : "bg-gradient-to-br from-purple-400 to-purple-600",
+          )}
+        >
+          <span
+            aria-hidden
+            className="absolute inset-1 rounded-full bg-white/10"
+          />
+          <motion.span
+            initial={shouldReduceMotion ? { opacity: 0 } : { scale: 0.4, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            transition={
+              shouldReduceMotion
+                ? { duration: 0 }
+                : {
+                    type: "spring",
+                    stiffness: 360,
+                    damping: 18,
+                    delay: 0.18,
+                  }
+            }
+            className="text-white"
+          >
+            <HeroIcon size={36} weight="bold" />
+          </motion.span>
+        </motion.div>
+      </div>
+
+      <motion.div
+        initial={
+          shouldReduceMotion ? { opacity: 0 } : { opacity: 0, y: 8 }
+        }
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.24, ease: "easeOut", delay: 0.12 }}
+        className="mt-5 flex max-w-md flex-col items-center gap-2 px-2 text-center"
+      >
+        <Text
+          variant="lead-medium"
+          as="h2"
+          className="text-textBlack"
+          data-testid="view-agent-name"
+        >
+          {hero.title}
+        </Text>
+        <Text variant="body" className="text-zinc-600">
+          {hero.description}
+        </Text>
+      </motion.div>
+
+      <motion.div
+        initial={
+          shouldReduceMotion ? { opacity: 0 } : { opacity: 0, y: 8 }
+        }
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.24, ease: "easeOut", delay: 0.18 }}
+        className="mt-6 flex w-full max-w-md items-center gap-3 rounded-[14px] border border-zinc-200 bg-white p-3 shadow-[0_1px_2px_rgba(15,15,20,0.04)]"
+      >
+        <div className="relative aspect-video h-12 shrink-0 overflow-hidden rounded-[8px] bg-zinc-100">
+          {thumbnailSrc ? (
+            <Image
+              src={thumbnailSrc}
+              alt=""
+              fill
+              sizes="86px"
+              className="object-cover"
+            />
+          ) : (
+            <div className="flex h-full w-full items-center justify-center text-zinc-400">
+              <ImageBrokenIcon size={20} weight="duotone" />
+            </div>
+          )}
+        </div>
+        <div className="flex min-w-0 flex-1 flex-col">
+          <Text
+            variant="body-medium"
+            as="span"
+            className="truncate text-textBlack"
+          >
+            {agentName}
+          </Text>
+          {subheader ? (
+            <Text variant="small" className="truncate text-zinc-500">
               {subheader}
             </Text>
-          </div>
-
-          <div
-            className="aspect-video h-64 w-full rounded-xl bg-neutral-200"
-            role="img"
-            aria-label={
-              thumbnailSrc ? "Agent thumbnail" : "Thumbnail placeholder"
-            }
-          >
-            {thumbnailSrc && (
-              <Image
-                src={thumbnailSrc}
-                alt="Agent thumbnail"
-                width={400}
-                height={280}
-                className="h-full w-full rounded-xl object-cover"
-                loading="lazy"
-              />
-            )}
-          </div>
-
-          {description ? (
-            <Text
-              variant="large"
-              className="line-clamp-1 text-ellipsis pt-2 text-center text-neutral-500"
-            >
-              {description}
-            </Text>
-          ) : null}
-
-          {reviewComments && status === SubmissionStatus.REJECTED ? (
-            <div className="w-full rounded-lg bg-red-50 p-4 dark:bg-red-950">
-              <Text
-                variant="body"
-                className="mb-1 font-semibold text-red-700 dark:text-red-300"
-              >
-                Review feedback
-              </Text>
-              <Text variant="body" className="text-red-600 dark:text-red-400">
-                {reviewComments}
-              </Text>
-            </div>
           ) : null}
         </div>
-      </div>
-      <div
-        className={`mt-10 flex ${
-          isDashboardPage ? "justify-center" : "justify-between"
-        } gap-4`}
-      >
-        <Button
-          variant={isDashboardPage ? "primary" : "secondary"}
-          onClick={onDone}
-          className={isDashboardPage ? "w-1/2" : "w-full"}
+        {isPending ? (
+          <span className="inline-flex items-center gap-1.5 rounded-full bg-amber-50 px-2.5 py-1 text-[11px] font-medium text-amber-800">
+            <ClockIcon size={12} weight="duotone" />
+            In review
+          </span>
+        ) : null}
+      </motion.div>
+
+      {reviewComments && status === SubmissionStatus.REJECTED ? (
+        <div className="mt-4 w-full max-w-md rounded-[14px] border border-rose-200 bg-rose-50 p-3">
+          <div className="mb-1 flex items-center gap-2 text-rose-700">
+            <WarningCircleIcon size={16} weight="duotone" />
+            <Text variant="small-medium" as="span" className="!text-current">
+              Review feedback
+            </Text>
+          </div>
+          <Text variant="small" className="text-rose-700">
+            {reviewComments}
+          </Text>
+        </div>
+      ) : null}
+
+      {status !== SubmissionStatus.REJECTED ? (
+        <motion.ol
+          initial={
+            shouldReduceMotion ? { opacity: 0 } : { opacity: 0, y: 8 }
+          }
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.24, ease: "easeOut", delay: 0.24 }}
+          className="mt-6 flex w-full max-w-md flex-col gap-3 px-2"
         >
-          Done
-        </Button>
-        {!isDashboardPage ? (
+          <Text variant="body-medium" as="span" className="text-textBlack">
+            What happens next
+          </Text>
+          <li className="flex items-start gap-3">
+            <span className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-full bg-purple-50 text-purple-600">
+              <PaperPlaneTiltIcon size={14} weight="bold" />
+            </span>
+            <div className="flex min-w-0 flex-col">
+              <Text variant="small-medium" as="span" className="text-textBlack">
+                Submitted for review
+              </Text>
+              <Text variant="small" className="text-zinc-500">
+                Your listing is queued in the marketplace review pipeline.
+              </Text>
+            </div>
+          </li>
+          <li className="flex items-start gap-3">
+            <span className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-full bg-amber-50 text-amber-700">
+              <ClockIcon size={14} weight="bold" />
+            </span>
+            <div className="flex min-w-0 flex-col">
+              <Text variant="small-medium" as="span" className="text-textBlack">
+                Reviewed within 1–2 business days
+              </Text>
+              <Text variant="small" className="text-zinc-500">
+                Our team checks the details, media, and safety of your agent.
+              </Text>
+            </div>
+          </li>
+          <li className="flex items-start gap-3">
+            <span className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-full bg-emerald-50 text-emerald-700">
+              <RocketLaunchIcon size={14} weight="bold" />
+            </span>
+            <div className="flex min-w-0 flex-col">
+              <Text variant="small-medium" as="span" className="text-textBlack">
+                Approved listings go live
+              </Text>
+              <Text variant="small" className="text-zinc-500">
+                You'll get an email; rejected listings come back with feedback.
+              </Text>
+            </div>
+          </li>
+        </motion.ol>
+      ) : null}
+
+      <div className="mt-8 w-full">
+      <StepFooter
+        secondary={
           <Button
+            variant="secondary"
+            size="small"
+            onClick={onDone}
+            className="w-full sm:w-auto"
+          >
+            Done
+          </Button>
+        }
+        primary={
+          <Button
+            size="small"
             onClick={onViewProgress}
-            className="w-full"
+            className="w-full sm:w-auto"
+            rightIcon={<ArrowRightIcon size={14} weight="bold" />}
             data-testid="view-progress-button"
           >
-            View progress
+            {isDashboardPage ? "View progress" : "Go to Creator Dashboard"}
           </Button>
-        ) : null}
+        }
+      />
       </div>
     </div>
   );

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentReviewStep.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentReviewStep.tsx
@@ -274,7 +274,7 @@ export function AgentReviewStep({
       ) : null}
 
       {status !== SubmissionStatus.REJECTED ? (
-        <motion.ol
+        <motion.div
           initial={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, y: 8 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.24, ease: "easeOut", delay: 0.24 }}
@@ -283,47 +283,61 @@ export function AgentReviewStep({
           <Text variant="body-medium" as="span" className="text-textBlack">
             What happens next
           </Text>
-          <li className="flex items-start gap-3">
-            <span className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-full bg-purple-50 text-purple-600">
-              <PaperPlaneTiltIcon size={14} weight="bold" />
-            </span>
-            <div className="flex min-w-0 flex-col">
-              <Text variant="small-medium" as="span" className="text-textBlack">
-                Submitted for review
-              </Text>
-              <Text variant="small" className="text-zinc-500">
-                Your listing is queued in the marketplace review pipeline.
-              </Text>
-            </div>
-          </li>
-          <li className="flex items-start gap-3">
-            <span className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-full bg-amber-50 text-amber-700">
-              <ClockIcon size={14} weight="bold" />
-            </span>
-            <div className="flex min-w-0 flex-col">
-              <Text variant="small-medium" as="span" className="text-textBlack">
-                Reviewed soon
-              </Text>
-              <Text variant="small" className="text-zinc-500">
-                Our team checks the details, media, and safety of your agent.
-              </Text>
-            </div>
-          </li>
-          <li className="flex items-start gap-3">
-            <span className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-full bg-emerald-50 text-emerald-700">
-              <RocketLaunchIcon size={14} weight="bold" />
-            </span>
-            <div className="flex min-w-0 flex-col">
-              <Text variant="small-medium" as="span" className="text-textBlack">
-                Approved listings go live
-              </Text>
-              <Text variant="small" className="text-zinc-500">
-                You&apos;ll get an email; rejected listings come back with
-                feedback.
-              </Text>
-            </div>
-          </li>
-        </motion.ol>
+          <ol className="flex flex-col gap-3">
+            <li className="flex items-start gap-3">
+              <span className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-full bg-purple-50 text-purple-600">
+                <PaperPlaneTiltIcon size={14} weight="bold" />
+              </span>
+              <div className="flex min-w-0 flex-col">
+                <Text
+                  variant="small-medium"
+                  as="span"
+                  className="text-textBlack"
+                >
+                  Submitted for review
+                </Text>
+                <Text variant="small" className="text-zinc-500">
+                  Your listing is queued in the marketplace review pipeline.
+                </Text>
+              </div>
+            </li>
+            <li className="flex items-start gap-3">
+              <span className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-full bg-amber-50 text-amber-700">
+                <ClockIcon size={14} weight="bold" />
+              </span>
+              <div className="flex min-w-0 flex-col">
+                <Text
+                  variant="small-medium"
+                  as="span"
+                  className="text-textBlack"
+                >
+                  Reviewed soon
+                </Text>
+                <Text variant="small" className="text-zinc-500">
+                  Our team checks the details, media, and safety of your agent.
+                </Text>
+              </div>
+            </li>
+            <li className="flex items-start gap-3">
+              <span className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-full bg-emerald-50 text-emerald-700">
+                <RocketLaunchIcon size={14} weight="bold" />
+              </span>
+              <div className="flex min-w-0 flex-col">
+                <Text
+                  variant="small-medium"
+                  as="span"
+                  className="text-textBlack"
+                >
+                  Approved listings go live
+                </Text>
+                <Text variant="small" className="text-zinc-500">
+                  You&apos;ll get an email; rejected listings come back with
+                  feedback.
+                </Text>
+              </div>
+            </li>
+          </ol>
+        </motion.div>
       ) : null}
 
       <div className="mt-8 w-full">

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentReviewStep.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentReviewStep.tsx
@@ -301,7 +301,7 @@ export function AgentReviewStep({
             </span>
             <div className="flex min-w-0 flex-col">
               <Text variant="small-medium" as="span" className="text-textBlack">
-                Reviewed within 1–2 business days
+                Reviewed soon
               </Text>
               <Text variant="small" className="text-zinc-500">
                 Our team checks the details, media, and safety of your agent.

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentReviewStep.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentReviewStep.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import * as React from "react";
-import { createPortal } from "react-dom";
 
 import Image from "next/image";
 import { motion, useReducedMotion } from "framer-motion";
@@ -87,39 +86,16 @@ export function AgentReviewStep({
   const HeroIcon = hero.Icon;
   const shouldReduceMotion = useReducedMotion();
   const isPending =
-    status !== SubmissionStatus.APPROVED && status !== SubmissionStatus.REJECTED;
+    status !== SubmissionStatus.APPROVED &&
+    status !== SubmissionStatus.REJECTED;
 
   const showCelebration = status !== SubmissionStatus.REJECTED;
-  const [portalTarget, setPortalTarget] = React.useState<HTMLElement | null>(
-    null,
-  );
-  React.useEffect(() => {
-    const target = document.querySelector(
-      "[data-dialog-content]",
-    ) as HTMLElement | null;
-    setPortalTarget(target);
-  }, []);
 
   return (
     <div
       aria-labelledby="modal-title"
       className="relative flex flex-col items-center pb-4 pt-10"
     >
-      {portalTarget
-        ? createPortal(
-            <>
-              <div
-                aria-hidden
-                className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-48 rounded-t-2xlarge bg-gradient-to-b from-purple-200/70 via-purple-100/40 to-transparent"
-              />
-              <div
-                aria-hidden
-                className="pointer-events-none absolute -top-16 left-1/2 -z-10 size-64 -translate-x-1/2 rounded-full bg-purple-300/40 blur-3xl"
-              />
-            </>,
-            portalTarget,
-          )
-        : null}
       {showCelebration ? (
         <Confetti
           options={{
@@ -199,7 +175,9 @@ export function AgentReviewStep({
             className="absolute inset-1 rounded-full bg-white/10"
           />
           <motion.span
-            initial={shouldReduceMotion ? { opacity: 0 } : { scale: 0.4, opacity: 0 }}
+            initial={
+              shouldReduceMotion ? { opacity: 0 } : { scale: 0.4, opacity: 0 }
+            }
             animate={{ scale: 1, opacity: 1 }}
             transition={
               shouldReduceMotion
@@ -219,9 +197,7 @@ export function AgentReviewStep({
       </div>
 
       <motion.div
-        initial={
-          shouldReduceMotion ? { opacity: 0 } : { opacity: 0, y: 8 }
-        }
+        initial={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, y: 8 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.24, ease: "easeOut", delay: 0.12 }}
         className="mt-5 flex max-w-md flex-col items-center gap-2 px-2 text-center"
@@ -240,9 +216,7 @@ export function AgentReviewStep({
       </motion.div>
 
       <motion.div
-        initial={
-          shouldReduceMotion ? { opacity: 0 } : { opacity: 0, y: 8 }
-        }
+        initial={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, y: 8 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.24, ease: "easeOut", delay: 0.18 }}
         className="mt-6 flex w-full max-w-md items-center gap-3 rounded-[14px] border border-zinc-200 bg-white p-3 shadow-[0_1px_2px_rgba(15,15,20,0.04)]"
@@ -300,9 +274,7 @@ export function AgentReviewStep({
 
       {status !== SubmissionStatus.REJECTED ? (
         <motion.ol
-          initial={
-            shouldReduceMotion ? { opacity: 0 } : { opacity: 0, y: 8 }
-          }
+          initial={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, y: 8 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.24, ease: "easeOut", delay: 0.24 }}
           className="mt-6 flex w-full max-w-md flex-col gap-3 px-2"
@@ -345,7 +317,8 @@ export function AgentReviewStep({
                 Approved listings go live
               </Text>
               <Text variant="small" className="text-zinc-500">
-                You&apos;ll get an email; rejected listings come back with feedback.
+                You&apos;ll get an email; rejected listings come back with
+                feedback.
               </Text>
             </div>
           </li>
@@ -353,29 +326,29 @@ export function AgentReviewStep({
       ) : null}
 
       <div className="mt-8 w-full">
-      <StepFooter
-        secondary={
-          <Button
-            variant="secondary"
-            size="small"
-            onClick={onDone}
-            className="w-full sm:w-auto"
-          >
-            Done
-          </Button>
-        }
-        primary={
-          <Button
-            size="small"
-            onClick={onViewProgress}
-            className="w-full sm:w-auto"
-            rightIcon={<ArrowRightIcon size={14} weight="bold" />}
-            data-testid="view-progress-button"
-          >
-            {isDashboardPage ? "View progress" : "Go to Creator Dashboard"}
-          </Button>
-        }
-      />
+        <StepFooter
+          secondary={
+            <Button
+              variant="secondary"
+              size="small"
+              onClick={onDone}
+              className="w-full sm:w-auto"
+            >
+              Done
+            </Button>
+          }
+          primary={
+            <Button
+              size="small"
+              onClick={onViewProgress}
+              className="w-full sm:w-auto"
+              rightIcon={<ArrowRightIcon size={14} weight="bold" />}
+              data-testid="view-progress-button"
+            >
+              {isDashboardPage ? "View progress" : "Go to Creator Dashboard"}
+            </Button>
+          }
+        />
       </div>
     </div>
   );

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentReviewStep.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentReviewStep.tsx
@@ -90,13 +90,14 @@ export function AgentReviewStep({
     status !== SubmissionStatus.REJECTED;
 
   const showCelebration = status !== SubmissionStatus.REJECTED;
+  const showConfetti = showCelebration && !shouldReduceMotion;
 
   return (
     <div
       aria-labelledby="modal-title"
       className="relative flex flex-col items-center pb-4 pt-10"
     >
-      {showCelebration ? (
+      {showConfetti ? (
         <Confetti
           options={{
             particleCount: 80,

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentReviewStep.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentReviewStep.tsx
@@ -345,7 +345,7 @@ export function AgentReviewStep({
                 Approved listings go live
               </Text>
               <Text variant="small" className="text-zinc-500">
-                You'll get an email; rejected listings come back with feedback.
+                You&apos;ll get an email; rejected listings come back with feedback.
               </Text>
             </div>
           </li>

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentSelectStep/AgentSelectStep.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentSelectStep/AgentSelectStep.tsx
@@ -1,10 +1,15 @@
 "use client";
 
-import * as React from "react";
-import Image from "next/image";
+import {
+  CheckCircleIcon,
+  PlusIcon,
+  WarningCircleIcon,
+} from "@phosphor-icons/react";
+
 import { Text } from "../../../../atoms/Text/Text";
 import { Button } from "../../../../atoms/Button/Button";
 import { StepHeader } from "../StepHeader";
+import { StepFooter } from "../StepFooter";
 import { Skeleton } from "@/components/__legacy__/ui/skeleton";
 import { useAgentSelectStep } from "./useAgentSelectStep";
 import { scrollbarStyles } from "@/components/styles/scrollbars";
@@ -48,22 +53,22 @@ export function AgentSelectStep({
 
   if (isLoading) {
     return (
-      <div className="mx-auto flex min-h-[70vh] w-full flex-col">
+      <div className="mx-auto flex w-full flex-col">
         <StepHeader
-          title="Publish Agent"
-          description="Select your project that you'd like to publish"
+          title="Choose an agent"
+          description="Pick the saved agent version you want to send to marketplace review."
+          currentStep="select"
         />
-        <div className="flex-grow p-4 sm:p-6">
-          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <div className="flex-grow pb-5">
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
             {Array.from({ length: 6 }).map((_, i) => (
               <div
                 key={i}
-                className="overflow-hidden rounded-2xl border border-neutral-200"
+                className="flex items-center gap-3 rounded-[12px] border border-zinc-200 bg-white p-3"
               >
-                <Skeleton className="h-32 w-full sm:h-40" />
-                <div className="flex flex-col gap-2 p-3">
-                  <Skeleton className="h-5 w-3/4" />
-                  <Skeleton className="h-4 w-1/2" />
+                <div className="flex flex-1 flex-col gap-2">
+                  <Skeleton className="h-4 w-1/3" />
+                  <Skeleton className="h-3 w-2/3" />
                 </div>
               </div>
             ))}
@@ -75,14 +80,24 @@ export function AgentSelectStep({
 
   if (error) {
     return (
-      <div className="mx-auto flex w-full max-w-[900px] flex-col rounded-3xl">
+      <div className="mx-auto flex w-full flex-col">
         <StepHeader
-          title="Publish Agent"
-          description="Select your project that you'd like to publish"
+          title="Choose an agent"
+          description="Pick the saved agent version you want to send to marketplace review."
+          currentStep="select"
         />
-        <div className="inline-flex h-[370px] flex-col items-center justify-center gap-[29px] px-4 py-5 sm:px-6">
-          <Text variant="lead" className="text-center text-red-600">
-            Failed to load agents. Please try again.
+        <div className="mt-5 flex min-h-[320px] flex-col items-center justify-center gap-4 rounded-[18px] border border-rose-100 bg-rose-50 px-6 py-8 text-center">
+          <WarningCircleIcon
+            size={32}
+            weight="duotone"
+            className="text-rose-600"
+          />
+          <Text variant="large-medium" className="text-rose-900">
+            We could not load your agents
+          </Text>
+          <Text variant="body" className="max-w-[420px] text-rose-700">
+            Refresh the list and try again. Your current marketplace submissions
+            are unchanged.
           </Text>
           <Button onClick={() => window.location.reload()} variant="secondary">
             Retry
@@ -93,34 +108,35 @@ export function AgentSelectStep({
   }
 
   return (
-    <div className="mx-auto flex w-full max-w-[900px] flex-col rounded-3xl">
+    <div className="mx-auto flex w-full flex-col">
       <StepHeader
-        title="Publish Agent"
-        description="Select your project that you'd like to publish"
+        title="Choose an agent"
+        description="Pick the saved agent version you want to send to marketplace review."
+        currentStep="select"
       />
 
       {myAgents.length === 0 ? (
-        <div className="inline-flex h-[370px] flex-col items-center justify-center gap-[29px] px-4 py-5 sm:px-6">
-          <Text variant="lead" className="text-center">
-            Uh-oh.. It seems like you don&apos;t have any agents in your
-            library. We&apos;d suggest you to create an agent in our builder
-            first
+        <div className="mt-5 flex min-h-[320px] flex-col items-center justify-center gap-4 rounded-[18px] border border-dashed border-zinc-300 bg-zinc-50 px-6 py-8 text-center">
+          <div className="flex size-11 items-center justify-center rounded-full bg-white text-zinc-700 shadow-[0_1px_2px_rgba(15,15,20,0.06)]">
+            <PlusIcon size={20} weight="bold" />
+          </div>
+          <Text variant="large-medium" className="text-textBlack">
+            No publishable agents yet
           </Text>
-          <Button
-            onClick={onOpenBuilder}
-            className="bg-neutral-800 text-white hover:bg-neutral-900"
-          >
-            Open builder
-          </Button>
+          <Text variant="body" className="max-w-[460px] text-zinc-600">
+            Create and save an agent in the builder. It will appear here when a
+            version is ready to submit.
+          </Text>
+          <Button onClick={onOpenBuilder}>Open builder</Button>
         </div>
       ) : (
         <>
-          <div className="flex-grow overflow-hidden p-4 sm:p-6">
+          <div className="flex-grow overflow-hidden pb-5">
             <h3 className="sr-only">List of agents</h3>
             <div
               className={cn(
                 scrollbarStyles,
-                "h-[300px] overflow-y-auto pr-2 sm:h-[400px] md:h-[500px]",
+                "max-h-[48vh] min-h-[280px] overflow-y-auto pr-2",
               )}
               role="region"
               aria-labelledby="agentListHeading"
@@ -128,68 +144,87 @@ export function AgentSelectStep({
               <div id="agentListHeading" className="sr-only">
                 Scrollable list of agents
               </div>
-              <div className="p-2">
-                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-                  {myAgents.map((agent) => (
-                    <div
+              <div className="grid grid-cols-1 gap-2 p-1 sm:grid-cols-2">
+                {myAgents.map((agent) => {
+                  const isSelected = selectedAgentId === agent.id;
+                  return (
+                    <button
+                      type="button"
                       key={agent.id}
                       data-testid="agent-card"
-                      className={`cursor-pointer select-none overflow-hidden rounded-2xl border border-neutral-200 shadow-sm transition-all ${
-                        selectedAgentId === agent.id
-                          ? "border-transparent shadow-none ring-4 ring-violet-600"
-                          : "hover:shadow-md"
-                      }`}
+                      className={cn(
+                        "group flex w-full cursor-pointer select-none items-center gap-3 rounded-[12px] border bg-white p-3 text-left transition-[border-color,box-shadow] duration-150 hover:border-purple-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-400 focus-visible:ring-offset-2",
+                        isSelected
+                          ? "border-purple-500 bg-purple-50/40 shadow-[0_0_0_3px_rgba(119,51,245,0.12)]"
+                          : "border-zinc-200",
+                      )}
                       onClick={() =>
                         handleAgentClick(agent.name, agent.id, agent.version)
                       }
-                      onKeyDown={(e) => {
-                        if (e.key === "Enter" || e.key === " ") {
-                          e.preventDefault();
-                          handleAgentClick(agent.name, agent.id, agent.version);
-                        }
-                      }}
-                      tabIndex={0}
-                      role="button"
-                      aria-pressed={selectedAgentId === agent.id}
+                      aria-pressed={isSelected}
                     >
-                      <div className="relative h-32 bg-zinc-400 sm:h-40">
-                        <Image
-                          src={agent.imageSrc}
-                          alt={agent.name}
-                          className="object-cover"
-                          fill
-                          sizes="(max-width: 640px) 100vw, (max-width: 768px) 50vw, 33vw"
-                        />
-                      </div>
-                      <div className="flex flex-col gap-2 p-3">
-                        <Text variant="large-medium">{agent.name}</Text>
-                        <Text variant="small" className="!text-neutral-500">
-                          Edited {agent.lastEdited}
+                      <div className="flex min-w-0 flex-1 flex-col gap-1">
+                        <div className="flex min-w-0 items-center gap-2">
+                          <Text
+                            variant="body-medium"
+                            as="span"
+                            className="truncate text-textBlack"
+                          >
+                            {agent.name}
+                          </Text>
+                          <span className="shrink-0 rounded-full bg-zinc-100 px-2 py-0.5 text-[11px] font-medium text-zinc-600">
+                            v{agent.version}
+                          </span>
+                        </div>
+                        <Text
+                          variant="small"
+                          as="span"
+                          className="truncate text-zinc-500"
+                        >
+                          {agent.description
+                            ? agent.description
+                            : `Edited ${agent.lastEdited}`}
                         </Text>
                       </div>
-                    </div>
-                  ))}
-                </div>
+                      {isSelected ? (
+                        <span className="flex size-6 shrink-0 items-center justify-center rounded-full bg-purple-500 text-white">
+                          <CheckCircleIcon size={14} weight="fill" />
+                        </span>
+                      ) : (
+                        <span
+                          aria-hidden
+                          className="size-5 shrink-0 rounded-full border border-zinc-300"
+                        />
+                      )}
+                    </button>
+                  );
+                })}
               </div>
             </div>
           </div>
 
-          <div className="flex justify-between gap-4 p-4 sm:p-6">
-            <Button
-              variant="secondary"
-              onClick={onCancel}
-              className="w-full sm:flex-1"
-            >
-              Back
-            </Button>
-            <Button
-              onClick={handleNext}
-              disabled={isNextDisabled}
-              className="w-full bg-neutral-800 text-white hover:bg-neutral-900 sm:flex-1"
-            >
-              Next
-            </Button>
-          </div>
+          <StepFooter
+            secondary={
+              <Button
+                variant="secondary"
+                size="small"
+                onClick={onCancel}
+                className="w-full sm:w-auto"
+              >
+                Cancel
+              </Button>
+            }
+            primary={
+              <Button
+                size="small"
+                onClick={handleNext}
+                disabled={isNextDisabled}
+                className="w-full sm:w-auto"
+              >
+                Continue
+              </Button>
+            }
+          />
         </>
       )}
     </div>

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentSelectStep/AgentSelectStep.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentSelectStep/AgentSelectStep.tsx
@@ -285,17 +285,17 @@ function PaginationBar({
   const pages = buildPageRange(page, totalPages);
 
   return (
-    <div className="flex flex-col items-center justify-between gap-2 pb-3 pt-1 text-zinc-500 sm:flex-row">
+    <div className="flex flex-col items-center justify-between gap-3 pb-3 pt-1 text-zinc-500 sm:flex-row">
       <Text variant="small" className="text-zinc-500">
         {start}–{end} of {totalItems}
       </Text>
-      <div className="flex items-center gap-1">
+      <div className="flex items-center gap-2">
         <button
           type="button"
           aria-label="Previous page"
           disabled={page <= 1}
           onClick={() => onChange(page - 1)}
-          className="flex size-8 items-center justify-center rounded-full border border-zinc-200 text-zinc-600 transition hover:border-zinc-300 disabled:cursor-not-allowed disabled:opacity-40"
+          className="flex size-9 items-center justify-center rounded-full border border-zinc-200 text-zinc-500 transition hover:border-zinc-300 hover:text-zinc-700 disabled:cursor-not-allowed disabled:opacity-40"
         >
           <CaretLeftIcon size={14} weight="bold" />
         </button>
@@ -303,7 +303,7 @@ function PaginationBar({
           entry === "…" ? (
             <span
               key={`gap-${idx}`}
-              className="px-1 text-xs text-zinc-400"
+              className="px-1 text-sm text-zinc-400"
               aria-hidden
             >
               …
@@ -315,10 +315,10 @@ function PaginationBar({
               onClick={() => onChange(entry)}
               aria-current={entry === page ? "page" : undefined}
               className={cn(
-                "flex size-8 items-center justify-center rounded-full border text-xs font-medium transition",
+                "flex size-9 items-center justify-center rounded-full text-sm font-medium transition",
                 entry === page
-                  ? "border-purple-500 bg-purple-500 text-white"
-                  : "border-zinc-200 text-zinc-600 hover:border-zinc-300",
+                  ? "bg-purple-500 text-white shadow-[0_4px_10px_-4px_rgba(119,51,245,0.55)]"
+                  : "border border-zinc-200 text-zinc-700 hover:border-zinc-300",
               )}
             >
               {entry}
@@ -330,7 +330,7 @@ function PaginationBar({
           aria-label="Next page"
           disabled={page >= totalPages}
           onClick={() => onChange(page + 1)}
-          className="flex size-8 items-center justify-center rounded-full border border-zinc-200 text-zinc-600 transition hover:border-zinc-300 disabled:cursor-not-allowed disabled:opacity-40"
+          className="flex size-9 items-center justify-center rounded-full border border-zinc-200 text-zinc-500 transition hover:border-zinc-300 hover:text-zinc-700 disabled:cursor-not-allowed disabled:opacity-40"
         >
           <CaretRightIcon size={14} weight="bold" />
         </button>

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentSelectStep/AgentSelectStep.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentSelectStep/AgentSelectStep.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import {
+  CaretLeftIcon,
+  CaretRightIcon,
   CheckCircleIcon,
   PlusIcon,
   WarningCircleIcon,
@@ -8,12 +10,14 @@ import {
 
 import { Text } from "../../../../atoms/Text/Text";
 import { Button } from "../../../../atoms/Button/Button";
+import { Select } from "../../../../atoms/Select/Select";
 import { StepHeader } from "../StepHeader";
 import { StepFooter } from "../StepFooter";
 import { Skeleton } from "@/components/__legacy__/ui/skeleton";
 import { useAgentSelectStep } from "./useAgentSelectStep";
 import { scrollbarStyles } from "@/components/styles/scrollbars";
 import { cn } from "@/lib/utils";
+import { MyAgentsSortBy } from "@/app/api/__generated__/models/myAgentsSortBy";
 
 interface Props {
   onSelect: (agentId: string, agentVersion: number) => void;
@@ -31,6 +35,11 @@ interface Props {
   onOpenBuilder: () => void;
 }
 
+const SORT_OPTIONS = [
+  { value: MyAgentsSortBy.most_recent, label: "Sort by: Most recent" },
+  { value: MyAgentsSortBy.name, label: "Sort by: Name" },
+];
+
 export function AgentSelectStep({
   onSelect,
   onCancel,
@@ -38,45 +47,22 @@ export function AgentSelectStep({
   onOpenBuilder,
 }: Props) {
   const {
-    // Data
     myAgents,
     isLoading,
+    isFetching,
     error,
-    // State
     selectedAgentId,
-    // Handlers
+    page,
+    totalPages,
+    totalItems,
+    pageSize,
+    sortBy,
     handleAgentClick,
     handleNext,
-    // Computed
+    handleSortChange,
+    goToPage,
     isNextDisabled,
   } = useAgentSelectStep({ onSelect, onNext });
-
-  if (isLoading) {
-    return (
-      <div className="mx-auto flex w-full flex-col">
-        <StepHeader
-          title="Choose an agent"
-          description="Pick the saved agent version you want to send to marketplace review."
-          currentStep="select"
-        />
-        <div className="flex-grow pb-5">
-          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-            {Array.from({ length: 6 }).map((_, i) => (
-              <div
-                key={i}
-                className="flex items-center gap-3 rounded-[12px] border border-zinc-200 bg-white p-3"
-              >
-                <div className="flex flex-1 flex-col gap-2">
-                  <Skeleton className="h-4 w-1/3" />
-                  <Skeleton className="h-3 w-2/3" />
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-      </div>
-    );
-  }
 
   if (error) {
     return (
@@ -107,6 +93,8 @@ export function AgentSelectStep({
     );
   }
 
+  const showEmpty = !isLoading && totalItems === 0 && myAgents.length === 0;
+
   return (
     <div className="mx-auto flex w-full flex-col">
       <StepHeader
@@ -115,7 +103,7 @@ export function AgentSelectStep({
         currentStep="select"
       />
 
-      {myAgents.length === 0 ? (
+      {showEmpty ? (
         <div className="mt-5 flex min-h-[320px] flex-col items-center justify-center gap-4 rounded-[18px] border border-dashed border-zinc-300 bg-zinc-50 px-6 py-8 text-center">
           <div className="flex size-11 items-center justify-center rounded-full bg-white text-zinc-700 shadow-[0_1px_2px_rgba(15,15,20,0.06)]">
             <PlusIcon size={20} weight="bold" />
@@ -131,77 +119,123 @@ export function AgentSelectStep({
         </div>
       ) : (
         <>
-          <div className="flex-grow overflow-hidden pb-5">
+          <div className="mt-2 flex items-center justify-end pb-3">
+            <div className="w-full sm:w-[220px]">
+              <Select
+                id="agent-sort"
+                label="Sort agents"
+                hideLabel
+                size="small"
+                value={sortBy}
+                onValueChange={handleSortChange}
+                options={SORT_OPTIONS}
+              />
+            </div>
+          </div>
+
+          <div className="flex-grow overflow-hidden pb-3">
             <h3 className="sr-only">List of agents</h3>
             <div
               className={cn(
                 scrollbarStyles,
-                "max-h-[48vh] min-h-[280px] overflow-y-auto pr-2",
+                "max-h-[44vh] min-h-[280px] overflow-y-auto pr-2",
               )}
               role="region"
               aria-labelledby="agentListHeading"
+              aria-busy={isFetching}
             >
               <div id="agentListHeading" className="sr-only">
                 Scrollable list of agents
               </div>
-              <div className="grid grid-cols-1 gap-2 p-1 sm:grid-cols-2">
-                {myAgents.map((agent) => {
-                  const isSelected = selectedAgentId === agent.id;
-                  return (
-                    <button
-                      type="button"
-                      key={agent.id}
-                      data-testid="agent-card"
-                      className={cn(
-                        "group flex w-full cursor-pointer select-none items-center gap-3 rounded-[12px] border bg-white p-3 text-left transition-[border-color,box-shadow] duration-150 hover:border-purple-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-400 focus-visible:ring-offset-2",
-                        isSelected
-                          ? "border-purple-500 bg-purple-50/40 shadow-[0_0_0_3px_rgba(119,51,245,0.12)]"
-                          : "border-zinc-200",
-                      )}
-                      onClick={() =>
-                        handleAgentClick(agent.name, agent.id, agent.version)
-                      }
-                      aria-pressed={isSelected}
+              {isLoading ? (
+                <div className="grid grid-cols-1 gap-2 p-1 sm:grid-cols-2">
+                  {Array.from({ length: 6 }).map((_, i) => (
+                    <div
+                      key={i}
+                      className="flex items-center gap-3 rounded-[12px] border border-zinc-200 bg-white p-3"
                     >
-                      <div className="flex min-w-0 flex-1 flex-col gap-1">
-                        <div className="flex min-w-0 items-center gap-2">
-                          <Text
-                            variant="body-medium"
-                            as="span"
-                            className="truncate text-textBlack"
-                          >
-                            {agent.name}
-                          </Text>
-                          <span className="shrink-0 rounded-full bg-zinc-100 px-2 py-0.5 text-[11px] font-medium text-zinc-600">
-                            v{agent.version}
-                          </span>
-                        </div>
-                        <Text
-                          variant="small"
-                          as="span"
-                          className="truncate text-zinc-500"
-                        >
-                          {agent.description
-                            ? agent.description
-                            : `Edited ${agent.lastEdited}`}
-                        </Text>
+                      <div className="flex flex-1 flex-col gap-2">
+                        <Skeleton className="h-4 w-1/3" />
+                        <Skeleton className="h-3 w-2/3" />
                       </div>
-                      {isSelected ? (
-                        <span className="flex size-6 shrink-0 items-center justify-center rounded-full bg-purple-500 text-white">
-                          <CheckCircleIcon size={14} weight="fill" />
-                        </span>
-                      ) : (
-                        <span
-                          aria-hidden
-                          className="size-5 shrink-0 rounded-full border border-zinc-300"
-                        />
-                      )}
-                    </button>
-                  );
-                })}
-              </div>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <div
+                  className={cn(
+                    "grid grid-cols-1 gap-2 p-1 transition-opacity sm:grid-cols-2",
+                    isFetching && "opacity-60",
+                  )}
+                >
+                  {myAgents.map((agent) => {
+                    const isSelected = selectedAgentId === agent.id;
+                    return (
+                      <button
+                        type="button"
+                        key={agent.id}
+                        data-testid="agent-card"
+                        className={cn(
+                          "group flex w-full cursor-pointer select-none items-center gap-3 rounded-[12px] border bg-white p-3 text-left transition-[border-color,box-shadow] duration-150 hover:border-purple-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-400 focus-visible:ring-offset-2",
+                          isSelected
+                            ? "border-purple-500 bg-purple-50/40 shadow-[0_0_0_3px_rgba(119,51,245,0.12)]"
+                            : "border-zinc-200",
+                        )}
+                        onClick={() =>
+                          handleAgentClick(agent.name, agent.id, agent.version)
+                        }
+                        aria-pressed={isSelected}
+                      >
+                        <div className="flex min-w-0 flex-1 flex-col gap-1">
+                          <div className="flex min-w-0 items-center gap-2">
+                            <Text
+                              variant="body-medium"
+                              as="span"
+                              className="truncate text-textBlack"
+                            >
+                              {agent.name}
+                            </Text>
+                            <span className="shrink-0 rounded-full bg-zinc-100 px-2 py-0.5 text-[11px] font-medium text-zinc-600">
+                              v{agent.version}
+                            </span>
+                          </div>
+                          <Text
+                            variant="small"
+                            as="span"
+                            className="truncate text-zinc-500"
+                          >
+                            {agent.description
+                              ? agent.description
+                              : `Edited ${agent.lastEdited}`}
+                          </Text>
+                        </div>
+                        {isSelected ? (
+                          <span className="flex size-6 shrink-0 items-center justify-center rounded-full bg-purple-500 text-white">
+                            <CheckCircleIcon size={14} weight="fill" />
+                          </span>
+                        ) : (
+                          <span
+                            aria-hidden
+                            className="size-5 shrink-0 rounded-full border border-zinc-300"
+                          />
+                        )}
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
             </div>
           </div>
+
+          {totalPages > 1 ? (
+            <PaginationBar
+              page={page}
+              totalPages={totalPages}
+              totalItems={totalItems}
+              pageSize={pageSize}
+              onChange={goToPage}
+            />
+          ) : null}
 
           <StepFooter
             secondary={
@@ -229,4 +263,92 @@ export function AgentSelectStep({
       )}
     </div>
   );
+}
+
+interface PaginationBarProps {
+  page: number;
+  totalPages: number;
+  totalItems: number;
+  pageSize: number;
+  onChange: (page: number) => void;
+}
+
+function PaginationBar({
+  page,
+  totalPages,
+  totalItems,
+  pageSize,
+  onChange,
+}: PaginationBarProps) {
+  const start = (page - 1) * pageSize + 1;
+  const end = Math.min(page * pageSize, totalItems);
+  const pages = buildPageRange(page, totalPages);
+
+  return (
+    <div className="flex flex-col items-center justify-between gap-2 pb-3 pt-1 text-zinc-500 sm:flex-row">
+      <Text variant="small" className="text-zinc-500">
+        {start}–{end} of {totalItems}
+      </Text>
+      <div className="flex items-center gap-1">
+        <button
+          type="button"
+          aria-label="Previous page"
+          disabled={page <= 1}
+          onClick={() => onChange(page - 1)}
+          className="flex size-8 items-center justify-center rounded-full border border-zinc-200 text-zinc-600 transition hover:border-zinc-300 disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          <CaretLeftIcon size={14} weight="bold" />
+        </button>
+        {pages.map((entry, idx) =>
+          entry === "…" ? (
+            <span
+              key={`gap-${idx}`}
+              className="px-1 text-xs text-zinc-400"
+              aria-hidden
+            >
+              …
+            </span>
+          ) : (
+            <button
+              key={entry}
+              type="button"
+              onClick={() => onChange(entry)}
+              aria-current={entry === page ? "page" : undefined}
+              className={cn(
+                "flex size-8 items-center justify-center rounded-full border text-xs font-medium transition",
+                entry === page
+                  ? "border-purple-500 bg-purple-500 text-white"
+                  : "border-zinc-200 text-zinc-600 hover:border-zinc-300",
+              )}
+            >
+              {entry}
+            </button>
+          ),
+        )}
+        <button
+          type="button"
+          aria-label="Next page"
+          disabled={page >= totalPages}
+          onClick={() => onChange(page + 1)}
+          className="flex size-8 items-center justify-center rounded-full border border-zinc-200 text-zinc-600 transition hover:border-zinc-300 disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          <CaretRightIcon size={14} weight="bold" />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function buildPageRange(current: number, total: number): (number | "…")[] {
+  if (total <= 7) {
+    return Array.from({ length: total }, (_, i) => i + 1);
+  }
+  const pages: (number | "…")[] = [1];
+  const left = Math.max(2, current - 1);
+  const right = Math.min(total - 1, current + 1);
+  if (left > 2) pages.push("…");
+  for (let i = left; i <= right; i += 1) pages.push(i);
+  if (right < total - 1) pages.push("…");
+  pages.push(total);
+  return pages;
 }

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentSelectStep/AgentSelectStep.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentSelectStep/AgentSelectStep.tsx
@@ -133,6 +133,7 @@ export function AgentSelectStep({
                 value={sortBy}
                 onValueChange={handleSortChange}
                 options={SORT_OPTIONS}
+                wrapperClassName="mb-0"
               />
             </div>
           </div>

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentSelectStep/AgentSelectStep.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentSelectStep/AgentSelectStep.tsx
@@ -119,7 +119,7 @@ export function AgentSelectStep({
         </div>
       ) : (
         <>
-          <div className="mt-2 flex items-center justify-end pb-3">
+          <div className="mt-2 flex items-center justify-start pb-1">
             <div className="w-full sm:w-[220px]">
               <Select
                 id="agent-sort"

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentSelectStep/AgentSelectStep.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentSelectStep/AgentSelectStep.tsx
@@ -4,7 +4,6 @@ import {
   CaretLeftIcon,
   CaretRightIcon,
   CheckCircleIcon,
-  FunnelIcon,
   PlusIcon,
   WarningCircleIcon,
 } from "@phosphor-icons/react";
@@ -15,17 +14,10 @@ import { Select } from "../../../../atoms/Select/Select";
 import { StepHeader } from "../StepHeader";
 import { StepFooter } from "../StepFooter";
 import { Skeleton } from "@/components/__legacy__/ui/skeleton";
-import { Checkbox } from "@/components/__legacy__/ui/checkbox";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/molecules/Popover/Popover";
 import { useAgentSelectStep } from "./useAgentSelectStep";
 import { scrollbarStyles } from "@/components/styles/scrollbars";
 import { cn } from "@/lib/utils";
 import { MyAgentsSortBy } from "@/app/api/__generated__/models/myAgentsSortBy";
-import { MyAgentsStatusFilter } from "@/app/api/__generated__/models/myAgentsStatusFilter";
 
 interface Props {
   onSelect: (agentId: string, agentVersion: number) => void;
@@ -48,13 +40,6 @@ const SORT_OPTIONS = [
   { value: MyAgentsSortBy.name, label: "Sort by: Alphabetical" },
 ];
 
-const FILTER_OPTIONS: { value: MyAgentsStatusFilter; label: string }[] = [
-  { value: MyAgentsStatusFilter.never_submitted, label: "Never submitted" },
-  { value: MyAgentsStatusFilter.draft, label: "Draft" },
-  { value: MyAgentsStatusFilter.submitted, label: "Submitted / In review" },
-  { value: MyAgentsStatusFilter.published, label: "Published" },
-];
-
 export function AgentSelectStep({
   onSelect,
   onCancel,
@@ -72,13 +57,9 @@ export function AgentSelectStep({
     totalItems,
     pageSize,
     sortBy,
-    statuses,
-    hasNoResults,
     handleAgentClick,
     handleNext,
     handleSortChange,
-    toggleStatus,
-    clearStatuses,
     goToPage,
     isNextDisabled,
   } = useAgentSelectStep({ onSelect, onNext });
@@ -112,12 +93,7 @@ export function AgentSelectStep({
     );
   }
 
-  const hasActiveFilters = statuses.length > 0;
-  const showEmpty =
-    !isLoading &&
-    !hasActiveFilters &&
-    totalItems === 0 &&
-    myAgents.length === 0;
+  const showEmpty = !isLoading && totalItems === 0 && myAgents.length === 0;
 
   return (
     <div className="mx-auto flex w-full flex-col">
@@ -143,7 +119,7 @@ export function AgentSelectStep({
         </div>
       ) : (
         <>
-          <div className="mt-2 flex flex-wrap items-center justify-between gap-2 pb-3">
+          <div className="mt-2 flex items-center justify-end pb-3">
             <div className="w-full sm:w-[220px]">
               <Select
                 id="agent-sort"
@@ -155,69 +131,6 @@ export function AgentSelectStep({
                 options={SORT_OPTIONS}
               />
             </div>
-            <Popover>
-              <PopoverTrigger asChild>
-                <button
-                  type="button"
-                  className={cn(
-                    "inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-400 focus-visible:ring-offset-1",
-                    hasActiveFilters
-                      ? "border-purple-300 bg-purple-50 text-purple-700"
-                      : "border-zinc-200 bg-white text-zinc-700 hover:border-zinc-300",
-                  )}
-                >
-                  <FunnelIcon size={14} weight="bold" />
-                  Filter
-                  {hasActiveFilters ? (
-                    <span className="inline-flex size-5 items-center justify-center rounded-full bg-purple-500 text-[11px] font-semibold text-white">
-                      {statuses.length}
-                    </span>
-                  ) : null}
-                </button>
-              </PopoverTrigger>
-              <PopoverContent align="end" className="w-60 p-3">
-                <div className="mb-2 flex items-center justify-between">
-                  <Text
-                    variant="small-medium"
-                    as="span"
-                    className="text-textBlack"
-                  >
-                    Filter by status
-                  </Text>
-                  {hasActiveFilters ? (
-                    <button
-                      type="button"
-                      onClick={clearStatuses}
-                      className="text-xs font-medium text-purple-600 hover:text-purple-700"
-                    >
-                      Clear
-                    </button>
-                  ) : null}
-                </div>
-                <ul className="flex flex-col gap-1">
-                  {FILTER_OPTIONS.map((option) => {
-                    const checked = statuses.includes(option.value);
-                    return (
-                      <li key={option.value}>
-                        <label
-                          className={cn(
-                            "flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm text-zinc-700 transition hover:bg-zinc-50",
-                            checked && "text-textBlack",
-                          )}
-                        >
-                          <Checkbox
-                            checked={checked}
-                            onCheckedChange={() => toggleStatus(option.value)}
-                            aria-label={option.label}
-                          />
-                          <span>{option.label}</span>
-                        </label>
-                      </li>
-                    );
-                  })}
-                </ul>
-              </PopoverContent>
-            </Popover>
           </div>
 
           <div className="flex-grow overflow-hidden pb-3">
@@ -247,22 +160,6 @@ export function AgentSelectStep({
                       </div>
                     </div>
                   ))}
-                </div>
-              ) : hasNoResults ? (
-                <div className="flex min-h-[240px] flex-col items-center justify-center gap-2 rounded-[12px] border border-dashed border-zinc-200 px-6 py-8 text-center">
-                  <Text variant="body-medium" className="text-textBlack">
-                    No agents match the selected filters
-                  </Text>
-                  <Text variant="small" className="text-zinc-500">
-                    Try a different combination or clear all filters.
-                  </Text>
-                  <Button
-                    variant="secondary"
-                    size="small"
-                    onClick={clearStatuses}
-                  >
-                    Clear filters
-                  </Button>
                 </div>
               ) : (
                 <div

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentSelectStep/AgentSelectStep.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentSelectStep/AgentSelectStep.tsx
@@ -133,7 +133,7 @@ export function AgentSelectStep({
                 value={sortBy}
                 onValueChange={handleSortChange}
                 options={SORT_OPTIONS}
-                wrapperClassName="mb-0"
+                wrapperClassName="mb-2"
               />
             </div>
           </div>

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentSelectStep/AgentSelectStep.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentSelectStep/AgentSelectStep.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import {
   CaretLeftIcon,
   CaretRightIcon,
@@ -57,12 +58,15 @@ export function AgentSelectStep({
     totalItems,
     pageSize,
     sortBy,
+    pageDirection,
     handleAgentClick,
     handleNext,
     handleSortChange,
     goToPage,
     isNextDisabled,
   } = useAgentSelectStep({ onSelect, onNext });
+
+  const shouldReduceMotion = useReducedMotion();
 
   if (error) {
     return (
@@ -119,7 +123,7 @@ export function AgentSelectStep({
         </div>
       ) : (
         <>
-          <div className="mt-2 flex items-center justify-start pb-1">
+          <div className="mt-2 flex items-center justify-start pb-0">
             <div className="w-full sm:w-[220px]">
               <Select
                 id="agent-sort"
@@ -162,67 +166,104 @@ export function AgentSelectStep({
                   ))}
                 </div>
               ) : (
-                <div
-                  className={cn(
-                    "grid grid-cols-1 gap-2 p-1 transition-opacity sm:grid-cols-2",
-                    isFetching && "opacity-60",
-                  )}
+                <AnimatePresence
+                  mode="wait"
+                  initial={false}
+                  custom={pageDirection}
                 >
-                  {myAgents.map((agent) => {
-                    const isSelected = selectedAgentId === agent.id;
-                    return (
-                      <button
-                        type="button"
-                        key={agent.id}
-                        data-testid="agent-card"
-                        className={cn(
-                          "group flex w-full cursor-pointer select-none items-center gap-3 rounded-[12px] border bg-white p-3 text-left transition-[border-color,box-shadow] duration-150 hover:border-purple-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-400 focus-visible:ring-offset-2",
-                          isSelected
-                            ? "border-purple-500 bg-purple-50/40 shadow-[0_0_0_3px_rgba(119,51,245,0.12)]"
-                            : "border-zinc-200",
-                        )}
-                        onClick={() =>
-                          handleAgentClick(agent.name, agent.id, agent.version)
-                        }
-                        aria-pressed={isSelected}
-                      >
-                        <div className="flex min-w-0 flex-1 flex-col gap-1">
-                          <div className="flex min-w-0 items-center gap-2">
+                  <motion.div
+                    key={page}
+                    custom={pageDirection}
+                    variants={{
+                      enter: (dir: number) => ({
+                        opacity: 0,
+                        x: shouldReduceMotion ? 0 : dir * 16,
+                      }),
+                      center: {
+                        opacity: 1,
+                        x: 0,
+                        transition: {
+                          duration: shouldReduceMotion ? 0 : 0.2,
+                          ease: [0.16, 1, 0.3, 1],
+                        },
+                      },
+                      exit: (dir: number) => ({
+                        opacity: 0,
+                        x: shouldReduceMotion ? 0 : dir * -16,
+                        transition: {
+                          duration: shouldReduceMotion ? 0 : 0.12,
+                          ease: [0.4, 0, 1, 1],
+                        },
+                      }),
+                    }}
+                    initial="enter"
+                    animate="center"
+                    exit="exit"
+                    className={cn(
+                      "grid grid-cols-1 gap-2 p-1 sm:grid-cols-2",
+                      isFetching && "opacity-90",
+                    )}
+                  >
+                    {myAgents.map((agent) => {
+                      const isSelected = selectedAgentId === agent.id;
+                      return (
+                        <button
+                          type="button"
+                          key={agent.id}
+                          data-testid="agent-card"
+                          className={cn(
+                            "group flex w-full cursor-pointer select-none items-center gap-3 rounded-[12px] border bg-white p-3 text-left transition-[border-color,box-shadow] duration-150 hover:border-purple-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-400 focus-visible:ring-offset-2",
+                            isSelected
+                              ? "border-purple-500 bg-purple-50/40 shadow-[0_0_0_3px_rgba(119,51,245,0.12)]"
+                              : "border-zinc-200",
+                          )}
+                          onClick={() =>
+                            handleAgentClick(
+                              agent.name,
+                              agent.id,
+                              agent.version,
+                            )
+                          }
+                          aria-pressed={isSelected}
+                        >
+                          <div className="flex min-w-0 flex-1 flex-col gap-1">
+                            <div className="flex min-w-0 items-center gap-2">
+                              <Text
+                                variant="body-medium"
+                                as="span"
+                                className="truncate text-textBlack"
+                              >
+                                {agent.name}
+                              </Text>
+                              <span className="shrink-0 rounded-full bg-zinc-100 px-2 py-0.5 text-[11px] font-medium text-zinc-600">
+                                v{agent.version}
+                              </span>
+                            </div>
                             <Text
-                              variant="body-medium"
+                              variant="small"
                               as="span"
-                              className="truncate text-textBlack"
+                              className="truncate text-zinc-500"
                             >
-                              {agent.name}
+                              {agent.description
+                                ? agent.description
+                                : `Edited ${agent.lastEdited}`}
                             </Text>
-                            <span className="shrink-0 rounded-full bg-zinc-100 px-2 py-0.5 text-[11px] font-medium text-zinc-600">
-                              v{agent.version}
-                            </span>
                           </div>
-                          <Text
-                            variant="small"
-                            as="span"
-                            className="truncate text-zinc-500"
-                          >
-                            {agent.description
-                              ? agent.description
-                              : `Edited ${agent.lastEdited}`}
-                          </Text>
-                        </div>
-                        {isSelected ? (
-                          <span className="flex size-6 shrink-0 items-center justify-center rounded-full bg-purple-500 text-white">
-                            <CheckCircleIcon size={14} weight="fill" />
-                          </span>
-                        ) : (
-                          <span
-                            aria-hidden
-                            className="size-5 shrink-0 rounded-full border border-zinc-300"
-                          />
-                        )}
-                      </button>
-                    );
-                  })}
-                </div>
+                          {isSelected ? (
+                            <span className="flex size-6 shrink-0 items-center justify-center rounded-full bg-purple-500 text-white">
+                              <CheckCircleIcon size={14} weight="fill" />
+                            </span>
+                          ) : (
+                            <span
+                              aria-hidden
+                              className="size-5 shrink-0 rounded-full border border-zinc-300"
+                            />
+                          )}
+                        </button>
+                      );
+                    })}
+                  </motion.div>
+                </AnimatePresence>
               )}
             </div>
           </div>
@@ -315,13 +356,21 @@ function PaginationBar({
               onClick={() => onChange(entry)}
               aria-current={entry === page ? "page" : undefined}
               className={cn(
-                "flex size-9 items-center justify-center rounded-full text-sm font-medium transition",
+                "relative flex size-9 items-center justify-center rounded-full text-sm font-medium transition",
                 entry === page
-                  ? "bg-purple-500 text-white shadow-[0_4px_10px_-4px_rgba(119,51,245,0.55)]"
+                  ? "text-white"
                   : "border border-zinc-200 text-zinc-700 hover:border-zinc-300",
               )}
             >
-              {entry}
+              {entry === page ? (
+                <motion.span
+                  layoutId="pagination-active-pill"
+                  aria-hidden
+                  className="absolute inset-0 rounded-full bg-purple-500 shadow-[0_4px_10px_-4px_rgba(119,51,245,0.55)]"
+                  transition={{ type: "spring", stiffness: 420, damping: 32 }}
+                />
+              ) : null}
+              <span className="relative">{entry}</span>
             </button>
           ),
         )}

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentSelectStep/AgentSelectStep.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentSelectStep/AgentSelectStep.tsx
@@ -4,6 +4,7 @@ import {
   CaretLeftIcon,
   CaretRightIcon,
   CheckCircleIcon,
+  FunnelIcon,
   PlusIcon,
   WarningCircleIcon,
 } from "@phosphor-icons/react";
@@ -14,10 +15,17 @@ import { Select } from "../../../../atoms/Select/Select";
 import { StepHeader } from "../StepHeader";
 import { StepFooter } from "../StepFooter";
 import { Skeleton } from "@/components/__legacy__/ui/skeleton";
+import { Checkbox } from "@/components/__legacy__/ui/checkbox";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/molecules/Popover/Popover";
 import { useAgentSelectStep } from "./useAgentSelectStep";
 import { scrollbarStyles } from "@/components/styles/scrollbars";
 import { cn } from "@/lib/utils";
 import { MyAgentsSortBy } from "@/app/api/__generated__/models/myAgentsSortBy";
+import { MyAgentsStatusFilter } from "@/app/api/__generated__/models/myAgentsStatusFilter";
 
 interface Props {
   onSelect: (agentId: string, agentVersion: number) => void;
@@ -37,7 +45,14 @@ interface Props {
 
 const SORT_OPTIONS = [
   { value: MyAgentsSortBy.most_recent, label: "Sort by: Most recent" },
-  { value: MyAgentsSortBy.name, label: "Sort by: Name" },
+  { value: MyAgentsSortBy.name, label: "Sort by: Alphabetical" },
+];
+
+const FILTER_OPTIONS: { value: MyAgentsStatusFilter; label: string }[] = [
+  { value: MyAgentsStatusFilter.never_submitted, label: "Never submitted" },
+  { value: MyAgentsStatusFilter.draft, label: "Draft" },
+  { value: MyAgentsStatusFilter.submitted, label: "Submitted / In review" },
+  { value: MyAgentsStatusFilter.published, label: "Published" },
 ];
 
 export function AgentSelectStep({
@@ -57,9 +72,13 @@ export function AgentSelectStep({
     totalItems,
     pageSize,
     sortBy,
+    statuses,
+    hasNoResults,
     handleAgentClick,
     handleNext,
     handleSortChange,
+    toggleStatus,
+    clearStatuses,
     goToPage,
     isNextDisabled,
   } = useAgentSelectStep({ onSelect, onNext });
@@ -93,7 +112,12 @@ export function AgentSelectStep({
     );
   }
 
-  const showEmpty = !isLoading && totalItems === 0 && myAgents.length === 0;
+  const hasActiveFilters = statuses.length > 0;
+  const showEmpty =
+    !isLoading &&
+    !hasActiveFilters &&
+    totalItems === 0 &&
+    myAgents.length === 0;
 
   return (
     <div className="mx-auto flex w-full flex-col">
@@ -119,7 +143,7 @@ export function AgentSelectStep({
         </div>
       ) : (
         <>
-          <div className="mt-2 flex items-center justify-end pb-3">
+          <div className="mt-2 flex flex-wrap items-center justify-between gap-2 pb-3">
             <div className="w-full sm:w-[220px]">
               <Select
                 id="agent-sort"
@@ -131,6 +155,69 @@ export function AgentSelectStep({
                 options={SORT_OPTIONS}
               />
             </div>
+            <Popover>
+              <PopoverTrigger asChild>
+                <button
+                  type="button"
+                  className={cn(
+                    "inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-400 focus-visible:ring-offset-1",
+                    hasActiveFilters
+                      ? "border-purple-300 bg-purple-50 text-purple-700"
+                      : "border-zinc-200 bg-white text-zinc-700 hover:border-zinc-300",
+                  )}
+                >
+                  <FunnelIcon size={14} weight="bold" />
+                  Filter
+                  {hasActiveFilters ? (
+                    <span className="inline-flex size-5 items-center justify-center rounded-full bg-purple-500 text-[11px] font-semibold text-white">
+                      {statuses.length}
+                    </span>
+                  ) : null}
+                </button>
+              </PopoverTrigger>
+              <PopoverContent align="end" className="w-60 p-3">
+                <div className="mb-2 flex items-center justify-between">
+                  <Text
+                    variant="small-medium"
+                    as="span"
+                    className="text-textBlack"
+                  >
+                    Filter by status
+                  </Text>
+                  {hasActiveFilters ? (
+                    <button
+                      type="button"
+                      onClick={clearStatuses}
+                      className="text-xs font-medium text-purple-600 hover:text-purple-700"
+                    >
+                      Clear
+                    </button>
+                  ) : null}
+                </div>
+                <ul className="flex flex-col gap-1">
+                  {FILTER_OPTIONS.map((option) => {
+                    const checked = statuses.includes(option.value);
+                    return (
+                      <li key={option.value}>
+                        <label
+                          className={cn(
+                            "flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm text-zinc-700 transition hover:bg-zinc-50",
+                            checked && "text-textBlack",
+                          )}
+                        >
+                          <Checkbox
+                            checked={checked}
+                            onCheckedChange={() => toggleStatus(option.value)}
+                            aria-label={option.label}
+                          />
+                          <span>{option.label}</span>
+                        </label>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </PopoverContent>
+            </Popover>
           </div>
 
           <div className="flex-grow overflow-hidden pb-3">
@@ -160,6 +247,22 @@ export function AgentSelectStep({
                       </div>
                     </div>
                   ))}
+                </div>
+              ) : hasNoResults ? (
+                <div className="flex min-h-[240px] flex-col items-center justify-center gap-2 rounded-[12px] border border-dashed border-zinc-200 px-6 py-8 text-center">
+                  <Text variant="body-medium" className="text-textBlack">
+                    No agents match the selected filters
+                  </Text>
+                  <Text variant="small" className="text-zinc-500">
+                    Try a different combination or clear all filters.
+                  </Text>
+                  <Button
+                    variant="secondary"
+                    size="small"
+                    onClick={clearStatuses}
+                  >
+                    Clear filters
+                  </Button>
                 </div>
               ) : (
                 <div

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentSelectStep/__tests__/AgentSelectStep.test.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentSelectStep/__tests__/AgentSelectStep.test.tsx
@@ -93,16 +93,14 @@ describe("AgentSelectStep", () => {
       />,
     );
 
-    const card = await screen.findByText(
-      "Agent 1",
-      {},
-      { timeout: 3000 },
-    );
+    const card = await screen.findByText("Agent 1", {}, { timeout: 3000 });
     fireEvent.click(card);
     expect(onSelect).toHaveBeenCalledWith("graph-1", 1);
 
     const continueBtn = screen.getByRole("button", { name: "Continue" });
-    await waitFor(() => expect(continueBtn).not.toHaveProperty("disabled", true));
+    await waitFor(() =>
+      expect(continueBtn).not.toHaveProperty("disabled", true),
+    );
 
     fireEvent.click(continueBtn);
     expect(onNext).toHaveBeenCalledWith(

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentSelectStep/__tests__/AgentSelectStep.test.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentSelectStep/__tests__/AgentSelectStep.test.tsx
@@ -1,0 +1,234 @@
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render } from "@/tests/integrations/test-utils";
+import { server } from "@/mocks/mock-server";
+import { http, HttpResponse } from "msw";
+
+vi.mock("@/lib/supabase/hooks/useSupabase", () => ({
+  useSupabase: () => ({ isLoggedIn: true }),
+}));
+
+import { AgentSelectStep } from "../AgentSelectStep";
+
+function fakeAgents(total: number, page: number, pageSize: number) {
+  const start = (page - 1) * pageSize;
+  return Array.from({ length: Math.min(pageSize, total - start) }, (_, i) => {
+    const idx = start + i + 1;
+    return {
+      graph_id: `graph-${idx}`,
+      graph_version: 1,
+      agent_name: `Agent ${idx}`,
+      description: `Description ${idx}`,
+      last_edited: new Date(
+        `2026-05-${String(((idx - 1) % 28) + 1).padStart(2, "0")}T00:00:00Z`,
+      ).toISOString(),
+      agent_image: null,
+      recommended_schedule_cron: null,
+    };
+  });
+}
+
+function installHandler(total = 47, pageSize = 10) {
+  server.use(
+    http.get(
+      "http://localhost:3000/api/proxy/api/store/my-unpublished-agents",
+      ({ request }) => {
+        const url = new URL(request.url);
+        const page = Number(url.searchParams.get("page") ?? "1");
+        const size = Number(url.searchParams.get("page_size") ?? pageSize);
+        return HttpResponse.json({
+          agents: fakeAgents(total, page, size),
+          pagination: {
+            current_page: page,
+            total_items: total,
+            total_pages: Math.ceil(total / size),
+            page_size: size,
+          },
+        });
+      },
+    ),
+  );
+}
+
+describe("AgentSelectStep", () => {
+  const onSelect = vi.fn();
+  const onCancel = vi.fn();
+  const onNext = vi.fn();
+  const onOpenBuilder = vi.fn();
+
+  beforeEach(() => {
+    onSelect.mockReset();
+    onCancel.mockReset();
+    onNext.mockReset();
+    onOpenBuilder.mockReset();
+  });
+
+  it("renders the loaded agents and a pagination bar when totalPages > 1", async () => {
+    installHandler(47, 10);
+    render(
+      <AgentSelectStep
+        onSelect={onSelect}
+        onCancel={onCancel}
+        onNext={onNext}
+        onOpenBuilder={onOpenBuilder}
+      />,
+    );
+
+    expect(
+      await screen.findByText("Agent 1", {}, { timeout: 3000 }),
+    ).toBeDefined();
+    expect(screen.getByText("Agent 10")).toBeDefined();
+    expect(screen.getByText("1–10 of 47")).toBeDefined();
+    expect(screen.getByRole("button", { name: "Next page" })).toBeDefined();
+  });
+
+  it("selecting an agent enables Continue and forwards data via onNext", async () => {
+    installHandler(12, 10);
+    render(
+      <AgentSelectStep
+        onSelect={onSelect}
+        onCancel={onCancel}
+        onNext={onNext}
+        onOpenBuilder={onOpenBuilder}
+      />,
+    );
+
+    const card = await screen.findByText(
+      "Agent 1",
+      {},
+      { timeout: 3000 },
+    );
+    fireEvent.click(card);
+    expect(onSelect).toHaveBeenCalledWith("graph-1", 1);
+
+    const continueBtn = screen.getByRole("button", { name: "Continue" });
+    await waitFor(() => expect(continueBtn).not.toHaveProperty("disabled", true));
+
+    fireEvent.click(continueBtn);
+    expect(onNext).toHaveBeenCalledWith(
+      "graph-1",
+      1,
+      expect.objectContaining({ name: "Agent 1" }),
+    );
+  });
+
+  it("clicking the Next page button advances to page 2", async () => {
+    installHandler(47, 10);
+    render(
+      <AgentSelectStep
+        onSelect={onSelect}
+        onCancel={onCancel}
+        onNext={onNext}
+        onOpenBuilder={onOpenBuilder}
+      />,
+    );
+
+    await screen.findByText("Agent 1", {}, { timeout: 3000 });
+
+    fireEvent.click(screen.getByRole("button", { name: "Next page" }));
+
+    await waitFor(
+      () => {
+        expect(screen.queryByText("11–20 of 47")).not.toBeNull();
+      },
+      { timeout: 3000 },
+    );
+  });
+
+  it("shows the empty state when the user has no agents", async () => {
+    server.use(
+      http.get(
+        "http://localhost:3000/api/proxy/api/store/my-unpublished-agents",
+        () =>
+          HttpResponse.json({
+            agents: [],
+            pagination: {
+              current_page: 1,
+              total_items: 0,
+              total_pages: 0,
+              page_size: 10,
+            },
+          }),
+      ),
+    );
+
+    render(
+      <AgentSelectStep
+        onSelect={onSelect}
+        onCancel={onCancel}
+        onNext={onNext}
+        onOpenBuilder={onOpenBuilder}
+      />,
+    );
+
+    expect(
+      await screen.findByText(
+        "No publishable agents yet",
+        {},
+        { timeout: 3000 },
+      ),
+    ).toBeDefined();
+
+    fireEvent.click(screen.getByRole("button", { name: "Open builder" }));
+    expect(onOpenBuilder).toHaveBeenCalled();
+  });
+
+  it("renders the ellipsis page range when total pages exceeds 7", async () => {
+    // 100 items / 10 per page = 10 pages → ellipsis branch is exercised.
+    installHandler(100, 10);
+    render(
+      <AgentSelectStep
+        onSelect={onSelect}
+        onCancel={onCancel}
+        onNext={onNext}
+        onOpenBuilder={onOpenBuilder}
+      />,
+    );
+
+    await screen.findByText("Agent 1", {}, { timeout: 3000 });
+
+    // The ellipsis character should show up between page chunks.
+    expect(screen.getAllByText("…").length).toBeGreaterThan(0);
+
+    // First and last pages are always shown.
+    expect(
+      screen.getByRole("button", { name: "1", current: "page" }),
+    ).toBeDefined();
+    expect(screen.getByRole("button", { name: "10" })).toBeDefined();
+
+    // Clicking a numeric page button jumps to that page.
+    fireEvent.click(screen.getByRole("button", { name: "10" }));
+    await waitFor(
+      () => {
+        expect(screen.queryByText("91–100 of 100")).not.toBeNull();
+      },
+      { timeout: 3000 },
+    );
+  });
+
+  it("renders the error state when the API fails", async () => {
+    server.use(
+      http.get(
+        "http://localhost:3000/api/proxy/api/store/my-unpublished-agents",
+        () => HttpResponse.json({ detail: "boom" }, { status: 500 }),
+      ),
+    );
+
+    render(
+      <AgentSelectStep
+        onSelect={onSelect}
+        onCancel={onCancel}
+        onNext={onNext}
+        onOpenBuilder={onOpenBuilder}
+      />,
+    );
+
+    expect(
+      await screen.findByText(
+        "We could not load your agents",
+        {},
+        { timeout: 3000 },
+      ),
+    ).toBeDefined();
+  });
+});

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentSelectStep/__tests__/useAgentSelectStep.test.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentSelectStep/__tests__/useAgentSelectStep.test.tsx
@@ -42,8 +42,9 @@ function buildAgent(idx: number) {
 
 function mockResponse(total: number, page: number, pageSize: number) {
   const start = (page - 1) * pageSize;
-  const agents = Array.from({ length: Math.min(pageSize, total - start) }, (_, i) =>
-    buildAgent(start + i + 1),
+  const agents = Array.from(
+    { length: Math.min(pageSize, total - start) },
+    (_, i) => buildAgent(start + i + 1),
   );
   return {
     status: 200,
@@ -63,9 +64,7 @@ function wrap(children: ReactNode) {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
-  return (
-    <QueryClientProvider client={client}>{children}</QueryClientProvider>
-  );
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
 }
 
 describe("useAgentSelectStep", () => {
@@ -103,7 +102,9 @@ describe("useAgentSelectStep", () => {
 
   it("handleAgentClick selects an agent and forwards to onSelect", async () => {
     const { result } = setup();
-    await waitFor(() => expect(result.current.myAgents.length).toBeGreaterThan(0));
+    await waitFor(() =>
+      expect(result.current.myAgents.length).toBeGreaterThan(0),
+    );
     act(() => {
       result.current.handleAgentClick("Agent 1", "graph-1", 1);
     });
@@ -114,7 +115,9 @@ describe("useAgentSelectStep", () => {
 
   it("handleNext invokes onNext only when an agent is selected", async () => {
     const { result } = setup();
-    await waitFor(() => expect(result.current.myAgents.length).toBeGreaterThan(0));
+    await waitFor(() =>
+      expect(result.current.myAgents.length).toBeGreaterThan(0),
+    );
 
     act(() => {
       result.current.handleNext();
@@ -130,7 +133,10 @@ describe("useAgentSelectStep", () => {
     expect(onNext).toHaveBeenCalledWith(
       "graph-1",
       1,
-      expect.objectContaining({ name: "Agent 1", description: "Description 1" }),
+      expect.objectContaining({
+        name: "Agent 1",
+        description: "Description 1",
+      }),
     );
   });
 

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentSelectStep/__tests__/useAgentSelectStep.test.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentSelectStep/__tests__/useAgentSelectStep.test.tsx
@@ -1,0 +1,179 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MyAgentsSortBy } from "@/app/api/__generated__/models/myAgentsSortBy";
+
+vi.mock("@/lib/supabase/hooks/useSupabase", () => ({
+  useSupabase: () => ({ isLoggedIn: true }),
+}));
+
+const getMyAgentsMock = vi.fn();
+vi.mock("@/app/api/__generated__/endpoints/store/store", () => ({
+  useGetV2GetMyAgents: (
+    params: unknown,
+    options: { query?: { select?: (res: unknown) => unknown } } = {},
+  ) => {
+    const res = getMyAgentsMock(params);
+    const select = options.query?.select;
+    const selected = select ? select(res) : res;
+    return {
+      data: selected,
+      isLoading: false,
+      isFetching: false,
+      error: null,
+    };
+  },
+}));
+
+import { useAgentSelectStep } from "../useAgentSelectStep";
+
+function buildAgent(idx: number) {
+  return {
+    graph_id: `graph-${idx}`,
+    graph_version: 1,
+    agent_name: `Agent ${idx}`,
+    description: `Description ${idx}`,
+    last_edited: new Date(`2026-05-${String(idx).padStart(2, "0")}T00:00:00Z`),
+    agent_image: null,
+    recommended_schedule_cron: null,
+  };
+}
+
+function mockResponse(total: number, page: number, pageSize: number) {
+  const start = (page - 1) * pageSize;
+  const agents = Array.from({ length: Math.min(pageSize, total - start) }, (_, i) =>
+    buildAgent(start + i + 1),
+  );
+  return {
+    status: 200,
+    data: {
+      agents,
+      pagination: {
+        current_page: page,
+        total_items: total,
+        total_pages: Math.ceil(total / pageSize),
+        page_size: pageSize,
+      },
+    },
+  };
+}
+
+function wrap(children: ReactNode) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+describe("useAgentSelectStep", () => {
+  const onSelect = vi.fn();
+  const onNext = vi.fn();
+
+  beforeEach(() => {
+    getMyAgentsMock.mockReset();
+    onSelect.mockReset();
+    onNext.mockReset();
+    getMyAgentsMock.mockImplementation((params: { page?: number }) =>
+      mockResponse(47, params?.page ?? 1, 10),
+    );
+  });
+
+  function setup() {
+    return renderHook(() => useAgentSelectStep({ onSelect, onNext }), {
+      wrapper: ({ children }) => wrap(children),
+    });
+  }
+
+  it("exposes the agents from the API mapped to the view-model", async () => {
+    const { result } = setup();
+    await waitFor(() => expect(result.current.myAgents).toHaveLength(10));
+    expect(result.current.myAgents[0]).toMatchObject({
+      id: "graph-1",
+      version: 1,
+      name: "Agent 1",
+    });
+    expect(result.current.totalPages).toBe(5);
+    expect(result.current.totalItems).toBe(47);
+    expect(result.current.pageSize).toBe(10);
+    expect(result.current.sortBy).toBe(MyAgentsSortBy.most_recent);
+  });
+
+  it("handleAgentClick selects an agent and forwards to onSelect", async () => {
+    const { result } = setup();
+    await waitFor(() => expect(result.current.myAgents.length).toBeGreaterThan(0));
+    act(() => {
+      result.current.handleAgentClick("Agent 1", "graph-1", 1);
+    });
+    expect(result.current.selectedAgentId).toBe("graph-1");
+    expect(result.current.isNextDisabled).toBe(false);
+    expect(onSelect).toHaveBeenCalledWith("graph-1", 1);
+  });
+
+  it("handleNext invokes onNext only when an agent is selected", async () => {
+    const { result } = setup();
+    await waitFor(() => expect(result.current.myAgents.length).toBeGreaterThan(0));
+
+    act(() => {
+      result.current.handleNext();
+    });
+    expect(onNext).not.toHaveBeenCalled();
+
+    act(() => {
+      result.current.handleAgentClick("Agent 1", "graph-1", 1);
+    });
+    act(() => {
+      result.current.handleNext();
+    });
+    expect(onNext).toHaveBeenCalledWith(
+      "graph-1",
+      1,
+      expect.objectContaining({ name: "Agent 1", description: "Description 1" }),
+    );
+  });
+
+  it("goToPage updates page and pageDirection, ignoring out-of-range values", async () => {
+    const { result } = setup();
+    await waitFor(() => expect(result.current.totalPages).toBe(5));
+
+    act(() => {
+      result.current.goToPage(2);
+    });
+    expect(result.current.page).toBe(2);
+    expect(result.current.pageDirection).toBe(1);
+
+    act(() => {
+      result.current.goToPage(1);
+    });
+    expect(result.current.page).toBe(1);
+    expect(result.current.pageDirection).toBe(-1);
+
+    act(() => {
+      result.current.goToPage(0); // below min, ignored
+    });
+    expect(result.current.page).toBe(1);
+
+    act(() => {
+      result.current.goToPage(99); // above max, ignored
+    });
+    expect(result.current.page).toBe(1);
+  });
+
+  it("handleSortChange resets to page 1", async () => {
+    const { result } = setup();
+    await waitFor(() => expect(result.current.totalPages).toBe(5));
+
+    act(() => {
+      result.current.goToPage(3);
+    });
+    expect(result.current.page).toBe(3);
+
+    act(() => {
+      result.current.handleSortChange(MyAgentsSortBy.name);
+    });
+    expect(result.current.sortBy).toBe(MyAgentsSortBy.name);
+    await waitFor(() => expect(result.current.page).toBe(1));
+  });
+});

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentSelectStep/useAgentSelectStep.ts
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentSelectStep/useAgentSelectStep.ts
@@ -3,7 +3,6 @@ import { keepPreviousData } from "@tanstack/react-query";
 import { useGetV2GetMyAgents } from "@/app/api/__generated__/endpoints/store/store";
 import { okData } from "@/app/api/helpers";
 import { MyAgentsSortBy } from "@/app/api/__generated__/models/myAgentsSortBy";
-import { MyAgentsStatusFilter } from "@/app/api/__generated__/models/myAgentsStatusFilter";
 import { useSupabase } from "@/lib/supabase/hooks/useSupabase";
 
 export interface Agent {
@@ -46,12 +45,11 @@ export function useAgentSelectStep({
   const [sortBy, setSortBy] = React.useState<MyAgentsSortBy>(
     MyAgentsSortBy.most_recent,
   );
-  const [statuses, setStatuses] = React.useState<MyAgentsStatusFilter[]>([]);
   const { isLoggedIn } = useSupabase();
 
   React.useEffect(() => {
     setPage(1);
-  }, [sortBy, statuses]);
+  }, [sortBy]);
 
   const {
     data: agentsData,
@@ -63,7 +61,6 @@ export function useAgentSelectStep({
       page,
       page_size: PAGE_SIZE,
       sort_by: sortBy,
-      ...(statuses.length > 0 ? { status: statuses } : {}),
     },
     {
       query: {
@@ -94,8 +91,6 @@ export function useAgentSelectStep({
   const myAgents = agentsData?.agents ?? [];
   const totalPages = agentsData?.pagination?.total_pages ?? 0;
   const totalItems = agentsData?.pagination?.total_items ?? 0;
-  const hasNoResults =
-    !isLoading && !isFetching && myAgents.length === 0 && statuses.length > 0;
 
   function handleAgentClick(_: string, agentId: string, agentVersion: number) {
     setSelectedAgentId(agentId);
@@ -121,18 +116,6 @@ export function useAgentSelectStep({
     setSortBy(value as MyAgentsSortBy);
   }
 
-  function toggleStatus(status: MyAgentsStatusFilter) {
-    setStatuses((prev) =>
-      prev.includes(status)
-        ? prev.filter((s) => s !== status)
-        : [...prev, status],
-    );
-  }
-
-  function clearStatuses() {
-    setStatuses([]);
-  }
-
   function goToPage(next: number) {
     if (next < 1 || (totalPages > 0 && next > totalPages)) return;
     setPage(next);
@@ -149,13 +132,9 @@ export function useAgentSelectStep({
     totalItems,
     pageSize: PAGE_SIZE,
     sortBy,
-    statuses,
-    hasNoResults,
     handleAgentClick,
     handleNext,
     handleSortChange,
-    toggleStatus,
-    clearStatuses,
     goToPage,
     isNextDisabled: !selectedAgentId || !selectedAgentVersion,
   };

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentSelectStep/useAgentSelectStep.ts
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentSelectStep/useAgentSelectStep.ts
@@ -41,6 +41,10 @@ export function useAgentSelectStep({
   const [selectedAgentVersion, setSelectedAgentVersion] = React.useState<
     number | null
   >(null);
+  // Capture the selected agent's full payload at click time so pagination
+  // doesn't drop it off the current page before the user hits Continue.
+  const [selectedAgentSnapshot, setSelectedAgentSnapshot] =
+    React.useState<Agent | null>(null);
   const [page, setPage] = React.useState(1);
   const [pageDirection, setPageDirection] = React.useState<1 | -1>(1);
   const [sortBy, setSortBy] = React.useState<MyAgentsSortBy>(
@@ -94,23 +98,24 @@ export function useAgentSelectStep({
   const totalItems = agentsData?.pagination?.total_items ?? 0;
 
   function handleAgentClick(_: string, agentId: string, agentVersion: number) {
+    const clicked = myAgents.find((a) => a.id === agentId) ?? null;
     setSelectedAgentId(agentId);
     setSelectedAgentVersion(agentVersion);
+    setSelectedAgentSnapshot(clicked);
     onSelect(agentId, agentVersion);
   }
 
   function handleNext() {
-    if (selectedAgentId && selectedAgentVersion) {
-      const selectedAgent = myAgents.find((a) => a.id === selectedAgentId);
-      if (selectedAgent) {
-        onNext(selectedAgentId, selectedAgentVersion, {
-          name: selectedAgent.name,
-          description: selectedAgent.description,
-          imageSrc: selectedAgent.imageSrc,
-          recommendedScheduleCron: selectedAgent.recommendedScheduleCron,
-        });
-      }
-    }
+    if (!selectedAgentId || !selectedAgentVersion) return;
+    const selectedAgent =
+      myAgents.find((a) => a.id === selectedAgentId) ?? selectedAgentSnapshot;
+    if (!selectedAgent) return;
+    onNext(selectedAgentId, selectedAgentVersion, {
+      name: selectedAgent.name,
+      description: selectedAgent.description,
+      imageSrc: selectedAgent.imageSrc,
+      recommendedScheduleCron: selectedAgent.recommendedScheduleCron,
+    });
   }
 
   function handleSortChange(value: string) {

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentSelectStep/useAgentSelectStep.ts
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentSelectStep/useAgentSelectStep.ts
@@ -3,6 +3,7 @@ import { keepPreviousData } from "@tanstack/react-query";
 import { useGetV2GetMyAgents } from "@/app/api/__generated__/endpoints/store/store";
 import { okData } from "@/app/api/helpers";
 import { MyAgentsSortBy } from "@/app/api/__generated__/models/myAgentsSortBy";
+import { MyAgentsStatusFilter } from "@/app/api/__generated__/models/myAgentsStatusFilter";
 import { useSupabase } from "@/lib/supabase/hooks/useSupabase";
 
 export interface Agent {
@@ -45,11 +46,12 @@ export function useAgentSelectStep({
   const [sortBy, setSortBy] = React.useState<MyAgentsSortBy>(
     MyAgentsSortBy.most_recent,
   );
+  const [statuses, setStatuses] = React.useState<MyAgentsStatusFilter[]>([]);
   const { isLoggedIn } = useSupabase();
 
   React.useEffect(() => {
     setPage(1);
-  }, [sortBy]);
+  }, [sortBy, statuses]);
 
   const {
     data: agentsData,
@@ -61,6 +63,7 @@ export function useAgentSelectStep({
       page,
       page_size: PAGE_SIZE,
       sort_by: sortBy,
+      ...(statuses.length > 0 ? { status: statuses } : {}),
     },
     {
       query: {
@@ -91,6 +94,8 @@ export function useAgentSelectStep({
   const myAgents = agentsData?.agents ?? [];
   const totalPages = agentsData?.pagination?.total_pages ?? 0;
   const totalItems = agentsData?.pagination?.total_items ?? 0;
+  const hasNoResults =
+    !isLoading && !isFetching && myAgents.length === 0 && statuses.length > 0;
 
   function handleAgentClick(_: string, agentId: string, agentVersion: number) {
     setSelectedAgentId(agentId);
@@ -116,6 +121,18 @@ export function useAgentSelectStep({
     setSortBy(value as MyAgentsSortBy);
   }
 
+  function toggleStatus(status: MyAgentsStatusFilter) {
+    setStatuses((prev) =>
+      prev.includes(status)
+        ? prev.filter((s) => s !== status)
+        : [...prev, status],
+    );
+  }
+
+  function clearStatuses() {
+    setStatuses([]);
+  }
+
   function goToPage(next: number) {
     if (next < 1 || (totalPages > 0 && next > totalPages)) return;
     setPage(next);
@@ -132,9 +149,13 @@ export function useAgentSelectStep({
     totalItems,
     pageSize: PAGE_SIZE,
     sortBy,
+    statuses,
+    hasNoResults,
     handleAgentClick,
     handleNext,
     handleSortChange,
+    toggleStatus,
+    clearStatuses,
     goToPage,
     isNextDisabled: !selectedAgentId || !selectedAgentVersion,
   };

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentSelectStep/useAgentSelectStep.ts
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentSelectStep/useAgentSelectStep.ts
@@ -46,6 +46,8 @@ export function useAgentSelectStep({
   } = useGetV2GetMyAgents(undefined, {
     query: {
       enabled: isLoggedIn,
+      refetchOnMount: "always",
+      staleTime: 0,
       select: (res) =>
         okData(res)
           ?.agents.map(

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentSelectStep/useAgentSelectStep.ts
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentSelectStep/useAgentSelectStep.ts
@@ -29,7 +29,7 @@ interface UseAgentSelectStepProps {
   ) => void;
 }
 
-const PAGE_SIZE = 12;
+const PAGE_SIZE = 10;
 
 export function useAgentSelectStep({
   onSelect,

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentSelectStep/useAgentSelectStep.ts
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentSelectStep/useAgentSelectStep.ts
@@ -42,6 +42,7 @@ export function useAgentSelectStep({
     number | null
   >(null);
   const [page, setPage] = React.useState(1);
+  const [pageDirection, setPageDirection] = React.useState<1 | -1>(1);
   const [sortBy, setSortBy] = React.useState<MyAgentsSortBy>(
     MyAgentsSortBy.most_recent,
   );
@@ -118,6 +119,7 @@ export function useAgentSelectStep({
 
   function goToPage(next: number) {
     if (next < 1 || (totalPages > 0 && next > totalPages)) return;
+    setPageDirection(next > page ? 1 : -1);
     setPage(next);
   }
 
@@ -132,6 +134,7 @@ export function useAgentSelectStep({
     totalItems,
     pageSize: PAGE_SIZE,
     sortBy,
+    pageDirection,
     handleAgentClick,
     handleNext,
     handleSortChange,

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentSelectStep/useAgentSelectStep.ts
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentSelectStep/useAgentSelectStep.ts
@@ -1,6 +1,8 @@
 import * as React from "react";
+import { keepPreviousData } from "@tanstack/react-query";
 import { useGetV2GetMyAgents } from "@/app/api/__generated__/endpoints/store/store";
 import { okData } from "@/app/api/helpers";
+import { MyAgentsSortBy } from "@/app/api/__generated__/models/myAgentsSortBy";
 import { useSupabase } from "@/lib/supabase/hooks/useSupabase";
 
 export interface Agent {
@@ -27,6 +29,8 @@ interface UseAgentSelectStepProps {
   ) => void;
 }
 
+const PAGE_SIZE = 12;
+
 export function useAgentSelectStep({
   onSelect,
   onNext,
@@ -37,20 +41,37 @@ export function useAgentSelectStep({
   const [selectedAgentVersion, setSelectedAgentVersion] = React.useState<
     number | null
   >(null);
+  const [page, setPage] = React.useState(1);
+  const [sortBy, setSortBy] = React.useState<MyAgentsSortBy>(
+    MyAgentsSortBy.most_recent,
+  );
   const { isLoggedIn } = useSupabase();
 
+  React.useEffect(() => {
+    setPage(1);
+  }, [sortBy]);
+
   const {
-    data: _myAgents,
+    data: agentsData,
     isLoading,
+    isFetching,
     error,
-  } = useGetV2GetMyAgents(undefined, {
-    query: {
-      enabled: isLoggedIn,
-      refetchOnMount: "always",
-      staleTime: 0,
-      select: (res) =>
-        okData(res)
-          ?.agents.map(
+  } = useGetV2GetMyAgents(
+    {
+      page,
+      page_size: PAGE_SIZE,
+      sort_by: sortBy,
+    },
+    {
+      query: {
+        enabled: isLoggedIn,
+        refetchOnMount: "always",
+        staleTime: 0,
+        placeholderData: keepPreviousData,
+        select: (res) => {
+          const payload = okData(res);
+          if (!payload) return null;
+          const agents = payload.agents.map(
             (agent): Agent => ({
               name: agent.agent_name,
               id: agent.graph_id,
@@ -60,31 +81,26 @@ export function useAgentSelectStep({
               description: agent.description || "",
               recommendedScheduleCron: agent.recommended_schedule_cron ?? null,
             }),
-          )
-          .sort(
-            (a: Agent, b: Agent) =>
-              new Date(b.lastEdited).getTime() -
-              new Date(a.lastEdited).getTime(),
-          ),
+          );
+          return { agents, pagination: payload.pagination };
+        },
+      },
     },
-  });
-  const myAgents = _myAgents ?? [];
+  );
 
-  const handleAgentClick = (
-    _: string,
-    agentId: string,
-    agentVersion: number,
-  ) => {
+  const myAgents = agentsData?.agents ?? [];
+  const totalPages = agentsData?.pagination?.total_pages ?? 0;
+  const totalItems = agentsData?.pagination?.total_items ?? 0;
+
+  function handleAgentClick(_: string, agentId: string, agentVersion: number) {
     setSelectedAgentId(agentId);
     setSelectedAgentVersion(agentVersion);
     onSelect(agentId, agentVersion);
-  };
+  }
 
-  const handleNext = () => {
+  function handleNext() {
     if (selectedAgentId && selectedAgentVersion) {
-      const selectedAgent = myAgents.find(
-        (agent) => agent.id === selectedAgentId,
-      );
+      const selectedAgent = myAgents.find((a) => a.id === selectedAgentId);
       if (selectedAgent) {
         onNext(selectedAgentId, selectedAgentVersion, {
           name: selectedAgent.name,
@@ -94,19 +110,32 @@ export function useAgentSelectStep({
         });
       }
     }
-  };
+  }
+
+  function handleSortChange(value: string) {
+    setSortBy(value as MyAgentsSortBy);
+  }
+
+  function goToPage(next: number) {
+    if (next < 1 || (totalPages > 0 && next > totalPages)) return;
+    setPage(next);
+  }
 
   return {
-    // Data
     myAgents,
     isLoading,
+    isFetching,
     error,
-    // State
     selectedAgentId,
-    // Handlers
+    page,
+    totalPages,
+    totalItems,
+    pageSize: PAGE_SIZE,
+    sortBy,
     handleAgentClick,
     handleNext,
-    // Computed
+    handleSortChange,
+    goToPage,
     isNextDisabled: !selectedAgentId || !selectedAgentVersion,
   };
 }

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/StepFooter.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/StepFooter.tsx
@@ -1,0 +1,15 @@
+import { ReactNode } from "react";
+
+type Props = {
+  primary: ReactNode;
+  secondary?: ReactNode;
+};
+
+export function StepFooter({ primary, secondary }: Props) {
+  return (
+    <div className="mt-2 flex flex-col-reverse gap-3 pt-5 sm:flex-row sm:items-center sm:justify-end">
+      {secondary}
+      {primary}
+    </div>
+  );
+}

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/StepHeader.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/StepHeader.tsx
@@ -3,19 +3,19 @@ import { Text } from "@/components/atoms/Text/Text";
 type Props = {
   title: string;
   description: string;
+  // Kept for API compatibility; rendering is owned by parent StepStrip now.
+  currentStep?: "select" | "info" | "review";
 };
 
 export function StepHeader({ title, description }: Props) {
   return (
-    <div className="relative border-b border-neutral-100 px-4 pb-4 sm:px-6 sm:pb-6">
-      <div className="text-center">
-        <Text variant="h3" className="text-xl">
-          {title}
-        </Text>
-        <Text variant="body-medium" className="!text-zinc-400">
-          {description}
-        </Text>
-      </div>
+    <div className="flex max-w-[640px] flex-col gap-1 px-1 pb-6 sm:px-2">
+      <Text variant="body" as="h2" className="text-textBlack">
+        {title}
+      </Text>
+      <Text variant="small" className="text-zinc-600">
+        {description}
+      </Text>
     </div>
   );
 }

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/StepStrip.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/StepStrip.tsx
@@ -1,0 +1,146 @@
+import { Fragment } from "react";
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+import { CheckIcon } from "@phosphor-icons/react";
+import { Text } from "@/components/atoms/Text/Text";
+import { cn } from "@/lib/utils";
+
+type Props = {
+  currentStep: "select" | "info" | "review";
+};
+
+const steps = [
+  { key: "select", label: "Agent" },
+  { key: "info", label: "Listing" },
+  { key: "review", label: "Review" },
+] as const;
+
+function getStepIndex(currentStep: Props["currentStep"]) {
+  return steps.findIndex((step) => step.key === currentStep);
+}
+
+export function StepStrip({ currentStep }: Props) {
+  const currentIndex = getStepIndex(currentStep);
+  const shouldReduceMotion = useReducedMotion();
+
+  return (
+    <div className="flex flex-col gap-6 px-1 pb-6 sm:px-2">
+      <div className="flex items-center gap-2 pr-12">
+        <Text variant="lead-medium" as="span" className="text-textBlack">
+          Publish agent
+        </Text>
+      </div>
+
+      <ol
+        aria-label="Publish progress"
+        className="flex w-full items-center gap-3"
+      >
+        {steps.map((step, index) => {
+          const isComplete = index < currentIndex;
+          const isCurrent = index === currentIndex;
+          const isLast = index === steps.length - 1;
+
+          return (
+            <Fragment key={step.key}>
+              <li
+                aria-current={isCurrent ? "step" : undefined}
+                className="flex shrink-0 items-center gap-2"
+              >
+                <motion.span
+                  animate={
+                    shouldReduceMotion
+                      ? undefined
+                      : { scale: isCurrent ? 1.04 : 1 }
+                  }
+                  transition={
+                    shouldReduceMotion
+                      ? { duration: 0 }
+                      : { duration: 0.22, ease: [0.16, 1, 0.3, 1] }
+                  }
+                  className={cn(
+                    "flex size-6 shrink-0 items-center justify-center rounded-full text-[12px] font-medium transition-colors",
+                    isCurrent
+                      ? "bg-zinc-900 text-white"
+                      : isComplete
+                        ? "bg-zinc-900 text-white"
+                        : "border border-zinc-300 bg-white text-zinc-400",
+                  )}
+                >
+                  <AnimatePresence mode="wait" initial={false}>
+                    {isComplete ? (
+                      <motion.span
+                        key="check"
+                        initial={
+                          shouldReduceMotion
+                            ? { opacity: 0 }
+                            : { opacity: 0, scale: 0.6 }
+                        }
+                        animate={{ opacity: 1, scale: 1 }}
+                        exit={
+                          shouldReduceMotion
+                            ? { opacity: 0 }
+                            : { opacity: 0, scale: 0.6 }
+                        }
+                        transition={{ duration: 0.2, ease: "easeOut" }}
+                        className="flex items-center justify-center"
+                      >
+                        <CheckIcon size={12} weight="bold" />
+                      </motion.span>
+                    ) : (
+                      <motion.span
+                        key="num"
+                        initial={
+                          shouldReduceMotion
+                            ? { opacity: 0 }
+                            : { opacity: 0, y: 4 }
+                        }
+                        animate={{ opacity: 1, y: 0 }}
+                        exit={
+                          shouldReduceMotion
+                            ? { opacity: 0 }
+                            : { opacity: 0, y: -4 }
+                        }
+                        transition={{ duration: 0.18, ease: "easeOut" }}
+                      >
+                        {index + 1}
+                      </motion.span>
+                    )}
+                  </AnimatePresence>
+                </motion.span>
+                <Text
+                  variant="small-medium"
+                  as="span"
+                  className={cn(
+                    "whitespace-nowrap !text-current transition-colors",
+                    isCurrent
+                      ? "text-zinc-950"
+                      : isComplete
+                        ? "text-zinc-700"
+                        : "font-normal text-zinc-400",
+                  )}
+                >
+                  {step.label}
+                </Text>
+              </li>
+              {!isLast ? (
+                <li aria-hidden className="relative h-0 flex-1">
+                  <span className="absolute inset-x-0 top-0 border-t border-solid border-zinc-200" />
+                  <motion.span
+                    initial={false}
+                    animate={{ scaleX: isComplete ? 1 : 0 }}
+                    style={{ transformOrigin: "left" }}
+                    transition={
+                      shouldReduceMotion
+                        ? { duration: 0 }
+                        : { duration: 0.32, ease: [0.16, 1, 0.3, 1] }
+                    }
+                    className="absolute inset-x-0 top-0 border-t border-solid border-zinc-900"
+                  />
+                </li>
+              ) : null}
+            </Fragment>
+          );
+        })}
+      </ol>
+    </div>
+  );
+}

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/__tests__/AgentReviewStep.test.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/__tests__/AgentReviewStep.test.tsx
@@ -64,9 +64,7 @@ describe("AgentReviewStep", () => {
       />,
     );
     expect(screen.getByText("Agent needs changes")).toBeDefined();
-    expect(
-      screen.getByText("Please clarify your description."),
-    ).toBeDefined();
+    expect(screen.getByText("Please clarify your description.")).toBeDefined();
     expect(screen.queryByText("What happens next")).toBeNull();
   });
 });

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/__tests__/AgentReviewStep.test.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/__tests__/AgentReviewStep.test.tsx
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { SubmissionStatus } from "@/app/api/__generated__/models/submissionStatus";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/marketplace",
+}));
+
+vi.mock("@/components/molecules/Confetti/Confetti", () => ({
+  Confetti: () => null,
+}));
+
+import { AgentReviewStep } from "../AgentReviewStep";
+
+const baseProps = {
+  agentName: "Test Agent",
+  subheader: "A subheader",
+  description: "A description",
+  onClose: vi.fn(),
+  onDone: vi.fn(),
+  onViewProgress: vi.fn(),
+};
+
+describe("AgentReviewStep", () => {
+  it("renders the pending hero, the timeline, and the footer", () => {
+    const onDone = vi.fn();
+    const onViewProgress = vi.fn();
+    render(
+      <AgentReviewStep
+        {...baseProps}
+        onDone={onDone}
+        onViewProgress={onViewProgress}
+      />,
+    );
+
+    expect(screen.getByText("Submission received")).toBeDefined();
+    expect(screen.getByText("Test Agent")).toBeDefined();
+
+    // Timeline copy from the SECRT-2324 refresh.
+    expect(screen.getByText("Submitted for review")).toBeDefined();
+    expect(screen.getByText("Reviewed soon")).toBeDefined();
+    expect(screen.getByText("Approved listings go live")).toBeDefined();
+
+    fireEvent.click(screen.getByRole("button", { name: "Done" }));
+    expect(onDone).toHaveBeenCalled();
+
+    fireEvent.click(screen.getByTestId("view-progress-button"));
+    expect(onViewProgress).toHaveBeenCalled();
+  });
+
+  it("renders the approved hero when status is APPROVED", () => {
+    render(
+      <AgentReviewStep {...baseProps} status={SubmissionStatus.APPROVED} />,
+    );
+    expect(screen.getByText("Agent approved")).toBeDefined();
+  });
+
+  it("renders the rejected hero + review comments and hides the timeline", () => {
+    render(
+      <AgentReviewStep
+        {...baseProps}
+        status={SubmissionStatus.REJECTED}
+        reviewComments="Please clarify your description."
+      />,
+    );
+    expect(screen.getByText("Agent needs changes")).toBeDefined();
+    expect(
+      screen.getByText("Please clarify your description."),
+    ).toBeDefined();
+    expect(screen.queryByText("What happens next")).toBeNull();
+  });
+});

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/__tests__/StepStrip.test.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/__tests__/StepStrip.test.tsx
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { StepStrip } from "../StepStrip";
+
+describe("StepStrip", () => {
+  it.each([
+    ["select" as const, 0],
+    ["info" as const, 1],
+    ["review" as const, 2],
+  ])("marks step %s as current", (step, expectedIndex) => {
+    render(<StepStrip currentStep={step} />);
+    const list = screen.getByRole("list", { name: "Publish progress" });
+    const items = list.querySelectorAll("li[aria-current='step']");
+    expect(items).toHaveLength(1);
+    const labels = ["Agent", "Listing", "Review"];
+    expect(items[0].textContent).toContain(labels[expectedIndex]);
+  });
+
+  it("renders all three steps", () => {
+    render(<StepStrip currentStep="select" />);
+    expect(screen.getByText("Agent")).toBeDefined();
+    expect(screen.getByText("Listing")).toBeDefined();
+    expect(screen.getByText("Review")).toBeDefined();
+    expect(screen.getByText("Publish agent")).toBeDefined();
+  });
+});

--- a/autogpt_platform/frontend/src/components/molecules/Dialog/components/DialogWrap.tsx
+++ b/autogpt_platform/frontend/src/components/molecules/Dialog/components/DialogWrap.tsx
@@ -139,7 +139,7 @@ export function DialogWrap({
             )}
             style={{
               scrollbarGutter: "stable",
-              marginRight: hasVerticalScrollbar ? "-14px" : "0px",
+              marginRight: hasVerticalScrollbar ? "-24px" : "0px",
             }}
           >
             {children}

--- a/autogpt_platform/frontend/src/components/molecules/Dialog/components/styles.ts
+++ b/autogpt_platform/frontend/src/components/molecules/Dialog/components/styles.ts
@@ -9,7 +9,7 @@ const commonStyles = {
 // Modal specific styles
 export const modalStyles = {
   ...commonStyles,
-  content: `${commonStyles.content} p-6 border border-stone-200 min-w-[40vw] max-w-[60vw] max-h-[95vh] top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 animate-fadein`,
+  content: `${commonStyles.content} p-6 min-w-[40vw] max-w-[60vw] max-h-[95vh] top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 animate-fadein`,
   iconWrap:
     "absolute top-2 right-3 bg-transparent p-2 rounded-full transition-colors duration-300 ease-in-out outline-none border-none",
   icon: "w-4 h-4 text-stone-800",

--- a/autogpt_platform/frontend/src/playwright/pages/marketplace.page.ts
+++ b/autogpt_platform/frontend/src/playwright/pages/marketplace.page.ts
@@ -215,7 +215,7 @@ export class MarketplacePage extends BasePage {
     await expect(publishAgentModal).toBeVisible();
     await expect(
       publishAgentModal.getByText(
-        "Select your project that you'd like to publish",
+        "Pick the saved agent version you want to send to marketplace review.",
       ),
     ).toBeVisible();
 
@@ -226,7 +226,7 @@ export class MarketplacePage extends BasePage {
     await expect(publishableAgentCard).toBeVisible({ timeout: 15000 });
     await publishableAgentCard.click();
     await publishAgentModal
-      .getByRole("button", { name: "Next", exact: true })
+      .getByRole("button", { name: "Continue", exact: true })
       .click();
 
     await expect(

--- a/autogpt_platform/frontend/src/playwright/pages/marketplace.page.ts
+++ b/autogpt_platform/frontend/src/playwright/pages/marketplace.page.ts
@@ -242,18 +242,22 @@ export class MarketplacePage extends BasePage {
       .getByLabel("Subheader")
       .fill("A deterministic marketplace submission");
     await publishAgentModal.getByLabel("Slug").fill(agentSlug);
-    await publishAgentModal
-      .getByLabel("YouTube video link")
-      .fill("https://www.youtube.com/watch?v=test123");
 
     await publishAgentModal.getByRole("combobox", { name: "Category" }).click();
     await this.page.getByRole("option", { name: "Other" }).click();
+
+    await publishAgentModal
+      .getByRole("button", { name: /Experience details/ })
+      .click();
 
     await publishAgentModal
       .getByLabel("Description")
       .fill(
         "A deterministic publish flow for consolidated Playwright coverage.",
       );
+    await publishAgentModal
+      .getByLabel("YouTube video link")
+      .fill("https://www.youtube.com/watch?v=test123");
 
     const submitButton = publishAgentModal.getByRole("button", {
       name: "Submit for review",

--- a/autogpt_platform/frontend/src/playwright/pages/marketplace.page.ts
+++ b/autogpt_platform/frontend/src/playwright/pages/marketplace.page.ts
@@ -266,7 +266,7 @@ export class MarketplacePage extends BasePage {
     await submitButton.click();
 
     await expect(
-      publishAgentModal.getByText("Agent is awaiting review"),
+      publishAgentModal.getByText("Submission received"),
     ).toBeVisible();
     await expect(
       publishAgentModal.getByTestId("view-progress-button"),


### PR DESCRIPTION
## Why
The existing publish-agent modal was visually inconsistent with the rest of the platform: a dense card layout, no progress signal between its three steps, and no transitions. Step 2 (listing) was an unstructured long form and step 3 (review) was a heavy preview panel. This PR redesigns the entire flow to fit our design system and adds polished step transitions.

## What
- New persistent stepper (`StepStrip`) with animated number → check transition and connector progress fill.
- Shared `StepFooter` for consistent secondary/primary buttons across steps.
- **Agent select**: two-column rounded list, purple selection state, selection radio (no fake thumbnails).
- **Listing form**: single-open accordion (Listing basics / Thumbnails / Experience details) with phosphor icons + per-section completion check (purple) and validation warning (rose). Title-tooltips on every input/select. Recommended-schedule trigger styled like an input. Compact thumbnail strip.
- **Review step**: edge-to-edge purple gradient + blur orb (via portal so it reaches dialog corners), animated tick with pulsing rings, confetti, "What happens next" timeline, and `Go to Creator Dashboard` CTA.
- Direction-aware slide transitions between steps, height auto-animates, respects `prefers-reduced-motion`.
- Reusable additions to design-system atoms: `labelVariant`, `labelClassName`, `labelTooltip` props on `Input` and `Select`. Default `Input`/`Select` border radius reduced from `rounded-3xl` to `rounded-xl`.

## How
- `PublishAgentModal` now owns the persistent `StepStrip` and wraps the active step in `AnimatePresence` (`mode="wait"`) with direction-aware variants. The wrapper uses `motion.div layout` so dialog body height interpolates instead of jumping.
- Each step component (`AgentSelectStep`, `AgentInfoStep`, `AgentReviewStep`) was rebuilt to use design-system atoms/molecules, the new `StepFooter`, and Framer Motion (tween / ease-out / under 300 ms per Emil Kowalski's animation principles).
- `AgentReviewStep` uses `react-dom`'s `createPortal` to render its gradient + blur into the dialog's `[data-dialog-content]`, escaping the scroll wrapper's `overflow-x-hidden` without modifying the shared `Dialog` molecule.
- Added a 320 ms delayed open of the first accordion in `AgentInfoStep` so the slide-in completes before the section unfolds.
- Playwright assertions in `marketplace.page.ts` updated to match the new copy ("Pick the saved agent version…", "Continue").


https://github.com/user-attachments/assets/9089c76a-f25d-4f3a-8535-ff41b1c10066


## Test plan
- [x] Open Publish flow from `/settings/creator-dashboard` and verify the stepper animation forward & back across all three steps.
- [x] Select agent → list shows two columns; selected card uses purple ring + radio.
- [x] Step 2: validate accordion open one-at-a-time, completion ticks, validation warnings, tooltips, single-line textareas, schedule button styling, thumbnails strip.
- [x] Submit → review step shows gradient banner, tick with pulsing rings, confetti, timeline, and footer buttons.
- [x] Verify focus rings are not clipped inside accordions.
- [x] Verify `prefers-reduced-motion` collapses animations to opacity swaps.
- [x] Existing Playwright marketplace publish flow passes with updated copy.
