### PR TITLE
perf(backend): drop eager-include on notification batch reads

### DIFF
--- a/autogpt_platform/backend/backend/data/notifications.py
+++ b/autogpt_platform/backend/backend/data/notifications.py
@@ -521,21 +521,15 @@ async def get_user_notification_oldest_message_in_batch(
     notification_type: NotificationType,
 ) -> UserNotificationEventDTO | None:
     try:
-        batch = await UserNotificationBatch.prisma().find_first(
-            where={"userId": user_id, "type": notification_type},
-            include={"Notifications": True},
+        oldest = await NotificationEvent.prisma().find_first(
+            where={
+                "UserNotificationBatch": {
+                    "is": {"userId": user_id, "type": notification_type}
+                }
+            },
+            order={"createdAt": "asc"},
         )
-        if not batch:
-            return None
-        if not batch.Notifications:
-            return None
-        sorted_notifications = sorted(batch.Notifications, key=lambda x: x.createdAt)
-
-        return (
-            UserNotificationEventDTO.from_db(sorted_notifications[0])
-            if sorted_notifications
-            else None
-        )
+        return UserNotificationEventDTO.from_db(oldest) if oldest else None
     except Exception as e:
         raise DatabaseError(
             f"Failed to get user notification last message in batch for user {user_id} and type {notification_type}: {e}"
@@ -659,6 +653,7 @@ async def get_user_notification_batch(
 async def get_all_batches_by_type(
     notification_type: NotificationType,
 ) -> list[UserNotificationBatchDTO]:
+    # Caller re-fetches events per batch when actually sending; no eager include here.
     try:
         batches = await UserNotificationBatch.prisma().find_many(
             where={
@@ -667,7 +662,6 @@ async def get_all_batches_by_type(
                     "some": {}  # Only return batches with at least one notification
                 },
             },
-            include={"Notifications": True},
         )
         return [UserNotificationBatchDTO.from_db(batch) for batch in batches]
     except Exception as e:

--- a/autogpt_platform/backend/backend/data/notifications_test.py
+++ b/autogpt_platform/backend/backend/data/notifications_test.py
@@ -19,6 +19,8 @@ from backend.data.notifications import (
     NotificationEventModel,
     create_or_add_to_user_notification_batch,
     empty_user_notification_batch,
+    get_all_batches_by_type,
+    get_user_notification_oldest_message_in_batch,
 )
 from backend.util.test import SpinTestServer
 
@@ -394,5 +396,69 @@ async def test_upsert_retries_on_unique_violation(
             where={"UserNotificationBatch": {"is": {"userId": user_id}}}
         )
         assert event_count == 2
+    finally:
+        await _cleanup_test_user(user_id)
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_get_oldest_message_returns_single_event(server: SpinTestServer):
+    # Hot-path egress fix: must return a single oldest event without dragging
+    # the whole batch back through Prisma's eager-include path.
+    user_id = f"notif-oldest-{uuid4()}"
+    await _create_test_user(user_id)
+
+    try:
+        for i in range(5):
+            await create_or_add_to_user_notification_batch(
+                user_id=user_id,
+                notification_type=NotificationType.AGENT_RUN,
+                notification_data=_make_agent_run_event(user_id, agent_name=f"e{i}"),
+            )
+
+        oldest = await get_user_notification_oldest_message_in_batch(
+            user_id, NotificationType.AGENT_RUN
+        )
+        assert oldest is not None
+        all_events = await NotificationEvent.prisma().find_many(
+            where={"UserNotificationBatch": {"is": {"userId": user_id}}},
+            order={"createdAt": "asc"},
+        )
+        assert oldest.created_at == all_events[0].createdAt
+    finally:
+        await _cleanup_test_user(user_id)
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_get_oldest_message_returns_none_when_empty(server: SpinTestServer):
+    user_id = f"notif-oldest-empty-{uuid4()}"
+    await _create_test_user(user_id)
+    try:
+        oldest = await get_user_notification_oldest_message_in_batch(
+            user_id, NotificationType.AGENT_RUN
+        )
+        assert oldest is None
+    finally:
+        await _cleanup_test_user(user_id)
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_get_all_batches_does_not_eager_load_events(server: SpinTestServer):
+    # Caller iterates batches and re-fetches events per batch when actually
+    # sending; loading them here was the egress hot path.
+    user_id = f"notif-allbatches-{uuid4()}"
+    await _create_test_user(user_id)
+
+    try:
+        for i in range(3):
+            await create_or_add_to_user_notification_batch(
+                user_id=user_id,
+                notification_type=NotificationType.AGENT_RUN,
+                notification_data=_make_agent_run_event(user_id, agent_name=f"e{i}"),
+            )
+
+        batches = await get_all_batches_by_type(NotificationType.AGENT_RUN)
+        mine = [b for b in batches if b.user_id == user_id]
+        assert len(mine) == 1
+        assert mine[0].notifications == []
     finally:
         await _cleanup_test_user(user_id)


### PR DESCRIPTION
## Why

Egress on the `agpt-prod` and `agpt-test` Supabase projects is dominated by a single query:

```sql
SELECT … FROM "platform"."NotificationEvent"
WHERE "userNotificationBatchId" IN ($1) OFFSET $2
```

Per `pg_stat_statements`:

| | calls | rows returned |
|---|---:|---:|
| prod | 455,803 | 281,229,277 |
| dev  | 820,787 | 347,820,981 |

It's the #1 query by row volume in both environments. The shape (`IN ($1)` with a single bind param) is Prisma materializing an eager `include={"Notifications": True}` — one IN-with-one-id per batch, run per polling iteration.

The email batcher in `notifications.py::_process_existing_batches` polls open batches per `NotificationType`, and:

1. `get_all_batches_by_type` returns every open batch with all events eager-loaded — but the caller only reads `batch.user_id`.
2. `get_user_notification_oldest_message_in_batch` fetches the batch + all events and sorts them in Python just to grab `[0]`.

So every poll iteration drags the full event payload back even when nothing is aged out and nothing will be sent. The existing fix in `create_or_add_to_user_notification_batch` already documents this exact failure mode for heavy `AGENT_RUN` users (see [notifications.py:467-472](https://github.com/Significant-Gravitas/AutoGPT/blob/dev/autogpt_platform/backend/backend/data/notifications.py#L467-L472)), but the read paths still had it.

## What

- `get_user_notification_oldest_message_in_batch` queries `NotificationEvent` directly with `order={"createdAt": "asc"}` and returns the single oldest row.
- `get_all_batches_by_type` drops the `include={"Notifications": True}`; the caller re-fetches events per batch via `get_user_notification_batch` only when an email actually needs to send.

## How

Both changes are equivalent at the call-site level:

- `_process_existing_batches` only reads `batch.user_id` from the list result and `oldest_message.created_at` from the oldest-event result — both still satisfied.
- `_should_email_user_based_on_aged_batch` (the other caller of the oldest-message query) only reads `oldest_message.created_at` — also satisfied.
- `UserNotificationBatchDTO.from_db` already tolerates `model.Notifications` being `None` (`for n in model.Notifications or []`), so the dropped include is safe.

Three integration tests added in `notifications_test.py` covering the new contract: oldest event returned by `createdAt`, `None` on empty batch, and `get_all_batches_by_type` not loading events.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas (n/a — minimal change, behaviour is obvious)
- [x] I have made corresponding changes to the documentation (n/a)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes (lint/format clean; integration tests run in CI against the test DB)
- [x] Any dependent changes have been merged and published in downstream modules
