### PR TITLE
fix: propagate tool credentials to orchestrator when run from Library/AutoPilot (#13144)

### DIFF
--- a/autogpt_platform/backend/backend/blocks/orchestrator.py
+++ b/autogpt_platform/backend/backend/blocks/orchestrator.py
@@ -1079,6 +1079,16 @@ class OrchestratorBlock(Block):
         # so the execution record is complete for from_db() reconstruction.
         merged_input_data = {**target_node.input_default, **raw_input_data}
 
+        # Also merge credential metadata from the graph execution's
+        # nodes_input_masks so tool nodes get their credentials even when
+        # launched by the orchestrator (e.g. from Library or AutoPilot).
+        # Without this, the credential metadata is only merged during the
+        # normal graph execution queue dispatch (manager.py:_on_graph_execution)
+        # but orchestrator tool calls bypass that path.
+        node_creds = getattr(execution_processor, "nodes_input_masks", None)
+        if node_creds and sink_node_id in node_creds:
+            merged_input_data.update(node_creds[sink_node_id])
+
         # Add all inputs to the execution
         if not merged_input_data:
             raise ValueError(f"Tool call has no input data: {tool_call}")

--- a/autogpt_platform/backend/backend/executor/manager.py
+++ b/autogpt_platform/backend/backend/executor/manager.py
@@ -963,6 +963,7 @@ class ExecutionProcessor:
         self.running_node_evaluation: dict[str, Future] = {}
         self.execution_stats = execution_stats
         self.execution_stats_lock = execution_stats_lock
+        self.nodes_input_masks = graph_exec.nodes_input_masks
         execution_queue = ExecutionQueue[NodeExecutionEntry]()
 
         running_node_execution = self.running_node_execution


### PR DESCRIPTION
Closes #13144

**Root cause**: Orchestrator tool execution bypassed the normal graph execution queue where credential metadata is merged into node inputs. Library/AutoPilot use orchestrated agent flows where sub-tools depend on this credential merge.

**Fix**: Stored `nodes_input_masks` on the ExecutionProcessor instance and made the orchestrator read + merge credential metadata before tool execution, matching the normal queue dispatch behavior.