### PR TITLE
test(frontend): cover LD context shape with buildLDContext helper

### DIFF
--- a/autogpt_platform/frontend/src/services/feature-flags/__tests__/helpers.test.ts
+++ b/autogpt_platform/frontend/src/services/feature-flags/__tests__/helpers.test.ts
@@ -1,0 +1,80 @@
+import type { User } from "@supabase/supabase-js";
+import { describe, expect, it } from "vitest";
+import { buildLDContext } from "../helpers";
+
+function userFixture(overrides: Partial<User> = {}): User {
+  return {
+    id: "00000000-0000-0000-0000-000000000001",
+    aud: "authenticated",
+    app_metadata: {},
+    user_metadata: {},
+    created_at: "2026-05-08T12:00:00Z",
+    email: "user@example.com",
+    role: "authenticated",
+    ...overrides,
+  } as User;
+}
+
+describe("buildLDContext", () => {
+  it("returns anonymous context when no user", () => {
+    expect(buildLDContext(null)).toEqual({
+      kind: "user",
+      key: "anonymous",
+      anonymous: true,
+    });
+  });
+
+  it("includes email, email_domain, role, created_at, and custom.role for a full user", () => {
+    const ctx = buildLDContext(userFixture());
+
+    expect(ctx).toEqual({
+      kind: "user",
+      key: "00000000-0000-0000-0000-000000000001",
+      anonymous: false,
+      email: "user@example.com",
+      email_domain: "example.com",
+      role: "authenticated",
+      created_at: "2026-05-08T12:00:00Z",
+      custom: { role: "authenticated" },
+    });
+  });
+
+  it("preserves the exact created_at string from Supabase (no normalization)", () => {
+    const ctx = buildLDContext(
+      userFixture({ created_at: "2025-01-15T08:30:45.123456Z" }),
+    );
+
+    expect("created_at" in ctx && ctx.created_at).toBe(
+      "2025-01-15T08:30:45.123456Z",
+    );
+  });
+
+  it("omits created_at when missing — falsy spread skips the key", () => {
+    const ctx = buildLDContext(
+      userFixture({ created_at: undefined as unknown as string }),
+    );
+
+    expect(ctx).not.toHaveProperty("created_at");
+    expect("email" in ctx && ctx.email).toBe("user@example.com");
+  });
+
+  it("omits role and leaves custom empty when role missing", () => {
+    const ctx = buildLDContext(userFixture({ role: undefined }));
+
+    expect(ctx).not.toHaveProperty("role");
+    expect("custom" in ctx && ctx.custom).toEqual({});
+  });
+
+  it("omits email and email_domain when email missing", () => {
+    const ctx = buildLDContext(userFixture({ email: undefined }));
+
+    expect(ctx).not.toHaveProperty("email");
+    expect(ctx).not.toHaveProperty("email_domain");
+  });
+
+  it("derives email_domain from the last @ segment of email", () => {
+    const ctx = buildLDContext(userFixture({ email: "a.b@sub.example.com" }));
+
+    expect("email_domain" in ctx && ctx.email_domain).toBe("sub.example.com");
+  });
+});

--- a/autogpt_platform/frontend/src/services/feature-flags/feature-flag-provider.tsx
+++ b/autogpt_platform/frontend/src/services/feature-flags/feature-flag-provider.tsx
@@ -7,6 +7,7 @@ import { LDProvider } from "launchdarkly-react-client-sdk";
 import type { ReactNode } from "react";
 import { useMemo } from "react";
 import { environment } from "../environment";
+import { buildLDContext } from "./helpers";
 
 const LAUNCHDARKLY_INIT_TIMEOUT_MS = 5000;
 
