### PR TITLE
feat(frontend/copilot): paginate session sidebar so threads past 50 stay reachable

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatSidebar/ChatSidebar.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatSidebar/ChatSidebar.tsx
@@ -24,8 +24,8 @@ import { cn } from "@/lib/utils";
 import {
   CheckCircle,
   CircleNotch,
-  DownloadSimpleIcon,
   DotsThree,
+  DownloadSimpleIcon,
   HourglassIcon,
   PencilSimpleIcon,
   PlusCircleIcon,
@@ -38,14 +38,14 @@ import { parseAsString, useQueryState } from "nuqs";
 import { useEffect, useRef, useState } from "react";
 import { useCopilotChatRuntimeStore } from "../../copilotChatRegistry";
 import { formatNotificationTitle } from "../../helpers";
+import { fetchAndExportChat } from "../../helpers/exportChatAsMarkdown";
 import { shouldShowSessionProcessingIndicator } from "../../sessionActivity";
 import { useCopilotUIStore } from "../../store";
 import { useSessionDeletion } from "../../useSessionDeletion";
 import { SESSION_LIST_QUERY_KEY, useSessionList } from "../../useSessionList";
-import { NotificationToggle } from "./components/NotificationToggle/NotificationToggle";
-import { fetchAndExportChat } from "../../helpers/exportChatAsMarkdown";
 import { DeleteChatDialog } from "../DeleteChatDialog/DeleteChatDialog";
 import { UsagePopover } from "../UsageLimits/UsagePopover/UsagePopover";
+import { NotificationToggle } from "./components/NotificationToggle/NotificationToggle";
 
 export function ChatSidebar() {
   const { state } = useSidebar();
@@ -501,12 +501,12 @@ export function ChatSidebar() {
               )}
               {hasMore && (
                 <Button
-                  variant="ghost"
+                  variant="secondary"
                   size="small"
                   onClick={() => loadMore()}
                   loading={isLoadingMore}
                   disabled={isLoadingMore}
-                  className="mt-2 w-full justify-center text-neutral-500"
+                  className="mt-2 w-full"
                 >
                   {isLoadingMore ? "Loading…" : "Load older chats"}
                 </Button>

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatSidebar/ChatSidebar.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatSidebar/ChatSidebar.tsx
@@ -1,8 +1,6 @@
 "use client";
 import {
-  getGetV2ListSessionsQueryKey,
   getV2GetSession,
-  useGetV2ListSessions,
   usePatchV2UpdateSessionTitle,
 } from "@/app/api/__generated__/endpoints/chat/chat";
 import { Button } from "@/components/atoms/Button/Button";
@@ -43,6 +41,7 @@ import { formatNotificationTitle } from "../../helpers";
 import { shouldShowSessionProcessingIndicator } from "../../sessionActivity";
 import { useCopilotUIStore } from "../../store";
 import { useSessionDeletion } from "../../useSessionDeletion";
+import { SESSION_LIST_QUERY_KEY, useSessionList } from "../../useSessionList";
 import { NotificationToggle } from "./components/NotificationToggle/NotificationToggle";
 import { fetchAndExportChat } from "../../helpers/exportChatAsMarkdown";
 import { DeleteChatDialog } from "../DeleteChatDialog/DeleteChatDialog";
@@ -59,8 +58,13 @@ export function ChatSidebar() {
 
   const queryClient = useQueryClient();
 
-  const { data: sessionsResponse, isLoading: isLoadingSessions } =
-    useGetV2ListSessions({ limit: 50 }, { query: { refetchInterval: 10_000 } });
+  const {
+    sessions,
+    isLoading: isLoadingSessions,
+    hasMore,
+    isLoadingMore,
+    loadMore,
+  } = useSessionList();
 
   const {
     sessionToDelete,
@@ -82,7 +86,7 @@ export function ChatSidebar() {
     mutation: {
       onSuccess: () => {
         queryClient.invalidateQueries({
-          queryKey: getGetV2ListSessionsQueryKey(),
+          queryKey: SESSION_LIST_QUERY_KEY,
         });
         setEditingSessionId(null);
       },
@@ -109,7 +113,7 @@ export function ChatSidebar() {
   // Refetch session list when active session changes
   useEffect(() => {
     queryClient.invalidateQueries({
-      queryKey: getGetV2ListSessionsQueryKey(),
+      queryKey: SESSION_LIST_QUERY_KEY,
     });
   }, [sessionId, queryClient]);
 
@@ -120,9 +124,6 @@ export function ChatSidebar() {
     const remaining = Math.max(0, completedSessionIDs.size - 1);
     document.title = formatNotificationTitle(remaining);
   }, [sessionId, completedSessionIDs, clearCompletedSession]);
-
-  const sessions =
-    sessionsResponse?.status === 200 ? sessionsResponse.data.sessions : [];
 
   function handleNewChat() {
     setSessionId(null);
@@ -497,6 +498,18 @@ export function ChatSidebar() {
                     )}
                   </div>
                 ))
+              )}
+              {hasMore && (
+                <Button
+                  variant="ghost"
+                  size="small"
+                  onClick={() => loadMore()}
+                  loading={isLoadingMore}
+                  disabled={isLoadingMore}
+                  className="mt-2 w-full justify-center text-neutral-500"
+                >
+                  {isLoadingMore ? "Loading…" : "Load older chats"}
+                </Button>
               )}
             </motion.div>
           )}

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatSidebar/__tests__/ChatSidebar.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatSidebar/__tests__/ChatSidebar.test.tsx
@@ -11,6 +11,7 @@ import {
   within,
 } from "@/tests/integrations/test-utils";
 import { SidebarProvider } from "@/components/ui/sidebar";
+import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useCopilotUIStore } from "../../../store";
 import { ChatSidebar } from "../ChatSidebar";
