### PR TITLE
fix(backend): expose websocket health route at /health

### DIFF
--- a/autogpt_platform/backend/backend/api/ws_api.py
+++ b/autogpt_platform/backend/backend/api/ws_api.py
@@ -332,7 +332,7 @@ async def websocket_router(
         update_websocket_connections(user_id, -1)
 
 
-@app.get("/")
+@app.get("/health")
 async def health():
     return {"status": "healthy"}
 

--- a/autogpt_platform/backend/backend/api/ws_api.py
+++ b/autogpt_platform/backend/backend/api/ws_api.py
@@ -332,6 +332,7 @@ async def websocket_router(
         update_websocket_connections(user_id, -1)
 
 
+@app.get("/")
 @app.get("/health")
 async def health():
     return {"status": "healthy"}

--- a/autogpt_platform/backend/backend/api/ws_api_test.py
+++ b/autogpt_platform/backend/backend/api/ws_api_test.py
@@ -520,7 +520,7 @@ def test_health_endpoint_returns_ok() -> None:
     ws_api.app.router.lifespan_context = _noop_lifespan
     try:
         with TestClient(ws_api.app) as client:
-            r = client.get("/")
+            r = client.get("/health")
         assert r.status_code == 200
         assert r.json() == {"status": "healthy"}
     finally:


### PR DESCRIPTION
## Why

The websocket server has a `/` route that returns `{"status": "healthy"}`, but it's unreachable through the public ingress (`ws-backend.agpt.co` only routes `/ws`). External uptime probes get 404, and we currently can't externally verify WS reachability — only pod health via in-cluster Prometheus.

## What

Renames the route from `@app.get("/")` to `@app.get("/health")` to match the convention used by `backend.agpt.co/health`. Paired with an infra PR that adds `/health` to the WS ingress paths and re-adds `dev-ws-server.agpt.co` / `ws-backend.agpt.co` to the GCP uptime check probe list.

## How

One-line change in `ws_api.py`. Once this lands and the WS deployment rolls, the infra PR will route `/health` externally and the uptime check picks up.
