### PR TITLE
perf(backend): cut three top egress queries via aggregation + caps

### DIFF
--- a/autogpt_platform/backend/backend/copilot/db.py
+++ b/autogpt_platform/backend/backend/copilot/db.py
@@ -255,7 +255,7 @@ async def update_chat_session(
     total_prompt_tokens: int | None = None,
     total_completion_tokens: int | None = None,
     title: str | None = None,
-) -> ChatSession | None:
+) -> ChatSessionInfo | None:
     """Update a chat session's mutable fields.
 
     Note: ``metadata`` (which includes ``dry_run``) is intentionally omitted —
@@ -277,12 +277,14 @@ async def update_chat_session(
     if title is not None:
         data["title"] = title
 
+    # Returns the bare session row (no eager Messages include): pulling the
+    # full message history per update was a top-egress query, and the only
+    # caller ignores the return value.
     session = await PrismaChatSession.prisma().update(
         where={"id": session_id},
         data=data,
-        include={"Messages": {"order_by": {"sequence": "asc"}}},
     )
-    return ChatSession.from_db(session) if session else None
+    return ChatSessionInfo.from_db(session) if session else None
 
 
 async def update_chat_session_title(

--- a/autogpt_platform/backend/backend/data/execution.py
+++ b/autogpt_platform/backend/backend/data/execution.py
@@ -60,6 +60,7 @@ from .includes import (
     EXECUTION_RESULT_INCLUDE,
     EXECUTION_RESULT_ORDER,
     GRAPH_EXECUTION_INCLUDE_WITH_NODES,
+    MAX_NODE_INPUT_OUTPUT_FETCH,
     graph_execution_include,
 )
 from .model import (
@@ -457,7 +458,14 @@ class NodeExecutionResult(BaseModel):
             input_data = type_utils.convert(_node_exec.executionData, BlockInput)
         else:
             input_data: BlockInput = defaultdict()
-            for data in _node_exec.Input or []:
+            inputs = _node_exec.Input or []
+            if len(inputs) >= MAX_NODE_INPUT_OUTPUT_FETCH:
+                logger.warning(
+                    "NodeExecution %s Input rows hit MAX_NODE_INPUT_OUTPUT_FETCH "
+                    "cap; result may be truncated",
+                    _node_exec.id,
+                )
+            for data in inputs:
                 input_data[data.name] = type_utils.convert(data.data, JsonValue)
 
         output_data: CompletedBlockOutput = defaultdict(list)
@@ -466,7 +474,14 @@ class NodeExecutionResult(BaseModel):
             for name, messages in stats.cleared_outputs.items():
                 output_data[name].extend(messages)
         else:
-            for data in _node_exec.Output or []:
+            outputs = _node_exec.Output or []
+            if len(outputs) >= MAX_NODE_INPUT_OUTPUT_FETCH:
+                logger.warning(
+                    "NodeExecution %s Output rows hit MAX_NODE_INPUT_OUTPUT_FETCH "
+                    "cap; result may be truncated",
+                    _node_exec.id,
+                )
+            for data in outputs:
                 output_data[data.name].append(type_utils.convert(data.data, JsonValue))
 
         graph_execution: AgentGraphExecution | None = _node_exec.GraphExecution

--- a/autogpt_platform/backend/backend/data/execution_io_cap_test.py
+++ b/autogpt_platform/backend/backend/data/execution_io_cap_test.py
@@ -1,0 +1,82 @@
+"""Coverage for the cap-hit warning path on NodeExecutionResult.from_db."""
+
+import logging
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+from prisma.enums import AgentExecutionStatus
+
+from backend.data.execution import NodeExecutionResult
+from backend.data.includes import MAX_NODE_INPUT_OUTPUT_FETCH
+
+
+def _make_io_row(name: str, value: str) -> MagicMock:
+    row = MagicMock()
+    row.name = name
+    row.data = value
+    return row
+
+
+def _make_node_exec(*, inputs: list, outputs: list, exec_id: str = "ne-1") -> MagicMock:
+    ne = MagicMock()
+    ne.id = exec_id
+    ne.stats = {}
+    ne.executionData = None
+    ne.Input = inputs
+    ne.Output = outputs
+    ne.agentGraphExecutionId = "ge-1"
+    ne.agentNodeId = "n-1"
+    ne.executionStatus = AgentExecutionStatus.COMPLETED
+    ne.addedTime = datetime.now(timezone.utc)
+    ne.queuedTime = None
+    ne.startedTime = None
+    ne.endedTime = None
+
+    ne.Node = MagicMock()
+    ne.Node.agentBlockId = "blk-1"
+
+    ne.GraphExecution = MagicMock()
+    ne.GraphExecution.userId = "u-1"
+    ne.GraphExecution.agentGraphId = "g-1"
+    ne.GraphExecution.agentGraphVersion = 1
+    return ne
+
+
+def test_node_exec_input_cap_logs_warning(caplog):
+    inputs = [
+        _make_io_row(f"in_{i}", f"v{i}") for i in range(MAX_NODE_INPUT_OUTPUT_FETCH)
+    ]
+    ne = _make_node_exec(inputs=inputs, outputs=[])
+
+    with caplog.at_level(logging.WARNING, logger="backend.data.execution"):
+        result = NodeExecutionResult.from_db(ne)
+
+    assert any(
+        "Input rows hit MAX_NODE_INPUT_OUTPUT_FETCH" in m for m in caplog.messages
+    )
+    assert isinstance(result, NodeExecutionResult)
+
+
+def test_node_exec_output_cap_logs_warning(caplog):
+    outputs = [_make_io_row("out", f"v{i}") for i in range(MAX_NODE_INPUT_OUTPUT_FETCH)]
+    ne = _make_node_exec(inputs=[], outputs=outputs)
+
+    with caplog.at_level(logging.WARNING, logger="backend.data.execution"):
+        result = NodeExecutionResult.from_db(ne)
+
+    assert any(
+        "Output rows hit MAX_NODE_INPUT_OUTPUT_FETCH" in m for m in caplog.messages
+    )
+    assert isinstance(result, NodeExecutionResult)
+
+
+def test_node_exec_under_cap_does_not_warn(caplog):
+    inputs = [_make_io_row(f"in_{i}", f"v{i}") for i in range(3)]
+    outputs = [_make_io_row("out", f"v{i}") for i in range(3)]
+    ne = _make_node_exec(inputs=inputs, outputs=outputs)
+
+    with caplog.at_level(logging.WARNING, logger="backend.data.execution"):
+        result = NodeExecutionResult.from_db(ne)
+
+    assert not any("MAX_NODE_INPUT_OUTPUT_FETCH" in m for m in caplog.messages)
+    assert isinstance(result, NodeExecutionResult)

--- a/autogpt_platform/backend/backend/data/generate_data.py
+++ b/autogpt_platform/backend/backend/data/generate_data.py
@@ -2,6 +2,8 @@ import asyncio
 import logging
 from datetime import datetime
 
+from pydantic import BaseModel, Field
+
 from backend.data.db import query_raw_with_schema
 from backend.data.graph import get_graph_metadata
 from backend.data.model import UserExecutionSummaryStats
@@ -9,6 +11,17 @@ from backend.util.exceptions import DatabaseError
 from backend.util.logging import TruncatedLogger
 
 logger = TruncatedLogger(logging.getLogger(__name__), prefix="[SummaryData]")
+
+
+class _ExecutionAggregates(BaseModel):
+    total_executions: int = 0
+    successful_runs: int = 0
+    failed_runs: int = 0
+    total_cost_cents: float = 0.0
+    total_walltime: float = 0.0
+    walltime_count: int = 0
+    cost_by_graph_id: dict[str, float] = Field(default_factory=dict)
+    usage_by_graph_id: dict[str, int] = Field(default_factory=dict)
 
 
 async def get_user_execution_summary_data(
@@ -21,91 +34,98 @@ async def get_user_execution_summary_data(
     making this the dominant row-egress query in the prior implementation.
     """
     try:
-        rows = await query_raw_with_schema(
-            """
-            SELECT
-                "agentGraphId" AS graph_id,
-                COUNT(*) AS total,
-                COUNT(*) FILTER (WHERE "executionStatus" = 'COMPLETED') AS successful,
-                COUNT(*) FILTER (WHERE "executionStatus" IN ('FAILED', 'TERMINATED')) AS failed,
-                COALESCE(SUM(("stats"::jsonb->>'cost')::numeric), 0) AS total_cost_cents,
-                COALESCE(SUM(("stats"::jsonb->>'walltime')::numeric), 0) AS total_walltime,
-                COUNT(*) FILTER (WHERE ("stats"::jsonb->>'walltime') IS NOT NULL) AS walltime_count
-            FROM {schema_prefix}"AgentGraphExecution"
-            WHERE "userId" = $1
-              AND "isDeleted" = false
-              AND "createdAt" >= $2
-              AND "createdAt" <= $3
-            GROUP BY "agentGraphId"
-            """,
-            user_id,
-            start_time,
-            end_time,
-        )
-
-        total_executions = 0
-        successful_runs = 0
-        failed_runs = 0
-        total_cost_cents = 0.0
-        total_walltime = 0.0
-        walltime_count = 0
-        cost_by_graph_id: dict[str, float] = {}
-        usage_by_graph_id: dict[str, int] = {}
-
-        for row in rows:
-            graph_id = row["graph_id"]
-            count = int(row["total"])
-            cost_cents = float(row["total_cost_cents"])
-
-            total_executions += count
-            successful_runs += int(row["successful"])
-            failed_runs += int(row["failed"])
-            total_cost_cents += cost_cents
-            total_walltime += float(row["total_walltime"])
-            walltime_count += int(row["walltime_count"])
-
-            usage_by_graph_id[graph_id] = count
-            cost_by_graph_id[graph_id] = cost_cents / 100
-
-        total_credits_used = total_cost_cents / 100
-        average_execution_time = (
-            total_walltime / walltime_count if walltime_count else 0
-        )
-
-        graph_ids = list(cost_by_graph_id.keys())
-        resolved_names = await asyncio.gather(
-            *(_resolve_agent_name(gid) for gid in graph_ids)
-        )
-        name_by_graph_id = dict(zip(graph_ids, resolved_names))
-
-        most_used_agent = "No agents used"
-        if usage_by_graph_id:
-            most_used_agent_id = max(
-                usage_by_graph_id, key=lambda k: usage_by_graph_id[k]
-            )
-            most_used_agent = name_by_graph_id[most_used_agent_id]
-
-        # Sum on name collisions (two distinct graphs can resolve to the same
-        # display name); a plain assign would silently drop one bucket.
-        cost_breakdown: dict[str, float] = {}
-        for graph_id, cost in cost_by_graph_id.items():
-            name = name_by_graph_id[graph_id]
-            cost_breakdown[name] = cost_breakdown.get(name, 0.0) + cost
-
-        return UserExecutionSummaryStats(
-            total_credits_used=total_credits_used,
-            total_executions=total_executions,
-            successful_runs=successful_runs,
-            failed_runs=failed_runs,
-            most_used_agent=most_used_agent,
-            total_execution_time=total_walltime,
-            average_execution_time=average_execution_time,
-            cost_breakdown=cost_breakdown,
-        )
-
+        rows = await _fetch_execution_aggregate_rows(user_id, start_time, end_time)
+        agg = _reduce_execution_rows(rows)
+        name_by_graph_id = await _resolve_agent_names(list(agg.cost_by_graph_id))
+        return _assemble_summary(agg, name_by_graph_id)
     except Exception as e:
         logger.error(f"Failed to get user summary data: {e}")
         raise DatabaseError(f"Failed to get user summary data: {e}") from e
