### PR TITLE
docs: fix Ayrshare comment typo

### DIFF
--- a/autogpt_platform/backend/backend/integrations/ayrshare.py
+++ b/autogpt_platform/backend/backend/integrations/ayrshare.py
@@ -544,7 +544,7 @@ class AyrshareClient:
         # It seems like there is only ever one post in the array, and within that
         # there are multiple postIds
 
-        # There is a seperate endpoint for bulk posting, so feels safe to just take
+        # There is a separate endpoint for bulk posting, so feels safe to just take
         # the first post from the array
 
         if len(response_data["posts"]) == 0:


### PR DESCRIPTION
### Why / What / How

**Why**: A comment in the Ayrshare integration contains a small typo: `seperate endpoint`.

**What**: Correct it to `separate endpoint`.

**How**: Comment-only typo fix. No runtime behavior changes.

### Changes 🏗️
- `autogpt_platform/backend/backend/integrations/ayrshare.py`: fix the comment typo.

### Checklist 📋
- [x] Ran `git diff --check`.
- [x] Confirmed no overlapping open PR for this specific typo.