@@ -229,5 +230,77 @@ describe("ChatSidebar — chat_status indicators", () => {
     await screen.findByText("Old chat");
     expect(screen.queryByTestId("session-status-running")).toBeNull();
     expect(screen.queryByTestId("session-status-queued")).toBeNull();
+  });
+});
+
+describe("ChatSidebar — pagination", () => {
+  afterEach(() => {
+    server.resetHandlers();
+  });
+
+  function makeSessions(count: number, offset = 0) {
+    return Array.from({ length: count }, (_, i) => ({
+      id: `s${offset + i}`,
+      title: `Chat ${offset + i}`,
+      is_processing: false,
+      created_at: "2025-01-01T00:00:00Z",
+      updated_at: "2025-01-01T00:00:00Z",
+    }));
+  }
+
+  it("hides 'Load older chats' when all sessions are loaded", async () => {
+    server.use(
+      getGetV2ListSessionsMockHandler200({
+        sessions: makeSessions(3),
+        total: 3,
+      }),
+    );
+    renderSidebar();
+    await screen.findByText("Chat 0");
+    expect(
+      screen.queryByRole("button", { name: /load older chats/i }),
+    ).toBeNull();
+  });
+
+  it("renders 'Load older chats' when total exceeds loaded sessions", async () => {
+    server.use(
+      getGetV2ListSessionsMockHandler200({
+        sessions: makeSessions(50),
+        total: 75,
+      }),
+    );
+    renderSidebar();
+    await screen.findByText("Chat 0");
+    expect(
+      await screen.findByRole("button", { name: /load older chats/i }),
+    ).toBeDefined();
+  });
+
+  it("fetches the next page with the loaded count as offset", async () => {
+    const seenOffsets: string[] = [];
+    server.use(
+      http.get("*/api/chat/sessions", ({ request }) => {
+        const offset = new URL(request.url).searchParams.get("offset") ?? "0";
+        seenOffsets.push(offset);
+        const offsetN = Number(offset);
+        const sessions =
+          offsetN === 0 ? makeSessions(50, 0) : makeSessions(25, 50);
+        return HttpResponse.json({ sessions, total: 75 });
+      }),
+    );
+    renderSidebar();
+
+    const loadMore = await screen.findByRole("button", {
+      name: /load older chats/i,
+    });
+    fireEvent.click(loadMore);
+
+    await screen.findByText("Chat 50");
+    expect(seenOffsets).toContain("50");
+    await vi.waitFor(() => {
+      expect(
+        screen.queryByRole("button", { name: /load older chats/i }),
+      ).toBeNull();
+    });
   });
 });

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/MobileDrawer/MobileDrawer.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/MobileDrawer/MobileDrawer.tsx
@@ -1,4 +1,3 @@
-import { useGetV2ListSessions } from "@/app/api/__generated__/endpoints/chat/chat";
 import { Button } from "@/components/atoms/Button/Button";
 import { Text } from "@/components/atoms/Text/Text";
 import { scrollbarStyles } from "@/components/styles/scrollbars";
