### PR TITLE
fix(frontend/library): autopilot pill counts copilot follow-ups only, not graph schedules

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/library/components/AgentBriefingPanel/BriefingTabContent.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/components/AgentBriefingPanel/BriefingTabContent.tsx
@@ -2,10 +2,7 @@
 
 import type { LibraryAgent } from "@/app/api/__generated__/models/libraryAgent";
 import { useListCopilotSkills } from "@/app/api/__generated__/endpoints/skills/skills";
-import {
-  useGetV1ListExecutionSchedulesForAUser,
-  useListCopilotFollowupSchedules,
-} from "@/app/api/__generated__/endpoints/schedules/schedules";
+import { useListCopilotFollowupSchedules } from "@/app/api/__generated__/endpoints/schedules/schedules";
 import { Button } from "@/components/atoms/Button/Button";
 import { useSitrepItems } from "../SitrepItem/useSitrepItems";
 import { SitrepItem } from "../SitrepItem/SitrepItem";
@@ -45,43 +42,41 @@ export function BriefingTabContent({ activeTab, agents }: Props) {
 function CopilotLibrarySummary() {
   // Discoverability is already gated by AGENT_BRIEFING at the parent
   // panel — this pill renders only inside AgentBriefingPanel, which is
-  // itself flag-gated.  No second flag here so we don't end up with two
-  // flags we'd always toggle together.
+  // itself flag-gated.  No second flag here because the count-based
+  // hide below already keeps the pill quiet for users who don't use
+  // the feature.
   const { data: skillsRes } = useListCopilotSkills({
     query: { staleTime: 30_000 },
   });
   const { data: followupsRes } = useListCopilotFollowupSchedules({
     query: { staleTime: 30_000 },
   });
-  // Graph schedules (recurring agent runs) live alongside followups in
-  // the unified Scheduled page — count them together so the briefing
-  // pill mirrors what the user sees there.
-  const { data: graphsRes } = useGetV1ListExecutionSchedulesForAUser({
-    query: { staleTime: 30_000 },
-  });
 
   const skillsCount =
     skillsRes && skillsRes.status === 200 ? skillsRes.data.length : 0;
-  const copilotFollowupsCount =
+  // Count only copilot follow-ups here — graph schedules (recurring
+  // agent runs) are already surfaced by the briefing's own "Scheduled"
+  // tab above, so folding them into this pill would double-count and
+  // confuse the "Autopilot library" framing.  The pill's link still
+  // goes to the unified `/library/followups` page, where both kinds
+  // are listed together.
+  const followupCount =
     followupsRes && followupsRes.status === 200 ? followupsRes.data.length : 0;
-  const graphSchedulesCount =
-    graphsRes && graphsRes.status === 200 ? graphsRes.data.length : 0;
-  const scheduledCount = copilotFollowupsCount + graphSchedulesCount;
 
   // Suppress the pill entirely when the user has no autopilot library
-  // content yet — surfacing "0 skills · 0 scheduled" is noise, not a
+  // content yet — surfacing "0 skills · 0 follow-ups" is noise, not a
   // discovery affordance.  The pill reappears the moment either count
-  // turns positive (e.g. on the next refetch after a store_skill /
-  // schedule_followup / add_graph_execution_schedule tool call).
-  if (skillsCount === 0 && scheduledCount === 0) {
+  // turns positive (e.g. after a store_skill / schedule_followup tool
+  // call).
+  if (skillsCount === 0 && followupCount === 0) {
     return null;
   }
 
   // Per-link hide: surface only the counts that are non-zero.  We
   // already returned ``null`` above when both are zero, so at least
-  // one of these two branches always renders.
+  // one branch always renders.
   const showSkills = skillsCount > 0;
-  const showScheduled = scheduledCount > 0;
+  const showFollowups = followupCount > 0;
 
   return (
     <div
@@ -100,16 +95,16 @@ function CopilotLibrarySummary() {
           {skillsCount} skill{skillsCount === 1 ? "" : "s"}
         </Link>
       ) : null}
-      {showSkills && showScheduled ? (
+      {showSkills && showFollowups ? (
         <span className="text-zinc-300">•</span>
       ) : null}
-      {showScheduled ? (
+      {showFollowups ? (
         <Link
           href="/library/followups"
           className="text-sm text-yellow-700 hover:underline"
           data-testid="copilot-library-followups-link"
         >
-          {scheduledCount} scheduled
+          {followupCount} follow-up{followupCount === 1 ? "" : "s"}
         </Link>
       ) : null}
     </div>

--- a/autogpt_platform/frontend/src/app/(platform)/library/components/AgentBriefingPanel/__tests__/BriefingTabContent.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/components/AgentBriefingPanel/__tests__/BriefingTabContent.test.tsx
@@ -8,7 +8,12 @@ import type { CopilotTurnJobInfo } from "@/app/api/__generated__/models/copilotT
 import type { GraphExecutionJobInfo } from "@/app/api/__generated__/models/graphExecutionJobInfo";
 import type { LibraryAgent } from "@/app/api/__generated__/models/libraryAgent";
 import { server } from "@/mocks/mock-server";
-import { fireEvent, render, screen } from "@/tests/integrations/test-utils";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@/tests/integrations/test-utils";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { BriefingTabContent } from "../BriefingTabContent";
 
@@ -427,9 +432,10 @@ describe("BriefingTabContent — CopilotLibrarySummary (Autopilot pill)", () => 
 
     // The pill suppresses entirely when both counts are zero — surfacing
     // "0 skills · 0 scheduled" would be noise, not a discovery affordance.
-    await new Promise((r) => setTimeout(r, 50));
-    expect(screen.queryByTestId("copilot-library-summary")).toBeNull();
-    expect(screen.queryByText("Autopilot library")).toBeNull();
+    await waitFor(() => {
+      expect(screen.queryByTestId("copilot-library-summary")).toBeNull();
+      expect(screen.queryByText("Autopilot library")).toBeNull();
+    });
   });
 
   it("shows only the skills link when scheduled count is zero", async () => {
@@ -494,9 +500,10 @@ describe("BriefingTabContent — CopilotLibrarySummary (Autopilot pill)", () => 
 
     render(<BriefingTabContent activeTab="all" agents={[]} />);
 
-    await new Promise((r) => setTimeout(r, 50));
-    expect(screen.queryByTestId("copilot-library-summary")).toBeNull();
-    expect(screen.queryByText("Autopilot library")).toBeNull();
+    await waitFor(() => {
+      expect(screen.queryByTestId("copilot-library-summary")).toBeNull();
+      expect(screen.queryByText("Autopilot library")).toBeNull();
+    });
   });
 
   it("shows both links with a separator when skills AND follow-ups are positive (singular pluralization)", async () => {

--- a/autogpt_platform/frontend/src/app/(platform)/library/components/AgentBriefingPanel/__tests__/BriefingTabContent.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/components/AgentBriefingPanel/__tests__/BriefingTabContent.test.tsx
@@ -452,7 +452,7 @@ describe("BriefingTabContent — CopilotLibrarySummary (Autopilot pill)", () => 
     expect(screen.queryByTestId("copilot-library-followups-link")).toBeNull();
   });
 
-  it("shows only the scheduled link when skills count is zero (sums followups + graph schedules)", async () => {
+  it("counts copilot follow-ups only (graph schedules are NOT folded in — they have their own briefing tab)", async () => {
     setupBriefingMocks();
     server.use(
       getListCopilotSkillsMockHandler([]),
@@ -460,6 +460,33 @@ describe("BriefingTabContent — CopilotLibrarySummary (Autopilot pill)", () => 
         makeFollowup({ id: "f1" }),
         makeFollowup({ id: "f2" }),
       ]),
+      // Graph schedules exist server-side but MUST NOT be added to the
+      // pill count — the briefing's own "Scheduled" tab already covers
+      // them, so folding them in here would double-count.
+      getGetV1ListExecutionSchedulesForAUserMockHandler([
+        makeGraphSchedule({ id: "g1" }),
+        makeGraphSchedule({ id: "g2" }),
+      ]),
+    );
+
+    render(<BriefingTabContent activeTab="all" agents={[]} />);
+
+    expect(await screen.findByText("Autopilot library")).toBeDefined();
+    expect(
+      screen.getByTestId("copilot-library-followups-link").textContent,
+    ).toBe("2 follow-ups");
+    expect(screen.queryByTestId("copilot-library-skills-link")).toBeNull();
+  });
+
+  it("hides the pill entirely when skills=0 AND copilot follow-ups=0 (even if graph schedules exist)", async () => {
+    setupBriefingMocks();
+    server.use(
+      getListCopilotSkillsMockHandler([]),
+      getListCopilotFollowupSchedulesMockHandler([]),
+      // Graph schedules alone don't count toward the autopilot pill —
+      // they belong to the "Scheduled" briefing tab. Pill must stay
+      // hidden so we don't surface a bare "Autopilot library" header
+      // with nothing actionable.
       getGetV1ListExecutionSchedulesForAUserMockHandler([
         makeGraphSchedule({ id: "g1" }),
       ]),
@@ -467,15 +494,12 @@ describe("BriefingTabContent — CopilotLibrarySummary (Autopilot pill)", () => 
 
     render(<BriefingTabContent activeTab="all" agents={[]} />);
 
-    expect(await screen.findByText("Autopilot library")).toBeDefined();
-    // 2 followups + 1 graph schedule = 3 total scheduled.
-    expect(
-      screen.getByTestId("copilot-library-followups-link").textContent,
-    ).toBe("3 scheduled");
-    expect(screen.queryByTestId("copilot-library-skills-link")).toBeNull();
+    await new Promise((r) => setTimeout(r, 50));
+    expect(screen.queryByTestId("copilot-library-summary")).toBeNull();
+    expect(screen.queryByText("Autopilot library")).toBeNull();
   });
 
-  it("shows both links with a separator when both counts are positive", async () => {
+  it("shows both links with a separator when skills AND follow-ups are positive (singular pluralization)", async () => {
     setupBriefingMocks();
     server.use(
       getListCopilotSkillsMockHandler([makeSkill({ name: "only-one" })]),
@@ -492,7 +516,7 @@ describe("BriefingTabContent — CopilotLibrarySummary (Autopilot pill)", () => 
     );
     expect(
       screen.getByTestId("copilot-library-followups-link").textContent,
-    ).toBe("1 scheduled");
+    ).toBe("1 follow-up");
     // Separator dot is only rendered when BOTH links are visible.
     const pill = screen.getByTestId("copilot-library-summary");
     expect(pill.textContent).toContain("•");


### PR DESCRIPTION
## Why

Spotted in the screenshot below — the autopilot library pill on `/library` was double-counting:

- The briefing's "**Scheduled 3**" tab already counts agents that have schedules attached.
- My PR #13202 added an "**Autopilot library — 4 scheduled**" pill at the bottom that sums copilot follow-ups + graph schedules (1 + 3 = 4).
- Reads as inconsistent ("3 vs 4") and dilutes the autopilot framing — graph schedules aren't an autopilot/copilot concept, they're an agent concept covered by the tab above.

Also: with the previous behaviour, a user who's never touched the copilot but has 1 graph schedule would still see an "Autopilot library 1 scheduled" pill, even though they have no autopilot-specific content.

## What

- Drop graph-schedules query + count from the pill.
- Count copilot follow-ups only.
- Rename link label `X scheduled` → `X follow-up(s)` so the count clearly belongs to autopilot.
- Pill still hides entirely when skills=0 AND follow-ups=0 (graph schedules alone no longer surface the autopilot header — they belong to the "Scheduled" briefing tab).
- Link destination unchanged — still `/library/followups`, which renders BOTH copilot follow-ups AND graph schedules (the unification from #13202 stays useful at the destination).

## How

```diff
-import {
-  useGetV1ListExecutionSchedulesForAUser,
-  useListCopilotFollowupSchedules,
-} from "@/app/api/__generated__/endpoints/schedules/schedules";
+import { useListCopilotFollowupSchedules } from "@/app/api/__generated__/endpoints/schedules/schedules";
@@
-  const { data: graphsRes } = useGetV1ListExecutionSchedulesForAUser({…});
-  …
-  const scheduledCount = copilotFollowupsCount + graphSchedulesCount;
-  if (skillsCount === 0 && scheduledCount === 0) return null;
+  const followupCount = …;
+  if (skillsCount === 0 && followupCount === 0) return null;
@@
-  {scheduledCount} scheduled
+  {followupCount} follow-up{followupCount === 1 ? "" : "s"}
```

No new feature flag — count-based hide already keeps the pill quiet for first-time users.

## Test coverage

Updated the BriefingTabContent vitest cases:

- `counts copilot follow-ups only (graph schedules are NOT folded in — they have their own briefing tab)` — asserts graph schedules don't inflate the count.
- `hides the pill entirely when skills=0 AND copilot follow-ups=0 (even if graph schedules exist)` — asserts graph schedules alone don't surface the autopilot label.
- `shows both links with a separator when skills AND follow-ups are positive (singular pluralization)` — verifies `1 skill` / `1 follow-up` singulars.

All 24 BriefingTabContent + 17 CostsBreakdown tests pass. Types clean.

## Out of scope

- No backend changes.
- Not changing the unified `/library/followups` destination page — it correctly renders both kinds.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review performed
- [x] Tests added for new behaviour (graph-schedules-don't-count + hide-on-zero with graph schedules present)
- [x] No new warnings
- [ ] CI green
