### PR TITLE
fix(platform): clarify builder cost display for OpenRouter and free providers

### DIFF
--- a/autogpt_platform/backend/backend/blocks/_base.py
+++ b/autogpt_platform/backend/backend/blocks/_base.py
@@ -18,7 +18,7 @@ from typing import (
 
 import jsonref
 import jsonschema
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from backend.data.block import BlockInput, BlockOutput, BlockOutputEntry
 from backend.data.model import (
@@ -138,10 +138,10 @@ class TokenRateDisplay(BaseModel):
     internal credit math in `BlockCost.cost_amount`.
     """
 
-    input_usd_per_1m: float
-    output_usd_per_1m: float
-    cache_read_usd_per_1m: Optional[float] = None
-    cache_creation_usd_per_1m: Optional[float] = None
+    input_usd_per_1m: float = Field(ge=0)
+    output_usd_per_1m: float = Field(ge=0)
+    cache_read_usd_per_1m: Optional[float] = Field(default=None, ge=0)
+    cache_creation_usd_per_1m: Optional[float] = Field(default=None, ge=0)
 
 
 class BlockCost(BaseModel):

--- a/autogpt_platform/backend/backend/blocks/_base.py
+++ b/autogpt_platform/backend/backend/blocks/_base.py
@@ -129,6 +129,21 @@ _DYNAMIC_COST_TYPES: frozenset[BlockCostType] = frozenset(
 )
 
 
+class TokenRateDisplay(BaseModel):
+    """Public per-1M-token USD rates surfaced to the builder UI.
+
+    Populated only on LLM block costs whose model has a TOKEN_COST rate.
+    cache_* fields are set only when the provider publishes a distinct
+    cached-token rate (Anthropic). Display-only — billing always uses the
+    internal credit math in `BlockCost.cost_amount`.
+    """
+
+    input_usd_per_1m: float
+    output_usd_per_1m: float
+    cache_read_usd_per_1m: Optional[float] = None
+    cache_creation_usd_per_1m: Optional[float] = None
+
+
 class BlockCost(BaseModel):
     cost_amount: int
     cost_filter: BlockInput
@@ -140,15 +155,10 @@ class BlockCost(BaseModel):
     # point-wise. Example: cost_amount=1, cost_divisor=10 under SECOND means
     # "1 credit per 10 seconds of walltime".
     cost_divisor: int = 1
-    # Per-1M-token USD rates surfaced to the builder UI so node cards can
-    # show real provider pricing instead of the internal credit number.
-    # Populated for entries whose model has a TOKEN_COST rate; None
-    # elsewhere. cache_read / cache_creation are populated only when the
-    # provider publishes a distinct cached-token rate (Anthropic).
-    input_usd_per_1m: Optional[float] = None
-    output_usd_per_1m: Optional[float] = None
-    cache_read_usd_per_1m: Optional[float] = None
-    cache_creation_usd_per_1m: Optional[float] = None
+    # LLM-specific display rate card. None on non-LLM blocks and on LLM
+    # entries whose model isn't in TOKEN_COST yet (those render
+    # "Pay-as-you-go" / flat-tier).
+    token_rate: Optional[TokenRateDisplay] = None
 
     def __init__(
         self,

--- a/autogpt_platform/backend/backend/blocks/_base.py
+++ b/autogpt_platform/backend/backend/blocks/_base.py
@@ -140,6 +140,15 @@ class BlockCost(BaseModel):
     # point-wise. Example: cost_amount=1, cost_divisor=10 under SECOND means
     # "1 credit per 10 seconds of walltime".
     cost_divisor: int = 1
+    # Per-1M-token USD rates surfaced to the builder UI so node cards can
+    # show real provider pricing instead of the internal credit number.
+    # Populated for entries whose model has a TOKEN_COST rate; None
+    # elsewhere. cache_read / cache_creation are populated only when the
+    # provider publishes a distinct cached-token rate (Anthropic).
+    input_usd_per_1m: Optional[float] = None
+    output_usd_per_1m: Optional[float] = None
+    cache_read_usd_per_1m: Optional[float] = None
+    cache_creation_usd_per_1m: Optional[float] = None
 
     def __init__(
         self,

--- a/autogpt_platform/backend/backend/data/block_cost_config.py
+++ b/autogpt_platform/backend/backend/data/block_cost_config.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Type
 
 from pydantic import BaseModel
 
-from backend.blocks._base import Block, BlockCost, BlockCostType
+from backend.blocks._base import Block, BlockCost, BlockCostType, TokenRateDisplay
 from backend.data.block import BlockInput
 from backend.data.model import APIKeyCredentials
 
@@ -409,26 +409,24 @@ def _lookup_llm_model(raw: "str | LlmModel | None") -> "LlmModel | None":
 _USD_PER_1M_DIVISOR = 150
 
 
-def _token_usd_rates(
-    model: LlmModel,
-) -> tuple[float | None, float | None, float | None, float | None]:
-    """Return (input, output, cache_read, cache_creation) USD/1M for `model`,
-    or all None if the model has no TOKEN_COST entry. cache_* are None when
-    the provider doesn't bill cached tokens at a distinct rate (most non-
-    Anthropic) — i.e. the corresponding TOKEN_COST field is zero.
+def _token_rate_display(model: LlmModel) -> TokenRateDisplay | None:
+    """Return the published per-1M-token USD `TokenRateDisplay` for `model`,
+    or None if the model has no TOKEN_COST entry. cache_* fields are set
+    only when the provider publishes a distinct cached-token rate (most
+    non-Anthropic providers store 0 in TOKEN_COST and surface None here).
     """
     rate = TOKEN_COST.get(model)
     if rate is None:
-        return None, None, None, None
-    cache_read = rate.cache_read / _USD_PER_1M_DIVISOR if rate.cache_read else None
-    cache_creation = (
-        rate.cache_creation / _USD_PER_1M_DIVISOR if rate.cache_creation else None
-    )
-    return (
-        rate.input / _USD_PER_1M_DIVISOR,
-        rate.output / _USD_PER_1M_DIVISOR,
-        cache_read,
-        cache_creation,
+        return None
+    return TokenRateDisplay(
+        input_usd_per_1m=rate.input / _USD_PER_1M_DIVISOR,
+        output_usd_per_1m=rate.output / _USD_PER_1M_DIVISOR,
+        cache_read_usd_per_1m=(
+            rate.cache_read / _USD_PER_1M_DIVISOR if rate.cache_read else None
+        ),
+        cache_creation_usd_per_1m=(
+            rate.cache_creation / _USD_PER_1M_DIVISOR if rate.cache_creation else None
+        ),
     )
 
 
@@ -436,7 +434,6 @@ def _tokens_llm_cost(model: LlmModel, credentials: APIKeyCredentials) -> BlockCo
     """Build a TOKENS BlockCost for `model` + `credentials`, attaching the
     public per-1M-token USD rates when the model has a TOKEN_COST entry.
     """
-    input_usd, output_usd, cache_read_usd, cache_creation_usd = _token_usd_rates(model)
     return BlockCost(
         cost_type=BlockCostType.TOKENS,
         cost_filter={
@@ -448,10 +445,7 @@ def _tokens_llm_cost(model: LlmModel, credentials: APIKeyCredentials) -> BlockCo
             },
         },
         cost_amount=MODEL_COST[model],
-        input_usd_per_1m=input_usd,
-        output_usd_per_1m=output_usd,
-        cache_read_usd_per_1m=cache_read_usd,
-        cache_creation_usd_per_1m=cache_creation_usd,
+        token_rate=_token_rate_display(model),
     )
 
 
@@ -460,7 +454,6 @@ def _groq_llm_cost(model: LlmModel) -> BlockCost:
     cost_filter shape so older graphs that stored just the credential id
     continue to match.
     """
-    input_usd, output_usd, cache_read_usd, cache_creation_usd = _token_usd_rates(model)
     return BlockCost(
         cost_type=BlockCostType.TOKENS,
         cost_filter={
@@ -468,10 +461,7 @@ def _groq_llm_cost(model: LlmModel) -> BlockCost:
             "credentials": {"id": groq_credentials.id},
         },
         cost_amount=MODEL_COST[model],
-        input_usd_per_1m=input_usd,
-        output_usd_per_1m=output_usd,
-        cache_read_usd_per_1m=cache_read_usd,
-        cache_creation_usd_per_1m=cache_creation_usd,
+        token_rate=_token_rate_display(model),
     )
 
 
@@ -480,7 +470,6 @@ def _open_router_llm_cost(model: LlmModel) -> BlockCost:
     still exposes the same per-1M-token USD rates so the builder UI shows
     the "$X in / $Y out per 1M tokens" pair instead of "Pay-as-you-go".
     """
-    input_usd, output_usd, cache_read_usd, cache_creation_usd = _token_usd_rates(model)
     return BlockCost(
         cost_type=BlockCostType.COST_USD,
         cost_filter={
@@ -492,10 +481,7 @@ def _open_router_llm_cost(model: LlmModel) -> BlockCost:
             },
         },
         cost_amount=150,
-        input_usd_per_1m=input_usd,
-        output_usd_per_1m=output_usd,
-        cache_read_usd_per_1m=cache_read_usd,
-        cache_creation_usd_per_1m=cache_creation_usd,
+        token_rate=_token_rate_display(model),
     )
 
 

