### PR TITLE
feat(backend/executor): persist activity-status LLM cost to PlatformCostLog

### DIFF
--- a/autogpt_platform/backend/backend/executor/activity_status_generator.py
+++ b/autogpt_platform/backend/backend/executor/activity_status_generator.py
@@ -22,7 +22,7 @@ from backend.data.model import (
     NodeExecutionStats,
 )
 from backend.data.platform_cost import PlatformCostEntry, usd_to_microdollars
-from backend.executor.cost_tracking import _schedule_log
+from backend.executor.cost_tracking import schedule_platform_cost_log
 from backend.util.feature_flag import Flag, is_feature_enabled
 from backend.util.settings import Settings
 from backend.util.truncate import truncate
@@ -31,15 +31,6 @@ if TYPE_CHECKING:
     from backend.data.db_manager import DatabaseManagerAsyncClient
 
 logger = logging.getLogger(__name__)
-
-# Synthetic identifiers used by ``PlatformCostLog`` for activity-status LLM
-# calls. These are not tied to any block_cost_config or credentials_store row;
-# the activity-status generator is platform-side overhead that runs after a
-# graph execution completes (not a user-triggered block), and we surface it in
-# the admin cost dashboard so per-user / per-graph_exec attribution stays
-# accurate. Mirrors the COPILOT_BLOCK_ID pattern in copilot.token_tracking.
-ACTIVITY_STATUS_BLOCK_ID = "activity_status"
-ACTIVITY_STATUS_CREDENTIAL_ID = "activity_status_system"
 
 
 # Default system prompt template for activity status generation
