### PR TITLE
hotfix(frontend): update profile handle URL hint

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/settings/profile/components/ProfileHeader/ProfileHeader.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/profile/components/ProfileHeader/ProfileHeader.tsx
@@ -161,7 +161,7 @@ export function ProfileHeader({
               Handle
             </Text>
             <Text variant="small" as="span" className="!text-zinc-400">
-              autogpt.com/@your-handle
+              agpt.co/@your-handle
             </Text>
           </div>
           <Input


### PR DESCRIPTION
## Summary

Hotfix cherry-pick of #13148 onto `master`.

Prod currently shows wrong domain `autogpt.com/@your-handle` in the profile handle hint. We don't own `autogpt.com` and NordVPN flags it as malware — urgent fix requested by @Torantulino.

- Cherry-picked commit: `50c5b8b1ee`
- Original dev PR: #13148

## Test plan

- [x] Verify profile handle hint shows correct domain on prod after deploy
- [x] CI green
