### PR TITLE
dx(skills): stop publishing dev test creds in /pr-test SKILL.md

### DIFF
--- a/.claude/skills/pr-test/SKILL.md
+++ b/.claude/skills/pr-test/SKILL.md
@@ -58,9 +58,9 @@ When testing features that depend on specific states (rate limits, credits, quot
    # Set a key with expiry
    docker exec $REDIS_CONTAINER redis-cli SET key value EX ttl
    # Example: Set rate limit counter to near-limit
-   docker exec $REDIS_CONTAINER redis-cli SET "rate_limit:user:test@test.com" 99 EX 3600
+   docker exec $REDIS_CONTAINER redis-cli SET "rate_limit:user:$PR_TEST_USER_EMAIL" 99 EX 3600
    # Example: Check current value
-   docker exec $REDIS_CONTAINER redis-cli GET "rate_limit:user:test@test.com"
+   docker exec $REDIS_CONTAINER redis-cli GET "rate_limit:user:$PR_TEST_USER_EMAIL"
    ```
 
 2. **Use API calls to check before/after state:**
@@ -126,9 +126,21 @@ RESULTS_DIR="$REPO_ROOT/test-results/PR-${PR_NUMBER}-${PR_TITLE}"
 mkdir -p $RESULTS_DIR
 ```
 
-**Test user credentials** (for logging into the UI or verifying results manually):
-- Email: `test@test.com`
-- Password: `testtest123`
+**Test user credentials** — required to log into the UI or call authenticated APIs.
+
+NEVER hardcode these in this SKILL, a PR comment, a screenshot, or any committed file. Sources, in priority order:
+
+1. **Env vars** (CI / preconfigured local shell): `$PR_TEST_USER_EMAIL` + `$PR_TEST_USER_PASSWORD`. If both are set, use them.
+2. **Interactive prompt** (everything else, including dev-preview runs): if the env vars are not set, ASK the user at the start of the run — e.g. "I need test-user credentials for this run; paste the email and password." Hold them in shell vars only for the duration of the run. Do not echo, log, or write them to disk.
+
+Lock the variables in for the rest of this SKILL:
+
+```bash
+: "${PR_TEST_USER_EMAIL:?Set PR_TEST_USER_EMAIL via env var or ask the user before running}"
+: "${PR_TEST_USER_PASSWORD:?Set PR_TEST_USER_PASSWORD via env var or ask the user before running}"
+```
+
+For **local docker-compose** runs, a fresh dev user is created on first call to the signup snippet below. For **dev-preview** runs, the test user lives in the project's Supabase — ask the user for the current valid credentials each session (the previously-shared `test@test.com` test account was disabled on 2026-05-23 after its credentials leaked into this very SKILL — do NOT re-introduce a default).
 
 ## Step 1: Understand the PR
 
@@ -478,10 +490,11 @@ done
 ANON_KEY=$(grep "NEXT_PUBLIC_SUPABASE_ANON_KEY=" $FRONTEND_DIR/.env | sed 's/.*NEXT_PUBLIC_SUPABASE_ANON_KEY=//' | tr -d '[:space:]')
 
 # Signup (idempotent — returns "User already registered" if exists)
+SIGNUP_PAYLOAD=$(jq -nc --arg e "$PR_TEST_USER_EMAIL" --arg p "$PR_TEST_USER_PASSWORD" '{email:$e,password:$p}')
 RESULT=$(curl -s -X POST 'http://localhost:8000/auth/v1/signup' \
   -H "apikey: $ANON_KEY" \
   -H 'Content-Type: application/json' \
-  -d '{"email":"test@test.com","password":"testtest123"}')
+  -d "$SIGNUP_PAYLOAD")
 
 # If "Database error finding user", restart supabase-auth and retry
 if echo "$RESULT" | grep -q "Database error"; then
@@ -489,14 +502,14 @@ if echo "$RESULT" | grep -q "Database error"; then
   curl -s -X POST 'http://localhost:8000/auth/v1/signup' \
     -H "apikey: $ANON_KEY" \
     -H 'Content-Type: application/json' \
