### PR TITLE
feat(frontend): split switch-to-yearly dialog copy into lines + surface charged-today amount

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/settings/billing/__tests__/billing-cards.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/billing/__tests__/billing-cards.test.tsx
@@ -217,6 +217,8 @@ describe("YourPlanCard cycle toggle", () => {
         billing_cycle: "monthly",
         tier_costs: { PRO: 5000, MAX: 32000 },
         tier_costs_yearly: { PRO: 51000, MAX: 326400 },
+        proration_credit_cents: 2500,
+        current_period_end: 1900000000,
         has_active_stripe_subscription: true,
         status: "active",
       }),
@@ -233,15 +235,18 @@ describe("YourPlanCard cycle toggle", () => {
     expect(
       await screen.findByText(/Switch Pro to yearly billing\?/i),
     ).toBeDefined();
-    expect(screen.getByText(/Save 15% with yearly billing\./i)).toBeDefined();
+    // Dialog body is rendered as separate lines, each its own Text node.
+    expect(screen.getByText(/^Save 15% with yearly billing\.$/)).toBeDefined();
+    expect(
+      screen.getByText(/^Pro yearly: \$510\.00\/year \(\$42\.50\/month\)\.$/),
+    ).toBeDefined();
+    // 51000 yearly - 2500 proration credit = 48500 cents = $485.00 charged today.
     expect(
       screen.getByText(
-        /Pro is \$42\.50\/month when billed yearly, charged as \$510\.00\/year instead of \$600\.00\/year monthly\./i,
+        /^Charged today: \$485\.00 \(prorated from your monthly plan\)\.$/,
       ),
     ).toBeDefined();
-    expect(
-      screen.getByText(/charged the prorated difference immediately/i),
-    ).toBeDefined();
+    expect(screen.getByText(/^Renews \$510\.00\/year on /)).toBeDefined();
     expect(
       screen.getByRole("button", { name: /switch to yearly/i }),
     ).toBeDefined();
@@ -272,13 +277,16 @@ describe("YourPlanCard cycle toggle", () => {
     ).toBeDefined();
     expect(
       screen.getByText(
-        /Max is \$272\.00\/month when billed yearly, charged as \$3,264\.00\/year instead of \$3,840\.00\/year monthly\./i,
+        /^Max yearly: \$3,264\.00\/year \(\$272\.00\/month\)\.$/,
       ),
     ).toBeDefined();
+    // No proration_credit_cents in this fixture → falls back to generic
+    // "prorated difference today" line instead of an exact dollar amount.
     expect(
-      screen.getByText(
-        /After this period, your plan renews yearly at \$3,264\.00\./i,
-      ),
+      screen.getByText(/^You'll be charged the prorated difference today\.$/),
+    ).toBeDefined();
+    expect(
+      screen.getByText(/^Renews at \$3,264\.00\/year after this period\.$/),
     ).toBeDefined();
   });
 
@@ -307,10 +315,11 @@ describe("YourPlanCard cycle toggle", () => {
     ).toBeDefined();
     expect(
       screen.getByText(
-        /switch to monthly billing at the end of your current yearly period/i,
+        /^Switches to monthly at the end of your current yearly period\.$/,
       ),
     ).toBeDefined();
-    expect(screen.getByText(/New monthly price: \$50\.00/)).toBeDefined();
+    expect(screen.getByText(/^New price: \$50\.00\/month\.$/)).toBeDefined();
+    expect(screen.getByText(/^No charge today\.$/)).toBeDefined();
   });
 
   it("falls back to the generic dialog title when prices are missing (NO_TIER-like)", async () => {
@@ -341,9 +350,10 @@ describe("YourPlanCard cycle toggle", () => {
     // No tier_costs / tier_costs_yearly in the payload — body falls back to
     // proration-only copy without the savings/pricing lines.
     expect(
-      screen.getByText(
-        /charged the prorated difference immediately\. After this period, your plan renews on the new yearly cadence\./i,
-      ),
+      screen.getByText(/^You'll be charged the prorated difference today\.$/),
+    ).toBeDefined();
+    expect(
+      screen.getByText(/^Renews on the new yearly cadence after this period\.$/),
     ).toBeDefined();
   });
 

--- a/autogpt_platform/frontend/src/app/(platform)/settings/billing/__tests__/billing-cards.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/billing/__tests__/billing-cards.test.tsx
@@ -356,7 +356,9 @@ describe("YourPlanCard cycle toggle", () => {
       screen.getByText(/^You'll be charged the prorated difference today\.$/),
     ).toBeDefined();
     expect(
-      screen.getByText(/^Renews on the new yearly cadence after this period\.$/),
+      screen.getByText(
+        /^Renews on the new yearly cadence after this period\.$/,
+      ),
     ).toBeDefined();
   });
 

--- a/autogpt_platform/frontend/src/app/(platform)/settings/billing/__tests__/billing-cards.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/billing/__tests__/billing-cards.test.tsx
@@ -235,18 +235,20 @@ describe("YourPlanCard cycle toggle", () => {
     expect(
       await screen.findByText(/Switch Pro to yearly billing\?/i),
     ).toBeDefined();
-    // Dialog body is rendered as separate lines, each its own Text node.
+    // Each line splits into a bold label span + regular value span, so we
+    // assert the two pieces separately.
     expect(screen.getByText(/^Save 15% with yearly billing\.$/)).toBeDefined();
+    expect(screen.getByText("Pro yearly:")).toBeDefined();
     expect(
-      screen.getByText(/^Pro yearly: \$510\.00\/year \(\$42\.50\/month\)\.$/),
+      screen.getByText(/^\$510\.00\/year \(\$42\.50\/month\)\.$/),
     ).toBeDefined();
     // 51000 yearly - 2500 proration credit = 48500 cents = $485.00 charged today.
+    expect(screen.getByText("Charged today:")).toBeDefined();
     expect(
-      screen.getByText(
-        /^Charged today: \$485\.00 \(prorated from your monthly plan\)\.$/,
-      ),
+      screen.getByText(/^\$485\.00 \(prorated from your monthly plan\)\.$/),
     ).toBeDefined();
-    expect(screen.getByText(/^Renews \$510\.00\/year on /)).toBeDefined();
+    expect(screen.getByText("Renews")).toBeDefined();
+    expect(screen.getByText(/^\$510\.00\/year on /)).toBeDefined();
     expect(
       screen.getByRole("button", { name: /switch to yearly/i }),
     ).toBeDefined();
@@ -275,18 +277,18 @@ describe("YourPlanCard cycle toggle", () => {
     expect(
       await screen.findByText(/Switch Max to yearly billing\?/i),
     ).toBeDefined();
+    expect(screen.getByText("Max yearly:")).toBeDefined();
     expect(
-      screen.getByText(
-        /^Max yearly: \$3,264\.00\/year \(\$272\.00\/month\)\.$/,
-      ),
+      screen.getByText(/^\$3,264\.00\/year \(\$272\.00\/month\)\.$/),
     ).toBeDefined();
     // No proration_credit_cents in this fixture → falls back to generic
     // "prorated difference today" line instead of an exact dollar amount.
     expect(
       screen.getByText(/^You'll be charged the prorated difference today\.$/),
     ).toBeDefined();
+    expect(screen.getByText("Renews")).toBeDefined();
     expect(
-      screen.getByText(/^Renews at \$3,264\.00\/year after this period\.$/),
+      screen.getByText(/^at \$3,264\.00\/year after this period\.$/),
     ).toBeDefined();
   });
 
@@ -318,7 +320,8 @@ describe("YourPlanCard cycle toggle", () => {
         /^Switches to monthly at the end of your current yearly period\.$/,
       ),
     ).toBeDefined();
-    expect(screen.getByText(/^New price: \$50\.00\/month\.$/)).toBeDefined();
+    expect(screen.getByText("New price:")).toBeDefined();
+    expect(screen.getByText(/^\$50\.00\/month\.$/)).toBeDefined();
     expect(screen.getByText(/^No charge today\.$/)).toBeDefined();
   });
 

--- a/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/SubscriptionTab/YourPlanCard/SwitchCycleDialog.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/SubscriptionTab/YourPlanCard/SwitchCycleDialog.tsx
@@ -37,9 +37,9 @@ export function SwitchCycleDialog({
             <div key={line.label ?? line.text} className="flex flex-wrap gap-1">
               {line.label ? (
                 <Text
-                  variant="body-medium"
+                  variant="body"
                   as="span"
-                  className="text-zinc-700"
+                  className="font-semibold text-zinc-700"
                 >
                   {line.label}
                 </Text>

--- a/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/SubscriptionTab/YourPlanCard/SwitchCycleDialog.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/SubscriptionTab/YourPlanCard/SwitchCycleDialog.tsx
@@ -9,7 +9,7 @@ interface Props {
   onOpenChange: (open: boolean) => void;
   targetCycle: "monthly" | "yearly";
   title?: string;
-  body: string;
+  body: string[];
   isSaving: boolean;
   onConfirm: () => void;
 }
@@ -32,10 +32,12 @@ export function SwitchCycleDialog({
       controlled={{ isOpen, set: onOpenChange }}
     >
       <Dialog.Content>
-        <div className="flex flex-col gap-4">
-          <Text variant="body" as="span" className="text-zinc-700">
-            {body}
-          </Text>
+        <div className="flex flex-col gap-2">
+          {body.map((line) => (
+            <Text key={line} variant="body" as="span" className="text-zinc-700">
+              {line}
+            </Text>
+          ))}
         </div>
 
         <Dialog.Footer>

--- a/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/SubscriptionTab/YourPlanCard/SwitchCycleDialog.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/SubscriptionTab/YourPlanCard/SwitchCycleDialog.tsx
@@ -9,7 +9,7 @@ interface Props {
   onOpenChange: (open: boolean) => void;
   targetCycle: "monthly" | "yearly";
   title?: string;
-  body: string[];
+  body: { text: string; emphasis?: boolean }[];
   isSaving: boolean;
   onConfirm: () => void;
 }
@@ -34,8 +34,13 @@ export function SwitchCycleDialog({
       <Dialog.Content>
         <div className="flex flex-col gap-2">
           {body.map((line) => (
-            <Text key={line} variant="body" as="span" className="text-zinc-700">
-              {line}
+            <Text
+              key={line.text}
+              variant={line.emphasis ? "body-medium" : "body"}
+              as="span"
+              className="text-zinc-700"
+            >
+              {line.text}
             </Text>
           ))}
         </div>

--- a/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/SubscriptionTab/YourPlanCard/SwitchCycleDialog.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/SubscriptionTab/YourPlanCard/SwitchCycleDialog.tsx
@@ -9,7 +9,7 @@ interface Props {
   onOpenChange: (open: boolean) => void;
   targetCycle: "monthly" | "yearly";
   title?: string;
-  body: { text: string; emphasis?: boolean }[];
+  body: { label?: string; text: string }[];
   isSaving: boolean;
   onConfirm: () => void;
 }
@@ -34,14 +34,20 @@ export function SwitchCycleDialog({
       <Dialog.Content>
         <div className="flex flex-col gap-2">
           {body.map((line) => (
-            <Text
-              key={line.text}
-              variant={line.emphasis ? "body-medium" : "body"}
-              as="span"
-              className="text-zinc-700"
-            >
-              {line.text}
-            </Text>
+            <div key={line.label ?? line.text} className="flex flex-wrap gap-1">
+              {line.label ? (
+                <Text
+                  variant="body-medium"
+                  as="span"
+                  className="text-zinc-700"
+                >
+                  {line.label}
+                </Text>
+              ) : null}
+              <Text variant="body" as="span" className="text-zinc-700">
+                {line.text}
+              </Text>
+            </div>
           ))}
         </div>
 

--- a/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/SubscriptionTab/YourPlanCard/SwitchCycleDialog.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/SubscriptionTab/YourPlanCard/SwitchCycleDialog.tsx
@@ -33,8 +33,11 @@ export function SwitchCycleDialog({
     >
       <Dialog.Content>
         <div className="flex flex-col gap-2">
-          {body.map((line) => (
-            <div key={line.label ?? line.text} className="flex flex-wrap gap-1">
+          {body.map((line, index) => (
+            <div
+              key={`${index}-${line.label ?? ""}-${line.text}`}
+              className="flex flex-wrap gap-1"
+            >
               {line.label ? (
                 <Text
                   variant="body"

--- a/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/SubscriptionTab/YourPlanCard/useYourPlanCard.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/SubscriptionTab/YourPlanCard/useYourPlanCard.ts
@@ -131,6 +131,14 @@ export function useYourPlanCard() {
   const currentTierKey = effectiveTier ?? "NO_TIER";
   const currentYearlyCents = tierCostsYearly[currentTierKey];
   const currentMonthlyCents = tierCosts[currentTierKey];
+  // Stripe credits the unused portion of the user's current monthly invoice
+  // when switching to yearly with proration_behavior="always_invoice"; the
+  // backend computes the same value (monthly_cost * remaining / total) and
+  // exposes it on the status payload so we can show the actual charge today.
+  const prorationCreditCents = subscription.data?.proration_credit_cents ?? 0;
+  const currentPeriodEndMs = subscription.data?.current_period_end
+    ? subscription.data.current_period_end * 1000
+    : null;
 
   const plan = subscription.data
     ? {
@@ -347,52 +355,69 @@ export function useYourPlanCard() {
       : `Switch ${tierLabel} to monthly billing?`;
   }
 
-  function getDialogBody(): string {
-    if (!pendingCycle) return "";
+  function getDialogBody(): string[] {
+    if (!pendingCycle) return [];
+    const periodEndLabel = currentPeriodEndMs
+      ? formatShortDate(currentPeriodEndMs)
+      : null;
     if (pendingCycle === "yearly") {
-      const yearly =
-        currentYearlyCents !== undefined ? formatCents(currentYearlyCents) : "";
       const tierLabel = effectiveTier ? PLAN_LABEL[effectiveTier] : null;
-      const prorationLine = [
-        "You'll be charged the prorated difference immediately.",
-        yearly
-          ? `After this period, your plan renews yearly at ${yearly}.`
-          : "After this period, your plan renews on the new yearly cadence.",
-      ].join(" ");
-      // Surface the yearly savings up front when we have both prices — the
-      // 15% discount is the user's primary motivator for accepting the
-      // prorated charge and shouldn't be buried.
-      if (
+      const hasPrices =
         currentMonthlyCents !== undefined &&
         currentYearlyCents !== undefined &&
         currentMonthlyCents > 0 &&
-        currentYearlyCents < currentMonthlyCents * 12
-      ) {
-        const annualMonthlyCents = currentMonthlyCents * 12;
-        const savingsPercent = Math.round(
-          ((annualMonthlyCents - currentYearlyCents) / annualMonthlyCents) *
-            100,
-        );
-        const monthlyEquivalent = formatCents(
-          Math.round(currentYearlyCents / 12),
-        );
-        const annualMonthly = formatCents(annualMonthlyCents);
-        const savingsLine = `Save ${savingsPercent}% with yearly billing.`;
-        const pricingLine = tierLabel
-          ? `${tierLabel} is ${monthlyEquivalent}/month when billed yearly, charged as ${yearly}/year instead of ${annualMonthly}/year monthly.`
-          : `It's ${monthlyEquivalent}/month when billed yearly, charged as ${yearly}/year instead of ${annualMonthly}/year monthly.`;
-        return [savingsLine, pricingLine, prorationLine].join(" ");
+        currentYearlyCents < currentMonthlyCents * 12;
+      if (!hasPrices) {
+        return [
+          "You'll be charged the prorated difference today.",
+          currentYearlyCents !== undefined
+            ? `Renews at ${formatCents(currentYearlyCents)}/year after this period.`
+            : "Renews on the new yearly cadence after this period.",
+        ];
       }
-      return prorationLine;
+      const yearly = formatCents(currentYearlyCents!);
+      const monthlyEquivalent = formatCents(
+        Math.round(currentYearlyCents! / 12),
+      );
+      const savingsPercent = Math.round(
+        ((currentMonthlyCents! * 12 - currentYearlyCents!) /
+          (currentMonthlyCents! * 12)) *
+          100,
+      );
+      const priceLine = tierLabel
+        ? `${tierLabel} yearly: ${yearly}/year (${monthlyEquivalent}/month).`
+        : `Yearly: ${yearly}/year (${monthlyEquivalent}/month).`;
+      // Net charge today = full yearly price minus the unused-monthly credit
+      // Stripe will apply. Only surface the exact amount when the backend
+      // returned a non-zero credit (admin-granted plans / no Stripe customer
+      // return 0 and we fall back to the generic line).
+      const netChargeCents = Math.max(
+        0,
+        currentYearlyCents! - prorationCreditCents,
+      );
+      const chargedTodayLine =
+        prorationCreditCents > 0
+          ? `Charged today: ${formatCents(netChargeCents)} (prorated from your monthly plan).`
+          : "You'll be charged the prorated difference today.";
+      const renewsLine = periodEndLabel
+        ? `Renews ${yearly}/year on ${periodEndLabel}.`
+        : `Renews at ${yearly}/year after this period.`;
+      return [
+        `Save ${savingsPercent}% with yearly billing.`,
+        priceLine,
+        chargedTodayLine,
+        renewsLine,
+      ];
     }
     const monthly =
       currentMonthlyCents !== undefined ? formatCents(currentMonthlyCents) : "";
     return [
-      "Your plan will switch to monthly billing at the end of your current yearly period; no charge today.",
-      monthly ? `New monthly price: ${monthly}.` : "",
-    ]
-      .filter(Boolean)
-      .join(" ");
+      periodEndLabel
+        ? `Switches to monthly billing on ${periodEndLabel}.`
+        : "Switches to monthly at the end of your current yearly period.",
+      monthly ? `New price: ${monthly}/month.` : "",
+      "No charge today.",
+    ].filter(Boolean);
   }
 
   function getTierUpgradeDialogBody(): string {

--- a/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/SubscriptionTab/YourPlanCard/useYourPlanCard.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/SubscriptionTab/YourPlanCard/useYourPlanCard.ts
@@ -355,7 +355,7 @@ export function useYourPlanCard() {
       : `Switch ${tierLabel} to monthly billing?`;
   }
 
-  function getDialogBody(): string[] {
+  function getDialogBody(): { text: string; emphasis?: boolean }[] {
     if (!pendingCycle) return [];
     const periodEndLabel = currentPeriodEndMs
       ? formatShortDate(currentPeriodEndMs)
@@ -369,10 +369,13 @@ export function useYourPlanCard() {
         currentYearlyCents < currentMonthlyCents * 12;
       if (!hasPrices) {
         return [
-          "You'll be charged the prorated difference today.",
-          currentYearlyCents !== undefined
-            ? `Renews at ${formatCents(currentYearlyCents)}/year after this period.`
-            : "Renews on the new yearly cadence after this period.",
+          { text: "You'll be charged the prorated difference today." },
+          {
+            text:
+              currentYearlyCents !== undefined
+                ? `Renews at ${formatCents(currentYearlyCents)}/year after this period.`
+                : "Renews on the new yearly cadence after this period.",
+          },
         ];
       }
       const yearly = formatCents(currentYearlyCents!);
@@ -403,21 +406,27 @@ export function useYourPlanCard() {
         ? `Renews ${yearly}/year on ${periodEndLabel}.`
         : `Renews at ${yearly}/year after this period.`;
       return [
-        `Save ${savingsPercent}% with yearly billing.`,
-        priceLine,
-        chargedTodayLine,
-        renewsLine,
+        { text: `Save ${savingsPercent}% with yearly billing.` },
+        { text: priceLine, emphasis: true },
+        { text: chargedTodayLine, emphasis: true },
+        { text: renewsLine, emphasis: true },
       ];
     }
     const monthly =
       currentMonthlyCents !== undefined ? formatCents(currentMonthlyCents) : "";
     return [
-      periodEndLabel
-        ? `Switches to monthly billing on ${periodEndLabel}.`
-        : "Switches to monthly at the end of your current yearly period.",
-      monthly ? `New price: ${monthly}/month.` : "",
-      "No charge today.",
-    ].filter(Boolean);
+      {
+        text: periodEndLabel
+          ? `Switches to monthly billing on ${periodEndLabel}.`
+          : "Switches to monthly at the end of your current yearly period.",
+      },
+      monthly
+        ? { text: `New price: ${monthly}/month.`, emphasis: true }
+        : null,
+      { text: "No charge today." },
+    ].filter((line): line is { text: string; emphasis?: boolean } =>
+      line !== null,
+    );
   }
 
   function getTierUpgradeDialogBody(): string {

--- a/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/SubscriptionTab/YourPlanCard/useYourPlanCard.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/SubscriptionTab/YourPlanCard/useYourPlanCard.ts
@@ -355,7 +355,7 @@ export function useYourPlanCard() {
       : `Switch ${tierLabel} to monthly billing?`;
   }
 
-  function getDialogBody(): { text: string; emphasis?: boolean }[] {
+  function getDialogBody(): { label?: string; text: string }[] {
     if (!pendingCycle) return [];
     const periodEndLabel = currentPeriodEndMs
       ? formatShortDate(currentPeriodEndMs)
@@ -387,9 +387,6 @@ export function useYourPlanCard() {
           (currentMonthlyCents! * 12)) *
           100,
       );
-      const priceLine = tierLabel
-        ? `${tierLabel} yearly: ${yearly}/year (${monthlyEquivalent}/month).`
-        : `Yearly: ${yearly}/year (${monthlyEquivalent}/month).`;
       // Net charge today = full yearly price minus the unused-monthly credit
       // Stripe will apply. Only surface the exact amount when the backend
       // returned a non-zero credit (admin-granted plans / no Stripe customer
@@ -398,18 +395,24 @@ export function useYourPlanCard() {
         0,
         currentYearlyCents! - prorationCreditCents,
       );
-      const chargedTodayLine =
+      const chargedToday =
         prorationCreditCents > 0
-          ? `Charged today: ${formatCents(netChargeCents)} (prorated from your monthly plan).`
-          : "You'll be charged the prorated difference today.";
-      const renewsLine = periodEndLabel
-        ? `Renews ${yearly}/year on ${periodEndLabel}.`
-        : `Renews at ${yearly}/year after this period.`;
+          ? {
+              label: "Charged today:",
+              text: `${formatCents(netChargeCents)} (prorated from your monthly plan).`,
+            }
+          : { text: "You'll be charged the prorated difference today." };
+      const renews = periodEndLabel
+        ? { label: "Renews", text: `${yearly}/year on ${periodEndLabel}.` }
+        : { label: "Renews", text: `at ${yearly}/year after this period.` };
       return [
         { text: `Save ${savingsPercent}% with yearly billing.` },
-        { text: priceLine, emphasis: true },
-        { text: chargedTodayLine, emphasis: true },
-        { text: renewsLine, emphasis: true },
+        {
+          label: tierLabel ? `${tierLabel} yearly:` : "Yearly:",
+          text: `${yearly}/year (${monthlyEquivalent}/month).`,
+        },
+        chargedToday,
+        renews,
       ];
     }
     const monthly =
@@ -421,10 +424,10 @@ export function useYourPlanCard() {
           : "Switches to monthly at the end of your current yearly period.",
       },
       monthly
-        ? { text: `New price: ${monthly}/month.`, emphasis: true }
+        ? { label: "New price:", text: `${monthly}/month.` }
         : null,
       { text: "No charge today." },
-    ].filter((line): line is { text: string; emphasis?: boolean } =>
+    ].filter((line): line is { label?: string; text: string } =>
       line !== null,
     );
   }

--- a/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/SubscriptionTab/YourPlanCard/useYourPlanCard.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/SubscriptionTab/YourPlanCard/useYourPlanCard.ts
@@ -362,11 +362,14 @@ export function useYourPlanCard() {
       : null;
     if (pendingCycle === "yearly") {
       const tierLabel = effectiveTier ? PLAN_LABEL[effectiveTier] : null;
+      // `<=` (not `<`) so a misconfigured 0%-savings yearly price still gets
+      // the explicit price breakdown rather than falling through to generic
+      // copy — the savings line itself is suppressed when savings == 0.
       const hasPrices =
         currentMonthlyCents !== undefined &&
         currentYearlyCents !== undefined &&
         currentMonthlyCents > 0 &&
-        currentYearlyCents < currentMonthlyCents * 12;
+        currentYearlyCents <= currentMonthlyCents * 12;
       if (!hasPrices) {
         return [
           { text: "You'll be charged the prorated difference today." },
@@ -406,14 +409,18 @@ export function useYourPlanCard() {
         ? { label: "Renews", text: `${yearly}/year on ${periodEndLabel}.` }
         : { label: "Renews", text: `at ${yearly}/year after this period.` };
       return [
-        { text: `Save ${savingsPercent}% with yearly billing.` },
+        savingsPercent > 0
+          ? { text: `Save ${savingsPercent}% with yearly billing.` }
+          : null,
         {
           label: tierLabel ? `${tierLabel} yearly:` : "Yearly:",
           text: `${yearly}/year (${monthlyEquivalent}/month).`,
         },
         chargedToday,
         renews,
-      ];
+      ].filter(
+        (line): line is { label?: string; text: string } => line !== null,
+      );
     }
     const monthly =
       currentMonthlyCents !== undefined ? formatCents(currentMonthlyCents) : "";
@@ -423,13 +430,9 @@ export function useYourPlanCard() {
           ? `Switches to monthly billing on ${periodEndLabel}.`
           : "Switches to monthly at the end of your current yearly period.",
       },
-      monthly
-        ? { label: "New price:", text: `${monthly}/month.` }
-        : null,
+      monthly ? { label: "New price:", text: `${monthly}/month.` } : null,
       { text: "No charge today." },
-    ].filter((line): line is { label?: string; text: string } =>
-      line !== null,
-    );
+    ].filter((line): line is { label?: string; text: string } => line !== null);
   }
 
   function getTierUpgradeDialogBody(): string {


### PR DESCRIPTION
### Why / What / How

**Why:** [SECRT-2348](https://linear.app/autogpt/issue/SECRT-2348) — the Settings → Subscription cycle-switch confirmation popup is too wordy and packs four different numbers into a single run-on sentence, so users can't quickly tell what they're being asked to pay. The ticket also asks us to show the exact prorated amount the user will be charged today when switching from monthly to yearly on Pro/Max.

**What:** Rewrites the body of `SwitchCycleDialog` (monthly→yearly *and* yearly→monthly) so each fact lives on its own line, and surfaces the real charged-today number computed from the backend's `proration_credit_cents`.

Before (one paragraph):
> Save 15% with yearly billing. Pro is $42.50/month when billed yearly, charged as $510.00/year instead of $600.00/year monthly. You'll be charged the prorated difference immediately. After this period, your plan renews yearly at $510.00.

<img width="662" height="342" alt="Screenshot 2026-05-13 at 12 58 15 PM" src="https://github.com/user-attachments/assets/b0924746-eded-4420-a828-d2642d9e72c8" />

<img width="724" height="364" alt="Screenshot 2026-05-13 at 1 00 23 PM" src="https://github.com/user-attachments/assets/bd3ff846-6741-4f1b-ab3b-078586ddff3b" />

After (four scannable lines):
> Save 15% with yearly billing.
> Pro yearly: $510.00/year ($42.50/month).
> Charged today: $485.00 (prorated from your monthly plan).
> Renews $510.00/year on May 14, 2030.

**How:**
- `useYourPlanCard.ts` — `getDialogBody()` now returns `string[]`. For monthly→yearly with both prices available, it builds four lines: savings %, consolidated yearly + monthly-equivalent price, exact charged-today amount, renewal line with the period-end date. For yearly→monthly it returns three lines (date of switch, new monthly price, "No charge today"). Falls back to a shorter two-line variant when prices are missing (e.g. BUSINESS tier).
- Charged-today math reuses what the backend already returns: `max(0, currentYearlyCents - proration_credit_cents)`. `proration_credit_cents` is already computed server-side via `get_proration_credit_cents` and matches what Stripe credits under `proration_behavior="always_invoice"`. When the backend returns `0` (admin-granted plans / no Stripe customer), we fall back to the generic "prorated difference today" line instead of showing `$0`.
- Renewal-date line uses `current_period_end` (already on `SubscriptionStatusResponse`) — no new backend fields.
- `SwitchCycleDialog.tsx` — `body` prop is now `string[]`; renders each line as its own `<Text>` row with `gap-2` spacing.
- Tier-upgrade and tier-downgrade dialogs are intentionally left alone — out of scope for this ticket.

### Changes 🏗️

- `useYourPlanCard.ts`: `getDialogBody()` returns `string[]`; reads `proration_credit_cents` and `current_period_end` from the subscription status response; computes savings %, monthly equivalent, net charge today, and renewal date.
- `SwitchCycleDialog.tsx`: `body: string` → `body: string[]`; iterates and renders each line as a stacked `<Text>` row.
- `billing-cards.test.tsx`: per-line anchored regex assertions for both directions; added `proration_credit_cents: 2500` + `current_period_end` to the Pro monthly→yearly fixture so the exact-amount path is exercised; the Max test keeps the fallback path covered.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Pro monthly user clicks Yearly toggle → dialog title reads "Switch Pro to yearly billing?" and body shows four separate lines including "Charged today: $X.XX (prorated from your monthly plan)."
  - [x] Max monthly user clicks Yearly toggle → dialog title reads "Switch Max to yearly billing?" with Max pricing on its own line.
  - [x] Pro yearly user clicks Monthly toggle → dialog shows three lines including "No charge today." on the last line.
  - [x] BUSINESS user (no tier_costs) → dialog falls back to two-line generic copy (no $0 leak).
  - [x] Confirm flow still POSTs `billing_cycle` correctly in both directions (existing tests cover this).
  - [x] `pnpm test:unit` passes for `billing-cards.test.tsx`.

#### For configuration changes:
- [x] `.env.default` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes
- [x] I have included a list of my configuration changes in the PR description (under **Changes**)
