### PR TITLE
fix(backend/copilot): mandate find_block before refusal + suppress false empty-completion on retry

### DIFF
--- a/autogpt_platform/backend/backend/copilot/prompting.py
+++ b/autogpt_platform/backend/backend/copilot/prompting.py
@@ -131,19 +131,61 @@ After building the file, reference it with `@@agptfile:` in other tools:
   non-overlapping scope to avoid redundant searches.
 
 
-### Tool Discovery Priority
+### Tool Discovery Priority — `find_block` is MANDATORY before any "no integration" reply
 
-When the user asks to interact with a service or API, follow this order:
+When the user asks to interact with a service, integration, platform, or API,
+your **first action** in that turn MUST be a `find_block` call with the
+service name. This is non-negotiable. Your prior knowledge of which
+integrations exist is unreliable — the block registry changes constantly
+and is the only source of truth.
 
-1. **find_block first** — Search platform blocks with `find_block`. The platform has hundreds of built-in blocks (Google Sheets, Docs, Calendar, Gmail, Slack, GitHub, etc.) that work without extra setup.
+Order of fallbacks (only after `find_block` returns nothing usable):
 
-2. **run_mcp_tool** — If no matching block exists, check if a hosted MCP server is available for the service. Only use known MCP server URLs from the registry.
+1. **`find_block` first — ALWAYS.** Search platform blocks with the service
+   name (e.g. `find_block(query="linkedin post")`,
+   `find_block(query="shopify orders")`). Hundreds of built-in blocks exist
+   (Google Sheets, Docs, Calendar, Gmail, Slack, GitHub, LinkedIn via Ayrshare,
+   etc.). Most "obscure" integrations have a block.
 
-3. **SendAuthenticatedWebRequestBlock** — If no block or MCP server exists, use `SendAuthenticatedWebRequestBlock` with existing host-scoped credentials. Check available credentials via `connect_integration`.
+2. **`run_mcp_tool`** — If `find_block` returns no match, check if a hosted MCP
+   server is available for the service. Only use known MCP server URLs from
+   the registry.
 
-4. **Manual API call** — As a last resort, guide the user to set up credentials and use `SendAuthenticatedWebRequestBlock` with direct API calls.
+3. **`SendAuthenticatedWebRequestBlock`** — If no block or MCP server exists,
+   use `SendAuthenticatedWebRequestBlock` with existing host-scoped
+   credentials. Check available credentials via `connect_integration`.
 
-**Never skip step 1.** Built-in blocks are more reliable, tested, and user-friendly than MCP or raw API calls.
+4. **Manual API call** — As a last resort, guide the user to set up
+   credentials and use `SendAuthenticatedWebRequestBlock` with direct API
+   calls.
+
+### Anti-pattern: refusing without searching (CRITICAL)
+
+**Never** emit any variant of these without a preceding `find_block` call in
+the current turn:
+
+- "We don't have a native X integration yet."
+- "X isn't supported on the platform."
+- "We can't do X / I can't access X."
+- "There's no block for X."
+- Any feature-request flow ("I'll flag this as a requested integration").
+
+If you have not called `find_block` for the service the user named, you do
+**not yet know** whether it exists. Refusing or pivoting to a workaround
+before searching wastes the user's turn and is a known regression. This rule
+overrides any worked example earlier in this prompt that shows a capability
+gap being declared without a preceding `find_block` call — those examples
+are wrong and should be ignored.
+
+Correct flow for *any* integration request, even ones you "know" don't
+exist:
+
+```
+1. find_block(query="<service> <action>")
+2. If a matching block exists → use it (or run with validate_only to inspect).
+3. If find_block returns no match → THEN state the gap and offer
+   SendAuthenticatedWebRequestBlock / browser automation / feature request.
+```
 
 ### Complex multi-step work
 - Use `TodoWrite` to track the plan once the job has 3+ distinct steps.

--- a/autogpt_platform/backend/backend/copilot/prompting_test.py
+++ b/autogpt_platform/backend/backend/copilot/prompting_test.py
@@ -30,3 +30,31 @@ class TestGetSdkSupplementStaticPlaceholder:
     def test_e2b_mode_has_no_session_placeholder(self):
         result = prompting.get_sdk_supplement(use_e2b=True)
         assert "<session-id>" not in result
