### PR TITLE
fix(backend): teach LlmModel about OpenRouter Anthropic aliases + dry-run sim default Haiku OR-slug

### DIFF
--- a/autogpt_platform/backend/backend/blocks/llm.py
+++ b/autogpt_platform/backend/backend/blocks/llm.py
@@ -116,11 +116,44 @@ class LlmModelMeta(EnumMeta):
     pass
 
 
+# OpenRouter exposes Anthropic models under canonical ``anthropic/<model>``
+# slugs that drop the snapshot-date suffix Anthropic's own API uses
+# (``claude-haiku-4-5-20251001`` → ``anthropic/claude-haiku-4-5``).  The
+# generic provider-prefix strip in ``_missing_`` can't reverse the date
+# truncation, so map the OpenRouter slugs to the canonical direct-Anthropic
+# enum values here.  Only models that exist on OpenRouter need entries; the
+# newer 4.6/4.7 enum values already lack a snapshot date so the prefix
+# strip alone is enough for them.
+_OPENROUTER_ALIASES: dict[str, str] = {
+    "anthropic/claude-haiku-4-5": "claude-haiku-4-5-20251001",
+    "anthropic/claude-opus-4-5": "claude-opus-4-5-20251101",
+    "anthropic/claude-sonnet-4-5": "claude-sonnet-4-5-20250929",
+}
+
+
 class LlmModel(str, Enum, metaclass=LlmModelMeta):
     @classmethod
     def _missing_(cls, value: object) -> "LlmModel | None":
-        """Handle provider-prefixed model names like 'anthropic/claude-sonnet-4-6'."""
-        if isinstance(value, str) and "/" in value:
+        """Resolve provider-prefixed model names.
+
+        Handles two shapes:
+
+        1. OpenRouter aliases for Anthropic models whose direct-API
+           identifier carries a snapshot suffix that the OpenRouter slug
+           drops — e.g. ``anthropic/claude-haiku-4-5`` ↔ enum value
+           ``claude-haiku-4-5-20251001``.  Looked up via
+           ``_OPENROUTER_ALIASES``.
+        2. Generic provider prefix strip — e.g.
+           ``anthropic/claude-sonnet-4-6`` → ``claude-sonnet-4-6``.
+        """
+        if not isinstance(value, str):
+            return None
+        if value in _OPENROUTER_ALIASES:
+            try:
+                return cls(_OPENROUTER_ALIASES[value])
+            except ValueError:
+                return None
+        if "/" in value:
             stripped = value.split("/", 1)[1]
             try:
                 return cls(stripped)

--- a/autogpt_platform/backend/backend/blocks/llm.py
+++ b/autogpt_platform/backend/backend/blocks/llm.py
@@ -8,6 +8,7 @@ import secrets
 from abc import ABC
 from enum import Enum, EnumMeta
 from json import JSONDecodeError
+from collections.abc import Mapping
 from typing import Any, Iterable, List, Literal, NamedTuple, Optional, cast
 
 import anthropic
@@ -116,21 +117,6 @@ class LlmModelMeta(EnumMeta):
     pass
 
 
-# OpenRouter exposes Anthropic models under canonical ``anthropic/<model>``
-# slugs that drop the snapshot-date suffix Anthropic's own API uses
-# (``claude-haiku-4-5-20251001`` → ``anthropic/claude-haiku-4-5``).  The
-# generic provider-prefix strip in ``_missing_`` can't reverse the date
-# truncation, so map the OpenRouter slugs to the canonical direct-Anthropic
-# enum values here.  Only models that exist on OpenRouter need entries; the
-# newer 4.6/4.7 enum values already lack a snapshot date so the prefix
-# strip alone is enough for them.
-_OPENROUTER_ALIASES: dict[str, str] = {
-    "anthropic/claude-haiku-4-5": "claude-haiku-4-5-20251001",
-    "anthropic/claude-opus-4-5": "claude-opus-4-5-20251101",
-    "anthropic/claude-sonnet-4-5": "claude-sonnet-4-5-20250929",
-}
-
-
 class LlmModel(str, Enum, metaclass=LlmModelMeta):
     @classmethod
     def _missing_(cls, value: object) -> "LlmModel | None":
