### PR TITLE
fix(backend): require Discord server managers for bot setup

### DIFF
--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter.py
@@ -189,15 +189,7 @@ class DiscordAdapter(PlatformAdapter):
 
         @self._client.event
         async def on_message(message: discord.Message) -> None:
-            # Always skip our own messages — without this we'd loop forever
-            # answering our own replies. Other bots are fine: in channels
-            # we still require an @mention, in threads we still require an
-            # explicit subscription, so the existing gates already bound the
-            # blast radius of bot-to-bot interactions.
-            if (
-                self._client.user is not None
-                and message.author.id == self._client.user.id
-            ):
+            if self._should_ignore_message(message):
                 return
             if self._on_message_callback is None:
                 return
@@ -228,6 +220,11 @@ class DiscordAdapter(PlatformAdapter):
                 mentionable_users=self._collect_mentionable_users(message),
             )
             await self._on_message_callback(ctx, self)
+
+    def _should_ignore_message(self, message: discord.Message) -> bool:
+        return (
+            self._client.user is not None and message.author.id == self._client.user.id
+        )
 
     def _is_mentioned(self, message: discord.Message) -> bool:
         if message.guild is None:

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter_test.py
@@ -135,6 +135,29 @@ class TestChannelType:
 # ── _is_mentioned ──────────────────────────────────────────────────────
 
 
+class TestShouldIgnoreMessage:
+    def test_ignores_own_message(self):
+        adapter, _ = _bare_adapter(bot_id=1000)
+        msg = _message("hi", [])
+        msg.author = MagicMock(id=1000, bot=True)
+
+        assert adapter._should_ignore_message(msg) is True
+
+    def test_allows_other_bot_message(self):
+        adapter, _ = _bare_adapter(bot_id=1000)
+        msg = _message("hi", [])
+        msg.author = MagicMock(id=2000, bot=True)
+
+        assert adapter._should_ignore_message(msg) is False
+
+    def test_allows_human_message(self):
+        adapter, _ = _bare_adapter(bot_id=1000)
+        msg = _message("hi", [])
+        msg.author = MagicMock(id=2000, bot=False)
+
+        assert adapter._should_ignore_message(msg) is False
+
+
 class TestIsMentioned:
     def test_dm_always_counts_as_mentioned(self):
         adapter, _ = _bare_adapter(bot_id=1000)

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/commands.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/commands.py
@@ -24,6 +24,7 @@ def register(tree: app_commands.CommandTree, api: BotBackend) -> None:
         name="setup",
         description="Link this server to an AutoGPT account for AutoPilot",
     )
+    @app_commands.default_permissions(manage_guild=True)
     async def setup_command(interaction: discord.Interaction) -> None:
         await _handle_setup(interaction, api)
 
@@ -44,6 +45,14 @@ async def _handle_setup(interaction: discord.Interaction, api: BotBackend) -> No
         await interaction.response.send_message(
             "This command can only be used in a server. "
             "To link your DMs, just send me a direct message.",
+            ephemeral=True,
+        )
+        return
+
+    if not interaction.permissions.manage_guild:
+        await interaction.response.send_message(
+            "Only members with the Manage Server permission can link this "
+            "server to an AutoGPT account.",
             ephemeral=True,
         )
         return

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/commands_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/commands_test.py
@@ -14,11 +14,12 @@ from ...bot_backend import LinkTokenResult
 from .commands import _handle_help, _handle_setup, _handle_unlink
 
 
-def _interaction(*, guild: bool = True) -> MagicMock:
+def _interaction(*, guild: bool = True, manage_guild: bool = True) -> MagicMock:
     interaction = MagicMock()
     interaction.response.send_message = AsyncMock()
     interaction.response.defer = AsyncMock()
     interaction.followup.send = AsyncMock()
+    interaction.permissions = MagicMock(manage_guild=manage_guild)
     if guild:
         # MagicMock treats `name` as a constructor kwarg for the mock's repr,
         # not as an attribute — so set it after construction.
@@ -53,6 +54,18 @@ class TestHandleSetup:
         await _handle_setup(interaction, api)
 
         interaction.response.send_message.assert_awaited_once()
+        api.create_link_token.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_non_admin_guild_invocation_is_rejected(self):
+        interaction = _interaction(manage_guild=False)
+        api = _api_with_token()
+        await _handle_setup(interaction, api)
+
+        interaction.response.send_message.assert_awaited_once()
+        assert interaction.response.send_message.await_args.kwargs["ephemeral"] is True
+        assert "Manage Server" in interaction.response.send_message.await_args.args[0]
+        interaction.response.defer.assert_not_awaited()
         api.create_link_token.assert_not_awaited()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
### Why / What / How

Why: Discord `/setup` links an entire server to an AutoGPT account, so it should only be available to users trusted to manage that server. Without this guard, any server member could initiate the link flow for the whole Discord server.

What: Require Discord `Manage Server` permission for the AutoPilot bot `/setup` command and add coverage for the permission check. Also keeps the message ignore behavior explicit: the bot ignores its own messages while still allowing other bots to participate normally.

How: Adds Discord command default permissions via `app_commands.default_permissions(manage_guild=True)` and a runtime permission guard in the setup handler before creating link tokens. Extracts the self-message check into a small adapter helper with tests.

### Changes 🏗️

- Require `Manage Server` permission for Discord `/setup` command registration.
- Add a runtime `/setup` permission check that returns an ephemeral error before token creation.
- Add tests covering non-admin setup rejection.
- Make Discord self-message ignore behavior explicit and test that other bot/human messages are still accepted.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `cd backend && poetry run pytest backend/copilot/bot backend/platform_linking backend/api/features/platform_linking -q`
  - [x] `cd backend && poetry run pyright backend/copilot/bot/adapters/discord backend/util/settings.py`
  - [x] `cd backend && poetry run lint --skip-pyright`

#### For configuration changes:

- [x] `.env.default` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes
- [x] I have included a list of my configuration changes in the PR description (under **Changes**)

No configuration changes required.