-    -d '{"email":"test@test.com","password":"testtest123"}'
+    -d "$SIGNUP_PAYLOAD"
 fi
 
 # Get auth token
 TOKEN=$(curl -s -X POST 'http://localhost:8000/auth/v1/token?grant_type=password' \
   -H "apikey: $ANON_KEY" \
   -H 'Content-Type: application/json' \
-  -d '{"email":"test@test.com","password":"testtest123"}' | jq -r '.access_token // ""')
+  -d "$SIGNUP_PAYLOAD" | jq -r '.access_token // ""')
 ```
 
 **Use this token for ALL API calls:**
@@ -601,9 +614,9 @@ agent-browser --session-name pr-test open 'http://localhost:3000/login' --timeou
 # Get interactive elements
 agent-browser --session-name pr-test snapshot | grep "textbox\|button"
 
-# Login
-agent-browser --session-name pr-test fill {email_ref} "test@test.com"
-agent-browser --session-name pr-test fill {password_ref} "testtest123"
+# Login (read creds from env — set PR_TEST_USER_EMAIL / PR_TEST_USER_PASSWORD or ask the user)
+agent-browser --session-name pr-test fill {email_ref} "$PR_TEST_USER_EMAIL"
+agent-browser --session-name pr-test fill {password_ref} "$PR_TEST_USER_PASSWORD"
 agent-browser --session-name pr-test click {login_button_ref}
 sleep 5
 

--- a/.claude/skills/pr-test/SKILL.md
+++ b/.claude/skills/pr-test/SKILL.md
@@ -133,11 +133,24 @@ NEVER hardcode these in this SKILL, a PR comment, a screenshot, or any committed
 1. **Env vars** (CI / preconfigured local shell): `$PR_TEST_USER_EMAIL` + `$PR_TEST_USER_PASSWORD`. If both are set, use them.
 2. **Interactive prompt** (everything else, including dev-preview runs): if the env vars are not set, ASK the user at the start of the run — e.g. "I need test-user credentials for this run; paste the email and password." Hold them in shell vars only for the duration of the run. Do not echo, log, or write them to disk.
 
-Lock the variables in for the rest of this SKILL:
+Acquire the variables — env first, prompt if missing — and only then lock them in:
 
 ```bash
-: "${PR_TEST_USER_EMAIL:?Set PR_TEST_USER_EMAIL via env var or ask the user before running}"
-: "${PR_TEST_USER_PASSWORD:?Set PR_TEST_USER_PASSWORD via env var or ask the user before running}"
+# 1. Prefer env vars (CI / preconfigured shell). If either is missing,
+#    ask the user — do NOT proceed silently with a default.
+if [ -z "${PR_TEST_USER_EMAIL:-}" ] || [ -z "${PR_TEST_USER_PASSWORD:-}" ]; then
+  echo "Test user credentials required for this run."
+  read -r -p   "Email:    " PR_TEST_USER_EMAIL
+  read -r -s -p "Password: " PR_TEST_USER_PASSWORD
+  echo
+  export PR_TEST_USER_EMAIL PR_TEST_USER_PASSWORD
+fi
+
+# 2. Lock them in — fail loudly if either is STILL unset (e.g. the user
+#    pressed Enter on an empty prompt). The error message names the var so
+#    the agent / operator knows what to fix.
+: "${PR_TEST_USER_EMAIL:?PR_TEST_USER_EMAIL is empty after env+prompt — supply a value before re-running}"
+: "${PR_TEST_USER_PASSWORD:?PR_TEST_USER_PASSWORD is empty after env+prompt — supply a value before re-running}"
 ```
 
 For **local docker-compose** runs, a fresh dev user is created on first call to the signup snippet below. For **dev-preview** runs, the test user lives in the project's Supabase — ask the user for the current valid credentials each session (the previously-shared `test@test.com` test account was disabled on 2026-05-23 after its credentials leaked into this very SKILL — do NOT re-introduce a default).
@@ -496,13 +509,15 @@ RESULT=$(curl -s -X POST 'http://localhost:8000/auth/v1/signup' \
   -H 'Content-Type: application/json' \
   -d "$SIGNUP_PAYLOAD")
 
-# If "Database error finding user", restart supabase-auth and retry
+# If "Database error finding user", restart supabase-auth and retry —
+# capture the retry result back into $RESULT so the token step below
+# reads the post-retry state, not the original failure.
 if echo "$RESULT" | grep -q "Database error"; then
   docker restart supabase-auth && sleep 5
-  curl -s -X POST 'http://localhost:8000/auth/v1/signup' \
+  RESULT=$(curl -s -X POST 'http://localhost:8000/auth/v1/signup' \
     -H "apikey: $ANON_KEY" \
     -H 'Content-Type: application/json' \
-    -d "$SIGNUP_PAYLOAD"
+    -d "$SIGNUP_PAYLOAD")
 fi
 
 # Get auth token

--- a/.claude/skills/pr-test/SKILL.md
+++ b/.claude/skills/pr-test/SKILL.md
@@ -136,13 +136,18 @@ NEVER hardcode these in this SKILL, a PR comment, a screenshot, or any committed
 Acquire the variables — env first, prompt if missing — and only then lock them in:
 
 ```bash