@@ -142,17 +128,16 @@ class LlmModel(str, Enum, metaclass=LlmModelMeta):
            identifier carries a snapshot suffix that the OpenRouter slug
            drops — e.g. ``anthropic/claude-haiku-4-5`` ↔ enum value
            ``claude-haiku-4-5-20251001``.  Looked up via
-           ``_OPENROUTER_ALIASES``.
+           ``_OPENROUTER_ALIASES`` (defined below the class so it can hold
+           ``LlmModel`` members directly).
         2. Generic provider prefix strip — e.g.
            ``anthropic/claude-sonnet-4-6`` → ``claude-sonnet-4-6``.
         """
         if not isinstance(value, str):
             return None
-        if value in _OPENROUTER_ALIASES:
-            try:
-                return cls(_OPENROUTER_ALIASES[value])
-            except ValueError:
-                return None
+        alias = _OPENROUTER_ALIASES.get(value)
+        if alias is not None:
+            return alias
         if "/" in value:
             stripped = value.split("/", 1)[1]
             try:
@@ -292,6 +277,24 @@ class LlmModel(str, Enum, metaclass=LlmModelMeta):
     @property
     def max_output_tokens(self) -> int | None:
         return self.metadata.max_output_tokens
+
+
+# OpenRouter exposes Anthropic models under canonical ``anthropic/<model>``
+# slugs that drop the snapshot-date suffix Anthropic's own API uses
+# (``claude-haiku-4-5-20251001`` → ``anthropic/claude-haiku-4-5``). The
+# generic provider-prefix strip in ``_missing_`` can't reverse the date
+# truncation, so map the OpenRouter slugs to ``LlmModel`` members here.
+# Only models whose canonical enum value carries a ``-YYYYMMDD`` snapshot
+# suffix need entries; values without a snapshot (4.6/4.7+) are already
+# covered by the prefix-strip path alone. Stored as ``LlmModel`` instances
+# (not strings) so a rename or snapshot rotation on the enum follows the
+# alias automatically — a stale entry becomes a load-time ``AttributeError``
+# rather than a silent ``_missing_`` miss at runtime.
+_OPENROUTER_ALIASES: Mapping[str, LlmModel] = {
+    "anthropic/claude-haiku-4-5": LlmModel.CLAUDE_4_5_HAIKU,
+    "anthropic/claude-opus-4-5": LlmModel.CLAUDE_4_5_OPUS,
+    "anthropic/claude-sonnet-4-5": LlmModel.CLAUDE_4_5_SONNET,
+}
 
 
 MODEL_METADATA = {

--- a/autogpt_platform/backend/backend/blocks/llm.py
+++ b/autogpt_platform/backend/backend/blocks/llm.py
@@ -6,9 +6,9 @@ import math
 import re
 import secrets
 from abc import ABC
+from collections.abc import Mapping
 from enum import Enum, EnumMeta
 from json import JSONDecodeError
-from collections.abc import Mapping
 from typing import Any, Iterable, List, Literal, NamedTuple, Optional, cast
 
 import anthropic

--- a/autogpt_platform/backend/backend/blocks/test/test_llm.py
+++ b/autogpt_platform/backend/backend/blocks/test/test_llm.py
@@ -1,4 +1,5 @@
 import asyncio
+import re
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -1581,3 +1582,23 @@ class TestLlmModelMissingHandler:
         # additive shortcut, not a silent catch-all.
         with pytest.raises(ValueError):
             llm.LlmModel("anthropic/claude-haiku-999")
+
+    def test_all_claude_snapshots_reachable_via_openrouter_slug(self) -> None:
+        """Every Claude enum value whose canonical form carries a trailing
+        ``-YYYYMMDD`` snapshot suffix must be reachable via the OpenRouter
+        ``anthropic/<base>`` slug — otherwise the dry-run simulator (and any
+        other caller passing the OpenRouter form) hits ``_missing_``'s
+        prefix-strip path with a string the enum doesn't recognise and
+        validation fails. Catches the drift class where a new snapshot-
+        dated Claude member is added without updating ``_OPENROUTER_ALIASES``.
+        """
+        snapshot_re = re.compile(r"^claude-(.+)-\d{8}$")
+        for member in llm.LlmModel:
+            match = snapshot_re.match(member.value)
+            if match is None:
+                continue
+            slug = f"anthropic/{match.group(1)}"
+            assert llm.LlmModel(slug) is member, (
+                f"OpenRouter alias missing for {member.value} — expected slug "
+                f"{slug!r} to resolve back to {member.name}"
+            )

--- a/autogpt_platform/backend/backend/blocks/test/test_llm.py
+++ b/autogpt_platform/backend/backend/blocks/test/test_llm.py
@@ -1047,9 +1047,9 @@ class TestUserErrorStatusCodeHandling:
                 async for _ in block.run(input_data, credentials=llm.TEST_CREDENTIALS):
                     pass
 
-        assert (
-            call_count == 1
-        ), f"Expected exactly 1 call for status {status_code}, got {call_count}"
+        assert call_count == 1, (
+            f"Expected exactly 1 call for status {status_code}, got {call_count}"
+        )
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("status_code", [401, 403, 429])
@@ -1078,9 +1078,9 @@ class TestUserErrorStatusCodeHandling:
                 async for _ in block.run(input_data, credentials=llm.TEST_CREDENTIALS):
                     pass
 
-        assert (
-            call_count == 1
-        ), f"Expected exactly 1 call for status {status_code}, got {call_count}"
+        assert call_count == 1, (
+            f"Expected exactly 1 call for status {status_code}, got {call_count}"
+        )
 
     @pytest.mark.asyncio
     async def test_server_error_retries(self):
@@ -1108,9 +1108,9 @@ class TestUserErrorStatusCodeHandling:
                 async for _ in block.run(input_data, credentials=llm.TEST_CREDENTIALS):
                     pass
 
-        assert (
-            call_count > 1
-        ), f"Expected multiple retry attempts for 500, got {call_count}"
+        assert call_count > 1, (
+            f"Expected multiple retry attempts for 500, got {call_count}"
+        )
 
     @pytest.mark.asyncio
     async def test_user_error_logs_warning_not_exception(self):
@@ -1344,9 +1344,9 @@ class TestAnthropicCacheControl:
         an_tools = captured_kwargs.get("tools")
         assert isinstance(an_tools, list)
         assert len(an_tools) == 2
-        assert (
-            an_tools[0].get("cache_control") is None
-        ), "Only last tool gets cache_control"
+        assert an_tools[0].get("cache_control") is None, (
+            "Only last tool gets cache_control"
+        )
         assert an_tools[-1].get("cache_control") == {"type": "ephemeral"}
 
     @pytest.mark.asyncio
@@ -1382,9 +1382,9 @@ class TestAnthropicCacheControl:
         import anthropic
 
         tools_arg = captured_kwargs.get("tools")
-        assert (
-            tools_arg is anthropic.NOT_GIVEN
-        ), "Empty tools should pass anthropic.NOT_GIVEN sentinel"
+        assert tools_arg is anthropic.NOT_GIVEN, (
+            "Empty tools should pass anthropic.NOT_GIVEN sentinel"
+        )
 
     @pytest.mark.asyncio
     async def test_empty_system_prompt_omits_system_key(self):
@@ -1416,9 +1416,9 @@ class TestAnthropicCacheControl:
                 max_tokens=50,
             )
 
-        assert (
-            "system" not in captured_kwargs
-        ), "system must be omitted when sysprompt is empty to avoid Anthropic 400"
+        assert "system" not in captured_kwargs, (
+            "system must be omitted when sysprompt is empty to avoid Anthropic 400"
+        )
 
     @pytest.mark.asyncio
     async def test_whitespace_only_system_prompt_omits_system_key(self):
@@ -1454,9 +1454,9 @@ class TestAnthropicCacheControl:
                 max_tokens=50,
             )
 
-        assert (
-            "system" not in captured_kwargs
-        ), "whitespace-only sysprompt must be omitted to avoid Anthropic 400"
+        assert "system" not in captured_kwargs, (
+            "whitespace-only sysprompt must be omitted to avoid Anthropic 400"
+        )
 
 
 class TestLLMRequestTimeout:
@@ -1545,6 +1545,39 @@ class TestLLMRequestTimeout:
                 async for _ in block.run(input_data, credentials=llm.TEST_CREDENTIALS):
                     pass
 
+        assert call_count["n"] == 1, (
+            f"Expected exactly 1 call (no retry on timeout), got {call_count['n']}"
+        )
+
+
+class TestLlmModelMissingHandler:
+    """``LlmModel._missing_`` resolves provider-prefixed slugs back to enum
+    members.  Used by the dry-run simulator to send an OpenRouter slug
+    (``anthropic/claude-haiku-4-5``) that OpenRouter's OpenAI-compat endpoint
+    accepts, while still validating through ``OrchestratorBlock.Input.model``
+    which is typed as ``LlmModel``."""
+
+    def test_openrouter_alias_maps_to_canonical(self) -> None:
+        # The OpenRouter slug for Haiku 4.5 drops the snapshot suffix that
+        # Anthropic's direct API uses — pure prefix strip wouldn't find it,
+        # so the alias map is required.
         assert (
-            call_count["n"] == 1
-        ), f"Expected exactly 1 call (no retry on timeout), got {call_count['n']}"
+            llm.LlmModel("anthropic/claude-haiku-4-5") is llm.LlmModel.CLAUDE_4_5_HAIKU
+        )
+        assert llm.LlmModel("anthropic/claude-opus-4-5") is llm.LlmModel.CLAUDE_4_5_OPUS
+        assert (
+            llm.LlmModel("anthropic/claude-sonnet-4-5")
+            is llm.LlmModel.CLAUDE_4_5_SONNET
+        )
+
+    def test_prefix_strip_still_works(self) -> None:
+        # 4.6/4.7 enum values already match OpenRouter's slug after prefix
+        # strip — no alias-map entry needed.
+        assert llm.LlmModel("anthropic/claude-opus-4-7") is llm.LlmModel.CLAUDE_4_7_OPUS
+        assert llm.LlmModel("anthropic/claude-opus-4-6") is llm.LlmModel.CLAUDE_4_6_OPUS
+
+    def test_unknown_slug_raises(self) -> None:
+        # Bare unknown strings still fail loudly — the alias map is an
+        # additive shortcut, not a silent catch-all.
+        with pytest.raises(ValueError):
+            llm.LlmModel("anthropic/claude-haiku-999")

--- a/autogpt_platform/backend/backend/blocks/test/test_llm.py
+++ b/autogpt_platform/backend/backend/blocks/test/test_llm.py
@@ -1592,7 +1592,10 @@ class TestLlmModelMissingHandler:
         validation fails. Catches the drift class where a new snapshot-
         dated Claude member is added without updating ``_OPENROUTER_ALIASES``.
         """
