### PR TITLE
feat(frontend/library): add empty state with build / marketplace CTAs

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/library/__tests__/empty-state.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/__tests__/empty-state.test.tsx
@@ -1,0 +1,138 @@
+import { describe, expect, test } from "vitest";
+import { render, screen } from "@/tests/integrations/test-utils";
+import { server } from "@/mocks/mock-server";
+import {
+  getGetV2ListLibraryAgentsMockHandler,
+  getGetV2ListLibraryAgentsResponseMock,
+  getGetV2ListFavoriteLibraryAgentsMockHandler,
+  getGetV2ListFavoriteLibraryAgentsResponseMock,
+} from "@/app/api/__generated__/endpoints/library/library.msw";
+import {
+  getGetV2ListLibraryFoldersMockHandler,
+  getGetV2ListLibraryFoldersResponseMock,
+} from "@/app/api/__generated__/endpoints/folders/folders.msw";
+import { getGetV1ListAllExecutionsMockHandler } from "@/app/api/__generated__/endpoints/graphs/graphs.msw";
+import { LibraryAgent } from "@/app/api/__generated__/models/libraryAgent";
+import LibraryPage from "../page";
+
+function makeAgent(overrides: Partial<LibraryAgent> = {}): LibraryAgent {
+  const base = getGetV2ListLibraryAgentsResponseMock().agents[0];
+  return { ...base, ...overrides };
+}
+
+function setupHandlers({
+  agents,
+  folders,
+}: {
+  agents?: LibraryAgent[];
+  folders?: Parameters<typeof getGetV2ListLibraryFoldersResponseMock>[0];
+} = {}) {
+  const agentList = agents ?? [];
+
+  server.use(
+    getGetV2ListLibraryAgentsMockHandler({
+      ...getGetV2ListLibraryAgentsResponseMock(),
+      agents: agentList,
+      pagination: {
+        total_items: agentList.length,
+        total_pages: 1,
+        current_page: 1,
+        page_size: 20,
+      },
+    }),
+    getGetV2ListFavoriteLibraryAgentsMockHandler({
+      ...getGetV2ListFavoriteLibraryAgentsResponseMock(),
+      agents: [],
+      pagination: {
+        total_items: 0,
+        total_pages: 1,
+        current_page: 1,
+        page_size: 10,
+      },
+    }),
+    getGetV2ListLibraryFoldersMockHandler(
+      folders
+        ? getGetV2ListLibraryFoldersResponseMock(folders)
+        : {
+            folders: [],
+            pagination: {
+              total_items: 0,
+              total_pages: 1,
+              current_page: 1,
+              page_size: 20,
+            },
+          },
+    ),
+    getGetV1ListAllExecutionsMockHandler([]),
+  );
+}
+
+describe("LibraryPage empty state", () => {
+  test("renders empty-state heading and copy when no agents and no folders", async () => {
+    setupHandlers();
+
+    render(<LibraryPage />);
+
+    expect(await screen.findByText("Your library is empty")).toBeDefined();
+    expect(
+      screen.getByText(/build your own agent from scratch/i),
+    ).toBeDefined();
+  });
+
+  test("renders Build an agent CTA pointing to /build", async () => {
+    setupHandlers();
+
+    render(<LibraryPage />);
+
+    const buildLink = await screen.findByRole("link", {
+      name: /build an agent/i,
+    });
+    expect(buildLink.getAttribute("href")).toBe("/build");
+  });
+
+  test("renders Browse marketplace CTA pointing to /marketplace", async () => {
+    setupHandlers();
+
+    render(<LibraryPage />);
+
+    const marketplaceLink = await screen.findByRole("link", {
+      name: /browse marketplace/i,
+    });
+    expect(marketplaceLink.getAttribute("href")).toBe("/marketplace");
+  });
+
+  test("does not render empty state when at least one agent exists", async () => {
+    setupHandlers({ agents: [makeAgent({ name: "Existing Agent" })] });
+
+    render(<LibraryPage />);
+
+    expect(await screen.findByText("Existing Agent")).toBeDefined();
+    expect(screen.queryByText("Your library is empty")).toBeNull();
+  });
+
+  test("does not render empty state when folders exist but no agents", async () => {
+    setupHandlers({
+      folders: {
+        folders: [
+          {
+            id: "f1",
+            user_id: "test-user",
+            name: "My Folder",
+            agent_count: 0,
+            subfolder_count: 0,
+            color: null,
+            icon: null,
+            parent_id: null,
+            created_at: new Date(),
+            updated_at: new Date(),
+          },
+        ],
+      },
+    });
+
+    render(<LibraryPage />);
+
+    expect(await screen.findByText("My Folder")).toBeDefined();
+    expect(screen.queryByText("Your library is empty")).toBeNull();
+  });
+});

