### PR TITLE
fix: guard LLM response against empty choices and replace bare except clauses

### DIFF
--- a/autogpt/llm_utils.py
+++ b/autogpt/llm_utils.py
@@ -145,6 +145,8 @@ def create_chat_completion(
             raise RuntimeError(f"Failed to get response after {num_retries} retries")
         else:
             quit(1)
+    if not response.choices:
+        raise ValueError("LLM returned empty response")
     resp = response.choices[0].message["content"]
     for plugin in CFG.plugins:
         if not plugin.can_handle_on_response():

--- a/autogpt/utils.py
+++ b/autogpt/utils.py
@@ -50,7 +50,7 @@ def get_bulletin_from_web() -> str:
         )
         if response.status_code == 200:
             return response.text
-    except:
+    except Exception:
         return ""
 
 
@@ -59,7 +59,7 @@ def get_current_git_branch() -> str:
         repo = Repo(search_parent_directories=True)
         branch = repo.active_branch
         return branch.name
-    except:
+    except Exception:
         return ""
 
 

--- a/tests/integration/milvus_memory_tests.py
+++ b/tests/integration/milvus_memory_tests.py
@@ -51,7 +51,7 @@ try:
             self.assertEqual(len(relevant_texts), k)
             self.assertIn(self.example_texts[1], relevant_texts)
 
-except:
+except Exception:
     print(
         "Skipping tests/integration/milvus_memory_tests.py as Milvus is not installed."
     )

--- a/tests/integration/weaviate_memory_tests.py
+++ b/tests/integration/weaviate_memory_tests.py
@@ -52,7 +52,7 @@ class TestWeaviateMemory(unittest.TestCase):
     def setUp(self):
         try:
             self.client.schema.delete_class(self.index)
-        except:
+        except Exception:
             pass
 
         self.memory = WeaviateMemory(self.cfg)

--- a/tests/milvus_memory_test.py
+++ b/tests/milvus_memory_test.py
@@ -68,5 +68,5 @@ try:
             stats = self.memory.get_stats()
             self.assertEqual(15, len(stats))
 
-except:
+except Exception:
     print("Milvus not installed, skipping tests")


### PR DESCRIPTION
## Summary

- **`autogpt/llm_utils.py`**: Add `if not response.choices: raise ValueError(...)` before `response.choices[0].message["content"]` — prevents `IndexError` when the OpenAI API returns an empty `choices` list (content-filtering, quota, streaming edge cases). Related: #9741
- **`autogpt/utils.py`**: Replace two bare `except:` with `except Exception:` — avoids silently swallowing `SystemExit` and `KeyboardInterrupt`
- **`tests/`**: Same bare-except cleanup in three test files

## Why

The OpenAI API can return `choices=[]` when content is filtered, a quota limit is hit, or during streaming edge cases. Without a guard, `response.choices[0]` raises `IndexError` instead of a meaningful error.

Bare `except:` catches `SystemExit` and `KeyboardInterrupt`, making the process unresponsive to Ctrl-C — replacing with `except Exception:` is the safer default.

## Detection

Found by [pact](https://github.com/qizwiz/pact) static analysis — `llm_response_unguarded` and `bare_except` failure modes.

## Test plan

- [ ] `python -m pytest tests/` passes
- [ ] Content-filter response path now raises `ValueError` with a clear message