-        snapshot_re = re.compile(r"^claude-(.+)-\d{8}$")
+        # Capture the full ``claude-...`` base so the OpenRouter slug is
+        # constructed correctly: ``claude-haiku-4-5-20251001`` →
+        # ``anthropic/claude-haiku-4-5`` (NOT ``anthropic/haiku-4-5``).
+        snapshot_re = re.compile(r"^(claude-.+)-\d{8}$")
         for member in llm.LlmModel:
             match = snapshot_re.match(member.value)
             if match is None:

--- a/autogpt_platform/backend/backend/blocks/test/test_llm.py
+++ b/autogpt_platform/backend/backend/blocks/test/test_llm.py
@@ -1048,9 +1048,9 @@ class TestUserErrorStatusCodeHandling:
                 async for _ in block.run(input_data, credentials=llm.TEST_CREDENTIALS):
                     pass
 
-        assert call_count == 1, (
-            f"Expected exactly 1 call for status {status_code}, got {call_count}"
-        )
+        assert (
+            call_count == 1
+        ), f"Expected exactly 1 call for status {status_code}, got {call_count}"
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("status_code", [401, 403, 429])
@@ -1079,9 +1079,9 @@ class TestUserErrorStatusCodeHandling:
                 async for _ in block.run(input_data, credentials=llm.TEST_CREDENTIALS):
                     pass
 
