### PR TITLE
fix(backend/blocks): orchestrator EXTENDED_THINKING emits final-answer only

### DIFF
--- a/autogpt_platform/backend/backend/blocks/orchestrator.py
+++ b/autogpt_platform/backend/backend/blocks/orchestrator.py
@@ -1701,7 +1701,21 @@ class OrchestratorBlock(Block):
             prefix=f"orchestrator-sdk-{execution_params.graph_exec_id}-"
         )
 
-        response_parts: list[str] = []
+        # ``final_response_parts`` is the agent's *final answer* — only the
+        # text from the last assistant message that has no tool calls.  We
+        # intentionally do NOT accumulate every assistant TextBlock across
+        # the SDK stream: those intermediate texts are narration between
+        # tool calls, not the composed answer the user wired into
+        # ``AgentOutputBlock``.  This matches BUILT_IN's behaviour where
+        # ``tool_call_loop`` only yields ``response.response_text`` once
+        # the model stops calling tools.  If the agent never produces a
+        # text-only message (e.g. it keeps calling tools until max
+        # iterations), ``final_response_parts`` stays empty and the
+        # ``finished`` output surfaces as an empty string — that's useful
+        # signal for dry-run / autopilot diagnostics ("the agent didn't
+        # compose a final answer; repair the prompt") rather than a
+        # transcript dump that masks the missing composition.
+        final_response_parts: list[str] = []
         conversation: list[dict[str, Any]] = list(prompt)  # Start with input prompt
         total_prompt_tokens = 0
         total_completion_tokens = 0
@@ -1788,7 +1802,6 @@ class OrchestratorBlock(Block):
                             for content_block in sdk_msg.content:
                                 if isinstance(content_block, TextBlock):
                                     text_parts.append(content_block.text)
-                                    response_parts.append(content_block.text)
                                 elif isinstance(content_block, ToolUseBlock):
                                     raw_name = getattr(content_block, "name", "unknown")
                                     # Strip MCP prefix for readability in
@@ -1802,6 +1815,13 @@ class OrchestratorBlock(Block):
                                             ),
                                         }
                                     )
+                            # Capture the final answer: the last assistant
+                            # message that has only text (no tool calls)
+                            # wins.  See ``final_response_parts`` declaration
+                            # for the rationale.
+                            if text_parts and not tool_use_parts:
+                                final_response_parts = list(text_parts)
+
                             if text_parts or tool_use_parts:
                                 msg_content = "".join(text_parts)
                                 if tool_use_parts:
@@ -1894,7 +1914,7 @@ class OrchestratorBlock(Block):
             yield "error", str(sdk_error)
             return
 
-        response_text = "".join(response_parts)
+        response_text = "".join(final_response_parts)
 
         yield "finished", response_text
         yield "conversations", conversation

--- a/autogpt_platform/backend/backend/blocks/orchestrator.py
+++ b/autogpt_platform/backend/backend/blocks/orchestrator.py
@@ -364,6 +364,33 @@ def _disambiguate_tool_names(tools: list[dict[str, Any]]) -> None:
             func["description"] = f"{original_desc} [Pre-configured: {summary}]"
 
 
+def _select_final_answer_parts(
+    text_parts: list[str],
+    has_tool_calls: bool,
+    current: list[str],
+) -> list[str]:
+    """Pick the text parts that should be treated as the agent's final
+    answer for the ``finished`` output pin in EXTENDED_THINKING SDK mode.
+
+    Contract: an assistant message contributes only when it carries text
+    AND no tool calls.  That means the model has stopped calling tools
+    and is composing a response — which is what ``finished`` is supposed
+    to surface to ``AgentOutputBlock``.  Messages with tool calls
+    (regardless of whether they also carry text) are intermediate
+    narration that belongs in ``conversations``, not the final answer.
+    Empty messages don't contribute.
+
+    The caller threads ``current`` across the SDK stream; the last
+    text-only message wins.  If no message in the run qualifies, the
+    returned list is empty and ``finished`` surfaces as ``""`` — useful
+    diagnostic signal that the agent's prompt didn't compose a final
+    answer.
+    """
+    if text_parts and not has_tool_calls:
+        return list(text_parts)
+    return current
+
+
 class OrchestratorBlock(Block):
     """A block that uses a language model to orchestrate tool calls.
 
@@ -1817,10 +1844,13 @@ class OrchestratorBlock(Block):
                                     )
                             # Capture the final answer: the last assistant
                             # message that has only text (no tool calls)
-                            # wins.  See ``final_response_parts`` declaration
-                            # for the rationale.
-                            if text_parts and not tool_use_parts:
-                                final_response_parts = list(text_parts)
+                            # wins.  See ``_select_final_answer_parts`` for
+                            # the contract + diagnostic-signal rationale.
+                            final_response_parts = _select_final_answer_parts(
+                                text_parts=text_parts,
+                                has_tool_calls=bool(tool_use_parts),
+                                current=final_response_parts,
+                            )
 
                             if text_parts or tool_use_parts:
                                 msg_content = "".join(text_parts)

--- a/autogpt_platform/backend/backend/blocks/orchestrator.py
+++ b/autogpt_platform/backend/backend/blocks/orchestrator.py
@@ -386,7 +386,7 @@ def _select_final_answer_parts(
     diagnostic signal that the agent's prompt didn't compose a final
     answer.
     """
