### PR TITLE
chore: ignore tmp/, screenshots/, test-screenshots/ scratch dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -200,3 +200,9 @@ test-results/
 # Playwright MCP / local browser-testing artifacts
 .playwright-mcp/
 copilot-session-switch-qa/
+
+# Agent-generated scratch dirs (pr-test screenshots, agent-browser artifacts).
+# See PR #13023 retro: these were committed by mistake several times.
+tmp/
+screenshots/
+test-screenshots/

--- a/.gitignore
+++ b/.gitignore
@@ -202,7 +202,6 @@ test-results/
 copilot-session-switch-qa/
 
 # Agent-generated scratch dirs (pr-test screenshots, agent-browser artifacts).
-# See PR #13023 retro: these were committed by mistake several times.
 tmp/
 screenshots/
 test-screenshots/


### PR DESCRIPTION
## Problem

Multiple recent PRs have accidentally committed agent-generated screenshots and tmp artifacts under `tmp/`, `screenshots/`, and `test-screenshots/`. These dirs are agent-browser / pr-test scratch space — they should never end up in the repo.

## Changes

Add three patterns near the bottom of `.gitignore`:

```
# Agent-generated scratch dirs (pr-test screenshots, agent-browser artifacts).
tmp/
screenshots/
test-screenshots/
```

## No source files affected

`git ls-files | grep -E '^(tmp|screenshots|test-screenshots)/'` returns no matches on `dev`. Nothing legitimate is being ignored — the broad patterns are safe. No manual removal of tracked files is needed.

This is a defensive change; no runtime behavior impact.

## Test plan

- [x] Confirmed `git status` ignores synthetic files in those paths:
  ```
  $ mkdir -p tmp screenshots test-screenshots
  $ touch tmp/test.png screenshots/test.png test-screenshots/test.png
  $ git status --short
   M .gitignore
  $ git check-ignore -v tmp/test.png screenshots/test.png test-screenshots/test.png
  .gitignore:206:tmp/	tmp/test.png
  .gitignore:207:screenshots/	screenshots/test.png
  .gitignore:208:test-screenshots/	test-screenshots/test.png
  ```
