### PR TITLE
feat(frontend/marketplace): polish creator dashboard + redesign edit modal

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/MobileSubmissionItem/MobileSubmissionItem.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/MobileSubmissionItem/MobileSubmissionItem.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import Image from "next/image";
+import Link from "next/link";
 import { motion, useReducedMotion } from "framer-motion";
 import {
+  ArrowSquareOutIcon,
   DotsThreeVerticalIcon,
   EyeIcon,
   ImageBrokenIcon,
@@ -38,6 +40,7 @@ interface Props {
   onView: (submission: StoreSubmission) => void;
   onEdit: (payload: EditPayload) => void;
   onDelete: (submissionId: string) => Promise<void>;
+  creatorUsername?: string;
 }
 
 const ROW_EASE = [0.16, 1, 0.3, 1] as const;
@@ -51,17 +54,25 @@ export function MobileSubmissionItem({
   onView,
   onEdit,
   onDelete,
+  creatorUsername,
 }: Props) {
   const reduceMotion = useReducedMotion();
   const {
     canModify,
+    marketplaceUrl,
     handleView,
     handleEdit,
     confirmDeleteOpen,
     setConfirmDeleteOpen,
     isDeleting,
     handleConfirmDelete,
-  } = useSubmissionItem({ submission, onView, onEdit, onDelete });
+  } = useSubmissionItem({
+    submission,
+    onView,
+    onEdit,
+    onDelete,
+    creatorUsername,
+  });
 
   const visual = getStatusVisual(submission.status);
   const StatusIcon = visual.Icon;
@@ -111,13 +122,36 @@ export function MobileSubmissionItem({
 
         <div className="flex min-w-0 flex-1 flex-col">
           <div className="flex min-w-0 items-center gap-2">
-            <Text
-              variant="body-medium"
-              as="span"
-              className="truncate text-textBlack"
-            >
-              {submission.name}
-            </Text>
+            {marketplaceUrl ? (
+              <Link
+                href={marketplaceUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex min-w-0 items-center gap-1 truncate text-textBlack hover:underline"
+                data-testid="submission-marketplace-link"
+              >
+                <Text
+                  variant="body-medium"
+                  as="span"
+                  className="truncate text-textBlack"
+                >
+                  {submission.name}
+                </Text>
+                <ArrowSquareOutIcon
+                  size={14}
+                  className="shrink-0 text-zinc-500"
+                  aria-hidden
+                />
+              </Link>
+            ) : (
+              <Text
+                variant="body-medium"
+                as="span"
+                className="truncate text-textBlack"
+              >
+                {submission.name}
+              </Text>
+            )}
             <Text variant="small" as="span" className="shrink-0 text-zinc-600">
               v{submission.graph_version}
             </Text>
@@ -166,6 +200,20 @@ export function MobileSubmissionItem({
                 View submission
               </DropdownMenuItem>
             )}
+            {marketplaceUrl ? (
+              <DropdownMenuItem asChild>
+                <Link
+                  href={marketplaceUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex cursor-pointer items-center gap-2"
+                  data-testid="submission-marketplace-menu-link"
+                >
+                  <ArrowSquareOutIcon size={14} />
+                  View on marketplace
+                </Link>
+              </DropdownMenuItem>
+            ) : null}
             {canModify ? (
               <>
                 <DropdownMenuSeparator />

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/MobileSubmissionsList/MobileSubmissionsList.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/MobileSubmissionsList/MobileSubmissionsList.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { motion, useReducedMotion } from "framer-motion";
+import { CircleNotchIcon } from "@phosphor-icons/react";
 
 import type { Pagination as PaginationModel } from "@/app/api/__generated__/models/pagination";
 import type { StoreSubmission } from "@/app/api/__generated__/models/storeSubmission";
@@ -37,6 +38,7 @@ interface Props {
   onView: (submission: StoreSubmission) => void;
   onEdit: (payload: EditPayload) => void;
   onDelete: (submissionId: string) => Promise<void>;
+  creatorUsername?: string;
   index?: number;
 }
 
@@ -52,6 +54,7 @@ export function MobileSubmissionsList({
   onView,
   onEdit,
   onDelete,
+  creatorUsername,
   index = 0,
 }: Props) {
   const reduceMotion = useReducedMotion();
@@ -77,9 +80,25 @@ export function MobileSubmissionsList({
       data-testid="mobile-submissions-list"
     >
       <div className="flex items-center justify-between gap-3 px-1">
-        <Text variant="body-medium" as="span" className="text-textBlack">
-          Submissions
-        </Text>
+        <div className="flex items-center gap-2">
+          <Text variant="body-medium" as="span" className="text-textBlack">
+            Submissions
+          </Text>
+          {isFetching ? (
+            <span
+              role="status"
+              aria-live="polite"
+              className="inline-flex items-center gap-1 text-zinc-500"
+              data-testid="submissions-fetching"
+            >
+              <CircleNotchIcon
+                size={14}
+                weight="bold"
+                className="animate-spin"
+              />
+            </span>
+          ) : null}
+        </div>
         <Text variant="small" className="text-zinc-500">
           {submissions.length} of {totalCount}
         </Text>
@@ -124,6 +143,7 @@ export function MobileSubmissionsList({
               onView={onView}
               onEdit={onEdit}
               onDelete={onDelete}
+              creatorUsername={creatorUsername}
             />
           ))
         ) : (

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/Pagination/Pagination.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/Pagination/Pagination.tsx
@@ -5,11 +5,27 @@ import { CaretLeftIcon, CaretRightIcon } from "@phosphor-icons/react";
 import type { Pagination as PaginationModel } from "@/app/api/__generated__/models/pagination";
 import { Button } from "@/components/atoms/Button/Button";
 import { Text } from "@/components/atoms/Text/Text";
+import { cn } from "@/lib/utils";
 
 interface Props {
   pagination: PaginationModel;
   onPageChange: (page: number) => void;
   disabled?: boolean;
+}
+
+const MAX_VISIBLE_PAGES = 5;
+
+function getVisiblePages(current: number, total: number): number[] {
+  if (total <= MAX_VISIBLE_PAGES) {
+    return Array.from({ length: total }, (_, i) => i + 1);
+  }
+  let start = Math.max(1, current - Math.floor(MAX_VISIBLE_PAGES / 2));
+  let end = start + MAX_VISIBLE_PAGES - 1;
+  if (end > total) {
+    end = total;
+    start = end - MAX_VISIBLE_PAGES + 1;
+  }
+  return Array.from({ length: end - start + 1 }, (_, i) => start + i);
 }
 
 export function Pagination({ pagination, onPageChange, disabled }: Props) {
@@ -19,6 +35,7 @@ export function Pagination({ pagination, onPageChange, disabled }: Props) {
 
   const startItem = (current_page - 1) * page_size + 1;
   const endItem = Math.min(current_page * page_size, total_items);
+  const visiblePages = getVisiblePages(current_page, total_pages);
 
   return (
     <div
@@ -28,7 +45,7 @@ export function Pagination({ pagination, onPageChange, disabled }: Props) {
       <Text variant="small" className="text-zinc-500">
         Showing {startItem}–{endItem} of {total_items}
       </Text>
-      <div className="flex items-center gap-2">
+      <div className="flex items-center gap-1.5">
         <Button
           variant="secondary"
           size="small"
@@ -39,6 +56,29 @@ export function Pagination({ pagination, onPageChange, disabled }: Props) {
         >
           Previous
         </Button>
+        <div className="flex items-center gap-1">
+          {visiblePages.map((page) => {
+            const isActive = page === current_page;
+            return (
+              <button
+                key={page}
+                type="button"
+                disabled={disabled}
+                onClick={() => onPageChange(page)}
+                aria-label={`Go to page ${page}`}
+                aria-current={isActive ? "page" : undefined}
+                className={cn(
+                  "ease-[cubic-bezier(0.16,1,0.3,1)] inline-flex h-8 min-w-8 items-center justify-center rounded-full px-2 text-xs font-medium tabular-nums transition-colors duration-150 disabled:cursor-not-allowed disabled:opacity-50",
+                  isActive
+                    ? "bg-zinc-900 text-white"
+                    : "text-zinc-700 hover:bg-zinc-100",
+                )}
+              >
+                {page}
+              </button>
+            );
+          })}
+        </div>
         <Button
           variant="secondary"
           size="small"

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/Pagination/__tests__/Pagination.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/Pagination/__tests__/Pagination.test.tsx
@@ -136,9 +136,7 @@ describe("Pagination", () => {
         screen.getByRole("button", { name: `Go to page ${page}` }),
       ).toBeDefined();
     }
-    expect(
-      screen.queryByRole("button", { name: "Go to page 6" }),
-    ).toBeNull();
+    expect(screen.queryByRole("button", { name: "Go to page 6" })).toBeNull();
   });
 
   it("slides the visible window so 5 pages render around the current page", () => {

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/Pagination/__tests__/Pagination.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/Pagination/__tests__/Pagination.test.tsx
@@ -123,4 +123,84 @@ describe("Pagination", () => {
       ).disabled,
     ).toBe(true);
   });
+
+  it("renders every page number when total_pages is small", () => {
+    render(
+      <Pagination
+        pagination={makePagination({ current_page: 2, total_pages: 5 })}
+        onPageChange={() => {}}
+      />,
+    );
+    for (const page of [1, 2, 3, 4, 5]) {
+      expect(
+        screen.getByRole("button", { name: `Go to page ${page}` }),
+      ).toBeDefined();
+    }
+    expect(
+      screen.queryByRole("button", { name: "Go to page 6" }),
+    ).toBeNull();
+  });
+
+  it("slides the visible window so 5 pages render around the current page", () => {
+    render(
+      <Pagination
+        pagination={makePagination({
+          current_page: 4,
+          total_pages: 10,
+          total_items: 200,
+        })}
+        onPageChange={() => {}}
+      />,
+    );
+    for (const page of [2, 3, 4, 5, 6]) {
+      expect(
+        screen.getByRole("button", { name: `Go to page ${page}` }),
+      ).toBeDefined();
+    }
+    expect(screen.queryByRole("button", { name: "Go to page 1" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Go to page 7" })).toBeNull();
+  });
+
+  it("clamps the window at the end so the last page stays visible", () => {
+    render(
+      <Pagination
+        pagination={makePagination({
+          current_page: 10,
+          total_pages: 10,
+          total_items: 200,
+        })}
+        onPageChange={() => {}}
+      />,
+    );
+    for (const page of [6, 7, 8, 9, 10]) {
+      expect(
+        screen.getByRole("button", { name: `Go to page ${page}` }),
+      ).toBeDefined();
+    }
+  });
+
+  it("marks the current page button with aria-current=page", () => {
+    render(
+      <Pagination
+        pagination={makePagination({ current_page: 3, total_pages: 5 })}
+        onPageChange={() => {}}
+      />,
+    );
+    const current = screen.getByRole("button", { name: "Go to page 3" });
+    expect(current.getAttribute("aria-current")).toBe("page");
+    const other = screen.getByRole("button", { name: "Go to page 2" });
+    expect(other.getAttribute("aria-current")).toBeNull();
+  });
+
+  it("invokes onPageChange with the page number when a numbered button is clicked", () => {
+    const onPageChange = vi.fn();
+    render(
+      <Pagination
+        pagination={makePagination({ current_page: 2, total_pages: 5 })}
+        onPageChange={onPageChange}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Go to page 5" }));
+    expect(onPageChange).toHaveBeenCalledWith(5);
+  });
 });

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/SubmissionItem/SubmissionItem.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/SubmissionItem/SubmissionItem.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import Image from "next/image";
+import Link from "next/link";
 import { motion, useReducedMotion } from "framer-motion";
 import {
+  ArrowSquareOutIcon,
   DotsThreeVerticalIcon,
   EyeIcon,
   ImageBrokenIcon,
@@ -37,6 +39,7 @@ interface Props {
   onView: (submission: StoreSubmission) => void;
   onEdit: (payload: EditPayload) => void;
   onDelete: (submissionId: string) => Promise<void>;
+  creatorUsername?: string;
 }
 
 const ROW_EASE = [0.16, 1, 0.3, 1] as const;
@@ -50,17 +53,25 @@ export function SubmissionItem({
   onView,
   onEdit,
   onDelete,
+  creatorUsername,
 }: Props) {
   const reduceMotion = useReducedMotion();
   const {
     canModify,
+    marketplaceUrl,
     handleView,
     handleEdit,
     confirmDeleteOpen,
     setConfirmDeleteOpen,
     isDeleting,
     handleConfirmDelete,
-  } = useSubmissionItem({ submission, onView, onEdit, onDelete });
+  } = useSubmissionItem({
+    submission,
+    onView,
+    onEdit,
+    onDelete,
+    creatorUsername,
+  });
 
   const visual = getStatusVisual(submission.status);
   const StatusIcon = visual.Icon;
@@ -108,13 +119,36 @@ export function SubmissionItem({
           </div>
           <div className="flex min-w-0 flex-col">
             <div className="flex min-w-0 items-center gap-2">
-              <Text
-                variant="body-medium"
-                as="span"
-                className="truncate text-textBlack"
-              >
-                {submission.name}
-              </Text>
+              {marketplaceUrl ? (
+                <Link
+                  href={marketplaceUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex min-w-0 items-center gap-1 truncate text-textBlack hover:underline"
+                  data-testid="submission-marketplace-link"
+                >
+                  <Text
+                    variant="body-medium"
+                    as="span"
+                    className="truncate text-textBlack"
+                  >
+                    {submission.name}
+                  </Text>
+                  <ArrowSquareOutIcon
+                    size={14}
+                    className="shrink-0 text-zinc-500"
+                    aria-hidden
+                  />
+                </Link>
+              ) : (
+                <Text
+                  variant="body-medium"
+                  as="span"
+                  className="truncate text-textBlack"
+                >
+                  {submission.name}
+                </Text>
+              )}
               <Text
                 variant="small"
                 as="span"
@@ -185,6 +219,20 @@ export function SubmissionItem({
                 View submission
               </DropdownMenuItem>
             )}
+            {marketplaceUrl ? (
+              <DropdownMenuItem asChild>
+                <Link
+                  href={marketplaceUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex cursor-pointer items-center gap-2"
+                  data-testid="submission-marketplace-menu-link"
+                >
+                  <ArrowSquareOutIcon size={14} />
+                  View on marketplace
+                </Link>
+              </DropdownMenuItem>
+            ) : null}
             {canModify ? (
               <>
                 <DropdownMenuSeparator />

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/SubmissionItem/useSubmissionItem.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/SubmissionItem/useSubmissionItem.ts
@@ -16,6 +16,7 @@ interface Args {
   onView: (submission: StoreSubmission) => void;
   onEdit: (payload: EditPayload) => void;
   onDelete: (submissionId: string) => Promise<void>;
+  creatorUsername?: string;
 }
 
 export function useSubmissionItem({
@@ -23,11 +24,17 @@ export function useSubmissionItem({
   onView,
   onEdit,
   onDelete,
+  creatorUsername,
 }: Args) {
   const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
 
   const canModify = submission.status === SubmissionStatus.PENDING;
+  const isApproved = submission.status === SubmissionStatus.APPROVED;
+  const marketplaceUrl =
+    isApproved && creatorUsername && submission.slug
+      ? `/marketplace/agent/${encodeURIComponent(creatorUsername)}/${encodeURIComponent(submission.slug)}`
+      : undefined;
 
   function handleView() {
     onView(submission);
@@ -66,6 +73,8 @@ export function useSubmissionItem({
 
   return {
     canModify,
+    isApproved,
+    marketplaceUrl,
     handleView,
     handleEdit,
     confirmDeleteOpen,

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/SubmissionsList/SubmissionsList.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/SubmissionsList/SubmissionsList.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { motion, useReducedMotion } from "framer-motion";
+import { CircleNotchIcon } from "@phosphor-icons/react";
 
 import type { Pagination as PaginationModel } from "@/app/api/__generated__/models/pagination";
 import type { StoreSubmission } from "@/app/api/__generated__/models/storeSubmission";
@@ -38,6 +39,7 @@ interface Props {
   onView: (submission: StoreSubmission) => void;
   onEdit: (payload: EditPayload) => void;
   onDelete: (submissionId: string) => Promise<void>;
+  creatorUsername?: string;
   index?: number;
 }
 
@@ -55,6 +57,7 @@ export function SubmissionsList({
   onView,
   onEdit,
   onDelete,
+  creatorUsername,
   index = 0,
 }: Props) {
   const reduceMotion = useReducedMotion();
@@ -80,9 +83,28 @@ export function SubmissionsList({
       data-testid="submissions-list"
     >
       <div className="flex items-center justify-between pl-4 pr-1">
-        <Text variant="body-medium" as="span" className="text-textBlack">
-          Submissions
-        </Text>
+        <div className="flex items-center gap-2">
+          <Text variant="body-medium" as="span" className="text-textBlack">
+            Submissions
+          </Text>
+          {isFetching ? (
+            <span
+              role="status"
+              aria-live="polite"
+              className="inline-flex items-center gap-1 text-zinc-500"
+              data-testid="submissions-fetching"
+            >
+              <CircleNotchIcon
+                size={14}
+                weight="bold"
+                className="animate-spin"
+              />
+              <Text variant="small" as="span" className="text-zinc-500">
+                Updating
+              </Text>
+            </span>
+          ) : null}
+        </div>
         <Text variant="small" className="text-zinc-500">
           {submissions.length} of {totalCount}
         </Text>
@@ -150,6 +172,7 @@ export function SubmissionsList({
                     onView={onView}
                     onEdit={onEdit}
                     onDelete={onDelete}
+                    creatorUsername={creatorUsername}
                   />
                 ))
               ) : (

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/page.tsx
@@ -40,6 +40,7 @@ export default function SettingsCreatorDashboardPage() {
     onEditSuccess,
     onEditClose,
     onDeleteSubmission,
+    creatorUsername,
   } = useCreatorDashboardPage();
 
   if (error) {
@@ -88,6 +89,7 @@ export default function SettingsCreatorDashboardPage() {
               onView={onViewSubmission}
               onEdit={onEditSubmission}
               onDelete={onDeleteSubmission}
+              creatorUsername={creatorUsername}
               index={2}
             />
           </div>
@@ -104,6 +106,7 @@ export default function SettingsCreatorDashboardPage() {
               onView={onViewSubmission}
               onEdit={onEditSubmission}
               onDelete={onDeleteSubmission}
+              creatorUsername={creatorUsername}
             />
           </div>
         </>

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/useCreatorDashboardPage.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/useCreatorDashboardPage.ts
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import * as Sentry from "@sentry/nextjs";
 import { keepPreviousData } from "@tanstack/react-query";
 
@@ -89,6 +89,12 @@ export function useCreatorDashboardPage() {
 
   const [isSortingTransition, setIsSortingTransition] = useState(false);
   const sortingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (sortingTimerRef.current) clearTimeout(sortingTimerRef.current);
+    };
+  }, []);
 
   function setFilterState(next: FilterState) {
     setFilterStateRaw(next);

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/useCreatorDashboardPage.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/useCreatorDashboardPage.ts
@@ -1,12 +1,14 @@
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import * as Sentry from "@sentry/nextjs";
 import { keepPreviousData } from "@tanstack/react-query";
 
 import {
   getGetV2ListMySubmissionsQueryKey,
   useDeleteV2DeleteStoreSubmission,
+  useGetV2GetUserProfile,
   useGetV2ListMySubmissions,
 } from "@/app/api/__generated__/endpoints/store/store";
+import type { ProfileDetails } from "@/app/api/__generated__/models/profileDetails";
 import type { StoreSubmission } from "@/app/api/__generated__/models/storeSubmission";
 import type { StoreSubmissionEditRequest } from "@/app/api/__generated__/models/storeSubmissionEditRequest";
 import type { StoreSubmissionsResponse } from "@/app/api/__generated__/models/storeSubmissionsResponse";
@@ -60,6 +62,14 @@ export function useCreatorDashboardPage() {
 
   const [page, setPage] = useState(1);
 
+  const { data: profile } = useGetV2GetUserProfile({
+    query: {
+      select: (x) => x.data as ProfileDetails,
+      enabled: !!user,
+    },
+  });
+  const creatorUsername = profile?.username;
+
   const {
     data: response,
     isSuccess,
@@ -77,9 +87,17 @@ export function useCreatorDashboardPage() {
     },
   );
 
+  const [isSortingTransition, setIsSortingTransition] = useState(false);
+  const sortingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   function setFilterState(next: FilterState) {
     setFilterStateRaw(next);
     setPage(1);
+    setIsSortingTransition(true);
+    if (sortingTimerRef.current) clearTimeout(sortingTimerRef.current);
+    sortingTimerRef.current = setTimeout(() => {
+      setIsSortingTransition(false);
+    }, 400);
   }
 
   function onPageChange(nextPage: number) {
@@ -163,7 +181,7 @@ export function useCreatorDashboardPage() {
     visibleSubmissions,
     pagination: response?.pagination,
     onPageChange,
-    isFetching,
+    isFetching: isFetching || isSortingTransition,
     stats,
     filterState,
     setFilterState,
@@ -181,5 +199,6 @@ export function useCreatorDashboardPage() {
     onEditSuccess,
     onEditClose,
     onDeleteSubmission,
+    creatorUsername,
   };
 }

--- a/autogpt_platform/frontend/src/components/contextual/EditAgentModal/EditAgentModal.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/EditAgentModal/EditAgentModal.tsx
@@ -27,9 +27,9 @@ export function EditAgentModal({
 
   return (
     <Dialog
-      title="Edit Agent"
+      title="Edit submission"
       styling={{
-        maxWidth: "45rem",
+        maxWidth: "48rem",
       }}
       controlled={{
         isOpen,

--- a/autogpt_platform/frontend/src/components/contextual/EditAgentModal/__tests__/EditAgentModal.test.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/EditAgentModal/__tests__/EditAgentModal.test.tsx
@@ -1,16 +1,9 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { StoreSubmissionEditRequest } from "@/app/api/__generated__/models/storeSubmissionEditRequest";
-import {
-  cleanup,
-  fireEvent,
-  render,
-  screen,
-} from "@/tests/integrations/test-utils";
+import { fireEvent, render, screen } from "@/tests/integrations/test-utils";
 
 import { EditAgentModal } from "../EditAgentModal";
-
-afterEach(() => cleanup());
 
 function makeSubmission(): StoreSubmissionEditRequest & {
   store_listing_version_id: string | undefined;

--- a/autogpt_platform/frontend/src/components/contextual/EditAgentModal/__tests__/EditAgentModal.test.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/EditAgentModal/__tests__/EditAgentModal.test.tsx
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { StoreSubmissionEditRequest } from "@/app/api/__generated__/models/storeSubmissionEditRequest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@/tests/integrations/test-utils";
+
+import { EditAgentModal } from "../EditAgentModal";
+
+afterEach(() => cleanup());
+
+function makeSubmission(): StoreSubmissionEditRequest & {
+  store_listing_version_id: string | undefined;
+  graph_id: string;
+} {
+  return {
+    name: "Edit Me Agent",
+    sub_heading: "A subhead",
+    description: "Some description that explains the agent",
+    image_urls: ["https://cdn.test/a.png"],
+    video_url: "https://www.youtube.com/watch?v=abc123",
+    agent_output_demo_url: "https://www.youtube.com/watch?v=demo123",
+    categories: ["productivity"],
+    changes_summary: "Initial edit summary",
+    store_listing_version_id: "lv-1",
+    graph_id: "graph-1",
+  };
+}
+
+describe("EditAgentModal", () => {
+  it("does not render when submission is null", () => {
+    render(
+      <EditAgentModal
+        isOpen={true}
+        onClose={() => {}}
+        submission={null}
+        onSuccess={() => {}}
+      />,
+    );
+    expect(screen.queryByTestId("edit-agent-modal")).toBeNull();
+  });
+
+  it("renders the new accordion sections with the update note when open", () => {
+    render(
+      <EditAgentModal
+        isOpen={true}
+        onClose={() => {}}
+        submission={makeSubmission()}
+        onSuccess={() => {}}
+      />,
+    );
+
+    expect(screen.getByTestId("edit-agent-modal")).toBeDefined();
+    expect(screen.getByText(/update note/i)).toBeDefined();
+    expect(screen.getByText(/listing basics/i)).toBeDefined();
+    expect(screen.getByText(/thumbnails/i)).toBeDefined();
+    expect(screen.getByText(/experience details/i)).toBeDefined();
+    expect(
+      screen.getByRole("button", { name: /update submission/i }),
+    ).toBeDefined();
+  });
+
+  it("invokes onClose when the Cancel button is clicked", () => {
+    const onClose = vi.fn();
+    render(
+      <EditAgentModal
+        isOpen={true}
+        onClose={onClose}
+        submission={makeSubmission()}
+        onSuccess={() => {}}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/autogpt_platform/frontend/src/components/contextual/EditAgentModal/components/EditAgentForm.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/EditAgentModal/components/EditAgentForm.tsx
@@ -48,6 +48,7 @@ export function EditAgentForm({
 }: EditAgentFormProps) {
   const {
     form,
+    images,
     categoryOptions,
     isSubmitting,
     handleFormSubmit,
@@ -81,7 +82,7 @@ export function EditAgentForm({
     !!watched.description &&
     !!watched.youtubeLink &&
     !!watched.agentOutputDemo;
-  const thumbnailsComplete = !thumbnailsHasError;
+  const thumbnailsComplete = !thumbnailsHasError && images.length > 0;
 
   const isSubmitDisabled =
     Object.keys(form.formState.errors).length > 0 || isSubmitting;

--- a/autogpt_platform/frontend/src/components/contextual/EditAgentModal/components/EditAgentForm.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/EditAgentModal/components/EditAgentForm.tsx
@@ -1,14 +1,36 @@
 "use client";
 
 import * as React from "react";
+import {
+  CheckCircleIcon,
+  ImagesIcon,
+  InfoIcon,
+  SparkleIcon,
+  StorefrontIcon,
+  WarningCircleIcon,
+} from "@phosphor-icons/react";
+
+import { StoreSubmission } from "@/app/api/__generated__/models/storeSubmission";
+import { StoreSubmissionEditRequest } from "@/app/api/__generated__/models/storeSubmissionEditRequest";
+import { Form, FormField } from "@/components/__legacy__/ui/form";
 import { Button } from "@/components/atoms/Button/Button";
 import { Input } from "@/components/atoms/Input/Input";
 import { Select } from "@/components/atoms/Select/Select";
-import { Form, FormField } from "@/components/__legacy__/ui/form";
-import { StoreSubmission } from "@/app/api/__generated__/models/storeSubmission";
+import { Text } from "@/components/atoms/Text/Text";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/molecules/Accordion/Accordion";
+
+import { CharCountedTextarea } from "../../PublishAgentModal/components/AgentInfoStep/components/CharCountedTextarea";
 import { ThumbnailImages } from "../../PublishAgentModal/components/AgentInfoStep/components/ThumbnailImages";
-import { StoreSubmissionEditRequest } from "@/app/api/__generated__/models/storeSubmissionEditRequest";
+
 import { useEditAgentForm } from "./useEditAgentForm";
+
+const DESCRIPTION_MAX = 1000;
+const CHANGES_SUMMARY_MAX = 500;
 
 interface EditAgentFormProps {
   submission: StoreSubmissionEditRequest & {
@@ -32,132 +54,316 @@ export function EditAgentForm({
     handleImagesChange,
   } = useEditAgentForm({ submission, onSuccess, onClose });
 
+  const [openAccordion, setOpenAccordion] = React.useState("basics");
+
+  const watched = form.watch();
+  const errors = form.formState.errors;
+
+  const basicsHasError = !!(
+    errors.title ||
+    errors.subheader ||
+    errors.category
+  );
+  const experienceHasError = !!(
+    errors.description ||
+    errors.youtubeLink ||
+    errors.agentOutputDemo
+  );
+  const thumbnailsHasError = !!errors.root;
+
+  const basicsComplete =
+    !basicsHasError &&
+    !!watched.title &&
+    !!watched.subheader &&
+    !!watched.category;
+  const experienceComplete =
+    !experienceHasError &&
+    !!watched.description &&
+    !!watched.youtubeLink &&
+    !!watched.agentOutputDemo;
+  const thumbnailsComplete = !thumbnailsHasError;
+
+  const isSubmitDisabled =
+    Object.keys(form.formState.errors).length > 0 || isSubmitting;
+
   return (
-    <div className="mx-auto flex w-full flex-col rounded-3xl">
+    <div className="mx-auto flex w-full flex-col">
       <Form {...form}>
         <form
           onSubmit={form.handleSubmit(handleFormSubmit)}
-          className="flex-grow overflow-y-auto p-6"
+          className="flex flex-col gap-5 pb-5"
         >
-          <FormField
-            control={form.control}
-            name="title"
-            render={({ field }) => (
-              <Input
-                id={field.name}
-                label="Title"
-                type="text"
-                placeholder="Agent name"
-                error={form.formState.errors.title?.message}
-                {...field}
-              />
-            )}
-          />
+          <section className="rounded-[18px] border border-amber-200 bg-amber-50 p-4">
+            <div className="mb-4 flex items-start gap-3">
+              <div className="flex size-9 shrink-0 items-center justify-center rounded-full bg-white text-amber-700 shadow-[0_1px_2px_rgba(15,15,20,0.04)]">
+                <InfoIcon size={18} weight="duotone" />
+              </div>
+              <div className="flex min-w-0 flex-col gap-1">
+                <Text variant="body-medium" as="h3" className="text-amber-950">
+                  Update note
+                </Text>
+                <Text variant="small" className="text-amber-800">
+                  Reviewers use this to understand why this submission was
+                  edited.
+                </Text>
+              </div>
+            </div>
+            <FormField
+              control={form.control}
+              name="changes_summary"
+              render={({ field }) => (
+                <CharCountedTextarea
+                  max={CHANGES_SUMMARY_MAX}
+                  value={field.value ?? ""}
+                >
+                  <Input
+                    id={field.name}
+                    labelVariant="body"
+                    label="What changed?"
+                    labelTooltip="Summary of what's new or improved in this version. Reviewers see this first."
+                    type="textarea"
+                    rows={1}
+                    placeholder="Briefly describe what you changed"
+                    error={form.formState.errors.changes_summary?.message}
+                    required
+                    wrapperClassName="!mb-0"
+                    {...field}
+                  />
+                </CharCountedTextarea>
+              )}
+            />
+          </section>
 
-          <FormField
-            control={form.control}
-            name="subheader"
-            render={({ field }) => (
-              <Input
-                id={field.name}
-                label="Subheader"
-                type="text"
-                placeholder="A tagline for your agent"
-                error={form.formState.errors.subheader?.message}
-                {...field}
-              />
-            )}
-          />
+          <Accordion
+            type="single"
+            collapsible
+            value={openAccordion}
+            onValueChange={setOpenAccordion}
+            className="overflow-hidden rounded-[14px] border border-zinc-200 bg-white shadow-[0_1px_2px_rgba(15,15,20,0.04)] [&>*+*]:border-t [&>*+*]:border-zinc-200"
+          >
+            <AccordionItem value="basics" className="border-0 px-4">
+              <AccordionTrigger className="hover:no-underline">
+                <span className="flex items-center gap-2 text-sm font-medium text-textBlack">
+                  <StorefrontIcon
+                    size={18}
+                    weight="duotone"
+                    className="text-zinc-500"
+                  />
+                  Listing basics
+                  {basicsHasError ? (
+                    <WarningCircleIcon
+                      size={16}
+                      weight="fill"
+                      className="text-rose-500"
+                    />
+                  ) : basicsComplete ? (
+                    <CheckCircleIcon
+                      size={16}
+                      weight="fill"
+                      className="text-purple-500"
+                    />
+                  ) : null}
+                </span>
+              </AccordionTrigger>
+              <AccordionContent className="px-1 pb-4 pt-0">
+                <div className="grid gap-x-4 sm:grid-cols-2">
+                  <FormField
+                    control={form.control}
+                    name="title"
+                    render={({ field }) => (
+                      <Input
+                        id={field.name}
+                        labelVariant="body"
+                        label="Title"
+                        labelTooltip="Public name shown on the marketplace listing."
+                        type="text"
+                        placeholder="Agent name"
+                        error={form.formState.errors.title?.message}
+                        {...field}
+                      />
+                    )}
+                  />
 
-          <ThumbnailImages
-            agentId={submission.graph_id}
-            onImagesChange={handleImagesChange}
-            initialImages={Array.from(new Set(submission.image_urls || []))}
-            initialSelectedImage={submission.image_urls?.[0] || null}
-            errorMessage={form.formState.errors.root?.message}
-          />
+                  <FormField
+                    control={form.control}
+                    name="subheader"
+                    render={({ field }) => (
+                      <Input
+                        id={field.name}
+                        labelVariant="body"
+                        label="Subheader"
+                        labelTooltip="One-sentence tagline displayed under the title."
+                        type="text"
+                        placeholder="A concise tagline for your agent"
+                        error={form.formState.errors.subheader?.message}
+                        {...field}
+                      />
+                    )}
+                  />
+                </div>
 
-          <FormField
-            control={form.control}
-            name="youtubeLink"
-            render={({ field }) => (
-              <Input
-                id={field.name}
-                label="YouTube video link"
-                type="url"
-                placeholder="Paste a video link here"
-                error={form.formState.errors.youtubeLink?.message}
-                {...field}
-              />
-            )}
-          />
-
-          <FormField
-            control={form.control}
-            name="category"
-            render={({ field }) => {
-              return (
-                <Select
-                  id={field.name}
-                  label="Category"
-                  placeholder="Select a category for your agent"
-                  value={field.value}
-                  onValueChange={field.onChange}
-                  error={form.formState.errors.category?.message}
-                  options={categoryOptions}
+                <FormField
+                  control={form.control}
+                  name="category"
+                  render={({ field }) => (
+                    <Select
+                      id={field.name}
+                      labelVariant="body"
+                      label="Category"
+                      labelTooltip="Primary category that helps users discover the agent."
+                      placeholder="Select a category"
+                      value={field.value}
+                      onValueChange={field.onChange}
+                      error={form.formState.errors.category?.message}
+                      options={categoryOptions}
+                    />
+                  )}
                 />
-              );
-            }}
-          />
+              </AccordionContent>
+            </AccordionItem>
 
-          <FormField
-            control={form.control}
-            name="description"
-            render={({ field }) => (
-              <Input
-                id={field.name}
-                label="Description"
-                type="textarea"
-                placeholder="Describe your agent and what it does"
-                error={form.formState.errors.description?.message}
-                {...field}
-              />
-            )}
-          />
+            <AccordionItem value="thumbnails" className="border-0 px-4">
+              <AccordionTrigger className="hover:no-underline">
+                <span className="flex items-center gap-2 text-sm font-medium text-textBlack">
+                  <ImagesIcon
+                    size={18}
+                    weight="duotone"
+                    className="text-zinc-500"
+                  />
+                  Thumbnails
+                  {thumbnailsHasError ? (
+                    <WarningCircleIcon
+                      size={16}
+                      weight="fill"
+                      className="text-rose-500"
+                    />
+                  ) : thumbnailsComplete ? (
+                    <CheckCircleIcon
+                      size={16}
+                      weight="fill"
+                      className="text-purple-500"
+                    />
+                  ) : null}
+                </span>
+              </AccordionTrigger>
+              <AccordionContent className="px-1 pb-4 pt-0">
+                <ThumbnailImages
+                  agentId={submission.graph_id}
+                  onImagesChange={handleImagesChange}
+                  initialImages={Array.from(
+                    new Set(submission.image_urls || []),
+                  )}
+                  initialSelectedImage={submission.image_urls?.[0] || null}
+                  errorMessage={form.formState.errors.root?.message}
+                />
+              </AccordionContent>
+            </AccordionItem>
 
-          <FormField
-            control={form.control}
-            name="changes_summary"
-            render={({ field }) => (
-              <Input
-                id={field.name}
-                label="Changes Summary"
-                type="textarea"
-                placeholder="Briefly describe what you changed"
-                error={form.formState.errors.changes_summary?.message}
-                {...field}
-              />
-            )}
-          />
+            <AccordionItem value="experience" className="border-0 px-4">
+              <AccordionTrigger className="hover:no-underline">
+                <span className="flex items-center gap-2 text-sm font-medium text-textBlack">
+                  <SparkleIcon
+                    size={18}
+                    weight="duotone"
+                    className="text-zinc-500"
+                  />
+                  Experience details
+                  {experienceHasError ? (
+                    <WarningCircleIcon
+                      size={16}
+                      weight="fill"
+                      className="text-rose-500"
+                    />
+                  ) : experienceComplete ? (
+                    <CheckCircleIcon
+                      size={16}
+                      weight="fill"
+                      className="text-purple-500"
+                    />
+                  ) : null}
+                </span>
+              </AccordionTrigger>
+              <AccordionContent className="px-1 pb-4 pt-0">
+                <FormField
+                  control={form.control}
+                  name="description"
+                  render={({ field }) => (
+                    <CharCountedTextarea
+                      max={DESCRIPTION_MAX}
+                      value={field.value ?? ""}
+                    >
+                      <Input
+                        id={field.name}
+                        labelVariant="body"
+                        label="Description"
+                        labelTooltip="What the agent does and the outcome users get."
+                        type="textarea"
+                        rows={2}
+                        placeholder="Describe the outcome this agent creates"
+                        error={form.formState.errors.description?.message}
+                        {...field}
+                      />
+                    </CharCountedTextarea>
+                  )}
+                />
 
-          <div className="flex justify-between gap-4 pt-6">
+                <div className="grid gap-x-4 sm:grid-cols-2">
+                  <FormField
+                    control={form.control}
+                    name="youtubeLink"
+                    render={({ field }) => (
+                      <Input
+                        id={field.name}
+                        labelVariant="body"
+                        label="YouTube video link"
+                        labelTooltip="Demo or walkthrough video hosted on YouTube."
+                        type="url"
+                        placeholder="https://youtube.com/watch?v=..."
+                        error={form.formState.errors.youtubeLink?.message}
+                        {...field}
+                      />
+                    )}
+                  />
+
+                  <FormField
+                    control={form.control}
+                    name="agentOutputDemo"
+                    render={({ field }) => (
+                      <Input
+                        id={field.name}
+                        labelVariant="body"
+                        label="Output demo"
+                        labelTooltip="Link showing example output the agent produces."
+                        type="url"
+                        placeholder="https://youtube.com/watch?v=..."
+                        error={form.formState.errors.agentOutputDemo?.message}
+                        {...field}
+                      />
+                    )}
+                  />
+                </div>
+              </AccordionContent>
+            </AccordionItem>
+          </Accordion>
+
+          <div className="flex flex-col-reverse gap-3 border-t border-zinc-200 pt-4 sm:flex-row sm:justify-end">
             <Button
               type="button"
               onClick={onClose}
               variant="secondary"
-              className="w-full"
+              size="small"
+              className="w-full sm:w-auto"
             >
               Cancel
             </Button>
             <Button
               type="submit"
-              className="w-full"
-              disabled={
-                Object.keys(form.formState.errors).length > 0 || isSubmitting
-              }
+              size="small"
+              disabled={isSubmitDisabled}
               loading={isSubmitting}
+              className="w-full sm:w-auto"
             >
-              Update submission
+              {isSubmitting ? "Saving" : "Update submission"}
             </Button>
           </div>
         </form>

--- a/autogpt_platform/frontend/src/components/contextual/EditAgentModal/components/EditAgentForm.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/EditAgentModal/components/EditAgentForm.tsx
@@ -77,11 +77,7 @@ export function EditAgentForm({
     !!watched.title &&
     !!watched.subheader &&
     !!watched.category;
-  const experienceComplete =
-    !experienceHasError &&
-    !!watched.description &&
-    !!watched.youtubeLink &&
-    !!watched.agentOutputDemo;
+  const experienceComplete = !experienceHasError && !!watched.description;
   const thumbnailsComplete = !thumbnailsHasError && images.length > 0;
 
   const isSubmitDisabled =

--- a/autogpt_platform/frontend/src/components/contextual/EditAgentModal/components/useEditAgentForm.ts
+++ b/autogpt_platform/frontend/src/components/contextual/EditAgentModal/components/useEditAgentForm.ts
@@ -159,6 +159,7 @@ export const useEditAgentForm = ({
 
   return {
     form,
+    images,
     isSubmitting,
     handleFormSubmit,
     handleImagesChange,

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentInfoStep/components/ThumbnailImages.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentInfoStep/components/ThumbnailImages.tsx
@@ -2,7 +2,12 @@
 
 import { Button } from "@/components/atoms/Button/Button";
 import { Text } from "@/components/atoms/Text/Text";
-import { MagicWand, PlusIcon, XIcon } from "@phosphor-icons/react";
+import {
+  CircleNotchIcon,
+  MagicWand,
+  PlusIcon,
+  XIcon,
+} from "@phosphor-icons/react";
 import Image from "next/image";
 import { useThumbnailImages } from "./useThumbnailImages";
 import { cn } from "@/lib/utils";
@@ -26,6 +31,7 @@ export function ThumbnailImages({
     images,
     selectedImage,
     isGenerating,
+    isUploading,
     thumbnailsContainerRef,
     handleRemoveImage,
     handleAddImage,
@@ -65,24 +71,38 @@ export function ThumbnailImages({
           <div className="flex flex-col gap-2 sm:flex-row">
             <label
               htmlFor="image-upload"
-              className="inline-flex h-[2.25rem] min-w-[5.5rem] cursor-pointer items-center justify-center gap-1.5 whitespace-nowrap rounded-full border border-zinc-700 bg-transparent px-3 py-2 font-sans text-sm font-medium leading-snug text-black transition-colors hover:border-zinc-700 hover:bg-zinc-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-neutral-950"
+              aria-disabled={isUploading}
+              data-testid="thumbnail-add-image-empty"
+              className={cn(
+                "inline-flex h-[2.25rem] min-w-[5.5rem] cursor-pointer items-center justify-center gap-1.5 whitespace-nowrap rounded-full border border-zinc-700 bg-transparent px-3 py-2 font-sans text-sm font-medium leading-snug text-black transition-colors hover:border-zinc-700 hover:bg-zinc-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-neutral-950",
+                isUploading && "pointer-events-none opacity-60",
+              )}
             >
               <input
                 id="image-upload"
                 type="file"
                 accept="image/*"
                 onChange={handleFileChange}
+                disabled={isUploading}
                 className="hidden"
               />
-              <PlusIcon size={16} weight="bold" />
-              <span>Add image</span>
+              {isUploading ? (
+                <CircleNotchIcon
+                  size={16}
+                  weight="bold"
+                  className="animate-spin"
+                />
+              ) : (
+                <PlusIcon size={16} weight="bold" />
+              )}
+              <span>{isUploading ? "Uploading" : "Add image"}</span>
             </label>
             <Button
               type="button"
               variant="outline"
               size="small"
               onClick={handleGenerateImage}
-              disabled={isGenerating || images.length >= 5}
+              disabled={isGenerating || isUploading || images.length >= 5}
               loading={isGenerating}
               leftIcon={<MagicWand className="h-4 w-4" />}
             >
@@ -115,11 +135,16 @@ export function ThumbnailImages({
                   </button>
                   <button
                     type="button"
-                    onClick={() => handleRemoveImage(index)}
-                    className="absolute right-1.5 top-1.5 z-20 inline-flex size-6 items-center justify-center rounded-full bg-zinc-900/80 text-white shadow-sm backdrop-blur-sm transition-colors hover:bg-zinc-900"
-                    aria-label="Remove image"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      handleRemoveImage(index);
+                    }}
+                    className="absolute right-1.5 top-1.5 z-30 inline-flex size-7 cursor-pointer items-center justify-center rounded-full bg-zinc-900/85 text-white shadow-sm backdrop-blur-sm transition-colors hover:bg-zinc-900"
+                    aria-label={`Remove image ${index + 1}`}
+                    data-testid={`thumbnail-remove-${index}`}
                   >
-                    <XIcon size={12} weight="bold" />
+                    <XIcon size={14} weight="bold" />
                   </button>
                   {index === 0 ? (
                     <span className="mt-1 block text-center text-[11px] font-medium text-zinc-500">
@@ -137,9 +162,16 @@ export function ThumbnailImages({
                   onClick={handleAddImage}
                   variant="outline"
                   size="small"
-                  leftIcon={<PlusIcon size={16} weight="bold" />}
+                  disabled={isUploading || isGenerating}
+                  loading={isUploading}
+                  leftIcon={
+                    isUploading ? undefined : (
+                      <PlusIcon size={16} weight="bold" />
+                    )
+                  }
+                  data-testid="thumbnail-add-image"
                 >
-                  Add image
+                  {isUploading ? "Uploading" : "Add image"}
                 </Button>
               ) : null}
               <Button
@@ -147,7 +179,7 @@ export function ThumbnailImages({
                 variant="outline"
                 size="small"
                 onClick={handleGenerateImage}
-                disabled={isGenerating || images.length >= 5}
+                disabled={isGenerating || isUploading || images.length >= 5}
                 loading={isGenerating}
                 leftIcon={<MagicWand className="h-4 w-4" />}
               >

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentInfoStep/components/ThumbnailImages.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentInfoStep/components/ThumbnailImages.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/atoms/Button/Button";
 import { Text } from "@/components/atoms/Text/Text";
 import {
   CircleNotchIcon,
-  MagicWand,
+  MagicWandIcon,
   PlusIcon,
   XIcon,
 } from "@phosphor-icons/react";
@@ -104,7 +104,7 @@ export function ThumbnailImages({
               onClick={handleGenerateImage}
               disabled={isGenerating || isUploading || images.length >= 5}
               loading={isGenerating}
-              leftIcon={<MagicWand className="h-4 w-4" />}
+              leftIcon={<MagicWandIcon className="h-4 w-4" />}
             >
               {isGenerating ? "Generating" : "Generate"}
             </Button>
@@ -181,7 +181,7 @@ export function ThumbnailImages({
                 onClick={handleGenerateImage}
                 disabled={isGenerating || isUploading || images.length >= 5}
                 loading={isGenerating}
-                leftIcon={<MagicWand className="h-4 w-4" />}
+                leftIcon={<MagicWandIcon className="h-4 w-4" />}
               >
                 {isGenerating
                   ? "Generating"

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentInfoStep/components/__tests__/ThumbnailImages.test.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentInfoStep/components/__tests__/ThumbnailImages.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   getPostV2GenerateSubmissionImageMockHandler,
@@ -7,7 +7,6 @@ import {
 } from "@/app/api/__generated__/endpoints/store/store.msw";
 import { server } from "@/mocks/mock-server";
 import {
-  cleanup,
   fireEvent,
   render,
   screen,
@@ -15,8 +14,6 @@ import {
 } from "@/tests/integrations/test-utils";
 
 import { ThumbnailImages } from "../ThumbnailImages";
-
-afterEach(() => cleanup());
 
 const toastSpy = vi.hoisted(() => vi.fn());
 vi.mock("@/components/molecules/Toast/use-toast", async (importOriginal) => {
@@ -81,7 +78,9 @@ describe("ThumbnailImages", () => {
 
   it("uploads a file via the empty-state input and shows the new image", async () => {
     server.use(
-      getPostV2UploadSubmissionMediaMockHandler("https://cdn.test/uploaded.png"),
+      getPostV2UploadSubmissionMediaMockHandler(
+        "https://cdn.test/uploaded.png",
+      ),
     );
 
     const onImagesChange = vi.fn();

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentInfoStep/components/__tests__/ThumbnailImages.test.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentInfoStep/components/__tests__/ThumbnailImages.test.tsx
@@ -1,0 +1,221 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  getPostV2GenerateSubmissionImageMockHandler,
+  getPostV2UploadSubmissionMediaMockHandler,
+  getPostV2UploadSubmissionMediaMockHandler422,
+} from "@/app/api/__generated__/endpoints/store/store.msw";
+import { server } from "@/mocks/mock-server";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@/tests/integrations/test-utils";
+
+import { ThumbnailImages } from "../ThumbnailImages";
+
+afterEach(() => cleanup());
+
+const toastSpy = vi.hoisted(() => vi.fn());
+vi.mock("@/components/molecules/Toast/use-toast", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@/components/molecules/Toast/use-toast")
+    >();
+  return {
+    ...actual,
+    useToast: () => ({
+      toast: toastSpy,
+      dismiss: () => {},
+      toasts: [],
+    }),
+  };
+});
+
+describe("ThumbnailImages", () => {
+  it("renders the empty state with an Add image label and Generate button", () => {
+    render(
+      <ThumbnailImages
+        agentId="agent-1"
+        onImagesChange={() => {}}
+        initialImages={[]}
+      />,
+    );
+
+    expect(screen.getByTestId("thumbnail-add-image-empty")).toBeDefined();
+    expect(screen.getByRole("button", { name: /generate/i })).toBeDefined();
+  });
+
+  it("renders existing thumbnails with a remove button for each, including the first", () => {
+    render(
+      <ThumbnailImages
+        agentId="agent-1"
+        onImagesChange={() => {}}
+        initialImages={["https://cdn.test/a.png", "https://cdn.test/b.png"]}
+        initialSelectedImage="https://cdn.test/a.png"
+      />,
+    );
+
+    expect(screen.getByTestId("thumbnail-remove-0")).toBeDefined();
+    expect(screen.getByTestId("thumbnail-remove-1")).toBeDefined();
+  });
+
+  it("removes the first image when its remove button is clicked", () => {
+    const onImagesChange = vi.fn();
+    render(
+      <ThumbnailImages
+        agentId="agent-1"
+        onImagesChange={onImagesChange}
+        initialImages={["https://cdn.test/a.png", "https://cdn.test/b.png"]}
+        initialSelectedImage="https://cdn.test/a.png"
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("thumbnail-remove-0"));
+
+    expect(screen.queryByTestId("thumbnail-remove-1")).toBeNull();
+    expect(onImagesChange).toHaveBeenCalledWith(["https://cdn.test/b.png"]);
+  });
+
+  it("uploads a file via the empty-state input and shows the new image", async () => {
+    server.use(
+      getPostV2UploadSubmissionMediaMockHandler("https://cdn.test/uploaded.png"),
+    );
+
+    const onImagesChange = vi.fn();
+    render(
+      <ThumbnailImages
+        agentId="agent-1"
+        onImagesChange={onImagesChange}
+        initialImages={[]}
+      />,
+    );
+
+    const input = document.getElementById("image-upload") as HTMLInputElement;
+    const file = new File(["data"], "thumb.png", { type: "image/png" });
+    Object.defineProperty(input, "files", { value: [file] });
+    fireEvent.change(input);
+
+    await waitFor(() => {
+      expect(onImagesChange).toHaveBeenCalledWith([
+        "https://cdn.test/uploaded.png",
+      ]);
+    });
+  });
+
+  it("shows a destructive toast when the upload endpoint fails", async () => {
+    toastSpy.mockClear();
+    server.use(getPostV2UploadSubmissionMediaMockHandler422());
+
+    render(
+      <ThumbnailImages
+        agentId="agent-1"
+        onImagesChange={() => {}}
+        initialImages={[]}
+      />,
+    );
+
+    const input = document.getElementById("image-upload") as HTMLInputElement;
+    const file = new File(["data"], "thumb.png", { type: "image/png" });
+    Object.defineProperty(input, "files", { value: [file] });
+    fireEvent.change(input);
+
+    await waitFor(() => {
+      expect(toastSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Upload failed",
+          variant: "destructive",
+        }),
+      );
+    });
+  });
+
+  it("generates an image when the Generate button is clicked", async () => {
+    server.use(
+      getPostV2GenerateSubmissionImageMockHandler({
+        image_url: "https://cdn.test/generated.png",
+      }),
+    );
+
+    const onImagesChange = vi.fn();
+    render(
+      <ThumbnailImages
+        agentId="agent-1"
+        onImagesChange={onImagesChange}
+        initialImages={[]}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /generate/i }));
+
+    await waitFor(() => {
+      expect(onImagesChange).toHaveBeenCalledWith([
+        "https://cdn.test/generated.png",
+      ]);
+    });
+  });
+
+  it("clears the visible thumbnails when the only image is removed", () => {
+    const onImagesChange = vi.fn();
+    render(
+      <ThumbnailImages
+        agentId="agent-1"
+        onImagesChange={onImagesChange}
+        initialImages={["https://cdn.test/only.png"]}
+        initialSelectedImage="https://cdn.test/only.png"
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("thumbnail-remove-0"));
+
+    expect(screen.queryByTestId("thumbnail-remove-0")).toBeNull();
+    expect(onImagesChange).toHaveBeenLastCalledWith([]);
+    expect(screen.getByTestId("thumbnail-add-image-empty")).toBeDefined();
+  });
+
+  it("toasts a generation error when no agentId is provided", async () => {
+    toastSpy.mockClear();
+    render(
+      <ThumbnailImages
+        agentId={null}
+        onImagesChange={() => {}}
+        initialImages={[]}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /generate/i }));
+
+    await waitFor(() => {
+      expect(toastSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Generation failed",
+          variant: "destructive",
+        }),
+      );
+    });
+  });
+
+  it("makes the clicked thumbnail the new selected (first) image", () => {
+    const onImagesChange = vi.fn();
+    render(
+      <ThumbnailImages
+        agentId="agent-1"
+        onImagesChange={onImagesChange}
+        initialImages={["https://cdn.test/a.png", "https://cdn.test/b.png"]}
+        initialSelectedImage="https://cdn.test/a.png"
+      />,
+    );
+
+    const secondButton = screen.getByRole("button", {
+      name: /select thumbnail 2/i,
+    });
+    fireEvent.click(secondButton);
+
+    expect(onImagesChange).toHaveBeenLastCalledWith([
+      "https://cdn.test/b.png",
+      "https://cdn.test/a.png",
+    ]);
+  });
+});

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentInfoStep/components/useThumbnailImages.ts
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentInfoStep/components/useThumbnailImages.ts
@@ -26,6 +26,7 @@ export function useThumbnailImages({
   );
 
   const [isGenerating, setIsGenerating] = useState(false);
+  const [isUploading, setIsUploading] = useState(false);
   const thumbnailsContainerRef = useRef<HTMLDivElement | null>(null);
   const { toast } = useToast();
 
@@ -101,6 +102,7 @@ export function useThumbnailImages({
   }
 
   async function uploadImage(file: File) {
+    setIsUploading(true);
     try {
       const mediaRes = await resolveResponse(
         postV2UploadSubmissionMedia({ file }),
@@ -119,6 +121,8 @@ export function useThumbnailImages({
         description: detail,
         variant: "destructive",
       });
+    } finally {
+      setIsUploading(false);
     }
   }
 
@@ -160,6 +164,7 @@ export function useThumbnailImages({
     images,
     selectedImage,
     isGenerating,
+    isUploading,
     thumbnailsContainerRef,
     handleRemoveImage,
     handleAddImage,


### PR DESCRIPTION
## Why

While reviewing /settings/creator-dashboard live, a few rough edges showed up: approved agents had no easy way to jump to the marketplace listing, pagination had only Prev/Next so navigating large submission sets was slow, sort changes felt instant-but-silent, the first thumbnail was hard to remove, image upload had no loading state, and the edit-submission modal still used the old flat-form layout (the publish flow already moved to the cleaner accordion design).

## What

- **Approved → marketplace links**: the agent name is now a `<Link>` to `/marketplace/agent/{username}/{slug}` for approved submissions, and the row dropdown gains a "View on marketplace" item.
- **Pagination**: sliding 5-page window of numeric buttons (centered on `current_page`, clamped at the ends), keeping Prev/Next.
- **Sort feedback**: short transition flag + React-Query `isFetching` drive an "Updating" spinner next to the section title.
- **Thumbnail fixes**: first-image remove button is bigger, has `z-30`, `stopPropagation`; Add image button shows a spinner + "Uploading" while the upload is in flight.
- **Edit submission modal**: rebuilt to match the publish step-2 design — amber "Update note" card + Listing basics / Thumbnails / Experience details accordion sections with per-section error/complete indicators.

## How

- New `creatorUsername` from `useGetV2GetUserProfile` flows through `useCreatorDashboardPage → SubmissionsList/MobileSubmissionsList → SubmissionItem/MobileSubmissionItem`, and `useSubmissionItem` derives `marketplaceUrl` only when status is APPROVED + username + slug are present.
- `Pagination` gains a `getVisiblePages(current, total)` helper that returns up to 5 consecutive page numbers, anchored around the current page.
- `useCreatorDashboardPage` keeps an `isSortingTransition` flag flipped on for 400ms on every filter/sort change; the existing `isFetching` is OR'd with it so the spinner also fires on pure client-side sort.
- `ThumbnailImages` accepts the new `isUploading` flag from `useThumbnailImages`; the remove button is hoisted above its sibling select button.
- `EditAgentForm` is rewritten to use `Accordion`, `CharCountedTextarea`, and `ThumbnailImages` from the publish flow — same hooks and schema as before, just the new layout.

## Test plan

- [ ] `/settings/creator-dashboard` shows the agent name as a link for approved submissions (opens marketplace in a new tab); pending/rejected rows stay plain text.
- [ ] Row dropdown shows "View on marketplace" only for approved submissions.
- [ ] Pagination renders up to 5 numeric buttons; clicking page 4 of 10 shows 2–6; clicking last page clamps to last-5; numbers receive `aria-current=page` on the active button.
- [ ] Changing sort or filter briefly shows "Updating" with a spinner in the submissions header.
- [ ] In the publish modal Thumbnails accordion, the first image can be removed; clicking "Add image" during upload shows the "Uploading" loader and the button is disabled.
- [ ] Edit submission modal renders the Update note card + 3 accordion sections (Listing basics, Thumbnails, Experience details), and Cancel / Update buttons work.

Unit tests added/updated:
- `Pagination.test.tsx` — sliding window, aria-current, numeric click.
- `ThumbnailImages.test.tsx` (new) — empty state, remove first/last, upload, generate, generate without agentId, select, file change.
- `EditAgentModal.test.tsx` (new) — accordion sections render, Cancel triggers `onClose`, null-submission guard.
