### PR TITLE
fix(backend/copilot-bot): recover deleted chat sessions instead of erroring

### DIFF
--- a/autogpt_platform/backend/backend/platform_linking/chat.py
+++ b/autogpt_platform/backend/backend/platform_linking/chat.py
@@ -50,18 +50,20 @@ async def start_chat_turn(request: BotChatRequest) -> ChatTurnHandle:
     """
     owner_user_id = await resolve_chat_owner(request)
 
+    session = None
     session_id = request.session_id
     if session_id:
         session = await get_chat_session(session_id, owner_user_id)
-        if not session:
-            raise NotFoundError("Session not found.")
-    else:
+    if session is None:
+        # The bot caches session IDs across turns and a cached session can
+        # be deleted from the web app in between — fall back to a fresh one
+        # so the conversation self-heals instead of erroring every turn.
         session = await create_chat_session(
             owner_user_id,
             dry_run=False,
             source_platform=request.platform.value.lower(),
         )
-        session_id = session.session_id
+    session_id = session.session_id
 
     # Persist the user message before enqueueing, mirroring the REST chat
     # endpoint — otherwise the executor runs against empty history.

--- a/autogpt_platform/backend/backend/platform_linking/chat_test.py
+++ b/autogpt_platform/backend/backend/platform_linking/chat_test.py
@@ -111,9 +111,13 @@ class TestStartChatTurn:
         mock_enqueue.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_existing_session_id_wrong_user_raises_not_found(self):
+    async def test_stale_session_id_falls_back_to_fresh_session(self):
+        # The bot caches session IDs across turns; a cached session can be
+        # deleted from the web app in between. start_chat_turn must recover
+        # by creating a fresh session instead of raising.
         db_mock = MagicMock()
         db_mock.find_user_link_owner = AsyncMock(return_value="owner-1")
+        session = MagicMock(session_id="sess-fresh")
 
         with (
             patch(
@@ -124,6 +128,24 @@ class TestStartChatTurn:
                 "backend.platform_linking.chat.get_chat_session",
                 new=AsyncMock(return_value=None),
             ),
+            patch(
+                "backend.platform_linking.chat.create_chat_session",
+                new=AsyncMock(return_value=session),
+            ) as mock_create,
+            patch(
+                "backend.platform_linking.chat.append_and_save_message",
+                new=AsyncMock(return_value=MagicMock()),
+            ),
+            patch(
+                "backend.platform_linking.chat.stream_registry"
+            ) as mock_stream_registry,
+            patch(
+                "backend.platform_linking.chat.enqueue_copilot_turn",
+                new=AsyncMock(),
+            ),
         ):
-            with pytest.raises(NotFoundError):
-                await start_chat_turn(_request(session_id="someone-elses"))
+            mock_stream_registry.create_session = AsyncMock()
+            handle = await start_chat_turn(_request(session_id="deleted-session"))
+
+        assert handle.session_id == "sess-fresh"
+        mock_create.assert_awaited_once()


### PR DESCRIPTION
### Why / What / How

**Why:** Deleting a Copilot chat session on the web app permanently bricks the corresponding Discord thread/DM. The bot caches the `session_id` in Redis under its own key (`copilot-bot:session:<platform>:<target_id>`). When the session is deleted on the web, `delete_chat_session` destroys the DB row and clears the *copilot* session cache — but it has no knowledge of the bot's mapping key, so that key keeps pointing at the dead session. The next message resolves the stale ID, `start_chat_turn` raises `NotFoundError("Session not found.")`, and since nothing ever clears the stale key, **every subsequent message fails identically**. Reported by Abhi during bot testing.

**What:** `start_chat_turn` now treats an unresolved `session_id` as "start fresh" instead of erroring — the conversation self-heals.

**How:** When the provided `session_id` doesn't resolve to a session (deleted, expired, or otherwise gone), fall back to `create_chat_session(...)` rather than raising. The handle then carries the new session ID, and the existing `on_session_id` callback (`bot_backend.stream_chat` → `handler._on_session_id`) writes it back into the bot's Redis cache — so the thread recovers automatically on the next message. This also covers session deletion by *any* cause, not just the web app. `start_chat_turn` is bot-only (sole caller is the `PlatformLinkingManager` RPC wrapper), and the `source_platform` value introduced in #13175 is preserved.

### Changes 🏗️

- `platform_linking/chat.py` — `start_chat_turn` falls back to a fresh session when a provided `session_id` no longer resolves, instead of raising `NotFoundError`.
- `platform_linking/chat_test.py` — replaced `test_existing_session_id_wrong_user_raises_not_found` with `test_stale_session_id_falls_back_to_fresh_session`, which reproduces the bug and verifies the recovery.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `test_stale_session_id_falls_back_to_fresh_session` fails against the pre-fix code (reproduces the bricked thread) and passes after the fix
  - [x] Full `platform_linking/chat_test.py` suite green (4 passed), `black` + `ruff` + `pyright` clean