-# 1. Prefer env vars (CI / preconfigured shell). If either is missing,
-#    ask the user — do NOT proceed silently with a default.
+# 1. Prefer env vars (CI / preconfigured shell). Prompt only for the
+#    specific var that is unset so an already-exported credential is
+#    not overwritten by the prompt when only the other one is missing.
 if [ -z "${PR_TEST_USER_EMAIL:-}" ] || [ -z "${PR_TEST_USER_PASSWORD:-}" ]; then
   echo "Test user credentials required for this run."
-  read -r -p   "Email:    " PR_TEST_USER_EMAIL
-  read -r -s -p "Password: " PR_TEST_USER_PASSWORD
-  echo
+  if [ -z "${PR_TEST_USER_EMAIL:-}" ]; then
+    read -r -p   "Email:    " PR_TEST_USER_EMAIL
+  fi
+  if [ -z "${PR_TEST_USER_PASSWORD:-}" ]; then
+    read -r -s -p "Password: " PR_TEST_USER_PASSWORD
+    echo
+  fi
   export PR_TEST_USER_EMAIL PR_TEST_USER_PASSWORD
 fi
 


### PR DESCRIPTION
## Why

`.claude/skills/pr-test/SKILL.md` had the dev test account's email + password hardcoded in **8 places** — the "Test user credentials" header, two Redis rate-limit examples, three signup/login curl snippets, and the agent-browser login flow. Because the repo is public, anyone on the internet who read the SKILL could sign in to `dev-builder.agpt.co` as that test user. The account was disabled on 2026-05-23 via `banned_until=2126-04-29` once the leak surfaced.

## What

- Every literal `test@test.com` / `testtest123` occurrence replaced with `$PR_TEST_USER_EMAIL` / `$PR_TEST_USER_PASSWORD` shell variables.
- New "Test user credentials" section mandates two acquisition paths, in order:
  1. Read env vars when set (CI / preconfigured shells).
  2. Otherwise ASK the user interactively at the start of the run; hold creds only in shell vars for the duration; never echo or persist.
- Inline `: "${PR_TEST_USER_EMAIL:?...}"` / `: "${PR_TEST_USER_PASSWORD:?...}"` guards force a hard failure if the agent forgot to acquire creds.
- A "do NOT re-introduce a default" warning calls out the prior leak so future SKILL edits don't reset progress.

## How

`jq -nc --arg e "$PR_TEST_USER_EMAIL" --arg p "$PR_TEST_USER_PASSWORD" '{email:$e,password:$p}'` builds the signup payload safely (escapes whatever the user pastes), then the existing curl/agent-browser flow reads from the env. No behaviour change for local docker-compose runs once the vars are set; dev-preview runs now require the agent to ask the user for creds each session.

## Test plan

- [x] `grep -c "test@test.com\\|testtest123" .claude/skills/pr-test/SKILL.md` → only the deliberate warning line remains (`do NOT re-introduce a default`); zero functional references.
- [ ] Manual: re-run `/pr-test` against `dev-builder.agpt.co` with `PR_TEST_USER_EMAIL` / `PR_TEST_USER_PASSWORD` set in the shell — confirms the agent-browser login still works after the rewrite.
- [ ] Manual: unset both vars and re-run `/pr-test` — confirms the guards trip and the agent prompts for creds instead of barreling on.
