### PR TITLE
ci(platform): pin pnpm via pnpm/action-setup in frontend CI

### DIFF
--- a/.github/workflows/platform-frontend-ci.yml
+++ b/.github/workflows/platform-frontend-ci.yml
@@ -46,8 +46,10 @@ jobs:
             components:
               - 'autogpt_platform/frontend/src/components/**'
 
-      - name: Enable corepack
-        run: corepack enable
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          package_json_file: autogpt_platform/frontend/package.json
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -67,8 +69,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Enable corepack
-        run: corepack enable
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          package_json_file: autogpt_platform/frontend/package.json
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -98,8 +102,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Enable corepack
-        run: corepack enable
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          package_json_file: autogpt_platform/frontend/package.json
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -130,8 +136,10 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Enable corepack
-        run: corepack enable
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          package_json_file: autogpt_platform/frontend/package.json
 
       - name: Set up Node
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Why

Follow-up to #13025. That PR fixed `platform-fullstack-ci.yml` but explicitly left `platform-frontend-ci.yml` alone because its dev runs were green (cache hits were masking the bug). On PR #13024 — after merging dev — the `setup` job in `platform-frontend-ci.yml` started failing with the exact same error this fix was made for:

```
##[error]Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.
```

The job log shows `Install dependencies to populate cache` running pnpm 10.20.0 successfully, then the `Post Set up Node` step erroring on the cache save. (Run: https://github.com/Significant-Gravitas/AutoGPT/actions/runs/25495084705/job/74812610294.)

## What

Replace `corepack enable` with `pnpm/action-setup@v4` keyed off `autogpt_platform/frontend/package.json` in all four `actions/setup-node@v6` consumers in this workflow:

- `setup`
- `lint`
- `chromatic`
- `integration_test`

## How

Same mechanism as #13025: `corepack enable` only installs shims; `actions/setup-node@v6` runs `pnpm store path` from the repo root, which has no `packageManager` field, so corepack falls back to its default (currently pnpm `11.x`) and the resolved cache path is `~/.local/share/pnpm/store/v11`. The actual `pnpm install` runs from `autogpt_platform/frontend/`, where `packageManager` pins `pnpm@10.20.0`, populating `~/.local/share/pnpm/store/v10`. Post-job tries to save the never-populated v11 path and fails.

`pnpm/action-setup@v4` reads `packageManager` from the file pointed to by `package_json_file` and installs that exact pnpm version onto `PATH` before `setup-node` resolves the cache path. The path `setup-node` sees and the path `pnpm install` populates both resolve to v10.

## Test plan
- [ ] After this merges, re-merge `dev` into PR #13024 (or any open PR) and confirm `setup`, `lint`, and `integration_test` no longer red out on `Post Set up Node`.
- [ ] Confirm the step output continues to show `Done in <Ns> using pnpm v10.20.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
