### PR TITLE
feat(frontend): default onboarding pricing to yearly with monthly-equivalent + Charged today

### DIFF
--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/__tests__/store.test.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/__tests__/store.test.ts
@@ -16,6 +16,12 @@ describe("useOnboardingWizardStore", () => {
       expect(state.painPoints).toEqual([]);
       expect(state.otherPainPoint).toBe("");
     });
+
+    it("defaults to yearly billing", () => {
+      expect(useOnboardingWizardStore.getState().selectedBilling).toBe(
+        "yearly",
+      );
+    });
   });
 
   describe("setName", () => {

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/__tests__/SubscriptionStep.test.tsx
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/__tests__/SubscriptionStep.test.tsx
@@ -40,17 +40,24 @@ describe("SubscriptionStep", () => {
     expect(screen.getByRole("heading", { name: /^Team$/ })).toBeDefined();
   });
 
-  test("monthly USD prices render with two decimals", () => {
+  test("defaults to yearly billing with the monthly-equivalent price and the annual charge", () => {
     render(<SubscriptionStep />);
-    expect(screen.getByText(/\$50\.00/)).toBeDefined();
-    expect(screen.getByText(/\$320\.00/)).toBeDefined();
+    expect(useOnboardingWizardStore.getState().selectedBilling).toBe("yearly");
+    expect(screen.getByText("$42.50")).toBeDefined();
+    expect(screen.getByText("$272.00")).toBeDefined();
+    expect(screen.getByText("Charged today: $510.00")).toBeDefined();
+    expect(screen.getByText("Charged today: $3,264.00")).toBeDefined();
+    expect(screen.getAllByText(/Save 15%/).length).toBeGreaterThan(0);
   });
 
-  test("toggling yearly billing updates the store and shows /year", () => {
+  test("switching to monthly shows the full monthly price and matching charged-today", () => {
     render(<SubscriptionStep />);
-    fireEvent.click(screen.getByRole("button", { name: /Yearly billing/i }));
-    expect(useOnboardingWizardStore.getState().selectedBilling).toBe("yearly");
-    expect(screen.getAllByText(/\/ year/i).length).toBeGreaterThan(0);
+    fireEvent.click(screen.getByRole("button", { name: /Monthly billing/i }));
+    expect(useOnboardingWizardStore.getState().selectedBilling).toBe("monthly");
+    expect(screen.getByText("$50.00")).toBeDefined();
+    expect(screen.getByText("$320.00")).toBeDefined();
+    expect(screen.getByText("Charged today: $50.00")).toBeDefined();
+    expect(screen.getByText("Charged today: $320.00")).toBeDefined();
   });
 
   test("selecting Pro persists selectedPlan, submits the profile, and redirects to Stripe Checkout", async () => {
@@ -104,7 +111,7 @@ describe("SubscriptionStep", () => {
     expect(capturedProfileBody!.pain_points).toEqual(["Repetitive work"]);
   });
 
-  test("toggling yearly + selecting Pro forwards billing_cycle=yearly", async () => {
+  test("default yearly + selecting Pro forwards billing_cycle=yearly", async () => {
     let capturedTierBody: {
       tier?: string;
       billing_cycle?: string;
@@ -121,7 +128,6 @@ describe("SubscriptionStep", () => {
     );
 
     render(<SubscriptionStep />);
-    fireEvent.click(screen.getByRole("button", { name: /Yearly billing/i }));
     fireEvent.click(screen.getByRole("button", { name: /Get Pro/i }));
 
     await waitFor(() => {
@@ -131,7 +137,7 @@ describe("SubscriptionStep", () => {
     expect(capturedTierBody!.billing_cycle).toBe("yearly");
   });
 
-  test("default monthly billing forwards billing_cycle=monthly", async () => {
+  test("switching to monthly + selecting Pro forwards billing_cycle=monthly", async () => {
     let capturedTierBody: { billing_cycle?: string } | null = null;
 
     server.use(
@@ -145,6 +151,7 @@ describe("SubscriptionStep", () => {
     );
 
     render(<SubscriptionStep />);
+    fireEvent.click(screen.getByRole("button", { name: /Monthly billing/i }));
     fireEvent.click(screen.getByRole("button", { name: /Get Pro/i }));
 
     await waitFor(() => {

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/store.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/store.ts
@@ -38,7 +38,7 @@ export const useOnboardingWizardStore = create<OnboardingWizardState>()(
       painPoints: [],
       otherPainPoint: "",
       selectedPlan: null,
-      selectedBilling: "monthly",
+      selectedBilling: "yearly",
       selectedCountryCode: "US",
       setName(name) {
         set({ name });
@@ -95,7 +95,7 @@ export const useOnboardingWizardStore = create<OnboardingWizardState>()(
           painPoints: [],
           otherPainPoint: "",
           selectedPlan: null,
-          selectedBilling: "monthly",
+          selectedBilling: "yearly",
           selectedCountryCode: "US",
         });
       },

--- a/autogpt_platform/frontend/src/app/(platform)/PaywallGate/__tests__/PaywallModal.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/PaywallGate/__tests__/PaywallModal.test.tsx
@@ -143,12 +143,14 @@ describe("PaywallModal — Monthly/Yearly cycle toggle", () => {
 
     render(<PaywallModal />);
 
-    // PRO monthly = 5000 cents = $50.00
+    // PRO monthly = 5000 cents = $50.00 (primary), $50.00 charged today
     expect(screen.getByText("$50.00")).toBeDefined();
     expect(screen.getByText("$320.00")).toBeDefined();
+    expect(screen.getByText("Charged today: $50.00")).toBeDefined();
+    expect(screen.getByText("Charged today: $320.00")).toBeDefined();
   });
 
-  it("toggling Yearly switches displayed prices to tier_costs_yearly", async () => {
+  it("toggling Yearly switches displayed prices to the monthly-equivalent and the annual total", async () => {
     setupMocks({
       subscription: {
         tier: "NO_TIER",
@@ -161,10 +163,13 @@ describe("PaywallModal — Monthly/Yearly cycle toggle", () => {
 
     fireEvent.click(screen.getByRole("radio", { name: /yearly/i }));
 
-    // PRO yearly = 51000 cents = $510.00; MAX yearly = 326400 cents = $3,264.00
+    // PRO yearly = 51000 cents → $42.50/mo primary, $510.00 charged today.
+    // MAX yearly = 326400 cents → $272.00/mo primary, $3,264.00 charged today.
     await waitFor(() => {
-      expect(screen.getByText("$510.00")).toBeDefined();
-      expect(screen.getByText("$3,264.00")).toBeDefined();
+      expect(screen.getByText("$42.50")).toBeDefined();
+      expect(screen.getByText("$272.00")).toBeDefined();
+      expect(screen.getByText("Charged today: $510.00")).toBeDefined();
+      expect(screen.getByText("Charged today: $3,264.00")).toBeDefined();
     });
   });
 });

--- a/autogpt_platform/frontend/src/app/(platform)/PaywallGate/__tests__/PaywallModal.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/PaywallGate/__tests__/PaywallModal.test.tsx
@@ -132,7 +132,7 @@ describe("PaywallModal — dynamic plan rendering", () => {
 });
 
 describe("PaywallModal — Monthly/Yearly cycle toggle", () => {
-  it("displays monthly prices by default", () => {
+  it("defaults to yearly billing with the monthly-equivalent price and the annual total", () => {
     setupMocks({
       subscription: {
         tier: "NO_TIER",
@@ -142,34 +142,34 @@ describe("PaywallModal — Monthly/Yearly cycle toggle", () => {
     });
 
     render(<PaywallModal />);
-
-    // PRO monthly = 5000 cents = $50.00 (primary), $50.00 charged today
-    expect(screen.getByText("$50.00")).toBeDefined();
-    expect(screen.getByText("$320.00")).toBeDefined();
-    expect(screen.getByText("Charged today: $50.00")).toBeDefined();
-    expect(screen.getByText("Charged today: $320.00")).toBeDefined();
-  });
-
-  it("toggling Yearly switches displayed prices to the monthly-equivalent and the annual total", async () => {
-    setupMocks({
-      subscription: {
-        tier: "NO_TIER",
-        tier_costs: { PRO: 5000, MAX: 32000 },
-        tier_costs_yearly: { PRO: 51000, MAX: 326400 },
-      },
-    });
-
-    render(<PaywallModal />);
-
-    fireEvent.click(screen.getByRole("radio", { name: /yearly/i }));
 
     // PRO yearly = 51000 cents → $42.50/mo primary, $510.00 charged today.
     // MAX yearly = 326400 cents → $272.00/mo primary, $3,264.00 charged today.
+    expect(screen.getByText("$42.50")).toBeDefined();
+    expect(screen.getByText("$272.00")).toBeDefined();
+    expect(screen.getByText("Charged today: $510.00")).toBeDefined();
+    expect(screen.getByText("Charged today: $3,264.00")).toBeDefined();
+  });
+
+  it("toggling Monthly switches displayed prices to the full monthly amounts", async () => {
+    setupMocks({
+      subscription: {
+        tier: "NO_TIER",
+        tier_costs: { PRO: 5000, MAX: 32000 },
+        tier_costs_yearly: { PRO: 51000, MAX: 326400 },
+      },
+    });
+
+    render(<PaywallModal />);
+
+    fireEvent.click(screen.getByRole("radio", { name: /monthly/i }));
+
+    // PRO monthly = 5000 cents = $50.00 (primary), $50.00 charged today
     await waitFor(() => {
-      expect(screen.getByText("$42.50")).toBeDefined();
-      expect(screen.getByText("$272.00")).toBeDefined();
-      expect(screen.getByText("Charged today: $510.00")).toBeDefined();
-      expect(screen.getByText("Charged today: $3,264.00")).toBeDefined();
+      expect(screen.getByText("$50.00")).toBeDefined();
+      expect(screen.getByText("$320.00")).toBeDefined();
+      expect(screen.getByText("Charged today: $50.00")).toBeDefined();
+      expect(screen.getByText("Charged today: $320.00")).toBeDefined();
     });
   });
 });
@@ -193,7 +193,7 @@ describe("PaywallModal — upgrade mutation", () => {
     });
   }
 
-  it("clicking Upgrade to Pro with monthly toggle fires {tier:PRO, billing_cycle:monthly}", async () => {
+  it("clicking Upgrade to Pro after switching to monthly fires {tier:PRO, billing_cycle:monthly}", async () => {
     stubLocation();
     const { mutateFn } = setupMocks({
       subscription: {
@@ -205,6 +205,7 @@ describe("PaywallModal — upgrade mutation", () => {
 
     render(<PaywallModal />);
 
+    fireEvent.click(screen.getByRole("radio", { name: /monthly/i }));
     fireEvent.click(screen.getByRole("button", { name: /upgrade to pro/i }));
 
     await waitFor(() => {
@@ -215,7 +216,7 @@ describe("PaywallModal — upgrade mutation", () => {
     expect(args.data.billing_cycle).toBe("monthly");
   });
 
-  it("clicking Upgrade to Pro with yearly toggle fires {tier:PRO, billing_cycle:yearly}", async () => {
+  it("clicking Upgrade to Pro with the default yearly toggle fires {tier:PRO, billing_cycle:yearly}", async () => {
     stubLocation();
     const { mutateFn } = setupMocks({
       subscription: {
@@ -227,7 +228,6 @@ describe("PaywallModal — upgrade mutation", () => {
 
     render(<PaywallModal />);
 
-    fireEvent.click(screen.getByRole("radio", { name: /yearly/i }));
     fireEvent.click(screen.getByRole("button", { name: /upgrade to pro/i }));
 
     await waitFor(() => {

--- a/autogpt_platform/frontend/src/app/(platform)/PaywallGate/usePaywallModal.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/PaywallGate/usePaywallModal.ts
@@ -55,7 +55,7 @@ export function usePaywallModal() {
   });
   const { mutateAsync: updateTier, isPending } = useUpdateSubscriptionTier();
   const [selectedCycle, setSelectedCycle] = useState<"monthly" | "yearly">(
-    "monthly",
+    "yearly",
   );
   const [selectedTier, setSelectedTier] = useState<string | null>(null);
   // When the user already has an active Stripe subscription (admin override

--- a/autogpt_platform/frontend/src/components/molecules/PlanCard/PlanCard.tsx
+++ b/autogpt_platform/frontend/src/components/molecules/PlanCard/PlanCard.tsx
@@ -29,16 +29,12 @@ export function PlanCard({
   loading = false,
   disabled = false,
 }: Props) {
-  const {
-    primaryPrice,
-    monthlyOriginal,
-    chargedToday,
-    discountPercent,
-  } = computePlanPricing({
-    plan,
-    country,
-    isYearly,
-  });
+  const { primaryPrice, monthlyOriginal, chargedToday, discountPercent } =
+    computePlanPricing({
+      plan,
+      country,
+      isYearly,
+    });
   const hl = plan.highlighted;
   const isTeam = plan.key === PLAN_KEYS.TEAM;
   const reduceMotion = useReducedMotion();

--- a/autogpt_platform/frontend/src/components/molecules/PlanCard/PlanCard.tsx
+++ b/autogpt_platform/frontend/src/components/molecules/PlanCard/PlanCard.tsx
@@ -29,7 +29,12 @@ export function PlanCard({
   loading = false,
   disabled = false,
 }: Props) {
-  const { displayPrice, monthlyEquiv, perLabel } = computePlanPricing({
+  const {
+    primaryPrice,
+    monthlyOriginal,
+    chargedToday,
+    discountPercent,
+  } = computePlanPricing({
     plan,
     country,
     isYearly,
@@ -136,7 +141,7 @@ export function PlanCard({
           </div>
 
           <div className="mb-1 flex flex-wrap items-baseline gap-x-1.5 gap-y-0.5">
-            {displayPrice !== null ? (
+            {primaryPrice !== null ? (
               <>
                 <span
                   className={cn(
@@ -145,23 +150,12 @@ export function PlanCard({
                   )}
                 >
                   {formatPrice(
-                    displayPrice,
+                    primaryPrice,
                     country.currencyCode,
                     country.symbol,
                   )}
                 </span>
-                <span className="text-xs text-zinc-400">{perLabel}</span>
-                {monthlyEquiv !== null && (
-                  <span className="text-xs text-zinc-800">
-                    (
-                    {formatPrice(
-                      monthlyEquiv,
-                      country.currencyCode,
-                      country.symbol,
-                    )}
-                    /month)
-                  </span>
-                )}
+                <span className="text-xs text-zinc-400">/ month</span>
               </>
             ) : (
               <span
@@ -174,6 +168,33 @@ export function PlanCard({
               </span>
             )}
           </div>
+
+          {monthlyOriginal !== null &&
+            discountPercent !== null &&
+            discountPercent > 0 && (
+              <div className="mb-1 flex flex-wrap items-center gap-x-1.5 gap-y-0.5">
+                <span className="inline-flex items-center rounded-full bg-emerald-50 px-1.5 py-0.5 text-[10px] font-semibold text-emerald-700">
+                  Save {discountPercent}%
+                </span>
+                <span className="text-xs text-zinc-500 line-through">
+                  {formatPrice(
+                    monthlyOriginal,
+                    country.currencyCode,
+                    country.symbol,
+                  )}
+                </span>
+              </div>
+            )}
+
+          {chargedToday !== null && (
+            <div className="mb-1 text-xs font-medium text-zinc-700">
+              {`Charged today: ${formatPrice(
+                chargedToday,
+                country.currencyCode,
+                country.symbol,
+              )}`}
+            </div>
+          )}
 
           <p className="mb-3.5 min-h-[30px] text-sm leading-relaxed text-zinc-800">
             {plan.description}

--- a/autogpt_platform/frontend/src/components/molecules/PlanCard/computePricing.test.ts
+++ b/autogpt_platform/frontend/src/components/molecules/PlanCard/computePricing.test.ts
@@ -38,35 +38,38 @@ function makePlan(overrides: Partial<PlanDef> = {}): PlanDef {
 }
 
 describe("computePlanPricing", () => {
-  test("monthly USD passes through the country rate", () => {
-    const { displayPrice, monthlyEquiv, perLabel } = computePlanPricing({
+  test("monthly USD: primary is the monthly price, no discount, charged today equals monthly", () => {
+    const result = computePlanPricing({
       plan: makePlan(),
       country: usdCountry,
       isYearly: false,
     });
-    expect(displayPrice).toBe(50);
-    expect(monthlyEquiv).toBeNull();
-    expect(perLabel).toBe("/ month");
+    expect(result.primaryPrice).toBe(50);
+    expect(result.chargedToday).toBe(50);
+    expect(result.monthlyOriginal).toBeNull();
+    expect(result.discountPercent).toBeNull();
   });
 
-  test("yearly applies the price factor and multiplies by 12", () => {
-    const { displayPrice, monthlyEquiv, perLabel } = computePlanPricing({
+  test("yearly USD: primary is the monthly-equivalent, charged today is the annual total", () => {
+    const result = computePlanPricing({
       plan: makePlan(),
       country: usdCountry,
       isYearly: true,
     });
-    expect(displayPrice).toBe(50 * YEARLY_PRICE_FACTOR * 12);
-    expect(monthlyEquiv).toBe(50 * YEARLY_PRICE_FACTOR);
-    expect(perLabel).toBe("/ year");
+    expect(result.primaryPrice).toBe(50 * YEARLY_PRICE_FACTOR);
+    expect(result.chargedToday).toBe(50 * YEARLY_PRICE_FACTOR * 12);
+    expect(result.monthlyOriginal).toBe(50);
+    expect(result.discountPercent).toBe(15);
   });
 
   test("non-USD currency multiplies by the country rate", () => {
-    const { displayPrice } = computePlanPricing({
+    const result = computePlanPricing({
       plan: makePlan({ usdMonthly: 50 }),
       country: brlCountry,
       isYearly: false,
     });
-    expect(displayPrice).toBe(250);
+    expect(result.primaryPrice).toBe(250);
+    expect(result.chargedToday).toBe(250);
   });
 
   test("usdMonthly === null returns null prices for both branches", () => {
@@ -80,19 +83,36 @@ describe("computePlanPricing", () => {
       country: usdCountry,
       isYearly: true,
     });
-    expect(monthly.displayPrice).toBeNull();
-    expect(monthly.monthlyEquiv).toBeNull();
-    expect(yearly.displayPrice).toBeNull();
-    expect(yearly.monthlyEquiv).toBeNull();
+    expect(monthly.primaryPrice).toBeNull();
+    expect(monthly.chargedToday).toBeNull();
+    expect(monthly.monthlyOriginal).toBeNull();
+    expect(monthly.discountPercent).toBeNull();
+    expect(yearly.primaryPrice).toBeNull();
+    expect(yearly.chargedToday).toBeNull();
+    expect(yearly.monthlyOriginal).toBeNull();
+    expect(yearly.discountPercent).toBeNull();
   });
 
   test("usdMonthly === 0 renders 0, not 'Contact us'", () => {
-    const { displayPrice, monthlyEquiv } = computePlanPricing({
+    const result = computePlanPricing({
       plan: makePlan({ usdMonthly: 0 }),
       country: usdCountry,
       isYearly: true,
     });
-    expect(displayPrice).toBe(0);
-    expect(monthlyEquiv).toBe(0);
+    expect(result.primaryPrice).toBe(0);
+    expect(result.chargedToday).toBe(0);
+    expect(result.discountPercent).toBeNull();
+  });
+
+  test("explicit usdYearly overrides the YEARLY_PRICE_FACTOR estimate", () => {
+    const result = computePlanPricing({
+      plan: makePlan({ usdMonthly: 50, usdYearly: 480 }),
+      country: usdCountry,
+      isYearly: true,
+    });
+    expect(result.chargedToday).toBe(480);
+    expect(result.primaryPrice).toBe(40);
+    expect(result.monthlyOriginal).toBe(50);
+    expect(result.discountPercent).toBe(20);
   });
 });

--- a/autogpt_platform/frontend/src/components/molecules/PlanCard/computePricing.ts
+++ b/autogpt_platform/frontend/src/components/molecules/PlanCard/computePricing.ts
@@ -32,7 +32,10 @@ export function computePlanPricing({
       ? monthlyLocal
       : null;
   const discountPercent =
-    isYearly && monthlyLocal !== null && monthlyLocal > 0 && monthlyEquiv !== null
+    isYearly &&
+    monthlyLocal !== null &&
+    monthlyLocal > 0 &&
+    monthlyEquiv !== null
       ? Math.round((1 - monthlyEquiv / monthlyLocal) * 100)
       : null;
 

--- a/autogpt_platform/frontend/src/components/molecules/PlanCard/computePricing.ts
+++ b/autogpt_platform/frontend/src/components/molecules/PlanCard/computePricing.ts
@@ -22,10 +22,24 @@ export function computePlanPricing({
       : monthlyLocal !== null
         ? monthlyLocal * YEARLY_PRICE_FACTOR * 12
         : null;
-  const displayPrice = isYearly ? yearlyLocal : monthlyLocal;
   const monthlyEquiv =
     isYearly && yearlyLocal !== null ? yearlyLocal / 12 : null;
-  const perLabel = isYearly ? "/ year" : "/ month";
 
-  return { displayPrice, monthlyEquiv, perLabel };
+  const primaryPrice = isYearly ? monthlyEquiv : monthlyLocal;
+  const chargedToday = isYearly ? yearlyLocal : monthlyLocal;
+  const monthlyOriginal =
+    isYearly && monthlyLocal !== null && monthlyEquiv !== null
+      ? monthlyLocal
+      : null;
+  const discountPercent =
+    isYearly && monthlyLocal !== null && monthlyLocal > 0 && monthlyEquiv !== null
+      ? Math.round((1 - monthlyEquiv / monthlyLocal) * 100)
+      : null;
+
+  return {
+    primaryPrice,
+    monthlyOriginal,
+    chargedToday,
+    discountPercent,
+  };
 }


### PR DESCRIPTION
### Why / What / How

**Why:** Onboarding pricing is a high-friction conversion point. We want users to land on the yearly plan by default (15% cheaper) and clearly understand the full annual amount they will be charged before they hit Stripe Checkout — no surprise after the redirect, no UI showing yearly while the backend charges monthly.

**What:** Defaults the onboarding subscription step to **Yearly billing** and rebuilds the PlanCard price block so both cycles show the per-month cost plus the actual upfront charge:

- Yearly Pro: `$42.50 / month`, `Save 15%` + `$50.00` (struck through), `Charged today: $510.00`
- Yearly Max: `$272.00 / month`, `Save 15%` + `$320.00` (struck through), `Charged today: $3,264.00`
- Monthly Pro / Max: `$50.00` / `$320.00` per month with `Charged today: $50.00` / `$320.00`

**How:**

- Flipped the Zustand store default + `reset()` for `selectedBilling` to `"yearly"`. SubscriptionStep already reads `selectedBilling` and forwards it to `/api/credits/subscription` as `billing_cycle`, so checkout stays in lockstep with the visible toggle.
- Reworked `computePlanPricing` to expose four explicit fields: `primaryPrice` (monthly-equivalent on yearly, monthly otherwise), `chargedToday` (annual total on yearly, monthly otherwise), `monthlyOriginal` (for the strikethrough), and a computed `discountPercent`. The discount is derived from actual prices, so the API-driven PaywallGate path (where `usdYearly` comes from Stripe) shows the real savings, not a hardcoded 15%.
- Updated `PlanCard.tsx` to render the new layout. `Contact us` / Team path is untouched.

<img width="1512" height="982" alt="Screenshot 2026-05-13 at 8 03 58 AM" src="https://github.com/user-attachments/assets/cd4fad78-3e43-4d18-96bc-e0698c76384c" />

<img width="1512" height="982" alt="Screenshot 2026-05-13 at 8 04 50 AM" src="https://github.com/user-attachments/assets/45617710-5ab6-49ea-9a37-61ee9c79aa96" />


Linear: SECRT-2346

### Changes 🏗️

- `store.ts` — `selectedBilling` initial state + `reset()` default → `"yearly"`.
- `computePricing.ts` — new return shape: `primaryPrice`, `monthlyOriginal`, `chargedToday`, `discountPercent`.
- `PlanCard.tsx` — new price block with `$X.XX / month` primary, `Save Y%` pill + struck-through original (yearly), `Charged today: $Z.ZZ` line (both cycles), `Contact us` preserved for Team.
- Tests:
  - `computePricing.test.ts` — asserts the new fields, including explicit `usdYearly` overriding the 15% estimate.
  - `store.test.ts` — adds default `"yearly"` check.
  - `SubscriptionStep.test.tsx` — covers yearly-default render ($42.50 / $272.00 / Charged today $510 + $3,264 / Save 15%), monthly toggle render, `billing_cycle=yearly` on default Pro, and `billing_cycle=monthly` after switching to Monthly.
  - `PaywallModal.test.tsx` — yearly toggle now asserts monthly-equivalent + `Charged today: $X` since PlanCard is shared.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- x ] I have tested my changes according to the test plan:
  - [x] New user → `/onboarding` → pricing screen defaults to **Yearly billing** with `Save 15%` visible in the toggle
  - [x] Pro card shows `$42.50 / month`, `Save 15%`, `$50.00` (struck through), `Charged today: $510.00`
  - [x] Max card shows `$272.00 / month`, `Save 15%`, `$320.00` (struck through), `Charged today: $3,264.00`
  - [x] Toggle Monthly → Pro `$50.00 / month`, `Charged today: $50.00`; Max `$320.00 / month`, `Charged today: $320.00`
  - [x] Toggle Yearly → Monthly → Yearly: card prices flip cleanly each time
  - [x] Click `Get Pro` while Yearly is selected → Stripe Checkout opens for Pro yearly price
  - [x] Click `Upgrade to Max` while Yearly is selected → Stripe Checkout opens for Max yearly price
  - [x] Click `Get Pro` while Monthly is selected → Stripe Checkout opens for Pro monthly price
  - [x] Click `Upgrade to Max` while Monthly is selected → Stripe Checkout opens for Max monthly price
  - [x] Cancel from Stripe Checkout → return to onboarding step 4 with the previously-selected cycle still showing
  - [x] Team card opens the Tally intake form and does not redirect to Stripe; not affected by the toggle
  - [x] Old "runs/month" language is absent from the onboarding pricing screen
  - [x] Mobile / 375px width: cards stack and the pricing block remains readable

#### For configuration changes:

- [x] `.env.default` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes
- [x] I have included a list of my configuration changes in the PR description (under **Changes**)