--- a/autogpt_platform/backend/backend/data/block_cost_config.py
+++ b/autogpt_platform/backend/backend/data/block_cost_config.py
@@ -91,6 +91,7 @@ from backend.integrations.credentials_store import (
     llama_api_credentials,
     mem0_credentials,
     nvidia_credentials,
+    ollama_credentials,
     open_router_credentials,
     openai_credentials,
     replicate_credentials,
@@ -256,6 +257,9 @@ TOKEN_COST: dict[LlmModel, TokenRate] = {
     LlmModel.CLAUDE_4_6_OPUS: TokenRate(
         input=750, output=3750, cache_read=75, cache_creation=938
     ),
+    LlmModel.CLAUDE_4_7_OPUS: TokenRate(
+        input=750, output=3750, cache_read=75, cache_creation=938
+    ),
     LlmModel.CLAUDE_4_5_OPUS: TokenRate(
         input=750, output=3750, cache_read=75, cache_creation=938
     ),
@@ -397,42 +401,75 @@ def _lookup_llm_model(raw: "str | LlmModel | None") -> "LlmModel | None":
         return None
 
 
+# TOKEN_COST stores credits per 1M tokens at a uniform 1.5x margin over the
+# published provider price (1 credit ≈ $0.01). Convert back to the public USD
+# rate for UI display so the builder shows real provider pricing instead of
+# the internal credit number. 150 = 100 cr/$ × 1.5x margin.
+_USD_PER_1M_DIVISOR = 150
+
+
+def _token_usd_rates(
+    model: LlmModel,
+) -> tuple[float | None, float | None, float | None, float | None]:
+    """Return (input, output, cache_read, cache_creation) USD/1M for `model`,
+    or all None if the model has no TOKEN_COST entry. cache_* are None when
+    the provider doesn't bill cached tokens at a distinct rate (most non-
+    Anthropic) — i.e. the corresponding TOKEN_COST field is zero.
+    """
+    rate = TOKEN_COST.get(model)
+    if rate is None:
+        return None, None, None, None
+    cache_read = rate.cache_read / _USD_PER_1M_DIVISOR if rate.cache_read else None
+    cache_creation = (
+        rate.cache_creation / _USD_PER_1M_DIVISOR if rate.cache_creation else None
+    )
+    return (
+        rate.input / _USD_PER_1M_DIVISOR,
+        rate.output / _USD_PER_1M_DIVISOR,
+        cache_read,
+        cache_creation,
+    )
+
+
+def _tokens_llm_cost(model: LlmModel, credentials) -> BlockCost:
+    """Build a TOKENS BlockCost for `model` + `credentials`, attaching the
+    public per-1M-token USD rates when the model has a TOKEN_COST entry.
+    """
+    input_usd, output_usd, cache_read_usd, cache_creation_usd = _token_usd_rates(model)
+    return BlockCost(
+        cost_type=BlockCostType.TOKENS,
+        cost_filter={
+            "model": model,
+            "credentials": {
+                "id": credentials.id,
+                "provider": credentials.provider,
+                "type": credentials.type,
+            },
+        },
+        cost_amount=MODEL_COST[model],
+        input_usd_per_1m=input_usd,
+        output_usd_per_1m=output_usd,
+        cache_read_usd_per_1m=cache_read_usd,
+        cache_creation_usd_per_1m=cache_creation_usd,
+    )
+
+
 LLM_COST = (
     # Anthropic Models
     [
-        BlockCost(
-            cost_type=BlockCostType.TOKENS,
-            cost_filter={
-                "model": model,
-                "credentials": {
-                    "id": anthropic_credentials.id,
-                    "provider": anthropic_credentials.provider,
-                    "type": anthropic_credentials.type,
-                },
-            },
-            cost_amount=cost,
-        )
-        for model, cost in MODEL_COST.items()
+        _tokens_llm_cost(model, anthropic_credentials)
+        for model in MODEL_COST
         if MODEL_METADATA[model].provider == "anthropic"
     ]
     # OpenAI Models
     + [
-        BlockCost(
-            cost_type=BlockCostType.TOKENS,
-            cost_filter={
-                "model": model,
-                "credentials": {
-                    "id": openai_credentials.id,
-                    "provider": openai_credentials.provider,
-                    "type": openai_credentials.type,
-                },
-            },
-            cost_amount=cost,
-        )
-        for model, cost in MODEL_COST.items()
+        _tokens_llm_cost(model, openai_credentials)
+        for model in MODEL_COST
         if MODEL_METADATA[model].provider == "openai"
     ]
-    # Groq Models
+    # Groq Models (credentials filter intentionally only uses id; rate-table
+    # lookup keys on model, so omitting provider/type avoids breaking older
+    # graphs that stored just the id).
     + [
         BlockCost(
             cost_type=BlockCostType.TOKENS,
@@ -440,15 +477,22 @@ LLM_COST = (
                 "model": model,
                 "credentials": {"id": groq_credentials.id},
             },
-            cost_amount=cost,
+            cost_amount=MODEL_COST[model],
+            input_usd_per_1m=_token_usd_rates(model)[0],
+            output_usd_per_1m=_token_usd_rates(model)[1],
+            cache_read_usd_per_1m=_token_usd_rates(model)[2],
+            cache_creation_usd_per_1m=_token_usd_rates(model)[3],
         )
-        for model, cost in MODEL_COST.items()
+        for model in MODEL_COST
         if MODEL_METADATA[model].provider == "groq"
     ]
     # Open Router Models: OpenRouter returns x-total-cost on every
     # response. Bill 150 cr/$ (1.5x margin) against the authoritative
     # USD value instead of maintaining per-model TOKEN_COST rates —
-    # provider pricing drift is handled upstream.
+    # provider pricing drift is handled upstream. We still surface
+    # input/output_usd_per_1m for display so the builder UI shows the
+    # same "$X / $Y per 1M" pair as direct-billed providers — final
+    # charge still settles against x-total-cost regardless.
     + [
         BlockCost(
             cost_type=BlockCostType.COST_USD,
@@ -461,60 +505,50 @@ LLM_COST = (
                 },
             },
             cost_amount=150,
+            input_usd_per_1m=_token_usd_rates(model)[0],
+            output_usd_per_1m=_token_usd_rates(model)[1],
+            cache_read_usd_per_1m=_token_usd_rates(model)[2],
+            cache_creation_usd_per_1m=_token_usd_rates(model)[3],
         )
         for model in MODEL_COST.keys()
         if MODEL_METADATA[model].provider == "open_router"
     ]
     # Llama API Models
     + [
-        BlockCost(
-            cost_type=BlockCostType.TOKENS,
-            cost_filter={
-                "model": model,
-                "credentials": {
-                    "id": llama_api_credentials.id,
-                    "provider": llama_api_credentials.provider,
-                    "type": llama_api_credentials.type,
-                },
-            },
-            cost_amount=cost,
-        )
-        for model, cost in MODEL_COST.items()
+        _tokens_llm_cost(model, llama_api_credentials)
+        for model in MODEL_COST
         if MODEL_METADATA[model].provider == "llama_api"
     ]
     # v0 by Vercel Models
     + [
-        BlockCost(
-            cost_type=BlockCostType.TOKENS,
-            cost_filter={
-                "model": model,
-                "credentials": {
-                    "id": v0_credentials.id,
-                    "provider": v0_credentials.provider,
-                    "type": v0_credentials.type,
-                },
-            },
-            cost_amount=cost,
-        )
-        for model, cost in MODEL_COST.items()
+        _tokens_llm_cost(model, v0_credentials)
+        for model in MODEL_COST
         if MODEL_METADATA[model].provider == "v0"
     ]
     # AI/ML Api Models
     + [
+        _tokens_llm_cost(model, aiml_api_credentials)
+        for model in MODEL_COST
+        if MODEL_METADATA[model].provider == "aiml_api"
+    ]
+    # Ollama: self-hosted, no provider charge. Explicit zero-cost entry so
+    # the builder UI can render "Free" instead of an empty cost label (which
+    # the user reads as "unknown" / missing data).
+    + [
         BlockCost(
-            cost_type=BlockCostType.TOKENS,
+            cost_type=BlockCostType.RUN,
+            cost_amount=0,
             cost_filter={
                 "model": model,
                 "credentials": {
-                    "id": aiml_api_credentials.id,
-                    "provider": aiml_api_credentials.provider,
-                    "type": aiml_api_credentials.type,
+                    "id": ollama_credentials.id,
+                    "provider": ollama_credentials.provider,
+                    "type": ollama_credentials.type,
                 },
             },
-            cost_amount=cost,
         )
-        for model, cost in MODEL_COST.items()
-        if MODEL_METADATA[model].provider == "aiml_api"
+        for model in MODEL_COST
+        if MODEL_METADATA[model].provider == "ollama"
     ]
 )
 

--- a/autogpt_platform/backend/backend/data/block_cost_config.py
+++ b/autogpt_platform/backend/backend/data/block_cost_config.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel
 
 from backend.blocks._base import Block, BlockCost, BlockCostType
 from backend.data.block import BlockInput
+from backend.data.model import APIKeyCredentials
 
 if TYPE_CHECKING:
     from backend.data.model import NodeExecutionStats
@@ -431,7 +432,7 @@ def _token_usd_rates(
     )
 
 
-def _tokens_llm_cost(model: LlmModel, credentials) -> BlockCost:
+def _tokens_llm_cost(model: LlmModel, credentials: APIKeyCredentials) -> BlockCost:
     """Build a TOKENS BlockCost for `model` + `credentials`, attaching the
     public per-1M-token USD rates when the model has a TOKEN_COST entry.
     """
@@ -447,6 +448,50 @@ def _tokens_llm_cost(model: LlmModel, credentials) -> BlockCost:
             },
         },
         cost_amount=MODEL_COST[model],
