### PR TITLE
feat(copilot): add Export Chat as Markdown option to session menu

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatSidebar/ChatSidebar.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatSidebar/ChatSidebar.tsx
@@ -26,7 +26,7 @@ import { cn } from "@/lib/utils";
 import {
   CheckCircle,
   CircleNotch,
-  DownloadSimple,
+  DownloadSimpleIcon,
   DotsThree,
   PlusCircleIcon,
   PlusIcon,
@@ -164,10 +164,14 @@ export function ChatSidebar() {
     try {
       await fetchAndExportChat(id, title, getV2GetSession);
       toast({ title: "Chat exported" });
-    } catch {
+    } catch (error) {
+      console.error("Failed to export chat:", { id, title, error });
       toast({
         title: "Export failed",
-        description: "Could not export this chat. Please try again.",
+        description:
+          error instanceof Error
+            ? error.message
+            : "Could not export this chat. Please try again.",
         variant: "destructive",
       });
     }
@@ -405,7 +409,7 @@ export function ChatSidebar() {
                               handleExportClick(e, session.id, session.title)
                             }
                           >
-                            <DownloadSimple className="mr-2 h-4 w-4" />
+                            <DownloadSimpleIcon className="mr-2 h-4 w-4" />
                             Export chat
                           </DropdownMenuItem>
                           <DropdownMenuItem

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatSidebar/ChatSidebar.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatSidebar/ChatSidebar.tsx
@@ -41,7 +41,7 @@ import { shouldShowSessionProcessingIndicator } from "../../sessionActivity";
 import { useCopilotUIStore } from "../../store";
 import { useSessionDeletion } from "../../useSessionDeletion";
 import { NotificationToggle } from "./components/NotificationToggle/NotificationToggle";
-import { exportChatAsMarkdown } from "../../helpers/exportChatAsMarkdown";
+import { fetchAndExportChat } from "../../helpers/exportChatAsMarkdown";
 import { DeleteChatDialog } from "../DeleteChatDialog/DeleteChatDialog";
 import { UsagePopover } from "../UsageLimits/UsagePopover/UsagePopover";
 
@@ -162,14 +162,7 @@ export function ChatSidebar() {
   ) {
     e.stopPropagation();
     try {
-      const response = await getV2GetSession(id, { limit: 2000 });
-      if (response.status !== 200) throw new Error("Failed to fetch session");
-      const messages = (response.data.messages ?? []) as {
-        role: string;
-        content: string | null;
-        tool_calls: unknown[] | null;
-      }[];
-      exportChatAsMarkdown(id, title, messages);
+      await fetchAndExportChat(id, title, getV2GetSession);
       toast({ title: "Chat exported" });
     } catch {
       toast({

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatSidebar/ChatSidebar.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatSidebar/ChatSidebar.tsx
@@ -28,8 +28,10 @@ import {
   CircleNotch,
   DownloadSimpleIcon,
   DotsThree,
+  PencilSimpleIcon,
   PlusCircleIcon,
   PlusIcon,
+  TrashIcon,
 } from "@phosphor-icons/react";
 import { useQueryClient } from "@tanstack/react-query";
 import { AnimatePresence, motion } from "framer-motion";
@@ -69,6 +71,9 @@ export function ChatSidebar() {
 
   const [editingSessionId, setEditingSessionId] = useState<string | null>(null);
   const [editingTitle, setEditingTitle] = useState("");
+  const [exportingSessionIds, setExportingSessionIds] = useState<Set<string>>(
+    new Set(),
+  );
   const renameInputRef = useRef<HTMLInputElement>(null);
   const renameCancelledRef = useRef(false);
 
@@ -161,6 +166,8 @@ export function ChatSidebar() {
     title: string | null | undefined,
   ) {
     e.stopPropagation();
+    if (exportingSessionIds.has(id)) return;
+    setExportingSessionIds((prev) => new Set(prev).add(id));
     try {
       await fetchAndExportChat(id, title, getV2GetSession);
       toast({ title: "Chat exported" });
@@ -173,6 +180,12 @@ export function ChatSidebar() {
             ? error.message
             : "Could not export this chat. Please try again.",
         variant: "destructive",
+      });
+    } finally {
+      setExportingSessionIds((prev) => {
+        const next = new Set(prev);
+        next.delete(id);
+        return next;
       });
     }
   }
@@ -330,7 +343,12 @@ export function ChatSidebar() {
                     ) : (
                       <button
                         onClick={() => handleSelectSession(session.id)}
-                        className="w-full px-3 py-2.5 pr-10 text-left"
+                        className={cn(
+                          "w-full px-3 py-2.5 text-left",
+                          exportingSessionIds.has(session.id)
+                            ? "pr-[68px]"
+                            : "pr-10",
+                        )}
                       >
                         <div className="flex min-w-0 max-w-full items-center gap-2">
                           <div className="min-w-0 flex-1">
@@ -385,6 +403,18 @@ export function ChatSidebar() {
                         </div>
                       </button>
                     )}
+                    {exportingSessionIds.has(session.id) && (
+                      <div
+                        className="pointer-events-none absolute right-9 top-1/2 z-10 -translate-y-1/2 rounded-full bg-white text-zinc-600 shadow-sm"
+                        aria-label="Exporting chat"
+                        title="Exporting chat…"
+                      >
+                        <div className="relative h-7 w-7">
+                          <div className="absolute inset-0 animate-spin rounded-full border-2 border-zinc-200 border-t-zinc-700" />
+                          <DownloadSimpleIcon className="absolute inset-0 m-auto h-3.5 w-3.5" />
+                        </div>
+                      </div>
+                    )}
                     {editingSessionId !== session.id && (
                       <DropdownMenu>
                         <DropdownMenuTrigger asChild>
@@ -402,15 +432,30 @@ export function ChatSidebar() {
                               handleRenameClick(e, session.id, session.title)
                             }
                           >
+                            <PencilSimpleIcon className="mr-2 h-4 w-4" />
                             Rename
                           </DropdownMenuItem>
                           <DropdownMenuItem
                             onClick={(e) =>
                               handleExportClick(e, session.id, session.title)
                             }
+                            onSelect={(e) => {
+                              if (exportingSessionIds.has(session.id))
+                                e.preventDefault();
+                            }}
+                            disabled={exportingSessionIds.has(session.id)}
                           >
-                            <DownloadSimpleIcon className="mr-2 h-4 w-4" />
-                            Export chat
+                            {exportingSessionIds.has(session.id) ? (
+                              <CircleNotch
+                                className="mr-2 h-4 w-4 animate-spin"
+                                weight="bold"
+                              />
+                            ) : (
+                              <DownloadSimpleIcon className="mr-2 h-4 w-4" />
+                            )}
+                            {exportingSessionIds.has(session.id)
+                              ? "Exporting…"
+                              : "Export chat"}
                           </DropdownMenuItem>
                           <DropdownMenuItem
                             onClick={(e) =>
@@ -419,6 +464,7 @@ export function ChatSidebar() {
                             disabled={isDeleting}
                             className="text-red-600 focus:bg-red-50 focus:text-red-600"
                           >
+                            <TrashIcon className="mr-2 h-4 w-4" />
                             Delete chat
                           </DropdownMenuItem>
                         </DropdownMenuContent>

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatSidebar/ChatSidebar.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatSidebar/ChatSidebar.tsx
@@ -1,6 +1,7 @@
 "use client";
 import {
   getGetV2ListSessionsQueryKey,
+  getV2GetSession,
   useGetV2ListSessions,
   usePatchV2UpdateSessionTitle,
 } from "@/app/api/__generated__/endpoints/chat/chat";
@@ -25,6 +26,7 @@ import { cn } from "@/lib/utils";
 import {
   CheckCircle,
   CircleNotch,
+  DownloadSimple,
   DotsThree,
   PlusCircleIcon,
   PlusIcon,
@@ -39,6 +41,7 @@ import { shouldShowSessionProcessingIndicator } from "../../sessionActivity";
 import { useCopilotUIStore } from "../../store";
 import { useSessionDeletion } from "../../useSessionDeletion";
 import { NotificationToggle } from "./components/NotificationToggle/NotificationToggle";
+import { exportChatAsMarkdown } from "../../helpers/exportChatAsMarkdown";
 import { DeleteChatDialog } from "../DeleteChatDialog/DeleteChatDialog";
 import { UsagePopover } from "../UsageLimits/UsagePopover/UsagePopover";
 
@@ -150,6 +153,31 @@ export function ChatSidebar() {
   ) {
     e.stopPropagation();
     requestDelete(id, title);
+  }
+
+  async function handleExportClick(
+    e: React.MouseEvent,
+    id: string,
+    title: string | null | undefined,
+  ) {
+    e.stopPropagation();
+    try {
+      const response = await getV2GetSession(id, { limit: 2000 });
+      if (response.status !== 200) throw new Error("Failed to fetch session");
+      const messages = (response.data.messages ?? []) as {
+        role: string;
+        content: string | null;
+        tool_calls: unknown[] | null;
+      }[];
+      exportChatAsMarkdown(id, title, messages);
+      toast({ title: "Chat exported" });
+    } catch {
+      toast({
+        title: "Export failed",
+        description: "Could not export this chat. Please try again.",
+        variant: "destructive",
+      });
+    }
   }
 
   function formatDate(dateString: string) {
@@ -378,6 +406,14 @@ export function ChatSidebar() {
                             }
                           >
                             Rename
+                          </DropdownMenuItem>
+                          <DropdownMenuItem
+                            onClick={(e) =>
+                              handleExportClick(e, session.id, session.title)
+                            }
+                          >
+                            <DownloadSimple className="mr-2 h-4 w-4" />
+                            Export chat
                           </DropdownMenuItem>
                           <DropdownMenuItem
                             onClick={(e) =>

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/helpers/__tests__/exportChatAsMarkdown.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/helpers/__tests__/exportChatAsMarkdown.test.ts
@@ -4,7 +4,12 @@ import { exportChatAsMarkdown } from "../exportChatAsMarkdown";
 describe("exportChatAsMarkdown", () => {
   let clickSpy: ReturnType<typeof vi.fn>;
   let removeSpy: ReturnType<typeof vi.fn>;
-  let anchor: { href: string; download: string; click: () => void; remove: () => void };
+  let anchor: {
+    href: string;
+    download: string;
+    click: () => void;
+    remove: () => void;
+  };
 
   beforeEach(() => {
     clickSpy = vi.fn();

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/helpers/__tests__/exportChatAsMarkdown.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/helpers/__tests__/exportChatAsMarkdown.test.ts
@@ -222,11 +222,11 @@ describe("fetchAndExportChat", () => {
     expect(anchor.download).toMatch(/\.md$/);
   });
 
-  it("throws when fetch returns non-200 status", async () => {
+  it("throws when fetch returns non-200 status (includes status code)", async () => {
     const mockFetch = vi.fn().mockResolvedValue({ status: 404, data: {} });
     await expect(
       fetchAndExportChat("session-1", "My Chat", mockFetch),
-    ).rejects.toThrow("Failed to fetch session");
+    ).rejects.toThrow("Failed to fetch session (status: 404)");
   });
 
   it("handles null messages array gracefully", async () => {

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/helpers/__tests__/exportChatAsMarkdown.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/helpers/__tests__/exportChatAsMarkdown.test.ts
@@ -119,6 +119,48 @@ describe("exportChatAsMarkdown", () => {
     expect(anchor.download).not.toContain("/");
   });
 
+  it("falls back to 'Untitled chat' when title is undefined", () => {
+    exportChatAsMarkdown("session-1", undefined, []);
+    expect(anchor.download).toContain("Untitled chat");
+  });
+
+  it("uses 'unknown_tool' when tool call has no function name", () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: null,
+        tool_calls: [{ function: { name: undefined, arguments: "{}" } }],
+      },
+    ];
+    exportChatAsMarkdown("session-1", "Test", messages);
+
+    const blob: Blob = (URL.createObjectURL as ReturnType<typeof vi.fn>).mock
+      .calls[0][0];
+    return blob.text().then((text) => {
+      expect(text).toContain("unknown_tool");
+    });
+  });
+
+  it("handles invalid JSON in tool call arguments gracefully", () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: null,
+        tool_calls: [
+          { function: { name: "my_tool", arguments: "not-valid-json" } },
+        ],
+      },
+    ];
+    exportChatAsMarkdown("session-1", "Test", messages);
+
+    const blob: Blob = (URL.createObjectURL as ReturnType<typeof vi.fn>).mock
+      .calls[0][0];
+    return blob.text().then((text) => {
+      expect(text).toContain("my_tool");
+      expect(text).toContain("not-valid-json");
+    });
+  });
+
   it("includes export date in the markdown body", () => {
     exportChatAsMarkdown("session-1", "Test", []);
 

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/helpers/__tests__/exportChatAsMarkdown.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/helpers/__tests__/exportChatAsMarkdown.test.ts
@@ -49,12 +49,12 @@ describe("exportChatAsMarkdown", () => {
 
   it("includes the chat title in the filename", () => {
     exportChatAsMarkdown("session-1", "My Chat", []);
-    expect(anchor.download).toContain("My-Chat");
+    expect(anchor.download).toContain("My Chat");
   });
 
-  it("falls back to 'Untitled-chat' when title is null", () => {
+  it("falls back to 'Untitled chat' when title is null", () => {
     exportChatAsMarkdown("session-1", null, []);
-    expect(anchor.download).toContain("Untitled-chat");
+    expect(anchor.download).toContain("Untitled chat");
   });
 
   it("renders user and assistant messages with headers", () => {

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/helpers/__tests__/exportChatAsMarkdown.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/helpers/__tests__/exportChatAsMarkdown.test.ts
@@ -275,6 +275,23 @@ describe("fetchAndExportChat", () => {
     expect(clickSpy).toHaveBeenCalled();
   });
 
+  it("throws when pagination cap is hit while has_more is still true", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      status: 200,
+      data: {
+        messages: [{ role: "user", content: "msg", tool_calls: null }],
+        has_more_messages: true,
+        oldest_sequence: 1,
+      },
+    });
+
+    await expect(
+      fetchAndExportChat("session-1", "My Chat", mockFetch),
+    ).rejects.toThrow(/exceeded \d+ messages/);
+
+    expect(clickSpy).not.toHaveBeenCalled();
+  });
+
   it("stops paginating when oldest_sequence is null even if has_more is true", async () => {
     const mockFetch = vi.fn().mockResolvedValue({
       status: 200,

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/helpers/__tests__/exportChatAsMarkdown.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/helpers/__tests__/exportChatAsMarkdown.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { exportChatAsMarkdown } from "../exportChatAsMarkdown";
+
+describe("exportChatAsMarkdown", () => {
+  let clickSpy: ReturnType<typeof vi.fn>;
+  let removeSpy: ReturnType<typeof vi.fn>;
+  let anchor: { href: string; download: string; click: () => void; remove: () => void };
+
+  beforeEach(() => {
+    clickSpy = vi.fn();
+    removeSpy = vi.fn();
+
+    anchor = { href: "", download: "", click: clickSpy, remove: removeSpy };
+
+    vi.stubGlobal(
+      "URL",
+      Object.assign(URL, {
+        createObjectURL: vi.fn().mockReturnValue("blob:fake-url"),
+        revokeObjectURL: vi.fn(),
+      }),
+    );
+
+    vi.spyOn(document, "createElement").mockReturnValue(
+      anchor as unknown as HTMLAnchorElement,
+    );
+
+    vi.spyOn(document.body, "appendChild").mockImplementation(
+      (node) => node as ChildNode,
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("triggers a download with .md extension", () => {
+    exportChatAsMarkdown("session-1", "My Chat", []);
+    expect(clickSpy).toHaveBeenCalled();
+    expect(removeSpy).toHaveBeenCalled();
+    expect(anchor.download).toMatch(/\.md$/);
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:fake-url");
+  });
+
+  it("includes the chat title in the filename", () => {
+    exportChatAsMarkdown("session-1", "My Chat", []);
+    expect(anchor.download).toContain("My-Chat");
+  });
+
+  it("falls back to 'Untitled-chat' when title is null", () => {
+    exportChatAsMarkdown("session-1", null, []);
+    expect(anchor.download).toContain("Untitled-chat");
+  });
+
+  it("renders user and assistant messages with headers", () => {
+    const messages = [
+      { role: "user", content: "Hello", tool_calls: null },
+      { role: "assistant", content: "Hi there", tool_calls: null },
+    ];
+    exportChatAsMarkdown("session-1", "Test", messages);
+
+    const blob: Blob = (URL.createObjectURL as ReturnType<typeof vi.fn>).mock
+      .calls[0][0];
+    return blob.text().then((text) => {
+      expect(text).toContain("## User");
+      expect(text).toContain("Hello");
+      expect(text).toContain("## Assistant");
+      expect(text).toContain("Hi there");
+    });
+  });
+
+  it("skips tool result messages (role === 'tool')", () => {
+    const messages = [
+      { role: "tool", content: "tool result", tool_calls: null },
+    ];
+    exportChatAsMarkdown("session-1", "Test", messages);
+
+    const blob: Blob = (URL.createObjectURL as ReturnType<typeof vi.fn>).mock
+      .calls[0][0];
+    return blob.text().then((text) => {
+      expect(text).not.toContain("tool result");
+      expect(text).not.toContain("## Tool");
+    });
+  });
+
+  it("renders tool calls as blockquotes with emoji", () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: null,
+        tool_calls: [
+          {
+            function: {
+              name: "search_web",
+              arguments: JSON.stringify({ query: "cats" }),
+            },
+          },
+        ],
+      },
+    ];
+    exportChatAsMarkdown("session-1", "Test", messages);
+
+    const blob: Blob = (URL.createObjectURL as ReturnType<typeof vi.fn>).mock
+      .calls[0][0];
+    return blob.text().then((text) => {
+      expect(text).toContain("> 🔧");
+      expect(text).toContain("search_web");
+    });
+  });
+
+  it("sanitizes path traversal in title", () => {
+    exportChatAsMarkdown("session-1", "../../etc/passwd", []);
+    expect(anchor.download).not.toContain("..");
+    expect(anchor.download).not.toContain("/");
+  });
+
+  it("includes export date in the markdown body", () => {
+    exportChatAsMarkdown("session-1", "Test", []);
+
+    const blob: Blob = (URL.createObjectURL as ReturnType<typeof vi.fn>).mock
+      .calls[0][0];
+    return blob.text().then((text) => {
+      expect(text).toMatch(/_Exported: \d{4}-\d{2}-\d{2}_/);
+    });
+  });
+});

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/helpers/__tests__/exportChatAsMarkdown.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/helpers/__tests__/exportChatAsMarkdown.test.ts
@@ -7,8 +7,8 @@ describe("exportChatAsMarkdown", () => {
   let anchor: {
     href: string;
     download: string;
-    click: () => void;
-    remove: () => void;
+    click: ReturnType<typeof vi.fn>;
+    remove: ReturnType<typeof vi.fn>;
   };
 
   beforeEach(() => {

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/helpers/__tests__/exportChatAsMarkdown.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/helpers/__tests__/exportChatAsMarkdown.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
-import { exportChatAsMarkdown } from "../exportChatAsMarkdown";
+import {
+  exportChatAsMarkdown,
+  fetchAndExportChat,
+} from "../exportChatAsMarkdown";
 
 describe("exportChatAsMarkdown", () => {
   let clickSpy: ReturnType<typeof vi.fn>;
@@ -169,5 +172,69 @@ describe("exportChatAsMarkdown", () => {
     return blob.text().then((text) => {
       expect(text).toMatch(/_Exported: \d{4}-\d{2}-\d{2}_/);
     });
+  });
+});
+
+describe("fetchAndExportChat", () => {
+  let clickSpy: ReturnType<typeof vi.fn>;
+  let anchor: {
+    href: string;
+    download: string;
+    click: ReturnType<typeof vi.fn>;
+    remove: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    clickSpy = vi.fn();
+    anchor = { href: "", download: "", click: clickSpy, remove: vi.fn() };
+
+    vi.stubGlobal(
+      "URL",
+      Object.assign(URL, {
+        createObjectURL: vi.fn().mockReturnValue("blob:fake-url"),
+        revokeObjectURL: vi.fn(),
+      }),
+    );
+
+    vi.spyOn(document, "createElement").mockReturnValue(
+      anchor as unknown as HTMLAnchorElement,
+    );
+
+    vi.spyOn(document.body, "appendChild").mockImplementation(
+      (node) => node as ChildNode,
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("calls exportChatAsMarkdown when fetch succeeds", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      status: 200,
+      data: {
+        messages: [{ role: "user", content: "Hello", tool_calls: null }],
+      },
+    });
+    await fetchAndExportChat("session-1", "My Chat", mockFetch);
+    expect(clickSpy).toHaveBeenCalled();
+    expect(anchor.download).toMatch(/\.md$/);
+  });
+
+  it("throws when fetch returns non-200 status", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ status: 404, data: {} });
+    await expect(
+      fetchAndExportChat("session-1", "My Chat", mockFetch),
+    ).rejects.toThrow("Failed to fetch session");
+  });
+
+  it("handles null messages array gracefully", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      status: 200,
+      data: { messages: null },
+    });
+    await fetchAndExportChat("session-1", "My Chat", mockFetch);
+    expect(clickSpy).toHaveBeenCalled();
   });
 });

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/helpers/__tests__/exportChatAsMarkdown.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/helpers/__tests__/exportChatAsMarkdown.test.ts
@@ -237,4 +237,57 @@ describe("fetchAndExportChat", () => {
     await fetchAndExportChat("session-1", "My Chat", mockFetch);
     expect(clickSpy).toHaveBeenCalled();
   });
+
+  it("paginates via before_sequence until has_more_messages is false", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        status: 200,
+        data: {
+          messages: [
+            { role: "user", content: "page2-msg-a", tool_calls: null },
+            { role: "assistant", content: "page2-msg-b", tool_calls: null },
+          ],
+          has_more_messages: true,
+          oldest_sequence: 42,
+        },
+      })
+      .mockResolvedValueOnce({
+        status: 200,
+        data: {
+          messages: [
+            { role: "user", content: "page1-msg-a", tool_calls: null },
+            { role: "assistant", content: "page1-msg-b", tool_calls: null },
+          ],
+          has_more_messages: false,
+          oldest_sequence: 1,
+        },
+      });
+
+    await fetchAndExportChat("session-1", "My Chat", mockFetch);
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockFetch).toHaveBeenNthCalledWith(1, "session-1", { limit: 200 });
+    expect(mockFetch).toHaveBeenNthCalledWith(2, "session-1", {
+      limit: 200,
+      before_sequence: 42,
+    });
+    expect(clickSpy).toHaveBeenCalled();
+  });
+
+  it("stops paginating when oldest_sequence is null even if has_more is true", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      status: 200,
+      data: {
+        messages: [{ role: "user", content: "Hello", tool_calls: null }],
+        has_more_messages: true,
+        oldest_sequence: null,
+      },
+    });
+
+    await fetchAndExportChat("session-1", "My Chat", mockFetch);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(clickSpy).toHaveBeenCalled();
+  });
 });

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/helpers/exportChatAsMarkdown.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/helpers/exportChatAsMarkdown.ts
@@ -1,0 +1,83 @@
+interface SessionChatMessage {
+  role: string;
+  content: string | null;
+  tool_calls: unknown[] | null;
+}
+
+interface ToolCall {
+  function?: {
+    name?: string;
+    arguments?: string;
+  };
+}
+
+function formatToolCalls(toolCalls: unknown[]): string {
+  return toolCalls
+    .map((tc) => {
+      const call = tc as ToolCall;
+      const name = call.function?.name ?? "unknown_tool";
+      let argsStr = "";
+      try {
+        const args = JSON.parse(call.function?.arguments ?? "{}") as Record<
+          string,
+          unknown
+        >;
+        argsStr = Object.entries(args)
+          .map(([k, v]) => `${k}=${JSON.stringify(v)}`)
+          .join(", ");
+      } catch {
+        argsStr = call.function?.arguments ?? "";
+      }
+      return `> 🔧 \`${name}(${argsStr})\``;
+    })
+    .join("\n");
+}
+
+function sanitizeFilename(name: string): string {
+  return name
+    .replace(/\.\./g, "_")
+    .replace(/[\\/:*?"<>|\x00-\x1f]/g, "_")
+    .replace(/^\.+/, "")
+    .slice(0, 100);
+}
+
+export function exportChatAsMarkdown(
+  _sessionId: string,
+  title: string | null | undefined,
+  messages: SessionChatMessage[],
+): void {
+  const displayTitle = title || "Untitled chat";
+  const date = new Date().toISOString().slice(0, 10);
+
+  const lines: string[] = [
+    `# ${displayTitle}`,
+    `_Exported: ${date}_`,
+    "",
+  ];
+
+  for (const msg of messages) {
+    if (msg.role === "tool") continue;
+
+    if (msg.role === "user") {
+      lines.push("## User", "");
+      if (msg.content) lines.push(msg.content, "");
+    } else if (msg.role === "assistant") {
+      lines.push("## Assistant", "");
+      if (msg.tool_calls && msg.tool_calls.length > 0) {
+        lines.push(formatToolCalls(msg.tool_calls), "");
+      }
+      if (msg.content) lines.push(msg.content, "");
+    }
+  }
+
+  const markdown = lines.join("\n");
+  const blob = new Blob([markdown], { type: "text/markdown;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `chat-${sanitizeFilename(displayTitle)}-${date}.md`;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/helpers/exportChatAsMarkdown.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/helpers/exportChatAsMarkdown.ts
@@ -77,3 +77,26 @@ export function exportChatAsMarkdown(
   a.remove();
   URL.revokeObjectURL(url);
 }
+
+export async function fetchAndExportChat(
+  id: string,
+  title: string | null | undefined,
+  fetchSession: (
+    id: string,
+    opts: { limit: number },
+  ) => Promise<{
+    status: number;
+    data: {
+      messages?: Array<{
+        role: string;
+        content: string | null;
+        tool_calls: unknown[] | null;
+      }> | null;
+    };
+  }>,
+): Promise<void> {
+  const response = await fetchSession(id, { limit: 2000 });
+  if (response.status !== 200) throw new Error("Failed to fetch session");
+  const messages = (response.data.messages ?? []) as SessionChatMessage[];
+  exportChatAsMarkdown(id, title, messages);
+}

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/helpers/exportChatAsMarkdown.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/helpers/exportChatAsMarkdown.ts
@@ -81,14 +81,22 @@ export function exportChatAsMarkdown(
 const EXPORT_PAGE_SIZE = 200;
 const EXPORT_MAX_PAGES = 100;
 
+interface SessionPageResponse {
+  status: number;
+  data: {
+    messages?: SessionChatMessage[] | null;
+    has_more_messages?: boolean | null;
+    oldest_sequence?: number | null;
+  };
+}
+
 export async function fetchAndExportChat(
   id: string,
   title: string | null | undefined,
   fetchSession: (
     id: string,
     opts: { limit: number; before_sequence?: number },
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ) => Promise<any>,
+  ) => Promise<SessionPageResponse>,
 ): Promise<void> {
   const allMessages: SessionChatMessage[] = [];
   let beforeSequence: number | undefined = undefined;
@@ -100,7 +108,9 @@ export async function fetchAndExportChat(
     if (beforeSequence !== undefined) opts.before_sequence = beforeSequence;
 
     const response = await fetchSession(id, opts);
-    if (response.status !== 200) throw new Error("Failed to fetch session");
+    if (response.status !== 200) {
+      throw new Error(`Failed to fetch session (status: ${response.status})`);
+    }
 
     const pageMessages = (response.data.messages ?? []) as SessionChatMessage[];
     allMessages.unshift(...pageMessages);

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/helpers/exportChatAsMarkdown.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/helpers/exportChatAsMarkdown.ts
@@ -78,14 +78,38 @@ export function exportChatAsMarkdown(
   URL.revokeObjectURL(url);
 }
 
+const EXPORT_PAGE_SIZE = 200;
+const EXPORT_MAX_PAGES = 100;
+
 export async function fetchAndExportChat(
   id: string,
   title: string | null | undefined,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  fetchSession: (id: string, opts: { limit: number }) => Promise<any>,
+  fetchSession: (
+    id: string,
+    opts: { limit: number; before_sequence?: number },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ) => Promise<any>,
 ): Promise<void> {
-  const response = await fetchSession(id, { limit: 2000 });
-  if (response.status !== 200) throw new Error("Failed to fetch session");
-  const messages = (response.data.messages ?? []) as SessionChatMessage[];
-  exportChatAsMarkdown(id, title, messages);
+  const allMessages: SessionChatMessage[] = [];
+  let beforeSequence: number | undefined = undefined;
+
+  for (let page = 0; page < EXPORT_MAX_PAGES; page++) {
+    const opts: { limit: number; before_sequence?: number } = {
+      limit: EXPORT_PAGE_SIZE,
+    };
+    if (beforeSequence !== undefined) opts.before_sequence = beforeSequence;
+
+    const response = await fetchSession(id, opts);
+    if (response.status !== 200) throw new Error("Failed to fetch session");
+
+    const pageMessages = (response.data.messages ?? []) as SessionChatMessage[];
+    allMessages.unshift(...pageMessages);
+
+    const hasMore = !!response.data.has_more_messages;
+    const oldestSeq = response.data.oldest_sequence;
+    if (!hasMore || oldestSeq == null) break;
+    beforeSequence = oldestSeq;
+  }
+
+  exportChatAsMarkdown(id, title, allMessages);
 }

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/helpers/exportChatAsMarkdown.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/helpers/exportChatAsMarkdown.ts
@@ -81,22 +81,10 @@ export function exportChatAsMarkdown(
 const EXPORT_PAGE_SIZE = 200;
 const EXPORT_MAX_PAGES = 100;
 
-interface SessionPageResponse {
-  status: number;
-  data: {
-    messages?: SessionChatMessage[] | null;
-    has_more_messages?: boolean | null;
-    oldest_sequence?: number | null;
-  };
-}
-
 export async function fetchAndExportChat(
   id: string,
   title: string | null | undefined,
-  fetchSession: (
-    id: string,
-    opts: { limit: number; before_sequence?: number },
-  ) => Promise<SessionPageResponse>,
+  fetchSession: typeof import("@/app/api/__generated__/endpoints/chat/chat").getV2GetSession,
 ): Promise<void> {
   const allMessages: SessionChatMessage[] = [];
   let beforeSequence: number | undefined = undefined;

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/helpers/exportChatAsMarkdown.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/helpers/exportChatAsMarkdown.ts
@@ -100,7 +100,8 @@ export async function fetchAndExportChat(
       throw new Error(`Failed to fetch session (status: ${response.status})`);
     }
 
-    const pageMessages = (response.data.messages ?? []) as SessionChatMessage[];
+    const pageMessages = (response.data.messages ??
+      []) as unknown as SessionChatMessage[];
     allMessages.unshift(...pageMessages);
 
     const hasMore = !!response.data.has_more_messages;

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/helpers/exportChatAsMarkdown.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/helpers/exportChatAsMarkdown.ts
@@ -88,6 +88,7 @@ export async function fetchAndExportChat(
 ): Promise<void> {
   const allMessages: SessionChatMessage[] = [];
   let beforeSequence: number | undefined = undefined;
+  let truncated = false;
 
   for (let page = 0; page < EXPORT_MAX_PAGES; page++) {
     const opts: { limit: number; before_sequence?: number } = {
@@ -107,7 +108,17 @@ export async function fetchAndExportChat(
     const hasMore = !!response.data.has_more_messages;
     const oldestSeq = response.data.oldest_sequence;
     if (!hasMore || oldestSeq == null) break;
+    if (page === EXPORT_MAX_PAGES - 1) {
+      truncated = true;
+      break;
+    }
     beforeSequence = oldestSeq;
+  }
+
+  if (truncated) {
+    throw new Error(
+      `Chat export exceeded ${EXPORT_MAX_PAGES * EXPORT_PAGE_SIZE} messages. Please contact support to export this chat.`,
+    );
   }
 
   exportChatAsMarkdown(id, title, allMessages);

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/helpers/exportChatAsMarkdown.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/helpers/exportChatAsMarkdown.ts
@@ -49,11 +49,7 @@ export function exportChatAsMarkdown(
   const displayTitle = title || "Untitled chat";
   const date = new Date().toISOString().slice(0, 10);
 
-  const lines: string[] = [
-    `# ${displayTitle}`,
-    `_Exported: ${date}_`,
-    "",
-  ];
+  const lines: string[] = [`# ${displayTitle}`, `_Exported: ${date}_`, ""];
 
   for (const msg of messages) {
     if (msg.role === "tool") continue;

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/helpers/exportChatAsMarkdown.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/helpers/exportChatAsMarkdown.ts
@@ -81,19 +81,8 @@ export function exportChatAsMarkdown(
 export async function fetchAndExportChat(
   id: string,
   title: string | null | undefined,
-  fetchSession: (
-    id: string,
-    opts: { limit: number },
-  ) => Promise<{
-    status: number;
-    data: {
-      messages?: Array<{
-        role: string;
-        content: string | null;
-        tool_calls: unknown[] | null;
-      }> | null;
-    };
-  }>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  fetchSession: (id: string, opts: { limit: number }) => Promise<any>,
 ): Promise<void> {
   const response = await fetchSession(id, { limit: 2000 });
   if (response.status !== 200) throw new Error("Failed to fetch session");


### PR DESCRIPTION
## Summary

Adds an **Export chat** option to the ⋯ dropdown on each CoPilot sidebar session. Clicking it fetches the full conversation and instantly downloads a `.md` file in the browser.

## Changes

### New file: `helpers/exportChatAsMarkdown.ts`
- Formats user/assistant turns as `## User` / `## Assistant` markdown headers
- Renders tool calls inline as `> 🔧 tool_name(args)` blockquotes — shows *what* the agent did without dumping raw JSON result blobs
- Skips `role === "tool"` result messages
- Sanitizes filename; uses Blob + anchor download pattern (same as `downloadArtifact.ts`)
- Filename format: `chat-<title>-<YYYY-MM-DD>.md`

### Modified: `ChatSidebar.tsx`
- Adds **Export chat** `DropdownMenuItem` (with `DownloadSimple` icon) between Rename and Delete chat
- Fetches full session on demand via `getV2GetSession` with `limit: 2000`
- Shows success/error toast feedback

## Testing
1. Open CoPilot, hover a session in the sidebar → click ⋯
2. **Export chat** appears between Rename and Delete chat
3. Clicking it downloads `chat-<title>-<date>.md` immediately
4. File contains `## User` / `## Assistant` sections; tool calls show as `> 🔧 tool_name(...)`
5. Error toast appears if the session fetch fails