### PR TITLE
fix(frontend): preserve numeric enum selections

### DIFF
--- a/autogpt_platform/frontend/src/components/renderers/InputRenderer/__tests__/FormRenderer.test.tsx
+++ b/autogpt_platform/frontend/src/components/renderers/InputRenderer/__tests__/FormRenderer.test.tsx
@@ -1,11 +1,13 @@
 import { fireEvent, screen, waitFor } from "@testing-library/react";
-import { RJSFSchema } from "@rjsf/utils";
+import { RJSFSchema, WidgetProps } from "@rjsf/utils";
+import React from "react";
 import { describe, expect, it, vi } from "vitest";
 
 import { BlockUIType } from "@/app/(platform)/build/components/types";
 import { render } from "@/tests/integrations/test-utils";
 
 import { FormRenderer } from "../FormRenderer";
+import { SelectWidget } from "../base/standard/widgets/SelectInput/SelectWidget";
 
 vi.mock("@/components/atoms/Select/Select", () => ({
   Select: ({
@@ -31,6 +33,64 @@ vi.mock("@/components/atoms/Select/Select", () => ({
       ))}
     </select>
   ),
+}));
+
+let mockMultiSelectValues: string[] = [];
+let mockMultiSelectOnChange: (values: string[]) => void = () => undefined;
+
+vi.mock("@/components/__legacy__/ui/multiselect", () => ({
+  MultiSelector: ({
+    values,
+    onValuesChange,
+    children,
+  }: {
+    values: string[];
+    onValuesChange: (values: string[]) => void;
+    children: React.ReactNode;
+  }) => (
+    <div>
+      {(() => {
+        mockMultiSelectValues = values;
+        mockMultiSelectOnChange = onValuesChange;
+        return children;
+      })()}
+    </div>
+  ),
+  MultiSelectorTrigger: ({ children }: { children: React.ReactNode }) => {
+    return (
+      <div>
+        <div data-testid="selected-values">
+          {mockMultiSelectValues.join(",")}
+        </div>
+        {children}
+      </div>
+    );
+  },
+  MultiSelectorInput: () => <input aria-label="multi-select-input" />,
+  MultiSelectorContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  MultiSelectorList: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  MultiSelectorItem: ({
+    value,
+    children,
+  }: {
+    value: string;
+    children: React.ReactNode;
+  }) => {
+    return (
+      <button
+        type="button"
+        onClick={() =>
+          mockMultiSelectOnChange([...mockMultiSelectValues, value])
+        }
+      >
+        {children}
+      </button>
+    );
+  },
 }));
 
 describe("FormRenderer", () => {
@@ -82,5 +142,46 @@ describe("FormRenderer", () => {
       const lastCall = handleChange.mock.calls.at(-1)?.[0];
       expect(lastCall.formData.reminder_minutes).toEqual([60]);
     });
+  });
+
+  it("round-trips numeric enum values for multiselects without exposing indexes", () => {
+    const onChange = vi.fn();
+
+    render(
+      <SelectWidget
+        id="reminder-minutes"
+        name="reminder-minutes"
+        label="Reminder Minutes"
+        schema={{
+          type: "array",
+          items: {
+            type: "integer",
+            enum: [10, 30, 60, 1440],
+          },
+        }}
+        options={{
+          enumOptions: [
+            { value: 10, label: "10" },
+            { value: 30, label: "30" },
+            { value: 60, label: "60" },
+            { value: 1440, label: "1440" },
+          ],
+        }}
+        value={[10, 60]}
+        onChange={onChange}
+        onBlur={vi.fn()}
+        onFocus={vi.fn()}
+        disabled={false}
+        readonly={false}
+        formContext={{ size: "small" }}
+        registry={{} as WidgetProps["registry"]}
+      />,
+    );
+
+    expect(screen.getByTestId("selected-values").textContent).toBe("10,60");
+
+    fireEvent.click(screen.getByRole("button", { name: "30" }));
+
+    expect(onChange).toHaveBeenCalledWith([10, 60, 30]);
   });
 });

