### PR TITLE
fix(backend): allow negative balance on post-flight reconciliation

### DIFF
--- a/autogpt_platform/backend/backend/data/credit.py
+++ b/autogpt_platform/backend/backend/data/credit.py
@@ -144,6 +144,7 @@ class UserCreditBase(ABC):
         user_id: str,
         cost: int,
         metadata: UsageTransactionMetadata,
+        fail_insufficient_credits: bool = True,
     ) -> int:
         """
         Spend the credits for the user based on the cost.
@@ -152,6 +153,12 @@ class UserCreditBase(ABC):
             user_id (str): The user ID.
             cost (int): The cost to spend.
             metadata (UsageTransactionMetadata): The metadata of the transaction.
+            fail_insufficient_credits (bool): When True (default) raise
+                InsufficientBalanceError if the wallet can't cover the spend.
+                When False the spend is recorded unconditionally and the
+                balance may go negative — used by post-flight reconciliation
+                so a delta charge that exceeds the wallet is captured as
+                debt instead of silently leaking.
 
         Returns:
             int: The remaining balance.
@@ -673,6 +680,7 @@ class UserCredit(UserCreditBase):
         user_id: str,
         cost: int,
         metadata: UsageTransactionMetadata,
+        fail_insufficient_credits: bool = True,
     ) -> int:
         if cost == 0:
             return 0
@@ -682,6 +690,7 @@ class UserCredit(UserCreditBase):
             amount=-cost,
             transaction_type=CreditTransactionType.USAGE,
             metadata=SafeJson(metadata.model_dump()),
+            fail_insufficient_credits=fail_insufficient_credits,
         )
 
         # Auto top-up if balance is below threshold.

--- a/autogpt_platform/backend/backend/data/db_manager.py
+++ b/autogpt_platform/backend/backend/data/db_manager.py
@@ -147,10 +147,15 @@ R = TypeVar("R")
 
 
 async def _spend_credits(
-    user_id: str, cost: int, metadata: UsageTransactionMetadata
+    user_id: str,
+    cost: int,
+    metadata: UsageTransactionMetadata,
+    fail_insufficient_credits: bool = True,
 ) -> int:
     user_credit_model = await get_user_credit_model(user_id)
-    return await user_credit_model.spend_credits(user_id, cost, metadata)
+    return await user_credit_model.spend_credits(
+        user_id, cost, metadata, fail_insufficient_credits=fail_insufficient_credits
+    )
 
 
 async def _get_credits(user_id: str) -> int:

--- a/autogpt_platform/backend/backend/executor/billing.py
+++ b/autogpt_platform/backend/backend/executor/billing.py
@@ -229,11 +229,12 @@ async def charge_reconciled_usage(
         # USAGE type so the refund is attributable to the same graph
         # execution in credit history.
         #
-        # For positive deltas (additional charge), pass
-        # `fail_insufficient_credits=False`: the SQL guard is bypassed so the
-        # spend always lands. The wallet may go negative; that's the point —
-        # we'd rather record real debt than leak the cost. Refunds (negative
-        # delta) keep the default since they only ever credit.
+        # `fail_insufficient_credits=False` is passed for every reconciliation
+        # spend. For positive deltas this bypasses the balance guard so the
+        # spend always lands — the wallet may go negative; that's the point,
+        # we'd rather record real debt than leak the cost. For negative deltas
+        # (refunds) the flag is moot: `amount = -cost > 0`, so the SQL guard's
+        # `$2 >= 0` short-circuit holds regardless.
         remaining_balance = await db_client.spend_credits(
             user_id=node_exec.user_id,
             cost=delta,

--- a/autogpt_platform/backend/backend/executor/billing.py
+++ b/autogpt_platform/backend/backend/executor/billing.py
@@ -193,15 +193,22 @@ async def charge_reconciled_usage(
     """Charge the dynamic portion of a block's cost from its execution stats.
 
     Computes post-flight cost from the execution stats and settles the delta