+
+
+class TestToolDiscoveryPriorityAntiPattern:
+    """The Tool Discovery Priority section must forbid claiming a capability
+    gap without calling ``find_block`` first — this is the regression the
+    LinkedIn-skip incident on dev (May 2026) exposed.
+    """
+
+    def test_supplement_contains_find_block_mandatory_language(self):
+        result = prompting.get_sdk_supplement(use_e2b=False)
+        # The header must signal that find_block is mandatory before any
+        # "no integration" reply.
+        assert "find_block` is MANDATORY" in result
+
+    def test_supplement_lists_the_forbidden_phrases(self):
+        result = prompting.get_sdk_supplement(use_e2b=False)
+        # The anti-pattern section must explicitly enumerate the
+        # phrases the model emitted in the regression so the model
+        # can pattern-match on its own draft and reject it.
+        assert "We don't have a native X integration yet." in result
+        assert "There's no block for X." in result
+
+    def test_supplement_includes_correct_flow_template(self):
+        result = prompting.get_sdk_supplement(use_e2b=False)
+        # The 3-step correct-flow block must be present so the model
+        # has a concrete template to follow, not just a prohibition.
+        assert "Correct flow" in result
+        assert 'find_block(query="<service> <action>")' in result

--- a/autogpt_platform/backend/backend/copilot/sdk/response_adapter.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/response_adapter.py
@@ -83,12 +83,9 @@ class SDKResponseAdapter:
         self.has_started_reasoning = False
         self.has_ended_reasoning = True
         self.render_reasoning_in_ui = render_reasoning_in_ui
-        # Set by the service layer when a retry adapter is constructed mid-turn
-        # and the prior attempt already streamed text/tool results to the wire.
-        # The empty-completion guard ignores its local "no content this attempt"
-        # signal in that case — the user already received content from a
-        # previous attempt, so surfacing "The model returned an empty response."
-        # on top would be a false-positive.
+        # Service layer forwards this from the prior adapter on a retry-recreate
+        # so the empty-completion guard doesn't false-fire on a benign empty
+        # trailing ResultMessage when the prior attempt already streamed content.
         self.prior_attempt_emitted_visible_content = False
         self.current_tool_calls: dict[str, dict[str, str]] = {}
         self.resolved_tool_calls: set[str] = set()
@@ -162,6 +159,21 @@ class SDKResponseAdapter:
     def has_unresolved_tool_calls(self) -> bool:
         """True when there are tool calls that haven't received output yet."""
         return bool(self.current_tool_calls.keys() - self.resolved_tool_calls)
+
+    @property
+    def emitted_visible_content(self) -> bool:
+        """True when this adapter (or a prior attempt it inherited from) has
+        already streamed user-visible content — text, reasoning, or a tool
+        result — onto the wire. Used by the retry path so the new adapter
+        can carry forward the prior attempt's visibility state without
+        reaching into private flags.
+        """
+        return (
+            self.has_started_text
+            or self.has_started_reasoning
+            or self._any_tool_results_seen
+            or self.prior_attempt_emitted_visible_content
+        )
 
     def convert_message(self, sdk_message: Message) -> list[StreamBaseResponse]:
         """Convert a single SDK message to Vercel AI SDK format."""
@@ -608,12 +620,7 @@ class SDKResponseAdapter:
             return False
         if self._any_tool_results_seen:
             return False
-        # When this adapter is a retry adapter constructed after a prior attempt
-        # already streamed text/tools to the wire, an empty ResultMessage on
-        # this attempt is not a "ghost finish" from the user's perspective —
-        # they already received content. Firing the error here would render
-        # a "model returned an empty response" overlay on top of working
-        # output.
+        # Retry adapter — prior attempt already streamed content to the wire.
         if self.prior_attempt_emitted_visible_content:
             return False
         usage = msg.usage or {}

--- a/autogpt_platform/backend/backend/copilot/sdk/response_adapter.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/response_adapter.py
@@ -83,6 +83,13 @@ class SDKResponseAdapter:
         self.has_started_reasoning = False
         self.has_ended_reasoning = True
         self.render_reasoning_in_ui = render_reasoning_in_ui
