### PR TITLE
feat(billing): enable Stripe automatic tax on checkout sessions

### DIFF
--- a/autogpt_platform/backend/backend/data/credit.py
+++ b/autogpt_platform/backend/backend/data/credit.py
@@ -1087,6 +1087,9 @@ class UserCredit(UserCreditBase):
             success_url=base_url + "/settings/billing?topup=success",
             cancel_url=base_url + "/settings/billing?topup=cancel",
             allow_promotion_codes=True,
+            automatic_tax={"enabled": True},
+            billing_address_collection="auto",
+            customer_update={"address": "auto"},
         )
 
         await self._add_transaction(
@@ -2274,6 +2277,9 @@ async def create_subscription_checkout(
             }
         },
         allow_promotion_codes=True,
+        automatic_tax={"enabled": True},
+        billing_address_collection="auto",
+        customer_update={"address": "auto"},
     )
     if not session.url:
         # An empty checkout URL for a paid upgrade is always an error; surfacing it


### PR DESCRIPTION
## Summary

Enables Stripe Tax automatic calculation on both the subscription upgrade and credit top-up checkout sessions.

## Changes

**File:** `autogpt_platform/backend/backend/data/credit.py`

Added three parameters to both `stripe.checkout.Session.create` calls:

```python
automatic_tax={enabled: True},
billing_address_collection=auto,
customer_update={address: auto},
```

**Affected functions:**
- `create_subscription_checkout()` — "Upgrade to Max" / plan upgrade flow
- `top_up_intent()` — "Add credits" top-up flow

## Why each parameter

| Parameter | Reason |
|---|---|
| `automatic_tax` | Activates Stripe Tax calculation at checkout |
| `billing_address_collection="auto"` | Collects country + postcode (minimum required for tax rate lookup) |
| `customer_update={"address": "auto"}` | Saves address back to Stripe Customer so repeat checkouts don't re-prompt |

## Prerequisites (Stripe Dashboard — before deploying)

1. Enable Stripe Tax: Dashboard → Tax → Enable
2. Set a default tax code on each product (e.g. `txcd_10000001` for SaaS)
3. Set default tax behavior (`exclusive` or `inclusive`)
4. Register at least one tax nexus jurisdiction

## Testing

- Checkout in test mode with a US address (e.g. California) → should show sales tax line item
- Checkout with a UK address → should show VAT
- Returning customer with saved address → should not be re-prompted for address