### PR TITLE
ci(platform): pin pnpm via pnpm/action-setup before setup-node

### DIFF
--- a/.github/workflows/platform-fullstack-ci.yml
+++ b/.github/workflows/platform-fullstack-ci.yml
@@ -33,8 +33,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Enable corepack
-        run: corepack enable
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          package_json_file: autogpt_platform/frontend/package.json
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -91,8 +93,10 @@ jobs:
 
       # ------------------------ Frontend setup ------------------------
 
-      - name: Set up Frontend - Enable corepack
-        run: corepack enable
+      - name: Set up Frontend - Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          package_json_file: autogpt_platform/frontend/package.json
 
       - name: Set up Frontend - Set up Node
         uses: actions/setup-node@v6
@@ -279,8 +283,10 @@ jobs:
 
           echo "✅ Database dump created for caching ($(wc -l < /tmp/e2e_test_data.sql) lines)"
 
-      - name: Set up tests - Enable corepack
-        run: corepack enable
+      - name: Set up tests - Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          package_json_file: autogpt_platform/frontend/package.json
 
       - name: Set up tests - Set up Node
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Why

`platform-fullstack-ci.yml` reliably reports a red `setup` and `end-to-end tests` even when every actual step passes. The failure is the post-job cache save in `actions/setup-node@v6`:

```
##[error]Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.
```

Tracing one of the failed runs (e.g. PR #13024, job 74806760603) shows:

1. The job runs `corepack enable`, which only installs shims.
2. `actions/setup-node@v6` resolves the pnpm cache path by running `pnpm store path` from the repo root.
3. The repo root has no `packageManager` field, so corepack falls back to its default — currently pnpm `11.x` — and the resolved path is `~/.local/share/pnpm/store/v11`.
4. The actual `pnpm install` runs from `autogpt_platform/frontend/`, where `packageManager` pins `pnpm@10.20.0`, so the populated store is `~/.local/share/pnpm/store/v10`.
5. Post-job tries to save the never-populated `v11` path → the validation error above. The job is marked failed even though Playwright, the Docker stack, and every real step succeed.

## What

Replace `corepack enable` with `pnpm/action-setup@v4` keyed off `autogpt_platform/frontend/package.json` in all three `actions/setup-node@v6` consumers in this workflow:

- the `setup` job
- the Frontend section of `check-api-types`
- the `e2e_test` job

## How

`pnpm/action-setup@v4` reads `packageManager` from the file pointed to by `package_json_file`, installs that exact pnpm version onto `PATH`, and runs before `setup-node` resolves the cache path. The path `setup-node` sees and the path `pnpm install` populates now both resolve to `~/.local/share/pnpm/store/v10`, so the post-job cache save succeeds.

`platform-frontend-ci.yml` uses the same `corepack enable` + `setup-node@v6` pattern, but its dev runs are currently green — likely because its cache key lands a hit and post-job skips path validation. Left untouched here to keep the PR scoped; can apply the same change in a follow-up if it starts flaking.

## Test plan
- [ ] Push triggers the workflow on this PR; the `setup`, `check-api-types`, and `end-to-end tests` jobs no longer fail in `Post Set up Node`.
- [ ] Confirm `pnpm install` still uses `pnpm@10.20.0` (visible in `Set up Frontend - Set up pnpm` / `Set up tests - Set up pnpm` step output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