-    if text_parts and not has_tool_calls:
+    if not has_tool_calls and any(part.strip() for part in text_parts):
         return list(text_parts)
     return current
 

--- a/autogpt_platform/backend/backend/blocks/test/test_orchestrator_execution_mode.py
+++ b/autogpt_platform/backend/backend/blocks/test/test_orchestrator_execution_mode.py
@@ -295,3 +295,15 @@ class TestSelectFinalAnswerParts:
         )
         text_parts.clear()
         assert result == ["final"]
+
+    def test_blank_text_only_message_keeps_current(self) -> None:
+        # Whitespace-only / empty-string text blocks with no tool calls
+        # would otherwise look like a "final" answer and clobber a real
+        # one captured earlier in the stream. The docstring says empty
+        # messages don't contribute — enforce that for blank strings too.
+        for blank in [[""], ["   "], ["\n"], ["", "  ", "\t"]]:
+            assert _select_final_answer_parts(
+                text_parts=blank,
+                has_tool_calls=False,
+                current=["real final answer"],
+            ) == ["real final answer"], f"blank={blank!r} clobbered current"

--- a/autogpt_platform/backend/backend/blocks/test/test_orchestrator_execution_mode.py
+++ b/autogpt_platform/backend/backend/blocks/test/test_orchestrator_execution_mode.py
@@ -11,7 +11,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from backend.blocks.llm import LlmModel
-from backend.blocks.orchestrator import ExecutionMode, OrchestratorBlock
+from backend.blocks.orchestrator import (
+    ExecutionMode,
+    OrchestratorBlock,
+    _select_final_answer_parts,
+)
 
 # ---------------------------------------------------------------------------
 # ExecutionMode enum integrity
@@ -200,3 +204,94 @@ class TestExtendedThinkingValidationRaisesInBlock:
                 execution_context=MagicMock(),
                 execution_processor=MagicMock(),
             )
+
+
+# ---------------------------------------------------------------------------
+# _select_final_answer_parts — pins the SDK-mode "finished" contract:
+# only the last text-only assistant message contributes; messages with
+# tool calls (text or no) are intermediate narration.
+# ---------------------------------------------------------------------------
+
+
+class TestSelectFinalAnswerParts:
+    """The helper is the testable extraction of the inline branch in
+    ``_execute_tools_sdk_mode`` that decides which assistant-message
+    texts make it into the ``finished`` output pin.  Covering it here
+    keeps the SDK path's contract pinned without mocking the full
+    Claude Agent SDK + MCP stream."""
+
+    def test_text_only_message_replaces_current(self) -> None:
+        # Model stopped calling tools and emitted text — that's the
+        # composed final answer.  Replaces any prior selection.
+        assert _select_final_answer_parts(
+            text_parts=["final answer"],
+            has_tool_calls=False,
+            current=["prior"],
+        ) == ["final answer"]
+
+    def test_text_with_tool_calls_keeps_current(self) -> None:
+        # Mixed text+tool messages are intermediate narration — keep
+        # the last text-only selection unchanged.
+        assert _select_final_answer_parts(
+            text_parts=["narration before tool"],
+            has_tool_calls=True,
+            current=["earlier final answer"],
+        ) == ["earlier final answer"]
+
+    def test_tool_only_message_keeps_current(self) -> None:
+        # Message with no text and only tool calls — keep current.
+        assert _select_final_answer_parts(
+            text_parts=[],
+            has_tool_calls=True,
+            current=["earlier final"],
+        ) == ["earlier final"]
+
+    def test_empty_message_keeps_current(self) -> None:
+        # Defensive: empty assistant message contributes nothing.
+        assert _select_final_answer_parts(
+            text_parts=[],
+            has_tool_calls=False,
+            current=["earlier final"],
+        ) == ["earlier final"]
+
+    def test_no_qualifying_message_returns_empty(self) -> None:
+        # The agent never composes a final answer (e.g. keeps calling
+        # tools until max iterations) — ``current`` stays empty so
+        # ``finished`` surfaces as ``""``, the diagnostic signal for
+        # autopilot / dry-run.
+        current: list[str] = []
+        for text, has_tools in [
+            (["narration"], True),
+            ([], True),
+            (["more narration"], True),
+        ]:
+            current = _select_final_answer_parts(
+                text_parts=text, has_tool_calls=has_tools, current=current
+            )
+        assert current == []
+
+    def test_last_text_only_message_wins_in_sequence(self) -> None:
+        # Multiple text-only messages over the run — the **last** one
+        # is the agent's answer (most recent composition).
+        current: list[str] = []
+        current = _select_final_answer_parts(
+            text_parts=["first answer"], has_tool_calls=False, current=current
+        )
+        current = _select_final_answer_parts(
+            text_parts=["narration"], has_tool_calls=True, current=current
+        )
+        current = _select_final_answer_parts(
+            text_parts=["second answer"], has_tool_calls=False, current=current
+        )
+        assert current == ["second answer"]
+
+    def test_returns_copy_not_reference(self) -> None:
+        # Defensive: the SDK call site reuses the ``text_parts`` list
+        # per-message; the helper must return a copy so subsequent
+        # mutations don't poison the captured final answer.
+        text_parts = ["final"]
+        result = _select_final_answer_parts(
+            text_parts=text_parts, has_tool_calls=False, current=[]
+        )
+        text_parts.clear()
+        assert result == ["final"]