--- a/autogpt_platform/frontend/src/components/renderers/InputRenderer/__tests__/FormRenderer.test.tsx
+++ b/autogpt_platform/frontend/src/components/renderers/InputRenderer/__tests__/FormRenderer.test.tsx
@@ -1,0 +1,86 @@
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { RJSFSchema } from "@rjsf/utils";
+import { describe, expect, it, vi } from "vitest";
+
+import { BlockUIType } from "@/app/(platform)/build/components/types";
+import { render } from "@/tests/integrations/test-utils";
+
+import { FormRenderer } from "../FormRenderer";
+
+vi.mock("@/components/atoms/Select/Select", () => ({
+  Select: ({
+    id,
+    value,
+    onValueChange,
+    options,
+  }: {
+    id: string;
+    value?: string;
+    onValueChange?: (value: string) => void;
+    options: { value: string; label: string }[];
+  }) => (
+    <select
+      aria-label={id}
+      value={value ?? ""}
+      onChange={(event) => onValueChange?.(event.target.value)}
+    >
+      {options.map((option) => (
+        <option key={option.value} value={option.value}>
+          {option.label}
+        </option>
+      ))}
+    </select>
+  ),
+}));
+
+describe("FormRenderer", () => {
+  it("round-trips numeric enum values for array item selects", async () => {
+    const handleChange = vi.fn();
+    const jsonSchema: RJSFSchema = {
+      type: "object",
+      properties: {
+        reminder_minutes: {
+          title: "Reminder Minutes",
+          type: "array",
+          items: {
+            title: "ReminderPreset",
+            type: "integer",
+            enum: [10, 30, 60, 1440],
+          },
+        },
+      },
+    };
+
+    render(
+      <FormRenderer
+        jsonSchema={jsonSchema}
+        handleChange={handleChange}
+        uiSchema={{}}
+        initialValues={{ reminder_minutes: [] }}
+        formContext={{
+          nodeId: "node-1",
+          uiType: BlockUIType.STANDARD,
+          showHandles: false,
+          size: "small",
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /add item/i }));
+
+    const select = screen.getByRole("combobox") as HTMLSelectElement;
+    expect(Array.from(select.options).map((option) => option.text)).toEqual([
+      "10",
+      "30",
+      "60",
+      "1440",
+    ]);
+
+    fireEvent.change(select, { target: { value: "2" } });
+
+    await waitFor(() => {
+      const lastCall = handleChange.mock.calls.at(-1)?.[0];
+      expect(lastCall.formData.reminder_minutes).toEqual([60]);
+    });
+  });
+});