-    against the pre-flight estimate. Positive delta → charge the user; negative
-    delta → refund the overcharge (happens when a TOKENS block's flat
-    MODEL_COST floor exceeds the real token-metered cost). Zero delta is a
-    no-op — common for RUN-only blocks and any balanced estimate.
+    against the pre-flight estimate. Positive delta → charge the user (allowed
+    to push the balance negative — see below); negative delta → refund the
+    overcharge (happens when a TOKENS block's flat MODEL_COST floor exceeds
+    the real token-metered cost). Zero delta is a no-op — common for RUN-only
+    blocks and any balanced estimate.
+
+    Negative-balance handling: positive deltas are recorded with
+    ``fail_insufficient_credits=False`` so a wallet that can't cover the
+    shortfall ends up in debt rather than producing a `billing_leak`. The
+    block already ran and the provider was already paid in real $$ — failing
+    the spend would just hide the cost. The debt is naturally cleared on the
+    next top-up (auto or manual), since top-ups simply add to the balance.
 
     Called once per node execution AFTER the block has finished running and
-    stats (walltime, tokens, provider_cost) are populated. Swallows its own
-    InsufficientBalanceError because reconciliation must never poison the
-    success path — log and move on; the shortfall is captured in telemetry.
+    stats (walltime, tokens, provider_cost) are populated. Swallows any
+    unexpected exception so reconciliation never poisons the success path.
     """
     try:
         db_client = get_database_manager_async_client()
@@ -221,6 +228,12 @@ async def charge_reconciled_usage(
         # amount is positive (i.e. credits back to the wallet). We reuse the
         # USAGE type so the refund is attributable to the same graph
         # execution in credit history.
+        #
+        # For positive deltas (additional charge), pass
+        # `fail_insufficient_credits=False`: the SQL guard is bypassed so the
+        # spend always lands. The wallet may go negative; that's the point —
+        # we'd rather record real debt than leak the cost. Refunds (negative
+        # delta) keep the default since they only ever credit.
         remaining_balance = await db_client.spend_credits(
             user_id=node_exec.user_id,
             cost=delta,
@@ -237,6 +250,7 @@ async def charge_reconciled_usage(
                     f"actual={post_flight} credits, pre-flight={pre_flight}"
                 ),
             ),
+            fail_insufficient_credits=False,
         )
         # Refunds can't push the balance below the threshold — skip.
         if delta > 0:
@@ -251,38 +265,6 @@ async def charge_reconciled_usage(
                 delta,
             )
         return delta, remaining_balance
-    except InsufficientBalanceError as e:
-        # Billing leak: work is already done, but the user cannot pay. Emit a
-        # structured ERROR so alerting can pick it up and ping the platform
-        # channel so the leak is visible in real time.
-        logger.error(
-            "billing_leak: insufficient balance after post-flight reconciliation",
-            extra={
-                "billing_leak": True,
-                "user_id": node_exec.user_id,
-                "graph_id": node_exec.graph_id,
-                "graph_exec_id": node_exec.graph_exec_id,
-                "node_exec_id": node_exec.node_exec_id,
-                "block_id": node_exec.block_id,
-                "cost": abs(e.amount),
-                "balance": e.balance,
-                "error": str(e),
-            },
-        )
-        try:
-            await discord_send_alert(
-                f"⚠️ billing_leak (post-flight reconciliation)\n"
-                f"user={node_exec.user_id} graph={node_exec.graph_id} "
-                f"exec={node_exec.graph_exec_id}\n"
-                f"block={node_exec.block_id} needed={abs(e.amount)} "
-                f"balance={e.balance}",
-                DiscordChannel.PLATFORM,
-            )
-        except Exception:
-            # Discord dispatch is best-effort; never let alert failure poison
-            # the success path of a completed block.
-            logger.exception("billing_leak discord alert dispatch failed")
-        return 0, 0
     except Exception:
         logger.exception(
             f"charge_reconciled_usage failed unexpectedly for block "

--- a/autogpt_platform/backend/backend/executor/billing_reconciliation_test.py
+++ b/autogpt_platform/backend/backend/executor/billing_reconciliation_test.py
@@ -159,6 +159,41 @@ async def test_cost_usd_charges_post_flight_delta(tmp_block_costs_override):
 
 
 @pytest.mark.asyncio
+async def test_positive_delta_passes_fail_insufficient_credits_false(
+    tmp_block_costs_override,
+):
+    """Reconciliation must call spend_credits with
+    fail_insufficient_credits=False on a positive delta — the wallet is
+    allowed to go negative so the platform records debt instead of leaking
+    the cost."""
+    tmp_block_costs_override(
+        [BlockCost(cost_amount=100, cost_type=BlockCostType.COST_USD)]
+    )
+    exec_entry = _node_exec(SearchTheWebBlock().id)
+    stats = NodeExecutionStats(provider_cost=0.05, provider_cost_type="cost_usd")
+
+    # Wallet went negative: the user had 1 credit, the delta is 5, the new
+    # balance is -4. spend_credits returns the post-spend balance.
+    db_client = _async_db_client(spend_credits_return=-4)
+    with (
+        patch(
+            "backend.executor.billing.get_database_manager_async_client",
+            return_value=db_client,
+        ),
+        patch("backend.executor.billing.get_db_client", return_value=MagicMock()),
+        patch("backend.executor.billing.handle_low_balance"),
+    ):
+        delta, remaining = await charge_reconciled_usage(exec_entry, stats)
+
+    assert delta == 5
+    assert remaining == -4
+    db_client.spend_credits.assert_awaited_once()
+    call_kwargs = db_client.spend_credits.await_args.kwargs
+    assert call_kwargs["cost"] == 5
+    assert call_kwargs["fail_insufficient_credits"] is False
+
+
+@pytest.mark.asyncio
 async def test_missing_block_returns_zero():
     exec_entry = _node_exec("deadbeef-0000-0000-0000-000000000000")
     stats = NodeExecutionStats(walltime=10)


### PR DESCRIPTION
## Background

`charge_reconciled_usage` runs after a block has already executed and the provider has already been paid in real $$. If the post-flight delta exceeds the user's wallet, `_add_transaction` raises `InsufficientBalanceError`; today that gets swallowed and logged as `billing_leak` (`executor/billing.py`) — the platform absorbs the cost.

This PR records the shortfall as wallet debt instead of leaking it.

## Why

We can't fail the block at this point — the work is already done and the user already received the output. The only honest options are:
1. **Leak it** (today): user pays nothing for the shortfall, platform eats the cost.
2. **Record it as debt** (this PR): wallet goes negative; the next top-up naturally clears it.

Option 2 is the standard pay-after-use accounting model. Real $$ → real bookkeeping.

## How

- `UserCreditBase.spend_credits` and `UserCredit.spend_credits` now accept `fail_insufficient_credits: bool = True` — default preserves existing behavior for every other caller.
- `_spend_credits` in `db_manager.py` forwards the kwarg through the `DatabaseManagerAsyncClient` proxy.
- `charge_reconciled_usage` passes `fail_insufficient_credits=False` so the post-flight delta lands unconditionally. The previous `except InsufficientBalanceError` arm is removed (it can no longer fire on this call site); the broader `except Exception` arm still catches genuinely unexpected errors.

## What changes for users

- **Balance stayed positive after reconciliation** — no change.
- **Balance went to zero mid-execution** — instead of getting the result for free, the wallet shows a negative balance. The next top-up (auto or manual) brings it back to positive by simple addition.
- **Auto top-up users** — `spend_credits` still triggers auto-top-up after the spend if balance < threshold; the existing low-balance notification path still fires for positive deltas.

## Companion to #13031

Independent — neither depends on the other:
- #13031 reduces the *frequency* of leaks by giving dynamic-cost blocks a non-zero pre-flight estimate (so the wallet is debited up front when it's most likely to cover).
- This PR closes the *remaining* leak surface for the cases where reconciliation still finds the wallet short.

Either can merge first.

## Test plan
- [x] poetry run pytest backend/executor/billing_reconciliation_test.py — 10 tests, including the new `test_positive_delta_passes_fail_insufficient_credits_false` that confirms the kwarg is forwarded and the wallet returns negative on a depleted balance.
- [x] Existing 9 reconciliation tests unchanged — refunds and zero-delta paths still behave correctly.
- [ ] Monitor `billing_leak` Discord alerts post-deploy: should drop to zero (or to genuinely-unexpected-exception cases only).
- [ ] Spot-check a user with a negative balance after deploy: confirm next top-up clears the debt naturally.