@@ -424,16 +415,14 @@ def _persist_activity_status_cost(
         tracking_type = "tokens"
         tracking_amount = float(input_tokens + output_tokens)
 
-    _schedule_log(
+    schedule_platform_cost_log(
         db_client,
         PlatformCostEntry(
             user_id=user_id,
             graph_exec_id=graph_exec_id,
             graph_id=graph_id,
-            block_id=ACTIVITY_STATUS_BLOCK_ID,
             block_name="activity_status_generator",
             provider="openai",
-            credential_id=ACTIVITY_STATUS_CREDENTIAL_ID,
             cost_microdollars=cost_microdollars,
             input_tokens=input_tokens or None,
             output_tokens=output_tokens or None,

--- a/autogpt_platform/backend/backend/executor/activity_status_generator.py
+++ b/autogpt_platform/backend/backend/executor/activity_status_generator.py
@@ -16,7 +16,13 @@ from pydantic import SecretStr
 from backend.blocks import get_block
 from backend.blocks.llm import AIStructuredResponseGeneratorBlock, LlmModel
 from backend.data.execution import ExecutionStatus, NodeExecutionResult
-from backend.data.model import APIKeyCredentials, GraphExecutionStats
+from backend.data.model import (
+    APIKeyCredentials,
+    GraphExecutionStats,
+    NodeExecutionStats,
+)
+from backend.data.platform_cost import PlatformCostEntry, usd_to_microdollars
+from backend.executor.cost_tracking import _schedule_log
 from backend.util.feature_flag import Flag, is_feature_enabled
 from backend.util.settings import Settings
 from backend.util.truncate import truncate
@@ -25,6 +31,15 @@ if TYPE_CHECKING:
     from backend.data.db_manager import DatabaseManagerAsyncClient
 
 logger = logging.getLogger(__name__)
+
+# Synthetic identifiers used by ``PlatformCostLog`` for activity-status LLM
+# calls. These are not tied to any block_cost_config or credentials_store row;
+# the activity-status generator is platform-side overhead that runs after a
+# graph execution completes (not a user-triggered block), and we surface it in
+# the admin cost dashboard so per-user / per-graph_exec attribution stays
+# accurate. Mirrors the COPILOT_BLOCK_ID pattern in copilot.token_tracking.
+ACTIVITY_STATUS_BLOCK_ID = "activity_status"
+ACTIVITY_STATUS_CREDENTIAL_ID = "activity_status_system"
 
 
 # Default system prompt template for activity status generation
@@ -358,6 +373,18 @@ async def generate_activity_status_for_execution(
             f"Generated activity status for {graph_exec_id}: {activity_response}"
         )
 
+        # Persist this LLM call's cost to PlatformCostLog so the admin
+        # dashboard attributes the spend per-user / per-graph_exec.
+        # Platform-side overhead (not user-billed and not user rate-limited).
+        _persist_activity_status_cost(
+            stats=structured_block.execution_stats,
+            user_id=user_id,
+            graph_exec_id=graph_exec_id,
+            graph_id=graph_id,
+            model_name=model_name,
+            db_client=db_client,
+        )
+
         return activity_response
 
     except Exception as e:
@@ -365,6 +392,57 @@ async def generate_activity_status_for_execution(
             f"Failed to generate activity status for execution {graph_exec_id}: {str(e)}"
         )
         return None
+
+
+def _persist_activity_status_cost(
+    *,
+    stats: NodeExecutionStats,
+    user_id: str,
+    graph_exec_id: str,
+    graph_id: str,
+    model_name: str,
+    db_client: "DatabaseManagerAsyncClient",
+) -> None:
+    """Schedule a PlatformCostLog entry for the activity-status LLM call.
+
+    Mirrors ``backend.copilot.token_tracking._schedule_cost_log``: the platform
+    pays for this call (system OpenAI key) but the user is not billed and not
+    rate-limited, so we skip ``record_cost_usage`` and only write to
+    ``PlatformCostLog`` for admin attribution.
+    """
+    cost_usd = stats.provider_cost
+    input_tokens = stats.input_token_count or 0
+    output_tokens = stats.output_token_count or 0
+    if cost_usd is None and input_tokens == 0 and output_tokens == 0:
+        return
+
+    cost_microdollars = usd_to_microdollars(cost_usd) if cost_usd is not None else None
+    if cost_usd is not None:
+        tracking_type = "cost_usd"
+        tracking_amount = float(cost_usd)
+    else:
+        tracking_type = "tokens"
+        tracking_amount = float(input_tokens + output_tokens)
+
+    _schedule_log(
+        db_client,
+        PlatformCostEntry(
+            user_id=user_id,
+            graph_exec_id=graph_exec_id,
+            graph_id=graph_id,
+            block_id=ACTIVITY_STATUS_BLOCK_ID,
+            block_name="activity_status_generator",
+            provider="openai",
+            credential_id=ACTIVITY_STATUS_CREDENTIAL_ID,
+            cost_microdollars=cost_microdollars,
+            input_tokens=input_tokens or None,
+            output_tokens=output_tokens or None,
+            model=model_name,
+            tracking_type=tracking_type,
+            tracking_amount=tracking_amount,
+            metadata={"source": "activity_status_generator"},
+        ),
+    )
 
 
 def _build_execution_summary(

--- a/autogpt_platform/backend/backend/executor/activity_status_generator.py
+++ b/autogpt_platform/backend/backend/executor/activity_status_generator.py
@@ -400,38 +400,54 @@ def _persist_activity_status_cost(
     pays for this call (system OpenAI key) but the user is not billed and not
     rate-limited, so we skip ``record_cost_usage`` and only write to
     ``PlatformCostLog`` for admin attribution.
+
+    Cost-logging is best-effort: any failure here is swallowed so a transient
+    DB / scheduling error never strips a successful activity-status response
+    from the user.
     """
-    cost_usd = stats.provider_cost
-    input_tokens = stats.input_token_count or 0
-    output_tokens = stats.output_token_count or 0
-    if cost_usd is None and input_tokens == 0 and output_tokens == 0:
-        return
+    try:
+        cost_usd = stats.provider_cost
+        input_tokens = stats.input_token_count or 0
+        output_tokens = stats.output_token_count or 0
+        # Skip when there is genuinely nothing to log. ``not cost_usd`` covers
+        # both ``None`` and ``0.0`` so a zero-cost zero-token call doesn't
+        # write an empty row that just dilutes dashboard averages.
+        if not cost_usd and input_tokens == 0 and output_tokens == 0:
+            return
 
-    cost_microdollars = usd_to_microdollars(cost_usd) if cost_usd is not None else None
-    if cost_usd is not None:
-        tracking_type = "cost_usd"
-        tracking_amount = float(cost_usd)
-    else:
-        tracking_type = "tokens"
-        tracking_amount = float(input_tokens + output_tokens)
+        cost_microdollars = (
+            usd_to_microdollars(cost_usd) if cost_usd is not None else None
+        )
+        if cost_usd is not None:
+            tracking_type = "cost_usd"
+            tracking_amount = float(cost_usd)
+        else:
+            tracking_type = "tokens"
+            tracking_amount = float(input_tokens + output_tokens)
 
-    schedule_platform_cost_log(
-        db_client,
-        PlatformCostEntry(
-            user_id=user_id,
-            graph_exec_id=graph_exec_id,
-            graph_id=graph_id,
-            block_name="activity_status_generator",
-            provider="openai",
-            cost_microdollars=cost_microdollars,
-            input_tokens=input_tokens or None,
-            output_tokens=output_tokens or None,
-            model=model_name,
-            tracking_type=tracking_type,
-            tracking_amount=tracking_amount,
-            metadata={"source": "activity_status_generator"},
-        ),
-    )
+        schedule_platform_cost_log(
+            db_client,
+            PlatformCostEntry(
+                user_id=user_id,
+                graph_exec_id=graph_exec_id,
+                graph_id=graph_id,
+                block_name="activity_status_generator",
+                provider="openai",
+                cost_microdollars=cost_microdollars,
+                input_tokens=input_tokens or None,
+                output_tokens=output_tokens or None,
+                model=model_name,
+                tracking_type=tracking_type,
+                tracking_amount=tracking_amount,
+                metadata={"source": "activity_status_generator"},
+            ),
+        )
+    except Exception:
+        logger.exception(
+            "Failed to persist activity-status cost for graph_exec %s; "
+            "the activity status itself was returned successfully",
+            graph_exec_id,
+        )
 
 
 def _build_execution_summary(

--- a/autogpt_platform/backend/backend/executor/activity_status_generator_test.py
+++ b/autogpt_platform/backend/backend/executor/activity_status_generator_test.py
@@ -9,7 +9,7 @@ import pytest
 
 from backend.blocks.llm import LlmModel, LLMResponse
 from backend.data.execution import ExecutionStatus, NodeExecutionResult
-from backend.data.model import GraphExecutionStats
+from backend.data.model import GraphExecutionStats, NodeExecutionStats
 from backend.executor.activity_status_generator import (
     _build_execution_summary,
     generate_activity_status_for_execution,
@@ -531,6 +531,9 @@ class TestGenerateActivityStatusForExecution:
 
             # Mock the structured block to return our expected response
             mock_instance = mock_structured_block.return_value
+            # Real NodeExecutionStats so the post-run cost-persist short-circuit
+            # has concrete numbers instead of MagicMock attributes.
+            mock_instance.execution_stats = NodeExecutionStats()
 
             async def mock_run(*args, **kwargs):
                 yield "response", {
@@ -559,6 +562,144 @@ class TestGenerateActivityStatusForExecution:
             mock_db_client.get_graph_metadata.assert_called_once()
             mock_db_client.get_graph.assert_called_once()
             mock_structured_block.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_generate_status_persists_platform_cost(
+        self, mock_node_executions, mock_execution_stats, mock_blocks
+    ):
+        """Successful generation schedules a PlatformCostLog entry with the
+        right user_id / graph_exec_id / model so admin attribution works."""
+        from backend.data.model import NodeExecutionStats
+
+        mock_db_client = AsyncMock()
+        mock_db_client.get_node_executions.return_value = mock_node_executions
+
+        mock_graph_metadata = MagicMock()
+        mock_graph_metadata.name = "Test Agent"
+        mock_graph_metadata.description = "A test agent"
+        mock_db_client.get_graph_metadata.return_value = mock_graph_metadata
+
+        mock_graph = MagicMock()
+        mock_graph.links = []
+        mock_db_client.get_graph.return_value = mock_graph
+
+        with patch(
+            "backend.executor.activity_status_generator.get_block"
+        ) as mock_get_block, patch(
+            "backend.executor.activity_status_generator.Settings"
+        ) as mock_settings, patch(
+            "backend.executor.activity_status_generator.AIStructuredResponseGeneratorBlock"
+        ) as mock_structured_block, patch(
+            "backend.executor.activity_status_generator.is_feature_enabled",
+            return_value=True,
+        ), patch(
+            "backend.executor.activity_status_generator._schedule_log"
+        ) as mock_schedule_log:
+            mock_get_block.side_effect = lambda block_id: mock_blocks.get(block_id)
+            mock_settings.return_value.secrets.openai_internal_api_key = "test_key"
+
+            mock_instance = mock_structured_block.return_value
+            # Simulate the block recording its OpenRouter-style USD cost.
+            mock_instance.execution_stats = NodeExecutionStats(
+                input_token_count=120,
+                output_token_count=40,
+                provider_cost=0.0042,
+                provider_cost_type="cost_usd",
+            )
+
+            async def mock_run(*args, **kwargs):
+                yield "response", {
+                    "activity_status": "Done.",
+                    "correctness_score": 0.9,
+                }
+
+            mock_instance.run = mock_run
+
+            result = await generate_activity_status_for_execution(
+                graph_exec_id="test_exec",
+                graph_id="test_graph",
+                graph_version=1,
+                execution_stats=mock_execution_stats,
+                db_client=mock_db_client,
+                user_id="test_user",
+                model_name="gpt-4o-mini",
+            )
+
+            assert result is not None
+            mock_schedule_log.assert_called_once()
+            args, _ = mock_schedule_log.call_args
+            scheduled_db_client, entry = args
+            assert scheduled_db_client is mock_db_client
+            assert entry.user_id == "test_user"
+            assert entry.graph_exec_id == "test_exec"
+            assert entry.graph_id == "test_graph"
+            assert entry.block_id == "activity_status"
+            assert entry.block_name == "activity_status_generator"
+            assert entry.provider == "openai"
+            assert entry.model == "gpt-4o-mini"
+            assert entry.tracking_type == "cost_usd"
+            assert entry.tracking_amount == pytest.approx(0.0042)
+            # 0.0042 USD * 1_000_000 µ$/USD = 4200 µ$
+            assert entry.cost_microdollars == 4200
+            assert entry.input_tokens == 120
+            assert entry.output_tokens == 40
+            assert entry.metadata == {"source": "activity_status_generator"}
+
+    @pytest.mark.asyncio
+    async def test_generate_status_no_cost_no_log(
+        self, mock_node_executions, mock_execution_stats, mock_blocks
+    ):
+        """When the block records neither cost nor tokens, skip the log
+        write so we don't pollute the cost dashboard with empty rows."""
+        from backend.data.model import NodeExecutionStats
+
+        mock_db_client = AsyncMock()
+        mock_db_client.get_node_executions.return_value = mock_node_executions
+        mock_graph_metadata = MagicMock()
+        mock_graph_metadata.name = "Test Agent"
+        mock_graph_metadata.description = "A test agent"
+        mock_db_client.get_graph_metadata.return_value = mock_graph_metadata
+        mock_graph = MagicMock()
+        mock_graph.links = []
+        mock_db_client.get_graph.return_value = mock_graph
+
+        with patch(
+            "backend.executor.activity_status_generator.get_block"
+        ) as mock_get_block, patch(
+            "backend.executor.activity_status_generator.Settings"
+        ) as mock_settings, patch(
+            "backend.executor.activity_status_generator.AIStructuredResponseGeneratorBlock"
+        ) as mock_structured_block, patch(
+            "backend.executor.activity_status_generator.is_feature_enabled",
+            return_value=True,
+        ), patch(
+            "backend.executor.activity_status_generator._schedule_log"
+        ) as mock_schedule_log:
+            mock_get_block.side_effect = lambda block_id: mock_blocks.get(block_id)
+            mock_settings.return_value.secrets.openai_internal_api_key = "test_key"
+
+            mock_instance = mock_structured_block.return_value
+            mock_instance.execution_stats = NodeExecutionStats()
+
+            async def mock_run(*args, **kwargs):
+                yield "response", {
+                    "activity_status": "Done.",
+                    "correctness_score": 0.9,
+                }
+
+            mock_instance.run = mock_run
+
+            result = await generate_activity_status_for_execution(
+                graph_exec_id="test_exec",
+                graph_id="test_graph",
+                graph_version=1,
+                execution_stats=mock_execution_stats,
+                db_client=mock_db_client,
+                user_id="test_user",
+            )
+
+            assert result is not None
+            mock_schedule_log.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_generate_status_feature_disabled(self, mock_execution_stats):
@@ -657,6 +798,7 @@ class TestGenerateActivityStatusForExecution:
 
             # Mock the structured block to return our expected response
             mock_instance = mock_structured_block.return_value
+            mock_instance.execution_stats = NodeExecutionStats()
 
             async def mock_run(*args, **kwargs):
                 yield "response", {
@@ -720,6 +862,7 @@ class TestIntegration:
 
             # Mock the structured block to return our expected response
             mock_instance = mock_structured_block.return_value
+            mock_instance.execution_stats = NodeExecutionStats()
 
             async def mock_run(*args, **kwargs):
                 yield "response", {

--- a/autogpt_platform/backend/backend/executor/activity_status_generator_test.py
+++ b/autogpt_platform/backend/backend/executor/activity_status_generator_test.py
@@ -594,7 +594,7 @@ class TestGenerateActivityStatusForExecution:
             return_value=True,
         ), patch(
             "backend.executor.activity_status_generator.schedule_platform_cost_log"
-        ) as mockschedule_platform_cost_log:
+        ) as mock_schedule_log:
             mock_get_block.side_effect = lambda block_id: mock_blocks.get(block_id)
             mock_settings.return_value.secrets.openai_internal_api_key = "test_key"
 
@@ -626,8 +626,8 @@ class TestGenerateActivityStatusForExecution:
             )
 
             assert result is not None
-            mockschedule_platform_cost_log.assert_called_once()
-            args, _ = mockschedule_platform_cost_log.call_args
+            mock_schedule_log.assert_called_once()
+            args, _ = mock_schedule_log.call_args
             scheduled_db_client, entry = args
             assert scheduled_db_client is mock_db_client
             assert entry.user_id == "test_user"
@@ -673,7 +673,7 @@ class TestGenerateActivityStatusForExecution:
             return_value=True,
         ), patch(
             "backend.executor.activity_status_generator.schedule_platform_cost_log"
-        ) as mockschedule_platform_cost_log:
+        ) as mock_schedule_log:
             mock_get_block.side_effect = lambda block_id: mock_blocks.get(block_id)
             mock_settings.return_value.secrets.openai_internal_api_key = "test_key"
 
@@ -698,7 +698,75 @@ class TestGenerateActivityStatusForExecution:
             )
 
             assert result is not None
-            mockschedule_platform_cost_log.assert_not_called()
+            mock_schedule_log.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_generate_status_tokens_only_branch(
+        self, mock_node_executions, mock_execution_stats, mock_blocks
+    ):
+        """When the provider doesn't report a USD cost but tokens are present,
+        log the entry with tracking_type='tokens' and the summed token count
+        as tracking_amount (so admin dashboards still see request volume even
+        when cost data is missing)."""
+        from backend.data.model import NodeExecutionStats
+
+        mock_db_client = AsyncMock()
+        mock_db_client.get_node_executions.return_value = mock_node_executions
+        mock_graph_metadata = MagicMock()
+        mock_graph_metadata.name = "Test Agent"
+        mock_graph_metadata.description = "A test agent"
+        mock_db_client.get_graph_metadata.return_value = mock_graph_metadata
+        mock_graph = MagicMock()
+        mock_graph.links = []
+        mock_db_client.get_graph.return_value = mock_graph
+
+        with patch(
+            "backend.executor.activity_status_generator.get_block"
+        ) as mock_get_block, patch(
+            "backend.executor.activity_status_generator.Settings"
+        ) as mock_settings, patch(
+            "backend.executor.activity_status_generator.AIStructuredResponseGeneratorBlock"
+        ) as mock_structured_block, patch(
+            "backend.executor.activity_status_generator.is_feature_enabled",
+            return_value=True,
+        ), patch(
+            "backend.executor.activity_status_generator.schedule_platform_cost_log"
+        ) as mock_schedule_log:
+            mock_get_block.side_effect = lambda block_id: mock_blocks.get(block_id)
+            mock_settings.return_value.secrets.openai_internal_api_key = "test_key"
+
+            mock_instance = mock_structured_block.return_value
+            mock_instance.execution_stats = NodeExecutionStats(
+                input_token_count=200,
+                output_token_count=80,
+                provider_cost=None,
+            )
+
+            async def mock_run(*args, **kwargs):
+                yield "response", {
+                    "activity_status": "Done.",
+                    "correctness_score": 0.9,
+                }
+
+            mock_instance.run = mock_run
+
+            result = await generate_activity_status_for_execution(
+                graph_exec_id="test_exec",
+                graph_id="test_graph",
+                graph_version=1,
+                execution_stats=mock_execution_stats,
+                db_client=mock_db_client,
+                user_id="test_user",
+            )
+
+            assert result is not None
+            mock_schedule_log.assert_called_once()
+            _, entry = mock_schedule_log.call_args.args
+            assert entry.tracking_type == "tokens"
+            assert entry.tracking_amount == 280.0
+            assert entry.cost_microdollars is None
+            assert entry.input_tokens == 200
+            assert entry.output_tokens == 80
 
     @pytest.mark.asyncio
     async def test_generate_status_feature_disabled(self, mock_execution_stats):

--- a/autogpt_platform/backend/backend/executor/activity_status_generator_test.py
+++ b/autogpt_platform/backend/backend/executor/activity_status_generator_test.py
@@ -593,8 +593,8 @@ class TestGenerateActivityStatusForExecution:
             "backend.executor.activity_status_generator.is_feature_enabled",
             return_value=True,
         ), patch(
-            "backend.executor.activity_status_generator._schedule_log"
-        ) as mock_schedule_log:
+            "backend.executor.activity_status_generator.schedule_platform_cost_log"
+        ) as mockschedule_platform_cost_log:
             mock_get_block.side_effect = lambda block_id: mock_blocks.get(block_id)
             mock_settings.return_value.secrets.openai_internal_api_key = "test_key"
 