-        assert call_count == 1, (
-            f"Expected exactly 1 call for status {status_code}, got {call_count}"
-        )
+        assert (
+            call_count == 1
+        ), f"Expected exactly 1 call for status {status_code}, got {call_count}"
 
     @pytest.mark.asyncio
     async def test_server_error_retries(self):
@@ -1109,9 +1109,9 @@ class TestUserErrorStatusCodeHandling:
                 async for _ in block.run(input_data, credentials=llm.TEST_CREDENTIALS):
                     pass
 
-        assert call_count > 1, (
-            f"Expected multiple retry attempts for 500, got {call_count}"
-        )
+        assert (
+            call_count > 1
+        ), f"Expected multiple retry attempts for 500, got {call_count}"
 
     @pytest.mark.asyncio
     async def test_user_error_logs_warning_not_exception(self):
@@ -1345,9 +1345,9 @@ class TestAnthropicCacheControl:
         an_tools = captured_kwargs.get("tools")
         assert isinstance(an_tools, list)
         assert len(an_tools) == 2
-        assert an_tools[0].get("cache_control") is None, (
-            "Only last tool gets cache_control"
-        )
+        assert (
+            an_tools[0].get("cache_control") is None
+        ), "Only last tool gets cache_control"
         assert an_tools[-1].get("cache_control") == {"type": "ephemeral"}
 
     @pytest.mark.asyncio
