### PR TITLE
fix(backend/copilot): default CHAT_USE_OPENROUTER back to true for OR observability

### DIFF
--- a/autogpt_platform/backend/backend/copilot/config.py
+++ b/autogpt_platform/backend/backend/copilot/config.py
@@ -414,15 +414,15 @@ class ChatConfig(BaseSettings):
         "(same pattern as `api_key` / `base_url`).",
     )
     use_openrouter: bool = Field(
-        default=False,
+        default=True,
         description="Route copilot LLM calls through the OpenRouter proxy. "
-        "Default is ``False``: main path goes direct to api.anthropic.com "
-        "via the OpenAI-compat endpoint (requires ``CHAT_DIRECT_ANTHROPIC_API_KEY`` "
-        "or ``ANTHROPIC_API_KEY``).  Set ``CHAT_USE_OPENROUTER=true`` (with "
-        "``CHAT_API_KEY`` + ``CHAT_BASE_URL=https://openrouter.ai/api/v1``) "
-        "to keep using OpenRouter.  The actual decision also requires the "
-        "credentials to be valid — use the ``openrouter_active`` property "
-        "for the final answer.",
+        "Default is ``True`` so all turns (main + aux: title, simulation, "
+        "future builder helpers) flow through OpenRouter for unified "
+        "observability and cost broadcasting.  Set ``CHAT_USE_OPENROUTER=false`` "
+        "(with ``CHAT_DIRECT_ANTHROPIC_API_KEY`` or ``ANTHROPIC_API_KEY``) to "
+        "route the main path direct to api.anthropic.com.  The actual decision "
+        "also requires the credentials to be valid — use the ``openrouter_active`` "
+        "property for the final answer.",
     )
     use_claude_code_subscription: bool = Field(
         default=False,


### PR DESCRIPTION
## Why

[#13034](https://github.com/Significant-Gravitas/AutoGPT/pull/13034) flipped `CHAT_USE_OPENROUTER` to default `false`, routing the copilot main client direct to `api.anthropic.com`. We need to revert that default so **everything copilot-related stays on OpenRouter** — main turn, title generation, simulation, future builder helpers — to keep unified observability (request/response broadcasting, cost tracking, per-call telemetry) in one place.

Direct-Anthropic mode remains supported and opt-in for deployments that explicitly want to bypass the proxy.

## What

- `ChatConfig.use_openrouter` default flipped from `False` back to `True`.
- Field description updated to reflect that OR is the default and direct-Anthropic is opt-in.

No other code changes — all the direct-Anthropic plumbing from #13034 (rate card, model normalizer, boot validators, aux client split, cost recovery) stays intact and is exercised whenever an operator opts into `CHAT_USE_OPENROUTER=false`.

## How

```bash
# OpenRouter (new/restored default — for observability)
# No env vars required; existing OPEN_ROUTER_API_KEY / CHAT_API_KEY are picked up.

# Direct Anthropic (opt-in — bypass OR proxy)
CHAT_USE_OPENROUTER=false
ANTHROPIC_API_KEY=sk-ant-...
# (optional) CHAT_AUX_API_KEY=sk-or-v1-...   # keep aux on OR
```

### Test plan

- [x] `pytest backend/copilot/{config,anthropic_rate_card,model_normalize}_test.py` — 77 passed locally
- [x] Field default verified at `backend/copilot/config.py:417` → `default=True`
