### PR TITLE
feat(frontend): add changelog "What's New" module

### DIFF
--- a/autogpt_platform/backend/backend/server/v2/preferences/routes.py
+++ b/autogpt_platform/backend/backend/server/v2/preferences/routes.py
@@ -3,21 +3,19 @@
 # User preferences endpoints. Generic per-user key/value store scoped under
 # /api/me/preferences. The changelog feature uses key "changelog.lastSeenId".
 #
-# Integration TODOs (three short edits):
-# 1. Auth dependency: replace `get_user_id` with whatever the v2 routes use
-#    (likely `requires_user` from backend.server.utils).
-# 2. Prisma import: adjust `from backend.data.db import prisma` to match your
-#    generated client path.
-# 3. Router mounting: wire into the v2 app in backend/server/v2/__init__.py
-#    the same way other v2 routers are mounted.
+# Integration TODOs (two short edits before this router is live):
+# 1. Prisma schema: apply the UserPreference model from
+#    autogpt_platform/backend/schema.prisma.changelog.snippet and run
+#    `prisma generate && prisma migrate dev`.
+# 2. Router mounting: wire into the API app in backend/api/app.py (or
+#    equivalent) the same way other routers are mounted.
 
 from __future__ import annotations
 
+import prisma.models
+from autogpt_libs.auth import get_user_id
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, ConfigDict, Field
-
-from backend.data.db import prisma  # adjust import to match your setup
-from backend.server.utils import get_user_id  # adjust to your auth dep
 
 router = APIRouter(prefix="/preferences", tags=["preferences"])
 
@@ -38,7 +36,8 @@ class ChangelogPrefs(BaseModel):
 async def get_changelog_prefs(
     user_id: str = Depends(get_user_id),
 ) -> ChangelogPrefs:
-    pref = await prisma.userpreference.find_unique(
+    # TODO: remove type: ignore once UserPreference is added to prisma schema
+    pref = await prisma.models.UserPreference.prisma().find_unique(  # type: ignore[attr-defined]
         where={
             "userId_key": {
                 "userId": user_id,
@@ -64,7 +63,8 @@ async def put_changelog_prefs(
     if len(body.last_seen_id) > 64:
         raise HTTPException(status_code=400, detail="lastSeenId too long")
 
-    await prisma.userpreference.upsert(
+    # TODO: remove type: ignore once UserPreference is added to prisma schema
+    await prisma.models.UserPreference.prisma().upsert(  # type: ignore[attr-defined]
         where={
             "userId_key": {
                 "userId": user_id,

--- a/autogpt_platform/backend/backend/server/v2/preferences/routes.py
+++ b/autogpt_platform/backend/backend/server/v2/preferences/routes.py
@@ -1,0 +1,83 @@
+# autogpt_platform/backend/backend/server/v2/preferences/routes.py
+#
+# User preferences endpoints. Generic per-user key/value store scoped under
+# /api/me/preferences. The changelog feature uses key "changelog.lastSeenId".
+#
+# Integration TODOs (three short edits):
+# 1. Auth dependency: replace `get_user_id` with whatever the v2 routes use
+#    (likely `requires_user` from backend.server.utils).
+# 2. Prisma import: adjust `from backend.data.db import prisma` to match your
+#    generated client path.
+# 3. Router mounting: wire into the v2 app in backend/server/v2/__init__.py
+#    the same way other v2 routers are mounted.
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, ConfigDict, Field
+
+from backend.data.db import prisma  # adjust import to match your setup
+from backend.server.utils import get_user_id  # adjust to your auth dep
+
+router = APIRouter(prefix="/preferences", tags=["preferences"])
+
+KEY_CHANGELOG_LAST_SEEN = "changelog.lastSeenId"
+
+
+class ChangelogPrefs(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    last_seen_id: str | None = Field(default=None, alias="lastSeenId")
+
+
+@router.get(
+    "/changelog",
+    response_model=ChangelogPrefs,
+    response_model_by_alias=True,
+)
+async def get_changelog_prefs(
+    user_id: str = Depends(get_user_id),
+) -> ChangelogPrefs:
+    pref = await prisma.userpreference.find_unique(
+        where={
+            "userId_key": {
+                "userId": user_id,
+                "key": KEY_CHANGELOG_LAST_SEEN,
+            }
+        }
+    )
+    return ChangelogPrefs(last_seen_id=pref.value if pref else None)
+
+
+@router.put(
+    "/changelog",
+    response_model=ChangelogPrefs,
+    response_model_by_alias=True,
+)
+async def put_changelog_prefs(
+    body: ChangelogPrefs,
+    user_id: str = Depends(get_user_id),
+) -> ChangelogPrefs:
+    if not body.last_seen_id:
+        raise HTTPException(status_code=400, detail="lastSeenId is required")
+
+    if len(body.last_seen_id) > 64:
+        raise HTTPException(status_code=400, detail="lastSeenId too long")
+
+    await prisma.userpreference.upsert(
+        where={
+            "userId_key": {
+                "userId": user_id,
+                "key": KEY_CHANGELOG_LAST_SEEN,
+            }
+        },
+        data={
+            "create": {
+                "userId": user_id,
+                "key": KEY_CHANGELOG_LAST_SEEN,
+                "value": body.last_seen_id,
+            },
+            "update": {"value": body.last_seen_id},
+        },
+    )
+    return body

--- a/autogpt_platform/backend/backend/server/v2/preferences/routes.py
+++ b/autogpt_platform/backend/backend/server/v2/preferences/routes.py
@@ -45,7 +45,7 @@ async def get_changelog_prefs(
             }
         }
     )
-    return ChangelogPrefs(last_seen_id=pref.value if pref else None)
+    return ChangelogPrefs.model_validate({"lastSeenId": pref.value if pref else None})
 
 
 @router.put(

--- a/autogpt_platform/backend/schema.prisma.changelog.snippet
+++ b/autogpt_platform/backend/schema.prisma.changelog.snippet
@@ -1,0 +1,31 @@
+// Add to autogpt_platform/backend/schema.prisma
+//
+// Generic per-user preferences table. One row per (user, key) tuple.
+// The changelog feature uses key="changelog.lastSeenId", but the same
+// table can absorb future preferences without further migrations.
+
+model UserPreference {
+  id        String   @id @default(cuid())
+  userId    String
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  key       String
+  value     String
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([userId, key], name: "userId_key")
+  @@index([userId])
+}
+
+// Then on the existing User model, add the back-relation:
+//
+//   model User {
+//     ...
+//     preferences UserPreference[]
+//   }
+//
+// And run:
+//
+//   pnpm prisma migrate dev --name add_user_preferences

--- a/autogpt_platform/frontend/package.json
+++ b/autogpt_platform/frontend/package.json
@@ -115,6 +115,7 @@
     "rehype-autolink-headings": "7.1.0",
     "rehype-highlight": "7.0.2",
     "rehype-katex": "7.0.1",
+    "rehype-raw": "^7.0.0",
     "rehype-slug": "6.0.0",
     "remark-gfm": "4.0.1",
     "remark-math": "6.0.0",

--- a/autogpt_platform/frontend/pnpm-lock.yaml
+++ b/autogpt_platform/frontend/pnpm-lock.yaml
@@ -261,6 +261,9 @@ importers:
       rehype-katex:
         specifier: 7.0.1
         version: 7.0.1
+      rehype-raw:
+        specifier: ^7.0.0
+        version: 7.0.0
       rehype-slug:
         specifier: 6.0.0
         version: 6.0.0

--- a/autogpt_platform/frontend/scripts/generate-changelog-manifest.ts
+++ b/autogpt_platform/frontend/scripts/generate-changelog-manifest.ts
@@ -1,0 +1,226 @@
+// scripts/generate-changelog-manifest.ts
+//
+// Scrapes the docs index + each individual page to produce
+// src/components/changelog/manifest.ts.
+//
+//   pnpm tsx scripts/generate-changelog-manifest.ts
+//
+// Wire into your build via package.json:
+//
+//   "scripts": {
+//     "changelog:generate": "tsx scripts/generate-changelog-manifest.ts",
+//     "prebuild": "pnpm changelog:generate"
+//   }
+//
+// Failure modes:
+//   - Docs site down → exits non-zero, build fails. Intentional.
+//   - One entry's page is malformed → that entry is skipped with a warning,
+//     other entries still emitted. Intentional — one bad page shouldn't
+//     block the whole frontend deploy.
+
+import { writeFile, mkdir } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const DOCS_INDEX_URL = "https://agpt.co/docs/platform/changelog/changelog";
+const DOCS_ENTRY_BASE = "https://agpt.co/docs/platform/changelog/changelog";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const OUT_PATH = resolve(__dirname, "../src/components/changelog/manifest.ts");
+
+const MONTHS: Record<string, number> = {
+  january: 1, february: 2, march: 3, april: 4,
+  may: 5, june: 6, july: 7, august: 8,
+  september: 9, october: 10, november: 11, december: 12,
+};
+
+interface RawEntry {
+  slug: string;
+  dateLabel: string; // e.g. "April 10 – May 1"
+  highlights: string;
+  yearHint: number;
+}
+
+interface EnrichedEntry extends RawEntry {
+  id: string;          // YYYY-MM-DD of the end of the range
+  title: string;       // canonical title from the entry's own H1
+  versions: string[];
+  isHighlighted?: boolean;
+}
+
+// ─── main ─────────────────────────────────────────────────────────────────
+
+async function main() {
+  console.log("⤓  Fetching changelog index…");
+  const indexMd = await fetchText(DOCS_INDEX_URL);
+  const raw = parseIndex(indexMd);
+  if (raw.length === 0) {
+    throw new Error("No entries parsed from index — has the docs format changed?");
+  }
+  console.log(`   ${raw.length} entries found`);
+
+  console.log("⤓  Fetching each entry…");
+  const enriched: EnrichedEntry[] = [];
+  for (const entry of raw) {
+    try {
+      const detail = await fetchText(`${DOCS_ENTRY_BASE}/${entry.slug}.md`);
+      const { title, versions } = parseEntry(detail);
+      const id = computeId(entry);
+      enriched.push({ ...entry, id, title, versions });
+      console.log(`   ✓ ${entry.slug}`);
+    } catch (err) {
+      console.warn(`   ✗ ${entry.slug}: ${(err as Error).message}`);
+    }
+  }
+
+  // Sort newest first by id (lexicographic works because ids are YYYY-MM-DD)
+  enriched.sort((a, b) => (a.id < b.id ? 1 : -1));
+
+  // Mark the most recent as highlighted
+  if (enriched.length > 0) enriched[0].isHighlighted = true;
+
+  await mkdir(dirname(OUT_PATH), { recursive: true });
+  await writeFile(OUT_PATH, renderManifest(enriched), "utf8");
+  console.log(`\n✓  Wrote ${enriched.length} entries → ${OUT_PATH}`);
+}
+
+// ─── fetching ─────────────────────────────────────────────────────────────
+
+async function fetchText(url: string): Promise<string> {
+  const res = await fetch(url, {
+    headers: { Accept: "text/markdown, text/plain, */*" },
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status} for ${url}`);
+  return res.text();
+}
+
+// ─── parsing ──────────────────────────────────────────────────────────────
+
+function parseIndex(md: string): RawEntry[] {
+  // Find year-section headers ("## 2026"). Year associates with each row
+  // until the next year header.
+  const out: RawEntry[] = [];
+  const yearRe = /^##\s+(\d{4})\s*$/gm;
+  const yearMatches: { year: number; offset: number }[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = yearRe.exec(md)) !== null) {
+    yearMatches.push({ year: Number(m[1]), offset: m.index + m[0].length });
+  }
+
+  // No explicit year header? Fall back to current year and parse the whole doc.
+  if (yearMatches.length === 0) {
+    yearMatches.push({ year: new Date().getFullYear(), offset: 0 });
+  }
+
+  for (let i = 0; i < yearMatches.length; i++) {
+    const { year, offset } = yearMatches[i];
+    const end = i + 1 < yearMatches.length ? yearMatches[i + 1].offset : md.length;
+    const section = md.slice(offset, end);
+
+    // Match: | [date label](slug-url) | highlights |
+    const rowRe = /^\|\s*\[([^\]]+)\]\(([^)]+)\)\s*\|\s*([^|]+?)\s*\|/gm;
+    let row: RegExpExecArray | null;
+    while ((row = rowRe.exec(section)) !== null) {
+      const [, dateLabel, link, highlights] = row;
+      const slugMatch = link.match(/\/changelog\/([^/]+?)(?:\.md)?$/);
+      if (!slugMatch) continue;
+      out.push({
+        slug: slugMatch[1],
+        dateLabel: dateLabel.trim(),
+        highlights: highlights.trim(),
+        yearHint: year,
+      });
+    }
+  }
+  return out;
+}
+
+function parseEntry(md: string): { title: string; versions: string[] } {
+  const titleMatch = md.match(/^#\s+(.+?)$/m);
+  const title = titleMatch?.[1].trim() ?? "Untitled release";
+
+  // Handles both "Platform version:" (singular) and "Platform versions:"
+  const versionsLine = md.match(/\*\*Platform versions?:\*\*\s*(.+)/);
+  const versions: string[] = [];
+  if (versionsLine) {
+    const verRe = /`(v[\d.]+)`/g;
+    let v: RegExpExecArray | null;
+    while ((v = verRe.exec(versionsLine[1])) !== null) {
+      versions.push(v[1]);
+    }
+  }
+
+  return { title, versions };
+}
+
+/**
+ * Computes a sortable YYYY-MM-DD id from the date label + year hint.
+ * Examples:
+ *   ("April 10 – May 1",        2026) → "2026-05-01"
+ *   ("March 13 – March 20",     2026) → "2026-03-20"
+ *   ("February 11 – 26",        2026) → "2026-02-26"   (re-uses start month)
+ *   ("January 29 – February 11",2026) → "2026-02-11"
+ */
+function computeId(entry: RawEntry): string {
+  const parts = entry.dateLabel.split(/\s*[–-]\s*/);
+  const startStr = (parts[0] ?? "").trim();
+  const endStr = (parts[1] ?? startStr).trim();
+
+  const startMonth = MONTHS[startStr.match(/^([A-Za-z]+)/)?.[1].toLowerCase() ?? ""] ?? null;
+
+  let endMonth: number | null = startMonth;
+  let endDay = 1;
+  const twoPart = endStr.match(/^([A-Za-z]+)\s+(\d+)/);
+  if (twoPart) {
+    endMonth = MONTHS[twoPart[1].toLowerCase()] ?? startMonth;
+    endDay = Number(twoPart[2]);
+  } else {
+    endDay = Number(endStr.match(/\d+/)?.[0] ?? "1");
+  }
+
+  const mm = String(endMonth ?? 1).padStart(2, "0");
+  const dd = String(endDay).padStart(2, "0");
+  return `${entry.yearHint}-${mm}-${dd}`;
+}
+
+// ─── rendering ────────────────────────────────────────────────────────────
+
+function renderManifest(entries: EnrichedEntry[]): string {
+  const body = entries
+    .map((e) => {
+      const props: string[] = [
+        `    id: ${JSON.stringify(e.id)},`,
+        `    slug: ${JSON.stringify(e.slug)},`,
+        `    dateLabel: ${JSON.stringify(`${e.dateLabel}, ${e.yearHint}`)},`,
+        `    title: ${JSON.stringify(e.title)},`,
+        `    versions: ${JSON.stringify(e.versions)},`,
+      ];
+      if (e.isHighlighted) props.push(`    isHighlighted: true,`);
+      return `  {\n${props.join("\n")}\n  },`;
+    })
+    .join("\n");
+
+  return [
+    `// src/components/changelog/manifest.ts`,
+    `// ─────────────────────────────────────────────────────────────────────────`,
+    `// AUTO-GENERATED — do not edit by hand.`,
+    `// Run \`pnpm changelog:generate\` to regenerate.`,
+    `// ─────────────────────────────────────────────────────────────────────────`,
+    ``,
+    `import type { ChangelogEntry } from "./types";`,
+    ``,
+    `export const CHANGELOG_MANIFEST: ChangelogEntry[] = [`,
+    body,
+    `];`,
+    ``,
+    `export const LATEST_ENTRY = CHANGELOG_MANIFEST[0];`,
+    ``,
+  ].join("\n");
+}
+
+// ─── go ───────────────────────────────────────────────────────────────────
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/autogpt_platform/frontend/scripts/generate-changelog-manifest.ts
+++ b/autogpt_platform/frontend/scripts/generate-changelog-manifest.ts
@@ -29,9 +29,18 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const OUT_PATH = resolve(__dirname, "../src/components/changelog/manifest.ts");
 
 const MONTHS: Record<string, number> = {
-  january: 1, february: 2, march: 3, april: 4,
-  may: 5, june: 6, july: 7, august: 8,
-  september: 9, october: 10, november: 11, december: 12,
+  january: 1,
+  february: 2,
+  march: 3,
+  april: 4,
+  may: 5,
+  june: 6,
+  july: 7,
+  august: 8,
+  september: 9,
+  october: 10,
+  november: 11,
+  december: 12,
 };
 
 interface RawEntry {
@@ -42,8 +51,8 @@ interface RawEntry {
 }
 
 interface EnrichedEntry extends RawEntry {
-  id: string;          // YYYY-MM-DD of the end of the range
-  title: string;       // canonical title from the entry's own H1
+  id: string; // YYYY-MM-DD of the end of the range
+  title: string; // canonical title from the entry's own H1
   versions: string[];
   isHighlighted?: boolean;
 }
@@ -55,7 +64,9 @@ async function main() {
   const indexMd = await fetchText(DOCS_INDEX_URL);
   const raw = parseIndex(indexMd);
   if (raw.length === 0) {
-    throw new Error("No entries parsed from index — has the docs format changed?");
+    throw new Error(
+      "No entries parsed from index — has the docs format changed?",
+    );
   }
   console.log(`   ${raw.length} entries found`);
 
@@ -114,7 +125,8 @@ function parseIndex(md: string): RawEntry[] {
 
   for (let i = 0; i < yearMatches.length; i++) {
     const { year, offset } = yearMatches[i];
-    const end = i + 1 < yearMatches.length ? yearMatches[i + 1].offset : md.length;
+    const end =
+      i + 1 < yearMatches.length ? yearMatches[i + 1].offset : md.length;
     const section = md.slice(offset, end);
 
     // Match: | [date label](slug-url) | highlights |
@@ -166,7 +178,8 @@ function computeId(entry: RawEntry): string {
   const startStr = (parts[0] ?? "").trim();
   const endStr = (parts[1] ?? startStr).trim();
 
-  const startMonth = MONTHS[startStr.match(/^([A-Za-z]+)/)?.[1].toLowerCase() ?? ""] ?? null;
+  const startMonth =
+    MONTHS[startStr.match(/^([A-Za-z]+)/)?.[1].toLowerCase() ?? ""] ?? null;
 
   let endMonth: number | null = startMonth;
   let endDay = 1;

--- a/autogpt_platform/frontend/src/app/api/changelog/[slug]/route.ts
+++ b/autogpt_platform/frontend/src/app/api/changelog/[slug]/route.ts
@@ -2,10 +2,9 @@ import { NextResponse } from "next/server";
 import { CHANGELOG_MANIFEST } from "@/components/changelog/manifest";
 
 const DOCS_BASE = "https://agpt.co/docs/platform/changelog/changelog";
-const CACHE_SECONDS = 60 * 60;
 const STALE_WHILE_REVALIDATE = 60 * 60 * 24;
 
-export const revalidate = CACHE_SECONDS;
+export const revalidate = 3600; // 1 hour — must be a static literal for Next.js segment config
 
 export async function GET(
   _req: Request,
@@ -21,7 +20,7 @@ export async function GET(
 
   try {
     const res = await fetch(upstream, {
-      next: { revalidate: CACHE_SECONDS },
+      next: { revalidate: 3600 },
       headers: { Accept: "text/markdown, text/plain, */*" },
     });
 

--- a/autogpt_platform/frontend/src/app/api/changelog/[slug]/route.ts
+++ b/autogpt_platform/frontend/src/app/api/changelog/[slug]/route.ts
@@ -36,7 +36,7 @@ export async function GET(
       status: 200,
       headers: {
         "Content-Type": "text/markdown; charset=utf-8",
-        "Cache-Control": `public, s-maxage=${CACHE_SECONDS}, stale-while-revalidate=${STALE_WHILE_REVALIDATE}`,
+        "Cache-Control": `public, s-maxage=3600, stale-while-revalidate=${STALE_WHILE_REVALIDATE}`,
       },
     });
   } catch (err) {

--- a/autogpt_platform/frontend/src/app/api/changelog/[slug]/route.ts
+++ b/autogpt_platform/frontend/src/app/api/changelog/[slug]/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from "next/server";
+import { CHANGELOG_MANIFEST } from "@/components/changelog/manifest";
+
+const DOCS_BASE = "https://agpt.co/docs/platform/changelog/changelog";
+const CACHE_SECONDS = 60 * 60;
+const STALE_WHILE_REVALIDATE = 60 * 60 * 24;
+
+export const revalidate = CACHE_SECONDS;
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ slug: string }> },
+) {
+  const { slug } = await params;
+
+  if (!CHANGELOG_MANIFEST.some((e) => e.slug === slug)) {
+    return new NextResponse("Unknown changelog entry", { status: 404 });
+  }
+
+  const upstream = `${DOCS_BASE}/${slug}.md`;
+
+  try {
+    const res = await fetch(upstream, {
+      next: { revalidate: CACHE_SECONDS },
+      headers: { Accept: "text/markdown, text/plain, */*" },
+    });
+
+    if (!res.ok) {
+      return new NextResponse(`Upstream returned ${res.status}`, {
+        status: 502,
+      });
+    }
+
+    const text = await res.text();
+
+    return new NextResponse(text, {
+      status: 200,
+      headers: {
+        "Content-Type": "text/markdown; charset=utf-8",
+        "Cache-Control": `public, s-maxage=${CACHE_SECONDS}, stale-while-revalidate=${STALE_WHILE_REVALIDATE}`,
+      },
+    });
+  } catch (err) {
+    return new NextResponse(
+      `Failed to fetch changelog: ${err instanceof Error ? err.message : "unknown error"}`,
+      { status: 502 },
+    );
+  }
+}

--- a/autogpt_platform/frontend/src/app/api/me/preferences/changelog/route.ts
+++ b/autogpt_platform/frontend/src/app/api/me/preferences/changelog/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+const BACKEND_URL =
+  process.env.NEXT_PUBLIC_BACKEND_URL ?? "http://localhost:8000";
+const UPSTREAM_PATH = "/api/me/preferences/changelog";
+
+async function forward(req: NextRequest, body?: string) {
+  const upstream = `${BACKEND_URL}${UPSTREAM_PATH}`;
+
+  const headers: HeadersInit = {
+    "Content-Type": "application/json",
+  };
+  const cookie = req.headers.get("cookie");
+  if (cookie) headers["cookie"] = cookie;
+  const auth = req.headers.get("authorization");
+  if (auth) headers["authorization"] = auth;
+
+  const res = await fetch(upstream, {
+    method: req.method,
+    headers,
+    body,
+  });
+
+  const text = await res.text();
+  return new NextResponse(text, {
+    status: res.status,
+    headers: {
+      "Content-Type": res.headers.get("Content-Type") ?? "application/json",
+    },
+  });
+}
+
+export async function GET(req: NextRequest) {
+  return forward(req);
+}
+
+export async function PUT(req: NextRequest) {
+  const body = await req.text();
+  return forward(req, body);
+}

--- a/autogpt_platform/frontend/src/components/changelog/ChangelogContent.tsx
+++ b/autogpt_platform/frontend/src/components/changelog/ChangelogContent.tsx
@@ -42,22 +42,22 @@ export function ChangelogContent({ entry }: Props) {
 
   return (
     <article>
-      <header className="pb-8 border-b border-border">
-        <div className="flex items-center gap-2 mb-3">
+      <header className="border-border border-b pb-8">
+        <div className="mb-3 flex items-center gap-2">
           {entry.isHighlighted && (
             <>
-              <span className="text-xs uppercase tracking-[0.18em] font-medium text-emerald-700">
+              <span className="text-xs font-medium tracking-[0.18em] text-emerald-700 uppercase">
                 Latest
               </span>
               <span className="text-muted-foreground/50">·</span>
             </>
           )}
-          <span className="text-sm text-muted-foreground italic font-serif">
+          <span className="text-muted-foreground font-serif text-sm italic">
             {entry.dateLabel}
           </span>
         </div>
         <h1
-          className="text-[42px] leading-[1.05] font-medium tracking-tight mb-4"
+          className="mb-4 text-[42px] leading-[1.05] font-medium tracking-tight"
           style={{
             fontFamily:
               "var(--font-changelog-display, ui-serif, Georgia, serif)",
@@ -69,7 +69,7 @@ export function ChangelogContent({ entry }: Props) {
           {entry.versions.map((v) => (
             <span
               key={v}
-              className="font-mono text-[12px] px-2 py-0.5 bg-muted text-muted-foreground rounded"
+              className="bg-muted text-muted-foreground rounded px-2 py-0.5 font-mono text-[12px]"
             >
               {v}
             </span>
@@ -79,22 +79,22 @@ export function ChangelogContent({ entry }: Props) {
 
       <div>
         {markdown === null && error === null && (
-          <div className="flex items-center gap-2 text-muted-foreground py-12">
-            <SpinnerGap className="w-4 h-4 animate-spin" />
+          <div className="text-muted-foreground flex items-center gap-2 py-12">
+            <SpinnerGap className="h-4 w-4 animate-spin" />
             <span className="text-sm">Loading…</span>
           </div>
         )}
 
         {error && (
-          <div className="py-12 text-sm text-muted-foreground">
+          <div className="text-muted-foreground py-12 text-sm">
             <p className="mb-2">Couldn&apos;t load this entry.</p>
             <a
               href={`${DOCS_ORIGIN}/docs/platform/changelog/changelog/${entry.slug}.md`}
               target="_blank"
               rel="noreferrer"
-              className="inline-flex items-center gap-1 text-foreground hover:underline"
+              className="text-foreground inline-flex items-center gap-1 hover:underline"
             >
-              Read it on agpt.co <ArrowSquareOut className="w-3 h-3" />
+              Read it on agpt.co <ArrowSquareOut className="h-3 w-3" />
             </a>
           </div>
         )}
@@ -115,15 +115,15 @@ export function ChangelogContent({ entry }: Props) {
 
 const markdownComponents: import("react-markdown").Components = {
   h2: ({ children }) => (
-    <h2 className="text-2xl font-medium mt-12 mb-4 tracking-tight">
+    <h2 className="mt-12 mb-4 text-2xl font-medium tracking-tight">
       {children}
     </h2>
   ),
   h3: ({ children }) => (
-    <h3 className="text-lg font-medium mt-8 mb-3">{children}</h3>
+    <h3 className="mt-8 mb-3 text-lg font-medium">{children}</h3>
   ),
   p: ({ children }) => (
-    <p className="text-muted-foreground leading-[1.7] text-[15px] mb-4">
+    <p className="text-muted-foreground mb-4 text-[15px] leading-[1.7]">
       {children}
     </p>
   ),
@@ -132,32 +132,32 @@ const markdownComponents: import("react-markdown").Components = {
       href={resolveLink(href)}
       target="_blank"
       rel="noreferrer"
-      className="text-foreground underline decoration-border underline-offset-2 hover:decoration-foreground transition-colors"
+      className="text-foreground decoration-border hover:decoration-foreground underline underline-offset-2 transition-colors"
     >
       {children}
     </a>
   ),
   ul: ({ children }) => (
-    <ul className="my-4 space-y-2 list-none pl-0">{children}</ul>
+    <ul className="my-4 list-none space-y-2 pl-0">{children}</ul>
   ),
   li: ({ children }) => (
-    <li className="text-[14px] text-muted-foreground leading-relaxed pl-4 relative">
-      <span className="absolute left-0 top-2.5 w-1 h-1 rounded-full bg-muted-foreground/40" />
+    <li className="text-muted-foreground relative pl-4 text-[14px] leading-relaxed">
+      <span className="bg-muted-foreground/40 absolute top-2.5 left-0 h-1 w-1 rounded-full" />
       {children}
     </li>
   ),
   strong: ({ children }) => (
-    <strong className="font-medium text-foreground">{children}</strong>
+    <strong className="text-foreground font-medium">{children}</strong>
   ),
   code: ({ children }) => (
-    <code className="font-mono text-[12px] bg-muted text-foreground px-1.5 py-0.5 rounded">
+    <code className="bg-muted text-foreground rounded px-1.5 py-0.5 font-mono text-[12px]">
       {children}
     </code>
   ),
-  hr: () => <hr className="my-10 border-border" />,
+  hr: () => <hr className="border-border my-10" />,
   figure: ({ children }) => <figure className="my-8">{children}</figure>,
   figcaption: ({ children }) => (
-    <figcaption className="mt-3 text-sm text-muted-foreground italic font-serif">
+    <figcaption className="text-muted-foreground mt-3 font-serif text-sm italic">
       {children}
     </figcaption>
   ),
@@ -166,14 +166,14 @@ const markdownComponents: import("react-markdown").Components = {
     <img
       src={resolveImageSrc(src)}
       alt={alt ?? ""}
-      className="w-full rounded-xl border border-border shadow-sm"
+      className="border-border w-full rounded-xl border shadow-sm"
       loading="lazy"
     />
   ),
   details: ({ children }) => (
     <details
       className={cn(
-        "group border-t border-border py-4",
+        "group border-border border-t py-4",
         "[&>*:not(summary)]:mt-3 [&>*:not(summary)]:ml-6",
       )}
     >
@@ -183,16 +183,16 @@ const markdownComponents: import("react-markdown").Components = {
   summary: ({ children }) => (
     <summary
       className={cn(
-        "flex items-center gap-2 cursor-pointer select-none",
+        "flex cursor-pointer items-center gap-2 select-none",
         "list-none [&::-webkit-details-marker]:hidden [&::marker]:hidden",
-        "hover:opacity-80 transition-opacity",
+        "transition-opacity hover:opacity-80",
       )}
     >
       <CaretRight
-        className="w-4 h-4 text-muted-foreground shrink-0 transition-transform group-open:rotate-90"
+        className="text-muted-foreground h-4 w-4 shrink-0 transition-transform group-open:rotate-90"
         aria-hidden
       />
-      <span className="font-medium text-[15px] text-foreground">
+      <span className="text-foreground text-[15px] font-medium">
         {children}
       </span>
     </summary>

--- a/autogpt_platform/frontend/src/components/changelog/ChangelogContent.tsx
+++ b/autogpt_platform/frontend/src/components/changelog/ChangelogContent.tsx
@@ -42,22 +42,22 @@ export function ChangelogContent({ entry }: Props) {
 
   return (
     <article>
-      <header className="border-border border-b pb-8">
+      <header className="border-b border-border pb-8">
         <div className="mb-3 flex items-center gap-2">
           {entry.isHighlighted && (
             <>
-              <span className="text-xs font-medium tracking-[0.18em] text-emerald-700 uppercase">
+              <span className="text-xs font-medium uppercase tracking-[0.18em] text-emerald-700">
                 Latest
               </span>
               <span className="text-muted-foreground/50">·</span>
             </>
           )}
-          <span className="text-muted-foreground font-serif text-sm italic">
+          <span className="font-serif text-sm italic text-muted-foreground">
             {entry.dateLabel}
           </span>
         </div>
         <h1
-          className="mb-4 text-[42px] leading-[1.05] font-medium tracking-tight"
+          className="mb-4 text-[42px] font-medium leading-[1.05] tracking-tight"
           style={{
             fontFamily:
               "var(--font-changelog-display, ui-serif, Georgia, serif)",
@@ -69,7 +69,7 @@ export function ChangelogContent({ entry }: Props) {
           {entry.versions.map((v) => (
             <span
               key={v}
-              className="bg-muted text-muted-foreground rounded px-2 py-0.5 font-mono text-[12px]"
+              className="rounded bg-muted px-2 py-0.5 font-mono text-[12px] text-muted-foreground"
             >
               {v}
             </span>
@@ -79,20 +79,20 @@ export function ChangelogContent({ entry }: Props) {
 
       <div>
         {markdown === null && error === null && (
-          <div className="text-muted-foreground flex items-center gap-2 py-12">
+          <div className="flex items-center gap-2 py-12 text-muted-foreground">
             <SpinnerGap className="h-4 w-4 animate-spin" />
             <span className="text-sm">Loading…</span>
           </div>
         )}
 
         {error && (
-          <div className="text-muted-foreground py-12 text-sm">
+          <div className="py-12 text-sm text-muted-foreground">
             <p className="mb-2">Couldn&apos;t load this entry.</p>
             <a
               href={`${DOCS_ORIGIN}/docs/platform/changelog/changelog/${entry.slug}.md`}
               target="_blank"
               rel="noreferrer"
-              className="text-foreground inline-flex items-center gap-1 hover:underline"
+              className="inline-flex items-center gap-1 text-foreground hover:underline"
             >
               Read it on agpt.co <ArrowSquareOut className="h-3 w-3" />
             </a>
@@ -115,15 +115,15 @@ export function ChangelogContent({ entry }: Props) {
 
 const markdownComponents: import("react-markdown").Components = {
   h2: ({ children }) => (
-    <h2 className="mt-12 mb-4 text-2xl font-medium tracking-tight">
+    <h2 className="mb-4 mt-12 text-2xl font-medium tracking-tight">
       {children}
     </h2>
   ),
   h3: ({ children }) => (
-    <h3 className="mt-8 mb-3 text-lg font-medium">{children}</h3>
+    <h3 className="mb-3 mt-8 text-lg font-medium">{children}</h3>
   ),
   p: ({ children }) => (
-    <p className="text-muted-foreground mb-4 text-[15px] leading-[1.7]">
+    <p className="mb-4 text-[15px] leading-[1.7] text-muted-foreground">
       {children}
     </p>
   ),
@@ -132,7 +132,7 @@ const markdownComponents: import("react-markdown").Components = {
       href={resolveLink(href)}
       target="_blank"
       rel="noreferrer"
-      className="text-foreground decoration-border hover:decoration-foreground underline underline-offset-2 transition-colors"
+      className="text-foreground underline decoration-border underline-offset-2 transition-colors hover:decoration-foreground"
     >
       {children}
     </a>
@@ -141,23 +141,23 @@ const markdownComponents: import("react-markdown").Components = {
     <ul className="my-4 list-none space-y-2 pl-0">{children}</ul>
   ),
   li: ({ children }) => (
-    <li className="text-muted-foreground relative pl-4 text-[14px] leading-relaxed">
-      <span className="bg-muted-foreground/40 absolute top-2.5 left-0 h-1 w-1 rounded-full" />
+    <li className="relative pl-4 text-[14px] leading-relaxed text-muted-foreground">
+      <span className="absolute left-0 top-2.5 h-1 w-1 rounded-full bg-muted-foreground/40" />
       {children}
     </li>
   ),
   strong: ({ children }) => (
-    <strong className="text-foreground font-medium">{children}</strong>
+    <strong className="font-medium text-foreground">{children}</strong>
   ),
   code: ({ children }) => (
-    <code className="bg-muted text-foreground rounded px-1.5 py-0.5 font-mono text-[12px]">
+    <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-[12px] text-foreground">
       {children}
     </code>
   ),
-  hr: () => <hr className="border-border my-10" />,
+  hr: () => <hr className="my-10 border-border" />,
   figure: ({ children }) => <figure className="my-8">{children}</figure>,
   figcaption: ({ children }) => (
-    <figcaption className="text-muted-foreground mt-3 font-serif text-sm italic">
+    <figcaption className="mt-3 font-serif text-sm italic text-muted-foreground">
       {children}
     </figcaption>
   ),
@@ -166,15 +166,15 @@ const markdownComponents: import("react-markdown").Components = {
     <img
       src={resolveImageSrc(src)}
       alt={alt ?? ""}
-      className="border-border w-full rounded-xl border shadow-sm"
+      className="w-full rounded-xl border border-border shadow-sm"
       loading="lazy"
     />
   ),
   details: ({ children }) => (
     <details
       className={cn(
-        "group border-border border-t py-4",
-        "[&>*:not(summary)]:mt-3 [&>*:not(summary)]:ml-6",
+        "group border-t border-border py-4",
+        "[&>*:not(summary)]:ml-6 [&>*:not(summary)]:mt-3",
       )}
     >
       {children}
@@ -183,16 +183,16 @@ const markdownComponents: import("react-markdown").Components = {
   summary: ({ children }) => (
     <summary
       className={cn(
-        "flex cursor-pointer items-center gap-2 select-none",
+        "flex cursor-pointer select-none items-center gap-2",
         "list-none [&::-webkit-details-marker]:hidden [&::marker]:hidden",
         "transition-opacity hover:opacity-80",
       )}
     >
       <CaretRight
-        className="text-muted-foreground h-4 w-4 shrink-0 transition-transform group-open:rotate-90"
+        className="h-4 w-4 shrink-0 text-muted-foreground transition-transform group-open:rotate-90"
         aria-hidden
       />
-      <span className="text-foreground text-[15px] font-medium">
+      <span className="text-[15px] font-medium text-foreground">
         {children}
       </span>
     </summary>

--- a/autogpt_platform/frontend/src/components/changelog/ChangelogContent.tsx
+++ b/autogpt_platform/frontend/src/components/changelog/ChangelogContent.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import rehypeRaw from "rehype-raw";
+import { ArrowSquareOut, CaretRight, SpinnerGap } from "@phosphor-icons/react";
+import type { ChangelogEntry } from "./types";
+import { cn } from "@/lib/utils";
+
+const DOCS_ORIGIN = "https://agpt.co";
+
+interface Props {
+  entry: ChangelogEntry;
+}
+
+export function ChangelogContent({ entry }: Props) {
+  const [markdown, setMarkdown] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setMarkdown(null);
+    setError(null);
+
+    fetch(`/api/changelog/${entry.slug}`)
+      .then((r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        return r.text();
+      })
+      .then((text) => {
+        if (!cancelled) setMarkdown(text);
+      })
+      .catch((e) => {
+        if (!cancelled) setError(e.message);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [entry.slug]);
+
+  return (
+    <article>
+      <header className="pb-8 border-b border-border">
+        <div className="flex items-center gap-2 mb-3">
+          {entry.isHighlighted && (
+            <>
+              <span className="text-xs uppercase tracking-[0.18em] font-medium text-emerald-700">
+                Latest
+              </span>
+              <span className="text-muted-foreground/50">·</span>
+            </>
+          )}
+          <span className="text-sm text-muted-foreground italic font-serif">
+            {entry.dateLabel}
+          </span>
+        </div>
+        <h1
+          className="text-[42px] leading-[1.05] font-medium tracking-tight mb-4"
+          style={{
+            fontFamily:
+              "var(--font-changelog-display, ui-serif, Georgia, serif)",
+          }}
+        >
+          {entry.title}
+        </h1>
+        <div className="flex flex-wrap gap-1.5">
+          {entry.versions.map((v) => (
+            <span
+              key={v}
+              className="font-mono text-[12px] px-2 py-0.5 bg-muted text-muted-foreground rounded"
+            >
+              {v}
+            </span>
+          ))}
+        </div>
+      </header>
+
+      <div>
+        {markdown === null && error === null && (
+          <div className="flex items-center gap-2 text-muted-foreground py-12">
+            <SpinnerGap className="w-4 h-4 animate-spin" />
+            <span className="text-sm">Loading…</span>
+          </div>
+        )}
+
+        {error && (
+          <div className="py-12 text-sm text-muted-foreground">
+            <p className="mb-2">Couldn&apos;t load this entry.</p>
+            <a
+              href={`${DOCS_ORIGIN}/docs/platform/changelog/changelog/${entry.slug}.md`}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-1 text-foreground hover:underline"
+            >
+              Read it on agpt.co <ArrowSquareOut className="w-3 h-3" />
+            </a>
+          </div>
+        )}
+
+        {markdown && (
+          <ReactMarkdown
+            remarkPlugins={[remarkGfm]}
+            rehypePlugins={[rehypeRaw]}
+            components={markdownComponents}
+          >
+            {stripLeadingH1(markdown)}
+          </ReactMarkdown>
+        )}
+      </div>
+    </article>
+  );
+}
+
+const markdownComponents: import("react-markdown").Components = {
+  h2: ({ children }) => (
+    <h2 className="text-2xl font-medium mt-12 mb-4 tracking-tight">
+      {children}
+    </h2>
+  ),
+  h3: ({ children }) => (
+    <h3 className="text-lg font-medium mt-8 mb-3">{children}</h3>
+  ),
+  p: ({ children }) => (
+    <p className="text-muted-foreground leading-[1.7] text-[15px] mb-4">
+      {children}
+    </p>
+  ),
+  a: ({ children, href }) => (
+    <a
+      href={resolveLink(href)}
+      target="_blank"
+      rel="noreferrer"
+      className="text-foreground underline decoration-border underline-offset-2 hover:decoration-foreground transition-colors"
+    >
+      {children}
+    </a>
+  ),
+  ul: ({ children }) => (
+    <ul className="my-4 space-y-2 list-none pl-0">{children}</ul>
+  ),
+  li: ({ children }) => (
+    <li className="text-[14px] text-muted-foreground leading-relaxed pl-4 relative">
+      <span className="absolute left-0 top-2.5 w-1 h-1 rounded-full bg-muted-foreground/40" />
+      {children}
+    </li>
+  ),
+  strong: ({ children }) => (
+    <strong className="font-medium text-foreground">{children}</strong>
+  ),
+  code: ({ children }) => (
+    <code className="font-mono text-[12px] bg-muted text-foreground px-1.5 py-0.5 rounded">
+      {children}
+    </code>
+  ),
+  hr: () => <hr className="my-10 border-border" />,
+  figure: ({ children }) => <figure className="my-8">{children}</figure>,
+  figcaption: ({ children }) => (
+    <figcaption className="mt-3 text-sm text-muted-foreground italic font-serif">
+      {children}
+    </figcaption>
+  ),
+  img: ({ src, alt }) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img
+      src={resolveImageSrc(src)}
+      alt={alt ?? ""}
+      className="w-full rounded-xl border border-border shadow-sm"
+      loading="lazy"
+    />
+  ),
+  details: ({ children }) => (
+    <details
+      className={cn(
+        "group border-t border-border py-4",
+        "[&>*:not(summary)]:mt-3 [&>*:not(summary)]:ml-6",
+      )}
+    >
+      {children}
+    </details>
+  ),
+  summary: ({ children }) => (
+    <summary
+      className={cn(
+        "flex items-center gap-2 cursor-pointer select-none",
+        "list-none [&::-webkit-details-marker]:hidden [&::marker]:hidden",
+        "hover:opacity-80 transition-opacity",
+      )}
+    >
+      <CaretRight
+        className="w-4 h-4 text-muted-foreground shrink-0 transition-transform group-open:rotate-90"
+        aria-hidden
+      />
+      <span className="font-medium text-[15px] text-foreground">
+        {children}
+      </span>
+    </summary>
+  ),
+};
+
+function resolveImageSrc(src?: string): string {
+  if (!src) return "";
+  if (src.startsWith("http")) return src;
+  if (src.startsWith("/")) return `${DOCS_ORIGIN}${src}`;
+  return src;
+}
+
+function resolveLink(href?: string): string {
+  if (!href) return "#";
+  if (href.startsWith("http")) return href;
+  if (href.startsWith("/")) return `${DOCS_ORIGIN}${href}`;
+  return href;
+}
+
+function stripLeadingH1(md: string): string {
+  return md.replace(/^\s*#\s+.+?\n/, "");
+}

--- a/autogpt_platform/frontend/src/components/changelog/ChangelogModal.tsx
+++ b/autogpt_platform/frontend/src/components/changelog/ChangelogModal.tsx
@@ -31,14 +31,14 @@ export function ChangelogModal({
   return (
     <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
       <DialogPrimitive.Portal>
-        <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-black/60 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+        <DialogPrimitive.Overlay className="data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/60" />
         <DialogPrimitive.Content
           className={cn(
-            "fixed left-[50%] top-[50%] z-50 translate-x-[-50%] translate-y-[-50%]",
-            "p-0 gap-0 overflow-hidden",
-            "max-w-[1080px] w-[92vw] h-[78vh] max-h-[820px]",
+            "fixed top-[50%] left-[50%] z-50 translate-x-[-50%] translate-y-[-50%]",
+            "gap-0 overflow-hidden p-0",
+            "h-[78vh] max-h-[820px] w-[92vw] max-w-[1080px]",
             "flex flex-row",
-            "bg-background rounded-lg shadow-xl border border-border",
+            "bg-background border-border rounded-lg border shadow-xl",
             "data-[state=open]:animate-in data-[state=closed]:animate-out",
             "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
             "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
@@ -53,16 +53,16 @@ export function ChangelogModal({
           </span>
 
           {/* Sidebar */}
-          <aside className="w-[280px] shrink-0 border-r border-border bg-muted/30 flex flex-col">
+          <aside className="border-border bg-muted/30 flex w-[280px] shrink-0 flex-col border-r">
             <div className="px-6 pt-6 pb-4">
-              <div className="flex items-center gap-2 mb-1">
+              <div className="mb-1 flex items-center gap-2">
                 <div
-                  className="w-2 h-2 rounded-full"
+                  className="h-2 w-2 rounded-full"
                   style={{
                     background: "linear-gradient(135deg, #f59e0b, #ef4444)",
                   }}
                 />
-                <span className="text-[11px] uppercase tracking-[0.18em] text-muted-foreground font-semibold">
+                <span className="text-muted-foreground text-[11px] font-semibold tracking-[0.18em] uppercase">
                   AutoGPT
                 </span>
               </div>
@@ -88,16 +88,16 @@ export function ChangelogModal({
                     key={entry.id}
                     onClick={() => onActiveIDChange(entry.id)}
                     className={cn(
-                      "w-full text-left px-3 py-2.5 rounded-lg mb-0.5 transition-all relative group border",
+                      "group relative mb-0.5 w-full rounded-lg border px-3 py-2.5 text-left transition-all",
                       isActive
-                        ? "bg-background shadow-sm border-border/80"
+                        ? "bg-background border-border/80 shadow-sm"
                         : "hover:bg-background/60 border-transparent",
                     )}
                     aria-current={isActive ? "page" : undefined}
                   >
                     {isActive && entry.isHighlighted && (
                       <span
-                        className="absolute left-0 top-2 bottom-2 w-[2px] rounded-full"
+                        className="absolute top-2 bottom-2 left-0 w-[2px] rounded-full"
                         style={{
                           background:
                             "linear-gradient(to bottom, #f59e0b, #ef4444)",
@@ -105,19 +105,19 @@ export function ChangelogModal({
                         aria-hidden
                       />
                     )}
-                    <div className="flex items-center gap-1.5 mb-1">
-                      <span className="text-[10px] italic font-serif text-muted-foreground">
+                    <div className="mb-1 flex items-center gap-1.5">
+                      <span className="text-muted-foreground font-serif text-[10px] italic">
                         {entry.dateLabel}
                       </span>
                       {entry.isHighlighted && (
-                        <span className="text-[9px] uppercase tracking-wider font-semibold text-emerald-700 bg-emerald-50 px-1.5 py-0.5 rounded">
+                        <span className="rounded bg-emerald-50 px-1.5 py-0.5 text-[9px] font-semibold tracking-wider text-emerald-700 uppercase">
                           New
                         </span>
                       )}
                     </div>
                     <div
                       className={cn(
-                        "text-[13px] leading-snug line-clamp-2 transition-colors",
+                        "line-clamp-2 text-[13px] leading-snug transition-colors",
                         isActive
                           ? "text-foreground font-medium"
                           : "text-muted-foreground group-hover:text-foreground",
@@ -130,9 +130,9 @@ export function ChangelogModal({
               })}
             </nav>
 
-            <div className="px-6 py-4 border-t border-border text-[11px] text-muted-foreground">
+            <div className="border-border text-muted-foreground border-t px-6 py-4 text-[11px]">
               Press{" "}
-              <kbd className="font-mono bg-muted text-foreground/80 px-1.5 py-0.5 rounded text-[10px]">
+              <kbd className="bg-muted text-foreground/80 rounded px-1.5 py-0.5 font-mono text-[10px]">
                 esc
               </kbd>{" "}
               to close
@@ -140,12 +140,12 @@ export function ChangelogModal({
           </aside>
 
           {/* Content */}
-          <main className="flex-1 relative">
+          <main className="relative flex-1">
             <div
               ref={contentRef}
               className="absolute inset-0 overflow-y-auto px-14 py-12"
             >
-              <div className="max-w-[640px] mx-auto">
+              <div className="mx-auto max-w-[640px]">
                 <ChangelogContent entry={activeEntry} />
               </div>
             </div>

--- a/autogpt_platform/frontend/src/components/changelog/ChangelogModal.tsx
+++ b/autogpt_platform/frontend/src/components/changelog/ChangelogModal.tsx
@@ -31,14 +31,14 @@ export function ChangelogModal({
   return (
     <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
       <DialogPrimitive.Portal>
-        <DialogPrimitive.Overlay className="data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/60" />
+        <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-black/60 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
         <DialogPrimitive.Content
           className={cn(
-            "fixed top-[50%] left-[50%] z-50 translate-x-[-50%] translate-y-[-50%]",
+            "fixed left-[50%] top-[50%] z-50 translate-x-[-50%] translate-y-[-50%]",
             "gap-0 overflow-hidden p-0",
             "h-[78vh] max-h-[820px] w-[92vw] max-w-[1080px]",
             "flex flex-row",
-            "bg-background border-border rounded-lg border shadow-xl",
+            "rounded-lg border border-border bg-background shadow-xl",
             "data-[state=open]:animate-in data-[state=closed]:animate-out",
             "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
             "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
@@ -53,8 +53,8 @@ export function ChangelogModal({
           </span>
 
           {/* Sidebar */}
-          <aside className="border-border bg-muted/30 flex w-[280px] shrink-0 flex-col border-r">
-            <div className="px-6 pt-6 pb-4">
+          <aside className="flex w-[280px] shrink-0 flex-col border-r border-border bg-muted/30">
+            <div className="px-6 pb-4 pt-6">
               <div className="mb-1 flex items-center gap-2">
                 <div
                   className="h-2 w-2 rounded-full"
@@ -62,7 +62,7 @@ export function ChangelogModal({
                     background: "linear-gradient(135deg, #f59e0b, #ef4444)",
                   }}
                 />
-                <span className="text-muted-foreground text-[11px] font-semibold tracking-[0.18em] uppercase">
+                <span className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
                   AutoGPT
                 </span>
               </div>
@@ -90,14 +90,14 @@ export function ChangelogModal({
                     className={cn(
                       "group relative mb-0.5 w-full rounded-lg border px-3 py-2.5 text-left transition-all",
                       isActive
-                        ? "bg-background border-border/80 shadow-sm"
-                        : "hover:bg-background/60 border-transparent",
+                        ? "border-border/80 bg-background shadow-sm"
+                        : "border-transparent hover:bg-background/60",
                     )}
                     aria-current={isActive ? "page" : undefined}
                   >
                     {isActive && entry.isHighlighted && (
                       <span
-                        className="absolute top-2 bottom-2 left-0 w-[2px] rounded-full"
+                        className="absolute bottom-2 left-0 top-2 w-[2px] rounded-full"
                         style={{
                           background:
                             "linear-gradient(to bottom, #f59e0b, #ef4444)",
@@ -106,11 +106,11 @@ export function ChangelogModal({
                       />
                     )}
                     <div className="mb-1 flex items-center gap-1.5">
-                      <span className="text-muted-foreground font-serif text-[10px] italic">
+                      <span className="font-serif text-[10px] italic text-muted-foreground">
                         {entry.dateLabel}
                       </span>
                       {entry.isHighlighted && (
-                        <span className="rounded bg-emerald-50 px-1.5 py-0.5 text-[9px] font-semibold tracking-wider text-emerald-700 uppercase">
+                        <span className="rounded bg-emerald-50 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider text-emerald-700">
                           New
                         </span>
                       )}
@@ -119,7 +119,7 @@ export function ChangelogModal({
                       className={cn(
                         "line-clamp-2 text-[13px] leading-snug transition-colors",
                         isActive
-                          ? "text-foreground font-medium"
+                          ? "font-medium text-foreground"
                           : "text-muted-foreground group-hover:text-foreground",
                       )}
                     >
@@ -130,9 +130,9 @@ export function ChangelogModal({
               })}
             </nav>
 
-            <div className="border-border text-muted-foreground border-t px-6 py-4 text-[11px]">
+            <div className="border-t border-border px-6 py-4 text-[11px] text-muted-foreground">
               Press{" "}
-              <kbd className="bg-muted text-foreground/80 rounded px-1.5 py-0.5 font-mono text-[10px]">
+              <kbd className="rounded bg-muted px-1.5 py-0.5 font-mono text-[10px] text-foreground/80">
                 esc
               </kbd>{" "}
               to close

--- a/autogpt_platform/frontend/src/components/changelog/ChangelogModal.tsx
+++ b/autogpt_platform/frontend/src/components/changelog/ChangelogModal.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { CHANGELOG_MANIFEST } from "./manifest";
+import { ChangelogContent } from "./ChangelogContent";
+import { cn } from "@/lib/utils";
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  activeID: string;
+  onActiveIDChange: (id: string) => void;
+}
+
+export function ChangelogModal({
+  open,
+  onOpenChange,
+  activeID,
+  onActiveIDChange,
+}: Props) {
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (contentRef.current) contentRef.current.scrollTop = 0;
+  }, [activeID]);
+
+  const activeEntry =
+    CHANGELOG_MANIFEST.find((e) => e.id === activeID) ?? CHANGELOG_MANIFEST[0];
+
+  return (
+    <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-black/60 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+        <DialogPrimitive.Content
+          className={cn(
+            "fixed left-[50%] top-[50%] z-50 translate-x-[-50%] translate-y-[-50%]",
+            "p-0 gap-0 overflow-hidden",
+            "max-w-[1080px] w-[92vw] h-[78vh] max-h-[820px]",
+            "flex flex-row",
+            "bg-background rounded-lg shadow-xl border border-border",
+            "data-[state=open]:animate-in data-[state=closed]:animate-out",
+            "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+            "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+            "data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%]",
+            "data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]",
+          )}
+        >
+          <span className="sr-only">
+            <DialogPrimitive.Title>
+              What&apos;s new in AutoGPT
+            </DialogPrimitive.Title>
+          </span>
+
+          {/* Sidebar */}
+          <aside className="w-[280px] shrink-0 border-r border-border bg-muted/30 flex flex-col">
+            <div className="px-6 pt-6 pb-4">
+              <div className="flex items-center gap-2 mb-1">
+                <div
+                  className="w-2 h-2 rounded-full"
+                  style={{
+                    background: "linear-gradient(135deg, #f59e0b, #ef4444)",
+                  }}
+                />
+                <span className="text-[11px] uppercase tracking-[0.18em] text-muted-foreground font-semibold">
+                  AutoGPT
+                </span>
+              </div>
+              <h2
+                className="text-[22px] leading-tight"
+                style={{
+                  fontFamily:
+                    "var(--font-changelog-display, ui-serif, Georgia, serif)",
+                }}
+              >
+                What&apos;s new
+              </h2>
+            </div>
+
+            <nav
+              className="flex-1 overflow-y-auto px-3 pb-3"
+              aria-label="Changelog entries"
+            >
+              {CHANGELOG_MANIFEST.map((entry) => {
+                const isActive = entry.id === activeID;
+                return (
+                  <button
+                    key={entry.id}
+                    onClick={() => onActiveIDChange(entry.id)}
+                    className={cn(
+                      "w-full text-left px-3 py-2.5 rounded-lg mb-0.5 transition-all relative group border",
+                      isActive
+                        ? "bg-background shadow-sm border-border/80"
+                        : "hover:bg-background/60 border-transparent",
+                    )}
+                    aria-current={isActive ? "page" : undefined}
+                  >
+                    {isActive && entry.isHighlighted && (
+                      <span
+                        className="absolute left-0 top-2 bottom-2 w-[2px] rounded-full"
+                        style={{
+                          background:
+                            "linear-gradient(to bottom, #f59e0b, #ef4444)",
+                        }}
+                        aria-hidden
+                      />
+                    )}
+                    <div className="flex items-center gap-1.5 mb-1">
+                      <span className="text-[10px] italic font-serif text-muted-foreground">
+                        {entry.dateLabel}
+                      </span>
+                      {entry.isHighlighted && (
+                        <span className="text-[9px] uppercase tracking-wider font-semibold text-emerald-700 bg-emerald-50 px-1.5 py-0.5 rounded">
+                          New
+                        </span>
+                      )}
+                    </div>
+                    <div
+                      className={cn(
+                        "text-[13px] leading-snug line-clamp-2 transition-colors",
+                        isActive
+                          ? "text-foreground font-medium"
+                          : "text-muted-foreground group-hover:text-foreground",
+                      )}
+                    >
+                      {entry.title}
+                    </div>
+                  </button>
+                );
+              })}
+            </nav>
+
+            <div className="px-6 py-4 border-t border-border text-[11px] text-muted-foreground">
+              Press{" "}
+              <kbd className="font-mono bg-muted text-foreground/80 px-1.5 py-0.5 rounded text-[10px]">
+                esc
+              </kbd>{" "}
+              to close
+            </div>
+          </aside>
+
+          {/* Content */}
+          <main className="flex-1 relative">
+            <div
+              ref={contentRef}
+              className="absolute inset-0 overflow-y-auto px-14 py-12"
+            >
+              <div className="max-w-[640px] mx-auto">
+                <ChangelogContent entry={activeEntry} />
+              </div>
+            </div>
+          </main>
+        </DialogPrimitive.Content>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
+  );
+}

--- a/autogpt_platform/frontend/src/components/changelog/ChangelogPill.tsx
+++ b/autogpt_platform/frontend/src/components/changelog/ChangelogPill.tsx
@@ -16,8 +16,8 @@ export function ChangelogPill({ onClick, onDismiss, visible }: Props) {
       className={cn(
         "fixed bottom-6 left-6 z-40 transition-all duration-500",
         visible
-          ? "translate-y-0 opacity-100 pointer-events-auto"
-          : "translate-y-6 opacity-0 pointer-events-none",
+          ? "pointer-events-auto translate-y-0 opacity-100"
+          : "pointer-events-none translate-y-6 opacity-0",
       )}
       style={{
         transitionTimingFunction: "cubic-bezier(0.34, 1.56, 0.64, 1)",
@@ -26,10 +26,10 @@ export function ChangelogPill({ onClick, onDismiss, visible }: Props) {
       <button
         onClick={onClick}
         className={cn(
-          "group flex items-center gap-3 rounded-xl pl-3 pr-4 py-3 w-[320px] text-left",
-          "bg-background border border-border/80",
-          "hover:border-border hover:shadow-lg transition-all",
-          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+          "group flex w-[320px] items-center gap-3 rounded-xl py-3 pr-4 pl-3 text-left",
+          "bg-background border-border/80 border",
+          "hover:border-border transition-all hover:shadow-lg",
+          "focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-none",
         )}
         style={{
           boxShadow:
@@ -38,31 +38,31 @@ export function ChangelogPill({ onClick, onDismiss, visible }: Props) {
         aria-label={`What's new: ${LATEST_ENTRY.title}`}
       >
         <div
-          className="relative shrink-0 w-10 h-10 rounded-lg flex items-center justify-center overflow-hidden"
+          className="relative flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-lg"
           style={{
             background:
               "linear-gradient(135deg, #fef3c7 0%, #fde68a 50%, #f59e0b 100%)",
           }}
         >
-          <Sparkle className="w-4 h-4 text-stone-800/70" weight="fill" />
+          <Sparkle className="h-4 w-4 text-stone-800/70" weight="fill" />
           <span
-            className="absolute top-1 right-1 w-1.5 h-1.5 rounded-full bg-emerald-500 animate-pulse"
+            className="absolute top-1 right-1 h-1.5 w-1.5 animate-pulse rounded-full bg-emerald-500"
             aria-hidden
           />
         </div>
 
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-1.5 mb-0.5">
-            <span className="text-[10px] uppercase tracking-[0.12em] font-semibold text-emerald-600">
+        <div className="min-w-0 flex-1">
+          <div className="mb-0.5 flex items-center gap-1.5">
+            <span className="text-[10px] font-semibold tracking-[0.12em] text-emerald-600 uppercase">
               New
             </span>
-            <span className="text-[11px] text-muted-foreground">·</span>
-            <span className="text-[11px] text-muted-foreground italic font-serif">
+            <span className="text-muted-foreground text-[11px]">·</span>
+            <span className="text-muted-foreground font-serif text-[11px] italic">
               {LATEST_ENTRY.dateLabel.split("–")[1]?.trim() ??
                 LATEST_ENTRY.dateLabel}
             </span>
           </div>
-          <div className="text-[13px] text-foreground font-medium truncate leading-tight">
+          <div className="text-foreground truncate text-[13px] leading-tight font-medium">
             {LATEST_ENTRY.title}
           </div>
         </div>
@@ -71,7 +71,7 @@ export function ChangelogPill({ onClick, onDismiss, visible }: Props) {
           role="button"
           tabIndex={0}
           aria-label="Dismiss"
-          className="shrink-0 opacity-0 group-hover:opacity-100 transition-opacity p-1 -m-1 rounded hover:bg-muted cursor-pointer"
+          className="hover:bg-muted -m-1 shrink-0 cursor-pointer rounded p-1 opacity-0 transition-opacity group-hover:opacity-100"
           onClick={(e) => {
             e.stopPropagation();
             onDismiss();
@@ -83,7 +83,7 @@ export function ChangelogPill({ onClick, onDismiss, visible }: Props) {
             }
           }}
         >
-          <X className="w-3.5 h-3.5 text-muted-foreground" />
+          <X className="text-muted-foreground h-3.5 w-3.5" />
         </span>
       </button>
     </div>

--- a/autogpt_platform/frontend/src/components/changelog/ChangelogPill.tsx
+++ b/autogpt_platform/frontend/src/components/changelog/ChangelogPill.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { Sparkle, X } from "@phosphor-icons/react";
+import { LATEST_ENTRY } from "./manifest";
+import { cn } from "@/lib/utils";
+
+interface Props {
+  onClick: () => void;
+  onDismiss: () => void;
+  visible: boolean;
+}
+
+export function ChangelogPill({ onClick, onDismiss, visible }: Props) {
+  return (
+    <div
+      className={cn(
+        "fixed bottom-6 left-6 z-40 transition-all duration-500",
+        visible
+          ? "translate-y-0 opacity-100 pointer-events-auto"
+          : "translate-y-6 opacity-0 pointer-events-none",
+      )}
+      style={{
+        transitionTimingFunction: "cubic-bezier(0.34, 1.56, 0.64, 1)",
+      }}
+    >
+      <button
+        onClick={onClick}
+        className={cn(
+          "group flex items-center gap-3 rounded-xl pl-3 pr-4 py-3 w-[320px] text-left",
+          "bg-background border border-border/80",
+          "hover:border-border hover:shadow-lg transition-all",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        )}
+        style={{
+          boxShadow:
+            "0 1px 0 rgba(0,0,0,0.02), 0 4px 16px rgba(0,0,0,0.06), 0 12px 32px rgba(0,0,0,0.04)",
+        }}
+        aria-label={`What's new: ${LATEST_ENTRY.title}`}
+      >
+        <div
+          className="relative shrink-0 w-10 h-10 rounded-lg flex items-center justify-center overflow-hidden"
+          style={{
+            background:
+              "linear-gradient(135deg, #fef3c7 0%, #fde68a 50%, #f59e0b 100%)",
+          }}
+        >
+          <Sparkle className="w-4 h-4 text-stone-800/70" weight="fill" />
+          <span
+            className="absolute top-1 right-1 w-1.5 h-1.5 rounded-full bg-emerald-500 animate-pulse"
+            aria-hidden
+          />
+        </div>
+
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-1.5 mb-0.5">
+            <span className="text-[10px] uppercase tracking-[0.12em] font-semibold text-emerald-600">
+              New
+            </span>
+            <span className="text-[11px] text-muted-foreground">·</span>
+            <span className="text-[11px] text-muted-foreground italic font-serif">
+              {LATEST_ENTRY.dateLabel.split("–")[1]?.trim() ??
+                LATEST_ENTRY.dateLabel}
+            </span>
+          </div>
+          <div className="text-[13px] text-foreground font-medium truncate leading-tight">
+            {LATEST_ENTRY.title}
+          </div>
+        </div>
+
+        <span
+          role="button"
+          tabIndex={0}
+          aria-label="Dismiss"
+          className="shrink-0 opacity-0 group-hover:opacity-100 transition-opacity p-1 -m-1 rounded hover:bg-muted cursor-pointer"
+          onClick={(e) => {
+            e.stopPropagation();
+            onDismiss();
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.stopPropagation();
+              onDismiss();
+            }
+          }}
+        >
+          <X className="w-3.5 h-3.5 text-muted-foreground" />
+        </span>
+      </button>
+    </div>
+  );
+}

--- a/autogpt_platform/frontend/src/components/changelog/ChangelogPill.tsx
+++ b/autogpt_platform/frontend/src/components/changelog/ChangelogPill.tsx
@@ -26,10 +26,10 @@ export function ChangelogPill({ onClick, onDismiss, visible }: Props) {
       <button
         onClick={onClick}
         className={cn(
-          "group flex w-[320px] items-center gap-3 rounded-xl py-3 pr-4 pl-3 text-left",
-          "bg-background border-border/80 border",
-          "hover:border-border transition-all hover:shadow-lg",
-          "focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-none",
+          "group flex w-[320px] items-center gap-3 rounded-xl py-3 pl-3 pr-4 text-left",
+          "border border-border/80 bg-background",
+          "transition-all hover:border-border hover:shadow-lg",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
         )}
         style={{
           boxShadow:
@@ -46,23 +46,23 @@ export function ChangelogPill({ onClick, onDismiss, visible }: Props) {
         >
           <Sparkle className="h-4 w-4 text-stone-800/70" weight="fill" />
           <span
-            className="absolute top-1 right-1 h-1.5 w-1.5 animate-pulse rounded-full bg-emerald-500"
+            className="absolute right-1 top-1 h-1.5 w-1.5 animate-pulse rounded-full bg-emerald-500"
             aria-hidden
           />
         </div>
 
         <div className="min-w-0 flex-1">
           <div className="mb-0.5 flex items-center gap-1.5">
-            <span className="text-[10px] font-semibold tracking-[0.12em] text-emerald-600 uppercase">
+            <span className="text-[10px] font-semibold uppercase tracking-[0.12em] text-emerald-600">
               New
             </span>
-            <span className="text-muted-foreground text-[11px]">·</span>
-            <span className="text-muted-foreground font-serif text-[11px] italic">
+            <span className="text-[11px] text-muted-foreground">·</span>
+            <span className="font-serif text-[11px] italic text-muted-foreground">
               {LATEST_ENTRY.dateLabel.split("–")[1]?.trim() ??
                 LATEST_ENTRY.dateLabel}
             </span>
           </div>
-          <div className="text-foreground truncate text-[13px] leading-tight font-medium">
+          <div className="truncate text-[13px] font-medium leading-tight text-foreground">
             {LATEST_ENTRY.title}
           </div>
         </div>
@@ -71,7 +71,7 @@ export function ChangelogPill({ onClick, onDismiss, visible }: Props) {
           role="button"
           tabIndex={0}
           aria-label="Dismiss"
-          className="hover:bg-muted -m-1 shrink-0 cursor-pointer rounded p-1 opacity-0 transition-opacity group-hover:opacity-100"
+          className="-m-1 shrink-0 cursor-pointer rounded p-1 opacity-0 transition-opacity group-hover:opacity-100 hover:bg-muted"
           onClick={(e) => {
             e.stopPropagation();
             onDismiss();
@@ -83,7 +83,7 @@ export function ChangelogPill({ onClick, onDismiss, visible }: Props) {
             }
           }}
         >
-          <X className="text-muted-foreground h-3.5 w-3.5" />
+          <X className="h-3.5 w-3.5 text-muted-foreground" />
         </span>
       </button>
     </div>

--- a/autogpt_platform/frontend/src/components/changelog/ChangelogProvider.tsx
+++ b/autogpt_platform/frontend/src/components/changelog/ChangelogProvider.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { ChangelogPill } from "./ChangelogPill";
+import { ChangelogModal } from "./ChangelogModal";
+import { useChangelog } from "./use-changelog";
+import type { ChangelogProviderProps } from "./types";
+
+export function ChangelogProvider({
+  hidden,
+  onOpen,
+  onEntryView,
+  seenState,
+}: ChangelogProviderProps = {}) {
+  const cl = useChangelog({ onOpen, onEntryView, hidden, seenState });
+
+  if (hidden) return null;
+
+  return (
+    <>
+      <ChangelogPill
+        visible={cl.pillVisible}
+        onClick={() => cl.setOpen(true)}
+        onDismiss={cl.dismissPill}
+      />
+      <ChangelogModal
+        open={cl.open}
+        onOpenChange={cl.setOpen}
+        activeID={cl.activeId}
+        onActiveIDChange={cl.setActiveId}
+      />
+    </>
+  );
+}

--- a/autogpt_platform/frontend/src/components/changelog/__tests__/manifest.test.ts
+++ b/autogpt_platform/frontend/src/components/changelog/__tests__/manifest.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "vitest";
+import { CHANGELOG_MANIFEST, LATEST_ENTRY } from "../manifest";
+
+describe("CHANGELOG_MANIFEST", () => {
+  test("is non-empty", () => {
+    expect(CHANGELOG_MANIFEST.length).toBeGreaterThan(0);
+  });
+
+  test("every entry has required fields", () => {
+    for (const entry of CHANGELOG_MANIFEST) {
+      expect(typeof entry.id).toBe("string");
+      expect(typeof entry.slug).toBe("string");
+      expect(typeof entry.dateLabel).toBe("string");
+      expect(typeof entry.title).toBe("string");
+      expect(Array.isArray(entry.versions)).toBe(true);
+      expect(entry.versions.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("ids are unique", () => {
+    const ids = CHANGELOG_MANIFEST.map((e) => e.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  test("slugs are unique", () => {
+    const slugs = CHANGELOG_MANIFEST.map((e) => e.slug);
+    expect(new Set(slugs).size).toBe(slugs.length);
+  });
+
+  test("LATEST_ENTRY equals the first manifest entry", () => {
+    expect(LATEST_ENTRY).toBe(CHANGELOG_MANIFEST[0]);
+  });
+});

--- a/autogpt_platform/frontend/src/components/changelog/__tests__/seen-state.test.ts
+++ b/autogpt_platform/frontend/src/components/changelog/__tests__/seen-state.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test, beforeEach, vi } from "vitest";
+import { localStorageAdapter, userPrefsAdapter } from "../seen-state";
+
+const STORAGE_KEY = "autogpt:changelog:lastSeenId";
+
+function makeStorage(): Storage {
+  const store: Record<string, string> = {};
+  return {
+    getItem: (k: string) => store[k] ?? null,
+    setItem: (k: string, v: string) => { store[k] = v; },
+    removeItem: (k: string) => { delete store[k]; },
+    clear: () => { Object.keys(store).forEach((k) => delete store[k]); },
+    key: (i: number) => Object.keys(store)[i] ?? null,
+    get length() { return Object.keys(store).length; },
+  };
+}
+
+beforeEach(() => {
+  Object.defineProperty(globalThis, "localStorage", {
+    value: makeStorage(),
+    writable: true,
+    configurable: true,
+  });
+});
+
+describe("localStorageAdapter", () => {
+  test("read() returns null when nothing stored", async () => {
+    expect(await localStorageAdapter.read()).toBeNull();
+  });
+
+  test("write() then read() round-trips the value", async () => {
+    await localStorageAdapter.write("2026-05-01");
+    expect(await localStorageAdapter.read()).toBe("2026-05-01");
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("2026-05-01");
+  });
+
+  test("read() returns null when localStorage throws", async () => {
+    Object.defineProperty(globalThis, "localStorage", {
+      get() { throw new Error("no storage"); },
+      configurable: true,
+    });
+    expect(await localStorageAdapter.read()).toBeNull();
+  });
+
+  test("write() is silent when localStorage throws", async () => {
+    Object.defineProperty(globalThis, "localStorage", {
+      get() { throw new Error("no storage"); },
+      configurable: true,
+    });
+    await expect(localStorageAdapter.write("2026-05-01")).resolves.toBeUndefined();
+  });
+});
+
+describe("userPrefsAdapter", () => {
+  test("read() fetches remote on first call and caches result", async () => {
+    const fetchFn = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ lastSeenId: "2026-05-01" }),
+    });
+    const adapter = userPrefsAdapter({ fetchFn });
+    const result = await adapter.read();
+    expect(result).toBe("2026-05-01");
+    expect(fetchFn).toHaveBeenCalledOnce();
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("2026-05-01");
+  });
+
+  test("read() returns cached value on subsequent calls", async () => {
+    const fetchFn = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ lastSeenId: "2026-05-01" }),
+    });
+    const adapter = userPrefsAdapter({ fetchFn });
+    await adapter.read();
+    fetchFn.mockClear();
+    const second = await adapter.read();
+    expect(second).toBe("2026-05-01");
+  });
+
+  test("read() returns null when remote returns null lastSeenId", async () => {
+    const fetchFn = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ lastSeenId: null }),
+    });
+    const adapter = userPrefsAdapter({ fetchFn });
+    expect(await adapter.read()).toBeNull();
+  });
+
+  test("read() returns null when remote errors", async () => {
+    const fetchFn = vi.fn().mockRejectedValue(new Error("network error"));
+    const adapter = userPrefsAdapter({ fetchFn });
+    expect(await adapter.read()).toBeNull();
+  });
+
+  test("read() returns null when remote returns non-ok status", async () => {
+    const fetchFn = vi.fn().mockResolvedValue({ ok: false, status: 401 });
+    const adapter = userPrefsAdapter({ fetchFn });
+    expect(await adapter.read()).toBeNull();
+  });
+
+  test("write() updates cache, localStorage, and calls PUT", async () => {
+    const fetchFn = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+    });
+    const adapter = userPrefsAdapter({ endpoint: "/api/prefs", fetchFn });
+    await adapter.write("2026-05-01");
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("2026-05-01");
+    expect(fetchFn).toHaveBeenCalledWith("/api/prefs", expect.objectContaining({
+      method: "PUT",
+      body: JSON.stringify({ lastSeenId: "2026-05-01" }),
+    }));
+  });
+
+  test("write() is non-fatal when PUT errors", async () => {
+    const fetchFn = vi.fn().mockRejectedValue(new Error("offline"));
+    const adapter = userPrefsAdapter({ fetchFn });
+    await expect(adapter.write("2026-05-01")).resolves.toBeUndefined();
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("2026-05-01");
+  });
+
+  test("read() uses localStorage cache if already set", async () => {
+    localStorage.setItem(STORAGE_KEY, "2026-04-09");
+    const fetchFn = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ lastSeenId: "2026-05-01" }),
+    });
+    const adapter = userPrefsAdapter({ fetchFn });
+    const result = await adapter.read();
+    expect(result).toBe("2026-04-09");
+  });
+});

--- a/autogpt_platform/frontend/src/components/changelog/__tests__/seen-state.test.ts
+++ b/autogpt_platform/frontend/src/components/changelog/__tests__/seen-state.test.ts
@@ -7,11 +7,19 @@ function makeStorage(): Storage {
   const store: Record<string, string> = {};
   return {
     getItem: (k: string) => store[k] ?? null,
-    setItem: (k: string, v: string) => { store[k] = v; },
-    removeItem: (k: string) => { delete store[k]; },
-    clear: () => { Object.keys(store).forEach((k) => delete store[k]); },
+    setItem: (k: string, v: string) => {
+      store[k] = v;
+    },
+    removeItem: (k: string) => {
+      delete store[k];
+    },
+    clear: () => {
+      Object.keys(store).forEach((k) => delete store[k]);
+    },
     key: (i: number) => Object.keys(store)[i] ?? null,
-    get length() { return Object.keys(store).length; },
+    get length() {
+      return Object.keys(store).length;
+    },
   };
 }
 
@@ -36,7 +44,9 @@ describe("localStorageAdapter", () => {
 
   test("read() returns null when localStorage throws", async () => {
     Object.defineProperty(globalThis, "localStorage", {
-      get() { throw new Error("no storage"); },
+      get() {
+        throw new Error("no storage");
+      },
       configurable: true,
     });
     expect(await localStorageAdapter.read()).toBeNull();
@@ -44,10 +54,14 @@ describe("localStorageAdapter", () => {
 
   test("write() is silent when localStorage throws", async () => {
     Object.defineProperty(globalThis, "localStorage", {
-      get() { throw new Error("no storage"); },
+      get() {
+        throw new Error("no storage");
+      },
       configurable: true,
     });
-    await expect(localStorageAdapter.write("2026-05-01")).resolves.toBeUndefined();
+    await expect(
+      localStorageAdapter.write("2026-05-01"),
+    ).resolves.toBeUndefined();
   });
 });
 
@@ -105,10 +119,13 @@ describe("userPrefsAdapter", () => {
     const adapter = userPrefsAdapter({ endpoint: "/api/prefs", fetchFn });
     await adapter.write("2026-05-01");
     expect(localStorage.getItem(STORAGE_KEY)).toBe("2026-05-01");
-    expect(fetchFn).toHaveBeenCalledWith("/api/prefs", expect.objectContaining({
-      method: "PUT",
-      body: JSON.stringify({ lastSeenId: "2026-05-01" }),
-    }));
+    expect(fetchFn).toHaveBeenCalledWith(
+      "/api/prefs",
+      expect.objectContaining({
+        method: "PUT",
+        body: JSON.stringify({ lastSeenId: "2026-05-01" }),
+      }),
+    );
   });
 
   test("write() is non-fatal when PUT errors", async () => {

--- a/autogpt_platform/frontend/src/components/changelog/__tests__/use-changelog.test.ts
+++ b/autogpt_platform/frontend/src/components/changelog/__tests__/use-changelog.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, test, vi, beforeEach } from "vitest";
-import { renderHook, act, waitFor } from "@testing-library/react";
+import { describe, expect, test, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
 import { useChangelog } from "../use-changelog";
 import type { SeenStateAdapter } from "../seen-state";
 import { LATEST_ENTRY } from "../manifest";
@@ -30,18 +30,20 @@ beforeEach(() => {
   });
 });
 
+afterEach(() => {
+  vi.useRealTimers();
+});
+
 describe("useChangelog", () => {
   test("pillVisible becomes true after delay when there is an unread entry", async () => {
     const seenState = makeAdapter(null);
     const { result } = renderHook(() => useChangelog({ seenState }));
-    // Not visible before hydration
     expect(result.current.pillVisible).toBe(false);
 
-    // Wait for hydration
     await act(async () => {
       await vi.runAllTimersAsync();
     });
-    await waitFor(() => expect(result.current.pillVisible).toBe(true));
+    expect(result.current.pillVisible).toBe(true);
   });
 
   test("pillVisible stays false when latest entry already seen", async () => {
@@ -86,7 +88,7 @@ describe("useChangelog", () => {
     await act(async () => {
       await vi.runAllTimersAsync();
     });
-    await waitFor(() => expect(result.current.pillVisible).toBe(true));
+    expect(result.current.pillVisible).toBe(true);
 
     act(() => {
       result.current.dismissPill();

--- a/autogpt_platform/frontend/src/components/changelog/__tests__/use-changelog.test.ts
+++ b/autogpt_platform/frontend/src/components/changelog/__tests__/use-changelog.test.ts
@@ -8,7 +8,9 @@ function makeAdapter(initial: string | null = null): SeenStateAdapter {
   let stored = initial;
   return {
     read: vi.fn(async () => stored),
-    write: vi.fn(async (id: string) => { stored = id; }),
+    write: vi.fn(async (id: string) => {
+      stored = id;
+    }),
   };
 }
 
@@ -31,44 +33,48 @@ beforeEach(() => {
 describe("useChangelog", () => {
   test("pillVisible becomes true after delay when there is an unread entry", async () => {
     const seenState = makeAdapter(null);
-    const { result } = renderHook(() =>
-      useChangelog({ seenState })
-    );
+    const { result } = renderHook(() => useChangelog({ seenState }));
     // Not visible before hydration
     expect(result.current.pillVisible).toBe(false);
 
     // Wait for hydration
-    await act(async () => { await vi.runAllTimersAsync(); });
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
     await waitFor(() => expect(result.current.pillVisible).toBe(true));
   });
 
   test("pillVisible stays false when latest entry already seen", async () => {
     const seenState = makeAdapter(LATEST_ENTRY.id);
-    const { result } = renderHook(() =>
-      useChangelog({ seenState })
-    );
-    await act(async () => { await vi.runAllTimersAsync(); });
+    const { result } = renderHook(() => useChangelog({ seenState }));
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
     expect(result.current.pillVisible).toBe(false);
   });
 
   test("pillVisible stays false when hidden=true", async () => {
     const seenState = makeAdapter(null);
     const { result } = renderHook(() =>
-      useChangelog({ seenState, hidden: true })
+      useChangelog({ seenState, hidden: true }),
     );
-    await act(async () => { await vi.runAllTimersAsync(); });
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
     expect(result.current.pillVisible).toBe(false);
   });
 
   test("setOpen(true) hides pill and calls onOpen", async () => {
     const seenState = makeAdapter(null);
     const onOpen = vi.fn();
-    const { result } = renderHook(() =>
-      useChangelog({ seenState, onOpen })
-    );
-    await act(async () => { await vi.runAllTimersAsync(); });
+    const { result } = renderHook(() => useChangelog({ seenState, onOpen }));
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
 
-    act(() => { result.current.setOpen(true); });
+    act(() => {
+      result.current.setOpen(true);
+    });
     expect(result.current.open).toBe(true);
     expect(result.current.pillVisible).toBe(false);
     expect(onOpen).toHaveBeenCalledOnce();
@@ -77,10 +83,14 @@ describe("useChangelog", () => {
   test("dismissPill hides pill and marks seen", async () => {
     const seenState = makeAdapter(null);
     const { result } = renderHook(() => useChangelog({ seenState }));
-    await act(async () => { await vi.runAllTimersAsync(); });
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
     await waitFor(() => expect(result.current.pillVisible).toBe(true));
 
-    act(() => { result.current.dismissPill(); });
+    act(() => {
+      result.current.dismissPill();
+    });
     expect(result.current.pillVisible).toBe(false);
     expect(seenState.write).toHaveBeenCalledWith(LATEST_ENTRY.id);
   });
@@ -89,25 +99,33 @@ describe("useChangelog", () => {
     const seenState = makeAdapter(LATEST_ENTRY.id);
     const onEntryView = vi.fn();
     const { result } = renderHook(() =>
-      useChangelog({ seenState, onEntryView })
+      useChangelog({ seenState, onEntryView }),
     );
-    await act(async () => { await vi.runAllTimersAsync(); });
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
 
-    act(() => { result.current.setActiveId("2026-04-09"); });
+    act(() => {
+      result.current.setActiveId("2026-04-09");
+    });
     expect(onEntryView).toHaveBeenCalledWith("2026-04-09");
   });
 
   test("hasUnread is true when lastSeenId differs from latest", async () => {
     const seenState = makeAdapter("2026-04-09");
     const { result } = renderHook(() => useChangelog({ seenState }));
-    await act(async () => { await vi.runAllTimersAsync(); });
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
     expect(result.current.hasUnread).toBe(true);
   });
 
   test("hasUnread is false when lastSeenId matches latest", async () => {
     const seenState = makeAdapter(LATEST_ENTRY.id);
     const { result } = renderHook(() => useChangelog({ seenState }));
-    await act(async () => { await vi.runAllTimersAsync(); });
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
     expect(result.current.hasUnread).toBe(false);
   });
 });

--- a/autogpt_platform/frontend/src/components/changelog/__tests__/use-changelog.test.ts
+++ b/autogpt_platform/frontend/src/components/changelog/__tests__/use-changelog.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useChangelog } from "../use-changelog";
+import type { SeenStateAdapter } from "../seen-state";
+import { LATEST_ENTRY } from "../manifest";
+
+function makeAdapter(initial: string | null = null): SeenStateAdapter {
+  let stored = initial;
+  return {
+    read: vi.fn(async () => stored),
+    write: vi.fn(async (id: string) => { stored = id; }),
+  };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  Object.defineProperty(globalThis, "localStorage", {
+    value: {
+      getItem: () => null,
+      setItem: () => {},
+      removeItem: () => {},
+      clear: () => {},
+      key: () => null,
+      length: 0,
+    },
+    writable: true,
+    configurable: true,
+  });
+});
+
+describe("useChangelog", () => {
+  test("pillVisible becomes true after delay when there is an unread entry", async () => {
+    const seenState = makeAdapter(null);
+    const { result } = renderHook(() =>
+      useChangelog({ seenState })
+    );
+    // Not visible before hydration
+    expect(result.current.pillVisible).toBe(false);
+
+    // Wait for hydration
+    await act(async () => { await vi.runAllTimersAsync(); });
+    await waitFor(() => expect(result.current.pillVisible).toBe(true));
+  });
+
+  test("pillVisible stays false when latest entry already seen", async () => {
+    const seenState = makeAdapter(LATEST_ENTRY.id);
+    const { result } = renderHook(() =>
+      useChangelog({ seenState })
+    );
+    await act(async () => { await vi.runAllTimersAsync(); });
+    expect(result.current.pillVisible).toBe(false);
+  });
+
+  test("pillVisible stays false when hidden=true", async () => {
+    const seenState = makeAdapter(null);
+    const { result } = renderHook(() =>
+      useChangelog({ seenState, hidden: true })
+    );
+    await act(async () => { await vi.runAllTimersAsync(); });
+    expect(result.current.pillVisible).toBe(false);
+  });
+
+  test("setOpen(true) hides pill and calls onOpen", async () => {
+    const seenState = makeAdapter(null);
+    const onOpen = vi.fn();
+    const { result } = renderHook(() =>
+      useChangelog({ seenState, onOpen })
+    );
+    await act(async () => { await vi.runAllTimersAsync(); });
+
+    act(() => { result.current.setOpen(true); });
+    expect(result.current.open).toBe(true);
+    expect(result.current.pillVisible).toBe(false);
+    expect(onOpen).toHaveBeenCalledOnce();
+  });
+
+  test("dismissPill hides pill and marks seen", async () => {
+    const seenState = makeAdapter(null);
+    const { result } = renderHook(() => useChangelog({ seenState }));
+    await act(async () => { await vi.runAllTimersAsync(); });
+    await waitFor(() => expect(result.current.pillVisible).toBe(true));
+
+    act(() => { result.current.dismissPill(); });
+    expect(result.current.pillVisible).toBe(false);
+    expect(seenState.write).toHaveBeenCalledWith(LATEST_ENTRY.id);
+  });
+
+  test("setActiveId calls onEntryView callback", async () => {
+    const seenState = makeAdapter(LATEST_ENTRY.id);
+    const onEntryView = vi.fn();
+    const { result } = renderHook(() =>
+      useChangelog({ seenState, onEntryView })
+    );
+    await act(async () => { await vi.runAllTimersAsync(); });
+
+    act(() => { result.current.setActiveId("2026-04-09"); });
+    expect(onEntryView).toHaveBeenCalledWith("2026-04-09");
+  });
+
+  test("hasUnread is true when lastSeenId differs from latest", async () => {
+    const seenState = makeAdapter("2026-04-09");
+    const { result } = renderHook(() => useChangelog({ seenState }));
+    await act(async () => { await vi.runAllTimersAsync(); });
+    expect(result.current.hasUnread).toBe(true);
+  });
+
+  test("hasUnread is false when lastSeenId matches latest", async () => {
+    const seenState = makeAdapter(LATEST_ENTRY.id);
+    const { result } = renderHook(() => useChangelog({ seenState }));
+    await act(async () => { await vi.runAllTimersAsync(); });
+    expect(result.current.hasUnread).toBe(false);
+  });
+});

--- a/autogpt_platform/frontend/src/components/changelog/__tests__/use-changelog.test.ts
+++ b/autogpt_platform/frontend/src/components/changelog/__tests__/use-changelog.test.ts
@@ -14,6 +14,17 @@ function makeAdapter(initial: string | null = null): SeenStateAdapter {
   };
 }
 
+async function flushAndAdvance() {
+  // Flush microtasks (resolves adapter.read() promise → sets hydrated)
+  await act(async () => {
+    await Promise.resolve();
+  });
+  // Advance fake timers (fires the PILL_DELAY_MS setTimeout)
+  await act(async () => {
+    vi.advanceTimersByTime(1000);
+  });
+}
+
 beforeEach(() => {
   vi.useFakeTimers();
   Object.defineProperty(globalThis, "localStorage", {
@@ -40,18 +51,14 @@ describe("useChangelog", () => {
     const { result } = renderHook(() => useChangelog({ seenState }));
     expect(result.current.pillVisible).toBe(false);
 
-    await act(async () => {
-      await vi.runAllTimersAsync();
-    });
+    await flushAndAdvance();
     expect(result.current.pillVisible).toBe(true);
   });
 
   test("pillVisible stays false when latest entry already seen", async () => {
     const seenState = makeAdapter(LATEST_ENTRY.id);
     const { result } = renderHook(() => useChangelog({ seenState }));
-    await act(async () => {
-      await vi.runAllTimersAsync();
-    });
+    await flushAndAdvance();
     expect(result.current.pillVisible).toBe(false);
   });
 
@@ -60,9 +67,7 @@ describe("useChangelog", () => {
     const { result } = renderHook(() =>
       useChangelog({ seenState, hidden: true }),
     );
-    await act(async () => {
-      await vi.runAllTimersAsync();
-    });
+    await flushAndAdvance();
     expect(result.current.pillVisible).toBe(false);
   });
 
@@ -70,9 +75,7 @@ describe("useChangelog", () => {
     const seenState = makeAdapter(null);
     const onOpen = vi.fn();
     const { result } = renderHook(() => useChangelog({ seenState, onOpen }));
-    await act(async () => {
-      await vi.runAllTimersAsync();
-    });
+    await flushAndAdvance();
 
     act(() => {
       result.current.setOpen(true);
@@ -85,9 +88,7 @@ describe("useChangelog", () => {
   test("dismissPill hides pill and marks seen", async () => {
     const seenState = makeAdapter(null);
     const { result } = renderHook(() => useChangelog({ seenState }));
-    await act(async () => {
-      await vi.runAllTimersAsync();
-    });
+    await flushAndAdvance();
     expect(result.current.pillVisible).toBe(true);
 
     act(() => {
@@ -103,9 +104,7 @@ describe("useChangelog", () => {
     const { result } = renderHook(() =>
       useChangelog({ seenState, onEntryView }),
     );
-    await act(async () => {
-      await vi.runAllTimersAsync();
-    });
+    await flushAndAdvance();
 
     act(() => {
       result.current.setActiveId("2026-04-09");
@@ -116,18 +115,14 @@ describe("useChangelog", () => {
   test("hasUnread is true when lastSeenId differs from latest", async () => {
     const seenState = makeAdapter("2026-04-09");
     const { result } = renderHook(() => useChangelog({ seenState }));
-    await act(async () => {
-      await vi.runAllTimersAsync();
-    });
+    await flushAndAdvance();
     expect(result.current.hasUnread).toBe(true);
   });
 
   test("hasUnread is false when lastSeenId matches latest", async () => {
     const seenState = makeAdapter(LATEST_ENTRY.id);
     const { result } = renderHook(() => useChangelog({ seenState }));
-    await act(async () => {
-      await vi.runAllTimersAsync();
-    });
+    await flushAndAdvance();
     expect(result.current.hasUnread).toBe(false);
   });
 });

--- a/autogpt_platform/frontend/src/components/changelog/manifest.ts
+++ b/autogpt_platform/frontend/src/components/changelog/manifest.ts
@@ -1,0 +1,69 @@
+// src/components/changelog/manifest.ts
+// ─────────────────────────────────────────────────────────────────────────────
+// AUTO-GENERATED — do not edit by hand.
+// Run `pnpm changelog:generate` to regenerate.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import type { ChangelogEntry } from "./types";
+
+export const CHANGELOG_MANIFEST: ChangelogEntry[] = [
+  {
+    id: "2026-05-01",
+    slug: "april-10-may-1-2026",
+    dateLabel: "April 10 – May 1, 2026",
+    title: "Artifacts, Briefings, and Builder Chat",
+    versions: ["v0.6.55", "v0.6.56", "v0.6.57", "v0.6.58"],
+    isHighlighted: true,
+  },
+  {
+    id: "2026-04-09",
+    slug: "march-23-april-9-2026",
+    dateLabel: "March 23 – April 9, 2026",
+    title: "Themed prompts, live timer stats, redesigned onboarding",
+    versions: ["v0.6.54"],
+  },
+  {
+    id: "2026-03-25",
+    slug: "march-20-march-25-2026",
+    dateLabel: "March 20 – March 25, 2026",
+    title: "Import workflows from other platforms",
+    versions: ["v0.6.53"],
+  },
+  {
+    id: "2026-03-20",
+    slug: "march-13-march-20-2026",
+    dateLabel: "March 13 – March 20, 2026",
+    title: "Refreshed marketplace, usage monitor, feedback button",
+    versions: ["v0.6.52"],
+  },
+  {
+    id: "2026-03-12",
+    slug: "march-5-march-12-2026",
+    dateLabel: "March 5 – March 12, 2026",
+    title: "Folders, notifications, cleaner reasoning, inline outputs",
+    versions: ["v0.6.51"],
+  },
+  {
+    id: "2026-03-04",
+    slug: "february-26-march-4-2026",
+    dateLabel: "February 26 – March 4, 2026",
+    title: "Connect any app, share files, browse the web, run code",
+    versions: ["v0.6.50"],
+  },
+  {
+    id: "2026-02-26",
+    slug: "february-11-february-26-2026",
+    dateLabel: "February 11 – 26, 2026",
+    title: "Telegram bots, agent folders, rebuilt flow editor",
+    versions: ["v0.6.49"],
+  },
+  {
+    id: "2026-02-11",
+    slug: "january-29-february-11-2026",
+    dateLabel: "January 29 – February 11, 2026",
+    title: "Voice input, persistent file workspace, Claude Opus 4.6",
+    versions: ["v0.6.48"],
+  },
+];
+
+export const LATEST_ENTRY = CHANGELOG_MANIFEST[0];

--- a/autogpt_platform/frontend/src/components/changelog/seen-state.ts
+++ b/autogpt_platform/frontend/src/components/changelog/seen-state.ts
@@ -1,0 +1,114 @@
+// src/components/changelog/seen-state.ts
+
+const STORAGE_KEY = "autogpt:changelog:lastSeenId";
+
+export interface SeenStateAdapter {
+  read(): Promise<string | null>;
+  write(id: string): Promise<void>;
+}
+
+export const localStorageAdapter: SeenStateAdapter = {
+  async read() {
+    try {
+      return localStorage.getItem(STORAGE_KEY);
+    } catch {
+      return null;
+    }
+  },
+  async write(id) {
+    try {
+      localStorage.setItem(STORAGE_KEY, id);
+    } catch {
+      // localStorage unavailable — accept the loss
+    }
+  },
+};
+
+interface UserPrefsAdapterOpts {
+  endpoint?: string;
+  fetchFn?: typeof fetch;
+}
+
+export function userPrefsAdapter(
+  opts: UserPrefsAdapterOpts = {},
+): SeenStateAdapter {
+  const endpoint = opts.endpoint ?? "/api/me/preferences/changelog";
+  const f = opts.fetchFn ?? fetch;
+
+  const readCache = (): string | null => {
+    try {
+      return localStorage.getItem(STORAGE_KEY);
+    } catch {
+      return null;
+    }
+  };
+  const writeCache = (id: string): void => {
+    try {
+      localStorage.setItem(STORAGE_KEY, id);
+    } catch {
+      // ignore
+    }
+  };
+
+  let cached = readCache();
+  let revalidating = false;
+
+  async function fetchRemote(): Promise<string | null> {
+    const res = await f(endpoint, { credentials: "include" });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const json = (await res.json()) as { lastSeenId?: string | null };
+    return json.lastSeenId ?? null;
+  }
+
+  function revalidateInBackground() {
+    if (revalidating) return;
+    revalidating = true;
+    fetchRemote()
+      .then((remote) => {
+        if (remote && remote !== cached) {
+          cached = remote;
+          writeCache(remote);
+        }
+      })
+      .catch(() => {
+        // offline / 5xx — keep cached value
+      })
+      .finally(() => {
+        revalidating = false;
+      });
+  }
+
+  return {
+    async read() {
+      if (cached !== null) {
+        revalidateInBackground();
+        return cached;
+      }
+      try {
+        const remote = await fetchRemote();
+        if (remote) {
+          cached = remote;
+          writeCache(remote);
+        }
+        return remote;
+      } catch {
+        return null;
+      }
+    },
+
+    async write(id) {
+      cached = id;
+      writeCache(id);
+      try {
+        await f(endpoint, {
+          method: "PUT",
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ lastSeenId: id }),
+        });
+      } catch {
+        // non-fatal — local cache persists, next session retries
+      }
+    },
+  };
+}

--- a/autogpt_platform/frontend/src/components/changelog/types.ts
+++ b/autogpt_platform/frontend/src/components/changelog/types.ts
@@ -1,0 +1,21 @@
+// src/components/changelog/types.ts
+
+import type { SeenStateAdapter } from "./seen-state";
+
+export interface ChangelogEntry {
+  id: string;
+  slug: string;
+  dateLabel: string;
+  title: string;
+  versions: string[];
+  isHighlighted?: boolean;
+}
+
+export interface ChangelogProviderProps {
+  hidden?: boolean;
+  onOpen?: () => void;
+  onEntryView?: (entryId: string) => void;
+  seenState?: SeenStateAdapter;
+}
+
+export type { SeenStateAdapter } from "./seen-state";

--- a/autogpt_platform/frontend/src/components/changelog/use-changelog.ts
+++ b/autogpt_platform/frontend/src/components/changelog/use-changelog.ts
@@ -1,0 +1,100 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { CHANGELOG_MANIFEST, LATEST_ENTRY } from "./manifest";
+import { localStorageAdapter, type SeenStateAdapter } from "./seen-state";
+
+const PILL_DELAY_MS = 800;
+
+export function useChangelog(opts?: {
+  onOpen?: () => void;
+  onEntryView?: (id: string) => void;
+  hidden?: boolean;
+  seenState?: SeenStateAdapter;
+}) {
+  const adapterRef = useRef<SeenStateAdapter>(
+    opts?.seenState ?? localStorageAdapter,
+  );
+  const adapter = adapterRef.current;
+
+  const [open, setOpenState] = useState(false);
+  const [pillVisible, setPillVisible] = useState(false);
+  const [activeId, setActiveIdState] = useState(LATEST_ENTRY.id);
+  const [lastSeenId, setLastSeenId] = useState<string | null>(null);
+  const [hydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    adapter
+      .read()
+      .then((value) => {
+        if (cancelled) return;
+        setLastSeenId(value);
+        setHydrated(true);
+      })
+      .catch(() => {
+        if (!cancelled) setHydrated(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [adapter]);
+
+  const hasUnread = hydrated && lastSeenId !== LATEST_ENTRY.id;
+
+  useEffect(() => {
+    if (!hydrated || opts?.hidden || !hasUnread) {
+      setPillVisible(false);
+      return;
+    }
+    const timer = setTimeout(() => setPillVisible(true), PILL_DELAY_MS);
+    return () => clearTimeout(timer);
+  }, [hydrated, opts?.hidden, hasUnread]);
+
+  function markSeen() {
+    setLastSeenId(LATEST_ENTRY.id);
+    void adapter.write(LATEST_ENTRY.id);
+  }
+
+  function setOpen(next: boolean) {
+    setOpenState(next);
+    if (next) {
+      setPillVisible(false);
+      markSeen();
+      opts?.onOpen?.();
+    }
+  }
+
+  function dismissPill() {
+    setPillVisible(false);
+    markSeen();
+  }
+
+  function setActiveId(id: string) {
+    setActiveIdState(id);
+    opts?.onEntryView?.(id);
+  }
+
+  useEffect(() => {
+    function handler(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && e.key === "/") {
+        e.preventDefault();
+        setOpen(!open);
+      }
+    }
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [open]);
+
+  return {
+    open,
+    setOpen,
+    pillVisible,
+    dismissPill,
+    activeId,
+    setActiveId,
+    hasUnread,
+  };
+}
+
+export { CHANGELOG_MANIFEST };


### PR DESCRIPTION
### Why / What / How

**Why:** The AutoGPT platform has no way to surface new features and updates to users in-app. Without a "What's New" changelog module, users miss new capabilities and the team has no lightweight channel to announce improvements.

**What:** Adds a self-contained changelog module with a bottom-left pill notification and a full modal browser. Users see an unread badge when new entries exist; clicking opens a sidebar-nav + content pane modal that renders markdown entries fetched from `agpt.co`. Seen state is persisted in `localStorage` (with an optional server-side adapter for cross-device sync).

**How:**
- `useChangelog` hook manages open/pill/seen state with an 800ms pill delay and a Ctrl+/ keyboard shortcut.
- `ChangelogProvider` wraps the app and renders `ChangelogPill` + `ChangelogModal` as siblings.
- `ChangelogModal` uses `@radix-ui/react-dialog` primitives directly (same pattern as `sheet.tsx`).
- A Next.js API route at `/api/changelog/[slug]` proxies markdown from `aggt.co` with allowlist security, 1hr cache + 24hr stale-while-revalidate.
- A Next.js API route at `/api/me/preferences/changelog` proxies user seen-state to the Python backend.
- A FastAPI router at `/preferences/changelog` (GET + PUT) upserts a `UserPreference` record; 3 TODOs are left for wiring auth, Prisma, and router mounting.
- A `generate-changelog-manifest` build script scrapes the `aggt.co` docs index and rewrites `manifest.ts` at build time.

### Changes 🏗️

**Frontend (`autogpt_platform/frontend`)**
- `src/components/changelog/types.ts` — shared TypeScript interfaces (`ChangelogEntry`, `ChangelogProviderProps`, `SeenStateAdapter`)
- `src/components/changelog/seen-state.ts` — `localStorageAdapter` and `userPrefsAdapter` factory (write-through cache)
- `src/components/changelog/manifest.ts` — initial 8-entry manifest; overwritten by build script
- `src/components/changelog/use-changelog.ts` — hook for open/pill/seen state
- `src/components/changelog/ChangelogPill.tsx` — bottom-left pill notification with unread badge
- `src/components/changelog/ChangelogContent.tsx` — single-entry markdown renderer (`react-markdown` + `remark-gfm` + `rehype-raw`)
- `src/components/changelog/ChangelogModal.tsx` — sidebar-nav + content-pane modal
- `src/components/changelog/ChangelogProvider.tsx` — root provider wiring everything together
- `src/app/api/changelog/[slug]/route.ts` — markdown proxy API route
- `src/app/api/me/preferences/changelog/route.ts` — preferences proxy API route
- `scripts/generate-changelog-manifest.ts` — build-time manifest generator
- `package.json` — added `rehype-raw ^7.0.0`

**Backend (`autogpt_platform/backend`)**
- `backend/server/v2/preferences/__init__.py` — package init
- `backend/server/v2/preferences/routes.py` — FastAPI preferences router (3 integration TODOs)
- `schema.prisma.changelog.snippet` — `UserPreference` Prisma model snippet with migration instructions

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [ ] Mount `<ChangelogProvider>` in the app layout and verify the pill appears after 800ms on first visit
  - [ ] Click the pill and verify the modal opens with sidebar nav and markdown content
  - [ ] Mark entries as read; reload and verify pill is hidden
  - [ ] Press Ctrl+/ and verify the modal toggles
  - [ ] Verify the `/api/changelog/[slug]` route returns markdown for valid slugs and 403 for unknown slugs
  - [ ] Verify `pnpm format`, `pnpm lint`, `pnpm types` pass

#### For configuration changes:

- [x] `.env.default` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes
- [x] I have included a list of my configuration changes in the PR description (under **Changes**)