@@ -1383,9 +1383,9 @@ class TestAnthropicCacheControl:
         import anthropic
 
         tools_arg = captured_kwargs.get("tools")
-        assert tools_arg is anthropic.NOT_GIVEN, (
-            "Empty tools should pass anthropic.NOT_GIVEN sentinel"
-        )
+        assert (
+            tools_arg is anthropic.NOT_GIVEN
+        ), "Empty tools should pass anthropic.NOT_GIVEN sentinel"
 
     @pytest.mark.asyncio
     async def test_empty_system_prompt_omits_system_key(self):
@@ -1417,9 +1417,9 @@ class TestAnthropicCacheControl:
                 max_tokens=50,
             )
 
-        assert "system" not in captured_kwargs, (
-            "system must be omitted when sysprompt is empty to avoid Anthropic 400"
-        )
+        assert (
+            "system" not in captured_kwargs
+        ), "system must be omitted when sysprompt is empty to avoid Anthropic 400"
 
     @pytest.mark.asyncio
     async def test_whitespace_only_system_prompt_omits_system_key(self):
@@ -1455,9 +1455,9 @@ class TestAnthropicCacheControl:
                 max_tokens=50,
             )
 
-        assert "system" not in captured_kwargs, (
-            "whitespace-only sysprompt must be omitted to avoid Anthropic 400"
-        )
+        assert (
+            "system" not in captured_kwargs
+        ), "whitespace-only sysprompt must be omitted to avoid Anthropic 400"
 
 
 class TestLLMRequestTimeout:
@@ -1546,9 +1546,9 @@ class TestLLMRequestTimeout:
                 async for _ in block.run(input_data, credentials=llm.TEST_CREDENTIALS):
                     pass
 
-        assert call_count["n"] == 1, (
-            f"Expected exactly 1 call (no retry on timeout), got {call_count['n']}"
-        )
+        assert (
+            call_count["n"] == 1
+        ), f"Expected exactly 1 call (no retry on timeout), got {call_count['n']}"
 
 
 class TestLlmModelMissingHandler:

--- a/autogpt_platform/backend/backend/copilot/config.py
+++ b/autogpt_platform/backend/backend/copilot/config.py
@@ -7,7 +7,6 @@ from urllib.parse import urlparse
 from pydantic import AliasChoices, Field, field_validator, model_validator
 from pydantic_settings import BaseSettings
 
