### PR TITLE
fix(backend/blocks): propagate tool credentials in Orchestrator dispatch

### DIFF
--- a/autogpt_platform/backend/backend/blocks/orchestrator.py
+++ b/autogpt_platform/backend/backend/blocks/orchestrator.py
@@ -1079,6 +1079,18 @@ class OrchestratorBlock(Block):
         # so the execution record is complete for from_db() reconstruction.
         merged_input_data = {**target_node.input_default, **raw_input_data}
 
+        # Merge credential metadata for the tool node. Library/AutoPilot runs
+        # ship credentials via graph_exec.nodes_input_masks instead of
+        # node.input_default; the normal queue dispatch in manager.py merges
+        # them, but the orchestrator's tool dispatch bypasses that path.
+        # Without this, tool blocks fail with missing-credentials when the
+        # agent is launched from anywhere except the Builder. (OPEN-3132)
+        nodes_input_masks = execution_processor.nodes_input_masks
+        if nodes_input_masks and (
+            sink_node_input_mask := nodes_input_masks.get(sink_node_id)
+        ):
+            merged_input_data.update(sink_node_input_mask)
+
         # Add all inputs to the execution
         if not merged_input_data:
             raise ValueError(f"Tool call has no input data: {tool_call}")
@@ -1142,7 +1154,7 @@ class OrchestratorBlock(Block):
                 tool_node_stats = await execution_processor.on_node_execution(
                     node_exec=node_exec_entry,
                     node_exec_progress=node_exec_progress,
-                    nodes_input_masks=None,
+                    nodes_input_masks=nodes_input_masks,
                     graph_stats_pair=graph_stats_pair,
                 )
                 if tool_node_stats is None:

--- a/autogpt_platform/backend/backend/blocks/orchestrator.py
+++ b/autogpt_platform/backend/backend/blocks/orchestrator.py
@@ -1084,7 +1084,7 @@ class OrchestratorBlock(Block):
         # node.input_default; the normal queue dispatch in manager.py merges
         # them, but the orchestrator's tool dispatch bypasses that path.
         # Without this, tool blocks fail with missing-credentials when the