+        # Set by the service layer when a retry adapter is constructed mid-turn
+        # and the prior attempt already streamed text/tool results to the wire.
+        # The empty-completion guard ignores its local "no content this attempt"
+        # signal in that case — the user already received content from a
+        # previous attempt, so surfacing "The model returned an empty response."
+        # on top would be a false-positive.
+        self.prior_attempt_emitted_visible_content = False
         self.current_tool_calls: dict[str, dict[str, str]] = {}
         self.resolved_tool_calls: set[str] = set()
         self.step_open = False
@@ -600,6 +607,14 @@ class SDKResponseAdapter:
         if self.current_tool_calls:
             return False
         if self._any_tool_results_seen:
+            return False
+        # When this adapter is a retry adapter constructed after a prior attempt
+        # already streamed text/tools to the wire, an empty ResultMessage on
+        # this attempt is not a "ghost finish" from the user's perspective —
+        # they already received content. Firing the error here would render
+        # a "model returned an empty response" overlay on top of working
+        # output.
+        if self.prior_attempt_emitted_visible_content:
             return False
         usage = msg.usage or {}
         output_tokens = usage.get("output_tokens") or 0

--- a/autogpt_platform/backend/backend/copilot/sdk/response_adapter_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/response_adapter_test.py
@@ -1861,3 +1861,28 @@ def test_retry_adapter_without_prior_content_still_surfaces_empty_completion():
     results = adapter.convert_message(msg)
     err = next(r for r in results if isinstance(r, StreamError))
     assert err.code == "empty_completion"
+
+
+def test_emitted_visible_content_property_combines_signals():
+    """The ``emitted_visible_content`` property must be True when any of the
+    underlying visibility signals is set, so the service-layer retry path
+    can forward the prior adapter's state without reaching into private
+    flags.
+    """
+    adapter = _adapter()
+    assert adapter.emitted_visible_content is False
+
+    adapter.has_started_text = True
+    assert adapter.emitted_visible_content is True
+    adapter.has_started_text = False
+
+    adapter.has_started_reasoning = True
+    assert adapter.emitted_visible_content is True
+    adapter.has_started_reasoning = False
+
+    adapter._any_tool_results_seen = True
+    assert adapter.emitted_visible_content is True
+    adapter._any_tool_results_seen = False
+
+    adapter.prior_attempt_emitted_visible_content = True
+    assert adapter.emitted_visible_content is True

--- a/autogpt_platform/backend/backend/copilot/sdk/response_adapter_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/response_adapter_test.py
@@ -1811,3 +1811,53 @@ def test_summary_walk_skips_fully_streamed_text():
     summary_deltas = [r for r in summary if isinstance(r, StreamTextDelta)]
     assert len(partial_deltas) == 1
     assert summary_deltas == []