--- a/autogpt_platform/frontend/src/components/renderers/InputRenderer/base/standard/widgets/SelectInput/SelectWidget.tsx
+++ b/autogpt_platform/frontend/src/components/renderers/InputRenderer/base/standard/widgets/SelectInput/SelectWidget.tsx
@@ -1,4 +1,8 @@
-import { WidgetProps } from "@rjsf/utils";
+import {
+  enumOptionsIndexForValue,
+  enumOptionsValueForIndex,
+  WidgetProps,
+} from "@rjsf/utils";
 import {
   InputType,
   mapJsonSchemaTypeToInputType,
@@ -13,7 +17,7 @@ import {
   MultiSelectorTrigger,
 } from "@/components/__legacy__/ui/multiselect";
 
-export const SelectWidget = (props: WidgetProps) => {
+export function SelectWidget(props: WidgetProps) {
   const {
     options,
     value,
@@ -27,16 +31,27 @@ export const SelectWidget = (props: WidgetProps) => {
   const enumOptions = options.enumOptions || [];
   const type = mapJsonSchemaTypeToInputType(props.schema);
   const { size = "small" } = formContext || {};
+  const selectedIndexes = enumOptionsIndexForValue(
+    value,
+    enumOptions,
+    type === InputType.MULTI_SELECT,
+  );
 
   // Determine select size based on context
   const selectSize = size === "large" ? "medium" : "small";
 
   const renderInput = () => {
     if (type === InputType.MULTI_SELECT) {
+      const selectedValues = Array.isArray(selectedIndexes)
+        ? selectedIndexes
+        : [];
+
       return (
         <MultiSelector
-          values={Array.isArray(value) ? value : []}
-          onValuesChange={onChange}
+          values={selectedValues}
+          onValuesChange={(newValues) =>
+            onChange(enumOptionsValueForIndex(newValues, enumOptions))
+          }
           className="w-full"
         >
           <MultiSelectorTrigger>
@@ -44,8 +59,11 @@ export const SelectWidget = (props: WidgetProps) => {
           </MultiSelectorTrigger>
           <MultiSelectorContent>
             <MultiSelectorList>
-              {enumOptions?.map((option: any) => (
-                <MultiSelectorItem key={option.value} value={option.value}>
+              {enumOptions.map((option, index) => (
+                <MultiSelectorItem
+                  key={`${String(option.value)}-${option.label}`}
+                  value={String(index)}
+                >
                   {option.label}
                 </MultiSelectorItem>
               ))}
@@ -54,6 +72,9 @@ export const SelectWidget = (props: WidgetProps) => {
         </MultiSelector>
       );
     }
+    const selectedValue =
+      typeof selectedIndexes === "string" ? selectedIndexes : "";
+
     return (
       <Select
         label=""
@@ -61,14 +82,16 @@ export const SelectWidget = (props: WidgetProps) => {
         hideLabel={true}
         disabled={disabled || readonly}
         size={selectSize as any}
-        value={value ?? ""}
-        onValueChange={onChange}
-        options={
-          enumOptions?.map((option: any) => ({
-            value: option.value,
-            label: option.label,
-          })) || []
+        value={selectedValue}
+        onValueChange={(newValue) =>
+          onChange(
+            enumOptionsValueForIndex(newValue, enumOptions, options.emptyValue),
+          )
         }
+        options={enumOptions.map((option, index) => ({
+          value: String(index),
+          label: option.label,
+        }))}
         wrapperClassName="!mb-0 "
         className={className}
       />
@@ -76,4 +99,4 @@ export const SelectWidget = (props: WidgetProps) => {
   };
 
   return renderInput();
-};
+}

--- a/autogpt_platform/frontend/src/components/renderers/InputRenderer/base/standard/widgets/SelectInput/SelectWidget.tsx
+++ b/autogpt_platform/frontend/src/components/renderers/InputRenderer/base/standard/widgets/SelectInput/SelectWidget.tsx
@@ -42,16 +42,38 @@ export function SelectWidget(props: WidgetProps) {
 
   const renderInput = () => {
     if (type === InputType.MULTI_SELECT) {
-      const selectedValues = Array.isArray(selectedIndexes)
-        ? selectedIndexes
-        : [];
+      const enumOptionIndexesByLabel = new Map<string, string>();
+      enumOptions.forEach((option, index) => {
+        if (!enumOptionIndexesByLabel.has(option.label)) {
+          enumOptionIndexesByLabel.set(option.label, String(index));
+        }
+      });
+
+      const selectedValues: string[] = [];
+      if (Array.isArray(selectedIndexes)) {
+        for (const index of selectedIndexes) {
+          const label = enumOptions[Number(index)]?.label;
+          if (typeof label === "string") {
+            selectedValues.push(label);
+          }
+        }
+      }
 
       return (
         <MultiSelector
           values={selectedValues}
-          onValuesChange={(newValues) =>
-            onChange(enumOptionsValueForIndex(newValues, enumOptions))
-          }
+          onValuesChange={(newValues) => {
+            const selectedOptionIndexes: string[] = [];
+            for (const label of newValues) {
+              const optionIndex = enumOptionIndexesByLabel.get(label);
+              if (optionIndex !== undefined) {
+                selectedOptionIndexes.push(optionIndex);
+              }
+            }
+            onChange(
+              enumOptionsValueForIndex(selectedOptionIndexes, enumOptions),
+            );
+          }}
           className="w-full"
         >
           <MultiSelectorTrigger>
@@ -59,10 +81,10 @@ export function SelectWidget(props: WidgetProps) {
           </MultiSelectorTrigger>
           <MultiSelectorContent>
             <MultiSelectorList>
-              {enumOptions.map((option, index) => (
+              {enumOptions.map((option) => (
                 <MultiSelectorItem
                   key={`${String(option.value)}-${option.label}`}
-                  value={String(index)}
+                  value={option.label}
                 >
                   {option.label}
                 </MultiSelectorItem>


### PR DESCRIPTION
### Why / What / How

This PR fixes SECRT-1310, where the Google Calendar Create Event block's Reminder Minutes array could render but selecting a reminder value did not update the form correctly.

The problem was in the shared RJSF select widget: it passed raw enum values directly to Radix/select components. RJSF enum widgets expect the UI layer to use string option indexes, then convert those indexes back to the original enum values. String enums mostly worked by accident, but numeric enums like `10`, `30`, `60`, and `1440` did not round-trip reliably.

This changes the custom select widget to use RJSF's enum conversion helpers for both select and multiselect paths, preserving numeric enum values in form data while keeping UI values string-safe.

### Changes 🏗️

- Updated `SelectWidget` to map enum values through RJSF option indexes before passing them to the UI select components.
- Converted selected UI indexes back to original enum values on change, preserving numeric values like `60` instead of string values.
- Added a regression test for an array of integer enum items matching the Google Calendar reminder minutes schema.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `pnpm vitest run src/components/renderers/InputRenderer/__tests__/FormRenderer.test.tsx`
  - [x] `pnpm types`
  - [x] `npx -y react-doctor@latest . --verbose --diff`
  - [x] `pnpm lint`

<details>
  <summary>Example test plan</summary>
  
  - [ ] Create from scratch and execute an agent with at least 3 blocks
  - [ ] Import an agent from file upload, and confirm it executes correctly
  - [ ] Upload agent to marketplace
  - [ ] Import an agent from marketplace and confirm it executes correctly
  - [ ] Edit an agent from monitor, and confirm it executes correctly
</details>

#### For configuration changes:

- [x] `.env.default` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes
- [x] I have included a list of my configuration changes in the PR description (under **Changes**)

No configuration changes.

<details>
  <summary>Examples of configuration changes</summary>

  - Changing ports
  - Adding new services that need to communicate with each other
  - Secrets or environment variable changes
  - New or infrastructure changes such as databases
</details>
