### PR TITLE
fix(backend/copilot): disallow ScheduleWakeup SDK built-in

### DIFF
--- a/autogpt_platform/backend/backend/copilot/sdk/tool_adapter.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/tool_adapter.py
@@ -825,6 +825,8 @@ _SDK_BUILTIN_TOOLS = [*_SDK_BUILTIN_FILE_TOOLS, *_SDK_BUILTIN_ALWAYS]
 #   — our MCP read_file handles tool-results paths via
 #   is_allowed_local_path() and has been the only Read available in
 #   prod without issues.
+# ScheduleWakeup: no /loop runtime in copilot turns; the handler returns
+#   {"scheduledFor": 0} and nothing is scheduled.
 SDK_DISALLOWED_TOOLS = [
     "Bash",
     "WebFetch",
@@ -833,6 +835,7 @@ SDK_DISALLOWED_TOOLS = [
     "Write",
     "Edit",
     "Read",
+    "ScheduleWakeup",
 ]
 
 # Tools that are blocked entirely in security hooks (defence-in-depth).

--- a/autogpt_platform/backend/backend/copilot/sdk/tool_adapter_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/tool_adapter_test.py
@@ -663,6 +663,9 @@ class TestSDKDisallowedTools:
         """WebFetch is disallowed due to SSRF risk."""
         assert "WebFetch" in SDK_DISALLOWED_TOOLS
 
+    def test_schedule_wakeup_tool_is_disallowed(self):
+        assert "ScheduleWakeup" in SDK_DISALLOWED_TOOLS
+
 
 # ---------------------------------------------------------------------------
 # _read_file_handler — bridge_and_annotate integration


### PR DESCRIPTION
## Why

The Claude Agent SDK CLI ships a `ScheduleWakeup` built-in that is only
functional inside Claude Code's `/loop` dynamic-mode runtime. Our
copilot/autopilot turns have no such runtime — each turn runs to
completion on a stateless `copilot_executor` worker. When invoked there,
`ScheduleWakeup`'s handler returns `{"scheduledFor": 0, "wasClamped": false}`
and nothing is actually scheduled.

We were not registering this tool ourselves, but it was also absent from
`SDK_DISALLOWED_TOOLS`, so the SDK exposed it to the model. The model
would call it, treat the success-shaped response as confirmation that a
follow-up was queued, and end the turn — leaving the user with a silent
session that promised work that will never happen.

## What

Add `"ScheduleWakeup"` to `SDK_DISALLOWED_TOOLS`. `BLOCKED_TOOLS` already
unpacks `SDK_DISALLOWED_TOOLS`, so the security-hook deny path
automatically covers any attempt to bypass the SDK filter.

Test added asserting `ScheduleWakeup` is in the list.

## How

`SDK_DISALLOWED_TOOLS` feeds `ClaudeAgentOptions.disallowed_tools` via
`get_sdk_disallowed_tools()`. The SDK strips disallowed tools from the
advertisement the model sees, so the model never gets the opportunity to
call it. The defence-in-depth security hook (`_validate_tool_access` in
`security_hooks.py`) rejects any sneaky call attempts via `BLOCKED_TOOLS`.

If we want a real "do this in 20 minutes" feature in copilot, the right
shape is a new MCP tool backed by the scheduler that enqueues a
`copilot_turn_schedule` row and fires `enqueue_copilot_turn` at the
target time. That's out of scope here — this PR just stops the misleading
no-op.

## Changes

- `tool_adapter.py`: add `"ScheduleWakeup"` to `SDK_DISALLOWED_TOOLS` with a
  one-line WHY comment.
- `tool_adapter_test.py`: assert membership.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