@@ -626,14 +626,13 @@ class TestGenerateActivityStatusForExecution:
             )
 
             assert result is not None
-            mock_schedule_log.assert_called_once()
-            args, _ = mock_schedule_log.call_args
+            mockschedule_platform_cost_log.assert_called_once()
+            args, _ = mockschedule_platform_cost_log.call_args
             scheduled_db_client, entry = args
             assert scheduled_db_client is mock_db_client
             assert entry.user_id == "test_user"
             assert entry.graph_exec_id == "test_exec"
             assert entry.graph_id == "test_graph"
-            assert entry.block_id == "activity_status"
             assert entry.block_name == "activity_status_generator"
             assert entry.provider == "openai"
             assert entry.model == "gpt-4o-mini"
@@ -673,8 +672,8 @@ class TestGenerateActivityStatusForExecution:
             "backend.executor.activity_status_generator.is_feature_enabled",
             return_value=True,
         ), patch(
-            "backend.executor.activity_status_generator._schedule_log"
-        ) as mock_schedule_log:
+            "backend.executor.activity_status_generator.schedule_platform_cost_log"
+        ) as mockschedule_platform_cost_log:
             mock_get_block.side_effect = lambda block_id: mock_blocks.get(block_id)
             mock_settings.return_value.secrets.openai_internal_api_key = "test_key"
 
