### PR TITLE
Clarify backend docs entry points

### DIFF
--- a/autogpt_platform/backend/README.advanced.md
+++ b/autogpt_platform/backend/README.advanced.md
@@ -1,1 +1,7 @@
-[Advanced Setup (Dev Branch)](https://dev-docs.agpt.co/platform/advanced_setup/#autogpt_agent_server_advanced_set_up)
+# AutoGPT Platform Backend Advanced Setup
+
+The advanced backend setup guide lives in the published documentation instead of
+this README so contributors and users have a single source of truth.
+
+- Released `master` branch docs: [Advanced Setup](https://docs.agpt.co/platform/advanced_setup/#autogpt_agent_server_advanced_set_up)
+- Development branch docs: [Advanced Setup](https://dev-docs.agpt.co/platform/advanced_setup/#autogpt_agent_server_advanced_set_up)

--- a/autogpt_platform/backend/README.md
+++ b/autogpt_platform/backend/README.md
@@ -1,1 +1,7 @@
-[Getting Started (Released)](https://docs.agpt.co/platform/getting-started/#autogpt_agent_server)
+# AutoGPT Platform Backend
+
+The backend setup guide lives in the published documentation instead of this
+README so contributors and users have a single source of truth.
+
+- Released `master` branch docs: [Getting Started](https://docs.agpt.co/platform/getting-started/#autogpt_agent_server)
+- Development branch docs: [Getting Started](https://dev-docs.agpt.co/platform/getting-started/#autogpt_agent_server)


### PR DESCRIPTION
## Summary
- replace the terse backend README link files with explicit docs entry points
- call out the released master docs and development branch docs separately
- keep backend setup docs centralized in the docs site

Closes #8887.

## Testing
- Not run; documentation-only change.