### PR TITLE
docs: fix dangling sso-guide.md link in api-guide

### DIFF
--- a/docs/platform/integrating/api-guide.md
+++ b/docs/platform/integrating/api-guide.md
@@ -37,7 +37,7 @@ OAuth is ideal for:
 - "Sign in with AutoGPT" (SSO, Single Sign-On) functionality
 - Applications that need user-specific permissions
 
-See the [SSO Integration Guide](sso-guide.md) for complete OAuth implementation details.
+See the [OAuth Integration Guide](oauth-guide.md) for complete OAuth implementation details, including the "Sign in with AutoGPT" SSO flow.
 
 ## Available Scopes
 
@@ -69,7 +69,7 @@ curl -H "X-API-Key: YOUR_API_KEY" \
 ### Using OAuth
 
 1. Register an OAuth application (contact platform administrator)
-2. Implement the OAuth flow as described in the [SSO Guide](sso-guide.md)
+2. Implement the OAuth flow as described in the [OAuth Guide](oauth-guide.md)
 3. Use the obtained access token:
 
 ```bash


### PR DESCRIPTION
### Why / What / How

**Why**: `docs/platform/integrating/api-guide.md` referenced `sso-guide.md` twice when describing the "Sign in with AutoGPT" / SSO flow, but that file does not exist in the repo. The OAuth/SSO content lives in `oauth-guide.md` in the same directory.

**What**: Repoint both links from `sso-guide.md` to `oauth-guide.md` and adjust the link text to match.

**How**: Two-line docs fix in a single markdown file. No code, schema, or behavior changes.

### Changes 🏗️
- `docs/platform/integrating/api-guide.md`: two link targets repointed from `sso-guide.md` to `oauth-guide.md`.

### Checklist 📋
- [x] Verified `docs/platform/integrating/oauth-guide.md` exists.
- [x] Verified no other file in the repo is named `sso-guide.md`.