@@ -699,7 +698,7 @@ class TestGenerateActivityStatusForExecution:
             )
 
             assert result is not None
-            mock_schedule_log.assert_not_called()
+            mockschedule_platform_cost_log.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_generate_status_feature_disabled(self, mock_execution_stats):

--- a/autogpt_platform/backend/backend/executor/cost_tracking.py
+++ b/autogpt_platform/backend/backend/executor/cost_tracking.py
@@ -100,7 +100,7 @@ async def drain_pending_cost_logs(timeout: float = 5.0) -> None:
             )
 
 
-def _schedule_log(
+def schedule_platform_cost_log(
     db_client: "DatabaseManagerAsyncClient", entry: PlatformCostEntry
 ) -> None:
     async def _safe_log() -> None:
@@ -263,7 +263,7 @@ async def log_system_credential_cost(
                 # type (USD for cost_usd, count for items/characters/per_run, etc.)
                 meta["provider_cost_raw"] = stats.provider_cost
 
-            _schedule_log(
+            schedule_platform_cost_log(
                 db_client,
                 PlatformCostEntry(
                     user_id=node_exec.user_id,


### PR DESCRIPTION
## Why

The post-execution **activity-status generator** ([`activity_status_generator.py`](autogpt_platform/backend/backend/executor/activity_status_generator.py)) runs an LLM call (gpt-4o-mini via the platform's `openai_internal_api_key`) on every completed graph run to produce a 1-3 sentence user-friendly summary + correctness score. It uses `AIStructuredResponseGeneratorBlock` to issue the call.

**Bug:** the block writes its `provider_cost` into a local `NodeExecutionStats` via `merge_stats`, but because the block runs **outside** the executor's `execute_node` loop, neither [`log_system_credential_cost`](autogpt_platform/backend/backend/executor/cost_tracking.py) nor `charge_reconciled_usage` ever fires — the cost is dropped on the floor when the function returns.

This is an **observability gap, not a billing gap**: the platform is paying OpenAI for activity-status generation on every completed graph execution, but those calls don't show up in the admin cost dashboard / per-user attribution.

The [simulator](autogpt_platform/backend/backend/executor/simulator.py) (same shape: platform-paid LLM call on the user's behalf) already routes through `persist_and_record_usage` so its spend is attributed correctly. This PR brings activity-status to parity.

## What

- New `_persist_activity_status_cost(...)` helper that builds a `PlatformCostEntry` and schedules it via `schedule_platform_cost_log` (renamed from the previously-private `_schedule_log` — see refactor commit) so external modules can use it without reaching into private API.
- Call site placed after `structured_block.run()` succeeds, before `return activity_response`. Reads `provider_cost`, `input_token_count`, `output_token_count` off `structured_block.execution_stats`.
- Helper body is wrapped in `try/except Exception` so any cost-log failure (transient DB / scheduling error) is logged but never strips a successful activity-status response from the user — cost-logging is strictly best-effort.
- Early-return guard uses `not cost_usd` so both `provider_cost is None` and `provider_cost == 0.0` (with zero tokens) short-circuit, avoiding empty rows that would dilute dashboard averages.
- Distinguishes `cost_usd`-tracked rows (`tracking_type="cost_usd"`) from tokens-only rows (`tracking_type="tokens"`, `tracking_amount = input + output`) so admins can still filter by request volume when the provider doesn't report a USD cost.
- Deliberately **does not** bill the user's wallet (no `spend_credits`) and **does not** count against the user's copilot rate-limit (no `record_cost_usage`) — activity-status is platform-side overhead, not user-triggered. Matches the simulator's stance for dry-run executions.

## How (tests)

`backend/executor/activity_status_generator_test.py`:
- `test_generate_status_persists_platform_cost`: stubs `execution_stats=NodeExecutionStats(input=120, output=40, provider_cost=0.0042)`, patches `schedule_platform_cost_log`, and asserts the entry carries the right `user_id` / `graph_exec_id` / `graph_id` / `block_name="activity_status_generator"` / `provider="openai"` / `model="gpt-4o-mini"` / `tracking_type="cost_usd"` / `cost_microdollars=4200` / `metadata.source="activity_status_generator"`.
- `test_generate_status_no_cost_no_log`: zero-cost zero-token case must skip the log write.
- `test_generate_status_tokens_only_branch`: provider returns no USD cost but tokens are present (input=200, output=80) — entry is logged with `tracking_type="tokens"`, `tracking_amount=280.0`, `cost_microdollars=None`.
- Updated three existing success-path tests to set `mock_instance.execution_stats = NodeExecutionStats()` so the new short-circuit has concrete numbers to compare against (was a `MagicMock` attribute before).

`poetry run pytest backend/executor/activity_status_generator_test.py` — 17 passed locally.
`poetry run pyright` / `poetry run ruff` — clean on touched files.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