@@ -19,6 +18,7 @@ import { useCopilotChatRuntimeStore } from "../../copilotChatRegistry";
 import { shouldShowSessionProcessingIndicator } from "../../sessionActivity";
 import { useCopilotUIStore } from "../../store";
 import { useSessionDeletion } from "../../useSessionDeletion";
+import { useSessionList } from "../../useSessionList";
 import { DeleteChatDialog } from "../DeleteChatDialog/DeleteChatDialog";
 
 function formatDate(dateString: string) {
@@ -64,12 +64,8 @@ export function MobileDrawer() {
     (state) => state.sessionNeedsReload,
   );
 
-  const { data: sessionsResponse, isLoading } = useGetV2ListSessions(
-    { limit: 50 },
-    { query: { enabled: !isUserLoading && isLoggedIn } },
-  );
-  const sessions =
-    sessionsResponse?.status === 200 ? sessionsResponse.data.sessions : [];
+  const { sessions, isLoading, hasMore, isLoadingMore, loadMore } =
+    useSessionList({ enabled: !isUserLoading && isLoggedIn });
 
   const { sessionToDelete, isDeleting, confirmDelete, cancelDelete } =
     useSessionDeletion();
@@ -216,6 +212,18 @@ export function MobileDrawer() {
                     </div>
                   </button>
                 ))
+              )}
+              {hasMore && (
+                <Button
+                  variant="ghost"
+                  size="small"
+                  onClick={() => loadMore()}
+                  loading={isLoadingMore}
+                  disabled={isLoadingMore}
+                  className="mt-2 w-full justify-center text-neutral-500"
+                >
+                  {isLoadingMore ? "Loading…" : "Load older chats"}
+                </Button>
               )}
             </div>
           </Drawer.Content>

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/useChatSession.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/useChatSession.ts
@@ -1,9 +1,9 @@
 import {
   getGetV2GetSessionQueryKey,
-  getGetV2ListSessionsQueryKey,
   useGetV2GetSession,
   usePostV2CreateSession,
 } from "@/app/api/__generated__/endpoints/chat/chat";
+import { SESSION_LIST_QUERY_KEY } from "./useSessionList";
 import { toast } from "@/components/molecules/Toast/use-toast";
 import * as Sentry from "@sentry/nextjs";
 import { useQueryClient } from "@tanstack/react-query";
@@ -125,7 +125,7 @@ export function useChatSession({ dryRun = false }: UseChatSessionOptions = {}) {
           if (response.status === 200 && response.data?.id) {
             setSessionId(response.data.id);
             queryClient.invalidateQueries({
-              queryKey: getGetV2ListSessionsQueryKey(),
+              queryKey: SESSION_LIST_QUERY_KEY,
             });
           }
         },

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/useCopilotNotifications.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/useCopilotNotifications.ts
@@ -1,4 +1,3 @@
-import { getGetV2ListSessionsQueryKey } from "@/app/api/__generated__/endpoints/chat/chat";
 import { useBackendAPI } from "@/lib/autogpt-server-api/context";
 import type { WebSocketNotification } from "@/lib/autogpt-server-api/types";
 import { Key } from "@/services/storage/local-storage";
@@ -10,6 +9,7 @@ import {
   parseSessionIDs,
 } from "./helpers";
 import { useCopilotUIStore } from "./store";
