### PR TITLE
fix(frontend): update profile handle URL hint

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/settings/profile/components/ProfileHeader/ProfileHeader.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/profile/components/ProfileHeader/ProfileHeader.tsx
@@ -161,7 +161,7 @@ export function ProfileHeader({
               Handle
             </Text>
             <Text variant="small" as="span" className="!text-zinc-400">
-              autogpt.com/@your-handle
+              agpt.co/@your-handle
             </Text>
           </div>
           <Input


### PR DESCRIPTION
### Why / What / How

The profile settings page showed `autogpt.com/@your-handle` as the example creator URL, but that domain is not the correct public platform domain.

This PR updates the handle helper text to use the shorter `agpt.co/@your-handle` format.

The change is a copy-only update in the profile header component. No behavior, routing, or API logic changes.

### Changes 🏗️

- Updated the profile handle URL hint from `autogpt.com/@your-handle` to `agpt.co/@your-handle`

### Checklist 📋

#### For code changes:
- [ ] I have clearly listed my changes in the PR description
- [ ] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [ ] Ran `pnpm lint` from `autogpt_platform/frontend`
  - [ ] Ran targeted Prettier check for `ProfileHeader.tsx`

<details>
  <summary>Example test plan</summary>
  
  - [ ] Create from scratch and execute an agent with at least 3 blocks
  - [ ] Import an agent from file upload, and confirm it executes correctly
  - [ ] Upload agent to marketplace
  - [ ] Import an agent from marketplace and confirm it executes correctly
  - [ ] Edit an agent from monitor, and confirm it executes correctly
</details>

#### For configuration changes:

- [ ] `.env.default` is updated or already compatible with my changes
- [ ] `docker-compose.yml` is updated or already compatible with my changes
- [ ] I have included a list of my configuration changes in the PR description (under **Changes**)

<details>
  <summary>Examples of configuration changes</summary>

  - Changing ports
  - Adding new services that need to communicate with each other
  - Secrets or environment variable changes
  - New or infrastructure changes such as databases
</details>
