### PR TITLE
feat(frontend): add subscription pricing experiment

### DIFF
--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/__tests__/store.test.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/__tests__/store.test.ts
@@ -21,6 +21,37 @@ describe("useOnboardingWizardStore", () => {
       expect(useOnboardingWizardStore.getState().selectedBilling).toBe(
         "yearly",
       );
+      expect(useOnboardingWizardStore.getState().hasUserSelectedBilling).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("billing selection", () => {
+    it("tracks when the billing cycle was selected by the user", () => {
+      useOnboardingWizardStore.getState().setSelectedBilling("monthly");
+
+      const state = useOnboardingWizardStore.getState();
+      expect(state.selectedBilling).toBe("monthly");
+      expect(state.hasUserSelectedBilling).toBe(true);
+    });
+
+    it("applies experiment billing until the user has selected a cycle", () => {
+      useOnboardingWizardStore
+        .getState()
+        .applyPricingExperimentBilling("monthly");
+      expect(useOnboardingWizardStore.getState().selectedBilling).toBe(
+        "monthly",
+      );
+
+      useOnboardingWizardStore.getState().setSelectedBilling("yearly");
+      useOnboardingWizardStore
+        .getState()
+        .applyPricingExperimentBilling("monthly");
+
+      const state = useOnboardingWizardStore.getState();
+      expect(state.selectedBilling).toBe("yearly");
+      expect(state.hasUserSelectedBilling).toBe(true);
     });
   });
 

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/SubscriptionStep.tsx
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/SubscriptionStep.tsx
@@ -5,13 +5,14 @@ import { FadeIn } from "@/components/atoms/FadeIn/FadeIn";
 import { Text } from "@/components/atoms/Text/Text";
 import { cn } from "@/lib/utils";
 import { PlanCard } from "@/components/molecules/PlanCard/PlanCard";
-import { PLAN_KEYS, PLANS } from "@/components/molecules/PlanCard/plans";
+import { PLAN_KEYS } from "@/components/molecules/PlanCard/plans";
 import { useSubscriptionStep } from "./useSubscriptionStep";
 
 export function SubscriptionStep() {
   const {
     billing,
     setBilling,
+    plans,
     country,
     isYearly,
     handlePlanSelect,
@@ -72,7 +73,7 @@ export function SubscriptionStep() {
 
         <div className="relative mt-2 w-full max-w-[75.625rem]">
           <div className="grid w-full grid-cols-1 gap-4 px-[1rem] md:grid-cols-3 md:px-0">
-            {PLANS.map((plan) => (
+            {plans.map((plan) => (
               <PlanCard
                 key={plan.key}
                 plan={plan}

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/helpers.ts
@@ -1,0 +1,92 @@
+import {
+  PLAN_KEYS,
+  PLANS,
+  type PlanDef,
+} from "@/components/molecules/PlanCard/plans";
+
+export const SUBSCRIPTION_PRICING_EXPERIMENT_FLAG =
+  "subscription-pricing-page-initial-state";
+
+const HIGHLIGHT_BADGE = "Best value";
+
+export type BillingCycle = "monthly" | "yearly";
+export type HighlightedPlanKey = typeof PLAN_KEYS.PRO | typeof PLAN_KEYS.MAX;
+export type SubscriptionPricingExperimentVariant =
+  | "monthly-pro"
+  | "monthly-max"
+  | "yearly-pro"
+  | "yearly-max";
+
+interface SubscriptionPricingExperimentConfig {
+  billing: BillingCycle;
+  highlightedPlan: HighlightedPlanKey;
+  variant: SubscriptionPricingExperimentVariant | "control";
+}
+
+const DEFAULT_EXPERIMENT_CONFIG: SubscriptionPricingExperimentConfig = {
+  billing: "yearly",
+  highlightedPlan: PLAN_KEYS.MAX,
+  variant: "control",
+};
+
+const EXPERIMENT_CONFIGS: Record<
+  SubscriptionPricingExperimentVariant,
+  SubscriptionPricingExperimentConfig
+> = {
+  "monthly-pro": {
+    billing: "monthly",
+    highlightedPlan: PLAN_KEYS.PRO,
+    variant: "monthly-pro",
+  },
+  "monthly-max": {
+    billing: "monthly",
+    highlightedPlan: PLAN_KEYS.MAX,
+    variant: "monthly-max",
+  },
+  "yearly-pro": {
+    billing: "yearly",
+    highlightedPlan: PLAN_KEYS.PRO,
+    variant: "yearly-pro",
+  },
+  "yearly-max": {
+    billing: "yearly",
+    highlightedPlan: PLAN_KEYS.MAX,
+    variant: "yearly-max",
+  },
+};
+
+function isExperimentVariant(
+  variant: string,
+): variant is SubscriptionPricingExperimentVariant {
+  return variant in EXPERIMENT_CONFIGS;
+}
+
+function isPaidExperimentPlan(plan: PlanDef) {
+  return plan.key === PLAN_KEYS.PRO || plan.key === PLAN_KEYS.MAX;
+}
+
+export function getSubscriptionPricingExperimentConfig(
+  variant: string | boolean | undefined,
+) {
+  if (typeof variant === "string" && isExperimentVariant(variant)) {
+    return EXPERIMENT_CONFIGS[variant];
+  }
+  return DEFAULT_EXPERIMENT_CONFIG;
+}
+
+export function getSubscriptionPricingExperimentPlans(
+  highlightedPlan: HighlightedPlanKey,
+  plans: PlanDef[] = PLANS,
+) {
+  return plans.map((plan) => {
+    if (!isPaidExperimentPlan(plan)) return plan;
+
+    const highlighted = plan.key === highlightedPlan;
+    return {
+      ...plan,
+      highlighted,
+      badge: highlighted ? HIGHLIGHT_BADGE : null,
+      buttonVariant: highlighted ? "primary" : "secondary",
+    } satisfies PlanDef;
+  });
+}

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/useSubscriptionPricingExperiment.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/useSubscriptionPricingExperiment.ts
@@ -1,0 +1,34 @@
+"use client";
+
+import { useFeatureFlagVariantKey } from "@posthog/react";
+import { useEffect } from "react";
+import { useOnboardingWizardStore } from "../../store";
+import {
+  getSubscriptionPricingExperimentConfig,
+  getSubscriptionPricingExperimentPlans,
+  SUBSCRIPTION_PRICING_EXPERIMENT_FLAG,
+} from "./helpers";
+
+export function useSubscriptionPricingExperiment() {
+  const variant = useFeatureFlagVariantKey(
+    SUBSCRIPTION_PRICING_EXPERIMENT_FLAG,
+  );
+  const applyPricingExperimentBilling = useOnboardingWizardStore(
+    (s) => s.applyPricingExperimentBilling,
+  );
+  const selectedBilling = useOnboardingWizardStore((s) => s.selectedBilling);
+  const hasUserSelectedBilling = useOnboardingWizardStore(
+    (s) => s.hasUserSelectedBilling,
+  );
+  const config = getSubscriptionPricingExperimentConfig(variant);
+
+  useEffect(() => {
+    applyPricingExperimentBilling(config.billing);
+  }, [applyPricingExperimentBilling, config.billing]);
+
+  return {
+    billing: hasUserSelectedBilling ? selectedBilling : config.billing,
+    plans: getSubscriptionPricingExperimentPlans(config.highlightedPlan),
+    variant: config.variant,
+  };
+}

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/useSubscriptionStep.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/useSubscriptionStep.ts
@@ -12,6 +12,7 @@ import {
   type PlanKey,
   TEAM_INTAKE_FORM_URL,
 } from "@/components/molecules/PlanCard/plans";
+import { useSubscriptionPricingExperiment } from "./useSubscriptionPricingExperiment";
 
 const PLAN_TO_TIER: Record<
   Exclude<PlanKey, typeof PLAN_KEYS.TEAM | typeof PLAN_KEYS.BUSINESS>,
@@ -26,7 +27,6 @@ interface CheckoutResponse {
 }
 
 export function useSubscriptionStep() {
-  const billing = useOnboardingWizardStore((s) => s.selectedBilling);
   const setSelectedBilling = useOnboardingWizardStore(
     (s) => s.setSelectedBilling,
   );
@@ -39,6 +39,7 @@ export function useSubscriptionStep() {
 
   const { mutateAsync: updateTier, isPending: isUpdatingTier } =
     useUpdateSubscriptionTier();
+  const { billing, plans } = useSubscriptionPricingExperiment();
   // Local guard that flips synchronously on first click so the profile-save
   // phase (which runs before `isUpdatingTier` becomes true) can't be
   // re-entered by a fast double-click queueing duplicate POSTs.
@@ -126,6 +127,7 @@ export function useSubscriptionStep() {
   return {
     billing,
     setBilling: setSelectedBilling,
+    plans,
     country,
     isYearly,
     handlePlanSelect,

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/__tests__/SubscriptionStep.test.tsx
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/__tests__/SubscriptionStep.test.tsx
@@ -10,7 +10,19 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { server } from "@/mocks/mock-server";
 import { environment } from "@/services/environment";
 import { useOnboardingWizardStore } from "../../store";
+import {
+  getSubscriptionPricingExperimentConfig,
+  getSubscriptionPricingExperimentPlans,
+} from "../SubscriptionStep/helpers";
 import { SubscriptionStep } from "../SubscriptionStep/SubscriptionStep";
+
+const postHog = vi.hoisted(() => ({
+  variant: undefined as string | boolean | undefined,
+}));
+
+vi.mock("@posthog/react", () => ({
+  useFeatureFlagVariantKey: () => postHog.variant,
+}));
 
 vi.mock("@/components/atoms/FadeIn/FadeIn", () => ({
   FadeIn: ({ children }: { children: React.ReactNode }) => (
@@ -25,11 +37,54 @@ vi.mock("@/components/atoms/AutoGPTLogo/AutoGPTLogo", () => ({
 afterEach(cleanup);
 
 beforeEach(() => {
+  postHog.variant = undefined;
   useOnboardingWizardStore.getState().reset();
   useOnboardingWizardStore.getState().goToStep(4);
   // Default tests to cloud mode so they exercise the Stripe Checkout path.
   // The local-bypass test below opts back into LOCAL.
   vi.spyOn(environment, "isLocal").mockReturnValue(false);
+});
+
+describe("subscription pricing experiment helpers", () => {
+  test("uses the current yearly Max experience as the default", () => {
+    expect(getSubscriptionPricingExperimentConfig(undefined)).toMatchObject({
+      billing: "yearly",
+      highlightedPlan: "MAX",
+      variant: "control",
+    });
+  });
+
+  test("maps PostHog variants to billing and highlighted plan config", () => {
+    expect(getSubscriptionPricingExperimentConfig("monthly-pro")).toMatchObject(
+      {
+        billing: "monthly",
+        highlightedPlan: "PRO",
+        variant: "monthly-pro",
+      },
+    );
+    expect(getSubscriptionPricingExperimentConfig("yearly-max")).toMatchObject({
+      billing: "yearly",
+      highlightedPlan: "MAX",
+      variant: "yearly-max",
+    });
+  });
+
+  test("moves the highlighted styling from Max to Pro", () => {
+    const plans = getSubscriptionPricingExperimentPlans("PRO");
+    const pro = plans.find((plan) => plan.key === "PRO");
+    const max = plans.find((plan) => plan.key === "MAX");
+
+    expect(pro).toMatchObject({
+      highlighted: true,
+      badge: "Best value",
+      buttonVariant: "primary",
+    });
+    expect(max).toMatchObject({
+      highlighted: false,
+      badge: null,
+      buttonVariant: "secondary",
+    });
+  });
 });
 
 describe("SubscriptionStep", () => {
@@ -48,6 +103,34 @@ describe("SubscriptionStep", () => {
     expect(screen.getByLabelText("Charged today: $510.00")).toBeDefined();
     expect(screen.getByLabelText("Charged today: $3,264.00")).toBeDefined();
     expect(screen.getAllByText(/Save 15%/).length).toBeGreaterThan(0);
+  });
+
+  test("PostHog monthly Pro variant starts on monthly billing", async () => {
+    postHog.variant = "monthly-pro";
+
+    render(<SubscriptionStep />);
+
+    await waitFor(() => {
+      expect(useOnboardingWizardStore.getState().selectedBilling).toBe(
+        "monthly",
+      );
+    });
+    expect(screen.getByLabelText("$50.00")).toBeDefined();
+    expect(screen.getByLabelText("Charged today: $50.00")).toBeDefined();
+  });
+
+  test("PostHog billing default does not override a user-selected cycle", async () => {
+    postHog.variant = "monthly-pro";
+    useOnboardingWizardStore.getState().setSelectedBilling("yearly");
+
+    render(<SubscriptionStep />);
+
+    await waitFor(() => {
+      expect(useOnboardingWizardStore.getState().selectedBilling).toBe(
+        "yearly",
+      );
+    });
+    expect(screen.getByLabelText("$42.50")).toBeDefined();
   });
 
   test("switching to monthly shows the full monthly price and matching charged-today", () => {

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/store.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/store.ts
@@ -13,6 +13,7 @@ interface OnboardingWizardState {
   otherPainPoint: string;
   selectedPlan: string | null;
   selectedBilling: "monthly" | "yearly";
+  hasUserSelectedBilling: boolean;
   selectedCountryCode: string;
   setName(name: string): void;
   setRole(role: string): void;
@@ -21,6 +22,7 @@ interface OnboardingWizardState {
   setOtherPainPoint(otherPainPoint: string): void;
   setSelectedPlan(plan: string): void;
   setSelectedBilling(billing: "monthly" | "yearly"): void;
+  applyPricingExperimentBilling(billing: "monthly" | "yearly"): void;
   setSelectedCountryCode(code: string): void;
   nextStep(): void;
   prevStep(): void;
@@ -39,6 +41,7 @@ export const useOnboardingWizardStore = create<OnboardingWizardState>()(
       otherPainPoint: "",
       selectedPlan: null,
       selectedBilling: "yearly",
+      hasUserSelectedBilling: false,
       selectedCountryCode: "US",
       setName(name) {
         set({ name });
@@ -68,7 +71,12 @@ export const useOnboardingWizardStore = create<OnboardingWizardState>()(
         set({ selectedPlan: plan });
       },
       setSelectedBilling(billing) {
-        set({ selectedBilling: billing });
+        set({ selectedBilling: billing, hasUserSelectedBilling: true });
+      },
+      applyPricingExperimentBilling(billing) {
+        set((state) =>
+          state.hasUserSelectedBilling ? state : { selectedBilling: billing },
+        );
       },
       setSelectedCountryCode(code) {
         set({ selectedCountryCode: code });
@@ -96,6 +104,7 @@ export const useOnboardingWizardStore = create<OnboardingWizardState>()(
           otherPainPoint: "",
           selectedPlan: null,
           selectedBilling: "yearly",
+          hasUserSelectedBilling: false,
           selectedCountryCode: "US",
         });
       },
@@ -128,6 +137,7 @@ export const useOnboardingWizardStore = create<OnboardingWizardState>()(
         painPoints: state.painPoints,
         otherPainPoint: state.otherPainPoint,
         selectedBilling: state.selectedBilling,
+        hasUserSelectedBilling: state.hasUserSelectedBilling,
         selectedCountryCode: state.selectedCountryCode,
       }),
     },


### PR DESCRIPTION
### Why / What / How

**Why:** We want to test whether defaulting the onboarding paywall to monthly vs yearly, and whether highlighting Pro vs Max as "Best value", moves conversion.

**What:** Wires the onboarding `SubscriptionStep` to a PostHog multivariate experiment (`subscription-pricing-page-initial-state`) with four variants — `monthly-pro`, `monthly-max`, `yearly-pro`, `yearly-max` — plus a control that keeps today's behavior (yearly + Max highlighted).

**How:** A new `useSubscriptionPricingExperiment` hook resolves the variant via `useFeatureFlagVariantKey`, seeds the store's default billing cycle, and returns a plan list with the chosen plan marked highlighted + badged "Best value". The store now tracks `hasUserSelectedBilling` so the experiment only sets the initial cycle — once the user clicks Monthly/Yearly themselves, their choice sticks across re-renders.

### Changes 🏗️

- `SubscriptionStep/helpers.ts`: variant → `{ billing, highlightedPlan }` mapping and plan transform
- `SubscriptionStep/useSubscriptionPricingExperiment.ts`: PostHog flag read + store sync
- `SubscriptionStep.tsx`: render the experiment-derived `plans` instead of the static `PLANS` import
- `onboarding/store.ts`: add `hasUserSelectedBilling` + `applyPricingExperimentBilling` so user choice beats experiment default
- Tests: store behavior (`store.test.ts`) and step render across variants (`SubscriptionStep.test.tsx`)

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [ ] Run onboarding with the flag unset — confirm yearly is selected and Max is highlighted
  - [ ] Override flag to \`monthly-pro\` — confirm monthly is selected and Pro is badged "Best value"
  - [ ] Override flag to \`yearly-pro\` — confirm yearly is selected and Pro is badged
  - [ ] After landing on the page, click Monthly while the experiment default is Yearly — confirm the choice sticks on re-render
  - [ ] \`pnpm test:unit\` passes for the new tests