### PR TITLE
fix(blocks): clean up Medium author ID copy

### DIFF
--- a/autogpt_platform/backend/backend/blocks/medium.py
+++ b/autogpt_platform/backend/backend/blocks/medium.py
@@ -46,8 +46,8 @@ class PublishToMediumBlock(Block):
     class Input(BlockSchemaInput):
         author_id: BlockSecret = SecretField(
             key="medium_author_id",
-            description="""The Medium AuthorID of the user. You can get this by calling the /me endpoint of the Medium API.\n\ncurl -H "Authorization: Bearer YOUR_ACCESS_TOKEN" https://api.medium.com/v1/me\n\nThe response will contain the authorId field.""",
-            placeholder="Enter the author's Medium AuthorID",
+            description="""The Medium author ID of the user. You can get this by calling the /me endpoint of the Medium API.\n\ncurl -H "Authorization: Bearer YOUR_ACCESS_TOKEN" https://api.medium.com/v1/me\n\nThe response will contain the authorId field.""",
+            placeholder="Enter the author's Medium author ID",
         )
         title: str = SchemaField(
             description="The title of your Medium post",

--- a/autogpt_platform/backend/backend/blocks/medium.py
+++ b/autogpt_platform/backend/backend/blocks/medium.py
@@ -46,7 +46,7 @@ class PublishToMediumBlock(Block):
     class Input(BlockSchemaInput):
         author_id: BlockSecret = SecretField(
             key="medium_author_id",
-            description="""The Medium author ID of the user. You can get this by calling the /me endpoint of the Medium API.\n\ncurl -H "Authorization: Bearer YOUR_ACCESS_TOKEN" https://api.medium.com/v1/me\n\nThe response will contain the authorId field.""",
+            description="""The Medium author ID of the user. You can get this by calling the /me endpoint of the Medium API.\n\ncurl -H "Authorization: Bearer YOUR_ACCESS_TOKEN" https://api.medium.com/v1/me\n\nThe response will contain the `authorId` field.""",
             placeholder="Enter the author's Medium author ID",
         )
         title: str = SchemaField(

--- a/docs/integrations/block-integrations/misc.md
+++ b/docs/integrations/block-integrations/misc.md
@@ -785,7 +785,7 @@ Configure publish_status to publish immediately, save as draft, or make unlisted
 
 | Input | Description | Type | Required |
 |-------|-------------|------|----------|
-| author_id | The Medium author ID of the user. You can get this by calling the /me endpoint of the Medium API.  curl -H "Authorization: Bearer YOUR_ACCESS_TOKEN" https://api.medium.com/v1/me  The response will contain the authorId field. | str | No |
+| author_id | The Medium author ID of the user. You can get this by calling the /me endpoint of the Medium API.  curl -H "Authorization: Bearer YOUR_ACCESS_TOKEN" https://api.medium.com/v1/me  The response will contain the `authorId` field. | str | No |
 | title | The title of your Medium post | str | Yes |
 | content | The main content of your Medium post | str | Yes |
 | content_format | The format of the content: 'html' or 'markdown' | str | Yes |

--- a/docs/integrations/block-integrations/misc.md
+++ b/docs/integrations/block-integrations/misc.md
@@ -785,7 +785,7 @@ Configure publish_status to publish immediately, save as draft, or make unlisted
 
 | Input | Description | Type | Required |
 |-------|-------------|------|----------|
-| author_id | The Medium AuthorID of the user. You can get this by calling the /me endpoint of the Medium API.  curl -H "Authorization: Bearer YOUR_ACCESS_TOKEN" https://api.medium.com/v1/me  The response will contain the authorId field. | str | No |
+| author_id | The Medium author ID of the user. You can get this by calling the /me endpoint of the Medium API.  curl -H "Authorization: Bearer YOUR_ACCESS_TOKEN" https://api.medium.com/v1/me  The response will contain the authorId field. | str | No |
 | title | The title of your Medium post | str | Yes |
 | content | The main content of your Medium post | str | Yes |
 | content_format | The format of the content: 'html' or 'markdown' | str | Yes |


### PR DESCRIPTION
### Why / What / How

The Medium publish block's author ID helper text used the less readable `AuthorID` spelling in user-facing schema copy.

This PR updates that description and placeholder to use `author ID` consistently.

The change is limited to schema metadata for the Medium block and does not alter runtime behavior.

### Changes 🏗️

- Updated the Medium `author_id` field description to say `author ID`.
- Updated the Medium `author_id` placeholder to match the revised wording.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `poetry run lint --skip-pyright`

<details>
  <summary>Example test plan</summary>
  
  - [ ] Create from scratch and execute an agent with at least 3 blocks
  - [ ] Import an agent from file upload, and confirm it executes correctly
  - [ ] Upload agent to marketplace
  - [ ] Import an agent from marketplace and confirm it executes correctly
  - [ ] Edit an agent from monitor, and confirm it executes correctly
</details>

#### For configuration changes:

- [x] `.env.default` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes
- [x] I have included a list of my configuration changes in the PR description (under **Changes**)

<details>
  <summary>Examples of configuration changes</summary>

  - Changing ports
  - Adding new services that need to communicate with each other
  - Secrets or environment variable changes
  - New or infrastructure changes such as databases
</details>
