### PR TITLE
feat(backend/copilot-bot): post intro message when added to a server

### DIFF
--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter.py
@@ -21,7 +21,7 @@ from ..base import (
     MessageHistoryEntry,
     PlatformAdapter,
 )
-from . import commands, config
+from . import commands, config, intro
 
 logger = logging.getLogger(__name__)
 THREAD_HISTORY_LIMIT = 20
@@ -186,6 +186,23 @@ class DiscordAdapter(PlatformAdapter):
                 logger.info(f"Synced {len(synced)} slash commands")
             except Exception:
                 logger.exception("Failed to sync slash commands")
+
+        @self._client.event
+        async def on_guild_join(guild: discord.Guild) -> None:
+            channel = intro.pick_intro_channel(guild)
+            if channel is None:
+                logger.info(
+                    "No sendable channel in guild %s for intro message", guild.id
+                )
+                return
+            try:
+                await channel.send(
+                    intro.intro_message(),
+                    tts=False,
+                    allowed_mentions=discord.AllowedMentions.none(),
+                )
+            except discord.HTTPException:
+                logger.exception("Failed to post intro message in guild %s", guild.id)
 
         @self._client.event
         async def on_message(message: discord.Message) -> None:

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/intro.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/intro.py
@@ -31,5 +31,5 @@ def intro_message() -> str:
         "thread for our chat.\n\n"
         "You can also **DM me** to chat 1:1 — send any message and I'll "
         "walk you through linking your own DMs.\n\n"
-        "Commands: `/help` `/setup` `/new` `/resume`"
+        "Commands: `/help` `/setup` `/new`"
     )

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/intro.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/intro.py
@@ -1,0 +1,35 @@
+"""Welcome message posted when AutoPilot is added to a Discord server."""
+
+import discord
+
+
+def pick_intro_channel(guild: discord.Guild) -> discord.TextChannel | None:
+    """Return the best channel to post the welcome message in.
+
+    Prefer the server's system channel; fall back to the first text channel
+    we can send in. ``None`` if there's nowhere we can post.
+    """
+    me = guild.me
+    if me is None:
+        return None
+    system_channel = guild.system_channel
+    if system_channel is not None and system_channel.permissions_for(me).send_messages:
+        return system_channel
+    for channel in guild.text_channels:
+        if channel.permissions_for(me).send_messages:
+            return channel
+    return None
+
+
+def intro_message() -> str:
+    return (
+        "**Hey, I'm AutoPilot — AutoGPT in your Discord.** Thanks for adding me!\n\n"
+        "To get started, a server admin runs `/setup` and follows the link "
+        "to connect this server to an AutoGPT account.\n\n"
+        "Once linked, mention me anywhere I can read messages "
+        "(e.g. `@AutoPilot summarise this channel`) and I'll spin up a "
+        "thread for our chat.\n\n"
+        "You can also **DM me** to chat 1:1 — send any message and I'll "
+        "walk you through linking your own DMs.\n\n"
+        "Commands: `/help` `/setup` `/new` `/resume`"
+    )

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/intro_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/intro_test.py
@@ -1,0 +1,74 @@
+"""Tests for the on-add intro helpers."""
+
+from unittest.mock import MagicMock
+
+import discord
+
+from .intro import intro_message, pick_intro_channel
+
+
+def _channel(name: str, sendable: bool) -> MagicMock:
+    ch = MagicMock(spec=discord.TextChannel)
+    ch.name = name
+    perms = MagicMock()
+    perms.send_messages = sendable
+    ch.permissions_for = MagicMock(return_value=perms)
+    return ch
+
+
+def _guild(
+    *,
+    system_channel: MagicMock | None,
+    text_channels: list[MagicMock],
+    has_me: bool = True,
+) -> MagicMock:
+    guild = MagicMock()
+    guild.me = MagicMock() if has_me else None
+    guild.system_channel = system_channel
+    guild.text_channels = text_channels
+    return guild
+
+
+def test_prefers_system_channel_when_sendable():
+    sys_ch = _channel("system", sendable=True)
+    other = _channel("other", sendable=True)
+    guild = _guild(system_channel=sys_ch, text_channels=[other])
+
+    assert pick_intro_channel(guild) is sys_ch
+
+
+def test_falls_back_to_first_sendable_text_channel():
+    sys_ch = _channel("system", sendable=False)
+    a = _channel("a", sendable=False)
+    b = _channel("b", sendable=True)
+    c = _channel("c", sendable=True)
+    guild = _guild(system_channel=sys_ch, text_channels=[a, b, c])
+
+    assert pick_intro_channel(guild) is b
+
+
+def test_returns_none_when_nothing_sendable():
+    sys_ch = _channel("system", sendable=False)
+    a = _channel("a", sendable=False)
+    guild = _guild(system_channel=sys_ch, text_channels=[a])
+
+    assert pick_intro_channel(guild) is None
+
+
+def test_no_system_channel_uses_first_sendable_text_channel():
+    a = _channel("a", sendable=True)
+    guild = _guild(system_channel=None, text_channels=[a])
+
+    assert pick_intro_channel(guild) is a
+
+
+def test_no_member_returns_none():
+    guild = _guild(system_channel=None, text_channels=[], has_me=False)
+
+    assert pick_intro_channel(guild) is None
+
+
+def test_intro_message_mentions_setup():
+    msg = intro_message()
+    assert "/setup" in msg
+    assert "AutoPilot" in msg


### PR DESCRIPTION
### Why / What / How

**Why:** When AutoPilot is added to a Discord server, there's no in-channel signal explaining how to set it up. A new admin has to *already know* to run `/setup` — otherwise the bot just sits there silently. That's a real onboarding gap; a welcome message at join time gives them the instructions in the channel they're already looking at.

**What:** When the bot is added to a server, it posts a one-shot welcome message with the `/setup` instructions, how to use the bot (mention or DM), and the available commands.

**How:**
- New `on_guild_join` event in `DiscordAdapter._register_events` — fires once per server-add.
- Helpers in a small `intro.py` (sibling to `commands.py`) so the adapter stays focused: `pick_intro_channel(guild)` picks the server's system channel if writable, falls back to the first text channel the bot has `send_messages` in, returns `None` if nothing's writable; `intro_message()` builds the copy. The handler is a no-op when there's nowhere to post.
- Posted with `AllowedMentions.none()` (no @ping risk).
- The commands list in the message intentionally **omits `/resume`** — `/resume` is DM-only and would be rejected in a server, so advertising it there would mislead.

### Changes 🏗️

- `adapters/discord/intro.py` (new) — `pick_intro_channel` + `intro_message`.
- `adapters/discord/adapter.py` — register `on_guild_join` event; calls `intro.*` and gracefully no-ops when no channel is writable.
- `adapters/discord/intro_test.py` (new) — covers system-channel preference, fallback to first sendable text channel, none-writable case, no-system-channel case, no-`guild.me` case, and that the message references `/setup`.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Full Discord-adapter suite green (56 passed), `black` + `ruff` + `pyright` clean
  - [x] Channel-picking logic covered: prefers `system_channel`, falls back to first sendable, no-op when nothing writable
  - [x] `/resume` is **not** in the in-server commands list (it's DM-only)