+        input_usd_per_1m=input_usd,
+        output_usd_per_1m=output_usd,
+        cache_read_usd_per_1m=cache_read_usd,
+        cache_creation_usd_per_1m=cache_creation_usd,
+    )
+
+
+def _groq_llm_cost(model: LlmModel) -> BlockCost:
+    """Groq variant of `_tokens_llm_cost` — keeps the legacy id-only
+    cost_filter shape so older graphs that stored just the credential id
+    continue to match.
+    """
+    input_usd, output_usd, cache_read_usd, cache_creation_usd = _token_usd_rates(model)
+    return BlockCost(
+        cost_type=BlockCostType.TOKENS,
+        cost_filter={
+            "model": model,
+            "credentials": {"id": groq_credentials.id},
+        },
+        cost_amount=MODEL_COST[model],
+        input_usd_per_1m=input_usd,
+        output_usd_per_1m=output_usd,
+        cache_read_usd_per_1m=cache_read_usd,
+        cache_creation_usd_per_1m=cache_creation_usd,
+    )
+
+
+def _open_router_llm_cost(model: LlmModel) -> BlockCost:
+    """OpenRouter variant — bills via COST_USD against x-total-cost, but
+    still exposes the same per-1M-token USD rates so the builder UI shows
+    the "$X in / $Y out per 1M tokens" pair instead of "Pay-as-you-go".
+    """
+    input_usd, output_usd, cache_read_usd, cache_creation_usd = _token_usd_rates(model)
+    return BlockCost(
+        cost_type=BlockCostType.COST_USD,
+        cost_filter={
+            "model": model,
+            "credentials": {
+                "id": open_router_credentials.id,
+                "provider": open_router_credentials.provider,
+                "type": open_router_credentials.type,
+            },
+        },
+        cost_amount=150,
         input_usd_per_1m=input_usd,
         output_usd_per_1m=output_usd,
         cache_read_usd_per_1m=cache_read_usd,
@@ -471,18 +516,7 @@ LLM_COST = (
     # lookup keys on model, so omitting provider/type avoids breaking older
     # graphs that stored just the id).
     + [
-        BlockCost(
-            cost_type=BlockCostType.TOKENS,
-            cost_filter={
-                "model": model,
-                "credentials": {"id": groq_credentials.id},
-            },
-            cost_amount=MODEL_COST[model],
-            input_usd_per_1m=_token_usd_rates(model)[0],
-            output_usd_per_1m=_token_usd_rates(model)[1],
-            cache_read_usd_per_1m=_token_usd_rates(model)[2],
-            cache_creation_usd_per_1m=_token_usd_rates(model)[3],
-        )
+        _groq_llm_cost(model)
         for model in MODEL_COST
         if MODEL_METADATA[model].provider == "groq"
     ]
@@ -494,23 +528,8 @@ LLM_COST = (
     # same "$X / $Y per 1M" pair as direct-billed providers — final
     # charge still settles against x-total-cost regardless.
     + [
-        BlockCost(
-            cost_type=BlockCostType.COST_USD,
-            cost_filter={
-                "model": model,
-                "credentials": {
-                    "id": open_router_credentials.id,
-                    "provider": open_router_credentials.provider,
-                    "type": open_router_credentials.type,
-                },
-            },
-            cost_amount=150,
-            input_usd_per_1m=_token_usd_rates(model)[0],
-            output_usd_per_1m=_token_usd_rates(model)[1],
-            cache_read_usd_per_1m=_token_usd_rates(model)[2],
-            cache_creation_usd_per_1m=_token_usd_rates(model)[3],
-        )
-        for model in MODEL_COST.keys()
+        _open_router_llm_cost(model)
+        for model in MODEL_COST
         if MODEL_METADATA[model].provider == "open_router"
     ]
     # Llama API Models

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/nodes/CustomNode/components/NodeCost.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/nodes/CustomNode/components/NodeCost.tsx
@@ -99,7 +99,7 @@ function getDisplay(
         kind: "fixed",
         amountText,
         suffix: "/run",
-        note: "Flat pre-flight estimate; the provider doesn't publish per-token rates for this model.",
+        note: "Pre-flight flat estimate — per-token rate not in our catalog yet.",
       };
     default:
       return { kind: "fixed", amountText, suffix: `/${blockCost.cost_type}` };

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/nodes/CustomNode/components/NodeCost.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/nodes/CustomNode/components/NodeCost.tsx
@@ -7,45 +7,102 @@ import { isCostFilterMatch } from "../../../../helper";
 import { useNodeStore } from "@/app/(platform)/build/stores/nodeStore";
 import { useShallow } from "zustand/react/shallow";
 
-type CostLabelKind = "fixed" | "per-unit" | "dynamic";
+type CostDisplay =
+  | { kind: "free" }
+  | {
+      kind: "token-rate";
+      input: number;
+      output: number;
+      cacheRead: number | null;
+      cacheCreation: number | null;
+    }
+  | { kind: "by-usd" }
+  | { kind: "fixed"; amountText: string; suffix: string; note?: string }
+  | { kind: "per-unit"; amountText: string; suffix: string; note?: string };
 
-interface CostLabel {
-  kind: CostLabelKind;
-  unitSuffix: string;
-  note?: string;
+function formatUsd(value: number): string {
+  return `$${value.toFixed(2)}`;
 }
 
-function getCostLabel(blockCost: BlockCost): CostLabel {
+function tokenRateTooltip(d: {
+  input: number;
+  output: number;
+  cacheRead: number | null;
+  cacheCreation: number | null;
+}): string {
+  const parts = [
+    `Input: ${formatUsd(d.input)} / 1M tokens`,
+    `Output: ${formatUsd(d.output)} / 1M tokens`,
+  ];
+  if (d.cacheRead != null)
+    parts.push(`Cached input: ${formatUsd(d.cacheRead)} / 1M tokens`);
+  if (d.cacheCreation != null)
+    parts.push(`Cache write: ${formatUsd(d.cacheCreation)} / 1M tokens`);
+  parts.push("Final charge scales with real usage (1.5× margin applied).");
+  return parts.join(" · ");
+}
+
+function getDisplay(
+  blockCost: BlockCost,
+  formatCredits: (n: number | null) => string,
+): CostDisplay {
+  // Token-rate pair takes precedence regardless of cost_type so that
+  // OpenRouter (COST_USD)-billed models show the same "$X / $Y per 1M"
+  // format as direct-billed providers when we have a published rate.
+  // The internal billing path (TOKENS vs COST_USD) is not user-facing.
+  if (
+    blockCost.input_usd_per_1m != null &&
+    blockCost.output_usd_per_1m != null
+  ) {
+    return {
+      kind: "token-rate",
+      input: blockCost.input_usd_per_1m,
+      output: blockCost.output_usd_per_1m,
+      cacheRead: blockCost.cache_read_usd_per_1m ?? null,
+      cacheCreation: blockCost.cache_creation_usd_per_1m ?? null,
+    };
+  }
+
+  if (blockCost.cost_type === BlockCostType.cost_usd) {
+    return { kind: "by-usd" };
+  }
+
+  if (
+    blockCost.cost_type === BlockCostType.run &&
+    blockCost.cost_amount === 0
+  ) {
+    return { kind: "free" };
+  }
+
   const divisor = blockCost.cost_divisor;
+  const amountText = formatCredits(blockCost.cost_amount);
+
   switch (blockCost.cost_type) {
     case BlockCostType.run:
-      return { kind: "fixed", unitSuffix: "/run" };
+      return { kind: "fixed", amountText, suffix: "/run" };
     case BlockCostType.byte:
-      return { kind: "per-unit", unitSuffix: "/byte" };
+      return { kind: "per-unit", amountText, suffix: "/byte" };
     case BlockCostType.second:
       return {
         kind: "per-unit",
-        unitSuffix: divisor && divisor > 1 ? `/ ${divisor}s` : "/sec",
+        amountText,
+        suffix: divisor && divisor > 1 ? `/ ${divisor}s` : "/sec",
       };
     case BlockCostType.items:
       return {
         kind: "per-unit",
-        unitSuffix: divisor && divisor > 1 ? `/ ${divisor} items` : "/item",
-      };
-    case BlockCostType.cost_usd:
-      return {
-        kind: "dynamic",
-        unitSuffix: "· by USD",
-        note: "Final charge scales with provider-reported USD spend",
+        amountText,
+        suffix: divisor && divisor > 1 ? `/ ${divisor} items` : "/item",
       };
     case BlockCostType.tokens:
       return {
-        kind: "dynamic",
-        unitSuffix: "· by tokens",
-        note: "Floor shown; final charge scales with real token usage (cached tokens discounted)",
+        kind: "fixed",
+        amountText,
+        suffix: "/run",
+        note: "Flat pre-flight estimate; the provider doesn't publish per-token rates for this model.",
       };
     default:
-      return { kind: "fixed", unitSuffix: `/${blockCost.cost_type}` };
+      return { kind: "fixed", amountText, suffix: `/${blockCost.cost_type}` };
   }
 }
 
@@ -69,24 +126,56 @@ export const NodeCost = ({
 
   if (!blockCost) return null;
 
-  const label = getCostLabel(blockCost);
-  const amountText =
-    label.kind === "fixed"
-      ? formatCredits(blockCost.cost_amount)
-      : blockCost.cost_amount > 0
-        ? `~${formatCredits(blockCost.cost_amount)}`
-        : "—";
+  const display = getDisplay(blockCost, formatCredits);
+
+  if (display.kind === "free") {
+    return (
+      <div className="mr-3 flex items-center gap-1 text-base font-light">
+        <CoinIcon className="h-3 w-3" />
+        <Text variant="small" className="!font-medium">
+          Free
+        </Text>
+      </div>
+    );
+  }
+
+  if (display.kind === "token-rate") {
+    return (
+      <div
+        className="mr-3 flex items-center gap-1 text-base font-light"
+        title={tokenRateTooltip(display)}
+      >
+        <CoinIcon className="h-3 w-3" />
+        <Text variant="small" className="!font-medium">
+          {`${formatUsd(display.input)} in / ${formatUsd(display.output)} out`}
+        </Text>
+        <Text variant="small">{" per 1M tokens"}</Text>
+      </div>
+    );
+  }
+
+  if (display.kind === "by-usd") {
+    return (
+      <div
+        className="mr-3 flex items-center gap-1 text-base font-light"
+        title="Pay-as-you-go pricing. Final charge matches the provider's per-token rate plus a 1.5× margin."
+      >
+        <CoinIcon className="h-3 w-3" />
+        <Text variant="small">Pay-as-you-go</Text>
+      </div>
+    );
+  }
 
   return (
     <div
       className="mr-3 flex items-center gap-1 text-base font-light"
-      title={label.note}
+      title={display.note}
     >
       <CoinIcon className="h-3 w-3" />
       <Text variant="small" className="!font-medium">
-        {amountText}
+        {display.amountText}
       </Text>
-      <Text variant="small">{` ${label.unitSuffix}`}</Text>
+      <Text variant="small">{` ${display.suffix}`}</Text>
     </div>
   );
 };

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/nodes/CustomNode/components/NodeCost.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/nodes/CustomNode/components/NodeCost.tsx
@@ -50,16 +50,13 @@ function getDisplay(
   // OpenRouter (COST_USD)-billed models show the same "$X / $Y per 1M"
   // format as direct-billed providers when we have a published rate.
   // The internal billing path (TOKENS vs COST_USD) is not user-facing.
-  if (
-    blockCost.input_usd_per_1m != null &&
-    blockCost.output_usd_per_1m != null
-  ) {
+  if (blockCost.token_rate) {
     return {
       kind: "token-rate",
-      input: blockCost.input_usd_per_1m,
-      output: blockCost.output_usd_per_1m,
-      cacheRead: blockCost.cache_read_usd_per_1m ?? null,
-      cacheCreation: blockCost.cache_creation_usd_per_1m ?? null,
+      input: blockCost.token_rate.input_usd_per_1m,
+      output: blockCost.token_rate.output_usd_per_1m,
+      cacheRead: blockCost.token_rate.cache_read_usd_per_1m ?? null,
+      cacheCreation: blockCost.token_rate.cache_creation_usd_per_1m ?? null,
     };
   }
 

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/nodes/CustomNode/components/__tests__/NodeCost.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/nodes/CustomNode/components/__tests__/NodeCost.test.tsx
@@ -23,7 +23,9 @@ function cost(overrides: Partial<BlockCost>): BlockCost {
 
 describe("NodeCost", () => {
   beforeEach(() => {
-    useNodeStore.setState({ getHardCodedValues: () => ({}) } as any);
+    useNodeStore.setState({
+      getHardCodedValues: () => ({}),
+    } as Partial<ReturnType<typeof useNodeStore.getState>>);
   });
 
   it("renders fixed /run label for RUN cost type", () => {
@@ -241,7 +243,7 @@ describe("NodeCost", () => {
   it("returns null when no matching blockCost found", () => {
     useNodeStore.setState({
       getHardCodedValues: () => ({ provider: "openai" }),
-    } as any);
+    } as Partial<ReturnType<typeof useNodeStore.getState>>);
     const { container } = render(
       <NodeCost
         blockCosts={[

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/nodes/CustomNode/components/__tests__/NodeCost.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/nodes/CustomNode/components/__tests__/NodeCost.test.tsx
@@ -90,7 +90,7 @@ describe("NodeCost", () => {
     expect(screen.getByText(/\/ 5 items/)).toBeTruthy();
   });
 
-  it("renders '· by USD' for COST_USD and shows approximate prefix for positive floor", () => {
+  it("renders 'Pay-as-you-go' for COST_USD without a published rate", () => {
     render(
       <NodeCost
         blockCosts={[
@@ -99,23 +99,70 @@ describe("NodeCost", () => {
         nodeId="n1"
       />,
     );
-    expect(screen.getByText(/~\$2\.00/)).toBeTruthy();
-    expect(screen.getByText(/· by USD/)).toBeTruthy();
+    expect(screen.getByText("Pay-as-you-go")).toBeTruthy();
+    expect(screen.queryByText(/\$/)).toBeNull();
   });
 
-  it("renders em-dash when dynamic cost has zero floor", () => {
+  it("renders explicit in/out USD pair for COST_USD when published rate is provided", () => {
     render(
       <NodeCost
         blockCosts={[
-          cost({ cost_type: BlockCostType.cost_usd, cost_amount: 0 }),
+          cost({
+            cost_type: BlockCostType.cost_usd,
+            cost_amount: 150,
+            input_usd_per_1m: 0.3,
+            output_usd_per_1m: 1.2,
+          }),
         ]}
         nodeId="n1"
       />,
     );
-    expect(screen.getByText("—")).toBeTruthy();
+    expect(screen.getByText("$0.30 in / $1.20 out")).toBeTruthy();
+    expect(screen.getByText(/per 1M tokens/)).toBeTruthy();
   });
 
-  it("renders '· by tokens' with floor hint for TOKENS", () => {
+  it("includes cache rates in the tooltip when present", () => {
+    render(
+      <NodeCost
+        blockCosts={[
+          cost({
+            cost_type: BlockCostType.tokens,
+            cost_amount: 14,
+            input_usd_per_1m: 5,
+            output_usd_per_1m: 25,
+            cache_read_usd_per_1m: 0.5,
+            cache_creation_usd_per_1m: 6.25,
+          }),
+        ]}
+        nodeId="n1"
+      />,
+    );
+    const tooltipHost = screen
+      .getByText("$5.00 in / $25.00 out")
+      .closest("div");
+    expect(tooltipHost?.getAttribute("title")).toMatch(/Cached input: \$0\.50/);
+    expect(tooltipHost?.getAttribute("title")).toMatch(/Cache write: \$6\.25/);
+  });
+
+  it("renders explicit in/out USD pair for TOKENS with published rates", () => {
+    render(
+      <NodeCost
+        blockCosts={[
+          cost({
+            cost_type: BlockCostType.tokens,
+            cost_amount: 14,
+            input_usd_per_1m: 5,
+            output_usd_per_1m: 25,
+          }),
+        ]}
+        nodeId="n1"
+      />,
+    );
+    expect(screen.getByText("$5.00 in / $25.00 out")).toBeTruthy();
+    expect(screen.getByText(/per 1M tokens/)).toBeTruthy();
+  });
+
+  it("falls back to flat /run for TOKENS without published rates", () => {
     render(
       <NodeCost
         blockCosts={[
@@ -124,8 +171,19 @@ describe("NodeCost", () => {
         nodeId="n1"
       />,
     );
-    expect(screen.getByText(/~\$1\.50/)).toBeTruthy();
-    expect(screen.getByText(/· by tokens/)).toBeTruthy();
+    expect(screen.getByText("$1.50")).toBeTruthy();
+    expect(screen.getByText(/\/run/)).toBeTruthy();
+  });
+
+  it("renders 'Free' for RUN cost type with zero amount", () => {
+    render(
+      <NodeCost
+        blockCosts={[cost({ cost_type: BlockCostType.run, cost_amount: 0 })]}
+        nodeId="n1"
+      />,
+    );
+    expect(screen.getByText("Free")).toBeTruthy();
+    expect(screen.queryByText(/\$/)).toBeNull();
   });
 
   it("renders /byte suffix for BYTE cost type", () => {

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/nodes/CustomNode/components/__tests__/NodeCost.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/nodes/CustomNode/components/__tests__/NodeCost.test.tsx
@@ -112,8 +112,10 @@ describe("NodeCost", () => {
           cost({
             cost_type: BlockCostType.cost_usd,
             cost_amount: 150,
-            input_usd_per_1m: 0.3,
-            output_usd_per_1m: 1.2,
+            token_rate: {
+              input_usd_per_1m: 0.3,
+              output_usd_per_1m: 1.2,
+            },
           }),
         ]}
         nodeId="n1"
@@ -130,10 +132,12 @@ describe("NodeCost", () => {
           cost({
             cost_type: BlockCostType.tokens,
             cost_amount: 14,
-            input_usd_per_1m: 5,
-            output_usd_per_1m: 25,
-            cache_read_usd_per_1m: 0.5,
-            cache_creation_usd_per_1m: 6.25,
+            token_rate: {
+              input_usd_per_1m: 5,
+              output_usd_per_1m: 25,
+              cache_read_usd_per_1m: 0.5,
+              cache_creation_usd_per_1m: 6.25,
+            },
           }),
         ]}
         nodeId="n1"
@@ -153,10 +157,12 @@ describe("NodeCost", () => {
           cost({
             cost_type: BlockCostType.tokens,
             cost_amount: 14,
-            input_usd_per_1m: 5,
-            output_usd_per_1m: 25,
-            cache_read_usd_per_1m: null,
-            cache_creation_usd_per_1m: null,
+            token_rate: {
+              input_usd_per_1m: 5,
+              output_usd_per_1m: 25,
+              cache_read_usd_per_1m: null,
+              cache_creation_usd_per_1m: null,
+            },
           }),
         ]}
         nodeId="n1"
@@ -179,8 +185,10 @@ describe("NodeCost", () => {
           cost({
             cost_type: BlockCostType.tokens,
             cost_amount: 14,
-            input_usd_per_1m: 5,
-            output_usd_per_1m: 25,
+            token_rate: {
+              input_usd_per_1m: 5,
+              output_usd_per_1m: 25,
+            },
           }),
         ]}
         nodeId="n1"

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/nodes/CustomNode/components/__tests__/NodeCost.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/nodes/CustomNode/components/__tests__/NodeCost.test.tsx
@@ -144,6 +144,32 @@ describe("NodeCost", () => {
     expect(tooltipHost?.getAttribute("title")).toMatch(/Cache write: \$6\.25/);
   });
 
+  it("omits cache rate lines from the tooltip when not provided", () => {
+    render(
+      <NodeCost
+        blockCosts={[
+          cost({
+            cost_type: BlockCostType.tokens,
+            cost_amount: 14,
+            input_usd_per_1m: 5,
+            output_usd_per_1m: 25,
+            cache_read_usd_per_1m: null,
+            cache_creation_usd_per_1m: null,
+          }),
+        ]}
+        nodeId="n1"
+      />,
+    );
+    const tooltipHost = screen
+      .getByText("$5.00 in / $25.00 out")
+      .closest("div");
+    const title = tooltipHost?.getAttribute("title") ?? "";
+    expect(title).not.toMatch(/Cached input/);
+    expect(title).not.toMatch(/Cache write/);
+    expect(title).toMatch(/Input: \$5\.00/);
+    expect(title).toMatch(/Output: \$25\.00/);
+  });
+
   it("renders explicit in/out USD pair for TOKENS with published rates", () => {
     render(
       <NodeCost

--- a/autogpt_platform/frontend/src/app/api/openapi.json
+++ b/autogpt_platform/frontend/src/app/api/openapi.json
@@ -10273,6 +10273,22 @@
             "type": "integer",
             "title": "Cost Divisor",
             "default": 1
+          },
+          "input_usd_per_1m": {
+            "anyOf": [{ "type": "number" }, { "type": "null" }],
+            "title": "Input Usd Per 1M"
+          },
+          "output_usd_per_1m": {
+            "anyOf": [{ "type": "number" }, { "type": "null" }],
+            "title": "Output Usd Per 1M"
+          },
+          "cache_read_usd_per_1m": {
+            "anyOf": [{ "type": "number" }, { "type": "null" }],
+            "title": "Cache Read Usd Per 1M"
+          },
+          "cache_creation_usd_per_1m": {
+            "anyOf": [{ "type": "number" }, { "type": "null" }],
+            "title": "Cache Creation Usd Per 1M"
           }
         },
         "type": "object",

--- a/autogpt_platform/frontend/src/app/api/openapi.json
+++ b/autogpt_platform/frontend/src/app/api/openapi.json
@@ -10274,12 +10274,22 @@
             "title": "Cost Divisor",
             "default": 1
           },
-          "input_usd_per_1m": {
-            "anyOf": [{ "type": "number" }, { "type": "null" }],
-            "title": "Input Usd Per 1M"
-          },
+          "token_rate": {
+            "anyOf": [
+              { "$ref": "#/components/schemas/TokenRateDisplay" },
+              { "type": "null" }
+            ]
+          }
+        },
+        "type": "object",
+        "required": ["cost_amount", "cost_filter", "cost_type"],
+        "title": "BlockCost"
+      },
+      "TokenRateDisplay": {
+        "properties": {
+          "input_usd_per_1m": { "type": "number", "title": "Input Usd Per 1M" },
           "output_usd_per_1m": {
-            "anyOf": [{ "type": "number" }, { "type": "null" }],
+            "type": "number",
             "title": "Output Usd Per 1M"
           },
           "cache_read_usd_per_1m": {
@@ -10292,8 +10302,8 @@
           }
         },
         "type": "object",
-        "required": ["cost_amount", "cost_filter", "cost_type"],
-        "title": "BlockCost"
+        "required": ["input_usd_per_1m", "output_usd_per_1m"],
+        "title": "TokenRateDisplay"
       },
       "BlockCostEstimateRow": {
         "properties": {

--- a/autogpt_platform/frontend/src/app/api/openapi.json
+++ b/autogpt_platform/frontend/src/app/api/openapi.json
@@ -10285,26 +10285,6 @@
         "required": ["cost_amount", "cost_filter", "cost_type"],
         "title": "BlockCost"
       },
-      "TokenRateDisplay": {
-        "properties": {
-          "input_usd_per_1m": { "type": "number", "title": "Input Usd Per 1M" },
-          "output_usd_per_1m": {
-            "type": "number",
-            "title": "Output Usd Per 1M"
-          },
-          "cache_read_usd_per_1m": {
-            "anyOf": [{ "type": "number" }, { "type": "null" }],
-            "title": "Cache Read Usd Per 1M"
-          },
-          "cache_creation_usd_per_1m": {
-            "anyOf": [{ "type": "number" }, { "type": "null" }],
-            "title": "Cache Creation Usd Per 1M"
-          }
-        },
-        "type": "object",
-        "required": ["input_usd_per_1m", "output_usd_per_1m"],
-        "title": "TokenRateDisplay"
-      },
       "BlockCostEstimateRow": {
         "properties": {
           "block_id": { "type": "string", "title": "Block Id" },
@@ -17813,6 +17793,27 @@
         "required": ["active"],
         "title": "TokenIntrospectionResult",
         "description": "Result of token introspection (RFC 7662)"
+      },
+      "TokenRateDisplay": {
+        "properties": {
+          "input_usd_per_1m": { "type": "number", "title": "Input Usd Per 1M" },
+          "output_usd_per_1m": {
+            "type": "number",
+            "title": "Output Usd Per 1M"
+          },
+          "cache_read_usd_per_1m": {
+            "anyOf": [{ "type": "number" }, { "type": "null" }],
+            "title": "Cache Read Usd Per 1M"
+          },
+          "cache_creation_usd_per_1m": {
+            "anyOf": [{ "type": "number" }, { "type": "null" }],
+            "title": "Cache Creation Usd Per 1M"
+          }
+        },
+        "type": "object",
+        "required": ["input_usd_per_1m", "output_usd_per_1m"],
+        "title": "TokenRateDisplay",
+        "description": "Public per-1M-token USD rates surfaced to the builder UI.\n\nPopulated only on LLM block costs whose model has a TOKEN_COST rate.\ncache_* fields are set only when the provider publishes a distinct\ncached-token rate (Anthropic). Display-only — billing always uses the\ninternal credit math in `BlockCost.cost_amount`."
       },
       "TokenRequestByCode": {
         "properties": {

--- a/autogpt_platform/frontend/src/app/api/openapi.json
+++ b/autogpt_platform/frontend/src/app/api/openapi.json
@@ -17796,17 +17796,22 @@
       },
       "TokenRateDisplay": {
         "properties": {
-          "input_usd_per_1m": { "type": "number", "title": "Input Usd Per 1M" },
+          "input_usd_per_1m": {
+            "type": "number",
+            "minimum": 0.0,
+            "title": "Input Usd Per 1M"
+          },
           "output_usd_per_1m": {
             "type": "number",
+            "minimum": 0.0,
             "title": "Output Usd Per 1M"
           },
           "cache_read_usd_per_1m": {
-            "anyOf": [{ "type": "number" }, { "type": "null" }],
+            "anyOf": [{ "type": "number", "minimum": 0.0 }, { "type": "null" }],
             "title": "Cache Read Usd Per 1M"
           },
           "cache_creation_usd_per_1m": {
-            "anyOf": [{ "type": "number" }, { "type": "null" }],
+            "anyOf": [{ "type": "number", "minimum": 0.0 }, { "type": "null" }],
             "title": "Cache Creation Usd Per 1M"
           }
         },


### PR DESCRIPTION
### Why / What / How

**Why:** The AI Text Generator (and every other LLM block) rendered the raw `cost_amount=150` for OpenRouter-routed models as if it were per-run credits → the node card showed `~$1.50/run` for every OR model regardless of which one the user picked. Backend billing was always correct (post-flight settles against `x-total-cost`), but the pre-flight display made cheap models like Qwen 3 look 10× more expensive than Claude Opus, and Ollama / Z.ai free models had no cost label at all. Surfaced by Craig in Discord thread [#1503736802299875441](https://discord.com/channels/1126875755960336515/1503736802299875441/1503736859782811710); follow-up feedback from Krzysztof (UX is unclear) and Toran (users shouldn't have to learn the difference between "billed by tokens" vs "billed by USD").

**What:** Replace the misleading cost amount with the provider's *published* per-1M-token USD rate, rendered the same way for every LLM regardless of internal billing path. Show "Free" for Ollama. Show "Pay-as-you-go" only when we genuinely don't have a published rate.

**How:**
- `BlockCost` now carries optional `input_usd_per_1m`, `output_usd_per_1m`, `cache_read_usd_per_1m`, `cache_creation_usd_per_1m` (USD/1M, derived from the existing `TOKEN_COST` credit/1M rates by dividing by 150 — the cr-per-$ multiplier that already encodes our 1.5× margin). Display-only; the billing path (`compute_token_credits` / `_coerce_usd × cost_amount`) is unchanged.
- All TOKENS-typed LLM_COST entries (Anthropic / OpenAI / Groq / AIML / Llama-API / v0) get rates wired through a new `_tokens_llm_cost()` helper.
- OpenRouter COST_USD entries *also* get rates wired when the model has a `TOKEN_COST` row — so OR-billed models (Mistral, Kimi, Cohere, Grok, Gemini, DeepSeek, Perplexity) display the same `$X.XX in / $Y.YY out per 1M tokens` as direct-billed providers.
- New explicit Ollama loop emits `cost_type=RUN, cost_amount=0` for each Ollama model so the node card renders "Free" instead of an empty label.
- Added missing `CLAUDE_4_7_OPUS` row to `TOKEN_COST` (was falling back to flat $0.14/run).
- Frontend `NodeCost.tsx` rewritten to:
  - Prefer the rate-pair display (`$X in / $Y out per 1M tokens`) whenever rates are present, regardless of `cost_type`.
  - Tooltip lists cached/cache-write rates when provider publishes them (Anthropic).
  - "Pay-as-you-go" for COST_USD without rates (no fake number).
  - "Free" for RUN with `cost_amount=0`.

### Changes 🏗️

- `backend/blocks/_base.py`: Add four optional USD/1M rate fields to `BlockCost`.
- `backend/data/block_cost_config.py`: New `_token_usd_rates()` and `_tokens_llm_cost()` helpers; populate rates on TOKENS, Groq, OpenRouter entries; add Ollama free-cost loop; add `CLAUDE_4_7_OPUS` to `TOKEN_COST`.
- `frontend/.../NodeCost.tsx`: Refactor display logic into a typed `CostDisplay` union; render in/out USD pair with cache-aware tooltip; "Free" / "Pay-as-you-go" branches.
- `frontend/.../NodeCost.test.tsx`: Update existing cases for the new copy; add coverage for token-rate pair (TOKENS + COST_USD), cache rates in tooltip, "Free" label, and "Pay-as-you-go" label.
- `frontend/src/app/api/openapi.json`: Regenerated to include the new optional fields.

### Checklist 📋

#### For code changes:
- [ ] I have clearly listed my changes in the PR description
- [ ] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [ ] Backend: `poetry run pytest backend/executor/block_usage_cost_test.py backend/executor/billing_reconciliation_test.py backend/blocks/test/test_block.py` (1031 passed locally)
  - [ ] Frontend: `npx vitest run .../NodeCost.test.tsx` (14 passed locally)
  - [ ] Manual: open AI Text Generator block in builder, verify Opus shows `$5.00 in / $25.00 out per 1M tokens` with cached rates in tooltip; Qwen 3 Coder shows "Pay-as-you-go"; an Ollama model shows "Free"
  - [ ] Manual: confirm post-flight billing for an OpenRouter call still settles against `x-total-cost` (no regression — `_coerce_usd × cost_amount=150` path untouched)