@@ -17,33 +18,7 @@ export function LaunchDarklyProvider({ children }: { children: ReactNode }) {
 
   const context = useMemo(() => {
     if (isUserLoading) return;
-
-    if (!user) {
-      return {
-        kind: "user" as const,
-        key: "anonymous",
-        anonymous: true,
-      };
-    }
-
-    // Mirror the context built by the backend
-    // (feature_flag.py:_fetch_user_context_data) so LaunchDarkly targeting
-    // rules evaluate identically on both sides.
-    return {
-      kind: "user" as const,
-      key: user.id,
-      anonymous: false,
-      ...(user.email && {
-        email: user.email,
-        email_domain: user.email.split("@").at(-1),
-      }),
-      ...(user.role && { role: user.role }),
-      // Supabase JS emits `Z`-suffixed ISO; backend emits `+00:00` — LD date matchers accept both.
-      ...(user.created_at && { created_at: user.created_at }),
-      custom: {
-        ...(user.role && { role: user.role }),
-      },
-    };
+    return buildLDContext(user);
   }, [user, isUserLoading]);
 
   if (!envEnabled) {

--- a/autogpt_platform/frontend/src/services/feature-flags/helpers.ts
+++ b/autogpt_platform/frontend/src/services/feature-flags/helpers.ts
@@ -1,0 +1,44 @@
+import type { User } from "@supabase/supabase-js";
+
+export type LDUserContext =
+  | {
+      kind: "user";
+      key: string;
+      anonymous: true;
+    }
+  | {
+      kind: "user";
+      key: string;
+      anonymous: false;
+      email?: string;
+      email_domain?: string;
+      role?: string;
+      created_at?: string;
+      custom: { role?: string };
+    };
+
+// Mirror the context built by the backend
+// (feature_flag.py:_fetch_user_context_data) so LaunchDarkly targeting
+// rules evaluate identically on both sides.
+//
+// Supabase JS emits `Z`-suffixed ISO; backend emits `+00:00` — LD date matchers accept both.
+export function buildLDContext(user: User | null): LDUserContext {
+  if (!user) {
+    return { kind: "user", key: "anonymous", anonymous: true };
+  }
+
+  return {
+    kind: "user",
+    key: user.id,
+    anonymous: false,
+    ...(user.email && {
+      email: user.email,
+      email_domain: user.email.split("@").at(-1),
+    }),
+    ...(user.role && { role: user.role }),
+    ...(user.created_at && { created_at: user.created_at }),
+    custom: {
+      ...(user.role && { role: user.role }),
+    },
+  };
+}


### PR DESCRIPTION
## Why

#13036 added `user.created_at` to the LaunchDarkly user context on both backend and frontend, but only the backend has unit-test coverage (`feature_flag_test.py::TestUserContext`). The frontend side — `feature-flag-provider.tsx` — had zero tests, meaning a future refactor that drops the `created_at` spread would silently break the `enable-platform-payment` cohort targeting (and any future date-based LD rule) without any CI signal.

## What

- Extract the inline `useMemo` body in `LaunchDarklyProvider` into a pure `buildLDContext(user)` helper in `services/feature-flags/helpers.ts`.
- Add `__tests__/helpers.test.ts` with seven shape assertions:
  - anonymous (no user) → `{kind, key:"anonymous", anonymous:true}`
  - full user → all six attributes + `custom.role`
  - exact `created_at` string preserved (no normalization)
  - missing `created_at` → key absent
  - missing `role` → no top-level role, `custom` empty
  - missing `email` → no `email`/`email_domain`
  - `email_domain` derived from last `@` segment

No runtime change; provider behaviour is identical (the helper returns the same object literal it built inline).

## How

`buildLDContext(user: User | null): LDUserContext` is a discriminated union — anonymous variant has `anonymous: true`, authenticated variant has `anonymous: false` plus optional attributes. The provider's `useMemo` now reads `if (isUserLoading) return; return buildLDContext(user);`. Helper is colocated with the provider under `services/feature-flags/` so it's discoverable.

## Test plan

- [x] `pnpm vitest run src/services/feature-flags/__tests__/helpers.test.ts` — 7/7 pass
- [x] `pnpm types` — clean
- [x] `pnpm lint` (scoped to changed files) — clean
- [ ] CI confirms full-suite parity post-merge