-from backend.blocks.llm import LlmModel
 from backend.util.clients import OPENROUTER_BASE_URL
 
 
@@ -111,14 +110,17 @@ class ChatConfig(BaseSettings):
         "via env without code changes.",
     )
     simulation_model: str = Field(
-        default=LlmModel.CLAUDE_4_5_HAIKU.value,
-        description="Model for dry-run block simulation. Must be a real LlmModel "
-        "slug — OrchestratorBlock's input validates this against the enum, and a "
-        "bad value here breaks every dry-run of an agent that contains an "
-        "Orchestrator. Default is Claude Haiku 4.5 because the Orchestrator "
-        "dry-run picks tools and produces a finish message, so a substitute "
-        "with stronger reasoning gives a more faithful preview than Flash-Lite "
-        "while staying cheap.",
+        default="anthropic/claude-haiku-4-5",
+        description="Model for dry-run block simulation. Must be in "
+        "OpenRouter ``<vendor>/<model>`` format AND resolvable through "
+        "``LlmModel`` (directly or via ``LlmModel._missing_``'s "
+        "``_OPENROUTER_ALIASES`` map). The LLM-simulation path hits "
+        "OpenRouter's OpenAI-compat endpoint, which rejects direct-Anthropic "
+        "snapshot IDs like ``claude-haiku-4-5-20251001`` with HTTP 400. "
+        "OrchestratorBlock validates this against ``LlmModel``, so it must "
+        "resolve there. Haiku 4.5 via OpenRouter is already used in "
+        "production for ``title_model``, so it's battle-tested through "
+        "this same client.",
     )
     api_key: str | None = Field(default=None, description="OpenAI API key")
     base_url: str | None = Field(

--- a/autogpt_platform/backend/backend/executor/simulator.py
+++ b/autogpt_platform/backend/backend/executor/simulator.py
@@ -39,7 +39,6 @@ from openai.types import CompletionUsage
 
 from backend.blocks.agent import AgentExecutorBlock
 from backend.blocks.io import AgentInputBlock, AgentOutputBlock
-from backend.blocks.llm import LlmModel
 from backend.blocks.orchestrator import OrchestratorBlock
 from backend.copilot.token_tracking import persist_and_record_usage
 from backend.util.clients import get_openai_client
@@ -48,13 +47,23 @@ logger = logging.getLogger(__name__)
 
 
 # Default simulator model — Claude Haiku 4.5 via the platform's OpenRouter
-# credential.  Dry-run isn't pure shape-matching for the Orchestrator block:
-# it picks tools and produces a finish message, so the substitute model's
-# reasoning quality affects how faithful the preview is.  Haiku 4.5 keeps
-# the substitute small/cheap while giving materially better tool-use
-# decisions than Flash-Lite.  Configurable via ChatConfig.simulation_model
-# (CHAT_SIMULATION_MODEL env var) — value must be a real LlmModel slug.
-_DEFAULT_SIMULATOR_MODEL = LlmModel.CLAUDE_4_5_HAIKU.value
+# credential, in OpenRouter slug form (``anthropic/claude-haiku-4-5``).
+# The LLM-simulation path (``_call_llm_for_simulation``) hits OpenRouter's
+# OpenAI-compat endpoint at ``openrouter.ai/api/v1/chat/completions``,
+# which only accepts ``<vendor>/<model>`` slugs — the direct-Anthropic
+# snapshot ID ``claude-haiku-4-5-20251001`` is rejected with HTTP 400.
+# For OrchestratorBlock dry-runs, this string is parsed via
+# ``LlmModel._missing_`` (the ``_OPENROUTER_ALIASES`` table maps it back
+# to ``LlmModel.CLAUDE_4_5_HAIKU``), and the orchestrator's Anthropic SDK
+# sends the snapshot value to OpenRouter's Anthropic-compat endpoint at
+# ``openrouter.ai/api/v1/messages``, which accepts both formats.  Haiku
+# 4.5 via OpenRouter is already battle-tested for copilot title generation
+# (see ``ChatConfig.title_model``) and gives materially better tool-use
+# decisions for Orchestrator dry-runs than the Flash-Lite tier while
+# staying cheap.  Configurable via ``ChatConfig.simulation_model``
+# (``CHAT_SIMULATION_MODEL`` env var) — overrides must satisfy both
+# constraints (OpenRouter-slug shape AND resolvable through ``LlmModel``).
+_DEFAULT_SIMULATOR_MODEL = "anthropic/claude-haiku-4-5"
 
 # OpenRouter-specific extra_body flag that embeds the real generation cost on
 # the response usage object.  Same shape used by the baseline copilot service

--- a/autogpt_platform/backend/backend/executor/simulator_test.py
+++ b/autogpt_platform/backend/backend/executor/simulator_test.py
@@ -570,17 +570,28 @@ def _sim_completion(*, content: str, usage: CompletionUsage) -> ChatCompletion:
 
 
 class TestDefaultSimulatorModel:
-    """Pin the default model — anyone flipping this without a cost review
-    trips the test, and anyone setting it to a non-enum value fails the
-    LlmModel parseability check (the bug class behind SECRT-2368)."""
+    """Pin the default model — three guards.  Anyone flipping this without
+    a cost review trips the value pin.  Anyone setting it to a non-enum
+    value fails the ``LlmModel`` parseability check (the bug class behind
+    SECRT-2368).  Anyone setting it to a direct-provider snapshot ID like
+    ``claude-haiku-4-5-20251001`` fails the OpenRouter-slug check —
+    OpenRouter's OpenAI-compat endpoint, which the LLM-simulation path
+    uses, rejects anything that isn't in ``<vendor>/<model>`` form."""
 
-    def test_default_is_haiku_4_5(self) -> None:
-        assert _DEFAULT_SIMULATOR_MODEL == "claude-haiku-4-5-20251001"
+    def test_default_is_haiku_openrouter_slug(self) -> None:
+        assert _DEFAULT_SIMULATOR_MODEL == "anthropic/claude-haiku-4-5"
 
     def test_default_parses_as_llm_model(self) -> None:
-        # OrchestratorBlock.Input.model is typed as LlmModel and rejects
-        # any default that isn't an enum member — keep this guard tight.
+        # OrchestratorBlock.Input.model is typed as LlmModel; the default
+        # must resolve through the enum (either directly or via the
+        # OpenRouter-alias map in ``LlmModel._missing_``).
         assert LlmModel(_DEFAULT_SIMULATOR_MODEL) is LlmModel.CLAUDE_4_5_HAIKU
+
+    def test_default_is_openrouter_slug(self) -> None:
+        # The LLM-simulation path hits OpenRouter's OpenAI-compat endpoint,
+        # which only accepts canonical ``<vendor>/<model>`` slugs.  Anything
+        # else returns HTTP 400 even if it's a real provider model.
+        assert "/" in _DEFAULT_SIMULATOR_MODEL
 
 
 class TestExtractCostUsd:


### PR DESCRIPTION
### Why / What / How

**Why:** PR #13171 (SECRT-2368) flipped the dry-run simulator default to `LlmModel.CLAUDE_4_5_HAIKU.value` = `"claude-haiku-4-5-20251001"`. That broke every dry-run on dev because the LLM-simulation path (`_call_llm_for_simulation`) hits OpenRouter's OpenAI-compat endpoint (`/api/v1/chat/completions`), which only accepts canonical `<vendor>/<model>` slugs and returns HTTP 400 `"<id> is not a valid model ID"` for direct-Anthropic snapshot IDs. User-visible: `[SIMULATOR ERROR — NOT A BLOCK FAILURE] Failed after 5 attempts: Error code: 400 - 'claude-haiku-4-5-20251001 is not a valid model ID'`.

**Verified empirically against OpenRouter:**

| Slug | `/v1/chat/completions` (OpenAI-compat) | `/v1/messages` (Anthropic-compat) |
|---|---|---|
| `claude-haiku-4-5-20251001` (snapshot) | ❌ 400 not valid | ✅ accepted |
| `anthropic/claude-haiku-4-5` (OR slug) | ✅ accepted | ✅ accepted |
| `anthropic/claude-haiku-4-5-20251001` (prefix + snapshot) | ❌ 400 not valid | — |

So the right default for the simulator is the **OpenRouter slug** (`anthropic/claude-haiku-4-5`), and we need `LlmModel` to resolve that string back to the existing `CLAUDE_4_5_HAIKU` enum member so `OrchestratorBlock.Input.model` validation still passes.

**What:**
- Add `_OPENROUTER_ALIASES: dict[str, str]` in `backend/blocks/llm.py` mapping the three Claude 4.5 OpenRouter slugs (`anthropic/claude-haiku-4-5`, `anthropic/claude-opus-4-5`, `anthropic/claude-sonnet-4-5`) to their direct-Anthropic snapshot enum values. The newer 4.6/4.7 entries don't carry the snapshot suffix, so the existing prefix-strip path already covers them.
- Extend `LlmModel._missing_` to consult `_OPENROUTER_ALIASES` first, then fall back to the existing provider-prefix strip.
- Change `_DEFAULT_SIMULATOR_MODEL` (in `backend/executor/simulator.py`) and `ChatConfig.simulation_model` default (in `backend/copilot/config.py`) to the bare string `"anthropic/claude-haiku-4-5"`. Both files drop their now-unused `LlmModel` import.
- Update `TestDefaultSimulatorModel` to pin the new default + assert it resolves to `LlmModel.CLAUDE_4_5_HAIKU` via the alias map, plus a `"/" in default` guard so a future revert to a snapshot ID trips at unit-test time.
- New `TestLlmModelMissingHandler` covering: alias-map resolution, prefix-strip fallback, and unknown-slug raising.

**How:**
- **LLM-simulation path** (`_call_llm_for_simulation`): sends `"anthropic/claude-haiku-4-5"` straight to OpenRouter's OpenAI-compat endpoint via `get_openai_client(prefer_openrouter=True)` — accepted.
- **Orchestrator dry-run path** (`prepare_dry_run` injects `"anthropic/claude-haiku-4-5"` as `model` on `OrchestratorBlock.Input`): Pydantic calls `LlmModel("anthropic/claude-haiku-4-5")`, hits `_missing_`, alias map returns `CLAUDE_4_5_HAIKU`. The orchestrator's Anthropic SDK then sends the enum's `.value` (`"claude-haiku-4-5-20251001"`) to OpenRouter's Anthropic-compat endpoint, which accepts both formats — also fine.

**Why not duplicate enum entries?** Per reviewer feedback ("this is weird having multiple models"): adding `CLAUDE_4_5_HAIKU_OPENROUTER` alongside the existing direct-Anthropic entry would duplicate metadata + cost lookups for the same model and pull the OpenRouter/direct routing distinction into the enum itself. The alias map keeps `LlmModel` as one entry per model while still letting both identifiers resolve through the validator.

### Changes 🏗️

- `_OPENROUTER_ALIASES` map + extended `_missing_` in `LlmModel`.
- Dry-run simulator default flipped from Haiku snapshot ID to Haiku OpenRouter slug.
- New unit tests for the alias-resolution path; updated `TestDefaultSimulatorModel` pin.
- No `LlmModel` enum members added or removed → no `llm.md` regen needed.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `poetry run pytest backend/executor/simulator_test.py::TestDefaultSimulatorModel backend/executor/simulator_test.py::TestPrepareDryRun backend/copilot/tools/test_dry_run.py::test_prepare_dry_run_orchestrator_block` — all green
  - [x] `poetry run pytest backend/blocks/test/test_llm.py::TestLlmModelMissingHandler` — 3 new tests, all green
  - [x] Empirical OpenRouter probes recorded above
  - [x] Direct e2e check: `LlmModel("anthropic/claude-haiku-4-5") is LlmModel.CLAUDE_4_5_HAIKU` ✓; `LlmModel("anthropic/claude-opus-4-7") is LlmModel.CLAUDE_4_7_OPUS` ✓
  - [x] `poetry run ruff format` + `poetry run ruff check` clean on all changed files
