### PR TITLE
fix(frontend): preserve cursor position when editing notes

### DIFF
--- a/autogpt_platform/frontend/src/components/renderers/InputRenderer/base/standard/widgets/TextInput/TextWidget.tsx
+++ b/autogpt_platform/frontend/src/components/renderers/InputRenderer/base/standard/widgets/TextInput/TextWidget.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState, useEffect } from "react";
 import { WidgetProps } from "@rjsf/utils";
 import {
   InputType,
@@ -88,9 +88,32 @@ export default function TextWidget(props: WidgetProps) {
     config.htmlType === "password" ||
     config.htmlType === "textarea";
 
+  const noteRef = useRef<HTMLTextAreaElement>(null);
+  const cursorPosRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (
+      uiType === BlockUIType.NOTE &&
+      noteRef.current &&
+      cursorPosRef.current !== null
+    ) {
+      noteRef.current.selectionStart = cursorPosRef.current;
+      noteRef.current.selectionEnd = cursorPosRef.current;
+      cursorPosRef.current = null;
+    }
+  });
+
   if (uiType === BlockUIType.NOTE) {
+    const handleNoteChange = (
+      e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+    ) => {
+      cursorPosRef.current = e.target.selectionStart;
+      handleChange(e);
+    };
+
     return (
       <Input
+        ref={noteRef}
         id={props.id}
         hideLabel={true}
         type={"textarea"}
@@ -99,7 +122,7 @@ export default function TextWidget(props: WidgetProps) {
         wrapperClassName="mb-0"
         value={props.value ?? ""}
         className="!h-[230px] resize-none rounded-none border-none bg-transparent p-0 placeholder:text-black/60 focus:ring-0"
-        onChange={handleChange}
+        onChange={handleNoteChange}
         placeholder={"Write your note here..."}
         required={props.required}
         disabled={props.disabled}


### PR DESCRIPTION
### Why / What / How

**Why:** Editing text in a sticky note block causes the cursor to jump to the bottom of the textarea on every keystroke, making it impossible to edit text at the top or middle of the note. Reported in #9252.

**What:** Preserve the cursor (caret) position in the notes textarea across re-renders triggered by state updates.

**How:** When the user types in the note textarea, we capture `selectionStart` into a ref before propagating the change event. After React re-renders with the new value (which normally resets cursor to end), a `useEffect` restores the saved cursor position from the ref. This is a standard pattern for controlled textareas that receive their value from external state.

### Changes 🏗️

- `autogpt_platform/frontend/src/components/renderers/InputRenderer/base/standard/widgets/TextInput/TextWidget.tsx`:
  - Added `useRef` and `useEffect` imports
  - Added `noteRef` (textarea element ref) and `cursorPosRef` (cursor position ref)
  - Added a post-render `useEffect` that restores cursor position for NOTE-type inputs
  - Created `handleNoteChange` wrapper that saves `selectionStart` before calling the existing `handleChange`
  - Passed `ref={noteRef}` to the Note `<Input>` component

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `pnpm format` passes with no changes
  - [x] `pnpm types` passes with no errors
  - [x] `pnpm lint` passes with no new warnings/errors
  - [x] Verified the fix logic: cursor position is saved before state update and restored after re-render