+
+
+def test_retry_adapter_with_prior_emitted_content_suppresses_empty_completion():
+    """Regression: when the service layer recreates the adapter for a retry
+    after the prior attempt already streamed text/tools to the wire, an empty
+    success ResultMessage on the retry must NOT surface as an empty_completion
+    StreamError — the user already received content from the prior attempt
+    and would otherwise see a spurious "model returned an empty response"
+    overlay on top of working output.
+    """
+    adapter = _adapter()
+    adapter.prior_attempt_emitted_visible_content = True
+    adapter.convert_message(SystemMessage(subtype="init", data={}))
+    msg = ResultMessage(
+        subtype="success",
+        duration_ms=100,
+        duration_api_ms=50,
+        is_error=False,
+        num_turns=1,
+        session_id="s1",
+        result="",
+        usage={"output_tokens": 0},
+    )
+    results = adapter.convert_message(msg)
+    types = [type(r).__name__ for r in results]
+    assert "StreamFinish" in types
+    assert "StreamError" not in types
+
+
+def test_retry_adapter_without_prior_content_still_surfaces_empty_completion():
+    """Counter-test: when prior_attempt_emitted_visible_content is False (the
+    default — first attempt), the SECRT-2252 guard must still fire on a
+    ghost-finished success.
+    """
+    adapter = _adapter()
+    assert adapter.prior_attempt_emitted_visible_content is False
+    adapter.convert_message(SystemMessage(subtype="init", data={}))
+    msg = ResultMessage(
+        subtype="success",
+        duration_ms=100,
+        duration_api_ms=50,
+        is_error=False,
+        num_turns=1,
+        session_id="s1",
+        result="",
+        usage={"output_tokens": 0},
+    )
+    results = adapter.convert_message(msg)
+    err = next(r for r in results if isinstance(r, StreamError))
+    assert err.code == "empty_completion"

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -4516,18 +4516,10 @@ async def stream_chat_completion_sdk(  # pyright: ignore[reportGeneralTypeIssues
                 # Carry the per-turn re-prompt cap forward so a transient
                 # retry mid-turn does not unlock another re-prompt round.
                 state.adapter.thinking_only_reprompted = state.thinking_only_reprompted
-                # If the prior attempt already streamed text or tool results to
-                # the wire, suppress the empty-completion guard on this retry
-                # adapter — the user has already received content, and a
-                # silent-finish ResultMessage on the retry would otherwise
-                # surface a spurious "model returned an empty response" overlay
-                # on top of working output.
-                if (
-                    prior_adapter.has_started_text
-                    or prior_adapter.has_started_reasoning
-                    or prior_adapter._any_tool_results_seen
-                    or prior_adapter.prior_attempt_emitted_visible_content
-                ):
+                # Forward prior visibility so the empty-completion guard on this
+                # retry adapter doesn't false-fire on top of content the user
+                # already received.
+                if prior_adapter.emitted_visible_content:
                     state.adapter.prior_attempt_emitted_visible_content = True
                 # Reset token accumulators so a failed attempt's partial
                 # usage is not double-counted in the successful attempt.

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -4507,6 +4507,7 @@ async def stream_chat_completion_sdk(  # pyright: ignore[reportGeneralTypeIssues
                 state.query_message = await _maybe_prepend_builder_context(
                     session, user_id, is_user_message, state.query_message
                 )
+                prior_adapter = state.adapter
                 state.adapter = SDKResponseAdapter(
                     message_id=message_id,
                     session_id=session_id,
@@ -4515,6 +4516,19 @@ async def stream_chat_completion_sdk(  # pyright: ignore[reportGeneralTypeIssues
                 # Carry the per-turn re-prompt cap forward so a transient
                 # retry mid-turn does not unlock another re-prompt round.
                 state.adapter.thinking_only_reprompted = state.thinking_only_reprompted
+                # If the prior attempt already streamed text or tool results to
+                # the wire, suppress the empty-completion guard on this retry
+                # adapter — the user has already received content, and a
+                # silent-finish ResultMessage on the retry would otherwise
+                # surface a spurious "model returned an empty response" overlay
+                # on top of working output.
+                if (
+                    prior_adapter.has_started_text
+                    or prior_adapter.has_started_reasoning
+                    or prior_adapter._any_tool_results_seen
+                    or prior_adapter.prior_attempt_emitted_visible_content
+                ):
+                    state.adapter.prior_attempt_emitted_visible_content = True
                 # Reset token accumulators so a failed attempt's partial
                 # usage is not double-counted in the successful attempt.
                 state.usage.reset()


### PR DESCRIPTION
## Why

Two production-visible regressions surfaced in the same dev session
(`d077d025-f6a3-455f-836f-9fe3039b2b98`):

1. **AutoPilot refused without searching.** User asked "Post a test post to
   linkedin for me". The model emitted *"We don't have a native LinkedIn
   integration yet. LinkedIn's API is also heavily restricted…"* with **zero
   tool calls** — never invoked `find_block`. When the user pushed back, the
   model immediately found `PostToLinkedInBlock` (Ayrshare) on the first
   `find_block(query="linkedin post")`. The model's own thinking from
   langfuse: *"The user is correct — I jumped straight to capability gap
   without first searching for blocks. Per my instructions, I should always
   `find_block` first for any integration request."* — i.e. the rule existed
   but was overridden by a vivid worked example in the system prompt.

2. **"Model returned an empty response" overlay on top of working output.**
   In the same session's recovery turn, after `find_block` + `run_block`
   succeeded and the model emitted *"Yes, we have a `PostToLinkedInBlock`
   via Ayrshare — and you're already connected…"*, a retry-adapter
   recreated mid-turn lost the prior attempt's `has_started_text` /
   `_any_tool_results_seen` state and false-fired
   `code=empty_completion` on the next ResultMessage.

Root causes:

- The Langfuse "CoPilot Prompt" Section 4 ("Capability Check") + Example 3
  (Shopify) explicitly modelled "We don't have a native [Platform]
  integration yet" as the *correct* response when the model "knows" the
  platform isn't supported — training the model to refuse without
  searching. The shared tool-notes supplement said "find_block first" but
  the worked example won.
- `SDKResponseAdapter` is rebuilt fresh on context-reduce retries
  (service.py:4510). Its empty-completion guard relies on per-attempt
  state, so a benign empty trailing ResultMessage on a retry — when the
  prior attempt already streamed text/tools to the wire — is
  indistinguishable from a true SECRT-2252 ghost finish and surfaces a
  spurious error overlay.

## What

Code-side fixes (Langfuse prompt is also patched on the `latest`/dev
label out-of-band; prod stays on its existing version pending review):

- **`prompting.py`** — rewrite `SHARED_TOOL_NOTES` "Tool Discovery
  Priority" to mark `find_block` as MANDATORY before any "no integration"
  reply. Add an explicit "Anti-pattern: refusing without searching"
  section that enumerates the exact phrases (`We don't have a native X
  integration yet.`, `There's no block for X.`, etc.) and shows the
  correct 3-step flow.
- **`response_adapter.py`** — add
  `prior_attempt_emitted_visible_content: bool = False` to
  `SDKResponseAdapter`; `_is_empty_completion` returns False when the
  flag is set, so the SECRT-2252 guard only fires when the *broader
  stream* has produced no content, not just the current attempt.
- **`service.py`** retry path — before swapping the adapter on
  `_reduce_context` retry, set the new adapter's
  `prior_attempt_emitted_visible_content` based on the prior adapter's
  `has_started_text` / `has_started_reasoning` /
  `_any_tool_results_seen` (and forward the flag transitively across
  multi-retry chains).
- **Tests** — `prompting_test.py::TestToolDiscoveryPriorityAntiPattern`
  (3 assertions on the new mandatory language + anti-pattern phrases +
  correct-flow template); `response_adapter_test.py` adds
  `test_retry_adapter_with_prior_emitted_content_suppresses_empty_completion`
  (positive: empty success on retry → StreamFinish, no StreamError) and
  `test_retry_adapter_without_prior_content_still_surfaces_empty_completion`
  (counter-test: SECRT-2252 still fires when the flag is False).

## How

The three fixes layer:

1. **System-prompt rule** (defence in depth) — code-side supplement now
   explicitly forbids the failure-mode phrases by exact wording; the
   model can pattern-match its own draft and reject it.
2. **Langfuse worked example** (root cause) — Section 4 + Example 3 of
   "CoPilot Prompt" rewritten on `latest` v30 to model search-first
   behaviour. Prod (`production` v27) untouched until reviewed.
3. **Adapter false-positive guard** — surface "model returned an empty
   response" only when the *whole stream* produced nothing, not just the
   current retry attempt.

## Test plan

- [x] `pytest backend/copilot/sdk/response_adapter_test.py -k "empty_completion or prior_attempt or retry_adapter"` — 3 passed.
- [x] `pytest backend/copilot/sdk/response_adapter_test.py::test_retry_adapter_with_prior_emitted_content_suppresses_empty_completion backend/copilot/sdk/response_adapter_test.py::test_retry_adapter_without_prior_content_still_surfaces_empty_completion` — 2 passed.
- [x] Direct supplement assertion (`from backend.copilot.prompting import get_sdk_supplement; ...`) — all pass.
- [x] `ruff check` clean on edited files.
- [x] Validated against trace `9f3feb3dd843aa1e537de92f23666cc9` /
      `746b49e0f6012ff94035d0ceb3f7fca6` (the LinkedIn dev session).
- [ ] Manual dev verification with a fresh integration request after
      `latest` v30 propagates (≤5 min Langfuse cache TTL).