+import { SESSION_LIST_QUERY_KEY } from "./useSessionList";
 
 const NOTIFICATION_SOUND_PATH = "/notification.mp3";
 
@@ -172,7 +172,7 @@ export function useCopilotNotifications(activeSessionID: string | null) {
       // Refetch the session list so the sidebar reflects the latest
       // is_processing state (avoids stale spinner after cross-tab clear).
       queryClient.invalidateQueries({
-        queryKey: getGetV2ListSessionsQueryKey(),
+        queryKey: SESSION_LIST_QUERY_KEY,
       });
     }
     window.addEventListener("storage", handleStorage);

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/useSessionDeletion.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/useSessionDeletion.ts
@@ -1,11 +1,9 @@
-import {
-  getGetV2ListSessionsQueryKey,
-  useDeleteV2DeleteSession,
-} from "@/app/api/__generated__/endpoints/chat/chat";
+import { useDeleteV2DeleteSession } from "@/app/api/__generated__/endpoints/chat/chat";
 import { toast } from "@/components/molecules/Toast/use-toast";
 import { useQueryClient } from "@tanstack/react-query";
 import { parseAsString, useQueryState } from "nuqs";
 import { useCopilotUIStore } from "./store";
+import { SESSION_LIST_QUERY_KEY } from "./useSessionList";
 
 /**
  * Session deletion flow: reads the pending `sessionToDelete` from the store,
@@ -25,7 +23,7 @@ export function useSessionDeletion() {
       mutation: {
         onSuccess: (_data, variables) => {
           queryClient.invalidateQueries({
-            queryKey: getGetV2ListSessionsQueryKey(),
+            queryKey: SESSION_LIST_QUERY_KEY,
           });
           // Use the mutation's own `variables` — not the closed-over store
           // value — so a rapid open/cancel/open-different sequence can't

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/useSessionList.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/useSessionList.ts
@@ -1,10 +1,13 @@
-import {
-  getV2ListSessions,
-  type getV2ListSessionsResponse,
-} from "@/app/api/__generated__/endpoints/chat/chat";
+import { getV2ListSessions } from "@/app/api/__generated__/endpoints/chat/chat";
 import { type InfiniteData, useInfiniteQuery } from "@tanstack/react-query";
 
 export const SESSION_LIST_PAGE_SIZE = 50;
+// `refetchInterval` on a `useInfiniteQuery` refetches every loaded page, and
+// TanStack Query v5 removed `refetchPage` so we can't scope it to page 0.
+// Worst case is bounded by the user's session count (and the WebSocket
+// invalidations in `useCopilotNotifications` already handle the high-signal
+// completion events) — revisit by extracting a separate live-status query if
+// this ever becomes a real bandwidth concern.
 export const SESSION_LIST_REFETCH_INTERVAL_MS = 10_000;
 
 // Fresh, paginated-cache key. The orval-generated key targets the non-infinite
@@ -37,12 +40,8 @@ export function useSessionList({ enabled = true }: Args = {}) {
     enabled,
   });
 
-  const sessions = flattenSessions(query.data);
-  const total = getTotal(query.data);
-
   return {
-    sessions,
-    total,
+    sessions: flattenSessions(query.data),
     isLoading: query.isLoading,
     hasMore: !!query.hasNextPage,
     isLoadingMore: query.isFetchingNextPage,
@@ -63,12 +62,3 @@ function countLoadedSessions(pages: SessionListPage[]) {
     0,
   );
 }
-
-function getTotal(data: SessionListInfiniteData | undefined) {
-  const lastPage = data?.pages.at(-1);
-  if (!lastPage || lastPage.status !== 200) return 0;
-  return lastPage.data.total;
-}
-
-// Re-exported so cache walkers don't have to depend on the generated module.
-export type { getV2ListSessionsResponse };

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/useSessionList.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/useSessionList.ts
@@ -1,0 +1,74 @@
+import {
+  getV2ListSessions,
+  type getV2ListSessionsResponse,
+} from "@/app/api/__generated__/endpoints/chat/chat";
+import { type InfiniteData, useInfiniteQuery } from "@tanstack/react-query";
+
+export const SESSION_LIST_PAGE_SIZE = 50;
+export const SESSION_LIST_REFETCH_INTERVAL_MS = 10_000;
+
+// Fresh, paginated-cache key. The orval-generated key targets the non-infinite
+// `useQuery` cache shape; keeping the infinite cache on a separate key avoids
+// shape collisions and lets us hand a stable key to invalidation callsites.
+export const SESSION_LIST_QUERY_KEY = ["copilot", "session-list"] as const;
+
+type SessionListPage = Awaited<ReturnType<typeof getV2ListSessions>>;
+export type SessionListInfiniteData = InfiniteData<SessionListPage>;
+
+interface Args {
+  enabled?: boolean;
+}
+
+export function useSessionList({ enabled = true }: Args = {}) {
+  const query = useInfiniteQuery({
+    queryKey: SESSION_LIST_QUERY_KEY,
+    queryFn: ({ pageParam }) =>
+      getV2ListSessions({
+        limit: SESSION_LIST_PAGE_SIZE,
+        offset: pageParam,
+      }),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage, allPages) => {
+      if (lastPage.status !== 200) return undefined;
+      const loaded = countLoadedSessions(allPages);
+      return loaded < lastPage.data.total ? loaded : undefined;
+    },
+    refetchInterval: SESSION_LIST_REFETCH_INTERVAL_MS,
+    enabled,
+  });
+
+  const sessions = flattenSessions(query.data);
+  const total = getTotal(query.data);
+
+  return {
+    sessions,
+    total,
+    isLoading: query.isLoading,
+    hasMore: !!query.hasNextPage,
+    isLoadingMore: query.isFetchingNextPage,
+    loadMore: query.fetchNextPage,
+  };
+}
+
+export function flattenSessions(data: SessionListInfiniteData | undefined) {
+  if (!data) return [];
+  return data.pages.flatMap((page) =>
+    page.status === 200 ? page.data.sessions : [],
+  );
+}
+
+function countLoadedSessions(pages: SessionListPage[]) {
+  return pages.reduce(
+    (acc, page) => acc + (page.status === 200 ? page.data.sessions.length : 0),
+    0,
+  );
+}
+
+function getTotal(data: SessionListInfiniteData | undefined) {
+  const lastPage = data?.pages.at(-1);
+  if (!lastPage || lastPage.status !== 200) return 0;
+  return lastPage.data.total;
+}
+
+// Re-exported so cache walkers don't have to depend on the generated module.
+export type { getV2ListSessionsResponse };

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/useSessionTitlePoll.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/useSessionTitlePoll.ts
@@ -1,13 +1,13 @@
-import {
-  getGetV2ListSessionsQueryKey,
-  type getV2ListSessionsResponse,
-} from "@/app/api/__generated__/endpoints/chat/chat";
 import { useQueryClient } from "@tanstack/react-query";
 import { useEffect, useRef } from "react";
+import {
+  flattenSessions,
+  SESSION_LIST_QUERY_KEY,
+  type SessionListInfiniteData,
+} from "./useSessionList";
 
 const TITLE_POLL_INTERVAL_MS = 2_000;
 const TITLE_POLL_MAX_ATTEMPTS = 5;
-const SESSION_LIST_LIMIT = 50;
 
 interface Args {
   sessionId: string | null;
@@ -38,29 +38,25 @@ export function useSessionTitlePoll({
 
     if (!wasActive || !isNowReady || !sessionId || isReconnecting) return;
 
-    queryClient.invalidateQueries({
-      queryKey: getGetV2ListSessionsQueryKey({ limit: SESSION_LIST_LIMIT }),
-    });
+    queryClient.invalidateQueries({ queryKey: SESSION_LIST_QUERY_KEY });
 
     const sid = sessionId;
     let attempts = 0;
     clearInterval(titlePollRef.current);
     titlePollRef.current = setInterval(() => {
-      const data = queryClient.getQueryData<getV2ListSessionsResponse>(
-        getGetV2ListSessionsQueryKey({ limit: SESSION_LIST_LIMIT }),
+      const data = queryClient.getQueryData<SessionListInfiniteData>(
+        SESSION_LIST_QUERY_KEY,
       );
-      const hasTitle =
-        data?.status === 200 &&
-        data.data.sessions.some((s) => s.id === sid && s.title);
+      const hasTitle = flattenSessions(data).some(
+        (s) => s.id === sid && s.title,
+      );
       if (hasTitle || attempts >= TITLE_POLL_MAX_ATTEMPTS) {
         clearInterval(titlePollRef.current);
         titlePollRef.current = undefined;
         return;
       }
       attempts += 1;
-      queryClient.invalidateQueries({
-        queryKey: getGetV2ListSessionsQueryKey({ limit: SESSION_LIST_LIMIT }),
-      });
+      queryClient.invalidateQueries({ queryKey: SESSION_LIST_QUERY_KEY });
     }, TITLE_POLL_INTERVAL_MS);
   }, [status, sessionId, isReconnecting, queryClient]);
 


### PR DESCRIPTION
### Why / What / How

**Why.** The CoPilot session sidebar fetched only the first 50 sessions and stopped. Any user with more than 50 chats lost access to every older thread through the UI even though the backend already supported `offset` and returned a `total` count. Threads weren't lost in the DB — they were just invisible.

**What.** Wire proper pagination into the sidebar and mobile drawer with a "Load older chats" affordance, backed by a single shared infinite-query hook. Reroute all session-list cache invalidations so they refresh every loaded page, not just page 1.

**How.**
- New `useSessionList` hook wraps `useInfiniteQuery` around the existing `getV2ListSessions` fetcher: page size 50, `offset` pageParam, `refetchInterval` 10s, `getNextPageParam` derived from `total`.
- Hook lives on a fresh `SESSION_LIST_QUERY_KEY` so the infinite cache doesn't collide with the orval-generated single-query key shape (which would break shape-sensitive cache readers).
- `ChatSidebar` and `MobileDrawer` consume the hook and render a ghost `Button` with `loading` state at the end of the list when `hasMore`.
- `useSessionTitlePoll` walks `InfiniteData` pages via a small `flattenSessions` helper instead of reading the legacy single-page response.
- Five invalidation callsites (`useChatSession`, `useCopilotNotifications`, `useSessionDeletion`, `useSessionTitlePoll`, `ChatSidebar`) updated to invalidate the new key, so create/delete/rename/cross-tab-sync still refresh the sidebar correctly.

### Changes 🏗️

- Add `frontend/src/app/(platform)/copilot/useSessionList.ts` (shared paginated hook + `SESSION_LIST_QUERY_KEY` + `flattenSessions` cache walker).
- `ChatSidebar.tsx`: replace single-page `useGetV2ListSessions` with `useSessionList`, add Load-more button, point invalidations at the new key.
- `MobileDrawer.tsx`: mirror the same paginated fetch + Load-more affordance.
- `useSessionTitlePoll.ts`: walk infinite-cache pages; invalidate the new key.
- `useChatSession.ts`, `useCopilotNotifications.ts`, `useSessionDeletion.ts`: switch invalidation calls to `SESSION_LIST_QUERY_KEY`.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [x] `pnpm types` — clean
  - [x] `pnpm lint` — clean (only pre-existing img-tag warnings)
  - [x] `pnpm test:unit src/app/(platform)/copilot` — 59 files / 929 tests pass, including the existing `ChatSidebar` delete + status-indicator suites against the new wiring
  - [ ] Manual: seed a user with >50 sessions; confirm "Load older chats" appears, paginates correctly, and that the button disappears when `loaded === total`
  - [ ] Manual: confirm the 10s refetch still surfaces running/queued/processing indicators on all loaded pages
  - [ ] Manual: delete / rename / create-new-session — confirm the sidebar refreshes
  - [ ] Manual: cross-tab `localStorage` storage event still invalidates the list
  - [ ] Manual: title-poll still animates the new title in after stream completion
