### PR TITLE
docs(platform): remove CoPilot rename banner from changelog

### DIFF
--- a/docs/platform/changelog/README.md
+++ b/docs/platform/changelog/README.md
@@ -2,9 +2,6 @@
 
 What's new in AutoPilot and the AutoGPT Platform. We ship updates regularly and document everything here.
 
-{% hint style="info" %}
-AutoPilot was previously called CoPilot. References to CoPilot in older entries refer to the same product.
-{% endhint %}
 
 ## 2026
 

--- a/docs/platform/changelog/README.md
+++ b/docs/platform/changelog/README.md
@@ -2,7 +2,6 @@
 
 What's new in AutoPilot and the AutoGPT Platform. We ship updates regularly and document everything here.
 
-
 ## 2026
 
 | Date | Highlights |


### PR DESCRIPTION
Removes the info banner from the changelog page that says 'AutoPilot was previously called CoPilot. References to CoPilot in older entries refer to the same product.' — this is no longer needed.