### PR TITLE
fix(backend): limit concurrent top-level tasks per user to 15

### DIFF
--- a/autogpt_platform/backend/backend/api/external/fastapi_app.py
+++ b/autogpt_platform/backend/backend/api/external/fastapi_app.py
@@ -31,7 +31,11 @@ async def _user_paywalled_handler(_request: Request, exc: UserPaywalledError):
 async def _concurrent_task_limit_handler(
     _request: Request, exc: ConcurrentTaskLimitError
 ):
-    return JSONResponse(status_code=429, content={"detail": str(exc)})
+    return JSONResponse(
+        status_code=429,
+        content={"detail": str(exc)},
+        headers={"Retry-After": "60"},
+    )
 
 
 # Add Prometheus instrumentation

--- a/autogpt_platform/backend/backend/api/external/fastapi_app.py
+++ b/autogpt_platform/backend/backend/api/external/fastapi_app.py
@@ -3,7 +3,7 @@ from fastapi.requests import Request
 from fastapi.responses import JSONResponse
 
 from backend.api.middleware.security import SecurityHeadersMiddleware
-from backend.copilot.rate_limit import UserPaywalledError
+from backend.copilot.rate_limit import ConcurrentTaskLimitError, UserPaywalledError
 from backend.monitoring.instrumentation import instrument_fastapi
 
 from .v1.routes import v1_router
@@ -25,6 +25,13 @@ external_api.include_router(v1_router, prefix="/v1")
 @external_api.exception_handler(UserPaywalledError)
 async def _user_paywalled_handler(_request: Request, exc: UserPaywalledError):
     return JSONResponse(status_code=402, content={"detail": str(exc)})
+
+
+@external_api.exception_handler(ConcurrentTaskLimitError)
+async def _concurrent_task_limit_handler(
+    _request: Request, exc: ConcurrentTaskLimitError
+):
+    return JSONResponse(status_code=429, content={"detail": str(exc)})
 
 
 # Add Prometheus instrumentation

--- a/autogpt_platform/backend/backend/api/rest_api.py
+++ b/autogpt_platform/backend/backend/api/rest_api.py
@@ -53,7 +53,7 @@ from backend.api.features.library.exceptions import (
     FolderValidationError,
 )
 from backend.blocks.llm import DEFAULT_LLM_MODEL
-from backend.copilot.rate_limit import UserPaywalledError
+from backend.copilot.rate_limit import ConcurrentTaskLimitError, UserPaywalledError
 from backend.data.model import Credentials
 from backend.integrations.providers import ProviderName
 from backend.monitoring.instrumentation import instrument_fastapi
@@ -314,6 +314,9 @@ app.add_exception_handler(ValueError, handle_internal_http_error(400))
 # server's perspective — the user just lacks entitlement.
 app.add_exception_handler(
     UserPaywalledError, handle_internal_http_error(402, log_error=False)
+)
+app.add_exception_handler(
+    ConcurrentTaskLimitError, handle_internal_http_error(429, log_error=False)
 )
 app.add_exception_handler(PreconditionFailed, handle_internal_http_error(428))
 app.add_exception_handler(Exception, handle_internal_http_error(500))

--- a/autogpt_platform/backend/backend/copilot/rate_limit.py
+++ b/autogpt_platform/backend/backend/copilot/rate_limit.py
@@ -486,8 +486,11 @@ class UserPaywalledError(Exception):
         super().__init__(message)
 
 
+CONCURRENT_TASK_LIMIT = 15
+
+
 class ConcurrentTaskLimitError(Exception):
-    """User has reached the maximum number of concurrent active tasks (15).
+    """User has reached the maximum number of concurrent active tasks.
 
     Raised by ``add_graph_execution`` for every entry point so the limit is
     enforced consistently across HTTP routes, external API, and scheduled runs.
@@ -496,7 +499,7 @@ class ConcurrentTaskLimitError(Exception):
 
     def __init__(
         self,
-        message: str = "You've reached the limit of 15 active tasks. Please wait for one of your current tasks to finish before starting a new one.",
+        message: str = f"You've reached the limit of {CONCURRENT_TASK_LIMIT} active tasks. Please wait for one of your current tasks to finish before starting a new one.",
     ) -> None:
         super().__init__(message)
 