### PR DESCRIPTION
### Why / What / How

**Why:** Discovered while debugging a debate-style orchestrator agent on dev preview. The two execution modes were producing structurally different `finished` outputs for the same block:

| Mode | `finished` content | What's wrong with it |
|---|---|---|
| `BUILT_IN` (agent loop via `tool_call_loop`) | `response.response_text` from the last LLM call (i.e. the model's final text-only response after it stopped calling tools) | **Correct** — this is the agent's composed answer |
| `EXTENDED_THINKING` (Claude Agent SDK) | `"".join(every TextBlock from every AssistantMessage)` | **Buggy** — accumulates every narration emitted between tool calls; the answer gets buried in working-log noise, and worse, *masks* prompts that never compose a real answer |

The original-direction commit (`0f4d348d0d`, now force-replaced) tried to fix the divergence by making BUILT_IN match EXTENDED_THINKING's accumulation. That was the wrong direction: BUILT_IN's last-answer behaviour is the correct contract, and the accumulation in EXTENDED_THINKING was hiding composition bugs that dry-run / autopilot should be able to detect.

**What:** Replace `response_parts.append(...)` (every TextBlock) with `final_response_parts = list(text_parts)` only when the assistant message has **no tool calls** — i.e. the model has stopped calling tools and is emitting its composed answer. The last such message wins.

**How:**

```diff
- response_parts: list[str] = []
+ final_response_parts: list[str] = []   # only the final-answer message's text
  ...
  if isinstance(sdk_msg, AssistantMessage):
      text_parts = []
      tool_use_parts = []
      for content_block in sdk_msg.content:
          if isinstance(content_block, TextBlock):
              text_parts.append(content_block.text)
-             response_parts.append(content_block.text)
          elif isinstance(content_block, ToolUseBlock):
              ...
+     # Capture the agent's final answer: last text-only message wins.
+     if text_parts and not tool_use_parts:
+         final_response_parts = list(text_parts)
  ...
- response_text = "".join(response_parts)
+ response_text = "".join(final_response_parts)
```

**Edge cases:**

- *Agent never stops calling tools (e.g. hits max iterations)*: `final_response_parts` stays empty → `finished` = `""`. This is the **correct** signal for dry-run / autopilot diagnostics: the prompt didn't compose a final answer, so the agent author needs to fix it. Previously the over-accumulation returned a transcript-shaped string that masked this failure mode.
- *Agent emits multiple text-only messages over the course of the run* (rare): the **last** one wins, matching "the model's most recent composed answer."
- *Agent emits text + tool calls in the same message*: that message's text is treated as narration belonging to `conversations`, not the answer (the `not tool_use_parts` guard).

**Existing tests:** all 14 in `test_orchestrator_execution_mode.py` still pass. No new SDK-mocking infrastructure exists in the test suite for this code path, so behavioural verification will happen on the next dev preview redeploy (combo branch redeployment to follow).

### Changes 🏗️

- `_execute_tools_sdk_mode` captures only the last assistant message's text-only content into `final_response_parts`.
- `finished` output yields `"".join(final_response_parts)` — empty string when the agent never composed a final answer (useful diagnostic signal).
- No change to `conversations` output (still carries the full back-and-forth).

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `poetry run pytest backend/blocks/test/test_orchestrator_execution_mode.py` — 14 tests pass
  - [x] `poetry run black` + `poetry run ruff check` clean
  - [ ] Manual verification on dev preview after combo redeploy