-        # agent is launched from anywhere except the Builder. (OPEN-3132)
+        # agent is launched from anywhere except the Builder.
         nodes_input_masks = execution_processor.nodes_input_masks
         if nodes_input_masks and (
             sink_node_input_mask := nodes_input_masks.get(sink_node_id)

--- a/autogpt_platform/backend/backend/blocks/test/test_orchestrator.py
+++ b/autogpt_platform/backend/backend/blocks/test/test_orchestrator.py
@@ -915,6 +915,7 @@ async def test_orchestrator_agent_mode():
         mock_execution_processor.running_node_execution = defaultdict(MagicMock)
         mock_execution_processor.execution_stats = MagicMock()
         mock_execution_processor.execution_stats_lock = threading.Lock()
+        mock_execution_processor.nodes_input_masks = None
 
         # Mock the on_node_execution method to return successful stats
         mock_node_stats = MagicMock()
@@ -1223,9 +1224,7 @@ async def test_orchestrator_agent_falls_back_to_graph_name():
 
 @pytest.mark.asyncio
 async def test_orchestrator_tool_merges_nodes_input_masks():
-    """Regression test for OPEN-3132.
-
-    When an Orchestrator-attached tool block requires credentials and the
+    """When an Orchestrator-attached tool block requires credentials and the
     agent is launched from Library/AutoPilot, those credentials live in
     `graph_exec.nodes_input_masks` (not in `node.input_default`). The
     orchestrator's tool dispatch must merge them into the tool node's

--- a/autogpt_platform/backend/backend/blocks/test/test_orchestrator.py
+++ b/autogpt_platform/backend/backend/blocks/test/test_orchestrator.py
@@ -1219,3 +1219,199 @@ async def test_orchestrator_agent_falls_back_to_graph_name():
     assert result["type"] == "function"
     assert result["function"]["name"] == "original_agent_name"  # Graph name cleaned
     assert result["function"]["_sink_node_id"] == "test-agent-node-id"
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_tool_merges_nodes_input_masks():
+    """Regression test for OPEN-3132.
+
+    When an Orchestrator-attached tool block requires credentials and the
+    agent is launched from Library/AutoPilot, those credentials live in
+    `graph_exec.nodes_input_masks` (not in `node.input_default`). The
+    orchestrator's tool dispatch must merge them into the tool node's
+    inputs; otherwise the tool fails with a missing-credentials error.
+    """
+    from backend.blocks.orchestrator import ExecutionParams, OrchestratorBlock, ToolInfo
+
+    block = OrchestratorBlock()
+
+    sink_node_id = "test-sink-node-id"
+    credentials_field = {
+        "id": "cred-123",
+        "provider": "openai",
+        "type": "api_key",
+        "title": "Test API key",
+    }
+
+    tool_call = MagicMock()
+    tool_call.id = "call_1"
+    tool_call.function = MagicMock()
+    tool_call.function.name = "search"
+
+    tool_info = ToolInfo(
+        tool_call=tool_call,
+        tool_name="search",
+        tool_def={
+            "type": "function",
+            "function": {
+                "name": "search",
+                "_sink_node_id": sink_node_id,
+                "_field_mapping": {},
+            },
+        },
+        input_data={"query": "hello"},
+        field_mapping={},
+    )
+
+    mock_target_node = MagicMock()
+    mock_target_node.block_id = "test-block-id"
+    mock_target_node.input_default = {}  # Library path: creds NOT here
+
+    mock_node_exec_result = MagicMock()
+    mock_node_exec_result.node_exec_id = "test-tool-exec-id"
+
+    mock_db_client = AsyncMock()
+    mock_db_client.get_node.return_value = mock_target_node
+    mock_db_client.upsert_execution_input.return_value = (
+        mock_node_exec_result,
+        {"query": "hello", "credentials": credentials_field},
+    )
+    mock_db_client.get_execution_outputs_by_node_exec_id.return_value = {"result": "ok"}
+
+    mock_node_stats = MagicMock()
+    mock_node_stats.error = None
+
+    mock_execution_processor = AsyncMock()
+    mock_execution_processor.running_node_execution = defaultdict(MagicMock)
+    mock_execution_processor.execution_stats = MagicMock()
+    mock_execution_processor.execution_stats_lock = threading.Lock()
+    mock_execution_processor.on_node_execution = AsyncMock(return_value=mock_node_stats)
+    mock_execution_processor.charge_node_usage = AsyncMock(return_value=(0, 1000))
+    # The credentials live in nodes_input_masks (Library/AutoPilot path),
+    # NOT in the node's input_default.
+    mock_execution_processor.nodes_input_masks = {
+        sink_node_id: {"credentials": credentials_field},
+    }
+
+    execution_params = ExecutionParams(
+        graph_id="g",
+        graph_version=1,
+        graph_exec_id="gx",
+        node_id="orch-node-id",
+        node_exec_id="orch-node-exec-id",
+        user_id="u",
+        execution_context=ExecutionContext(human_in_the_loop_safe_mode=False),
+    )
+
+    with patch(
+        "backend.blocks.orchestrator.get_database_manager_async_client",
+        return_value=mock_db_client,
+    ):
+        await block._execute_single_tool_with_manager(
+            tool_info=tool_info,
+            execution_params=execution_params,
+            execution_processor=mock_execution_processor,
+        )
+
+    # Verify the credential metadata was upserted as an input on the tool
+    # node — this is the assertion that fails before the fix.
+    upserted_input_names = {
+        call.kwargs.get("input_name") or call.args[2]
+        for call in mock_db_client.upsert_execution_input.call_args_list
+    }
+    assert "credentials" in upserted_input_names, (
+        "Tool node did not receive credentials from nodes_input_masks — "
+        "Library/AutoPilot runs would fail with missing-credentials."
+    )
+
+    # And on_node_execution receives the same masks so downstream dispatch
+    # stays consistent with the normal queue path.
+    on_node_call = mock_execution_processor.on_node_execution.call_args
+    assert on_node_call.kwargs["nodes_input_masks"] == {
+        sink_node_id: {"credentials": credentials_field},
+    }
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_tool_works_without_nodes_input_masks():
+    """Builder path (no nodes_input_masks): tool dispatch still works."""
+    from backend.blocks.orchestrator import ExecutionParams, OrchestratorBlock, ToolInfo
+
+    block = OrchestratorBlock()
+    sink_node_id = "test-sink-node-id"
+
+    tool_call = MagicMock()
+    tool_call.id = "call_1"
+    tool_call.function = MagicMock()
+    tool_call.function.name = "search"
+
+    tool_info = ToolInfo(
+        tool_call=tool_call,
+        tool_name="search",
+        tool_def={
+            "type": "function",
+            "function": {
+                "name": "search",
+                "_sink_node_id": sink_node_id,
+                "_field_mapping": {},
+            },
+        },
+        input_data={"query": "hello"},
+        field_mapping={},
+    )
+
+    mock_target_node = MagicMock()
+    mock_target_node.block_id = "test-block-id"
+    # Builder path: credentials baked into input_default
+    mock_target_node.input_default = {
+        "credentials": {"id": "x", "provider": "p", "type": "api_key", "title": "t"}
+    }
+
+    mock_node_exec_result = MagicMock()
+    mock_node_exec_result.node_exec_id = "test-tool-exec-id"
+
+    mock_db_client = AsyncMock()
+    mock_db_client.get_node.return_value = mock_target_node
+    mock_db_client.upsert_execution_input.return_value = (
+        mock_node_exec_result,
+        {"query": "hello"},
+    )
+    mock_db_client.get_execution_outputs_by_node_exec_id.return_value = {}
+
+    mock_node_stats = MagicMock()
+    mock_node_stats.error = None
+
+    mock_execution_processor = AsyncMock()
+    mock_execution_processor.running_node_execution = defaultdict(MagicMock)
+    mock_execution_processor.execution_stats = MagicMock()
+    mock_execution_processor.execution_stats_lock = threading.Lock()
+    mock_execution_processor.on_node_execution = AsyncMock(return_value=mock_node_stats)
+    mock_execution_processor.charge_node_usage = AsyncMock(return_value=(0, 1000))
+    mock_execution_processor.nodes_input_masks = None
+
+    execution_params = ExecutionParams(
+        graph_id="g",
+        graph_version=1,
+        graph_exec_id="gx",
+        node_id="orch-node-id",
+        node_exec_id="orch-node-exec-id",
+        user_id="u",
+        execution_context=ExecutionContext(human_in_the_loop_safe_mode=False),
+    )
+
+    with patch(
+        "backend.blocks.orchestrator.get_database_manager_async_client",
+        return_value=mock_db_client,
+    ):
+        await block._execute_single_tool_with_manager(
+            tool_info=tool_info,
+            execution_params=execution_params,
+            execution_processor=mock_execution_processor,
+        )
+
+    assert mock_execution_processor.on_node_execution.call_count == 1
+    # No masks were passed through
+    assert (
+        mock_execution_processor.on_node_execution.call_args.kwargs["nodes_input_masks"]
+        is None
+    )

--- a/autogpt_platform/backend/backend/blocks/test/test_orchestrator_dynamic_fields.py
+++ b/autogpt_platform/backend/backend/blocks/test/test_orchestrator_dynamic_fields.py
@@ -622,6 +622,7 @@ async def test_validation_errors_dont_pollute_conversation():
                 mock_execution_processor = AsyncMock()
                 mock_execution_processor.execution_stats = MagicMock()
                 mock_execution_processor.execution_stats_lock = MagicMock()
+                mock_execution_processor.nodes_input_masks = None
 
                 # Create a mock NodeExecutionProgress for the sink node
                 mock_node_exec_progress = MagicMock()

--- a/autogpt_platform/backend/backend/blocks/test/test_orchestrator_responses_api.py
+++ b/autogpt_platform/backend/backend/blocks/test/test_orchestrator_responses_api.py
@@ -954,6 +954,7 @@ async def test_agent_mode_conversation_valid_for_responses_api():
     ep.running_node_execution = defaultdict(MagicMock)
     ep.execution_stats = MagicMock()
     ep.execution_stats_lock = threading.Lock()
+    ep.nodes_input_masks = None
     ns = MagicMock(error=None)
     ep.on_node_execution = AsyncMock(return_value=ns)
     # Mock charge_node_usage (called after successful tool execution).

--- a/autogpt_platform/backend/backend/executor/manager.py
+++ b/autogpt_platform/backend/backend/executor/manager.py
@@ -793,6 +793,7 @@ class ExecutionProcessor:
         set_service_name("GraphExecutor")
         self.tid = threading.get_ident()
         self.creds_manager = IntegrationCredentialsManager()
+        self.nodes_input_masks: Optional[NodesInputMasks] = None
         self.node_execution_loop = asyncio.new_event_loop()
         self.node_evaluation_loop = asyncio.new_event_loop()
         self.node_execution_thread = threading.Thread(
@@ -963,6 +964,11 @@ class ExecutionProcessor:
         self.running_node_evaluation: dict[str, Future] = {}
         self.execution_stats = execution_stats
         self.execution_stats_lock = execution_stats_lock
+        # Expose nodes_input_masks so OrchestratorBlock tool dispatch can
+        # merge credential metadata into tool node inputs. The normal queue
+        # dispatch below merges it directly into queued_node_exec.inputs;
+        # the orchestrator path bypasses the queue and reads from here.
+        self.nodes_input_masks = graph_exec.nodes_input_masks
         execution_queue = ExecutionQueue[NodeExecutionEntry]()
 
         running_node_execution = self.running_node_execution


### PR DESCRIPTION
### Why / What / How

**Why** — Linear [OPEN-3132](https://linear.app/autogpt/issue/OPEN-3132/orchestrator-tool-credentials-missing-when-run-from-library-or) (Urgent / production). Agents built with `OrchestratorBlock` + a credential-bearing tool block run fine from the Builder but fail with a missing-credentials error when launched from the Library or AutoPilot.

Root cause: the Builder persists credential metadata into `node.input_default`, so it travels with the node. Library/AutoPilot strip that and instead ship credentials separately in `graph_exec.nodes_input_masks`. The normal queue dispatch in `manager._on_graph_execution` merges those masks into the queued node's inputs — but `OrchestratorBlock._execute_single_tool_with_manager` dispatches tool calls directly through `on_node_execution`, bypassing that merge step. The tool node therefore runs without its credentials.

**What** — Make the orchestrator's tool-dispatch path honour `nodes_input_masks`, matching the behaviour of the normal queue dispatch.

**How**
- `ExecutionProcessor` now stores `nodes_input_masks` on the instance (initialised to `None` in `on_graph_executor_start`, set per-execution in `_on_graph_execution`).
- `_execute_single_tool_with_manager` reads the mask for the sink node and merges it into `merged_input_data` before calling `upsert_execution_input`.
- The same `nodes_input_masks` is now forwarded to `on_node_execution` (was hardcoded `None`) so downstream dispatch from the tool node stays consistent with the normal path.

### Changes 🏗️

- `backend/executor/manager.py`
  - `ExecutionProcessor.on_graph_executor_start`: declare `self.nodes_input_masks: Optional[NodesInputMasks] = None` so the attribute is always defined.
  - `ExecutionProcessor._on_graph_execution`: set `self.nodes_input_masks = graph_exec.nodes_input_masks` alongside the other per-execution state holders.
- `backend/blocks/orchestrator.py`
  - `_execute_single_tool_with_manager`: merge `execution_processor.nodes_input_masks[sink_node_id]` into the tool node's inputs before upsert.
  - Same function: pass `nodes_input_masks` to `on_node_execution` instead of `None`.
- `backend/blocks/test/test_orchestrator.py`: two new regression tests covering the Library/AutoPilot path (creds in `nodes_input_masks`) and the Builder path (creds in `input_default`, masks `None`).
- `backend/blocks/test/test_orchestrator_responses_api.py`, `backend/blocks/test/test_orchestrator_dynamic_fields.py`: pin `mock_execution_processor.nodes_input_masks = None` so existing mocks keep the Builder path now that the orchestrator actually reads the attribute.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Standalone repro: `OrchestratorBlock._execute_single_tool_with_manager` invoked with `nodes_input_masks={sink: {"credentials": {...}}}` and empty `input_default` → `upsert_execution_input` is now called with `input_name="credentials"` (was missing before the fix).
  - [x] Builder regression: same call with creds in `input_default` and `nodes_input_masks=None` still works; `on_node_execution` receives `nodes_input_masks=None` so behaviour is unchanged.
  - [x] `pyright` / `black` / `isort` clean on the modified files.
  - [ ] Manual E2E: build an agent with an Orchestrator + credential-bearing tool block, save it, launch it from the Library — tool block runs with credentials.
  - [ ] Manual E2E: launch the same agent from AutoPilot — tool block runs with credentials.
  - [ ] Manual regression: launch the same agent from the Builder (unchanged path) — still works.

#### For configuration changes:

- [x] `.env.default` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes
- [x] I have included a list of my configuration changes in the PR description (under **Changes**)