--- a/autogpt_platform/backend/backend/copilot/rate_limit.py
+++ b/autogpt_platform/backend/backend/copilot/rate_limit.py
@@ -486,6 +486,21 @@ class UserPaywalledError(Exception):
         super().__init__(message)
 
 
+class ConcurrentTaskLimitError(Exception):
+    """User has reached the maximum number of concurrent active tasks (15).
+
+    Raised by ``add_graph_execution`` for every entry point so the limit is
+    enforced consistently across HTTP routes, external API, and scheduled runs.
+    Maps to HTTP 429 in the API layer.
+    """
+
+    def __init__(
+        self,
+        message: str = "You've reached the limit of 15 active tasks. Please wait for one of your current tasks to finish before starting a new one.",
+    ) -> None:
+        super().__init__(message)
+
+
 async def get_usage_status(
     user_id: str,
     daily_cost_limit: int,

--- a/autogpt_platform/backend/backend/data/db_manager.py
+++ b/autogpt_platform/backend/backend/data/db_manager.py
@@ -471,6 +471,7 @@ class DatabaseManagerAsyncClient(AppServiceClient):
     get_graph_execution = d.get_graph_execution
     get_graph_execution_meta = d.get_graph_execution_meta
     get_graph_executions = d.get_graph_executions
+    get_graph_executions_count = d.get_graph_executions_count
     get_node_execution = d.get_node_execution
     get_node_executions = d.get_node_executions
     update_graph_execution_stats = d.update_graph_execution_stats

--- a/autogpt_platform/backend/backend/data/execution.py
+++ b/autogpt_platform/backend/backend/data/execution.py
@@ -618,6 +618,7 @@ async def get_graph_executions_count(
     started_time_lte: Optional[datetime] = None,
     updated_time_gte: Optional[datetime] = None,
     updated_time_lte: Optional[datetime] = None,
+    top_level_only: bool = False,
 ) -> int:
     """
     Get count of graph executions with optional filters.
@@ -666,6 +667,9 @@ async def get_graph_executions_count(
 
     if statuses:
         where_filter["OR"] = [{"executionStatus": status} for status in statuses]
+
+    if top_level_only:
+        where_filter["parentGraphExecutionId"] = None
 
     count = await AgentGraphExecution.prisma().count(where=where_filter)
     return count

--- a/autogpt_platform/backend/backend/executor/billing.py
+++ b/autogpt_platform/backend/backend/executor/billing.py
@@ -24,7 +24,7 @@ from backend.util.clients import (
 )
 from backend.util.exceptions import InsufficientBalanceError
 from backend.util.logging import TruncatedLogger
-from backend.util.metrics import DiscordChannel, discord_send_alert
+from backend.util.metrics import DiscordChannel
 from backend.util.settings import Settings
 
 from .utils import LogMetadata, block_usage_cost, execution_usage_cost

--- a/autogpt_platform/backend/backend/executor/utils.py
+++ b/autogpt_platform/backend/backend/executor/utils.py
@@ -11,7 +11,11 @@ from pydantic import BaseModel, JsonValue, ValidationError
 
 from backend.blocks import get_block
 from backend.blocks._base import Block, BlockCostType, BlockType
-from backend.copilot.rate_limit import UserPaywalledError, is_user_paywalled
+from backend.copilot.rate_limit import (
+    ConcurrentTaskLimitError,
+    UserPaywalledError,
+    is_user_paywalled,
+)
 from backend.data import execution as execution_db
 from backend.data import graph as graph_db
 from backend.data import human_review as human_review_db
@@ -1233,6 +1237,24 @@ async def add_graph_execution(
         wdb = workspace_db
     else:
         edb = udb = gdb = odb = wdb = get_database_manager_async_client()
+
+    is_top_level_new_execution = not graph_exec_id and (
+        execution_context is None or execution_context.parent_execution_id is None
+    )
+    if is_top_level_new_execution:
+        _CONCURRENT_TASK_LIMIT = 15
+        active_count = await edb.get_graph_executions_count(
+            user_id=user_id,
+            statuses=[
+                ExecutionStatus.INCOMPLETE,
+                ExecutionStatus.QUEUED,
+                ExecutionStatus.RUNNING,
+                ExecutionStatus.REVIEW,
+            ],
+            top_level_only=True,
+        )
+        if active_count >= _CONCURRENT_TASK_LIMIT:
+            raise ConcurrentTaskLimitError()
 
     # Get or create the graph execution
     if graph_exec_id:

--- a/autogpt_platform/backend/backend/executor/utils.py
+++ b/autogpt_platform/backend/backend/executor/utils.py
@@ -1300,31 +1300,38 @@ async def add_graph_execution(
             # Acquire a per-user Redis lock so the count check and row insert
             # are atomic — prevents two simultaneous requests from both reading
             # count=14 and both sneaking through before either insert lands.
+            from redis.exceptions import LockError
+
             from backend.data.redis_client import get_redis_async
 
             redis = await get_redis_async()
             lock_key = f"concurrent_task_limit:{user_id}"
-            async with redis.lock(lock_key, timeout=10, blocking_timeout=15):
-                active_count = await edb.get_graph_executions_count(
-                    user_id=user_id,
-                    statuses=_active_statuses,
-                    top_level_only=True,
-                )
-                if active_count >= CONCURRENT_TASK_LIMIT:
-                    raise ConcurrentTaskLimitError()
+            try:
+                async with redis.lock(lock_key, timeout=10, blocking_timeout=15):
+                    active_count = await edb.get_graph_executions_count(
+                        user_id=user_id,
+                        statuses=_active_statuses,
+                        top_level_only=True,
+                    )
+                    if active_count >= CONCURRENT_TASK_LIMIT:
+                        raise ConcurrentTaskLimitError()
 
-                graph_exec = await edb.create_graph_execution(
-                    user_id=user_id,
-                    graph_id=graph_id,
-                    graph_version=graph.version,
-                    inputs=inputs or {},
-                    credential_inputs=graph_credentials_inputs,
-                    nodes_input_masks=nodes_input_masks,
-                    starting_nodes_input=starting_nodes_input,
-                    preset_id=preset_id,
-                    parent_graph_exec_id=parent_exec_id,
-                    is_dry_run=dry_run,
-                )
+                    graph_exec = await edb.create_graph_execution(
+                        user_id=user_id,
+                        graph_id=graph_id,
+                        graph_version=graph.version,
+                        inputs=inputs or {},
+                        credential_inputs=graph_credentials_inputs,
+                        nodes_input_masks=nodes_input_masks,
+                        starting_nodes_input=starting_nodes_input,
+                        preset_id=preset_id,
+                        parent_graph_exec_id=parent_exec_id,
+                        is_dry_run=dry_run,
+                    )
+            except ConcurrentTaskLimitError:
+                raise
+            except LockError:
+                raise ConcurrentTaskLimitError()
         else:
             graph_exec = await edb.create_graph_execution(
                 user_id=user_id,

--- a/autogpt_platform/backend/backend/executor/utils.py
+++ b/autogpt_platform/backend/backend/executor/utils.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel, JsonValue, ValidationError
 from backend.blocks import get_block
 from backend.blocks._base import Block, BlockCostType, BlockType
 from backend.copilot.rate_limit import (
+    CONCURRENT_TASK_LIMIT,
     ConcurrentTaskLimitError,
     UserPaywalledError,
     is_user_paywalled,
@@ -528,9 +529,9 @@ async def _validate_node_input_credentials(
             except ValidationError as e:
                 # Validation error means credentials were provided but invalid
                 # This should always be an error, even if optional
-                credential_errors[node.id][
-                    field_name
-                ] = f"{CRED_ERR_INVALID_PREFIX} {e}"
+                credential_errors[node.id][field_name] = (
+                    f"{CRED_ERR_INVALID_PREFIX} {e}"
+                )
                 continue
 
             try:
@@ -541,15 +542,15 @@ async def _validate_node_input_credentials(
             except Exception as e:
                 # Handle any errors fetching credentials
                 # If credentials were explicitly configured but unavailable, it's an error
-                credential_errors[node.id][
-                    field_name
-                ] = f"{CRED_ERR_NOT_AVAILABLE_PREFIX} {e}"
+                credential_errors[node.id][field_name] = (
+                    f"{CRED_ERR_NOT_AVAILABLE_PREFIX} {e}"
+                )
                 continue
 
             if not credentials:
-                credential_errors[node.id][
-                    field_name
-                ] = f"{CRED_ERR_UNKNOWN_PREFIX}{credentials_meta.id}"
+                credential_errors[node.id][field_name] = (
+                    f"{CRED_ERR_UNKNOWN_PREFIX}{credentials_meta.id}"
+                )
                 continue
 
             if (
@@ -659,18 +660,18 @@ async def _validate_node_input_credentials(
                             _mark_optional_skip()
                             continue
                         has_missing_credentials = True
-                        credential_errors[node.id][
-                            field_name
-                        ] = f"{CRED_ERR_NOT_AVAILABLE_PREFIX} {e}"
+                        credential_errors[node.id][field_name] = (
+                            f"{CRED_ERR_NOT_AVAILABLE_PREFIX} {e}"
+                        )
                         continue
                     if not creds:
                         if field_is_optional:
                             _mark_optional_skip()
                             continue
                         has_missing_credentials = True
-                        credential_errors[node.id][
-                            field_name
-                        ] = f"{CRED_ERR_UNKNOWN_PREFIX}{cred_id}"
+                        credential_errors[node.id][field_name] = (
+                            f"{CRED_ERR_UNKNOWN_PREFIX}{cred_id}"
+                        )
 
         # If node has optional credentials and any are missing, skip the
         # node so the executor doesn't try to execute it with None creds.
@@ -1241,20 +1242,13 @@ async def add_graph_execution(
     is_top_level_new_execution = not graph_exec_id and (
         execution_context is None or execution_context.parent_execution_id is None
     )
-    if is_top_level_new_execution:
-        _CONCURRENT_TASK_LIMIT = 15
-        active_count = await edb.get_graph_executions_count(
-            user_id=user_id,
-            statuses=[
-                ExecutionStatus.INCOMPLETE,
-                ExecutionStatus.QUEUED,
-                ExecutionStatus.RUNNING,
-                ExecutionStatus.REVIEW,
-            ],
-            top_level_only=True,
-        )
-        if active_count >= _CONCURRENT_TASK_LIMIT:
-            raise ConcurrentTaskLimitError()
+
+    _active_statuses = [
+        ExecutionStatus.INCOMPLETE,
+        ExecutionStatus.QUEUED,
+        ExecutionStatus.RUNNING,
+        ExecutionStatus.REVIEW,
+    ]
 
     # Get or create the graph execution
     if graph_exec_id:
@@ -1302,18 +1296,48 @@ async def add_graph_execution(
             dry_run=dry_run,
         )
 
-        graph_exec = await edb.create_graph_execution(
-            user_id=user_id,
-            graph_id=graph_id,
-            graph_version=graph.version,
-            inputs=inputs or {},
-            credential_inputs=graph_credentials_inputs,
-            nodes_input_masks=nodes_input_masks,
-            starting_nodes_input=starting_nodes_input,
-            preset_id=preset_id,
-            parent_graph_exec_id=parent_exec_id,
-            is_dry_run=dry_run,
-        )
+        if is_top_level_new_execution:
+            # Acquire a per-user Redis lock so the count check and row insert
+            # are atomic — prevents two simultaneous requests from both reading
+            # count=14 and both sneaking through before either insert lands.
+            from backend.data.redis_client import get_redis_async
+
+            redis = await get_redis_async()
+            lock_key = f"concurrent_task_limit:{user_id}"
+            async with redis.lock(lock_key, timeout=10, blocking_timeout=15):
+                active_count = await edb.get_graph_executions_count(
+                    user_id=user_id,
+                    statuses=_active_statuses,
+                    top_level_only=True,
+                )
+                if active_count >= CONCURRENT_TASK_LIMIT:
+                    raise ConcurrentTaskLimitError()
+
+                graph_exec = await edb.create_graph_execution(
+                    user_id=user_id,
+                    graph_id=graph_id,
+                    graph_version=graph.version,
+                    inputs=inputs or {},
+                    credential_inputs=graph_credentials_inputs,
+                    nodes_input_masks=nodes_input_masks,
+                    starting_nodes_input=starting_nodes_input,
+                    preset_id=preset_id,
+                    parent_graph_exec_id=parent_exec_id,
+                    is_dry_run=dry_run,
+                )
+        else:
+            graph_exec = await edb.create_graph_execution(
+                user_id=user_id,
+                graph_id=graph_id,
+                graph_version=graph.version,
+                inputs=inputs or {},
+                credential_inputs=graph_credentials_inputs,
+                nodes_input_masks=nodes_input_masks,
+                starting_nodes_input=starting_nodes_input,
+                preset_id=preset_id,
+                parent_graph_exec_id=parent_exec_id,
+                is_dry_run=dry_run,
+            )
 
         logger.info(
             f"Created graph execution #{graph_exec.id} for graph "

--- a/autogpt_platform/backend/backend/executor/utils.py
+++ b/autogpt_platform/backend/backend/executor/utils.py
@@ -529,9 +529,9 @@ async def _validate_node_input_credentials(
             except ValidationError as e:
                 # Validation error means credentials were provided but invalid
                 # This should always be an error, even if optional
-                credential_errors[node.id][field_name] = (
-                    f"{CRED_ERR_INVALID_PREFIX} {e}"
-                )
+                credential_errors[node.id][
+                    field_name
+                ] = f"{CRED_ERR_INVALID_PREFIX} {e}"
                 continue
 
             try:
@@ -542,15 +542,15 @@ async def _validate_node_input_credentials(
             except Exception as e:
                 # Handle any errors fetching credentials
                 # If credentials were explicitly configured but unavailable, it's an error
-                credential_errors[node.id][field_name] = (
-                    f"{CRED_ERR_NOT_AVAILABLE_PREFIX} {e}"
-                )
+                credential_errors[node.id][
+                    field_name
+                ] = f"{CRED_ERR_NOT_AVAILABLE_PREFIX} {e}"
                 continue
 
             if not credentials:
-                credential_errors[node.id][field_name] = (
-                    f"{CRED_ERR_UNKNOWN_PREFIX}{credentials_meta.id}"
-                )
+                credential_errors[node.id][
+                    field_name
+                ] = f"{CRED_ERR_UNKNOWN_PREFIX}{credentials_meta.id}"
                 continue
 
             if (
@@ -660,18 +660,18 @@ async def _validate_node_input_credentials(
                             _mark_optional_skip()
                             continue
                         has_missing_credentials = True
-                        credential_errors[node.id][field_name] = (
-                            f"{CRED_ERR_NOT_AVAILABLE_PREFIX} {e}"
-                        )
+                        credential_errors[node.id][
+                            field_name
+                        ] = f"{CRED_ERR_NOT_AVAILABLE_PREFIX} {e}"
                         continue
                     if not creds:
                         if field_is_optional:
                             _mark_optional_skip()
                             continue
                         has_missing_credentials = True
-                        credential_errors[node.id][field_name] = (
-                            f"{CRED_ERR_UNKNOWN_PREFIX}{cred_id}"
-                        )
+                        credential_errors[node.id][
+                            field_name
+                        ] = f"{CRED_ERR_UNKNOWN_PREFIX}{cred_id}"
 
         # If node has optional credentials and any are missing, skip the
         # node so the executor doesn't try to execute it with None creds.

--- a/autogpt_platform/backend/backend/executor/utils_test.py
+++ b/autogpt_platform/backend/backend/executor/utils_test.py
@@ -1800,3 +1800,91 @@ async def test_add_graph_execution_bypass_paywall_skips_check(
         )
 
     paywall_mock.assert_not_called()
+
+
+# ============================================================================
+# Concurrent task limit: users with 15+ active top-level executions must be
+# rejected before any new execution is created.
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_add_graph_execution_concurrent_limit_blocks_at_15(
+    mocker: MockerFixture,
+):
+    """User at exactly 15 active top-level executions is rejected."""
+    from backend.copilot.rate_limit import ConcurrentTaskLimitError
+
+    mocker.patch(
+        "backend.executor.utils.is_user_paywalled",
+        new=mocker.AsyncMock(return_value=False),
+    )
+    mocker.patch("backend.executor.utils.prisma").is_connected.return_value = True
+    mock_edb = mocker.patch("backend.executor.utils.execution_db")
+    mock_edb.get_graph_executions_count = mocker.AsyncMock(return_value=15)
+    mock_edb.create_graph_execution = mocker.AsyncMock()
+
+    with pytest.raises(ConcurrentTaskLimitError):
+        await add_graph_execution(graph_id="g", user_id="heavy-user")
+
+    mock_edb.create_graph_execution.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_add_graph_execution_concurrent_limit_allows_at_14(
+    mocker: MockerFixture,
+):
+    """User with 14 active tasks is allowed past the concurrent limit gate."""
+    mocker.patch(
+        "backend.executor.utils.is_user_paywalled",
+        new=mocker.AsyncMock(return_value=False),
+    )
+    mocker.patch("backend.executor.utils.prisma").is_connected.return_value = True
+    mocker.patch("backend.executor.utils.user_db")
+    mocker.patch("backend.executor.utils.graph_db")
+    mocker.patch("backend.executor.utils.workspace_db")
+    mocker.patch("backend.executor.utils.onboarding_db")
+    mock_edb = mocker.patch("backend.executor.utils.execution_db")
+    mock_edb.get_graph_executions_count = mocker.AsyncMock(return_value=14)
+    # Force an early sentinel error after the gate to confirm it was passed.
+    mock_edb.get_graph_execution = mocker.AsyncMock(
+        side_effect=RuntimeError("passed limit gate")
+    )
+    mock_edb.create_graph_execution = mocker.AsyncMock()
+
+    with pytest.raises(RuntimeError, match="passed limit gate"):
+        await add_graph_execution(
+            graph_id="g",
+            user_id="normal-user",
+            graph_exec_id="existing-id",
+        )
+
+
+@pytest.mark.asyncio
+async def test_add_graph_execution_concurrent_limit_skipped_for_sub_graphs(
+    mocker: MockerFixture,
+):
+    """Sub-graph executions (execution_context with a parent) bypass the limit."""
+    from backend.data.execution import ExecutionContext
+
+    mocker.patch(
+        "backend.executor.utils.is_user_paywalled",
+        new=mocker.AsyncMock(return_value=False),
+    )
+    mocker.patch("backend.executor.utils.prisma").is_connected.return_value = True
+    mocker.patch("backend.executor.utils.user_db")
+    mocker.patch("backend.executor.utils.graph_db")
+    mocker.patch("backend.executor.utils.workspace_db")
+    mocker.patch("backend.executor.utils.onboarding_db")
+    mock_edb = mocker.patch("backend.executor.utils.execution_db")
+    mock_edb.get_graph_executions_count = mocker.AsyncMock(return_value=99)
+    mock_edb.create_graph_execution = mocker.AsyncMock(
+        side_effect=RuntimeError("reached create")
+    )
+
+    ctx = ExecutionContext(parent_execution_id="parent-exec")
+
+    with pytest.raises(RuntimeError, match="reached create"):
+        await add_graph_execution(graph_id="g", user_id="user", execution_context=ctx)
+
+    mock_edb.get_graph_executions_count.assert_not_called()

--- a/autogpt_platform/backend/backend/executor/utils_test.py
+++ b/autogpt_platform/backend/backend/executor/utils_test.py
@@ -394,6 +394,7 @@ async def test_add_graph_execution_is_repeatable(mocker: MockerFixture):
         nodes_to_skip,
     )
     mock_prisma.is_connected.return_value = True
+    mock_edb.get_graph_executions_count = mocker.AsyncMock(return_value=0)
     mock_edb.create_graph_execution = mocker.AsyncMock(return_value=mock_graph_exec)
     mock_edb.update_graph_execution_stats = mocker.AsyncMock(
         return_value=mock_graph_exec
@@ -548,6 +549,7 @@ async def test_add_graph_execution_via_rpc_returns_typed_user(
             human_in_the_loop_safe_mode=False, sensitive_action_safe_mode=False
         )
     )
+    mock_db_client.get_graph_executions_count = mocker.AsyncMock(return_value=0)
     mock_db_client.create_graph_execution = mocker.AsyncMock(
         return_value=mock_graph_exec
     )
@@ -773,6 +775,7 @@ async def test_add_graph_execution_with_nodes_to_skip(mocker: MockerFixture):
         nodes_to_skip,  # This should be passed through
     )
     mock_prisma.is_connected.return_value = True
+    mock_edb.get_graph_executions_count = mocker.AsyncMock(return_value=0)
     mock_edb.create_graph_execution = mocker.AsyncMock(return_value=mock_graph_exec)
     mock_edb.update_graph_execution_stats = mocker.AsyncMock(
         return_value=mock_graph_exec

--- a/autogpt_platform/backend/backend/executor/utils_test.py
+++ b/autogpt_platform/backend/backend/executor/utils_test.py
@@ -1808,6 +1808,22 @@ async def test_add_graph_execution_bypass_paywall_skips_check(
 # ============================================================================
 
 
+def _make_noop_redis_lock(mocker: MockerFixture):
+    """Return a mock get_redis_async whose .lock() is a no-op async context manager."""
+    lock_cm = mocker.MagicMock()
+    lock_cm.__aenter__ = mocker.AsyncMock(return_value=None)
+    lock_cm.__aexit__ = mocker.AsyncMock(return_value=False)
+    # MagicMock (not AsyncMock) so .lock() is a regular callable returning lock_cm,
+    # not an async method that returns a coroutine.
+    mock_redis = mocker.MagicMock()
+    mock_redis.lock.return_value = lock_cm
+    mock_get_redis = mocker.patch(
+        "backend.data.redis_client.get_redis_async",
+        new=mocker.AsyncMock(return_value=mock_redis),
+    )
+    return mock_get_redis
+
+
 @pytest.mark.asyncio
 async def test_add_graph_execution_concurrent_limit_blocks_at_15(
     mocker: MockerFixture,
@@ -1820,6 +1836,11 @@ async def test_add_graph_execution_concurrent_limit_blocks_at_15(
         new=mocker.AsyncMock(return_value=False),
     )
     mocker.patch("backend.executor.utils.prisma").is_connected.return_value = True
+    _make_noop_redis_lock(mocker)
+    mocker.patch(
+        "backend.executor.utils.validate_and_construct_node_execution_input",
+        new=mocker.AsyncMock(return_value=(mocker.MagicMock(version=1), [], {}, set())),
+    )
     mock_edb = mocker.patch("backend.executor.utils.execution_db")
     mock_edb.get_graph_executions_count = mocker.AsyncMock(return_value=15)
     mock_edb.create_graph_execution = mocker.AsyncMock()
@@ -1840,24 +1861,23 @@ async def test_add_graph_execution_concurrent_limit_allows_at_14(
         new=mocker.AsyncMock(return_value=False),
     )
     mocker.patch("backend.executor.utils.prisma").is_connected.return_value = True
-    mocker.patch("backend.executor.utils.user_db")
-    mocker.patch("backend.executor.utils.graph_db")
-    mocker.patch("backend.executor.utils.workspace_db")
-    mocker.patch("backend.executor.utils.onboarding_db")
+    _make_noop_redis_lock(mocker)
+    mocker.patch(
+        "backend.executor.utils.validate_and_construct_node_execution_input",
+        new=mocker.AsyncMock(return_value=(mocker.MagicMock(version=1), [], {}, set())),
+    )
     mock_edb = mocker.patch("backend.executor.utils.execution_db")
     mock_edb.get_graph_executions_count = mocker.AsyncMock(return_value=14)
-    # Force an early sentinel error after the gate to confirm it was passed.
-    mock_edb.get_graph_execution = mocker.AsyncMock(
+    # Force a sentinel error at create_graph_execution to confirm the limit gate
+    # was passed. No graph_exec_id so this is a genuine new top-level execution.
+    mock_edb.create_graph_execution = mocker.AsyncMock(
         side_effect=RuntimeError("passed limit gate")
     )
-    mock_edb.create_graph_execution = mocker.AsyncMock()
 
     with pytest.raises(RuntimeError, match="passed limit gate"):
-        await add_graph_execution(
-            graph_id="g",
-            user_id="normal-user",
-            graph_exec_id="existing-id",
-        )
+        await add_graph_execution(graph_id="g", user_id="normal-user")
+
+    mock_edb.get_graph_executions_count.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -1876,6 +1896,10 @@ async def test_add_graph_execution_concurrent_limit_skipped_for_sub_graphs(
     mocker.patch("backend.executor.utils.graph_db")
     mocker.patch("backend.executor.utils.workspace_db")
     mocker.patch("backend.executor.utils.onboarding_db")
+    mocker.patch(
+        "backend.executor.utils.validate_and_construct_node_execution_input",
+        new=mocker.AsyncMock(return_value=(mocker.MagicMock(version=1), [], {}, set())),
+    )
     mock_edb = mocker.patch("backend.executor.utils.execution_db")
     mock_edb.get_graph_executions_count = mocker.AsyncMock(return_value=99)
     mock_edb.create_graph_execution = mocker.AsyncMock(

--- a/autogpt_platform/backend/backend/executor/utils_test.py
+++ b/autogpt_platform/backend/backend/executor/utils_test.py
@@ -1915,3 +1915,42 @@ async def test_add_graph_execution_concurrent_limit_skipped_for_sub_graphs(
         await add_graph_execution(graph_id="g", user_id="user", execution_context=ctx)
 
     mock_edb.get_graph_executions_count.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_add_graph_execution_concurrent_limit_lock_timeout_raises_429(
+    mocker: MockerFixture,
+):
+    """Redis LockError (blocking_timeout exhausted) surfaces as ConcurrentTaskLimitError."""
+    from redis.exceptions import LockError
+
+    from backend.copilot.rate_limit import ConcurrentTaskLimitError
+
+    mocker.patch(
+        "backend.executor.utils.is_user_paywalled",
+        new=mocker.AsyncMock(return_value=False),
+    )
+    mocker.patch("backend.executor.utils.prisma").is_connected.return_value = True
+
+    # Build a redis mock whose .lock() raises LockError on acquisition.
+    lock_cm = mocker.MagicMock()
+    lock_cm.__aenter__ = mocker.AsyncMock(side_effect=LockError("timed out"))
+    lock_cm.__aexit__ = mocker.AsyncMock(return_value=False)
+    mock_redis = mocker.MagicMock()
+    mock_redis.lock.return_value = lock_cm
+    mocker.patch(
+        "backend.data.redis_client.get_redis_async",
+        new=mocker.AsyncMock(return_value=mock_redis),
+    )
+    mocker.patch(
+        "backend.executor.utils.validate_and_construct_node_execution_input",
+        new=mocker.AsyncMock(return_value=(mocker.MagicMock(version=1), [], {}, set())),
+    )
+    mock_edb = mocker.patch("backend.executor.utils.execution_db")
+    mock_edb.get_graph_executions_count = mocker.AsyncMock(return_value=0)
+    mock_edb.create_graph_execution = mocker.AsyncMock()
+
+    with pytest.raises(ConcurrentTaskLimitError):
+        await add_graph_execution(graph_id="g", user_id="busy-user")
+
+    mock_edb.create_graph_execution.assert_not_called()


### PR DESCRIPTION
## Changes

- Add `ConcurrentTaskLimitError` exception (maps to HTTP 429) in `copilot/rate_limit.py`
- Register 429 handler in both `rest_api.py` (internal API) and `external/fastapi_app.py` (external API)
- Add `top_level_only` filter to `get_graph_executions_count` in `execution.py` — counts only executions with no parent, ignoring internally-spawned sub-graphs
- Expose `get_graph_executions_count` on `DatabaseManagerAsyncClient` (was missing)
- In `add_graph_execution()`: after the paywall gate, count active (INCOMPLETE/QUEUED/RUNNING/REVIEW) top-level executions for the user; raise `ConcurrentTaskLimitError` if ≥ 15
- Sub-graph executions (those with an `execution_context.parent_execution_id`) bypass the check
- Re-queued executions (`graph_exec_id` provided) also bypass the check — limit is for new starts only
- Error message: _"You've reached the limit of 15 active tasks. Please wait for one of your current tasks to finish before starting a new one."_

## Why

Security + stability hotfix: users can spawn hundreds of concurrent tasks via the API before the credit system catches up, causing system-wide errors. This is a hard guard before paid users are onboarded.

Closes [SECRT-2335](https://linear.app/autogpt/issue/SECRT-2335)

## Testing

- [ ] Unit tests added for: blocks-at-15 (rejected), blocks-at-14 (allowed), sub-graph bypasses limit
- [ ] `poetry run format` passes clean
- [ ] CI

## Checklist

- [x] I have filled out the **Changes** section above
- [x] I have added/updated tests for new behaviour
- [x] No out-of-scope changes beyond the hotfix