### PR TITLE
fix(frontend): drop /signup → / hop that flashes /copilot before /onboarding

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/login/useLoginPage.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/login/useLoginPage.ts
@@ -30,9 +30,14 @@ export function useLoginPage() {
       ? rawNext
       : null;
 
+  // Only honour explicit `?next=` deep links here. Generic "already logged in
+  // on /login, get me out" is handled by OnboardingProvider so the user lands
+  // straight on /onboarding or /copilot. Otherwise we'd bounce
+  // /login → / → /copilot → /onboarding, and each hop renders before the next
+  // redirect — that intermediate /copilot render is the flash users see.
   useEffect(() => {
-    if (isLoggedIn && !isLoggingIn) {
-      router.push(nextUrl || "/");
+    if (isLoggedIn && !isLoggingIn && nextUrl) {
+      router.replace(nextUrl);
     }
   }, [isLoggedIn, isLoggingIn, nextUrl, router]);
 

--- a/autogpt_platform/frontend/src/app/(platform)/signup/useSignupPage.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/signup/useSignupPage.ts
@@ -24,9 +24,14 @@ export function useSignupPage() {
   // Get redirect destination from 'next' query parameter
   const nextUrl = searchParams.get("next");
 
+  // Only honour explicit `?next=` deep links here. Generic "already logged in
+  // on /signup, get me out" is handled by OnboardingProvider so the user lands
+  // straight on /onboarding or /copilot. Otherwise we'd bounce
+  // /signup → / → /copilot → /onboarding, and each hop renders before the next
+  // redirect — that intermediate /copilot render is the flash users see.
   useEffect(() => {
-    if (isLoggedIn && !isSigningUp) {
-      router.push(nextUrl || "/");
+    if (isLoggedIn && !isSigningUp && nextUrl) {
+      router.replace(nextUrl);
     }
   }, [isLoggedIn, isSigningUp, nextUrl, router]);
 

--- a/autogpt_platform/frontend/src/providers/onboarding/onboarding-provider.tsx
+++ b/autogpt_platform/frontend/src/providers/onboarding/onboarding-provider.tsx
@@ -112,6 +112,11 @@ export default function OnboardingProvider({
   }, []);
 
   const isOnOnboardingRoute = pathname.startsWith("/onboarding");
+  // Logged-in users sitting on the auth pages need to be routed onward by us;
+  // otherwise the signup/login pages show their `isLoggedIn` loader forever.
+  // Handling them here (instead of in useSignupPage/useLoginPage) avoids the
+  // /signup → / → /copilot → /onboarding bounce that flashes /copilot.
+  const isOnAuthRoute = pathname === "/signup" || pathname === "/login";
 
   const fetchOnboarding = useCallback(async () => {
     const onboarding = await resolveResponse(getV1OnboardingState());
@@ -139,7 +144,7 @@ export default function OnboardingProvider({
         if (!is_completed && !isOnOnboardingRoute) {
           router.replace("/onboarding");
           return;
-        } else if (is_completed && isOnOnboardingRoute) {
+        } else if (is_completed && (isOnOnboardingRoute || isOnAuthRoute)) {
           router.replace("/copilot");
           return;
         }
@@ -171,7 +176,7 @@ export default function OnboardingProvider({
     }
 
     initializeOnboarding();
-  }, [api, isOnOnboardingRoute, router, isLoggedIn, pathname]);
+  }, [api, isOnOnboardingRoute, isOnAuthRoute, router, isLoggedIn, pathname]);
 
   const handleOnboardingNotification = useCallback(
     (notification: WebSocketNotification) => {


### PR DESCRIPTION
### Why / What / How

**Why**: New users who finish the signup form, and logged-in users who land on `/signup` or `/login`, briefly see the `/copilot` homescreen before being sent to `/onboarding`. The bounce is `/signup` → `/` → `/copilot` → `/onboarding`, and each hop renders before the next redirect kicks in — the intermediate `/copilot` render is the flash users see. The LD angle is real: `LaunchDarklyProvider` unmounts/remounts its subtree on every `isUserLoading` flip, which resets `OnboardingProvider.hasInitialized` and delays the corrective redirect behind another awaited `getV1CheckIfOnboardingIsCompleted` call. While that promise is in flight, `/copilot` sits on screen.

**What**: Stop `useSignupPage` / `useLoginPage` from pushing to `"/"` when the user is logged in (which always redirects to `/copilot` via `app/page.tsx`). Let `OnboardingProvider` make the routing decision, and extend it to also handle completed users sitting on `/signup` or `/login` so they aren't stranded on the auth-page loader.

**How**:
1. Narrow the auth-page `useEffect`s so they only honour an explicit `?next=` deep link. The generic "I'm logged in, get me off this page" case is now routed by `OnboardingProvider`, which knows whether to send the user to `/onboarding` or `/copilot`.
2. Add `isOnAuthRoute` to the `OnboardingProvider`'s "completed" branch so a logged-in user with completed onboarding on `/signup` or `/login` is sent straight to `/copilot` (otherwise they'd be stuck on `LoadingSignup` forever now that the auth-page redirect is gone).

### Changes 🏗️

- `useSignupPage.ts`: skip the `router.push("/")` when no `?next=` is set.
- `useLoginPage.ts`: same change for the `/login` mirror of the same useEffect.
- `onboarding-provider.tsx`: introduce `isOnAuthRoute`; broaden the completed-onboarding redirect to include `/signup` and `/login`; add it to the effect dep list.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [x] `pnpm format`, `pnpm lint`, `pnpm types`, `pnpm test:unit` all pass on the branch (203 test files / 2660 tests passing)
  - [ ] Fresh signup: confirm the user goes straight to `/onboarding` welcome step with no `/copilot` flicker
  - [ ] Re-visit `/signup` while logged in with incomplete onboarding: should land on `/onboarding`, no `/copilot` flicker
  - [ ] Re-visit `/signup` while logged in with completed onboarding: should land on `/copilot`
  - [ ] Re-visit `/signup?next=/library` while logged in: should land on `/library`
  - [ ] Same matrix for `/login`
