### PR TITLE
fix(frontend): make auth panel vortex animation frame-rate independent

### DIFF
--- a/autogpt_platform/frontend/src/components/auth/AuthSplitLayout/AuthMarketingPanel.tsx
+++ b/autogpt_platform/frontend/src/components/auth/AuthSplitLayout/AuthMarketingPanel.tsx
@@ -27,7 +27,8 @@ export function AuthMarketingPanel({
       backgroundColor="transparent"
       particleCount={350}
       baseHue={260}
-      rangeSpeed={1.2}
+      baseSpeed={0.08}
+      rangeSpeed={0.22}
       baseRadius={1}
       rangeRadius={2}
     >

--- a/autogpt_platform/frontend/src/components/ui/vortex.tsx
+++ b/autogpt_platform/frontend/src/components/ui/vortex.tsx
@@ -40,6 +40,8 @@ export function Vortex(props: VortexProps) {
   const zOff = 0.0005;
   const backgroundColor = props.backgroundColor || "#000000";
   let tick = 0;
+  let lastTime = 0;
+  let dtFrames = 1;
   const noise3D = createNoise3D();
   let particleProps = new Float32Array(particlePropsLength);
   const center: [number, number] = [0, 0];
@@ -72,6 +74,7 @@ export function Vortex(props: VortexProps) {
       if (ctx) {
         resize(canvas);
         initParticles();
+        lastTime = performance.now();
         draw(canvas, ctx);
       }
     }
@@ -104,7 +107,11 @@ export function Vortex(props: VortexProps) {
   }
 
   function draw(canvas: HTMLCanvasElement, ctx: CanvasRenderingContext2D) {
-    tick++;
+    const now = performance.now();
+    const dt = Math.min((now - lastTime) / 1000, 1 / 30);
+    lastTime = now;
+    dtFrames = dt * 60;
+    tick += dtFrames;
 
     ctx.clearRect(0, 0, canvas.width, canvas.height);
 
@@ -142,19 +149,20 @@ export function Vortex(props: VortexProps) {
     const x = particleProps[i];
     const y = particleProps[i2];
     const n = noise3D(x * xOff, y * yOff, tick * zOff) * noiseSteps * TAU;
-    const vx = lerp(particleProps[i3], Math.cos(n), 0.5);
-    const vy = lerp(particleProps[i4], Math.sin(n), 0.5);
+    const smoothing = 1 - Math.pow(0.5, dtFrames);
+    const vx = lerp(particleProps[i3], Math.cos(n), smoothing);
+    const vy = lerp(particleProps[i4], Math.sin(n), smoothing);
     let life = particleProps[i5];
     const ttl = particleProps[i6];
     const speed = particleProps[i7];
-    const x2 = x + vx * speed;
-    const y2 = y + vy * speed;
+    const x2 = x + vx * speed * dtFrames;
+    const y2 = y + vy * speed * dtFrames;
     const radius = particleProps[i8];
     const hue = particleProps[i9];
 
     drawParticle(x, y, x2, y2, life, ttl, radius, hue, ctx);
 
-    life++;
+    life += dtFrames;
 
     particleProps[i] = x2;
     particleProps[i2] = y2;


### PR DESCRIPTION
### Why / What / How

**Why:** The vortex particle animation on the login/signup left panel was tied to frame rate. Higher-refresh displays (120/144/240Hz) ran the animation up to ~2.4× faster than 60Hz, and slower CPUs made it crawl unevenly. The user reported it "feels tied to CPU speed."

**What:** Make the vortex animation frame-rate independent using delta time, and slow the overall drift on the auth marketing panel.

**How:**
- `vortex.tsx`: track `lastTime` via `performance.now()` each frame and compute `dtFrames = dt * 60` (normalized to a 60 fps reference, capped at 2 frames to avoid jumps after tab inactivity). Scale all per-frame increments by `dtFrames`:
  - position: `x + vx * speed * dtFrames`
  - noise advance: `tick += dtFrames`
  - life: `life += dtFrames`
  - velocity smoothing uses the frame-rate-independent form `1 - 0.5^dtFrames` instead of constant `0.5`
- `AuthMarketingPanel.tsx`: lower `rangeSpeed` from `1.2` to `0.22` and add `baseSpeed={0.08}` so particles drift slowly (range 0.08–0.30 vs. 0–1.2 before).

Result: identical perceived speed across 60/120/144/240Hz displays and across CPU tiers, at a calmer overall pace.

### Changes 🏗️

- `src/components/ui/vortex.tsx`: delta-time scaling for `tick`, particle position, life, and velocity smoothing.
- `src/components/auth/AuthSplitLayout/AuthMarketingPanel.tsx`: lower vortex speed (`baseSpeed=0.08`, `rangeSpeed=0.22`).

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [ ] Open `/login` and `/signup` on a 60Hz display — particles drift slowly and smoothly
  - [ ] Open the same pages on a high-refresh display (120/144Hz) — animation speed matches 60Hz, not visibly faster
  - [ ] Switch tabs and return — animation does not "jump" on resume (delta clamp at 1/30s)
  - [ ] Resize window — particles continue without artifacts
