### PR TITLE
chore(backend): seed block preflight estimates from 30d prod usage

### DIFF
--- a/autogpt_platform/backend/backend/data/block_preflight_estimates.json
+++ b/autogpt_platform/backend/backend/data/block_preflight_estimates.json
@@ -1,6 +1,61 @@
 {
   "version": 1,
-  "generated_at": null,
-  "source_window_days": null,
-  "estimates": {}
+  "generated_at": "2026-05-11T08:29:28.322148+00:00",
+  "source_window_days": 30,
+  "estimates": {
+    "3b191d9f-356f-482d-8238-ba04b6d18381": {
+      "block_name": "OrchestratorBlock",
+      "cost_type": "cost_usd",
+      "samples": 3227,
+      "mean_credits": 6
+    },
+    "1f292d4a-41a4-4977-9684-7c8d560b9f91": {
+      "block_name": "AITextGeneratorBlock",
+      "cost_type": "cost_usd",
+      "samples": 2283,
+      "mean_credits": 4
+    },
+    "87840993-2053-44b7-8da4-187ad4ee518c": {
+      "block_name": "SearchTheWebBlock",
+      "cost_type": "cost_usd",
+      "samples": 1202,
+      "mean_credits": 1
+    },
+    "a0a69be1-4528-491c-a85a-a4ab6873e3f0": {
+      "block_name": "AITextSummarizerBlock",
+      "cost_type": "cost_usd",
+      "samples": 1105,
+      "mean_credits": 8
+    },
+    "c40d75a2-d0ea-44c9-a4f6-634bb3bdab1a": {
+      "block_name": "ReplicateModelBlock",
+      "cost_type": "cost_usd",
+      "samples": 633,
+      "mean_credits": 10
+    },
+    "0b02b072-abe7-11ef-8372-fb5d162dd712": {
+      "block_name": "ExecuteCodeBlock",
+      "cost_type": "second",
+      "samples": 63,
+      "mean_credits": 1
+    },
+    "9c0b0450-d199-458b-a731-072189dd6593": {
+      "block_name": "AIListGeneratorBlock",
+      "cost_type": "cost_usd",
+      "samples": 36,
+      "mean_credits": 5
+    },
+    "c8a5f2e9-8b3d-4a7e-9f6c-1d5e3c9b7a4f": {
+      "block_name": "PerplexityBlock",
+      "cost_type": "cost_usd",
+      "samples": 21,
+      "mean_credits": 5
+    },
+    "ed55ac19-356e-4243-a6cb-bc599e9b716f": {
+      "block_name": "AIStructuredResponseGeneratorBlock",
+      "cost_type": "cost_usd",
+      "samples": 16,
+      "mean_credits": 6
+    }
+  }
 }

--- a/autogpt_platform/backend/backend/executor/billing_reconciliation_test.py
+++ b/autogpt_platform/backend/backend/executor/billing_reconciliation_test.py
@@ -10,7 +10,17 @@ from backend.blocks.jina.search import SearchTheWebBlock
 from backend.data.block_cost_config import BLOCK_COSTS
 from backend.data.execution import ExecutionContext, NodeExecutionEntry
 from backend.data.model import NodeExecutionStats
+from backend.executor import utils as executor_utils
 from backend.executor.billing import charge_reconciled_usage
+
+
+@pytest.fixture(autouse=True)
+def _stub_preflight_estimate(monkeypatch):
+    """Force `get_preflight_estimate` to return 0 in this module's tests so
+    they don't accidentally couple to a populated
+    `block_preflight_estimates.json` once the admin export tool seeds it.
+    """
+    monkeypatch.setattr(executor_utils, "get_preflight_estimate", lambda _bid: 0)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Why

PR #13031 landed the pre-flight estimate machinery for dynamic-cost blocks (`SECOND` / `ITEMS` / `COST_USD`) but ships an empty `block_preflight_estimates.json` — every dynamic-cost block still pre-charges 0. This PR populates the JSON so the platform pre-charges a historical mean at block start, and post-flight reconciliation (`charge_reconciled_usage`) only has to settle a small delta instead of the full cost.

Shrinks the `billing_leak` surface: today, if a user's wallet empties between block start and reconciliation, the entire dynamic cost is uncollectable. With this seed in place, the bulk is collected up front, and the residual delta is what reconciliation handles (positive → debt allowed via `fail_insufficient_credits=False` from #13043; negative → refund via USAGE row with negative cost).

## What

Replaces `autogpt_platform/backend/backend/data/block_preflight_estimates.json` with 9 dynamic-cost blocks aggregated from prod `CreditTransaction` USAGE rows.

| Block | cost_type | samples (30d) | mean_credits |
|---|---|---:|---:|
| OrchestratorBlock | cost_usd | 3,227 | 6 |
| AITextGeneratorBlock | cost_usd | 2,283 | 4 |
| SearchTheWebBlock | cost_usd | 1,202 | 1 |
| AITextSummarizerBlock | cost_usd | 1,105 | 8 |
| ReplicateModelBlock | cost_usd | 633 | 10 |
| ExecuteCodeBlock | second | 63 | 1 |
| AIListGeneratorBlock | cost_usd | 36 | 5 |
| PerplexityBlock | cost_usd | 21 | 5 |
| AIStructuredResponseGeneratorBlock | cost_usd | 16 | 6 |

13 other dynamic-cost blocks on dev had <10 samples in the 30d window and are intentionally omitted — they continue to pre-charge 0 (unchanged from today). They'll get seeded once they have enough volume.

## How

1. Ran the same SQL as `compute_block_cost_estimates` (per-`(block_id, node_exec_id)` sum, then mean across executions, `min_samples=10`, 30d window) against the prod `CreditTransaction` table via `kubectl exec` against an `autogpt-server` pod — no credentials left the cluster.
2. `cost_type` was re-resolved against `BLOCK_COSTS` on this branch to match the dev runtime classification (no reclassifications needed — all 9 blocks have the same dynamic cost type on prod and dev).
3. Format matches the loader in `block_preflight_estimates.py` — `version`, `generated_at`, `source_window_days` are metadata; only `estimates.{block_id}.mean_credits` is consumed at runtime.

## Behaviour at runtime

For each of these 9 blocks, every execution now:
1. Pre-charges `mean_credits` at start (was 0).
2. Computes actual cost from execution stats post-flight.
3. Settles `delta = actual - mean_credits`:
   - `delta > 0` → additional USAGE charge (wallet allowed to go negative).
   - `delta < 0` → refund as USAGE row with negative cost.
   - `delta == 0` → no-op.

**Net charge per execution is unchanged.** Only the timing of the debit shifts forward.

## Test plan

- [ ] Spot-check OrchestratorBlock + AITextGeneratorBlock in PostHog / Grafana — confirm the 30d mean is in the right ballpark.
- [ ] Verify `pnpm types` / `poetry run lint` pass (JSON-only change — should be a no-op).
- [ ] Post-deploy on dev: run an OrchestratorBlock execution, confirm a pre-flight USAGE row of ~6 credits, then a reconciliation row settling the delta.
- [ ] No regression on TOKENS blocks (excluded by `DYNAMIC_COST_TYPES`; `compute_token_credits` continues to provide the per-model floor at pre-flight).