+
+
+async def _fetch_execution_aggregate_rows(
+    user_id: str, start_time: datetime, end_time: datetime
+) -> list[dict]:
+    return await query_raw_with_schema(
+        """
+        SELECT
+            "agentGraphId" AS graph_id,
+            COUNT(*) AS total,
+            COUNT(*) FILTER (WHERE "executionStatus" = 'COMPLETED') AS successful,
+            COUNT(*) FILTER (WHERE "executionStatus" IN ('FAILED', 'TERMINATED')) AS failed,
+            COALESCE(SUM(("stats"::jsonb->>'cost')::numeric), 0) AS total_cost_cents,
+            COALESCE(SUM(("stats"::jsonb->>'walltime')::numeric), 0) AS total_walltime,
+            COUNT(*) FILTER (WHERE ("stats"::jsonb->>'walltime') IS NOT NULL) AS walltime_count
+        FROM {schema_prefix}"AgentGraphExecution"
+        WHERE "userId" = $1
+          AND "isDeleted" = false
+          AND "createdAt" >= $2
+          AND "createdAt" <= $3
+        GROUP BY "agentGraphId"
+        """,
+        user_id,
+        start_time,
+        end_time,
+    )
+
+
+def _reduce_execution_rows(rows: list[dict]) -> _ExecutionAggregates:
+    agg = _ExecutionAggregates()
+    for row in rows:
+        graph_id = row["graph_id"]
+        count = int(row["total"])
+        cost_cents = float(row["total_cost_cents"])
+
+        agg.total_executions += count
+        agg.successful_runs += int(row["successful"])
+        agg.failed_runs += int(row["failed"])
+        agg.total_cost_cents += cost_cents
+        agg.total_walltime += float(row["total_walltime"])
+        agg.walltime_count += int(row["walltime_count"])
+        agg.usage_by_graph_id[graph_id] = count
+        agg.cost_by_graph_id[graph_id] = cost_cents / 100
+    return agg
+
+
+async def _resolve_agent_names(graph_ids: list[str]) -> dict[str, str]:
+    resolved = await asyncio.gather(*(_resolve_agent_name(gid) for gid in graph_ids))
+    return dict(zip(graph_ids, resolved))
+
+
+def _assemble_summary(
+    agg: _ExecutionAggregates, name_by_graph_id: dict[str, str]
+) -> UserExecutionSummaryStats:
+    most_used_agent = "No agents used"
+    if agg.usage_by_graph_id:
+        # Tuple key gives a deterministic tie-break by graph_id when execution
+        # counts match, instead of relying on dict insertion order.
+        most_used_agent_id = max(
+            agg.usage_by_graph_id,
+            key=lambda k: (agg.usage_by_graph_id[k], k),
+        )
+        most_used_agent = name_by_graph_id[most_used_agent_id]
+
+    # Sum on name collisions (two distinct graphs can resolve to the same
+    # display name); a plain assign would silently drop one bucket.
+    cost_breakdown: dict[str, float] = {}
+    for graph_id, cost in agg.cost_by_graph_id.items():
+        name = name_by_graph_id[graph_id]
+        cost_breakdown[name] = cost_breakdown.get(name, 0.0) + cost
+
+    average_execution_time = (
+        agg.total_walltime / agg.walltime_count if agg.walltime_count else 0
+    )
+
+    return UserExecutionSummaryStats(
+        total_credits_used=agg.total_cost_cents / 100,
+        total_executions=agg.total_executions,
+        successful_runs=agg.successful_runs,
+        failed_runs=agg.failed_runs,
+        most_used_agent=most_used_agent,
+        total_execution_time=agg.total_walltime,
+        average_execution_time=average_execution_time,
+        cost_breakdown=cost_breakdown,
+    )
 
 
 async def _resolve_agent_name(graph_id: str) -> str:

--- a/autogpt_platform/backend/backend/data/generate_data.py
+++ b/autogpt_platform/backend/backend/data/generate_data.py
@@ -59,8 +59,8 @@ async def _fetch_execution_aggregate_rows(
         FROM {schema_prefix}"AgentGraphExecution"
         WHERE "userId" = $1
           AND "isDeleted" = false
-          AND "createdAt" >= $2
-          AND "createdAt" <= $3
+          AND "createdAt" >= $2::timestamp
+          AND "createdAt" <= $3::timestamp
         GROUP BY "agentGraphId"
         """,
         user_id,

--- a/autogpt_platform/backend/backend/data/generate_data.py
+++ b/autogpt_platform/backend/backend/data/generate_data.py
@@ -1,10 +1,7 @@
 import logging
-from collections import defaultdict
 from datetime import datetime
 
-from prisma.enums import AgentExecutionStatus
-
-from backend.data.execution import get_graph_executions
+from backend.data.db import query_raw_with_schema
 from backend.data.graph import get_graph_metadata
 from backend.data.model import UserExecutionSummaryStats
 from backend.util.exceptions import DatabaseError
@@ -16,90 +13,82 @@ logger = TruncatedLogger(logging.getLogger(__name__), prefix="[SummaryData]")
 async def get_user_execution_summary_data(
     user_id: str, start_time: datetime, end_time: datetime
 ) -> UserExecutionSummaryStats:
-    """Gather all summary data for a user in a time range.
+    """Aggregate per-graph execution stats for a user via grouped SQL.
 
-    This function fetches graph executions once and aggregates all required
-    statistics in a single pass for efficiency.
+    Pulls only one summary row per agentGraphId instead of every individual
+    AgentGraphExecution: heavy users had thousands of executions per call,
+    making this the dominant row-egress query in the prior implementation.
     """
     try:
-        # Fetch graph executions once
-        executions = await get_graph_executions(
-            user_id=user_id,
-            created_time_gte=start_time,
-            created_time_lte=end_time,
+        rows = await query_raw_with_schema(
+            """
+            SELECT
+                "agentGraphId" AS graph_id,
+                COUNT(*) AS total,
+                COUNT(*) FILTER (WHERE "executionStatus" = 'COMPLETED') AS successful,
+                COUNT(*) FILTER (WHERE "executionStatus" IN ('FAILED', 'TERMINATED')) AS failed,
+                COALESCE(SUM(("stats"::jsonb->>'cost')::numeric), 0) AS total_cost_cents,
+                COALESCE(SUM(("stats"::jsonb->>'walltime')::numeric), 0) AS total_walltime,
+                COUNT(*) FILTER (WHERE ("stats"::jsonb->>'walltime') IS NOT NULL) AS walltime_count
+            FROM {schema_prefix}"AgentGraphExecution"
+            WHERE "userId" = $1
+              AND "isDeleted" = false
+              AND "createdAt" >= $2
+              AND "createdAt" <= $3
+            GROUP BY "agentGraphId"
+            """,
+            user_id,
+            start_time,
+            end_time,
         )
 
-        # Initialize aggregation variables
-        total_credits_used = 0.0
-        total_executions = len(executions)
+        total_executions = 0
         successful_runs = 0
         failed_runs = 0
-        terminated_runs = 0
-        execution_times = []
-        agent_usage = defaultdict(int)
-        cost_by_graph_id = defaultdict(float)
+        total_cost_cents = 0.0
+        total_walltime = 0.0
+        walltime_count = 0
+        cost_by_graph_id: dict[str, float] = {}
+        usage_by_graph_id: dict[str, int] = {}
 
-        # Single pass through executions to aggregate all stats
-        for execution in executions:
-            # Count execution statuses (including TERMINATED as failed)
-            if execution.status == AgentExecutionStatus.COMPLETED:
-                successful_runs += 1
-            elif execution.status == AgentExecutionStatus.FAILED:
-                failed_runs += 1
-            elif execution.status == AgentExecutionStatus.TERMINATED:
-                terminated_runs += 1
+        for row in rows:
+            graph_id = row["graph_id"]
+            count = int(row["total"])
+            cost_cents = float(row["total_cost_cents"])
 
-            # Aggregate costs from stats
-            if execution.stats and hasattr(execution.stats, "cost"):
-                cost_in_dollars = execution.stats.cost / 100
-                total_credits_used += cost_in_dollars
-                cost_by_graph_id[execution.graph_id] += cost_in_dollars
+            total_executions += count
+            successful_runs += int(row["successful"])
+            failed_runs += int(row["failed"])
+            total_cost_cents += cost_cents
+            total_walltime += float(row["total_walltime"])
+            walltime_count += int(row["walltime_count"])
 
-            # Collect execution times
-            if execution.stats and hasattr(execution.stats, "duration"):
-                execution_times.append(execution.stats.duration)
+            usage_by_graph_id[graph_id] = count
+            cost_by_graph_id[graph_id] = cost_cents / 100
 
-            # Count agent usage
-            agent_usage[execution.graph_id] += 1
-
-        # Calculate derived stats
-        total_execution_time = sum(execution_times)
+        total_credits_used = total_cost_cents / 100
         average_execution_time = (
-            total_execution_time / len(execution_times) if execution_times else 0
+            total_walltime / walltime_count if walltime_count else 0
         )
 
-        # Find most used agent
         most_used_agent = "No agents used"
-        if agent_usage:
-            most_used_agent_id = max(agent_usage, key=lambda k: agent_usage[k])
-            try:
-                graph_meta = await get_graph_metadata(graph_id=most_used_agent_id)
-                most_used_agent = (
-                    graph_meta.name if graph_meta else f"Agent {most_used_agent_id[:8]}"
-                )
-            except Exception:
-                logger.warning(f"Could not get metadata for graph {most_used_agent_id}")
-                most_used_agent = f"Agent {most_used_agent_id[:8]}"
+        if usage_by_graph_id:
+            most_used_agent_id = max(
+                usage_by_graph_id, key=lambda k: usage_by_graph_id[k]
+            )
+            most_used_agent = await _resolve_agent_name(most_used_agent_id)
 
-        # Convert graph_ids to agent names for cost breakdown
-        cost_breakdown = {}
+        cost_breakdown: dict[str, float] = {}
         for graph_id, cost in cost_by_graph_id.items():
-            try:
-                graph_meta = await get_graph_metadata(graph_id=graph_id)
-                agent_name = graph_meta.name if graph_meta else f"Agent {graph_id[:8]}"
-            except Exception:
-                logger.warning(f"Could not get metadata for graph {graph_id}")
-                agent_name = f"Agent {graph_id[:8]}"
-            cost_breakdown[agent_name] = cost
+            cost_breakdown[await _resolve_agent_name(graph_id)] = cost
 
-        # Build the summary stats object (include terminated runs as failed)
         return UserExecutionSummaryStats(
             total_credits_used=total_credits_used,
             total_executions=total_executions,
             successful_runs=successful_runs,
-            failed_runs=failed_runs + terminated_runs,
+            failed_runs=failed_runs,
             most_used_agent=most_used_agent,
-            total_execution_time=total_execution_time,
+            total_execution_time=total_walltime,
             average_execution_time=average_execution_time,
             cost_breakdown=cost_breakdown,
         )
@@ -107,3 +96,12 @@ async def get_user_execution_summary_data(
     except Exception as e:
         logger.error(f"Failed to get user summary data: {e}")
         raise DatabaseError(f"Failed to get user summary data: {e}") from e
+
+
+async def _resolve_agent_name(graph_id: str) -> str:
+    try:
+        graph_meta = await get_graph_metadata(graph_id=graph_id)
+        return graph_meta.name if graph_meta else f"Agent {graph_id[:8]}"
+    except Exception:
+        logger.warning(f"Could not get metadata for graph {graph_id}")
+        return f"Agent {graph_id[:8]}"

--- a/autogpt_platform/backend/backend/data/generate_data.py
+++ b/autogpt_platform/backend/backend/data/generate_data.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from datetime import datetime
 
@@ -71,16 +72,25 @@ async def get_user_execution_summary_data(
             total_walltime / walltime_count if walltime_count else 0
         )
 
+        graph_ids = list(cost_by_graph_id.keys())
+        resolved_names = await asyncio.gather(
+            *(_resolve_agent_name(gid) for gid in graph_ids)
+        )
+        name_by_graph_id = dict(zip(graph_ids, resolved_names))
+
         most_used_agent = "No agents used"
         if usage_by_graph_id:
             most_used_agent_id = max(
                 usage_by_graph_id, key=lambda k: usage_by_graph_id[k]
             )
-            most_used_agent = await _resolve_agent_name(most_used_agent_id)
+            most_used_agent = name_by_graph_id[most_used_agent_id]
 
+        # Sum on name collisions (two distinct graphs can resolve to the same
+        # display name); a plain assign would silently drop one bucket.
         cost_breakdown: dict[str, float] = {}
         for graph_id, cost in cost_by_graph_id.items():
-            cost_breakdown[await _resolve_agent_name(graph_id)] = cost
+            name = name_by_graph_id[graph_id]
+            cost_breakdown[name] = cost_breakdown.get(name, 0.0) + cost
 
         return UserExecutionSummaryStats(
             total_credits_used=total_credits_used,

--- a/autogpt_platform/backend/backend/data/generate_data.py
+++ b/autogpt_platform/backend/backend/data/generate_data.py
@@ -133,5 +133,5 @@ async def _resolve_agent_name(graph_id: str) -> str:
         graph_meta = await get_graph_metadata(graph_id=graph_id)
         return graph_meta.name if graph_meta else f"Agent {graph_id[:8]}"
     except Exception:
-        logger.warning(f"Could not get metadata for graph {graph_id}")
+        logger.warning(f"Could not get metadata for graph {graph_id}", exc_info=True)
         return f"Agent {graph_id[:8]}"

--- a/autogpt_platform/backend/backend/data/generate_data_test.py
+++ b/autogpt_platform/backend/backend/data/generate_data_test.py
@@ -257,3 +257,38 @@ async def test_summary_excludes_out_of_window(server: SpinTestServer):
         assert stats.total_credits_used == pytest.approx(100 / 100)
     finally:
         await _cleanup(user_id, [graph_a])
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_summary_falls_back_when_graph_metadata_missing(server: SpinTestServer):
+    # If a graph is deleted but executions still reference it, name resolution
+    # must fall back to a short-id label instead of raising.
+    user_id = f"sum-orphan-{uuid4()}"
+    graph_id = f"orphan-graph-{uuid4()}"
+    await _create_test_user(user_id)
+    await _create_graph(graph_id, user_id, "TempName")
+
+    now = datetime.now(timezone.utc)
+    try:
+        await _create_exec(
+            f"o1-{uuid4()}",
+            user_id,
+            graph_id,
+            AgentExecutionStatus.COMPLETED,
+            42,
+            1.0,
+            now - timedelta(hours=1),
+        )
+
+        # Delete the graph row before summary runs, leaving the execution
+        # behind with a now-orphaned agentGraphId.
+        await AgentGraph.prisma().delete_many(where={"id": graph_id})
+
+        stats = await get_user_execution_summary_data(
+            user_id, now - timedelta(hours=2), now
+        )
+        expected_fallback = f"Agent {graph_id[:8]}"
+        assert stats.most_used_agent == expected_fallback
+        assert stats.cost_breakdown == {expected_fallback: pytest.approx(42 / 100)}
+    finally:
+        await _cleanup(user_id, [graph_id])

--- a/autogpt_platform/backend/backend/data/generate_data_test.py
+++ b/autogpt_platform/backend/backend/data/generate_data_test.py
@@ -9,7 +9,11 @@ from prisma.enums import AgentExecutionStatus
 from prisma.errors import UniqueViolationError
 from prisma.models import AgentGraph, AgentGraphExecution, User
 
-from backend.data.generate_data import get_user_execution_summary_data
+from backend.data import generate_data
+from backend.data.generate_data import (
+    _resolve_agent_name,
+    get_user_execution_summary_data,
+)
 from backend.util.json import SafeJson
 from backend.util.test import SpinTestServer
 
@@ -257,6 +261,20 @@ async def test_summary_excludes_out_of_window(server: SpinTestServer):
         assert stats.total_credits_used == pytest.approx(100 / 100)
     finally:
         await _cleanup(user_id, [graph_a])
+
+
+@pytest.mark.asyncio
+async def test_resolve_agent_name_falls_back_on_exception(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # Direct unit test: when get_graph_metadata raises, _resolve_agent_name
+    # logs and returns the short-id fallback.
+    async def boom(graph_id: str, version=None):
+        raise RuntimeError("simulated DB blip")
+
+    monkeypatch.setattr(generate_data, "get_graph_metadata", boom)
+    name = await _resolve_agent_name("abcdef0123456789")
+    assert name == "Agent abcdef01"
 
 
 @pytest.mark.asyncio(loop_scope="session")

--- a/autogpt_platform/backend/backend/data/generate_data_test.py
+++ b/autogpt_platform/backend/backend/data/generate_data_test.py
@@ -1,0 +1,213 @@
+"""Tests for the SQL-aggregated user execution summary."""
+
+import logging
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
+
+import pytest
+from prisma.enums import AgentExecutionStatus
+from prisma.errors import UniqueViolationError
+from prisma.models import AgentGraph, AgentGraphExecution, User
+
+from backend.data.generate_data import get_user_execution_summary_data
+from backend.util.json import SafeJson
+from backend.util.test import SpinTestServer
+
+logger = logging.getLogger(__name__)
+
+
+async def _create_test_user(user_id: str) -> None:
+    try:
+        await User.prisma().create(
+            data={
+                "id": user_id,
+                "email": f"test-{user_id}@example.com",
+                "name": f"Test User {user_id[:8]}",
+            }
+        )
+    except UniqueViolationError:
+        pass
+
+
+async def _create_graph(graph_id: str, user_id: str, name: str) -> None:
+    try:
+        await AgentGraph.prisma().create(
+            data={
+                "id": graph_id,
+                "version": 1,
+                "name": name,
+                "description": "test",
+                "userId": user_id,
+                "isActive": True,
+            }
+        )
+    except UniqueViolationError:
+        pass
+
+
+async def _create_exec(
+    exec_id: str,
+    user_id: str,
+    graph_id: str,
+    status: AgentExecutionStatus,
+    cost_cents: int,
+    walltime_s: float,
+    created_at: datetime,
+) -> None:
+    await AgentGraphExecution.prisma().create(
+        data={
+            "id": exec_id,
+            "agentGraphId": graph_id,
+            "agentGraphVersion": 1,
+            "executionStatus": status,
+            "userId": user_id,
+            "createdAt": created_at,
+            "stats": SafeJson({"cost": cost_cents, "walltime": walltime_s}),
+        }
+    )
+
+
+async def _cleanup(user_id: str, graph_ids: list[str]) -> None:
+    try:
+        await AgentGraphExecution.prisma().delete_many(where={"userId": user_id})
+        for gid in graph_ids:
+            await AgentGraph.prisma().delete_many(where={"id": gid})
+        await User.prisma().delete_many(where={"id": user_id})
+    except Exception as exc:
+        logger.warning("cleanup for %s failed: %s", user_id, exc)
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_summary_empty_returns_zero_stats(server: SpinTestServer):
+    user_id = f"sum-empty-{uuid4()}"
+    await _create_test_user(user_id)
+    try:
+        now = datetime.now(timezone.utc)
+        stats = await get_user_execution_summary_data(
+            user_id, now - timedelta(days=1), now
+        )
+        assert stats.total_executions == 0
+        assert stats.successful_runs == 0
+        assert stats.failed_runs == 0
+        assert stats.total_credits_used == 0
+        assert stats.total_execution_time == 0
+        assert stats.average_execution_time == 0
+        assert stats.cost_breakdown == {}
+        assert stats.most_used_agent == "No agents used"
+    finally:
+        await _cleanup(user_id, [])
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_summary_aggregates_by_status_and_graph(server: SpinTestServer):
+    user_id = f"sum-agg-{uuid4()}"
+    graph_a = f"graph-a-{uuid4()}"
+    graph_b = f"graph-b-{uuid4()}"
+    await _create_test_user(user_id)
+    await _create_graph(graph_a, user_id, "Alpha")
+    await _create_graph(graph_b, user_id, "Beta")
+
+    now = datetime.now(timezone.utc)
+    in_window = now - timedelta(hours=1)
+
+    try:
+        # Graph A: 2 successful (50 + 75 cents), 1 failed (25 cents)
+        await _create_exec(
+            f"a1-{uuid4()}",
+            user_id,
+            graph_a,
+            AgentExecutionStatus.COMPLETED,
+            50,
+            1.5,
+            in_window,
+        )
+        await _create_exec(
+            f"a2-{uuid4()}",
+            user_id,
+            graph_a,
+            AgentExecutionStatus.COMPLETED,
+            75,
+            2.5,
+            in_window,
+        )
+        await _create_exec(
+            f"a3-{uuid4()}",
+            user_id,
+            graph_a,
+            AgentExecutionStatus.FAILED,
+            25,
+            0.5,
+            in_window,
+        )
+        # Graph B: 1 terminated (10 cents) — counted as failed
+        await _create_exec(
+            f"b1-{uuid4()}",
+            user_id,
+            graph_b,
+            AgentExecutionStatus.TERMINATED,
+            10,
+            0.1,
+            in_window,
+        )
+
+        stats = await get_user_execution_summary_data(
+            user_id, now - timedelta(hours=2), now
+        )
+
+        assert stats.total_executions == 4
+        assert stats.successful_runs == 2
+        assert stats.failed_runs == 2  # 1 FAILED + 1 TERMINATED
+        assert stats.total_credits_used == pytest.approx((50 + 75 + 25 + 10) / 100)
+        assert stats.total_execution_time == pytest.approx(1.5 + 2.5 + 0.5 + 0.1)
+        assert stats.average_execution_time == pytest.approx(
+            (1.5 + 2.5 + 0.5 + 0.1) / 4
+        )
+        # Most-used agent is Graph A (3 executions vs Graph B's 1)
+        assert stats.most_used_agent == "Alpha"
+        # Cost breakdown keyed by agent name
+        assert stats.cost_breakdown == {
+            "Alpha": pytest.approx((50 + 75 + 25) / 100),
+            "Beta": pytest.approx(10 / 100),
+        }
+    finally:
+        await _cleanup(user_id, [graph_a, graph_b])
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_summary_excludes_out_of_window(server: SpinTestServer):
+    user_id = f"sum-window-{uuid4()}"
+    graph_a = f"graph-w-{uuid4()}"
+    await _create_test_user(user_id)
+    await _create_graph(graph_a, user_id, "InWindow")
+
+    now = datetime.now(timezone.utc)
+    in_window = now - timedelta(hours=1)
+    out_of_window = now - timedelta(days=10)
+
+    try:
+        await _create_exec(
+            f"in-{uuid4()}",
+            user_id,
+            graph_a,
+            AgentExecutionStatus.COMPLETED,
+            100,
+            1.0,
+            in_window,
+        )
+        await _create_exec(
+            f"out-{uuid4()}",
+            user_id,
+            graph_a,
+            AgentExecutionStatus.COMPLETED,
+            200,
+            2.0,
+            out_of_window,
+        )
+
+        stats = await get_user_execution_summary_data(
+            user_id, now - timedelta(hours=2), now
+        )
+        assert stats.total_executions == 1
+        assert stats.total_credits_used == pytest.approx(100 / 100)
+    finally:
+        await _cleanup(user_id, [graph_a])

--- a/autogpt_platform/backend/backend/data/generate_data_test.py
+++ b/autogpt_platform/backend/backend/data/generate_data_test.py
@@ -277,36 +277,15 @@ async def test_resolve_agent_name_falls_back_on_exception(
     assert name == "Agent abcdef01"
 
 
-@pytest.mark.asyncio(loop_scope="session")
-async def test_summary_falls_back_when_graph_metadata_missing(server: SpinTestServer):
-    # If a graph is deleted but executions still reference it, name resolution
-    # must fall back to a short-id label instead of raising.
-    user_id = f"sum-orphan-{uuid4()}"
-    graph_id = f"orphan-graph-{uuid4()}"
-    await _create_test_user(user_id)
-    await _create_graph(graph_id, user_id, "TempName")
+@pytest.mark.asyncio
+async def test_resolve_agent_name_falls_back_when_metadata_missing(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # When get_graph_metadata returns None (e.g. graph not found),
+    # _resolve_agent_name must produce a short-id label.
+    async def returns_none(graph_id: str, version=None):
+        return None
 
-    now = datetime.now(timezone.utc)
-    try:
-        await _create_exec(
-            f"o1-{uuid4()}",
-            user_id,
-            graph_id,
-            AgentExecutionStatus.COMPLETED,
-            42,
-            1.0,
-            now - timedelta(hours=1),
-        )
-
-        # Delete the graph row before summary runs, leaving the execution
-        # behind with a now-orphaned agentGraphId.
-        await AgentGraph.prisma().delete_many(where={"id": graph_id})
-
-        stats = await get_user_execution_summary_data(
-            user_id, now - timedelta(hours=2), now
-        )
-        expected_fallback = f"Agent {graph_id[:8]}"
-        assert stats.most_used_agent == expected_fallback
-        assert stats.cost_breakdown == {expected_fallback: pytest.approx(42 / 100)}
-    finally:
-        await _cleanup(user_id, [graph_id])
+    monkeypatch.setattr(generate_data, "get_graph_metadata", returns_none)
+    name = await _resolve_agent_name("abcdef0123456789")
+    assert name == "Agent abcdef01"

--- a/autogpt_platform/backend/backend/data/generate_data_test.py
+++ b/autogpt_platform/backend/backend/data/generate_data_test.py
@@ -174,6 +174,52 @@ async def test_summary_aggregates_by_status_and_graph(server: SpinTestServer):
 
 
 @pytest.mark.asyncio(loop_scope="session")
+async def test_summary_sums_costs_on_agent_name_collision(server: SpinTestServer):
+    # Two distinct agentGraphIds resolving to the same display name must sum
+    # into the same cost_breakdown bucket, not overwrite each other.
+    user_id = f"sum-collide-{uuid4()}"
+    graph_a = f"graph-c1-{uuid4()}"
+    graph_b = f"graph-c2-{uuid4()}"
+    await _create_test_user(user_id)
+    await _create_graph(graph_a, user_id, "Scraper")
+    await _create_graph(graph_b, user_id, "Scraper")
+
+    now = datetime.now(timezone.utc)
+    in_window = now - timedelta(hours=1)
+
+    try:
+        await _create_exec(
+            f"c1-{uuid4()}",
+            user_id,
+            graph_a,
+            AgentExecutionStatus.COMPLETED,
+            30,
+            1.0,
+            in_window,
+        )
+        await _create_exec(
+            f"c2-{uuid4()}",
+            user_id,
+            graph_b,
+            AgentExecutionStatus.COMPLETED,
+            70,
+            2.0,
+            in_window,
+        )
+
+        stats = await get_user_execution_summary_data(
+            user_id, now - timedelta(hours=2), now
+        )
+
+        assert stats.cost_breakdown == {
+            "Scraper": pytest.approx((30 + 70) / 100),
+        }
+        assert stats.total_credits_used == pytest.approx(100 / 100)
+    finally:
+        await _cleanup(user_id, [graph_a, graph_b])
+
+
+@pytest.mark.asyncio(loop_scope="session")
 async def test_summary_excludes_out_of_window(server: SpinTestServer):
     user_id = f"sum-window-{uuid4()}"
     graph_a = f"graph-w-{uuid4()}"

--- a/autogpt_platform/backend/backend/data/includes.py
+++ b/autogpt_platform/backend/backend/data/includes.py
@@ -21,9 +21,13 @@ EXECUTION_RESULT_ORDER: list[prisma.types.AgentNodeExecutionOrderByInput] = [
     {"addedTime": "desc"},
 ]
 
+# Cap per-execution Input/Output fanout so a node with thousands of I/O rows
+# can't drag the full set back on an include path that runs hot.
+MAX_NODE_INPUT_OUTPUT_FETCH = 100
+
 EXECUTION_RESULT_INCLUDE: prisma.types.AgentNodeExecutionInclude = {
-    "Input": {"order_by": {"time": "asc"}},
-    "Output": {"order_by": {"time": "asc"}},
+    "Input": {"order_by": {"time": "asc"}, "take": MAX_NODE_INPUT_OUTPUT_FETCH},
+    "Output": {"order_by": {"time": "asc"}, "take": MAX_NODE_INPUT_OUTPUT_FETCH},
     "Node": True,
     "GraphExecution": True,
 }

--- a/autogpt_platform/backend/backend/data/includes.py
+++ b/autogpt_platform/backend/backend/data/includes.py
@@ -21,9 +21,12 @@ EXECUTION_RESULT_ORDER: list[prisma.types.AgentNodeExecutionOrderByInput] = [
     {"addedTime": "desc"},
 ]
 
-# Cap per-execution Input/Output fanout so a node with thousands of I/O rows
-# can't drag the full set back on an include path that runs hot.
-MAX_NODE_INPUT_OUTPUT_FETCH = 100
+# Defensive cap on per-execution Input/Output fanout. Set well above the
+# realistic p99 (~tens of rows per node execution) so the cap only kicks in
+# on pathological cases — `NodeExecutionResult.from_db` rebuilds input/output
+# dicts from these rows, so silently truncating real data would corrupt the
+# result. Matches `MAX_NODE_EXECUTIONS_FETCH` for symmetry.
+MAX_NODE_INPUT_OUTPUT_FETCH = 1000
 
 EXECUTION_RESULT_INCLUDE: prisma.types.AgentNodeExecutionInclude = {
     "Input": {"order_by": {"time": "asc"}, "take": MAX_NODE_INPUT_OUTPUT_FETCH},


### PR DESCRIPTION
## Why

Follow-up to #13030. After that PR removed the dominant `NotificationEvent` query from prod and dev egress, the next-largest queries by row volume in `pg_stat_statements` (prod) are:

| Rank | Query | Calls | Rows | rpc |
|---|---|---:|---:|---:|
| 2 | `ChatMessage WHERE sessionId IN ($1) ORDER BY sequence ASC OFFSET $2` | 84,821 | 75,307,064 | 887 |
| 3-4 | `AgentNodeExecutionInputOutput` Input/Output relations | 26 M | 84 M | 2-3 |
| 6, 8, 11, 22 | `AgentGraphExecution WHERE userId=$1 AND isDeleted=false ORDER BY createdAt DESC` (no LIMIT) | 9,290 | 55 M | 4,000-8,500 |

All three traced to specific code paths. This PR fixes them.

## What

1. **`update_chat_session`** ([copilot/db.py](autogpt_platform/backend/backend/copilot/db.py)) drops `include={"Messages": ...}`. The only caller (`model.py:694`) ignores the return value, so the function was paying ~887 messages of egress per call for nothing. Return type narrowed from `ChatSession` to `ChatSessionInfo` since the message list is no longer fetched.

2. **`EXECUTION_RESULT_INCLUDE`** ([data/includes.py](autogpt_platform/backend/backend/data/includes.py)) gains `take=MAX_NODE_INPUT_OUTPUT_FETCH = 100` on the `Input` and `Output` relations. The hot path was unbounded and would fan out as Prisma's `IN ($1)` per-node-execution N+1 — average rpc was small but call count was 26 M, and a pathological node could blow it up.

3. **`get_user_execution_summary_data`** ([data/generate_data.py](autogpt_platform/backend/backend/data/generate_data.py)) rewritten to use a single grouped SQL aggregation (`COUNT FILTER`, `SUM("stats"::jsonb->>'cost')`, `GROUP BY agentGraphId`) instead of pulling every `AgentGraphExecution` row into Python. Heavy users had thousands of executions per call.

## How

For (1), the diff is a 1-line include drop plus a return-type narrow. Pyright confirms the only caller doesn't read the value.

For (2), `MAX_NODE_INPUT_OUTPUT_FETCH = 100` is a defensive cap. Real node executions virtually never exceed a handful of I/O rows; 100 is well above the p99.

For (3), the SQL fits all aggregations in one query:

```sql
SELECT "agentGraphId" AS graph_id,
       COUNT(*) AS total,
       COUNT(*) FILTER (WHERE "executionStatus" = 'COMPLETED') AS successful,
       COUNT(*) FILTER (WHERE "executionStatus" IN ('FAILED', 'TERMINATED')) AS failed,
       COALESCE(SUM(("stats"::jsonb->>'cost')::numeric), 0) AS total_cost_cents,
       COALESCE(SUM(("stats"::jsonb->>'walltime')::numeric), 0) AS total_walltime,
       COUNT(*) FILTER (WHERE ("stats"::jsonb->>'walltime') IS NOT NULL) AS walltime_count
  FROM "AgentGraphExecution"
 WHERE "userId" = $1 AND "isDeleted" = false
   AND "createdAt" BETWEEN $2 AND $3
 GROUP BY "agentGraphId"
```

One row per `agentGraphId` instead of every row, then per-graph metadata lookup for the agent name.

**Behaviour-preserving except for one latent fix:** the prior implementation read `execution.stats.duration`, but the executor writes `walltime` (see `executor/manager.py:609`); `duration` was never set on stats objects, so `total_execution_time` was always 0 and `average_execution_time` always 0 in summary emails. The refactor reads `walltime`, which is the correct field.

## Tests

Added integration tests in [data/generate_data_test.py](autogpt_platform/backend/backend/data/generate_data_test.py) covering:

- Empty result returns zero stats and `"No agents used"`
- Multi-graph + multi-status aggregation: counts, costs, walltime sums, and most-used-agent resolution
- Out-of-window executions are excluded by `createdAt` filter

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (n/a)
- [x] My changes generate no new warnings (pyright/ruff/black clean)
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes (CI runs against the test DB)
- [x] Any dependent changes have been merged and published in downstream modules