--- a/autogpt_platform/frontend/src/app/(platform)/library/components/LibraryAgentList/LibraryAgentList.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/components/LibraryAgentList/LibraryAgentList.tsx
@@ -17,6 +17,7 @@ import {
 } from "framer-motion";
 import { LibraryFolderEditDialog } from "../LibraryFolderEditDialog/LibraryFolderEditDialog";
 import { LibraryFolderDeleteDialog } from "../LibraryFolderDeleteDialog/LibraryFolderDeleteDialog";
+import { LibraryEmptyState } from "../LibraryEmptyState/LibraryEmptyState";
 import type { LibraryTab, AgentStatusFilter, FleetSummary } from "../../types";
 import { useLibraryAgentList } from "./useLibraryAgentList";
 import { AgentBriefingPanel } from "../AgentBriefingPanel/AgentBriefingPanel";
@@ -134,6 +135,17 @@ export function LibraryAgentList({
 
   const agentStatusMap = useAgentStatusMap(agents);
 
+  const hasNoFolders =
+    !showFolders || (foldersData?.folders?.length ?? 0) === 0;
+  const isPristineEmpty =
+    !agentLoading &&
+    !isFavoritesTab &&
+    agents.length === 0 &&
+    hasNoFolders &&
+    !searchTerm &&
+    !selectedFolderId &&
+    statusFilter === "all";
+
   return (
     <>
       {isAgentBriefingEnabled &&
@@ -195,6 +207,8 @@ export function LibraryAgentList({
             <HeartIcon className="h-10 w-10" />
             <Text variant="body">No favorite agents yet</Text>
           </div>
+        ) : isPristineEmpty ? (
+          <LibraryEmptyState />
         ) : (
           <InfiniteScroll
             isFetchingNextPage={isFetchingNextPage}

--- a/autogpt_platform/frontend/src/app/(platform)/library/components/LibraryEmptyState/LibraryEmptyState.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/components/LibraryEmptyState/LibraryEmptyState.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import { Button } from "@/components/atoms/Button/Button";
+import { Text } from "@/components/atoms/Text/Text";
+import { PlusIcon, StorefrontIcon } from "@phosphor-icons/react";
+import { motion, useReducedMotion } from "framer-motion";
+
+const EASE_OUT_QUINT = [0.22, 1, 0.36, 1] as const;
+
+export function LibraryEmptyState() {
+  const shouldReduceMotion = useReducedMotion();
+
+  function fadeUp(delay: number) {
+    if (shouldReduceMotion) {
+      return {
+        initial: { opacity: 0 },
+        animate: { opacity: 1 },
+        transition: { duration: 0.2, delay: 0 },
+      };
+    }
+    return {
+      initial: { opacity: 0, y: 8 },
+      animate: { opacity: 1, y: 0 },
+      transition: { duration: 0.35, ease: EASE_OUT_QUINT, delay },
+    };
+  }
+
+  return (
+    <div className="flex flex-col items-center justify-center gap-8 px-6 py-16 text-center">
+      <motion.div {...fadeUp(0)}>
+        <StackedCardsIllustration />
+      </motion.div>
+
+      <div className="flex max-w-md flex-col items-center gap-2">
+        <motion.div {...fadeUp(0.28)}>
+          <Text variant="h3" className="text-zinc-900">
+            Your library is empty
+          </Text>
+        </motion.div>
+        <motion.div {...fadeUp(0.36)}>
+          <Text variant="body" className="text-zinc-500">
+            Build your own agent from scratch, or grab one from the marketplace
+            to get started.
+          </Text>
+        </motion.div>
+      </div>
+
+      <div className="flex flex-col items-center gap-3 sm:flex-row">
+        <motion.div {...fadeUp(0.44)}>
+          <Button
+            as="NextLink"
+            href="/build"
+            variant="primary"
+            size="large"
+            leftIcon={<PlusIcon className="h-4 w-4" weight="bold" />}
+          >
+            Build an agent
+          </Button>
+        </motion.div>
+        <motion.div {...fadeUp(0.5)}>
+          <Button
+            as="NextLink"
+            href="/marketplace"
+            variant="secondary"
+            size="large"
+            leftIcon={<StorefrontIcon className="h-4 w-4" weight="bold" />}
+          >
+            Browse marketplace
+          </Button>
+        </motion.div>
+      </div>
+    </div>
+  );
+}
+
+const CARDS = [
+  { x: 80, y: 8, width: 320, opacity: 0.55 },
+  { x: 48, y: 48, width: 384, opacity: 0.8 },
+  { x: 8, y: 92, width: 464, opacity: 1 },
+];
+
+function StackedCardsIllustration() {
+  const shouldReduceMotion = useReducedMotion();
+
+  return (
+    <svg
+      width="480"
+      height="170"
+      viewBox="0 0 480 170"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      className="select-none"
+    >
+      {CARDS.map((card, i) => (
+        <motion.g
+          key={i}
+          initial={
+            shouldReduceMotion
+              ? { opacity: 0 }
+              : { opacity: 0, y: 12, scale: 0.97 }
+          }
+          animate={
+            shouldReduceMotion
+              ? { opacity: card.opacity }
+              : { opacity: card.opacity, y: 0, scale: 1 }
+          }
+          transition={{
+            duration: shouldReduceMotion ? 0.2 : 0.45,
+            ease: EASE_OUT_QUINT,
+            delay: shouldReduceMotion ? 0 : i * 0.08,
+          }}
+          style={{ transformOrigin: "240px 96px", transformBox: "fill-box" }}
+        >
+          <Card x={card.x} y={card.y} width={card.width} />
+        </motion.g>
+      ))}
+    </svg>
+  );
+}
+
+type CardProps = {
+  x: number;
+  y: number;
+  width: number;
+};
+
+function Card({ x, y, width }: CardProps) {
+  const height = 56;
+  const radius = 14;
+  const padding = 16;
+  const dotRadius = 8;
+
+  return (
+    <g>
+      <rect
+        x={x}
+        y={y}
+        width={width}
+        height={height}
+        rx={radius}
+        ry={radius}
+        fill="white"
+        stroke="#E4E4E7"
+        strokeWidth={1}
+      />
+      <circle
+        cx={x + padding + dotRadius}
+        cy={y + height / 2}
+        r={dotRadius}
+        fill="#E4E4E7"
+      />
+      <rect
+        x={x + padding + dotRadius * 2 + 12}
+        y={y + height / 2 - 6}
+        width={width * 0.35}
+        height={12}
+        rx={6}
+        ry={6}
+        fill="#E4E4E7"
+      />
+      <rect
+        x={x + width - padding - 80}
+        y={y + height / 2 - 6}
+        width={12}
+        height={12}
+        rx={3}
+        ry={3}
+        fill="#E4E4E7"
+      />
+      <rect
+        x={x + width - padding - 60}
+        y={y + height / 2 - 6}
+        width={12}
+        height={12}
+        rx={3}
+        ry={3}
+        fill="#E4E4E7"
+      />
+      <rect
+        x={x + width - padding - 40}
+        y={y + height / 2 - 6}
+        width={32}
+        height={12}
+        rx={6}
+        ry={6}
+        fill="#E4E4E7"
+      />
+    </g>
+  );
+}


### PR DESCRIPTION
## Why

A user opening `/library` for the first time (zero agents, zero folders) saw an entirely blank grid below the header — no guidance, no call to action, no indication of what to do next. Existing empty-state copy only existed for the **Favorites** tab; the main "All" tab fell through to an empty `InfiniteScroll` and rendered nothing.

This is a poor onboarding moment for net-new users and looks like a broken page for users who deleted all their agents.


https://github.com/user-attachments/assets/7b3b2097-36bb-4fc6-82de-78da30e1f287



## What

Adds a dedicated `LibraryEmptyState` rendered only in the **pristine** zero-state on the main tab:

- ✅ no agents
- ✅ no folders
- ✅ no active search term
- ✅ not inside a folder
- ✅ `statusFilter === "all"`
- ✅ not the favorites tab (which keeps its existing `HeartIcon` empty state)

Other empty cases (search-no-results, status-filter-empty, empty subfolder) keep their current behaviour so the CTAs don't appear in inappropriate contexts.

## How

**New component** — [`LibraryEmptyState/LibraryEmptyState.tsx`](autogpt_platform/frontend/src/app/(platform)/library/components/LibraryEmptyState/LibraryEmptyState.tsx)

- **Custom SVG illustration** — three stacked, progressively-wider rounded "agent cards" (avatar circle + title bar + action squares + trailing pill). No external assets, just inline SVG.
- **Two CTAs** using the design-system `Button` atom (`size="large"`, `as="NextLink"`):
  - Primary → `/build` ("Build an agent")
  - Secondary → `/marketplace` ("Browse marketplace")
- **Copy** uses the design-system `Text` atom.

**Animation** — applies Emil Kowalski's animation principles:

- Staggered fade-up entrance for every child (illustration → heading → body → CTAs)
- The 3 cards inside the illustration also stagger (back-to-front, 80 ms apart) so the deck visually "deals out"
- Shared `cubic-bezier(0.22, 1, 0.36, 1)` (out-quint) curve, ~350 ms per element
- Only `transform` + `opacity` animated (GPU-friendly)
- Respects `prefers-reduced-motion` via `useReducedMotion`: collapses to a single 200 ms opacity fade with no stagger and no translate

**Wired into** [`LibraryAgentList.tsx`](autogpt_platform/frontend/src/app/(platform)/library/components/LibraryAgentList/LibraryAgentList.tsx) — added a single `isPristineEmpty` derivation guarding the existing render branch ladder, just below the favorites empty state.

## Tests

New integration test file — [`empty-state.test.tsx`](autogpt_platform/frontend/src/app/(platform)/library/__tests__/empty-state.test.tsx) covering:

- Renders heading + body copy on zero-state
- "Build an agent" CTA points to `/build`
- "Browse marketplace" CTA points to `/marketplace`
- Empty state is **not** rendered when at least one agent exists
- Empty state is **not** rendered when folders exist (even with zero agents)

## Test plan

- [x] `pnpm test:unit` — new `empty-state.test.tsx` passes
- [x] Visual: open `/library` with a fresh user → see illustration + CTAs animate in
- [x] Visual: with agents present → empty state is hidden
- [x] Visual: search a non-existent term → search-empty state shown (not new empty state)
- [x] Visual: filter by a status with no matches → existing filter-exhaust UX preserved
- [x] Visual: navigate into an empty folder → does not render the new empty state
- [x] A11y: with `prefers-reduced-motion: reduce`, only opacity fades — no translate, no stagger
- [x] CTAs route via Next.js client navigation (no full page reload)
