### PR TITLE
feat(platform/library): sort agents by last executed

### DIFF
--- a/autogpt_platform/backend/backend/api/features/library/db.py
+++ b/autogpt_platform/backend/backend/api/features/library/db.py
@@ -189,15 +189,57 @@ async def list_library_agents(
     elif sort_by == library_model.LibraryAgentSort.UPDATED_AT:
         order_by = {"updatedAt": "desc"}
 
-    library_agents = await prisma.models.LibraryAgent.prisma().find_many(
-        where=where_clause,
-        include=library_agent_include(
-            user_id, include_nodes=False, include_executions=include_executions
-        ),
-        order=order_by,
-        skip=(page - 1) * page_size,
-        take=page_size,
-    )
+    # For LAST_EXECUTED sort, we need to fetch all agents with their latest
+    # execution, sort in-memory by execution time, then apply pagination.
+    if sort_by == library_model.LibraryAgentSort.LAST_EXECUTED:
+        library_agents = await prisma.models.LibraryAgent.prisma().find_many(
+            where=where_clause,
+            include=library_agent_include(
+                user_id,
+                include_nodes=False,
+                include_executions=True,
+                execution_limit=1,
+            ),
+        )
+
+        def get_sort_key(
+            agent: prisma.models.LibraryAgent,
+        ) -> tuple[int, datetime]:
+            """Sort key: agents with executions first (0), then by execution time desc.
+
+            Agents without executions get priority 1 and sort by createdAt.
+            """
+            graph = agent.AgentGraph
+            if (
+                graph
+                and getattr(graph, "Executions", None)
+                and len(graph.Executions) > 0
+            ):
+                execution = graph.Executions[0]
+                exec_time = execution.updatedAt or execution.createdAt
+                return (0, exec_time)
+            return (1, agent.createdAt)
+
+        library_agents.sort(key=get_sort_key, reverse=True)
+        # Agents with executions should come first (priority 0 < 1),
+        # but we reversed, so re-sort: priority ASC, time DESC
+        library_agents.sort(
+            key=lambda a: (get_sort_key(a)[0], -get_sort_key(a)[1].timestamp())
+        )
+
+        # Apply pagination in-memory
+        start = (page - 1) * page_size
+        library_agents = library_agents[start : start + page_size]
+    else:
+        library_agents = await prisma.models.LibraryAgent.prisma().find_many(
+            where=where_clause,
+            include=library_agent_include(
+                user_id, include_nodes=False, include_executions=include_executions
+            ),
+            order=order_by,
+            skip=(page - 1) * page_size,
+            take=page_size,
+        )
     agent_count = await prisma.models.LibraryAgent.prisma().count(where=where_clause)
 
     logger.debug(f"Retrieved {len(library_agents)} library agents for user #{user_id}")

--- a/autogpt_platform/backend/backend/api/features/library/model.py
+++ b/autogpt_platform/backend/backend/api/features/library/model.py
@@ -560,6 +560,7 @@ class LibraryAgentSort(str, Enum):
 
     CREATED_AT = "createdAt"
     UPDATED_AT = "updatedAt"
+    LAST_EXECUTED = "lastExecuted"
 
 
 class LibraryAgentUpdateRequest(pydantic.BaseModel):

--- a/autogpt_platform/frontend/src/app/(platform)/library/components/LibrarySortMenu/LibrarySortMenu.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/components/LibrarySortMenu/LibrarySortMenu.tsx
@@ -25,10 +25,13 @@ export function LibrarySortMenu({ setLibrarySort }: Props) {
       <Select onValueChange={handleSortChange}>
         <SelectTrigger className="!m-0 ml-1 w-fit space-x-1 border-none !bg-transparent px-[1rem] text-sm underline underline-offset-4 !shadow-none !ring-offset-transparent">
           <ArrowDownNarrowWideIcon className="h-4 w-4 sm:hidden" />
-          <SelectValue placeholder="Last Modified" />
+          <SelectValue placeholder="Last Executed" />
         </SelectTrigger>
         <SelectContent>
           <SelectGroup>
+            <SelectItem value={LibraryAgentSort.lastExecuted}>
+              Last Executed
+            </SelectItem>
             <SelectItem value={LibraryAgentSort.createdAt}>
               Creation Date
             </SelectItem>

--- a/autogpt_platform/frontend/src/app/(platform)/library/components/LibrarySortMenu/useLibrarySortMenu.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/library/components/LibrarySortMenu/useLibrarySortMenu.ts
@@ -15,8 +15,10 @@ export function useLibrarySortMenu({ setLibrarySort }: Props) {
         return "Creation Date";
       case LibraryAgentSort.updatedAt:
         return "Last Modified";
+      case LibraryAgentSort.lastExecuted:
+        return "Last Executed";
       default:
-        return "Last Modified";
+        return "Last Executed";
     }
   };
 

--- a/autogpt_platform/frontend/src/app/(platform)/library/components/useLibraryListPage.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/library/components/useLibraryListPage.ts
@@ -14,11 +14,11 @@ export function useLibraryListPage() {
   // Ensure sort param is always present in URL (even if default)
   useEffect(() => {
     if (!librarySortRaw) {
-      setLibrarySortRaw(LibraryAgentSort.updatedAt, { shallow: false });
+      setLibrarySortRaw(LibraryAgentSort.lastExecuted, { shallow: false });
     }
   }, [librarySortRaw, setLibrarySortRaw]);
 
-  const librarySort = librarySortRaw || LibraryAgentSort.updatedAt;
+  const librarySort = librarySortRaw || LibraryAgentSort.lastExecuted;
 
   const setLibrarySort = useCallback(
     (value: LibraryAgentSort) => {

--- a/autogpt_platform/frontend/src/app/api/openapi.json
+++ b/autogpt_platform/frontend/src/app/api/openapi.json
@@ -13286,7 +13286,7 @@
       },
       "LibraryAgentSort": {
         "type": "string",
-        "enum": ["createdAt", "updatedAt"],
+        "enum": ["createdAt", "updatedAt", "lastExecuted"],
         "title": "LibraryAgentSort",
         "description": "Possible sort options for sorting library agents."
       },

--- a/autogpt_platform/frontend/src/lib/autogpt-server-api/types.ts
+++ b/autogpt_platform/frontend/src/lib/autogpt-server-api/types.ts
@@ -600,6 +600,7 @@ export type LibraryAgentPresetUpdatable = Partial<
 export enum LibraryAgentSortEnum {
   CREATED_AT = "createdAt",
   UPDATED_AT = "updatedAt",
+  LAST_EXECUTED = "lastExecuted",
 }
 
 /* *** CREDENTIALS *** */


### PR DESCRIPTION
### Why / What / How

**Why:** Issue #9860 requests that the Library page sorts agents by "most recently ran" so users can quickly find agents they've been actively using.

**What:** Adds a "Last Executed" sort option to the Library page. Agents with recent executions appear first (newest execution timestamp), while agents without executions fall back to `createdAt` ordering.

**How:** 
- Backend: Added `LAST_EXECUTED` to `LibraryAgentSort` enum. The query fetches agents with their latest execution timestamp (limit=1), then sorts in-memory: executed agents first by newest execution, non-executed agents by creation date.
- Frontend: Updated the sort menu component, hook, and page default to include and use the new sort option.

### Changes 🏗️

- `backend/api/features/library/model.py` — Added `LAST_EXECUTED = "lastExecuted"` enum value
- `backend/api/features/library/db.py` — Added sorting logic that fetches latest execution per agent and sorts accordingly
- `frontend/src/app/(platform)/library/components/LibrarySortMenu/LibrarySortMenu.tsx` — Added "Last Executed" menu item
- `frontend/src/app/(platform)/library/components/LibrarySortMenu/useLibrarySortMenu.ts` — Added label for new sort option
- `frontend/src/app/(platform)/library/components/useLibraryListPage.ts` — Changed default sort to `lastExecuted`
- `frontend/src/app/api/openapi.json` — Added enum value to schema
- `frontend/src/lib/autogpt-server-api/types.ts` — Added enum value to TS types

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Python files compile cleanly (`python3 -m py_compile`)
  - [x] Frontend API client regenerated (`pnpm generate:api`)
  - [ ] Manual test: open Library page, verify "Last Executed" sort option appears and reorders agents
  - [ ] Manual test: run an agent, return to Library, verify it appears at top
