### PR TITLE
fix(copilot): strip null credential fields before validation

### DIFF
--- a/autogpt_platform/backend/backend/copilot/tools/helpers.py
+++ b/autogpt_platform/backend/backend/copilot/tools/helpers.py
@@ -598,6 +598,14 @@ async def prepare_block_for_execution(
             session_id=session_id,
         )
 
+    # LLMs sometimes pass `"credentials": null` instead of omitting the field.
+    # Treat null credential fields as absent so the injection path below can
+    # populate them, and so _base.validate_data doesn't reject null against a
+    # required object schema.
+    for field_name in block.input_schema.get_credentials_fields():
+        if field_name in input_data and input_data[field_name] is None:
+            input_data.pop(field_name)
+
     matched_credentials, missing_credentials = await resolve_block_credentials(
         user_id, block, input_data
     )

--- a/autogpt_platform/backend/backend/copilot/tools/helpers_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/helpers_test.py
@@ -1043,6 +1043,144 @@ async def test_prepare_block_file_ref_expansion_error() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Null credential-field normalisation tests
+# ---------------------------------------------------------------------------
+
+
+def _make_block_with_cred_field(
+    field_name: str = "credentials",
+) -> MagicMock:
+    """Simple block that declares one credential-typed input field."""
+    block = _make_simple_block(
+        required=["term"],
+        properties={
+            "term": {"type": "string"},
+            field_name: {"type": "object"},
+        },
+    )
+    block.input_schema.get_credentials_fields.return_value = {
+        field_name: MagicMock()
+    }
+    return block
+
+
+@pytest.mark.asyncio
+async def test_prepare_block_null_credentials_field_stripped() -> None:
+    """Passing credentials=None is equivalent to omitting the field entirely."""
+    block = _make_block_with_cred_field()
+    excl_ids, excl_types = _patch_excluded()
+    with (
+        patch("backend.copilot.tools.helpers.get_block", return_value=block),
+        excl_ids,
+        excl_types,
+        patch(
+            "backend.copilot.tools.helpers.resolve_block_credentials",
+            AsyncMock(return_value=({}, [])),
+        ),
+        patch(
+            "backend.copilot.tools.helpers.expand_file_refs_in_args",
+            AsyncMock(side_effect=lambda d, *a, **kw: d),
+        ),
+    ):
+        result = await prepare_block_for_execution(
+            block_id="blk-1",
+            input_data={"term": "hello", "credentials": None},
+            user_id=_PREP_USER,
+            session=_make_prep_session(),
+            session_id=_PREP_SESSION,
+            dry_run=False,
+        )
+    assert isinstance(result, BlockPreparation)
+
+
+@pytest.mark.asyncio
+async def test_prepare_block_null_credentials_same_as_absent() -> None:
+    """credentials=None and no credentials key produce identical results."""
+    block = _make_block_with_cred_field()
+    excl_ids, excl_types = _patch_excluded()
+
+    async def _run(input_data: dict):
+        with (
+            patch("backend.copilot.tools.helpers.get_block", return_value=block),
+            excl_ids,
+            excl_types,
+            patch(
+                "backend.copilot.tools.helpers.resolve_block_credentials",
+                AsyncMock(return_value=({}, [])),
+            ),
+            patch(
+                "backend.copilot.tools.helpers.expand_file_refs_in_args",
+                AsyncMock(side_effect=lambda d, *a, **kw: d),
+            ),
+        ):
+            return await prepare_block_for_execution(
+                block_id="blk-1",
+                input_data=input_data,
+                user_id=_PREP_USER,
+                session=_make_prep_session(),
+                session_id=_PREP_SESSION,
+                dry_run=False,
+            )
+
+    result_absent = await _run({"term": "hello"})
+    result_null = await _run({"term": "hello", "credentials": None})
+    assert type(result_absent) is type(result_null)
+    assert isinstance(result_absent, BlockPreparation)
+
+
+@pytest.mark.asyncio
+async def test_prepare_block_null_non_credential_field_not_stripped() -> None:
+    """Null on a regular (non-credential) field is left intact."""
+    block = _make_block_with_cred_field()
+    # Override schema to also include a non-credential nullable field
+    block.input_schema.jsonschema.return_value = {
+        "type": "object",
+        "properties": {
+            "term": {"type": "string"},
+            "optional_note": {"type": ["string", "null"]},
+            "credentials": {"type": "object"},
+        },
+        "required": ["term"],
+    }
+    excl_ids, excl_types = _patch_excluded()
+    captured: list[dict] = []
+
+    async def _capture_resolve(user_id, block, input_data):
+        captured.append(dict(input_data))
+        return {}, []
+
+    with (
+        patch("backend.copilot.tools.helpers.get_block", return_value=block),
+        excl_ids,
+        excl_types,
+        patch(
+            "backend.copilot.tools.helpers.resolve_block_credentials",
+            side_effect=_capture_resolve,
+        ),
+        patch(
+            "backend.copilot.tools.helpers.expand_file_refs_in_args",
+            AsyncMock(side_effect=lambda d, *a, **kw: d),
+        ),
+    ):
+        await prepare_block_for_execution(
+            block_id="blk-1",
+            input_data={"term": "hello", "optional_note": None, "credentials": None},
+            user_id=_PREP_USER,
+            session=_make_prep_session(),
+            session_id=_PREP_SESSION,
+            dry_run=False,
+        )
+
+    assert len(captured) == 1
+    seen = captured[0]
+    # credentials (credential field) should have been stripped
+    assert "credentials" not in seen
+    # optional_note (non-credential field) must remain
+    assert "optional_note" in seen
+    assert seen["optional_note"] is None
+
+
+# ---------------------------------------------------------------------------
 # Auto-credentials (Google Drive picker) regression tests for execute_block
 # ---------------------------------------------------------------------------
 

--- a/autogpt_platform/backend/backend/copilot/tools/helpers_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/helpers_test.py
@@ -1058,9 +1058,7 @@ def _make_block_with_cred_field(
             field_name: {"type": "object"},
         },
     )
-    block.input_schema.get_credentials_fields.return_value = {
-        field_name: MagicMock()
-    }
+    block.input_schema.get_credentials_fields.return_value = {field_name: MagicMock()}
     return block
 
 


### PR DESCRIPTION
## Summary

LLMs sometimes pass `{"credentials": null}` instead of omitting the field entirely. This causes `_base.validate_data` to reject the input with `'credentials' is a required property`, even though valid connected credentials exist for the user.

The credential injection path in `helpers.py` (lines ~256–260) only fires when the field is **absent** from `input_data`. Passing `null` bypasses injection and then fails schema validation.

## Fix

In `prepare_block_for_execution`, before `resolve_block_credentials` is called, strip any credential-typed fields whose value is `None`. This normalises `{"credentials": null}` to the same state as omitting the field.

```python
for field_name in block.input_schema.get_credentials_fields():
    if field_name in input_data and input_data[field_name] is None:
        input_data.pop(field_name)
```

Scoped to credential fields only — null values on non-credential fields still surface as validation errors.

## Scope

- ✅ `copilot/tools/helpers.py` — copilot tool path only
- ❌ `blocks/_base.py` — not touched (shared with graph execution)
- ❌ `executor/manager.py` — not touched (has its own null-handling path)

Closes SECRT-2372