### PR TITLE
fix: update Terms of Use and Privacy Policy links to agpt.co

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/signup/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/signup/page.tsx
@@ -135,7 +135,7 @@ export default function SignupPage() {
                           I agree to the
                         </Text>
                         <Link
-                          href="https://auto-gpt.notion.site/Terms-of-Use-11400ef5bece80d0b087d7831c5fd6bf"
+                          href="https://agpt.co/legal/platform-terms-of-use"
                           variant="secondary"
                         >
                           Terms of Use
@@ -147,7 +147,7 @@ export default function SignupPage() {
                           and
                         </Text>
                         <Link
-                          href="https://www.notion.so/auto-gpt/Privacy-Policy-ab11c9c20dbd4de1a15dcffe84d77984"
+                          href="https://agpt.co/legal/platform-privacy-policy"
                           variant="secondary"
                         >
                           Privacy Policy


### PR DESCRIPTION
## Summary

Fixes stale Notion URLs on the /signup page, replacing them with the correct agpt.co legal pages.

**File:** `autogpt_platform/frontend/src/app/(platform)/signup/page.tsx`

| Link | Old URL | New URL |
|------|---------|---------|
| Terms of Use | `auto-gpt.notion.site/Terms-of-Use-...` | `https://agpt.co/legal/platform-terms-of-use` |
| Privacy Policy | `notion.so/auto-gpt/Privacy-Policy-...` | `https://agpt.co/legal/platform-privacy-policy` |