### PR TITLE
fix(frontend/builder): open publish dialog scoped to current agent

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/build/components/BuilderActions/BuilderActions.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/BuilderActions/BuilderActions.tsx
@@ -1,4 +1,4 @@
-import { parseAsString, useQueryStates } from "nuqs";
+import { parseAsInteger, parseAsString, useQueryStates } from "nuqs";
 import { AgentOutputs } from "./components/AgentOutputs/AgentOutputs";
 import { RunGraph } from "./components/RunGraph/RunGraph";
 import { ScheduleGraph } from "./components/ScheduleGraph/ScheduleGraph";
@@ -6,8 +6,9 @@ import { PublishToMarketplace } from "./components/PublishToMarketplace/PublishT
 import { memo } from "react";
 
 export const BuilderActions = memo(() => {
-  const [{ flowID }] = useQueryStates({
+  const [{ flowID, flowVersion }] = useQueryStates({
     flowID: parseAsString,
+    flowVersion: parseAsInteger,
   });
   return (
     <div
@@ -17,7 +18,7 @@ export const BuilderActions = memo(() => {
       <AgentOutputs flowID={flowID} />
       <RunGraph flowID={flowID} />
       <ScheduleGraph flowID={flowID} />
-      <PublishToMarketplace flowID={flowID} />
+      <PublishToMarketplace flowID={flowID} flowVersion={flowVersion} />
     </div>
   );
 });

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/BuilderActions/__tests__/BuilderActions.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/BuilderActions/__tests__/BuilderActions.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import { NuqsTestingAdapter } from "nuqs/adapters/testing";
-import { describe, expect, test, vi } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 
 const publishToMarketplaceMock = vi.hoisted(() => vi.fn());
 
@@ -22,37 +22,67 @@ vi.mock("../components/PublishToMarketplace/PublishToMarketplace", () => ({
     flowVersion: number | null;
   }) => {
     publishToMarketplaceMock(props);
-    return (
-      <div
-        data-flow-id={props.flowID ?? ""}
-        data-flow-version={props.flowVersion ?? ""}
-        data-testid="publish-to-marketplace"
-      />
-    );
+    return <div data-testid="publish-to-marketplace" />;
   },
 }));
 
 import { BuilderActions } from "../BuilderActions";
 
-describe("BuilderActions", () => {
-  test("passes flow id and numeric flow version from query state into publish", () => {
-    render(
-      <NuqsTestingAdapter searchParams="?flowID=graph-1&flowVersion=7">
-        <BuilderActions />
-      </NuqsTestingAdapter>,
-    );
+function renderBuilderActions(searchParams: string) {
+  render(
+    <NuqsTestingAdapter searchParams={searchParams}>
+      <BuilderActions />
+    </NuqsTestingAdapter>,
+  );
+}
 
-    expect(
-      screen.getByTestId("publish-to-marketplace").getAttribute("data-flow-id"),
-    ).toBe("graph-1");
-    expect(
-      screen
-        .getByTestId("publish-to-marketplace")
-        .getAttribute("data-flow-version"),
-    ).toBe("7");
+describe("BuilderActions", () => {
+  beforeEach(() => {
+    publishToMarketplaceMock.mockClear();
+  });
+
+  test("passes flow id and numeric flow version from query state into publish", () => {
+    renderBuilderActions("?flowID=graph-1&flowVersion=7");
+
     expect(publishToMarketplaceMock).toHaveBeenCalledWith({
       flowID: "graph-1",
       flowVersion: 7,
+    });
+  });
+
+  test("passes null flow version when the query param is missing", () => {
+    renderBuilderActions("?flowID=graph-1");
+
+    expect(publishToMarketplaceMock).toHaveBeenCalledWith({
+      flowID: "graph-1",
+      flowVersion: null,
+    });
+  });
+
+  test("passes null flow id when the query param is missing", () => {
+    renderBuilderActions("?flowVersion=7");
+
+    expect(publishToMarketplaceMock).toHaveBeenCalledWith({
+      flowID: null,
+      flowVersion: 7,
+    });
+  });
+
+  test("passes null values when query params are absent", () => {
+    renderBuilderActions("");
+
+    expect(publishToMarketplaceMock).toHaveBeenCalledWith({
+      flowID: null,
+      flowVersion: null,
+    });
+  });
+
+  test("passes null flow version when the query param is invalid", () => {
+    renderBuilderActions("?flowID=graph-1&flowVersion=abc");
+
+    expect(publishToMarketplaceMock).toHaveBeenCalledWith({
+      flowID: "graph-1",
+      flowVersion: null,
     });
   });
 });

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/BuilderActions/__tests__/BuilderActions.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/BuilderActions/__tests__/BuilderActions.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from "@testing-library/react";
+import { NuqsTestingAdapter } from "nuqs/adapters/testing";
+import { describe, expect, test, vi } from "vitest";
+
+const publishToMarketplaceMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../components/AgentOutputs/AgentOutputs", () => ({
+  AgentOutputs: () => <div />,
+}));
+
+vi.mock("../components/RunGraph/RunGraph", () => ({
+  RunGraph: () => <div />,
+}));
+
+vi.mock("../components/ScheduleGraph/ScheduleGraph", () => ({
+  ScheduleGraph: () => <div />,
+}));
+
+vi.mock("../components/PublishToMarketplace/PublishToMarketplace", () => ({
+  PublishToMarketplace: (props: {
+    flowID: string | null;
+    flowVersion: number | null;
+  }) => {
+    publishToMarketplaceMock(props);
+    return (
+      <div
+        data-flow-id={props.flowID ?? ""}
+        data-flow-version={props.flowVersion ?? ""}
+        data-testid="publish-to-marketplace"
+      />
+    );
+  },
+}));
+
+import { BuilderActions } from "../BuilderActions";
+
+describe("BuilderActions", () => {
+  test("passes flow id and numeric flow version from query state into publish", () => {
+    render(
+      <NuqsTestingAdapter searchParams="?flowID=graph-1&flowVersion=7">
+        <BuilderActions />
+      </NuqsTestingAdapter>,
+    );
+
+    expect(
+      screen.getByTestId("publish-to-marketplace").getAttribute("data-flow-id"),
+    ).toBe("graph-1");
+    expect(
+      screen
+        .getByTestId("publish-to-marketplace")
+        .getAttribute("data-flow-version"),
+    ).toBe("7");
+    expect(publishToMarketplaceMock).toHaveBeenCalledWith({
+      flowID: "graph-1",
+      flowVersion: 7,
+    });
+  });
+});

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/BuilderActions/components/PublishToMarketplace/PublishToMarketplace.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/BuilderActions/components/PublishToMarketplace/PublishToMarketplace.tsx
@@ -8,9 +8,16 @@ import { PublishAgentModal } from "@/components/contextual/PublishAgentModal/Pub
 import { ShareIcon } from "@phosphor-icons/react";
 import { usePublishToMarketplace } from "./usePublishToMarketplace";
 
-export const PublishToMarketplace = ({ flowID }: { flowID: string | null }) => {
+interface Props {
+  flowID: string | null;
+  flowVersion: number | null;
+}
+
+export function PublishToMarketplace({ flowID, flowVersion }: Props) {
   const { handlePublishToMarketplace, publishState, handleStateChange } =
-    usePublishToMarketplace({ flowID });
+    usePublishToMarketplace({ flowID, flowVersion });
+
+  const isDisabled = !flowID || flowVersion === null;
 
   return (
     <>
@@ -20,7 +27,7 @@ export const PublishToMarketplace = ({ flowID }: { flowID: string | null }) => {
             variant="outline"
             size="icon"
             onClick={handlePublishToMarketplace}
-            disabled={!flowID}
+            disabled={isDisabled}
           >
             <ShareIcon className="size-4" />
           </Button>
@@ -32,8 +39,9 @@ export const PublishToMarketplace = ({ flowID }: { flowID: string | null }) => {
         targetState={publishState}
         onStateChange={handleStateChange}
         preSelectedAgentId={flowID || undefined}
+        preSelectedAgentVersion={flowVersion ?? undefined}
         showTrigger={false}
       />
     </>
   );
-};
+}

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/BuilderActions/components/PublishToMarketplace/__tests__/PublishToMarketplace.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/BuilderActions/components/PublishToMarketplace/__tests__/PublishToMarketplace.test.tsx
@@ -51,7 +51,9 @@ const FLOW_ID = "graph-1";
 const FLOW_VERSION = 3;
 const AGENT_NAME = "My Builder Agent";
 
-function makeAgent(overrides: Partial<MyUnpublishedAgent> = {}): MyUnpublishedAgent {
+function makeAgent(
+  overrides: Partial<MyUnpublishedAgent> = {},
+): MyUnpublishedAgent {
   return {
     graph_id: FLOW_ID,
     graph_version: FLOW_VERSION,

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/BuilderActions/components/PublishToMarketplace/__tests__/PublishToMarketplace.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/BuilderActions/components/PublishToMarketplace/__tests__/PublishToMarketplace.test.tsx
@@ -21,9 +21,16 @@ vi.mock("@/lib/supabase/hooks/useSupabase", () => ({
   useSupabase: mockUseSupabase,
 }));
 
-vi.mock("@sentry/nextjs", () => ({
-  captureException: vi.fn(),
-}));
+vi.mock("@sentry/nextjs", async () => {
+  const actual =
+    await vi.importActual<typeof import("@sentry/nextjs")>("@sentry/nextjs");
+  return {
+    ...actual,
+    captureException: vi.fn(),
+    getTraceData: vi.fn(() => ({})),
+    withServerActionInstrumentation: vi.fn((_, __, callback) => callback()),
+  };
+});
 
 vi.mock("@/components/contextual/CronScheduler/cron-scheduler-dialog", () => ({
   CronExpressionDialog: () => null,
@@ -128,9 +135,24 @@ describe("PublishToMarketplace (builder)", () => {
 
     expect(screen.queryByText(/choose an agent/i)).toBeNull();
 
+    expect(await screen.findByDisplayValue(AGENT_NAME)).toBeDefined();
+  });
+
+  test("closes the modal when going back from the pre-scoped listing form", async () => {
+    installScopedHandlers();
+
+    render(
+      <PublishToMarketplace flowID={FLOW_ID} flowVersion={FLOW_VERSION} />,
+    );
+
+    fireEvent.click(screen.getByRole("button"));
+
+    expect(await screen.findByDisplayValue(AGENT_NAME)).toBeDefined();
+
+    fireEvent.click(screen.getByRole("button", { name: /back/i }));
+
     await waitFor(() => {
-      const titleInput = screen.getByLabelText(/title/i) as HTMLInputElement;
-      expect(titleInput.value).toBe(AGENT_NAME);
+      expect(screen.queryByTestId("publish-agent-modal")).toBeNull();
     });
   });
 

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/BuilderActions/components/PublishToMarketplace/__tests__/PublishToMarketplace.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/BuilderActions/components/PublishToMarketplace/__tests__/PublishToMarketplace.test.tsx
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import {
+  getGetV2GetMyAgentsMockHandler,
+  getGetV2ListMySubmissionsMockHandler,
+} from "@/app/api/__generated__/endpoints/store/store.msw";
+import type { MyUnpublishedAgent } from "@/app/api/__generated__/models/myUnpublishedAgent";
+import type { MyUnpublishedAgentsResponse } from "@/app/api/__generated__/models/myUnpublishedAgentsResponse";
+import type { StoreSubmissionsResponse } from "@/app/api/__generated__/models/storeSubmissionsResponse";
+import { server } from "@/mocks/mock-server";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@/tests/integrations/test-utils";
+
+const mockUseSupabase = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/supabase/hooks/useSupabase", () => ({
+  useSupabase: mockUseSupabase,
+}));
+
+vi.mock("@sentry/nextjs", () => ({
+  captureException: vi.fn(),
+}));
+
+vi.mock("@/components/contextual/CronScheduler/cron-scheduler-dialog", () => ({
+  CronExpressionDialog: () => null,
+}));
+
+vi.mock(
+  "@/components/contextual/PublishAgentModal/components/AgentInfoStep/components/ThumbnailImages",
+  () => ({
+    ThumbnailImages: () => <div data-testid="thumbnail-images-mock" />,
+  }),
+);
+
+import { PublishToMarketplace } from "../PublishToMarketplace";
+
+const testUser = {
+  id: "user-1",
+  email: "user@example.com",
+  app_metadata: {},
+  user_metadata: {},
+  aud: "authenticated",
+  created_at: "2026-01-01T00:00:00.000Z",
+};
+
+const FLOW_ID = "graph-1";
+const FLOW_VERSION = 3;
+const AGENT_NAME = "My Builder Agent";
+
+function makeAgent(overrides: Partial<MyUnpublishedAgent> = {}): MyUnpublishedAgent {
+  return {
+    graph_id: FLOW_ID,
+    graph_version: FLOW_VERSION,
+    agent_name: AGENT_NAME,
+    description: "An agent created in the builder",
+    last_edited: new Date("2026-04-01T00:00:00Z"),
+    ...overrides,
+  };
+}
+
+function makeAgentsResponse(
+  agents: MyUnpublishedAgent[],
+): MyUnpublishedAgentsResponse {
+  return {
+    agents,
+    pagination: {
+      total_items: agents.length,
+      total_pages: 1,
+      current_page: 1,
+      page_size: agents.length || 20,
+    },
+  };
+}
+
+function makeEmptySubmissionsResponse(): StoreSubmissionsResponse {
+  return {
+    submissions: [],
+    pagination: {
+      total_items: 0,
+      total_pages: 1,
+      current_page: 1,
+      page_size: 20,
+    },
+    stats: {
+      total: 0,
+      approved: 0,
+      pending: 0,
+      total_runs: 0,
+      average_rating: null,
+    },
+  };
+}
+
+function installScopedHandlers() {
+  server.use(
+    getGetV2GetMyAgentsMockHandler(makeAgentsResponse([makeAgent()])),
+    getGetV2ListMySubmissionsMockHandler(makeEmptySubmissionsResponse()),
+  );
+}
+
+describe("PublishToMarketplace (builder)", () => {
+  beforeEach(() => {
+    mockUseSupabase.mockReturnValue({
+      user: testUser,
+      isLoggedIn: true,
+      isUserLoading: false,
+      supabase: {},
+    });
+  });
+
+  test("opens the listing form pre-scoped to the current agent and skips the picker", async () => {
+    installScopedHandlers();
+
+    render(
+      <PublishToMarketplace flowID={FLOW_ID} flowVersion={FLOW_VERSION} />,
+    );
+
+    fireEvent.click(screen.getByRole("button"));
+
+    expect(await screen.findByTestId("publish-agent-modal")).toBeDefined();
+    expect(await screen.findByText("Build the store listing")).toBeDefined();
+
+    expect(screen.queryByText(/choose an agent/i)).toBeNull();
+
+    await waitFor(() => {
+      const titleInput = screen.getByLabelText(/title/i) as HTMLInputElement;
+      expect(titleInput.value).toBe(AGENT_NAME);
+    });
+  });
+
+  test("disables the publish button when flowVersion is missing", () => {
+    render(<PublishToMarketplace flowID={FLOW_ID} flowVersion={null} />);
+
+    const button = screen.getByRole("button");
+    expect((button as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  test("disables the publish button when flowID is missing", () => {
+    render(<PublishToMarketplace flowID={null} flowVersion={FLOW_VERSION} />);
+
+    const button = screen.getByRole("button");
+    expect((button as HTMLButtonElement).disabled).toBe(true);
+  });
+});

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/BuilderActions/components/PublishToMarketplace/usePublishToMarketplace.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/BuilderActions/components/PublishToMarketplace/usePublishToMarketplace.ts
@@ -17,24 +17,27 @@ const defaultPublishState: PublishState = {
 
 interface UsePublishToMarketplaceProps {
   flowID: string | null;
+  flowVersion: number | null;
 }
 
 export function usePublishToMarketplace({
   flowID,
+  flowVersion,
 }: UsePublishToMarketplaceProps) {
   const [publishState, setPublishState] =
     useState<PublishState>(defaultPublishState);
 
-  const handlePublishToMarketplace = () => {
-    if (!flowID) return;
+  function handlePublishToMarketplace() {
+    if (!flowID || flowVersion === null) return;
 
-    // Open the publish modal starting with the select step
+    // Builder already knows the agent — skip the picker and jump straight
+    // to the listing form pre-scoped to the current graph/version.
     setPublishState({
       isOpen: true,
-      step: "select",
+      step: "info",
       submissionData: null,
     });
-  };
+  }
 
   const handleStateChange = useCallback((newState: PublishState) => {
     setPublishState(newState);

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/usePublishAgentModal.ts
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/usePublishAgentModal.ts
@@ -269,6 +269,14 @@ export function usePublishAgentModal({
 
   function handleBack() {
     if (currentState.step === "info") {
+      // When the modal was opened pre-scoped to a specific agent (e.g. from
+      // the builder or library), there is no upstream picker to go back to —
+      // close the modal instead of surfacing a picker the caller intentionally
+      // skipped.
+      if (preSelectedAgentId) {
+        handleClose();
+        return;
+      }
       updateState({
         ...currentState,
         step: "select",


### PR DESCRIPTION
### Why / What / How

**Why:** Clicking **Publish** from the builder opened the generic publish flow with the agent picker — even though the builder already knows the agent the user is editing. Users had to re-pick the same agent before reaching the listing form. ([SECRT-2361](https://linear.app/autogpt/issue/SECRT-2361))

**What:** Pre-scope the publish dialog to the current agent (`graphID` + `graphVersion`) and skip the picker step when launched from the builder. Library and Dashboard entry points still open with the picker as before.

**How:** The `PublishAgentModal` already supports a scoped mode — Library uses it today by opening at `step: "info"` with `preSelectedAgentId` + `preSelectedAgentVersion`. The builder simply wasn't passing the version through and was opening at `step: "select"`. Threaded `flowVersion` through `BuilderActions → PublishToMarketplace → usePublishToMarketplace`, and opened the modal at the listing step. As a defensive fix in `usePublishAgentModal.handleBack`, scoped opens (any caller passing `preSelectedAgentId`) now close the modal on Back instead of surfacing the picker the caller intentionally skipped — this also fixes the same latent issue in the Library entry point.

### Changes 🏗️

- `BuilderActions.tsx` — read `flowVersion` from `useQueryStates` and pass it to `PublishToMarketplace`.
- `PublishToMarketplace.tsx` — accept `flowVersion`, forward to the hook, pass `preSelectedAgentVersion` to the modal, disable the trigger if either id or version is missing. Switched to a function declaration with `interface Props`.
- `usePublishToMarketplace.ts` — guard on both `flowID` and `flowVersion`; open the modal at `step: "info"` instead of `"select"`.
- `usePublishAgentModal.ts` — in `handleBack`, when `step === "info"` and `preSelectedAgentId` is set, call `handleClose()` instead of returning to the picker.
- New integration test: `PublishToMarketplace/__tests__/PublishToMarketplace.test.tsx` (Vitest + RTL + MSW).

No backend changes.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [ ] From the builder, click **Publish** → the listing form opens pre-filled with the current agent (no picker shown).
  - [ ] Click **Back** from the listing form (scoped open) → modal closes (does not surface picker).
  - [ ] From **Library** → publish an agent → still opens scoped on that agent; Back closes.
  - [ ] From **Dashboard / Become a Creator** → publish → picker still shows; selecting an agent advances to the listing step as before.
  - [ ] Submit a listing end-to-end from the builder entry point → review step renders.
  - [ ] Open builder URL without `flowVersion` query param → Publish button is disabled.
  - [ ] New integration test passes: `pnpm test:unit src/app/\(platform\)/build/components/BuilderActions/components/PublishToMarketplace/__tests__/PublishToMarketplace.test.tsx`
