### PR TITLE
fix(backend/copilot-bot): only answer other bots when @mentioned

### DIFF
--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter.py
@@ -222,9 +222,13 @@ class DiscordAdapter(PlatformAdapter):
             await self._on_message_callback(ctx, self)
 
     def _should_ignore_message(self, message: discord.Message) -> bool:
-        return (
-            self._client.user is not None and message.author.id == self._client.user.id
-        )
+        if self._client.user is not None and message.author.id == self._client.user.id:
+            return True
+        # Other bots reach us only by @mentioning us; without this gate two
+        # bots in a shared thread (our own dev + prod included) loop forever.
+        if message.author.bot:
+            return not self._is_mentioned(message)
+        return False
 
     def _is_mentioned(self, message: discord.Message) -> bool:
         if message.guild is None:

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter_test.py
@@ -143,10 +143,24 @@ class TestShouldIgnoreMessage:
 
         assert adapter._should_ignore_message(msg) is True
 
-    def test_allows_other_bot_message(self):
-        adapter, _ = _bare_adapter(bot_id=1000)
+    def test_ignores_unmentioned_bot_message(self):
+        # A bot that doesn't @mention us is skipped — otherwise two bots
+        # sharing a thread (our own dev + prod included) loop forever.
+        adapter, client = _bare_adapter(bot_id=1000)
         msg = _message("hi", [])
         msg.author = MagicMock(id=2000, bot=True)
+        msg.guild = MagicMock()
+        client.user.mentioned_in.return_value = False
+
+        assert adapter._should_ignore_message(msg) is True
+
+    def test_allows_mentioned_bot_message(self):
+        # Another bot can still reach us by explicitly @mentioning us.
+        adapter, client = _bare_adapter(bot_id=1000)
+        msg = _message("hi", [])
+        msg.author = MagicMock(id=2000, bot=True)
+        msg.guild = MagicMock()
+        client.user.mentioned_in.return_value = True
 
         assert adapter._should_ignore_message(msg) is False
 


### PR DESCRIPTION
### Why / What / How

**Why:** Two AutoPilot deployments (prod + AutoPilot-Dev) sharing a Discord server fell into an infinite feedback loop. Both were subscribed to the same thread, so each one kept answering the other's replies — forever.

PR #13039 ("allow bot-to-bot") swapped the original `if message.author.bot: return` skip for a self-ID-only check, on the assumption that the @mention requirement (channels) and thread-subscription requirement (threads) would bound bot-to-bot traffic. They don't: a sibling deployment is a *different user ID*, so the self-ID check never catches it, and once both bots subscribe to a thread the subscription gate is satisfied for **each** of them.

**What:** `_should_ignore_message` (Discord adapter) now ignores another bot's message **unless that bot explicitly @mentions us**. Our own messages are still always skipped; human messages are unaffected.

**How:** Three guard branches:
1. Author is us → ignore (Discord echoes our own sends back over the gateway).
2. Author is another bot → ignore *unless* `_is_mentioned()` (the bot @mentioned us).
3. Otherwise (human) → don't ignore.

This kills the silent thread loop — a plain bot reply with no @mention is dropped — while keeping the intentional bot-to-bot path open: a bot that explicitly addresses AutoPilot still gets a response.

> Residual note: two bots that @mention *each other* every turn can still loop. That is a much narrower failure mode and is the deliberate "bots can talk" path, so it is intentionally left open. A turn-count circuit breaker can be added later if needed.

### Changes 🏗️

- `_should_ignore_message` (Discord adapter): skip another bot's message unless it @mentions us; the existing self-skip is preserved.
- Tests: replaced `test_allows_other_bot_message` with `test_ignores_unmentioned_bot_message` (regression test for the loop) and `test_allows_mentioned_bot_message`.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `test_ignores_unmentioned_bot_message` fails against the pre-fix code (reproduces the loop) and passes after the fix
  - [x] `test_allows_mentioned_bot_message` confirms an explicit @mention from another bot still gets through
  - [x] Full Discord adapter suite green (`poetry run pytest backend/copilot/bot/adapters/discord/adapter_test.py` — 42 passed), `black` + `ruff` clean
