### PR TITLE
feat(platform): add Bots settings page with per-platform link management

### DIFF
--- a/autogpt_platform/backend/backend/api/features/platform_linking/registry.py
+++ b/autogpt_platform/backend/backend/api/features/platform_linking/registry.py
@@ -5,15 +5,17 @@ enabled on this deployment, and how to build their "Add bot to your server"
 invite URL. New platforms slot in by adding a row + their config check below.
 """
 
-from dataclasses import dataclass
 from urllib.parse import urlencode
+
+from pydantic import BaseModel, ConfigDict
 
 from backend.copilot.bot.adapters.discord import config as discord_config
 
 
-@dataclass(frozen=True)
-class PlatformMeta:
+class PlatformMeta(BaseModel):
     """Static + runtime metadata for one chat-bot platform."""
+
+    model_config = ConfigDict(frozen=True)
 
     platform: str  # canonical key, matches PlatformLinkInfo.platform (uppercase)
     display_name: str

--- a/autogpt_platform/backend/backend/api/features/platform_linking/registry.py
+++ b/autogpt_platform/backend/backend/api/features/platform_linking/registry.py
@@ -1,0 +1,57 @@
+"""Per-platform metadata for the Bots settings page.
+
+API-facing source of truth for which chat-bot platforms exist, which are
+enabled on this deployment, and how to build their "Add bot to your server"
+invite URL. New platforms slot in by adding a row + their config check below.
+"""
+
+from dataclasses import dataclass
+from urllib.parse import urlencode
+
+from backend.copilot.bot.adapters.discord import config as discord_config
+
+
+@dataclass(frozen=True)
+class PlatformMeta:
+    """Static + runtime metadata for one chat-bot platform."""
+
+    platform: str  # canonical key, matches PlatformLinkInfo.platform (uppercase)
+    display_name: str
+    icon: str  # filename under /public/integrations/<icon>
+    enabled: bool
+    add_bot_url: str | None  # null when the platform has no invite URL we can build
+
+
+def enabled_platforms() -> list[PlatformMeta]:
+    """Return metadata for every platform currently enabled on this deployment.
+
+    Platforms whose adapter isn't configured (missing credentials) are
+    omitted entirely so the Bots page hides them.
+    """
+    all_platforms = [_discord_meta()]
+    return [platform for platform in all_platforms if platform.enabled]
+
+
+def _discord_meta() -> PlatformMeta:
+    enabled = bool(discord_config.get_bot_token())
+    return PlatformMeta(
+        platform="DISCORD",
+        display_name="Discord",
+        icon="discord.png",
+        enabled=enabled,
+        add_bot_url=_discord_invite_url() if enabled else None,
+    )
+
+
+def _discord_invite_url() -> str | None:
+    client_id = discord_config.get_client_id()
+    if not client_id:
+        return None
+    params = urlencode(
+        {
+            "client_id": client_id,
+            "scope": "bot applications.commands",
+            "permissions": discord_config.get_invite_permissions(),
+        }
+    )
+    return f"https://discord.com/oauth2/authorize?{params}"

--- a/autogpt_platform/backend/backend/api/features/platform_linking/registry_test.py
+++ b/autogpt_platform/backend/backend/api/features/platform_linking/registry_test.py
@@ -1,0 +1,57 @@
+"""Tests for the bot-platforms registry."""
+
+from unittest.mock import patch
+
+from backend.api.features.platform_linking.registry import enabled_platforms
+
+
+def test_discord_excluded_when_bot_token_not_set():
+    with patch(
+        "backend.api.features.platform_linking.registry.discord_config.get_bot_token",
+        return_value="",
+    ):
+        assert enabled_platforms() == []
+
+
+def test_discord_appears_with_invite_url_when_client_id_set():
+    with (
+        patch(
+            "backend.api.features.platform_linking.registry.discord_config.get_bot_token",
+            return_value="token",
+        ),
+        patch(
+            "backend.api.features.platform_linking.registry.discord_config.get_client_id",
+            return_value="my-client-id",
+        ),
+        patch(
+            "backend.api.features.platform_linking.registry.discord_config.get_invite_permissions",
+            return_value="123",
+        ),
+    ):
+        platforms = enabled_platforms()
+
+    assert len(platforms) == 1
+    discord = platforms[0]
+    assert discord.platform == "DISCORD"
+    assert discord.enabled is True
+    assert discord.add_bot_url is not None
+    assert "client_id=my-client-id" in discord.add_bot_url
+    assert "permissions=123" in discord.add_bot_url
+
+
+def test_discord_appears_without_invite_url_when_client_id_missing():
+    with (
+        patch(
+            "backend.api.features.platform_linking.registry.discord_config.get_bot_token",
+            return_value="token",
+        ),
+        patch(
+            "backend.api.features.platform_linking.registry.discord_config.get_client_id",
+            return_value="",
+        ),
+    ):
+        platforms = enabled_platforms()
+
+    assert len(platforms) == 1
+    assert platforms[0].enabled is True
+    assert platforms[0].add_bot_url is None

--- a/autogpt_platform/backend/backend/api/features/platform_linking/routes.py
+++ b/autogpt_platform/backend/backend/api/features/platform_linking/routes.py
@@ -142,7 +142,9 @@ async def list_bot_platforms(
     db = platform_linking_db()
     user_links = await db.list_user_links(user_id)
     server_links = await db.list_server_links(user_id)
-    dm_by_platform = {link.platform: link for link in user_links}
+    dm_by_platform: dict[str, PlatformUserLinkInfo] = {}
+    for link in user_links:
+        dm_by_platform.setdefault(link.platform, link)
     servers_by_platform: dict[str, list[PlatformLinkInfo]] = {}
     for link in server_links:
         servers_by_platform.setdefault(link.platform, []).append(link)

--- a/autogpt_platform/backend/backend/api/features/platform_linking/routes.py
+++ b/autogpt_platform/backend/backend/api/features/platform_linking/routes.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter, HTTPException, Path, Security
 
 from backend.data.db_accessors import platform_linking_db
 from backend.platform_linking.models import (
+    BotPlatformInfo,
     ConfirmLinkResponse,
     ConfirmUserLinkResponse,
     DeleteLinkResponse,
@@ -22,6 +23,8 @@ from backend.util.exceptions import (
     NotAuthorizedError,
     NotFoundError,
 )
+
+from . import registry
 
 logger = logging.getLogger(__name__)
 
@@ -124,6 +127,36 @@ async def list_my_user_links(
     user_id: Annotated[str, Security(auth.get_user_id)],
 ) -> list[PlatformUserLinkInfo]:
     return await platform_linking_db().list_user_links(user_id)
+
+
+@router.get(
+    "/platforms",
+    response_model=list[BotPlatformInfo],
+    dependencies=[Security(auth.requires_user)],
+    summary="List bot platforms enabled on this deployment plus the caller's links",
+    operation_id="list_bot_platforms",
+)
+async def list_bot_platforms(
+    user_id: Annotated[str, Security(auth.get_user_id)],
+) -> list[BotPlatformInfo]:
+    db = platform_linking_db()
+    user_links = await db.list_user_links(user_id)
+    server_links = await db.list_server_links(user_id)
+    dm_by_platform = {link.platform: link for link in user_links}
+    servers_by_platform: dict[str, list[PlatformLinkInfo]] = {}
+    for link in server_links:
+        servers_by_platform.setdefault(link.platform, []).append(link)
+    return [
+        BotPlatformInfo(
+            platform=meta.platform,
+            display_name=meta.display_name,
+            icon=meta.icon,
+            add_bot_url=meta.add_bot_url,
+            dm_link=dm_by_platform.get(meta.platform),
+            server_links=servers_by_platform.get(meta.platform, []),
+        )
+        for meta in registry.enabled_platforms()
+    ]
 
 
 @router.delete(

--- a/autogpt_platform/backend/backend/api/features/platform_linking/routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/platform_linking/routes_test.py
@@ -354,6 +354,43 @@ class TestListBotPlatforms:
         assert [s.id for s in result[0].server_links] == ["srv-a", "srv-b"]
 
     @pytest.mark.asyncio
+    async def test_picks_newest_dm_link_when_multiple_for_same_platform(self):
+        from backend.api.features.platform_linking.routes import list_bot_platforms
+
+        newer = PlatformUserLinkInfo(
+            id="dm-new",
+            platform="DISCORD",
+            platform_user_id="discord-user-2",
+            platform_username="newer-handle",
+            linked_at=datetime(2026, 5, 10, tzinfo=timezone.utc),
+        )
+        older = PlatformUserLinkInfo(
+            id="dm-old",
+            platform="DISCORD",
+            platform_user_id="discord-user-1",
+            platform_username="older-handle",
+            linked_at=datetime(2026, 5, 1, tzinfo=timezone.utc),
+        )
+        db = _db_mock(
+            list_user_links=AsyncMock(return_value=[newer, older]),
+            list_server_links=AsyncMock(return_value=[]),
+        )
+        with (
+            patch(
+                "backend.api.features.platform_linking.routes.platform_linking_db",
+                return_value=db,
+            ),
+            patch(
+                "backend.api.features.platform_linking.routes.registry.enabled_platforms",
+                return_value=[_discord_meta()],
+            ),
+        ):
+            result = await list_bot_platforms(user_id="u1")
+
+        assert result[0].dm_link is not None
+        assert result[0].dm_link.id == "dm-new"
+
+    @pytest.mark.asyncio
     async def test_omits_platforms_whose_adapter_isnt_configured(self):
         from backend.api.features.platform_linking.routes import list_bot_platforms
 

--- a/autogpt_platform/backend/backend/api/features/platform_linking/routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/platform_linking/routes_test.py
@@ -1,10 +1,13 @@
 """Route tests: domain exceptions → HTTPException status codes."""
 
+from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
 
+from backend.api.features.platform_linking.registry import PlatformMeta
+from backend.platform_linking.models import PlatformLinkInfo, PlatformUserLinkInfo
 from backend.util.exceptions import (
     LinkAlreadyExistsError,
     LinkFlowMismatchError,
@@ -20,6 +23,18 @@ def _db_mock(**method_configs):
     for name, mock in method_configs.items():
         setattr(db, name, mock)
     return db
+
+
+def _discord_meta(
+    *, enabled: bool = True, add_bot_url: str | None = "https://invite"
+) -> PlatformMeta:
+    return PlatformMeta(
+        platform="DISCORD",
+        display_name="Discord",
+        icon="discord.png",
+        enabled=enabled,
+        add_bot_url=add_bot_url,
+    )
 
 
 class TestTokenInfoRouteTranslation:
@@ -262,3 +277,100 @@ class TestAdversarialDeleteLinkId:
             for link_id in ("'; DROP TABLE links;--", "../../etc/passwd", ""):
                 response = client.delete(f"/api/platform-linking/links/{link_id}")
                 assert response.status_code in (404, 405)
+
+
+class TestListBotPlatforms:
+    @pytest.mark.asyncio
+    async def test_returns_enabled_platforms_with_no_links(self):
+        from backend.api.features.platform_linking.routes import list_bot_platforms
+
+        db = _db_mock(
+            list_user_links=AsyncMock(return_value=[]),
+            list_server_links=AsyncMock(return_value=[]),
+        )
+        with (
+            patch(
+                "backend.api.features.platform_linking.routes.platform_linking_db",
+                return_value=db,
+            ),
+            patch(
+                "backend.api.features.platform_linking.routes.registry.enabled_platforms",
+                return_value=[_discord_meta()],
+            ),
+        ):
+            result = await list_bot_platforms(user_id="u1")
+
+        assert len(result) == 1
+        assert result[0].platform == "DISCORD"
+        assert result[0].add_bot_url == "https://invite"
+        assert result[0].dm_link is None
+        assert result[0].server_links == []
+
+    @pytest.mark.asyncio
+    async def test_attaches_callers_dm_and_server_links(self):
+        from backend.api.features.platform_linking.routes import list_bot_platforms
+
+        dm_link = PlatformUserLinkInfo(
+            id="dm-1",
+            platform="DISCORD",
+            platform_user_id="discord-user-1",
+            platform_username="bently",
+            linked_at=datetime(2026, 5, 1, tzinfo=timezone.utc),
+        )
+        server_a = PlatformLinkInfo(
+            id="srv-a",
+            platform="DISCORD",
+            platform_server_id="111",
+            owner_platform_user_id="discord-user-1",
+            server_name="Server A",
+            linked_at=datetime(2026, 5, 1, tzinfo=timezone.utc),
+        )
+        server_b = PlatformLinkInfo(
+            id="srv-b",
+            platform="DISCORD",
+            platform_server_id="222",
+            owner_platform_user_id="discord-user-1",
+            server_name="Server B",
+            linked_at=datetime(2026, 5, 2, tzinfo=timezone.utc),
+        )
+        db = _db_mock(
+            list_user_links=AsyncMock(return_value=[dm_link]),
+            list_server_links=AsyncMock(return_value=[server_a, server_b]),
+        )
+        with (
+            patch(
+                "backend.api.features.platform_linking.routes.platform_linking_db",
+                return_value=db,
+            ),
+            patch(
+                "backend.api.features.platform_linking.routes.registry.enabled_platforms",
+                return_value=[_discord_meta()],
+            ),
+        ):
+            result = await list_bot_platforms(user_id="discord-user-1")
+
+        assert result[0].dm_link is not None
+        assert result[0].dm_link.id == "dm-1"
+        assert [s.id for s in result[0].server_links] == ["srv-a", "srv-b"]
+
+    @pytest.mark.asyncio
+    async def test_omits_platforms_whose_adapter_isnt_configured(self):
+        from backend.api.features.platform_linking.routes import list_bot_platforms
+
+        db = _db_mock(
+            list_user_links=AsyncMock(return_value=[]),
+            list_server_links=AsyncMock(return_value=[]),
+        )
+        with (
+            patch(
+                "backend.api.features.platform_linking.routes.platform_linking_db",
+                return_value=db,
+            ),
+            patch(
+                "backend.api.features.platform_linking.routes.registry.enabled_platforms",
+                return_value=[],
+            ),
+        ):
+            result = await list_bot_platforms(user_id="u1")
+
+        assert result == []

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter.py
@@ -176,6 +176,11 @@ class DiscordAdapter(PlatformAdapter):
         @self._client.event
         async def on_ready() -> None:
             logger.info(f"Discord bot connected as {self._client.user}")
+            # Refresh display names for every guild we're currently in — keeps
+            # the Bots settings page in sync with renames and backfills any
+            # rows that pre-date name capture. Cheap: in-memory cache only,
+            # no Discord API calls.
+            await self._refresh_known_server_names()
             # Sync slash commands once per process — on_ready fires on every
             # gateway reconnect, but the command tree only needs uploading once.
             if self._commands_synced:
@@ -186,6 +191,15 @@ class DiscordAdapter(PlatformAdapter):
                 logger.info(f"Synced {len(synced)} slash commands")
             except Exception:
                 logger.exception("Failed to sync slash commands")
+
+        @self._client.event
+        async def on_guild_join(guild: discord.Guild) -> None:
+            await self._refresh_server_name(guild)
+
+        @self._client.event
+        async def on_guild_update(before: discord.Guild, after: discord.Guild) -> None:
+            if before.name != after.name:
+                await self._refresh_server_name(after)
 
         @self._client.event
         async def on_message(message: discord.Message) -> None:
@@ -220,6 +234,23 @@ class DiscordAdapter(PlatformAdapter):
                 mentionable_users=self._collect_mentionable_users(message),
             )
             await self._on_message_callback(ctx, self)
+
+    async def _refresh_known_server_names(self) -> None:
+        """Push current display names for every guild the bot is in."""
+        for guild in self._client.guilds:
+            await self._refresh_server_name(guild)
+
+    async def _refresh_server_name(self, guild: discord.Guild) -> None:
+        if not guild.name:
+            return
+        try:
+            await self._api.refresh_server_name(
+                platform="discord",
+                platform_server_id=str(guild.id),
+                server_name=guild.name,
+            )
+        except Exception:
+            logger.exception("Failed to refresh display name for guild %s", guild.id)
 
     def _should_ignore_message(self, message: discord.Message) -> bool:
         return (

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter_test.py
@@ -457,3 +457,46 @@ class TestCollectMentionableUsers:
         adapter, _ = _bare_adapter(bot_id=1000)
         msg = _message("<@1000> hi", mentions=[_mention(1000, "AutoPilot")])
         assert adapter._collect_mentionable_users(msg) == ()
+
+
+def _bare_adapter_with_api() -> tuple[DiscordAdapter, MagicMock, MagicMock]:
+    adapter, client = _bare_adapter(bot_id=1000)
+    api = MagicMock()
+    api.refresh_server_name = AsyncMock()
+    adapter._api = api
+    return adapter, client, api
+
+
+def _guild(guild_id: int, name: str | None) -> MagicMock:
+    g = MagicMock()
+    g.id = guild_id
+    g.name = name
+    return g
+
+
+class TestRefreshServerNames:
+    @pytest.mark.asyncio
+    async def test_pushes_every_guild_to_the_backend(self):
+        adapter, client, api = _bare_adapter_with_api()
+        client.guilds = [_guild(1, "Server One"), _guild(2, "Server Two")]
+        await adapter._refresh_known_server_names()
+        assert api.refresh_server_name.await_count == 2
+        api.refresh_server_name.assert_any_await(
+            platform="discord", platform_server_id="1", server_name="Server One"
+        )
+        api.refresh_server_name.assert_any_await(
+            platform="discord", platform_server_id="2", server_name="Server Two"
+        )
+
+    @pytest.mark.asyncio
+    async def test_skips_guild_with_blank_name(self):
+        adapter, _, api = _bare_adapter_with_api()
+        await adapter._refresh_server_name(_guild(99, ""))
+        api.refresh_server_name.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_swallows_backend_errors(self):
+        adapter, _, api = _bare_adapter_with_api()
+        api.refresh_server_name.side_effect = RuntimeError("rpc down")
+        # Must not raise — refreshing names is never critical-path.
+        await adapter._refresh_server_name(_guild(1, "Server One"))

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/config.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/config.py
@@ -7,9 +7,26 @@ def get_bot_token() -> str:
     return Settings().secrets.autopilot_bot_discord_token
 
 
+def get_client_id() -> str:
+    return Settings().secrets.autopilot_bot_discord_client_id
+
+
+def get_invite_permissions() -> str:
+    return (
+        Settings().secrets.autopilot_bot_discord_permissions
+        or DEFAULT_INVITE_PERMISSIONS
+    )
+
+
 # Discord message content limit (hard platform cap)
 MAX_MESSAGE_LENGTH = 2000
 
 # Flush the streaming buffer at 1900 — leaves 100-char headroom under the
 # 2000 cap so the boundary-splitter has room to reach a natural break point.
 CHUNK_FLUSH_AT = 1900
+
+# Sensible default Discord permissions for the "Add to server" invite URL —
+# covers send messages, embed links, attach files, read history, add
+# reactions, use external emoji, slash commands, public threads, and sending
+# in threads. Override per-deployment via AUTOPILOT_BOT_DISCORD_PERMISSIONS.
+DEFAULT_INVITE_PERMISSIONS = "377957124928"

--- a/autogpt_platform/backend/backend/copilot/bot/bot_backend.py
+++ b/autogpt_platform/backend/backend/copilot/bot/bot_backend.py
@@ -95,6 +95,25 @@ class BotBackend:
         )
         return ResolveResult(linked=resp.linked)
 
+    async def refresh_server_name(
+        self, platform: str, platform_server_id: str, server_name: str
+    ) -> None:
+        """Push the bot's authoritative display name for a server into the DB.
+
+        Called by adapters whenever they learn or re-learn a server's name —
+        e.g. Discord's on_ready and on_guild_join. The Bots settings page
+        renders whatever is in the DB, so this keeps stale or missing names
+        in sync with what the bot is actually connected to. Best-effort:
+        failures are logged on the manager side, never raised.
+        """
+        if not server_name:
+            return
+        await self._client.refresh_server_link_name(
+            platform=Platform(platform.upper()),
+            platform_server_id=platform_server_id,
+            server_name=server_name,
+        )
+
     async def create_link_token(
         self,
         platform: str,

--- a/autogpt_platform/backend/backend/copilot/bot/bot_backend_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/bot_backend_test.py
@@ -15,6 +15,7 @@ from backend.copilot.response_model import (
 from backend.platform_linking.models import (
     ChatTurnHandle,
     LinkTokenResponse,
+    Platform,
     ResolveResponse,
 )
 from backend.util.exceptions import (
@@ -53,6 +54,24 @@ class TestResolve:
         )
         result = await api.resolve_user("discord", "u1")
         assert result.linked is False
+
+
+class TestRefreshServerName:
+    @pytest.mark.asyncio
+    async def test_forwards_uppercased_platform(self, api: BotBackend):
+        api._client.refresh_server_link_name = AsyncMock()
+        await api.refresh_server_name("discord", "g1", "AutoGPT HQ")
+        api._client.refresh_server_link_name.assert_awaited_once_with(
+            platform=Platform.DISCORD,
+            platform_server_id="g1",
+            server_name="AutoGPT HQ",
+        )
+
+    @pytest.mark.asyncio
+    async def test_skips_call_when_server_name_is_empty(self, api: BotBackend):
+        api._client.refresh_server_link_name = AsyncMock()
+        await api.refresh_server_name("discord", "g1", "")
+        api._client.refresh_server_link_name.assert_not_awaited()
 
 
 class TestCreateLinkTokens:

--- a/autogpt_platform/backend/backend/data/db_manager.py
+++ b/autogpt_platform/backend/backend/data/db_manager.py
@@ -375,6 +375,7 @@ class DatabaseManager(AppService):
     confirm_user_link = _(platform_linking_db.confirm_user_link)
     list_server_links = _(platform_linking_db.list_server_links)
     list_user_links = _(platform_linking_db.list_user_links)
+    refresh_server_link_name = _(platform_linking_db.refresh_server_link_name)
     delete_server_link = _(platform_linking_db.delete_server_link)
     delete_user_link = _(platform_linking_db.delete_user_link)
     cleanup_expired_platform_link_tokens = _(
@@ -616,6 +617,7 @@ class DatabaseManagerAsyncClient(AppServiceClient):
     confirm_user_link = d.confirm_user_link
     list_server_links = d.list_server_links
     list_user_links = d.list_user_links
+    refresh_server_link_name = d.refresh_server_link_name
     delete_server_link = d.delete_server_link
     delete_user_link = d.delete_user_link
     cleanup_expired_platform_link_tokens = d.cleanup_expired_platform_link_tokens

--- a/autogpt_platform/backend/backend/platform_linking/db.py
+++ b/autogpt_platform/backend/backend/platform_linking/db.py
@@ -396,6 +396,50 @@ async def list_user_links(user_id: str) -> list[PlatformUserLinkInfo]:
     ]
 
 
+# ── Backfill ──────────────────────────────────────────────────────────
+
+
+async def refresh_server_link_name(
+    platform: str, platform_server_id: str, server_name: str
+) -> None:
+    """Update the display name on a PlatformLink row, keyed by platform + server ID.
+
+    Called by chat-bot adapters when they learn (or re-learn) a server's
+    display name — e.g. Discord's on_ready / on_guild_join events. The bot
+    only knows the platform-side identifiers, not the AutoGPT PlatformLink
+    UUID, so we key off (platform, platform_server_id), which is unique.
+
+    No-ops if no matching link exists (the bot is in a server the user
+    never linked) or the row's name already matches. Best-effort: DB errors
+    are logged but not raised — refreshing a display name is never
+    critical-path.
+    """
+    if not server_name:
+        return
+    try:
+        # `serverName: {"not": ...}` excludes NULL rows in SQL (`NULL != 'x'`
+        # is NULL, not true), so we OR in the explicit NULL case to make
+        # sure first-time backfills land for legacy links.
+        await PlatformLink.prisma().update_many(
+            where={
+                "platform": platform,
+                "platformServerId": platform_server_id,
+                "OR": [
+                    {"serverName": None},
+                    {"serverName": {"not": server_name}},
+                ],
+            },
+            data={"serverName": server_name},
+        )
+    except Exception as exc:
+        logger.warning(
+            "Failed to refresh server_name for %s server %s: %s",
+            platform,
+            platform_server_id,
+            exc,
+        )
+
+
 # ── Deletion ──────────────────────────────────────────────────────────
 
 

--- a/autogpt_platform/backend/backend/platform_linking/db_test.py
+++ b/autogpt_platform/backend/backend/platform_linking/db_test.py
@@ -25,6 +25,7 @@ from .db import (
     delete_user_link,
     get_link_token_info,
     get_link_token_status,
+    refresh_server_link_name,
     resolve_server_link,
     resolve_user_link,
 )
@@ -511,3 +512,45 @@ class TestCleanupExpired:
             mock_model.prisma.return_value.delete_many = AsyncMock(return_value=0)
             count = await cleanup_expired_platform_link_tokens()
         assert count == 0
+
+
+# ── Refresh server-link display name ───────────────────────────────────
+
+
+class TestRefreshServerLinkName:
+    @pytest.mark.asyncio
+    async def test_no_op_when_name_blank(self):
+        with patch("backend.platform_linking.db.PlatformLink") as mock_model:
+            mock_model.prisma.return_value.update_many = AsyncMock()
+            await refresh_server_link_name("DISCORD", "g1", "")
+        mock_model.prisma.return_value.update_many.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_filter_matches_null_rows_and_differing_rows(self):
+        """The filter MUST include both NULL serverName rows and rows whose
+        serverName differs. `{not: 'x'}` alone excludes NULLs (SQL: NULL != 'x'
+        is NULL, not true), which was leaving legacy backfills stuck. The
+        bug surfaced as servers showing as their ID forever on the Bots page."""
+        with patch("backend.platform_linking.db.PlatformLink") as mock_model:
+            mock_model.prisma.return_value.update_many = AsyncMock()
+            await refresh_server_link_name("DISCORD", "g1", "AutoGPT HQ")
+
+        update_many = mock_model.prisma.return_value.update_many
+        update_many.assert_awaited_once()
+        await_args = update_many.await_args
+        assert await_args is not None
+        where = await_args.kwargs["where"]
+        assert where["platform"] == "DISCORD"
+        assert where["platformServerId"] == "g1"
+        # OR clause must cover the NULL case explicitly.
+        assert {"serverName": None} in where["OR"]
+        assert {"serverName": {"not": "AutoGPT HQ"}} in where["OR"]
+
+    @pytest.mark.asyncio
+    async def test_swallows_db_errors(self):
+        with patch("backend.platform_linking.db.PlatformLink") as mock_model:
+            mock_model.prisma.return_value.update_many = AsyncMock(
+                side_effect=RuntimeError("db down")
+            )
+            # Must not raise.
+            await refresh_server_link_name("DISCORD", "g1", "x")

--- a/autogpt_platform/backend/backend/platform_linking/manager.py
+++ b/autogpt_platform/backend/backend/platform_linking/manager.py
@@ -62,6 +62,14 @@ class PlatformLinkingManager(AppService):
     async def start_chat_turn(self, request: BotChatRequest) -> ChatTurnHandle:
         return await start_chat_turn(request)
 
+    @expose
+    async def refresh_server_link_name(
+        self, platform: Platform, platform_server_id: str, server_name: str
+    ) -> None:
+        await platform_linking_db().refresh_server_link_name(
+            platform.value, platform_server_id, server_name
+        )
+
 
 class PlatformLinkingManagerClient(AppServiceClient):
     @classmethod
@@ -80,3 +88,6 @@ class PlatformLinkingManagerClient(AppServiceClient):
         PlatformLinkingManager.get_link_token_status
     )
     start_chat_turn = endpoint_to_async(PlatformLinkingManager.start_chat_turn)
+    refresh_server_link_name = endpoint_to_async(
+        PlatformLinkingManager.refresh_server_link_name
+    )

--- a/autogpt_platform/backend/backend/platform_linking/manager_test.py
+++ b/autogpt_platform/backend/backend/platform_linking/manager_test.py
@@ -156,6 +156,20 @@ class TestManagerWiring:
         stub.assert_awaited_once_with(req)
         assert result is fake_response
 
+    @pytest.mark.asyncio
+    async def test_refresh_server_link_name_delegates(self):
+        manager = PlatformLinkingManager()
+        db_mock = MagicMock()
+        db_mock.refresh_server_link_name = AsyncMock()
+        with patch(
+            "backend.platform_linking.manager.platform_linking_db",
+            return_value=db_mock,
+        ):
+            await manager.refresh_server_link_name(Platform.DISCORD, "g1", "AutoGPT HQ")
+        db_mock.refresh_server_link_name.assert_awaited_once_with(
+            "DISCORD", "g1", "AutoGPT HQ"
+        )
+
 
 class TestAdversarialConfirmRace:
     """Concurrent confirm of one token: exactly one winner via ``update_many``

--- a/autogpt_platform/backend/backend/platform_linking/models.py
+++ b/autogpt_platform/backend/backend/platform_linking/models.py
@@ -154,6 +154,21 @@ class PlatformUserLinkInfo(BaseModel):
     linked_at: datetime
 
 
+class BotPlatformInfo(BaseModel):
+    """A bot platform enabled on this deployment plus the caller's links to it.
+
+    Platforms whose adapter isn't configured (missing token/credentials) are
+    omitted from the response entirely — the Bots settings page hides them.
+    """
+
+    platform: str
+    display_name: str
+    icon: str
+    add_bot_url: str | None = None
+    dm_link: PlatformUserLinkInfo | None = None
+    server_links: list[PlatformLinkInfo] = Field(default_factory=list)
+
+
 class ConfirmLinkResponse(BaseModel):
     success: bool
     link_type: LinkType = LinkType.SERVER

--- a/autogpt_platform/backend/backend/util/settings.py
+++ b/autogpt_platform/backend/backend/util/settings.py
@@ -726,6 +726,17 @@ class Secrets(UpdateTrackingModel["Secrets"], BaseSettings):
         description="Discord bot token for the CoPilot chat bridge. When set, "
         "the bridge enables its Discord adapter.",
     )
+    autopilot_bot_discord_client_id: str = Field(
+        default="",
+        description="Discord application client ID for the CoPilot bot. Used "
+        "to build the 'Add to server' invite URL on the Bots settings page; "
+        "the bot itself doesn't need it.",
+    )
+    autopilot_bot_discord_permissions: str = Field(
+        default="",
+        description="Discord permissions bitfield for the 'Add to server' "
+        "invite URL. Overrides the built-in default when non-empty.",
+    )
 
     smtp_server: str = Field(default="", description="SMTP server IP")
     smtp_port: str = Field(default="", description="SMTP server port")

--- a/autogpt_platform/frontend/src/app/(platform)/settings/bots/__tests__/main.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/bots/__tests__/main.test.tsx
@@ -8,7 +8,6 @@ import {
 } from "@/tests/integrations/test-utils";
 import { server } from "@/mocks/mock-server";
 import {
-  getDeletePlatformLinkingUnlinkADmUserLinkMockHandler,
   getDeletePlatformLinkingUnlinkADmUserLinkMockHandler401,
   getDeletePlatformLinkingUnlinkAPlatformServerMockHandler,
   getListBotPlatformsMockHandler,
@@ -180,9 +179,12 @@ describe("SettingsBotsPage", () => {
       await screen.findByRole("button", { name: /unlink dm on discord/i }),
     );
 
-    // Use a fresh handler that no longer returns the DM link so we can
-    // assert the row is NOT refreshed away — only the failing call ran.
-    server.use(getDeletePlatformLinkingUnlinkADmUserLinkMockHandler());
-    expect(screen.getByText("bently")).toBeDefined();
+    // Swap the GET handler so a refetch would drop the DM row. If the failed
+    // mutation wrongly invalidated platforms, "bently" would vanish. Asserting
+    // it stays proves no refetch fired.
+    server.use(getListBotPlatformsMockHandler([discordPlatform()]));
+    await waitFor(() => {
+      expect(screen.getByText("bently")).toBeDefined();
+    });
   });
 });

--- a/autogpt_platform/frontend/src/app/(platform)/settings/bots/__tests__/main.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/bots/__tests__/main.test.tsx
@@ -1,0 +1,188 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@/tests/integrations/test-utils";
+import { server } from "@/mocks/mock-server";
+import {
+  getDeletePlatformLinkingUnlinkADmUserLinkMockHandler,
+  getDeletePlatformLinkingUnlinkADmUserLinkMockHandler401,
+  getDeletePlatformLinkingUnlinkAPlatformServerMockHandler,
+  getListBotPlatformsMockHandler,
+  getListBotPlatformsMockHandler401,
+} from "@/app/api/__generated__/endpoints/platform-linking/platform-linking.msw";
+import type { BotPlatformInfo } from "@/app/api/__generated__/models/botPlatformInfo";
+
+import SettingsBotsPage from "../page";
+
+function discordPlatform(
+  overrides: Partial<BotPlatformInfo> = {},
+): BotPlatformInfo {
+  return {
+    platform: "DISCORD",
+    display_name: "Discord",
+    icon: "discord.png",
+    add_bot_url: "https://discord.com/oauth2/authorize?client_id=123",
+    dm_link: undefined,
+    server_links: [],
+    ...overrides,
+  };
+}
+
+describe("SettingsBotsPage", () => {
+  test("renders the header and the Discord card with an Add bot button", async () => {
+    server.use(getListBotPlatformsMockHandler([discordPlatform()]));
+
+    render(<SettingsBotsPage />);
+
+    expect(
+      await screen.findByRole("heading", { name: /^bots$/i }),
+    ).toBeDefined();
+    expect(
+      await screen.findByRole("heading", { name: /discord/i }),
+    ).toBeDefined();
+    expect(
+      screen.getByRole("link", { name: /add bot to discord/i }),
+    ).toBeDefined();
+  });
+
+  test("shows the 'no bots enabled' empty state when no platforms are configured", async () => {
+    server.use(getListBotPlatformsMockHandler([]));
+
+    render(<SettingsBotsPage />);
+
+    expect(await screen.findByText(/no bots enabled/i)).toBeDefined();
+  });
+
+  test("renders an error card on 401 instead of the platform list", async () => {
+    server.use(getListBotPlatformsMockHandler401());
+
+    render(<SettingsBotsPage />);
+
+    expect(await screen.findByText(/something went wrong/i)).toBeDefined();
+  });
+
+  test("shows the DM-not-linked tile and an unlinked indicator when no DM link", async () => {
+    server.use(getListBotPlatformsMockHandler([discordPlatform()]));
+
+    render(<SettingsBotsPage />);
+
+    expect(
+      await screen.findByText(/dm the bot on discord to link/i),
+    ).toBeDefined();
+    expect(screen.getByText(/not linked/i)).toBeDefined();
+  });
+
+  test("shows the DM username and an Unlink button when DM link exists", async () => {
+    server.use(
+      getListBotPlatformsMockHandler([
+        discordPlatform({
+          dm_link: {
+            id: "dm-1",
+            platform: "DISCORD",
+            platform_user_id: "u-1",
+            platform_username: "bently",
+            linked_at: new Date("2024-01-01T00:00:00Z"),
+          },
+        }),
+      ]),
+    );
+
+    render(<SettingsBotsPage />);
+
+    expect(await screen.findByText("bently")).toBeDefined();
+    expect(
+      screen.getByRole("button", { name: /unlink dm on discord/i }),
+    ).toBeDefined();
+  });
+
+  test("shows a 'Bot not in server' indicator when the server name is missing", async () => {
+    server.use(
+      getListBotPlatformsMockHandler([
+        discordPlatform({
+          server_links: [
+            {
+              id: "srv-orphan",
+              platform: "DISCORD",
+              platform_server_id: "1126875755960336515",
+              owner_platform_user_id: "u-1",
+              server_name: null,
+              linked_at: new Date("2024-01-01T00:00:00Z"),
+            },
+          ],
+        }),
+      ]),
+    );
+
+    render(<SettingsBotsPage />);
+
+    expect(await screen.findByText("1126875755960336515")).toBeDefined();
+    expect(screen.getByText(/bot not in server/i)).toBeDefined();
+  });
+
+  test("clicking unlink on a linked server fires the API and the row is gone after refetch", async () => {
+    server.use(
+      getListBotPlatformsMockHandler([
+        discordPlatform({
+          server_links: [
+            {
+              id: "srv-1",
+              platform: "DISCORD",
+              platform_server_id: "111",
+              owner_platform_user_id: "u-1",
+              server_name: "AutoGPT HQ",
+              linked_at: new Date("2024-01-01T00:00:00Z"),
+            },
+          ],
+        }),
+      ]),
+      getDeletePlatformLinkingUnlinkAPlatformServerMockHandler({
+        success: true,
+      }),
+    );
+
+    render(<SettingsBotsPage />);
+
+    const unlinkBtn = await screen.findByRole("button", {
+      name: /unlink autogpt hq/i,
+    });
+
+    server.use(getListBotPlatformsMockHandler([discordPlatform()]));
+    fireEvent.click(unlinkBtn);
+
+    await waitFor(() => {
+      expect(screen.queryByText("AutoGPT HQ")).toBeNull();
+    });
+  });
+
+  test("a 401 on DM unlink keeps the row in place", async () => {
+    server.use(
+      getListBotPlatformsMockHandler([
+        discordPlatform({
+          dm_link: {
+            id: "dm-1",
+            platform: "DISCORD",
+            platform_user_id: "u-1",
+            platform_username: "bently",
+            linked_at: new Date("2024-01-01T00:00:00Z"),
+          },
+        }),
+      ]),
+      getDeletePlatformLinkingUnlinkADmUserLinkMockHandler401(),
+    );
+
+    render(<SettingsBotsPage />);
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: /unlink dm on discord/i }),
+    );
+
+    // Use a fresh handler that no longer returns the DM link so we can
+    // assert the row is NOT refreshed away — only the failing call ran.
+    server.use(getDeletePlatformLinkingUnlinkADmUserLinkMockHandler());
+    expect(screen.getByText("bently")).toBeDefined();
+  });
+});

--- a/autogpt_platform/frontend/src/app/(platform)/settings/bots/components/BotCard/BotCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/bots/components/BotCard/BotCard.tsx
@@ -17,7 +17,7 @@ type Props = {
 };
 
 export function BotCard({ platform }: Props) {
-  const { pendingId, unlinkServerLink, unlinkDmLink } = useBotCard();
+  const { isPending, unlinkServerLink, unlinkDmLink } = useBotCard();
   const serverLinks = platform.server_links ?? [];
 
   return (
@@ -61,7 +61,7 @@ export function BotCard({ platform }: Props) {
         <BotCardDmTile
           platformName={platform.display_name}
           dmLink={platform.dm_link ?? null}
-          pendingId={pendingId}
+          isPending={isPending}
           onUnlink={unlinkDmLink}
         />
       </section>
@@ -77,7 +77,7 @@ export function BotCard({ platform }: Props) {
         <BotCardServerList
           platformName={platform.display_name}
           serverLinks={serverLinks}
-          pendingId={pendingId}
+          isPending={isPending}
           onUnlink={unlinkServerLink}
         />
       </section>

--- a/autogpt_platform/frontend/src/app/(platform)/settings/bots/components/BotCard/BotCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/bots/components/BotCard/BotCard.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import Image from "next/image";
+import { PlusIcon } from "@phosphor-icons/react";
+
+import { Button } from "@/components/atoms/Button/Button";
+import { Card } from "@/components/atoms/Card/Card";
+import { Text } from "@/components/atoms/Text/Text";
+import type { BotPlatformInfo } from "@/app/api/__generated__/models/botPlatformInfo";
+
+import { BotCardDmTile } from "./BotCardDmTile";
+import { BotCardServerList } from "./BotCardServerList";
+import { useBotCard } from "./useBotCard";
+
+type Props = {
+  platform: BotPlatformInfo;
+};
+
+export function BotCard({ platform }: Props) {
+  const { pendingId, unlinkServerLink, unlinkDmLink } = useBotCard();
+  const serverLinks = platform.server_links ?? [];
+
+  return (
+    <Card className="flex flex-col gap-5 p-5">
+      <header className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <Image
+            src={`/integrations/${platform.icon}`}
+            alt={`${platform.display_name} icon`}
+            width={32}
+            height={32}
+            className="rounded-md"
+          />
+          <Text variant="large-medium" as="h2" className="text-textBlack">
+            {platform.display_name}
+          </Text>
+        </div>
+        {platform.add_bot_url ? (
+          <Button
+            as="NextLink"
+            href={platform.add_bot_url}
+            target="_blank"
+            rel="noopener noreferrer"
+            variant="primary"
+            size="small"
+            leftIcon={<PlusIcon size={16} />}
+          >
+            Add bot to {platform.display_name}
+          </Button>
+        ) : null}
+      </header>
+
+      <section className="flex flex-col gap-2">
+        <Text
+          variant="small-medium"
+          as="span"
+          className="uppercase tracking-wide text-zinc-500"
+        >
+          Direct messages
+        </Text>
+        <BotCardDmTile
+          platformName={platform.display_name}
+          dmLink={platform.dm_link ?? null}
+          pendingId={pendingId}
+          onUnlink={unlinkDmLink}
+        />
+      </section>
+
+      <section className="flex flex-col gap-2">
+        <Text
+          variant="small-medium"
+          as="span"
+          className="uppercase tracking-wide text-zinc-500"
+        >
+          Linked servers
+        </Text>
+        <BotCardServerList
+          platformName={platform.display_name}
+          serverLinks={serverLinks}
+          pendingId={pendingId}
+          onUnlink={unlinkServerLink}
+        />
+      </section>
+    </Card>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/settings/bots/components/BotCard/BotCardDmTile.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/bots/components/BotCard/BotCardDmTile.tsx
@@ -7,14 +7,14 @@ import type { PlatformUserLinkInfo } from "@/app/api/__generated__/models/platfo
 type Props = {
   platformName: string;
   dmLink: PlatformUserLinkInfo | null;
-  pendingId: string | null;
+  isPending: (linkId: string) => boolean;
   onUnlink: (linkId: string) => void;
 };
 
 export function BotCardDmTile({
   platformName,
   dmLink,
-  pendingId,
+  isPending,
   onUnlink,
 }: Props) {
   const title = dmLink
@@ -42,7 +42,7 @@ export function BotCardDmTile({
           variant="outline"
           size="small"
           leftIcon={<TrashIcon size={16} />}
-          loading={pendingId === dmLink.id}
+          loading={isPending(dmLink.id)}
           onClick={() => onUnlink(dmLink.id)}
           aria-label={`Unlink DM on ${platformName}`}
         >

--- a/autogpt_platform/frontend/src/app/(platform)/settings/bots/components/BotCard/BotCardDmTile.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/bots/components/BotCard/BotCardDmTile.tsx
@@ -1,0 +1,58 @@
+import { ChatCircleDotsIcon, LinkIcon, TrashIcon } from "@phosphor-icons/react";
+
+import { Button } from "@/components/atoms/Button/Button";
+import { Text } from "@/components/atoms/Text/Text";
+import type { PlatformUserLinkInfo } from "@/app/api/__generated__/models/platformUserLinkInfo";
+
+type Props = {
+  platformName: string;
+  dmLink: PlatformUserLinkInfo | null;
+  pendingId: string | null;
+  onUnlink: (linkId: string) => void;
+};
+
+export function BotCardDmTile({
+  platformName,
+  dmLink,
+  pendingId,
+  onUnlink,
+}: Props) {
+  const title = dmLink
+    ? (dmLink.platform_username ?? `User ${dmLink.platform_user_id}`)
+    : `DM the bot on ${platformName} to link`;
+  const subtitle = dmLink
+    ? "Your DM channel is linked to this account."
+    : "Send the bot a direct message to start the link flow.";
+
+  return (
+    <div className="flex items-center justify-between gap-3 rounded-large border border-zinc-200 px-4 py-3">
+      <div className="flex min-w-0 items-center gap-3">
+        <ChatCircleDotsIcon size={20} className="shrink-0 text-zinc-500" />
+        <div className="flex min-w-0 flex-col">
+          <Text variant="body-medium" as="span" className="text-textBlack">
+            {title}
+          </Text>
+          <Text variant="small" as="span" className="text-zinc-500">
+            {subtitle}
+          </Text>
+        </div>
+      </div>
+      {dmLink ? (
+        <Button
+          variant="outline"
+          size="small"
+          leftIcon={<TrashIcon size={16} />}
+          loading={pendingId === dmLink.id}
+          onClick={() => onUnlink(dmLink.id)}
+          aria-label={`Unlink DM on ${platformName}`}
+        >
+          Unlink
+        </Button>
+      ) : (
+        <span className="inline-flex items-center gap-1 text-xs text-zinc-500">
+          <LinkIcon size={14} /> Not linked
+        </span>
+      )}
+    </div>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/settings/bots/components/BotCard/BotCardServerList.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/bots/components/BotCard/BotCardServerList.tsx
@@ -1,0 +1,112 @@
+import { TrashIcon, UsersIcon, WarningCircleIcon } from "@phosphor-icons/react";
+
+import { Button } from "@/components/atoms/Button/Button";
+import { Text } from "@/components/atoms/Text/Text";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/atoms/Tooltip/BaseTooltip";
+import type { PlatformLinkInfo } from "@/app/api/__generated__/models/platformLinkInfo";
+
+type Props = {
+  platformName: string;
+  serverLinks: PlatformLinkInfo[];
+  pendingId: string | null;
+  onUnlink: (linkId: string) => void;
+};
+
+export function BotCardServerList({
+  platformName,
+  serverLinks,
+  pendingId,
+  onUnlink,
+}: Props) {
+  if (serverLinks.length === 0) {
+    return (
+      <div className="rounded-large border border-dashed border-zinc-200 px-4 py-3">
+        <Text variant="small" as="span" className="text-zinc-500">
+          No servers linked yet. Use &quot;Add bot to {platformName}&quot; to
+          invite the bot.
+        </Text>
+      </div>
+    );
+  }
+
+  return (
+    <ul className="flex flex-col gap-2">
+      {serverLinks.map((link) => (
+        <BotCardServerRow
+          key={link.id}
+          link={link}
+          platformName={platformName}
+          isPending={pendingId === link.id}
+          onUnlink={() => onUnlink(link.id)}
+        />
+      ))}
+    </ul>
+  );
+}
+
+type RowProps = {
+  link: PlatformLinkInfo;
+  platformName: string;
+  isPending: boolean;
+  onUnlink: () => void;
+};
+
+function BotCardServerRow({
+  link,
+  platformName,
+  isPending,
+  onUnlink,
+}: RowProps) {
+  const botMissing = !link.server_name;
+  const displayLabel = link.server_name ?? link.platform_server_id;
+
+  return (
+    <li className="flex items-center justify-between gap-3 rounded-large border border-zinc-200 px-4 py-3">
+      <div className="flex min-w-0 items-center gap-3">
+        <UsersIcon size={20} className="shrink-0 text-zinc-500" />
+        <div className="flex min-w-0 flex-col">
+          <Text
+            variant="body-medium"
+            as="span"
+            className="truncate text-textBlack"
+          >
+            {displayLabel}
+          </Text>
+          {botMissing ? (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="inline-flex items-center gap-1 text-xs text-amber-600">
+                  <WarningCircleIcon size={14} weight="fill" /> Bot not in
+                  server
+                </span>
+              </TooltipTrigger>
+              <TooltipContent>
+                {platformName} can&apos;t see this server, so we can&apos;t
+                resolve its name. Re-invite the bot, or unlink to remove this
+                row.
+              </TooltipContent>
+            </Tooltip>
+          ) : (
+            <Text variant="small" as="span" className="text-zinc-500">
+              Linked by you
+            </Text>
+          )}
+        </div>
+      </div>
+      <Button
+        variant="outline"
+        size="small"
+        leftIcon={<TrashIcon size={16} />}
+        loading={isPending}
+        onClick={onUnlink}
+        aria-label={`Unlink ${displayLabel}`}
+      >
+        Unlink
+      </Button>
+    </li>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/settings/bots/components/BotCard/BotCardServerList.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/bots/components/BotCard/BotCardServerList.tsx
@@ -12,14 +12,14 @@ import type { PlatformLinkInfo } from "@/app/api/__generated__/models/platformLi
 type Props = {
   platformName: string;
   serverLinks: PlatformLinkInfo[];
-  pendingId: string | null;
+  isPending: (linkId: string) => boolean;
   onUnlink: (linkId: string) => void;
 };
 
 export function BotCardServerList({
   platformName,
   serverLinks,
-  pendingId,
+  isPending,
   onUnlink,
 }: Props) {
   if (serverLinks.length === 0) {
@@ -40,7 +40,7 @@ export function BotCardServerList({
           key={link.id}
           link={link}
           platformName={platformName}
-          isPending={pendingId === link.id}
+          isPending={isPending(link.id)}
           onUnlink={() => onUnlink(link.id)}
         />
       ))}

--- a/autogpt_platform/frontend/src/app/(platform)/settings/bots/components/BotCard/useBotCard.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/bots/components/BotCard/useBotCard.ts
@@ -1,0 +1,63 @@
+import { useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+
+import {
+  getListBotPlatformsQueryKey,
+  useDeletePlatformLinkingUnlinkADmUserLink,
+  useDeletePlatformLinkingUnlinkAPlatformServer,
+} from "@/app/api/__generated__/endpoints/platform-linking/platform-linking";
+import { useToast } from "@/components/molecules/Toast/use-toast";
+
+export function useBotCard() {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+  const [pendingId, setPendingId] = useState<string | null>(null);
+
+  const invalidatePlatforms = () =>
+    queryClient.invalidateQueries({ queryKey: getListBotPlatformsQueryKey() });
+
+  function showError(action: string) {
+    toast({
+      title: `Couldn't ${action}`,
+      description: "Please try again in a moment.",
+      variant: "destructive",
+    });
+  }
+
+  const unlinkServer = useDeletePlatformLinkingUnlinkAPlatformServer({
+    mutation: {
+      onSuccess: () => {
+        invalidatePlatforms();
+      },
+      onError: () => showError("unlink the server"),
+      onSettled: () => setPendingId(null),
+    },
+  });
+
+  const unlinkDm = useDeletePlatformLinkingUnlinkADmUserLink({
+    mutation: {
+      onSuccess: () => {
+        invalidatePlatforms();
+      },
+      onError: () => showError("unlink the DM"),
+      onSettled: () => setPendingId(null),
+    },
+  });
+
+  function unlinkServerLink(linkId: string) {
+    setPendingId(linkId);
+    unlinkServer.mutate({ linkId });
+  }
+
+  function unlinkDmLink(linkId: string) {
+    setPendingId(linkId);
+    unlinkDm.mutate({ linkId });
+  }
+
+  return {
+    pendingId,
+    isUnlinking: unlinkServer.isPending || unlinkDm.isPending,
+    unlinkServerLink,
+    unlinkDmLink,
+  };
+}

--- a/autogpt_platform/frontend/src/app/(platform)/settings/bots/components/BotCard/useBotCard.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/bots/components/BotCard/useBotCard.ts
@@ -11,7 +11,29 @@ import { useToast } from "@/components/molecules/Toast/use-toast";
 export function useBotCard() {
   const queryClient = useQueryClient();
   const { toast } = useToast();
-  const [pendingId, setPendingId] = useState<string | null>(null);
+  // Track every in-flight link ID independently. A single string would
+  // get clobbered when the first of two concurrent unlinks settles,
+  // re-enabling the still-pending button and allowing a duplicate DELETE.
+  const [pendingIds, setPendingIds] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
+
+  function markPending(linkId: string) {
+    setPendingIds((prev) => {
+      const next = new Set(prev);
+      next.add(linkId);
+      return next;
+    });
+  }
+
+  function clearPending(linkId: string) {
+    setPendingIds((prev) => {
+      if (!prev.has(linkId)) return prev;
+      const next = new Set(prev);
+      next.delete(linkId);
+      return next;
+    });
+  }
 
   const invalidatePlatforms = () =>
     queryClient.invalidateQueries({ queryKey: getListBotPlatformsQueryKey() });
@@ -26,36 +48,36 @@ export function useBotCard() {
 
   const unlinkServer = useDeletePlatformLinkingUnlinkAPlatformServer({
     mutation: {
-      onSuccess: () => {
-        invalidatePlatforms();
-      },
+      onSuccess: () => invalidatePlatforms(),
       onError: () => showError("unlink the server"),
-      onSettled: () => setPendingId(null),
     },
   });
 
   const unlinkDm = useDeletePlatformLinkingUnlinkADmUserLink({
     mutation: {
-      onSuccess: () => {
-        invalidatePlatforms();
-      },
+      onSuccess: () => invalidatePlatforms(),
       onError: () => showError("unlink the DM"),
-      onSettled: () => setPendingId(null),
     },
   });
 
   function unlinkServerLink(linkId: string) {
-    setPendingId(linkId);
-    unlinkServer.mutate({ linkId });
+    if (pendingIds.has(linkId)) return;
+    markPending(linkId);
+    unlinkServer.mutate({ linkId }, { onSettled: () => clearPending(linkId) });
   }
 
   function unlinkDmLink(linkId: string) {
-    setPendingId(linkId);
-    unlinkDm.mutate({ linkId });
+    if (pendingIds.has(linkId)) return;
+    markPending(linkId);
+    unlinkDm.mutate({ linkId }, { onSettled: () => clearPending(linkId) });
+  }
+
+  function isPending(linkId: string) {
+    return pendingIds.has(linkId);
   }
 
   return {
-    pendingId,
+    isPending,
     isUnlinking: unlinkServer.isPending || unlinkDm.isPending,
     unlinkServerLink,
     unlinkDmLink,

--- a/autogpt_platform/frontend/src/app/(platform)/settings/bots/components/BotsHeader/BotsHeader.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/bots/components/BotsHeader/BotsHeader.tsx
@@ -6,10 +6,10 @@ export function BotsHeader() {
   return (
     <div className="flex flex-col items-start gap-4 pb-6 pl-4 sm:flex-row sm:items-start sm:justify-between">
       <div className="flex min-w-0 flex-col">
-        <Text variant="h4" as="h1" className="leading-[28px] text-[#1F1F20]">
+        <Text variant="h4" as="h1" className="leading-[28px] text-zinc-900">
           Bots
         </Text>
-        <Text variant="body" className="mt-4 max-w-[600px] text-[#505057]">
+        <Text variant="body" className="mt-4 max-w-[600px] text-zinc-600">
           Connect AutoGPT bots to your chat platforms. Add a bot to one of your
           servers, link a DM channel so the bot can talk to you directly, or
           unlink an existing connection.

--- a/autogpt_platform/frontend/src/app/(platform)/settings/bots/components/BotsHeader/BotsHeader.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/bots/components/BotsHeader/BotsHeader.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { Text } from "@/components/atoms/Text/Text";
+
+export function BotsHeader() {
+  return (
+    <div className="flex flex-col items-start gap-4 pb-6 pl-4 sm:flex-row sm:items-start sm:justify-between">
+      <div className="flex min-w-0 flex-col">
+        <Text variant="h4" as="h1" className="leading-[28px] text-[#1F1F20]">
+          Bots
+        </Text>
+        <Text variant="body" className="mt-4 max-w-[600px] text-[#505057]">
+          Connect AutoGPT bots to your chat platforms. Add a bot to one of your
+          servers, link a DM channel so the bot can talk to you directly, or
+          unlink an existing connection.
+        </Text>
+      </div>
+    </div>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/settings/bots/components/BotsList/BotsList.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/bots/components/BotsList/BotsList.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { ErrorCard } from "@/components/molecules/ErrorCard/ErrorCard";
+import { Text } from "@/components/atoms/Text/Text";
+
+import { BotCard } from "../BotCard/BotCard";
+import { useBotsList } from "./useBotsList";
+
+export function BotsList() {
+  const { platforms, isLoading, isError, error, refetch, isEmpty } =
+    useBotsList();
+
+  if (isLoading) {
+    return (
+      <div className="flex w-full flex-col gap-3 px-4">
+        <div className="h-40 animate-pulse rounded-large bg-zinc-100" />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="flex w-full flex-col gap-3 px-4">
+        <ErrorCard
+          context="bots"
+          responseError={
+            error instanceof Error ? { message: error.message } : undefined
+          }
+          onRetry={() => refetch()}
+        />
+      </div>
+    );
+  }
+
+  if (isEmpty) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-2 px-6 py-10 text-center">
+        <Text variant="large-medium" as="span" className="text-textBlack">
+          No bots enabled
+        </Text>
+        <Text variant="body" className="max-w-[360px] text-zinc-500">
+          No chat-bot platforms are configured on this deployment. Ask an
+          administrator to enable Discord, Slack, or another adapter.
+        </Text>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex w-full flex-col gap-4 px-4 pb-4">
+      {platforms.map((platform) => (
+        <BotCard key={platform.platform} platform={platform} />
+      ))}
+    </div>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/settings/bots/components/BotsList/useBotsList.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/bots/components/BotsList/useBotsList.ts
@@ -1,0 +1,18 @@
+import { useListBotPlatforms } from "@/app/api/__generated__/endpoints/platform-linking/platform-linking";
+
+export function useBotsList() {
+  const { data, isLoading, isError, error, refetch } = useListBotPlatforms({
+    query: { retry: false },
+  });
+
+  const platforms = data?.status === 200 ? data.data : [];
+
+  return {
+    platforms,
+    isLoading,
+    isError,
+    error,
+    refetch,
+    isEmpty: !isLoading && !isError && platforms.length === 0,
+  };
+}

--- a/autogpt_platform/frontend/src/app/(platform)/settings/bots/components/BotsList/useBotsList.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/bots/components/BotsList/useBotsList.ts
@@ -1,9 +1,10 @@
 import { useListBotPlatforms } from "@/app/api/__generated__/endpoints/platform-linking/platform-linking";
 
 export function useBotsList() {
-  const { data, isLoading, isError, error, refetch } = useListBotPlatforms({
-    query: { retry: false },
-  });
+  const { data, isLoading, isSuccess, isError, error, refetch } =
+    useListBotPlatforms({
+      query: { retry: false },
+    });
 
   const platforms = data?.status === 200 ? data.data : [];
 
@@ -13,6 +14,6 @@ export function useBotsList() {
     isError,
     error,
     refetch,
-    isEmpty: !isLoading && !isError && platforms.length === 0,
+    isEmpty: isSuccess && platforms.length === 0,
   };
 }

--- a/autogpt_platform/frontend/src/app/(platform)/settings/bots/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/bots/page.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { BotsHeader } from "./components/BotsHeader/BotsHeader";
+import { BotsList } from "./components/BotsList/BotsList";
+
+export default function SettingsBotsPage() {
+  return (
+    <>
+      <BotsHeader />
+      <BotsList />
+    </>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/settings/components/SettingsSidebar/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/components/SettingsSidebar/helpers.ts
@@ -1,5 +1,6 @@
 import {
   ChartLineUpIcon,
+  ChatsCircleIcon,
   CreditCardIcon,
   KeyIcon,
   PlugsConnectedIcon,
@@ -27,6 +28,7 @@ export const settingsNavItems: SettingsNavItem[] = [
     href: "/settings/integrations",
     Icon: PlugsConnectedIcon,
   },
+  { label: "Bots", href: "/settings/bots", Icon: ChatsCircleIcon },
   { label: "AutoGPT API Keys", href: "/settings/api-keys", Icon: KeyIcon },
   {
     label: "Creator Dashboard",

--- a/autogpt_platform/frontend/src/app/api/openapi.json
+++ b/autogpt_platform/frontend/src/app/api/openapi.json
@@ -13,7 +13,11 @@
         "summary": "Export Block Cost Estimates",
         "description": "Aggregate per-block average credits-per-execution over [start, end].\n\nCapped at ANALYTICS_MAX_DAYS days. Returns only blocks whose current cost\ntype is dynamic (SECOND/ITEMS/COST_USD) — static-cost blocks already\ncharge correctly pre-flight and don't need an estimate override. TOKENS\nis excluded because `compute_token_credits` already supplies a per-model\nfloor at pre-flight; a per-block historical mean would lose that\ngranularity.",
         "operationId": "getV2Export block cost estimates",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "start",
@@ -21,8 +25,13 @@
             "required": false,
             "schema": {
               "anyOf": [
-                { "type": "string", "format": "date-time" },
-                { "type": "null" }
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "null"
+                }
               ],
               "description": "ISO timestamp (inclusive)",
               "title": "Start"
@@ -35,8 +44,13 @@
             "required": false,
             "schema": {
               "anyOf": [
-                { "type": "string", "format": "date-time" },
-                { "type": "null" }
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "null"
+                }
               ],
               "description": "ISO timestamp (inclusive)",
               "title": "End"
@@ -75,7 +89,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -103,7 +119,11 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/admin/diagnostics/executions": {
@@ -127,7 +147,11 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/admin/diagnostics/executions/cleanup-all-orphaned": {
@@ -151,7 +175,11 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/admin/diagnostics/executions/cleanup-all-stuck-queued": {
@@ -175,7 +203,11 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/admin/diagnostics/executions/cleanup-orphaned": {
@@ -187,7 +219,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/StopExecutionsRequest" }
+              "schema": {
+                "$ref": "#/components/schemas/StopExecutionsRequest"
+              }
             }
           },
           "required": true
@@ -210,12 +244,18 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/admin/diagnostics/executions/failed": {
@@ -224,25 +264,41 @@
         "summary": "List Failed Executions",
         "description": "Get detailed list of failed executions.\n\nArgs:\n    limit: Maximum number of executions to return (default 100)\n    offset: Number of executions to skip (default 0)\n    hours: Number of hours to look back (default 24)\n\nReturns:\n    List of failed executions with error details",
         "operationId": "getV2List failed executions",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "limit",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "default": 100, "title": "Limit" }
+            "schema": {
+              "type": "integer",
+              "default": 100,
+              "title": "Limit"
+            }
           },
           {
             "name": "offset",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "default": 0, "title": "Offset" }
+            "schema": {
+              "type": "integer",
+              "default": 0,
+              "title": "Offset"
+            }
           },
           {
             "name": "hours",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "default": 24, "title": "Hours" }
+            "schema": {
+              "type": "integer",
+              "default": 24,
+              "title": "Hours"
+            }
           }
         ],
         "responses": {
@@ -263,7 +319,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -276,19 +334,31 @@
         "summary": "List Invalid Executions",
         "description": "Get detailed list of executions in invalid states (READ-ONLY).\n\nInvalid states indicate data corruption and require manual investigation:\n- QUEUED but has startedAt (impossible - can't start while queued)\n- RUNNING but no startedAt (impossible - can't run without starting)\n\n⚠️ NO BULK ACTIONS PROVIDED - These need case-by-case investigation.\n\nEach invalid execution likely has a different root cause (crashes, race conditions,\nDB corruption). Investigate the execution history and logs to determine appropriate\naction (manual cleanup, status fix, or leave as-is if system recovered).\n\nArgs:\n    limit: Maximum number of executions to return (default 100)\n    offset: Number of executions to skip (default 0)\n\nReturns:\n    List of invalid state executions with details",
         "operationId": "getV2List invalid executions",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "limit",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "default": 100, "title": "Limit" }
+            "schema": {
+              "type": "integer",
+              "default": 100,
+              "title": "Limit"
+            }
           },
           {
             "name": "offset",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "default": 0, "title": "Offset" }
+            "schema": {
+              "type": "integer",
+              "default": 0,
+              "title": "Offset"
+            }
           }
         ],
         "responses": {
@@ -309,7 +379,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -322,19 +394,31 @@
         "summary": "List Long-Running Executions",
         "description": "Get detailed list of long-running executions (RUNNING status >24h).\n\nArgs:\n    limit: Maximum number of executions to return (default 100)\n    offset: Number of executions to skip (default 0)\n\nReturns:\n    List of long-running executions with details",
         "operationId": "getV2List long-running executions",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "limit",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "default": 100, "title": "Limit" }
+            "schema": {
+              "type": "integer",
+              "default": 100,
+              "title": "Limit"
+            }
           },
           {
             "name": "offset",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "default": 0, "title": "Offset" }
+            "schema": {
+              "type": "integer",
+              "default": 0,
+              "title": "Offset"
+            }
           }
         ],
         "responses": {
@@ -355,7 +439,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -368,19 +454,31 @@
         "summary": "List Orphaned Executions",
         "description": "Get detailed list of orphaned executions (>24h old, likely not in executor).\n\nArgs:\n    limit: Maximum number of executions to return (default 100)\n    offset: Number of executions to skip (default 0)\n\nReturns:\n    List of orphaned executions with details",
         "operationId": "getV2List orphaned executions",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "limit",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "default": 100, "title": "Limit" }
+            "schema": {
+              "type": "integer",
+              "default": 100,
+              "title": "Limit"
+            }
           },
           {
             "name": "offset",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "default": 0, "title": "Offset" }
+            "schema": {
+              "type": "integer",
+              "default": 0,
+              "title": "Offset"
+            }
           }
         ],
         "responses": {
@@ -401,7 +499,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -417,7 +517,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/StopExecutionRequest" }
+              "schema": {
+                "$ref": "#/components/schemas/StopExecutionRequest"
+              }
             }
           },
           "required": true
@@ -440,12 +542,18 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/admin/diagnostics/executions/requeue-all-stuck": {
@@ -469,7 +577,11 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/admin/diagnostics/executions/requeue-bulk": {
@@ -481,7 +593,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/StopExecutionsRequest" }
+              "schema": {
+                "$ref": "#/components/schemas/StopExecutionsRequest"
+              }
             }
           },
           "required": true
@@ -504,12 +618,18 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/admin/diagnostics/executions/running": {
@@ -518,19 +638,31 @@
         "summary": "List Running Executions",
         "description": "Get detailed list of running and queued executions (recent, likely active).\n\nArgs:\n    limit: Maximum number of executions to return (default 100)\n    offset: Number of executions to skip (default 0)\n\nReturns:\n    List of running executions with details",
         "operationId": "getV2List running executions",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "limit",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "default": 100, "title": "Limit" }
+            "schema": {
+              "type": "integer",
+              "default": 100,
+              "title": "Limit"
+            }
           },
           {
             "name": "offset",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "default": 0, "title": "Offset" }
+            "schema": {
+              "type": "integer",
+              "default": 0,
+              "title": "Offset"
+            }
           }
         ],
         "responses": {
@@ -551,7 +683,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -567,7 +701,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/StopExecutionRequest" }
+              "schema": {
+                "$ref": "#/components/schemas/StopExecutionRequest"
+              }
             }
           },
           "required": true
@@ -590,12 +726,18 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/admin/diagnostics/executions/stop-all-long-running": {
@@ -619,7 +761,11 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/admin/diagnostics/executions/stop-bulk": {
@@ -631,7 +777,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/StopExecutionsRequest" }
+              "schema": {
+                "$ref": "#/components/schemas/StopExecutionsRequest"
+              }
             }
           },
           "required": true
@@ -654,12 +802,18 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/admin/diagnostics/executions/stuck-queued": {
@@ -668,19 +822,31 @@
         "summary": "List Stuck Queued Executions",
         "description": "Get detailed list of stuck queued executions (QUEUED >1h, never started).\n\nArgs:\n    limit: Maximum number of executions to return (default 100)\n    offset: Number of executions to skip (default 0)\n\nReturns:\n    List of stuck queued executions with details",
         "operationId": "getV2List stuck queued executions",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "limit",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "default": 100, "title": "Limit" }
+            "schema": {
+              "type": "integer",
+              "default": 100,
+              "title": "Limit"
+            }
           },
           {
             "name": "offset",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "default": 0, "title": "Offset" }
+            "schema": {
+              "type": "integer",
+              "default": 0,
+              "title": "Offset"
+            }
           }
         ],
         "responses": {
@@ -701,7 +867,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -729,7 +897,11 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/admin/diagnostics/schedules/all": {
@@ -738,19 +910,31 @@
         "summary": "List All User Schedules",
         "description": "Get detailed list of all user schedules (excludes system monitoring jobs).\n\nArgs:\n    limit: Maximum number of schedules to return (default 100)\n    offset: Number of schedules to skip (default 0)\n\nReturns:\n    List of schedules with details",
         "operationId": "getV2List all user schedules",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "limit",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "default": 100, "title": "Limit" }
+            "schema": {
+              "type": "integer",
+              "default": 100,
+              "title": "Limit"
+            }
           },
           {
             "name": "offset",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "default": 0, "title": "Offset" }
+            "schema": {
+              "type": "integer",
+              "default": 0,
+              "title": "Offset"
+            }
           }
         ],
         "responses": {
@@ -771,7 +955,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -812,12 +998,18 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/admin/diagnostics/schedules/orphaned": {
@@ -841,7 +1033,11 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/admin/platform-costs/dashboard": {
@@ -849,7 +1045,11 @@
         "tags": ["v2", "admin", "platform-cost", "admin"],
         "summary": "Get Platform Cost Dashboard",
         "operationId": "getV2Get platform cost dashboard",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "start",
@@ -857,8 +1057,13 @@
             "required": false,
             "schema": {
               "anyOf": [
-                { "type": "string", "format": "date-time" },
-                { "type": "null" }
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "null"
+                }
               ],
               "title": "Start"
             }
@@ -869,8 +1074,13 @@
             "required": false,
             "schema": {
               "anyOf": [
-                { "type": "string", "format": "date-time" },
-                { "type": "null" }
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "null"
+                }
               ],
               "title": "End"
             }
@@ -880,7 +1090,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "Provider"
             }
           },
@@ -889,7 +1106,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "User Id"
             }
           },
@@ -898,7 +1122,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "Model"
             }
           },
@@ -907,7 +1138,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "Block Name"
             }
           },
@@ -916,7 +1154,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "Tracking Type"
             }
           },
@@ -925,7 +1170,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "Graph Exec Id"
             }
           }
@@ -948,7 +1200,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -960,7 +1214,11 @@
         "tags": ["v2", "admin", "platform-cost", "admin"],
         "summary": "Get Platform Cost Logs",
         "operationId": "getV2Get platform cost logs",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "start",
@@ -968,8 +1226,13 @@
             "required": false,
             "schema": {
               "anyOf": [
-                { "type": "string", "format": "date-time" },
-                { "type": "null" }
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "null"
+                }
               ],
               "title": "Start"
             }
@@ -980,8 +1243,13 @@
             "required": false,
             "schema": {
               "anyOf": [
-                { "type": "string", "format": "date-time" },
-                { "type": "null" }
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "null"
+                }
               ],
               "title": "End"
             }
@@ -991,7 +1259,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "Provider"
             }
           },
@@ -1000,7 +1275,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "User Id"
             }
           },
@@ -1032,7 +1314,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "Model"
             }
           },
@@ -1041,7 +1330,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "Block Name"
             }
           },
@@ -1050,7 +1346,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "Tracking Type"
             }
           },
@@ -1059,7 +1362,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "Graph Exec Id"
             }
           }
@@ -1082,7 +1392,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -1094,7 +1406,11 @@
         "tags": ["v2", "admin", "platform-cost", "admin"],
         "summary": "Export Platform Cost Logs",
         "operationId": "getV2Export platform cost logs",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "start",
@@ -1102,8 +1418,13 @@
             "required": false,
             "schema": {
               "anyOf": [
-                { "type": "string", "format": "date-time" },
-                { "type": "null" }
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "null"
+                }
               ],
               "title": "Start"
             }
@@ -1114,8 +1435,13 @@
             "required": false,
             "schema": {
               "anyOf": [
-                { "type": "string", "format": "date-time" },
-                { "type": "null" }
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "null"
+                }
               ],
               "title": "End"
             }
@@ -1125,7 +1451,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "Provider"
             }
           },
@@ -1134,7 +1467,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "User Id"
             }
           },
@@ -1143,7 +1483,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "Model"
             }
           },
@@ -1152,7 +1499,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "Block Name"
             }
           },
@@ -1161,7 +1515,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "Tracking Type"
             }
           },
@@ -1170,7 +1531,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "Graph Exec Id"
             }
           }
@@ -1193,7 +1561,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -1218,7 +1588,11 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": { "application/json": { "schema": {} } }
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
@@ -1227,12 +1601,18 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/analytics/log_raw_metric": {
@@ -1243,7 +1623,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/LogRawMetricRequest" }
+              "schema": {
+                "$ref": "#/components/schemas/LogRawMetricRequest"
+              }
             }
           },
           "required": true
@@ -1251,7 +1633,11 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": { "application/json": { "schema": {} } }
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
@@ -1260,12 +1646,18 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/api-keys": {
@@ -1280,7 +1672,9 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "items": { "$ref": "#/components/schemas/APIKeyInfo" },
+                  "items": {
+                    "$ref": "#/components/schemas/APIKeyInfo"
+                  },
                   "type": "array",
                   "title": "Response Getv1List User Api Keys"
                 }
@@ -1291,7 +1685,11 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       },
       "post": {
         "tags": ["v1", "api-keys"],
@@ -1301,7 +1699,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/CreateAPIKeyRequest" }
+              "schema": {
+                "$ref": "#/components/schemas/CreateAPIKeyRequest"
+              }
             }
           },
           "required": true
@@ -1324,12 +1724,18 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/api-keys/{key_id}": {
@@ -1338,13 +1744,20 @@
         "summary": "Revoke API key",
         "description": "Revoke an API key",
         "operationId": "deleteV1Revoke api key",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "key_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Key Id" }
+            "schema": {
+              "type": "string",
+              "title": "Key Id"
+            }
           }
         ],
         "responses": {
@@ -1352,7 +1765,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/APIKeyInfo" }
+                "schema": {
+                  "$ref": "#/components/schemas/APIKeyInfo"
+                }
               }
             }
           },
@@ -1363,7 +1778,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -1374,13 +1791,20 @@
         "summary": "Get specific API key",
         "description": "Get a specific API key",
         "operationId": "getV1Get specific api key",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "key_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Key Id" }
+            "schema": {
+              "type": "string",
+              "title": "Key Id"
+            }
           }
         ],
         "responses": {
@@ -1388,7 +1812,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/APIKeyInfo" }
+                "schema": {
+                  "$ref": "#/components/schemas/APIKeyInfo"
+                }
               }
             }
           },
@@ -1399,7 +1825,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -1412,13 +1840,20 @@
         "summary": "Update key permissions",
         "description": "Update API key permissions",
         "operationId": "putV1Update key permissions",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "key_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Key Id" }
+            "schema": {
+              "type": "string",
+              "title": "Key Id"
+            }
           }
         ],
         "requestBody": {
@@ -1436,7 +1871,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/APIKeyInfo" }
+                "schema": {
+                  "$ref": "#/components/schemas/APIKeyInfo"
+                }
               }
             }
           },
@@ -1447,7 +1884,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -1460,13 +1899,20 @@
         "summary": "Suspend API key",
         "description": "Suspend an API key",
         "operationId": "postV1Suspend api key",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "key_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Key Id" }
+            "schema": {
+              "type": "string",
+              "title": "Key Id"
+            }
           }
         ],
         "responses": {
@@ -1474,7 +1920,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/APIKeyInfo" }
+                "schema": {
+                  "$ref": "#/components/schemas/APIKeyInfo"
+                }
               }
             }
           },
@@ -1485,7 +1933,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -1500,13 +1950,21 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": { "application/json": { "schema": {} } }
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/auth/user/email": {
@@ -1517,7 +1975,10 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": { "type": "string", "title": "Email" }
+              "schema": {
+                "type": "string",
+                "title": "Email"
+              }
             }
           },
           "required": true
@@ -1528,7 +1989,9 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": { "type": "string" },
+                  "additionalProperties": {
+                    "type": "string"
+                  },
                   "type": "object",
                   "title": "Response Postv1Update User Email"
                 }
@@ -1542,12 +2005,18 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/auth/user/preferences": {
@@ -1570,7 +2039,11 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       },
       "post": {
         "tags": ["v1", "auth"],
@@ -1604,12 +2077,18 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/auth/user/timezone": {
@@ -1623,7 +2102,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/TimezoneResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/TimezoneResponse"
+                }
               }
             }
           },
@@ -1631,7 +2112,11 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       },
       "post": {
         "tags": ["v1", "auth"],
@@ -1641,7 +2126,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/UpdateTimezoneRequest" }
+              "schema": {
+                "$ref": "#/components/schemas/UpdateTimezoneRequest"
+              }
             }
           },
           "required": true
@@ -1651,7 +2138,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/TimezoneResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/TimezoneResponse"
+                }
               }
             }
           },
@@ -1662,12 +2151,18 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/blocks": {
@@ -1681,7 +2176,10 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "items": { "additionalProperties": true, "type": "object" },
+                  "items": {
+                    "additionalProperties": true,
+                    "type": "object"
+                  },
                   "type": "array",
                   "title": "Response Getv1List Available Blocks"
                 }
@@ -1692,7 +2190,11 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/blocks/{block_id}/execute": {
@@ -1700,13 +2202,20 @@
         "tags": ["v1", "blocks"],
         "summary": "Execute graph block",
         "operationId": "postV1Execute graph block",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "block_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Block Id" }
+            "schema": {
+              "type": "string",
+              "title": "Block Id"
+            }
           }
         ],
         "requestBody": {
@@ -1728,7 +2237,10 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "additionalProperties": { "type": "array", "items": {} },
+                  "additionalProperties": {
+                    "type": "array",
+                    "items": {}
+                  },
                   "title": "Response Postv1Execute Graph Block"
                 }
               }
@@ -1744,7 +2256,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -1757,14 +2271,25 @@
         "summary": "Get Builder blocks",
         "description": "Get blocks based on either category, type, or provider.",
         "operationId": "getV2Get builder blocks",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "category",
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "Category"
             }
           },
@@ -1778,7 +2303,9 @@
                   "enum": ["all", "input", "action", "output"],
                   "type": "string"
                 },
-                { "type": "null" }
+                {
+                  "type": "null"
+                }
               ],
               "title": "Type"
             }
@@ -1793,7 +2320,9 @@
                   "type": "string",
                   "description": "Provider name for integrations. Can be any string value, including custom provider names."
                 },
-                { "type": "null" }
+                {
+                  "type": "null"
+                }
               ],
               "title": "Provider"
             }
@@ -1802,13 +2331,21 @@
             "name": "page",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "default": 1, "title": "Page" }
+            "schema": {
+              "type": "integer",
+              "default": 1,
+              "title": "Page"
+            }
           },
           {
             "name": "page_size",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "default": 50, "title": "Page Size" }
+            "schema": {
+              "type": "integer",
+              "default": 50,
+              "title": "Page Size"
+            }
           }
         ],
         "responses": {
@@ -1816,7 +2353,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/BlockResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/BlockResponse"
+                }
               }
             }
           },
@@ -1827,7 +2366,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -1840,7 +2381,11 @@
         "summary": "Get specific blocks",
         "description": "Get specific blocks by their IDs.",
         "operationId": "getV2Get specific blocks",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "block_ids",
@@ -1848,7 +2393,9 @@
             "required": true,
             "schema": {
               "type": "array",
-              "items": { "type": "string" },
+              "items": {
+                "type": "string"
+              },
               "title": "Block Ids"
             }
           }
@@ -1860,7 +2407,9 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/BlockInfo" },
+                  "items": {
+                    "$ref": "#/components/schemas/BlockInfo"
+                  },
                   "title": "Response Getv2Get Specific Blocks"
                 }
               }
@@ -1873,7 +2422,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -1886,7 +2437,11 @@
         "summary": "Get Builder block categories",
         "description": "Get all block categories with a specified number of blocks per category.",
         "operationId": "getV2Get builder block categories",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "blocks_per_category",
@@ -1921,7 +2476,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -1939,7 +2496,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/CountResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/CountResponse"
+                }
               }
             }
           },
@@ -1947,7 +2506,11 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/builder/providers": {
@@ -1956,19 +2519,31 @@
         "summary": "Get Builder integration providers",
         "description": "Get all integration providers with their block counts.",
         "operationId": "getV2Get builder integration providers",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "page",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "default": 1, "title": "Page" }
+            "schema": {
+              "type": "integer",
+              "default": 1,
+              "title": "Page"
+            }
           },
           {
             "name": "page_size",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "default": 50, "title": "Page Size" }
+            "schema": {
+              "type": "integer",
+              "default": 50,
+              "title": "Page Size"
+            }
           }
         ],
         "responses": {
@@ -1976,7 +2551,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ProviderResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ProviderResponse"
+                }
               }
             }
           },
@@ -1987,7 +2564,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -2000,14 +2579,25 @@
         "summary": "Builder search",
         "description": "Search for blocks (including integrations), marketplace agents, and user library agents.",
         "operationId": "getV2Builder search",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "search_query",
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "Search Query"
             }
           },
@@ -2016,7 +2606,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "Filter"
             }
           },
@@ -2025,7 +2622,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "Search Id"
             }
           },
@@ -2035,8 +2639,15 @@
             "required": false,
             "schema": {
               "anyOf": [
-                { "type": "array", "items": { "type": "string" } },
-                { "type": "null" }
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "type": "null"
+                }
               ],
               "title": "By Creator"
             }
@@ -2045,13 +2656,21 @@
             "name": "page",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "default": 1, "title": "Page" }
+            "schema": {
+              "type": "integer",
+              "default": 1,
+              "title": "Page"
+            }
           },
           {
             "name": "page_size",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "default": 50, "title": "Page Size" }
+            "schema": {
+              "type": "integer",
+              "default": 50,
+              "title": "Page Size"
+            }
           }
         ],
         "responses": {
@@ -2059,7 +2678,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/SearchResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/SearchResponse"
+                }
               }
             }
           },
@@ -2070,7 +2691,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -2088,7 +2711,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/SuggestionsResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/SuggestionsResponse"
+                }
               }
             }
           },
@@ -2096,7 +2721,11 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/chat/config/ttl": {
@@ -2156,48 +2785,90 @@
               "application/json": {
                 "schema": {
                   "anyOf": [
-                    { "$ref": "#/components/schemas/AgentsFoundResponse" },
-                    { "$ref": "#/components/schemas/NoResultsResponse" },
-                    { "$ref": "#/components/schemas/AgentDetailsResponse" },
+                    {
+                      "$ref": "#/components/schemas/AgentsFoundResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/NoResultsResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/AgentDetailsResponse"
+                    },
                     {
                       "$ref": "#/components/schemas/SetupRequirementsResponse"
                     },
-                    { "$ref": "#/components/schemas/ExecutionStartedResponse" },
-                    { "$ref": "#/components/schemas/NeedLoginResponse" },
-                    { "$ref": "#/components/schemas/ErrorResponse" },
+                    {
+                      "$ref": "#/components/schemas/ExecutionStartedResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/NeedLoginResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ErrorResponse"
+                    },
                     {
                       "$ref": "#/components/schemas/InputValidationErrorResponse"
                     },
-                    { "$ref": "#/components/schemas/AgentOutputResponse" },
+                    {
+                      "$ref": "#/components/schemas/AgentOutputResponse"
+                    },
                     {
                       "$ref": "#/components/schemas/UnderstandingUpdatedResponse"
                     },
-                    { "$ref": "#/components/schemas/AgentPreviewResponse" },
-                    { "$ref": "#/components/schemas/AgentSavedResponse" },
+                    {
+                      "$ref": "#/components/schemas/AgentPreviewResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/AgentSavedResponse"
+                    },
                     {
                       "$ref": "#/components/schemas/ClarificationNeededResponse"
                     },
-                    { "$ref": "#/components/schemas/SuggestedGoalResponse" },
-                    { "$ref": "#/components/schemas/BlockListResponse" },
-                    { "$ref": "#/components/schemas/BlockDetailsResponse" },
-                    { "$ref": "#/components/schemas/BlockOutputResponse" },
-                    { "$ref": "#/components/schemas/DocSearchResultsResponse" },
-                    { "$ref": "#/components/schemas/DocPageResponse" },
+                    {
+                      "$ref": "#/components/schemas/SuggestedGoalResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/BlockListResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/BlockDetailsResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/BlockOutputResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/DocSearchResultsResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/DocPageResponse"
+                    },
                     {
                       "$ref": "#/components/schemas/MCPToolsDiscoveredResponse"
                     },
-                    { "$ref": "#/components/schemas/MCPToolOutputResponse" },
-                    { "$ref": "#/components/schemas/ScheduleListResponse" },
-                    { "$ref": "#/components/schemas/ScheduleDeletedResponse" },
-                    { "$ref": "#/components/schemas/MemoryStoreResponse" },
-                    { "$ref": "#/components/schemas/MemorySearchResponse" },
+                    {
+                      "$ref": "#/components/schemas/MCPToolOutputResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ScheduleListResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ScheduleDeletedResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/MemoryStoreResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/MemorySearchResponse"
+                    },
                     {
                       "$ref": "#/components/schemas/MemoryForgetCandidatesResponse"
                     },
                     {
                       "$ref": "#/components/schemas/MemoryForgetConfirmResponse"
                     },
-                    { "$ref": "#/components/schemas/TodoWriteResponse" }
+                    {
+                      "$ref": "#/components/schemas/TodoWriteResponse"
+                    }
                   ],
                   "title": "Response Getv2[Dummy] Tool Response Type Export For Codegen"
                 }
@@ -2213,7 +2884,11 @@
         "summary": "List Sessions",
         "description": "List chat sessions for the authenticated user.\n\nReturns a paginated list of chat sessions belonging to the current user,\nordered by most recently updated.\n\nArgs:\n    user_id: The authenticated user's ID.\n    limit: Maximum number of sessions to return (1-100).\n    offset: Number of sessions to skip for pagination.\n\nReturns:\n    ListSessionsResponse: List of session summaries and total count.",
         "operationId": "getV2ListSessions",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "limit",
@@ -2257,7 +2932,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -2268,14 +2945,22 @@
         "summary": "Create Session",
         "description": "Create (or get-or-create) a chat session.\n\nTwo modes, selected by the request body:\n\n- Default: create a fresh session for the user. ``dry_run=True`` forces\n  run_block and run_agent calls to use dry-run simulation.\n- Builder-bound: when ``builder_graph_id`` is set, get-or-create keyed\n  on ``(user_id, builder_graph_id)``. Returns the existing session for\n  that graph or creates one locked to it.  Graph ownership is validated\n  inside :func:`get_or_create_builder_session`; raises 404 on\n  unauthorized access.  Write-side scope is enforced per-tool\n  (``edit_agent`` / ``run_agent`` reject any ``agent_id`` other than\n  the bound graph) and a small blacklist hides tools that conflict\n  with the panel's scope (see :data:`BUILDER_BLOCKED_TOOLS`).\n\nArgs:\n    user_id: The authenticated user ID parsed from the JWT (required).\n    request: Optional request body with ``dry_run`` and/or\n        ``builder_graph_id``.\n\nReturns:\n    CreateSessionResponse: Details of the resulting session.",
         "operationId": "postV2CreateSession",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
                 "anyOf": [
-                  { "$ref": "#/components/schemas/CreateSessionRequest" },
-                  { "type": "null" }
+                  {
+                    "$ref": "#/components/schemas/CreateSessionRequest"
+                  },
+                  {
+                    "type": "null"
+                  }
                 ],
                 "title": "Request"
               }
@@ -2300,7 +2985,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -2313,26 +3000,39 @@
         "summary": "Delete Session",
         "description": "Delete a chat session.\n\nPermanently removes a chat session and all its messages.\nOnly the owner can delete their sessions.\n\nArgs:\n    session_id: The session ID to delete.\n    user_id: The authenticated user's ID.\n\nReturns:\n    204 No Content on success.\n\nRaises:\n    HTTPException: 404 if session not found or not owned by user.",
         "operationId": "deleteV2DeleteSession",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "session_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Session Id" }
+            "schema": {
+              "type": "string",
+              "title": "Session Id"
+            }
           }
         ],
         "responses": {
-          "204": { "description": "Successful Response" },
+          "204": {
+            "description": "Successful Response"
+          },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
-          "404": { "description": "Session not found or access denied" },
+          "404": {
+            "description": "Session not found or access denied"
+          },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -2343,13 +3043,20 @@
         "summary": "Get Session",
         "description": "Retrieve the details of a specific chat session.\n\nSupports cursor-based pagination via ``limit`` and ``before_sequence``.\nWhen no pagination params are provided, returns the most recent messages.",
         "operationId": "getV2GetSession",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "session_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Session Id" }
+            "schema": {
+              "type": "string",
+              "title": "Session Id"
+            }
           },
           {
             "name": "limit",
@@ -2369,8 +3076,13 @@
             "required": false,
             "schema": {
               "anyOf": [
-                { "type": "integer", "minimum": 0 },
-                { "type": "null" }
+                {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                {
+                  "type": "null"
+                }
               ],
               "title": "Before Sequence"
             }
@@ -2394,7 +3106,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -2407,13 +3121,20 @@
         "summary": "Session Assign User",
         "description": "Assign an authenticated user to a chat session.\n\nUsed (typically post-login) to claim an existing anonymous session as the current authenticated user.\n\nArgs:\n    session_id: The identifier for the (previously anonymous) session.\n    user_id: The authenticated user's ID to associate with the session.\n\nReturns:\n    dict: Status of the assignment.",
         "operationId": "patchV2SessionAssignUser",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "session_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Session Id" }
+            "schema": {
+              "type": "string",
+              "title": "Session Id"
+            }
           }
         ],
         "responses": {
@@ -2436,7 +3157,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -2449,13 +3172,20 @@
         "summary": "Cancel Session Task",
         "description": "Cancel an in-flight task for a session.\n\nHandles both lifecycle states uniformly:\n\n* **Queued** (``chatStatus='queued'``) — the dispatcher hasn't\n  claimed the row yet.  Flip the session back to ``idle`` and\n  return; no executor cancel event needed.\n* **Running** (``chatStatus='running'``) — publish a cancel event\n  to the executor via RabbitMQ FANOUT, then poll Redis until the\n  task status flips out of ``running`` or a 5 s timeout is hit.",
         "operationId": "postV2CancelSessionTask",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "session_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Session Id" }
+            "schema": {
+              "type": "string",
+              "title": "Session Id"
+            }
           }
         ],
         "responses": {
@@ -2476,7 +3206,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -2489,13 +3221,20 @@
         "summary": "Get Pending Messages",
         "description": "Peek at the pending-message buffer without consuming it.\n\nReturns the current contents of the session's pending message buffer\nso the frontend can restore the queued-message indicator after a page\nrefresh and clear it correctly once a turn drains the buffer.",
         "operationId": "getV2GetPendingMessages",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "session_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Session Id" }
+            "schema": {
+              "type": "string",
+              "title": "Session Id"
+            }
           }
         ],
         "responses": {
@@ -2512,12 +3251,16 @@
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
-          "404": { "description": "Session not found or access denied" },
+          "404": {
+            "description": "Session not found or access denied"
+          },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -2528,13 +3271,20 @@
         "summary": "Queue Pending Message",
         "description": "Queue a follow-up message while the session has an active turn.",
         "operationId": "postV2QueuePendingMessage",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "session_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Session Id" }
+            "schema": {
+              "type": "string",
+              "title": "Session Id"
+            }
           }
         ],
         "requestBody": {
@@ -2561,7 +3311,9 @@
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
-          "404": { "description": "Session not found or access denied" },
+          "404": {
+            "description": "Session not found or access denied"
+          },
           "409": {
             "description": "Session has no active turn to receive pending messages"
           },
@@ -2569,11 +3321,15 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           },
-          "429": { "description": "Call-frequency cap exceeded" },
+          "429": {
+            "description": "Call-frequency cap exceeded"
+          },
           "503": {
             "description": "Chat service degraded (Redis unavailable); client should honour the Retry-After header before retrying."
           }
@@ -2586,17 +3342,26 @@
         "summary": "Disconnect Session Stream",
         "description": "Disconnect all active SSE listeners for a session.\n\nCalled by the frontend when the user switches away from a chat so the\nbackend releases XREAD listeners immediately rather than waiting for\nthe 5-10 s timeout.",
         "operationId": "deleteV2DisconnectSessionStream",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "session_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Session Id" }
+            "schema": {
+              "type": "string",
+              "title": "Session Id"
+            }
           }
         ],
         "responses": {
-          "204": { "description": "Successful Response" },
+          "204": {
+            "description": "Successful Response"
+          },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
@@ -2604,7 +3369,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -2615,19 +3382,30 @@
         "summary": "Resume Session Stream",
         "description": "Resume an active stream for a session.\n\nCalled by the AI SDK's ``useChat(resume: true)`` on page load.\nChecks for an active (in-progress) task on the session and either replays\nthe full SSE stream or returns 204 No Content if nothing is running.\n\nAlways replays the active turn from ``0-0``. The AI SDK UI-message parser\nkeeps text/reasoning part state inside a single parser instance; resuming\nfrom a Redis cursor can skip the ``*-start`` events required by later\n``*-delta`` chunks.",
         "operationId": "getV2ResumeSessionStream",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "session_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Session Id" }
+            "schema": {
+              "type": "string",
+              "title": "Session Id"
+            }
           }
         ],
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": { "application/json": { "schema": {} } }
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
@@ -2636,7 +3414,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -2647,27 +3427,40 @@
         "summary": "Stream Chat Post",
         "description": "Start a new turn and return an AI SDK UI message stream.\n\nReturns an SSE stream (``text/event-stream``) with Vercel AI SDK chunks\n(text fragments, tool-call UI, tool results). The generation runs in a\nbackground task that survives client disconnects; reconnect via\n``GET /sessions/{session_id}/stream`` to resume.\n\nFollow-up messages typed while a turn is already running should use\n``POST /sessions/{session_id}/messages/pending``. If an older client still\nposts that follow-up here, we queue it defensively but still return a valid\nempty UI-message stream so AI SDK transports never receive a JSON body from\nthe stream endpoint.\n\nArgs:\n    session_id: The chat session identifier.\n    request: Request body with message, is_user_message, and optional context.\n    user_id: Authenticated user ID.",
         "operationId": "postV2StreamChatPost",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "session_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Session Id" }
+            "schema": {
+              "type": "string",
+              "title": "Session Id"
+            }
           }
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/StreamChatRequest" }
+              "schema": {
+                "$ref": "#/components/schemas/StreamChatRequest"
+              }
             }
           }
         },
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": { "application/json": { "schema": {} } }
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
@@ -2675,12 +3468,16 @@
           "402": {
             "description": "Subscription required (NO_TIER user, paywall on)"
           },
-          "404": { "description": "Session not found or access denied" },
+          "404": {
+            "description": "Session not found or access denied"
+          },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           },
@@ -2699,13 +3496,20 @@
         "summary": "Update session title",
         "description": "Update the title of a chat session.\n\nAllows the user to rename their chat session.\n\nArgs:\n    session_id: The session ID to update.\n    request: Request body containing the new title.\n    user_id: The authenticated user's ID.\n\nReturns:\n    dict: Status of the update.\n\nRaises:\n    HTTPException: 404 if session not found or not owned by user.",
         "operationId": "patchV2Update session title",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "session_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Session Id" }
+            "schema": {
+              "type": "string",
+              "title": "Session Id"
+            }
           }
         ],
         "requestBody": {
@@ -2734,12 +3538,16 @@
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
-          "404": { "description": "Session not found or access denied" },
+          "404": {
+            "description": "Session not found or access denied"
+          },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -2767,7 +3575,11 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/chat/usage": {
@@ -2781,7 +3593,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/CoPilotUsagePublic" }
+                "schema": {
+                  "$ref": "#/components/schemas/CoPilotUsagePublic"
+                }
               }
             }
           },
@@ -2789,7 +3603,11 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/chat/usage/reset": {
@@ -2815,7 +3633,9 @@
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
-          "402": { "description": "Payment Required (insufficient credits)" },
+          "402": {
+            "description": "Payment Required (insufficient credits)"
+          },
           "429": {
             "description": "Too Many Requests (max daily resets exceeded or reset in progress)"
           },
@@ -2823,7 +3643,11 @@
             "description": "Service Unavailable (Redis reset failed; credits refunded or support needed)"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/copilot/admin/rate_limit": {
@@ -2832,14 +3656,25 @@
         "summary": "Get User Rate Limit",
         "description": "Get a user's current usage and effective rate limits. Admin-only.\n\nAccepts either ``user_id`` or ``email`` as a query parameter.\nWhen ``email`` is provided the user is looked up by email first.",
         "operationId": "getV2Get user rate limit",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "user_id",
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "User Id"
             }
           },
@@ -2848,7 +3683,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "Email"
             }
           }
@@ -2871,7 +3713,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -2912,12 +3756,18 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/copilot/admin/rate_limit/search_users": {
@@ -2926,19 +3776,30 @@
         "summary": "Search Users by Name or Email",
         "description": "Search users by partial email or name. Admin-only.\n\nQueries the User table directly — returns results even for users\nwithout credit transaction history.",
         "operationId": "getV2Search users by name or email",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "query",
             "in": "query",
             "required": true,
-            "schema": { "type": "string", "title": "Query" }
+            "schema": {
+              "type": "string",
+              "title": "Query"
+            }
           },
           {
             "name": "limit",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "default": 20, "title": "Limit" }
+            "schema": {
+              "type": "integer",
+              "default": 20,
+              "title": "Limit"
+            }
           }
         ],
         "responses": {
@@ -2948,7 +3809,9 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/UserSearchResult" },
+                  "items": {
+                    "$ref": "#/components/schemas/UserSearchResult"
+                  },
                   "title": "Response Getv2Search Users By Name Or Email"
                 }
               }
@@ -2961,7 +3824,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -2974,13 +3839,20 @@
         "summary": "Get User Rate Limit Tier",
         "description": "Get a user's current rate-limit tier. Admin-only.\n\nReturns 404 if the user does not exist in the database.",
         "operationId": "getV2Get user rate limit tier",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "user_id",
             "in": "query",
             "required": true,
-            "schema": { "type": "string", "title": "User Id" }
+            "schema": {
+              "type": "string",
+              "title": "User Id"
+            }
           }
         ],
         "responses": {
@@ -2988,7 +3860,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/UserTierResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/UserTierResponse"
+                }
               }
             }
           },
@@ -2999,7 +3873,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -3010,12 +3886,18 @@
         "summary": "Set User Rate Limit Tier",
         "description": "Set a user's rate-limit tier. Admin-only.\n\nReturns 404 if the user does not exist in the database.",
         "operationId": "postV2Set user rate limit tier",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/SetUserTierRequest" }
+              "schema": {
+                "$ref": "#/components/schemas/SetUserTierRequest"
+              }
             }
           }
         },
@@ -3024,7 +3906,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/UserTierResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/UserTierResponse"
+                }
               }
             }
           },
@@ -3035,7 +3919,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -3053,7 +3939,9 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": { "type": "integer" },
+                  "additionalProperties": {
+                    "type": "integer"
+                  },
                   "type": "object",
                   "title": "Response Getv1Get User Credits"
                 }
@@ -3064,7 +3952,11 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       },
       "patch": {
         "tags": ["v1", "credits"],
@@ -3073,13 +3965,21 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": { "application/json": { "schema": {} } }
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       },
       "post": {
         "tags": ["v1", "credits"],
@@ -3088,7 +3988,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/RequestTopUp" }
+              "schema": {
+                "$ref": "#/components/schemas/RequestTopUp"
+              }
             }
           },
           "required": true
@@ -3096,7 +3998,11 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": { "application/json": { "schema": {} } }
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
@@ -3105,12 +4011,18 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/credits/admin/add_credits": {
@@ -3146,12 +4058,18 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/credits/admin/copilot-usage/export": {
@@ -3160,7 +4078,11 @@
         "summary": "Export Copilot Weekly Usage vs Rate Limit",
         "description": "Export per-(user, ISO week) copilot spend with the user's tier limit.\n\nUses the same 90-day window cap and 100k row cap as the credit export.",
         "operationId": "getV2Export copilot weekly usage vs rate limit",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "start",
@@ -3168,8 +4090,13 @@
             "required": false,
             "schema": {
               "anyOf": [
-                { "type": "string", "format": "date-time" },
-                { "type": "null" }
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "null"
+                }
               ],
               "description": "ISO timestamp (inclusive)",
               "title": "Start"
@@ -3182,8 +4109,13 @@
             "required": false,
             "schema": {
               "anyOf": [
-                { "type": "string", "format": "date-time" },
-                { "type": "null" }
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "null"
+                }
               ],
               "description": "ISO timestamp (inclusive)",
               "title": "End"
@@ -3209,7 +4141,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -3222,7 +4156,11 @@
         "summary": "Export Credit Transactions",
         "description": "Export CreditTransaction rows in [start, end].\n\nCapped at CREDIT_EXPORT_MAX_DAYS days and CREDIT_EXPORT_MAX_ROWS rows;\nover-cap requests fail fast with 400 so callers narrow the window\ninstead of receiving silently truncated data.",
         "operationId": "getV2Export credit transactions",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "start",
@@ -3230,8 +4168,13 @@
             "required": false,
             "schema": {
               "anyOf": [
-                { "type": "string", "format": "date-time" },
-                { "type": "null" }
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "null"
+                }
               ],
               "description": "ISO timestamp (inclusive)",
               "title": "Start"
@@ -3244,8 +4187,13 @@
             "required": false,
             "schema": {
               "anyOf": [
-                { "type": "string", "format": "date-time" },
-                { "type": "null" }
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "null"
+                }
               ],
               "description": "ISO timestamp (inclusive)",
               "title": "End"
@@ -3258,8 +4206,12 @@
             "required": false,
             "schema": {
               "anyOf": [
-                { "$ref": "#/components/schemas/CreditTransactionType" },
-                { "type": "null" }
+                {
+                  "$ref": "#/components/schemas/CreditTransactionType"
+                },
+                {
+                  "type": "null"
+                }
               ],
               "title": "Transaction Type"
             }
@@ -3269,7 +4221,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "User Id"
             }
           },
@@ -3304,7 +4263,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -3316,14 +4277,25 @@
         "tags": ["v2", "admin", "credits", "admin"],
         "summary": "Get All Users History",
         "operationId": "getV2Get all users history",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "search",
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "Search"
             }
           },
@@ -3331,13 +4303,21 @@
             "name": "page",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "default": 1, "title": "Page" }
+            "schema": {
+              "type": "integer",
+              "default": 1,
+              "title": "Page"
+            }
           },
           {
             "name": "page_size",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "default": 20, "title": "Page Size" }
+            "schema": {
+              "type": "integer",
+              "default": 20,
+              "title": "Page Size"
+            }
           },
           {
             "name": "transaction_filter",
@@ -3345,8 +4325,12 @@
             "required": false,
             "schema": {
               "anyOf": [
-                { "$ref": "#/components/schemas/CreditTransactionType" },
-                { "type": "null" }
+                {
+                  "$ref": "#/components/schemas/CreditTransactionType"
+                },
+                {
+                  "type": "null"
+                }
               ],
               "title": "Transaction Filter"
             }
@@ -3367,7 +4351,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/UserHistoryResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/UserHistoryResponse"
+                }
               }
             }
           },
@@ -3378,7 +4364,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -3395,7 +4383,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/AutoTopUpConfig" }
+                "schema": {
+                  "$ref": "#/components/schemas/AutoTopUpConfig"
+                }
               }
             }
           },
@@ -3403,7 +4393,11 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       },
       "post": {
         "tags": ["v1", "credits"],
@@ -3413,7 +4407,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/AutoTopUpConfig" }
+              "schema": {
+                "$ref": "#/components/schemas/AutoTopUpConfig"
+              }
             }
           },
           "required": true
@@ -3437,12 +4433,18 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/credits/invoices": {
@@ -3451,7 +4453,11 @@
         "summary": "List Stripe invoices",
         "description": "Recent Stripe invoices for the current user.\n\nEach item includes ``hosted_invoice_url`` (Stripe-hosted view) and\n``invoice_pdf_url`` (direct PDF download). Returns an empty list when\nthe credit system is disabled or the user has no Stripe customer yet.",
         "operationId": "getV1List stripe invoices",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "limit",
@@ -3473,7 +4479,9 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/InvoiceListItem" },
+                  "items": {
+                    "$ref": "#/components/schemas/InvoiceListItem"
+                  },
                   "title": "Response Getv1List Stripe Invoices"
                 }
               }
@@ -3486,7 +4494,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -3504,7 +4514,9 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": { "type": "string" },
+                  "additionalProperties": {
+                    "type": "string"
+                  },
                   "type": "object",
                   "title": "Response Getv1Manage Payment Methods"
                 }
@@ -3515,7 +4527,11 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/credits/refunds": {
@@ -3529,7 +4545,9 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "items": { "$ref": "#/components/schemas/RefundRequest" },
+                  "items": {
+                    "$ref": "#/components/schemas/RefundRequest"
+                  },
                   "type": "array",
                   "title": "Response Getv1Get Refund Requests"
                 }
@@ -3540,7 +4558,11 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/credits/stripe_webhook": {
@@ -3551,7 +4573,11 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": { "application/json": { "schema": {} } }
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
           }
         }
       }
@@ -3576,7 +4602,11 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       },
       "post": {
         "tags": ["v1", "credits"],
@@ -3610,12 +4640,18 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/credits/transactions": {
@@ -3623,7 +4659,11 @@
         "tags": ["v1", "credits"],
         "summary": "Get credit history",
         "operationId": "getV1Get credit history",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "transaction_time",
@@ -3631,8 +4671,13 @@
             "required": false,
             "schema": {
               "anyOf": [
-                { "type": "string", "format": "date-time" },
-                { "type": "null" }
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "null"
+                }
               ],
               "title": "Transaction Time"
             }
@@ -3642,7 +4687,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "Transaction Type"
             }
           },
@@ -3662,7 +4714,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/TransactionHistory" }
+                "schema": {
+                  "$ref": "#/components/schemas/TransactionHistory"
+                }
               }
             }
           },
@@ -3673,7 +4727,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -3685,13 +4741,20 @@
         "tags": ["v1", "credits"],
         "summary": "Refund credit transaction",
         "operationId": "postV1Refund credit transaction",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "transaction_key",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Transaction Key" }
+            "schema": {
+              "type": "string",
+              "title": "Transaction Key"
+            }
           }
         ],
         "requestBody": {
@@ -3700,7 +4763,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "additionalProperties": { "type": "string" },
+                "additionalProperties": {
+                  "type": "string"
+                },
                 "title": "Metadata"
               }
             }
@@ -3725,7 +4790,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -3742,13 +4809,21 @@
             "application/json": {
               "schema": {
                 "oneOf": [
-                  { "$ref": "#/components/schemas/PostmarkDeliveryWebhook" },
-                  { "$ref": "#/components/schemas/PostmarkBounceWebhook" },
+                  {
+                    "$ref": "#/components/schemas/PostmarkDeliveryWebhook"
+                  },
+                  {
+                    "$ref": "#/components/schemas/PostmarkBounceWebhook"
+                  },
                   {
                     "$ref": "#/components/schemas/PostmarkSpamComplaintWebhook"
                   },
-                  { "$ref": "#/components/schemas/PostmarkOpenWebhook" },
-                  { "$ref": "#/components/schemas/PostmarkClickWebhook" },
+                  {
+                    "$ref": "#/components/schemas/PostmarkOpenWebhook"
+                  },
+                  {
+                    "$ref": "#/components/schemas/PostmarkClickWebhook"
+                  },
                   {
                     "$ref": "#/components/schemas/PostmarkSubscriptionChangeWebhook"
                   }
@@ -3773,18 +4848,28 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": { "application/json": { "schema": {} } }
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
           },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "APIKeyAuthenticator-X-Postmark-Webhook-Token": [] }]
+        "security": [
+          {
+            "APIKeyAuthenticator-X-Postmark-Webhook-Token": []
+          }
+        ]
       }
     },
     "/api/email/unsubscribe": {
@@ -3797,19 +4882,28 @@
             "name": "token",
             "in": "query",
             "required": true,
-            "schema": { "type": "string", "title": "Token" }
+            "schema": {
+              "type": "string",
+              "title": "Token"
+            }
           }
         ],
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": { "application/json": { "schema": {} } }
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
           },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -3840,7 +4934,11 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/executions/admin/execution_accuracy_trends": {
@@ -3849,20 +4947,34 @@
         "summary": "Get Execution Accuracy Trends and Alerts",
         "description": "Get execution accuracy trends with moving averages and alert detection.\nSimple single-query approach.",
         "operationId": "getV2Get execution accuracy trends and alerts",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "graph_id",
             "in": "query",
             "required": true,
-            "schema": { "type": "string", "title": "Graph Id" }
+            "schema": {
+              "type": "string",
+              "title": "Graph Id"
+            }
           },
           {
             "name": "user_id",
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "User Id"
             }
           },
@@ -3870,7 +4982,11 @@
             "name": "days_back",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "default": 30, "title": "Days Back" }
+            "schema": {
+              "type": "integer",
+              "default": 30,
+              "title": "Days Back"
+            }
           },
           {
             "name": "drop_threshold",
@@ -3911,7 +5027,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -3952,12 +5070,18 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/executions/admin/execution_analytics/config": {
@@ -3981,7 +5105,11 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/executions/cost-summary": {
@@ -3990,7 +5118,11 @@
         "summary": "User cost summary",
         "description": "Aggregated cost breakdown for the calling user's graph executions.",
         "operationId": "getV1User cost summary",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "since",
@@ -3998,8 +5130,13 @@
             "required": false,
             "schema": {
               "anyOf": [
-                { "type": "string", "format": "date-time" },
-                { "type": "null" }
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "null"
+                }
               ],
               "description": "Window start (UTC). Defaults to start of current calendar month.",
               "title": "Since"
@@ -4012,8 +5149,13 @@
             "required": false,
             "schema": {
               "anyOf": [
-                { "type": "string", "format": "date-time" },
-                { "type": "null" }
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "null"
+                }
               ],
               "description": "Window end (UTC). Defaults to now.",
               "title": "Until"
@@ -4053,7 +5195,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -4065,17 +5209,26 @@
         "tags": ["v1", "graphs"],
         "summary": "Delete graph execution",
         "operationId": "deleteV1Delete graph execution",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "graph_exec_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Graph Exec Id" }
+            "schema": {
+              "type": "string",
+              "title": "Graph Exec Id"
+            }
           }
         ],
         "responses": {
-          "204": { "description": "Successful Response" },
+          "204": {
+            "description": "Successful Response"
+          },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
@@ -4083,7 +5236,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -4096,7 +5251,11 @@
         "summary": "Upload file to cloud storage",
         "description": "Upload a file to cloud storage and return a storage key that can be used\nwith FileStoreBlock and AgentFileInputBlock.\n\nArgs:\n    file: The file to upload\n    user_id: The user ID\n    provider: Cloud storage provider (\"gcs\", \"s3\", \"azure\")\n    expiration_hours: Hours until file expires (1-48)\n\nReturns:\n    Dict containing the cloud storage path and signed URL",
         "operationId": "postV1Upload file to cloud storage",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "expiration_hours",
@@ -4137,7 +5296,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -4155,7 +5316,9 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "items": { "$ref": "#/components/schemas/GraphMeta" },
+                  "items": {
+                    "$ref": "#/components/schemas/GraphMeta"
+                  },
                   "type": "array",
                   "title": "Response Getv1List User Graphs"
                 }
@@ -4166,7 +5329,11 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       },
       "post": {
         "tags": ["v1", "graphs"],
@@ -4175,7 +5342,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/CreateGraph" }
+              "schema": {
+                "$ref": "#/components/schemas/CreateGraph"
+              }
             }
           },
           "required": true
@@ -4185,7 +5354,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/GraphModel" }
+                "schema": {
+                  "$ref": "#/components/schemas/GraphModel"
+                }
               }
             }
           },
@@ -4196,12 +5367,18 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/graphs/{graph_id}": {
@@ -4209,13 +5386,20 @@
         "tags": ["v1", "graphs"],
         "summary": "Delete graph permanently",
         "operationId": "deleteV1Delete graph permanently",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "graph_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Graph Id" }
+            "schema": {
+              "type": "string",
+              "title": "Graph Id"
+            }
           }
         ],
         "responses": {
@@ -4223,7 +5407,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/DeleteGraphResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteGraphResponse"
+                }
               }
             }
           },
@@ -4234,7 +5420,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -4244,20 +5432,34 @@
         "tags": ["v1", "graphs"],
         "summary": "Get specific graph",
         "operationId": "getV1Get specific graph",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "graph_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Graph Id" }
+            "schema": {
+              "type": "string",
+              "title": "Graph Id"
+            }
           },
           {
             "name": "version",
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "integer" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "Version"
             }
           },
@@ -4277,7 +5479,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/GraphModel" }
+                "schema": {
+                  "$ref": "#/components/schemas/GraphModel"
+                }
               }
             }
           },
@@ -4288,7 +5492,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -4298,20 +5504,29 @@
         "tags": ["v1", "graphs"],
         "summary": "Update graph version",
         "operationId": "putV1Update graph version",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "graph_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Graph Id" }
+            "schema": {
+              "type": "string",
+              "title": "Graph Id"
+            }
           }
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/Graph" }
+              "schema": {
+                "$ref": "#/components/schemas/Graph"
+              }
             }
           }
         },
@@ -4320,7 +5535,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/GraphModel" }
+                "schema": {
+                  "$ref": "#/components/schemas/GraphModel"
+                }
               }
             }
           },
@@ -4331,7 +5548,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -4343,20 +5562,34 @@
         "tags": ["v1", "graphs"],
         "summary": "Execute graph agent",
         "operationId": "postV1Execute graph agent",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "graph_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Graph Id" }
+            "schema": {
+              "type": "string",
+              "title": "Graph Id"
+            }
           },
           {
             "name": "graph_version",
             "in": "path",
             "required": true,
             "schema": {
-              "anyOf": [{ "type": "integer" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "Graph Version"
             }
           },
@@ -4365,7 +5598,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "Preset Id"
             }
           }
@@ -4384,7 +5624,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/GraphExecutionMeta" }
+                "schema": {
+                  "$ref": "#/components/schemas/GraphExecutionMeta"
+                }
               }
             }
           },
@@ -4398,11 +5640,15 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           },
-          "503": { "description": "Subscription state temporarily unavailable" }
+          "503": {
+            "description": "Subscription state temporarily unavailable"
+          }
         }
       }
     },
@@ -4411,13 +5657,20 @@
         "tags": ["v1", "graphs"],
         "summary": "List graph executions",
         "operationId": "getV1List graph executions",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "graph_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Graph Id" }
+            "schema": {
+              "type": "string",
+              "title": "Graph Id"
+            }
           },
           {
             "name": "page",
@@ -4465,7 +5718,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -4477,19 +5732,29 @@
         "tags": ["v1", "graphs"],
         "summary": "Get execution details",
         "operationId": "getV1Get execution details",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "graph_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Graph Id" }
+            "schema": {
+              "type": "string",
+              "title": "Graph Id"
+            }
           },
           {
             "name": "graph_exec_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Graph Exec Id" }
+            "schema": {
+              "type": "string",
+              "title": "Graph Exec Id"
+            }
           }
         ],
         "responses": {
@@ -4499,8 +5764,12 @@
               "application/json": {
                 "schema": {
                   "anyOf": [
-                    { "$ref": "#/components/schemas/GraphExecution" },
-                    { "$ref": "#/components/schemas/GraphExecutionWithNodes" }
+                    {
+                      "$ref": "#/components/schemas/GraphExecution"
+                    },
+                    {
+                      "$ref": "#/components/schemas/GraphExecutionWithNodes"
+                    }
                   ],
                   "title": "Response Getv1Get Execution Details"
                 }
@@ -4514,7 +5783,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -4527,23 +5798,35 @@
         "summary": "Disable Execution Sharing",
         "description": "Disable sharing for a graph execution.",
         "operationId": "deleteV1DisableExecutionSharing",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "graph_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Graph Id" }
+            "schema": {
+              "type": "string",
+              "title": "Graph Id"
+            }
           },
           {
             "name": "graph_exec_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Graph Exec Id" }
+            "schema": {
+              "type": "string",
+              "title": "Graph Exec Id"
+            }
           }
         ],
         "responses": {
-          "204": { "description": "Successful Response" },
+          "204": {
+            "description": "Successful Response"
+          },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
@@ -4551,7 +5834,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -4562,19 +5847,29 @@
         "summary": "Enable Execution Sharing",
         "description": "Enable sharing for a graph execution.",
         "operationId": "postV1EnableExecutionSharing",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "graph_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Graph Id" }
+            "schema": {
+              "type": "string",
+              "title": "Graph Id"
+            }
           },
           {
             "name": "graph_exec_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Graph Exec Id" }
+            "schema": {
+              "type": "string",
+              "title": "Graph Exec Id"
+            }
           }
         ],
         "requestBody": {
@@ -4592,7 +5887,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ShareResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ShareResponse"
+                }
               }
             }
           },
@@ -4603,7 +5900,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -4615,19 +5914,29 @@
         "tags": ["v1", "graphs"],
         "summary": "Stop graph execution",
         "operationId": "postV1Stop graph execution",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "graph_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Graph Id" }
+            "schema": {
+              "type": "string",
+              "title": "Graph Id"
+            }
           },
           {
             "name": "graph_exec_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Graph Exec Id" }
+            "schema": {
+              "type": "string",
+              "title": "Graph Exec Id"
+            }
           }
         ],
         "responses": {
@@ -4637,8 +5946,12 @@
               "application/json": {
                 "schema": {
                   "anyOf": [
-                    { "$ref": "#/components/schemas/GraphExecutionMeta" },
-                    { "type": "null" }
+                    {
+                      "$ref": "#/components/schemas/GraphExecutionMeta"
+                    },
+                    {
+                      "type": "null"
+                    }
                   ],
                   "title": "Response Postv1Stop Graph Execution"
                 }
@@ -4652,7 +5965,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -4664,13 +5979,20 @@
         "tags": ["v1", "schedules"],
         "summary": "List execution schedules for a graph",
         "operationId": "getV1List execution schedules for a graph",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "graph_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Graph Id" }
+            "schema": {
+              "type": "string",
+              "title": "Graph Id"
+            }
           }
         ],
         "responses": {
@@ -4695,7 +6017,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -4705,7 +6029,11 @@
         "tags": ["v1", "schedules"],
         "summary": "Create execution schedule",
         "operationId": "postV1Create execution schedule",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "graph_id",
@@ -4747,7 +6075,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -4760,20 +6090,29 @@
         "summary": "Update graph settings",
         "description": "Update graph settings for the user's library agent.",
         "operationId": "patchV1Update graph settings",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "graph_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Graph Id" }
+            "schema": {
+              "type": "string",
+              "title": "Graph Id"
+            }
           }
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/GraphSettings" }
+              "schema": {
+                "$ref": "#/components/schemas/GraphSettings"
+              }
             }
           }
         },
@@ -4782,7 +6121,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/GraphSettings" }
+                "schema": {
+                  "$ref": "#/components/schemas/GraphSettings"
+                }
               }
             }
           },
@@ -4793,7 +6134,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -4805,13 +6148,20 @@
         "tags": ["v1", "graphs"],
         "summary": "Get all graph versions",
         "operationId": "getV1Get all graph versions",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "graph_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Graph Id" }
+            "schema": {
+              "type": "string",
+              "title": "Graph Id"
+            }
           }
         ],
         "responses": {
@@ -4821,7 +6171,9 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/GraphModel" },
+                  "items": {
+                    "$ref": "#/components/schemas/GraphModel"
+                  },
                   "title": "Response Getv1Get All Graph Versions"
                 }
               }
@@ -4834,7 +6186,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -4846,27 +6200,40 @@
         "tags": ["v1", "graphs"],
         "summary": "Set active graph version",
         "operationId": "putV1Set active graph version",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "graph_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Graph Id" }
+            "schema": {
+              "type": "string",
+              "title": "Graph Id"
+            }
           }
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/SetGraphActiveVersion" }
+              "schema": {
+                "$ref": "#/components/schemas/SetGraphActiveVersion"
+              }
             }
           }
         },
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": { "application/json": { "schema": {} } }
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
@@ -4875,7 +6242,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -4887,20 +6256,34 @@
         "tags": ["v1", "graphs"],
         "summary": "Get graph version",
         "operationId": "getV1Get graph version",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "graph_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Graph Id" }
+            "schema": {
+              "type": "string",
+              "title": "Graph Id"
+            }
           },
           {
             "name": "version",
             "in": "path",
             "required": true,
             "schema": {
-              "anyOf": [{ "type": "integer" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "Version"
             }
           },
@@ -4920,7 +6303,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/GraphModel" }
+                "schema": {
+                  "$ref": "#/components/schemas/GraphModel"
+                }
               }
             }
           },
@@ -4931,7 +6316,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -4949,7 +6336,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/AyrshareSSOResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/AyrshareSSOResponse"
+                }
               }
             }
           },
@@ -4957,7 +6346,11 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/integrations/credentials": {
@@ -4984,7 +6377,11 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/integrations/providers": {
@@ -4999,7 +6396,9 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "items": { "$ref": "#/components/schemas/ProviderMetadata" },
+                  "items": {
+                    "$ref": "#/components/schemas/ProviderMetadata"
+                  },
                   "type": "array",
                   "title": "Response Getv1Listproviders"
                 }
@@ -5020,7 +6419,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ProviderConstants" }
+                "schema": {
+                  "$ref": "#/components/schemas/ProviderConstants"
+                }
               }
             }
           }
@@ -5079,7 +6480,9 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "items": { "type": "string" },
+                  "items": {
+                    "type": "string"
+                  },
                   "type": "array",
                   "title": "Response Getv1Listsystemproviders"
                 }
@@ -5094,19 +6497,30 @@
         "tags": ["v1", "integrations"],
         "summary": "Webhook Ping",
         "operationId": "postV1WebhookPing",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "webhook_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Our ID for the webhook" }
+            "schema": {
+              "type": "string",
+              "title": "Our ID for the webhook"
+            }
           }
         ],
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": { "application/json": { "schema": {} } }
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
@@ -5115,7 +6529,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -5127,7 +6543,11 @@
         "tags": ["v1", "integrations"],
         "summary": "Exchange OAuth code for tokens",
         "operationId": "postV1Exchange oauth code for tokens",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "provider",
@@ -5168,7 +6588,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -5180,7 +6602,11 @@
         "tags": ["v1", "integrations"],
         "summary": "List Credentials By Provider",
         "operationId": "getV1ListCredentialsByProvider",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "provider",
@@ -5215,7 +6641,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -5225,7 +6653,11 @@
         "tags": ["v1", "integrations"],
         "summary": "Create Credentials",
         "operationId": "postV1Create credentials",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "provider",
@@ -5244,10 +6676,18 @@
             "application/json": {
               "schema": {
                 "oneOf": [
-                  { "$ref": "#/components/schemas/OAuth2Credentials" },
-                  { "$ref": "#/components/schemas/APIKeyCredentials" },
-                  { "$ref": "#/components/schemas/UserPasswordCredentials" },
-                  { "$ref": "#/components/schemas/HostScopedCredentials" }
+                  {
+                    "$ref": "#/components/schemas/OAuth2Credentials"
+                  },
+                  {
+                    "$ref": "#/components/schemas/APIKeyCredentials"
+                  },
+                  {
+                    "$ref": "#/components/schemas/UserPasswordCredentials"
+                  },
+                  {
+                    "$ref": "#/components/schemas/HostScopedCredentials"
+                  }
                 ],
                 "discriminator": {
                   "propertyName": "type",
@@ -5281,7 +6721,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -5293,7 +6735,11 @@
         "tags": ["v1", "integrations"],
         "summary": "Delete Credentials",
         "operationId": "deleteV1DeleteCredentials",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "provider",
@@ -5351,7 +6797,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -5361,7 +6809,11 @@
         "tags": ["v1", "integrations"],
         "summary": "Get Specific Credential By ID",
         "operationId": "getV1Get specific credential by id",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "provider",
@@ -5401,7 +6853,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -5414,7 +6868,11 @@
         "summary": "Issue a short-lived access token for a provider-hosted picker",
         "description": "Return the raw access token for an OAuth2 credential so the frontend\ncan initialize a provider-hosted picker (e.g. Google Drive Picker).\n\n`GET /{provider}/credentials/{cred_id}` deliberately strips secrets (see\n`CredentialsMetaResponse` + `TestGetCredentialReturnsMetaOnly` in\n`router_test.py`). That hardening broke the Drive picker, which needs the\nraw access token to call `google.picker.Builder.setOAuthToken(...)`. This\nendpoint carves a narrow, explicit hole: the caller must own the\ncredential, it must be OAuth2, and the endpoint returns only the access\ntoken + its expiry — nothing else about the credential. SDK-default\ncredentials are excluded for the same reason as `get_credential`.",
         "operationId": "postV1GetPickerToken",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "provider",
@@ -5441,7 +6899,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/PickerTokenResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/PickerTokenResponse"
+                }
               }
             }
           },
@@ -5452,7 +6912,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -5464,7 +6926,11 @@
         "tags": ["v1", "integrations"],
         "summary": "Initiate OAuth flow",
         "operationId": "getV1Initiate oauth flow",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "provider",
@@ -5491,7 +6957,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "ID of existing credential to upgrade scopes for"
             }
           }
@@ -5501,7 +6974,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/LoginResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/LoginResponse"
+                }
               }
             }
           },
@@ -5512,7 +6987,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -5539,19 +7016,28 @@
             "name": "webhook_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Our ID for the webhook" }
+            "schema": {
+              "type": "string",
+              "title": "Our ID for the webhook"
+            }
           }
         ],
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": { "application/json": { "schema": {} } }
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
           },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -5564,14 +7050,25 @@
         "summary": "List Library Agents",
         "description": "Get all agents in the user's library (both created and saved).",
         "operationId": "getV2List library agents",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "search_term",
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "description": "Search term to filter agents",
               "title": "Search Term"
             },
@@ -5619,7 +7116,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "description": "Filter by folder ID",
               "title": "Folder Id"
             },
@@ -5642,7 +7146,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "boolean" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "description": "Filter by hidden status. True = only hidden, False = only non-hidden, omit = all agents.",
               "title": "Is Hidden"
             },
@@ -5667,7 +7178,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -5678,7 +7191,11 @@
         "summary": "Add Marketplace Agent",
         "description": "Add an agent from the marketplace to the user's library.",
         "operationId": "postV2Add marketplace agent",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -5694,7 +7211,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/LibraryAgent" }
+                "schema": {
+                  "$ref": "#/components/schemas/LibraryAgent"
+                }
               }
             }
           },
@@ -5705,7 +7224,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -5717,20 +7238,34 @@
         "tags": ["v2", "library", "private"],
         "summary": "Get Library Agent By Graph Id",
         "operationId": "getV2GetLibraryAgentByGraphId",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "graph_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Graph Id" }
+            "schema": {
+              "type": "string",
+              "title": "Graph Id"
+            }
           },
           {
             "name": "version",
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "integer" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "Version"
             }
           }
@@ -5740,7 +7275,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/LibraryAgent" }
+                "schema": {
+                  "$ref": "#/components/schemas/LibraryAgent"
+                }
               }
             }
           },
@@ -5751,7 +7288,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -5764,7 +7303,11 @@
         "summary": "List Favorite Library Agents",
         "description": "Get all favorite agents in the user's library.",
         "operationId": "getV2List favorite library agents",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "page",
@@ -5811,7 +7354,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -5824,13 +7369,20 @@
         "summary": "Get Agent By Store ID",
         "description": "Get Library Agent from Store Listing Version ID.",
         "operationId": "getV2Get agent by store id",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "store_listing_version_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Store Listing Version Id" }
+            "schema": {
+              "type": "string",
+              "title": "Store Listing Version Id"
+            }
           }
         ],
         "responses": {
@@ -5840,8 +7392,12 @@
               "application/json": {
                 "schema": {
                   "anyOf": [
-                    { "$ref": "#/components/schemas/LibraryAgent" },
-                    { "type": "null" }
+                    {
+                      "$ref": "#/components/schemas/LibraryAgent"
+                    },
+                    {
+                      "type": "null"
+                    }
                   ],
                   "title": "Response Getv2Get Agent By Store Id"
                 }
@@ -5855,7 +7411,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -5868,19 +7426,30 @@
         "summary": "Delete Library Agent",
         "description": "Soft-delete the specified library agent.",
         "operationId": "deleteV2Delete library agent",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "library_agent_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Library Agent Id" }
+            "schema": {
+              "type": "string",
+              "title": "Library Agent Id"
+            }
           }
         ],
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": { "application/json": { "schema": {} } }
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
@@ -5889,7 +7458,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -5899,13 +7470,20 @@
         "tags": ["v2", "library", "private"],
         "summary": "Get Library Agent",
         "operationId": "getV2Get library agent",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "library_agent_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Library Agent Id" }
+            "schema": {
+              "type": "string",
+              "title": "Library Agent Id"
+            }
           }
         ],
         "responses": {
@@ -5913,7 +7491,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/LibraryAgent" }
+                "schema": {
+                  "$ref": "#/components/schemas/LibraryAgent"
+                }
               }
             }
           },
@@ -5924,7 +7504,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -5935,13 +7517,20 @@
         "summary": "Update Library Agent",
         "description": "Update the library agent with the given fields.",
         "operationId": "patchV2Update library agent",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "library_agent_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Library Agent Id" }
+            "schema": {
+              "type": "string",
+              "title": "Library Agent Id"
+            }
           }
         ],
         "requestBody": {
@@ -5959,7 +7548,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/LibraryAgent" }
+                "schema": {
+                  "$ref": "#/components/schemas/LibraryAgent"
+                }
               }
             }
           },
@@ -5970,7 +7561,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -5982,13 +7575,20 @@
         "tags": ["v2", "library", "private"],
         "summary": "Fork Library Agent",
         "operationId": "postV2Fork library agent",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "library_agent_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Library Agent Id" }
+            "schema": {
+              "type": "string",
+              "title": "Library Agent Id"
+            }
           }
         ],
         "responses": {
@@ -5996,7 +7596,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/LibraryAgent" }
+                "schema": {
+                  "$ref": "#/components/schemas/LibraryAgent"
+                }
               }
             }
           },
@@ -6007,7 +7609,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -6020,13 +7624,20 @@
         "summary": "List Trigger Agents",
         "description": "List trigger agents linked to the given parent agent.",
         "operationId": "getV2List trigger agents",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "library_agent_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Library Agent Id" }
+            "schema": {
+              "type": "string",
+              "title": "Library Agent Id"
+            }
           }
         ],
         "responses": {
@@ -6036,7 +7647,9 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/LibraryAgent" },
+                  "items": {
+                    "$ref": "#/components/schemas/LibraryAgent"
+                  },
                   "title": "Response Getv2List Trigger Agents"
                 }
               }
@@ -6049,7 +7662,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -6062,14 +7677,25 @@
         "summary": "List Library Folders",
         "description": "List folders for the authenticated user.\n\nArgs:\n    user_id: ID of the authenticated user.\n    parent_id: Optional parent folder ID to filter by.\n    include_relations: Whether to include agent and subfolder relations for counts.\n\nReturns:\n    A FolderListResponse containing folders.",
         "operationId": "getV2List library folders",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "parent_id",
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "description": "Filter by parent folder ID. If not provided, returns root-level folders.",
               "title": "Parent Id"
             },
@@ -6093,7 +7719,9 @@
             "description": "List of folders",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/FolderListResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/FolderListResponse"
+                }
               }
             }
           },
@@ -6104,11 +7732,15 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           },
-          "500": { "description": "Server error" }
+          "500": {
+            "description": "Server error"
+          }
         }
       },
       "post": {
@@ -6116,12 +7748,18 @@
         "summary": "Create Folder",
         "description": "Create a new folder.\n\nArgs:\n    payload: The folder creation request.\n    user_id: ID of the authenticated user.\n\nReturns:\n    The created LibraryFolder.",
         "operationId": "postV2Create folder",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/FolderCreateRequest" }
+              "schema": {
+                "$ref": "#/components/schemas/FolderCreateRequest"
+              }
             }
           }
         },
@@ -6130,25 +7768,37 @@
             "description": "Folder created successfully",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/LibraryFolder" }
+                "schema": {
+                  "$ref": "#/components/schemas/LibraryFolder"
+                }
               }
             }
           },
-          "400": { "description": "Validation error" },
+          "400": {
+            "description": "Validation error"
+          },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
-          "404": { "description": "Parent folder not found" },
-          "409": { "description": "Folder name conflict" },
+          "404": {
+            "description": "Parent folder not found"
+          },
+          "409": {
+            "description": "Folder name conflict"
+          },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           },
-          "500": { "description": "Server error" }
+          "500": {
+            "description": "Server error"
+          }
         }
       }
     },
@@ -6161,7 +7811,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/BulkMoveAgentsRequest" }
+              "schema": {
+                "$ref": "#/components/schemas/BulkMoveAgentsRequest"
+              }
             }
           },
           "required": true
@@ -6172,7 +7824,9 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "items": { "$ref": "#/components/schemas/LibraryAgent" },
+                  "items": {
+                    "$ref": "#/components/schemas/LibraryAgent"
+                  },
                   "type": "array",
                   "title": "Response Postv2Bulk Move Agents"
                 }
@@ -6182,18 +7836,28 @@
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
-          "404": { "description": "Folder not found" },
+          "404": {
+            "description": "Folder not found"
+          },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           },
-          "500": { "description": "Server error" }
+          "500": {
+            "description": "Server error"
+          }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/library/folders/tree": {
@@ -6207,16 +7871,24 @@
             "description": "Folder tree structure",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/FolderTreeResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/FolderTreeResponse"
+                }
               }
             }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
-          "500": { "description": "Server error" }
+          "500": {
+            "description": "Server error"
+          }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/library/folders/{folder_id}": {
@@ -6225,30 +7897,45 @@
         "summary": "Delete Folder",
         "description": "Soft-delete a folder and all its contents.\n\nArgs:\n    folder_id: ID of the folder to delete.\n    user_id: ID of the authenticated user.\n\nReturns:\n    204 No Content if successful.",
         "operationId": "deleteV2Delete folder",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "folder_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Folder Id" }
+            "schema": {
+              "type": "string",
+              "title": "Folder Id"
+            }
           }
         ],
         "responses": {
-          "204": { "description": "Folder deleted successfully" },
+          "204": {
+            "description": "Folder deleted successfully"
+          },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
-          "404": { "description": "Folder not found" },
+          "404": {
+            "description": "Folder not found"
+          },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           },
-          "500": { "description": "Server error" }
+          "500": {
+            "description": "Server error"
+          }
         }
       },
       "get": {
@@ -6256,13 +7943,20 @@
         "summary": "Get Folder",
         "description": "Get a specific folder.\n\nArgs:\n    folder_id: ID of the folder to retrieve.\n    user_id: ID of the authenticated user.\n\nReturns:\n    The requested LibraryFolder.",
         "operationId": "getV2Get folder",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "folder_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Folder Id" }
+            "schema": {
+              "type": "string",
+              "title": "Folder Id"
+            }
           }
         ],
         "responses": {
@@ -6270,23 +7964,31 @@
             "description": "Folder details",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/LibraryFolder" }
+                "schema": {
+                  "$ref": "#/components/schemas/LibraryFolder"
+                }
               }
             }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
-          "404": { "description": "Folder not found" },
+          "404": {
+            "description": "Folder not found"
+          },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           },
-          "500": { "description": "Server error" }
+          "500": {
+            "description": "Server error"
+          }
         }
       },
       "patch": {
@@ -6294,20 +7996,29 @@
         "summary": "Update Folder",
         "description": "Update a folder's properties.\n\nArgs:\n    folder_id: ID of the folder to update.\n    payload: The folder update request.\n    user_id: ID of the authenticated user.\n\nReturns:\n    The updated LibraryFolder.",
         "operationId": "patchV2Update folder",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "folder_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Folder Id" }
+            "schema": {
+              "type": "string",
+              "title": "Folder Id"
+            }
           }
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/FolderUpdateRequest" }
+              "schema": {
+                "$ref": "#/components/schemas/FolderUpdateRequest"
+              }
             }
           }
         },
@@ -6316,25 +8027,37 @@
             "description": "Folder updated successfully",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/LibraryFolder" }
+                "schema": {
+                  "$ref": "#/components/schemas/LibraryFolder"
+                }
               }
             }
           },
-          "400": { "description": "Validation error" },
+          "400": {
+            "description": "Validation error"
+          },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
-          "404": { "description": "Folder not found" },
-          "409": { "description": "Folder name conflict" },
+          "404": {
+            "description": "Folder not found"
+          },
+          "409": {
+            "description": "Folder name conflict"
+          },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           },
-          "500": { "description": "Server error" }
+          "500": {
+            "description": "Server error"
+          }
         }
       }
     },
@@ -6344,20 +8067,29 @@
         "summary": "Move Folder",
         "description": "Move a folder to a new parent.\n\nArgs:\n    folder_id: ID of the folder to move.\n    payload: The move request with target parent.\n    user_id: ID of the authenticated user.\n\nReturns:\n    The moved LibraryFolder.",
         "operationId": "postV2Move folder",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "folder_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Folder Id" }
+            "schema": {
+              "type": "string",
+              "title": "Folder Id"
+            }
           }
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/FolderMoveRequest" }
+              "schema": {
+                "$ref": "#/components/schemas/FolderMoveRequest"
+              }
             }
           }
         },
@@ -6366,25 +8098,37 @@
             "description": "Folder moved successfully",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/LibraryFolder" }
+                "schema": {
+                  "$ref": "#/components/schemas/LibraryFolder"
+                }
               }
             }
           },
-          "400": { "description": "Validation error (circular reference)" },
+          "400": {
+            "description": "Validation error (circular reference)"
+          },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
-          "404": { "description": "Folder or target parent not found" },
-          "409": { "description": "Folder name conflict in target location" },
+          "404": {
+            "description": "Folder or target parent not found"
+          },
+          "409": {
+            "description": "Folder name conflict in target location"
+          },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           },
-          "500": { "description": "Server error" }
+          "500": {
+            "description": "Server error"
+          }
         }
       }
     },
@@ -6394,7 +8138,11 @@
         "summary": "List presets",
         "description": "Retrieve a paginated list of presets for the current user.",
         "operationId": "getV2List presets",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "page",
@@ -6423,7 +8171,14 @@
             "in": "query",
             "required": true,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "description": "Allows to filter presets by a specific agent graph",
               "title": "Graph Id"
             },
@@ -6448,7 +8203,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -6459,7 +8216,11 @@
         "summary": "Create a new preset",
         "description": "Create a new preset for the current user.",
         "operationId": "postV2Create a new preset",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -6483,7 +8244,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/LibraryAgentPreset" }
+                "schema": {
+                  "$ref": "#/components/schemas/LibraryAgentPreset"
+                }
               }
             }
           },
@@ -6494,7 +8257,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -6522,7 +8287,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/LibraryAgentPreset" }
+                "schema": {
+                  "$ref": "#/components/schemas/LibraryAgentPreset"
+                }
               }
             }
           },
@@ -6533,12 +8300,18 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/library/presets/{preset_id}": {
@@ -6547,17 +8320,26 @@
         "summary": "Delete a preset",
         "description": "Delete an existing preset by its ID.",
         "operationId": "deleteV2Delete a preset",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "preset_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Preset Id" }
+            "schema": {
+              "type": "string",
+              "title": "Preset Id"
+            }
           }
         ],
         "responses": {
-          "204": { "description": "Successful Response" },
+          "204": {
+            "description": "Successful Response"
+          },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
@@ -6565,7 +8347,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -6576,13 +8360,20 @@
         "summary": "Get a specific preset",
         "description": "Retrieve details for a specific preset by its ID.",
         "operationId": "getV2Get a specific preset",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "preset_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Preset Id" }
+            "schema": {
+              "type": "string",
+              "title": "Preset Id"
+            }
           }
         ],
         "responses": {
@@ -6590,7 +8381,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/LibraryAgentPreset" }
+                "schema": {
+                  "$ref": "#/components/schemas/LibraryAgentPreset"
+                }
               }
             }
           },
@@ -6601,7 +8394,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -6612,13 +8407,20 @@
         "summary": "Update an existing preset",
         "description": "Update an existing preset by its ID.",
         "operationId": "patchV2Update an existing preset",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "preset_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Preset Id" }
+            "schema": {
+              "type": "string",
+              "title": "Preset Id"
+            }
           }
         ],
         "requestBody": {
@@ -6636,7 +8438,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/LibraryAgentPreset" }
+                "schema": {
+                  "$ref": "#/components/schemas/LibraryAgentPreset"
+                }
               }
             }
           },
@@ -6647,7 +8451,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -6660,13 +8466,20 @@
         "summary": "Execute a preset",
         "description": "Execute a preset with the given graph and node input for the current user.",
         "operationId": "postV2Execute a preset",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "preset_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Preset Id" }
+            "schema": {
+              "type": "string",
+              "title": "Preset Id"
+            }
           }
         ],
         "requestBody": {
@@ -6683,7 +8496,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/GraphExecutionMeta" }
+                "schema": {
+                  "$ref": "#/components/schemas/GraphExecutionMeta"
+                }
               }
             }
           },
@@ -6697,11 +8512,15 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           },
-          "503": { "description": "Subscription state temporarily unavailable" }
+          "503": {
+            "description": "Subscription state temporarily unavailable"
+          }
         }
       }
     },
@@ -6714,7 +8533,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/DiscoverToolsRequest" }
+              "schema": {
+                "$ref": "#/components/schemas/DiscoverToolsRequest"
+              }
             }
           },
           "required": true
@@ -6737,12 +8558,18 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/mcp/oauth/callback": {
@@ -6779,12 +8606,18 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/mcp/oauth/login": {
@@ -6796,7 +8629,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/MCPOAuthLoginRequest" }
+              "schema": {
+                "$ref": "#/components/schemas/MCPOAuthLoginRequest"
+              }
             }
           },
           "required": true
@@ -6819,12 +8654,18 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/mcp/token": {
@@ -6836,7 +8677,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/MCPStoreTokenRequest" }
+              "schema": {
+                "$ref": "#/components/schemas/MCPStoreTokenRequest"
+              }
             }
           },
           "required": true
@@ -6859,12 +8702,18 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/oauth/app/{client_id}": {
@@ -6873,13 +8722,20 @@
         "summary": "Get Oauth App Info",
         "description": "Get public information about an OAuth application.\n\nThis endpoint is used by the consent screen to display application details\nto the user before they authorize access.\n\nReturns:\n- name: Application name\n- description: Application description (if provided)\n- scopes: List of scopes the application is allowed to request",
         "operationId": "getOauthGetOauthAppInfo",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "client_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Client Id" }
+            "schema": {
+              "type": "string",
+              "title": "Client Id"
+            }
           }
         ],
         "responses": {
@@ -6896,12 +8752,16 @@
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
-          "404": { "description": "Application not found or disabled" },
+          "404": {
+            "description": "Application not found or disabled"
+          },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -6933,7 +8793,11 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/oauth/apps/{app_id}/logo": {
@@ -6942,20 +8806,29 @@
         "summary": "Update App Logo",
         "description": "Update the logo URL for an OAuth application.\n\nOnly the application owner can update the logo.\nThe logo should be uploaded first using the media upload endpoint,\nthen this endpoint is called with the resulting URL.\n\nLogo requirements:\n- Must be square (1:1 aspect ratio)\n- Minimum 512x512 pixels\n- Maximum 2048x2048 pixels\n\nReturns the updated application info.",
         "operationId": "patchOauthUpdateAppLogo",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "app_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "App Id" }
+            "schema": {
+              "type": "string",
+              "title": "App Id"
+            }
           }
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/UpdateAppLogoRequest" }
+              "schema": {
+                "$ref": "#/components/schemas/UpdateAppLogoRequest"
+              }
             }
           }
         },
@@ -6977,7 +8850,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -6990,13 +8865,20 @@
         "summary": "Upload App Logo",
         "description": "Upload a logo image for an OAuth application.\n\nRequirements:\n- Image must be square (1:1 aspect ratio)\n- Minimum 512x512 pixels\n- Maximum 2048x2048 pixels\n- Allowed formats: JPEG, PNG, WebP\n- Maximum file size: 3MB\n\nThe image is uploaded to cloud storage and the app's logoUrl is updated.\nReturns the updated application info.",
         "operationId": "postOauthUploadAppLogo",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "app_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "App Id" }
+            "schema": {
+              "type": "string",
+              "title": "App Id"
+            }
           }
         ],
         "requestBody": {
@@ -7027,7 +8909,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -7040,13 +8924,20 @@
         "summary": "Update App Status",
         "description": "Enable or disable an OAuth application.\n\nOnly the application owner can update the status.\nWhen disabled, the application cannot be used for new authorizations\nand existing access tokens will fail validation.\n\nReturns the updated application info.",
         "operationId": "patchOauthUpdateAppStatus",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "app_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "App Id" }
+            "schema": {
+              "type": "string",
+              "title": "App Id"
+            }
           }
         ],
         "requestBody": {
@@ -7077,7 +8968,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -7093,7 +8986,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/AuthorizeRequest" }
+              "schema": {
+                "$ref": "#/components/schemas/AuthorizeRequest"
+              }
             }
           },
           "required": true
@@ -7103,7 +8998,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/AuthorizeResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/AuthorizeResponse"
+                }
               }
             }
           },
@@ -7114,12 +9011,18 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/oauth/introspect": {
@@ -7153,7 +9056,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -7169,7 +9074,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/Body_postOauthRevoke" }
+              "schema": {
+                "$ref": "#/components/schemas/Body_postOauthRevoke"
+              }
             }
           },
           "required": true
@@ -7177,13 +9084,19 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": { "application/json": { "schema": {} } }
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
           },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -7201,8 +9114,12 @@
             "application/json": {
               "schema": {
                 "anyOf": [
-                  { "$ref": "#/components/schemas/TokenRequestByCode" },
-                  { "$ref": "#/components/schemas/TokenRequestByRefreshToken" }
+                  {
+                    "$ref": "#/components/schemas/TokenRequestByCode"
+                  },
+                  {
+                    "$ref": "#/components/schemas/TokenRequestByRefreshToken"
+                  }
                 ],
                 "title": "Request"
               }
@@ -7215,7 +9132,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/TokenResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/TokenResponse"
+                }
               }
             }
           },
@@ -7223,7 +9142,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -7240,7 +9161,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/UserOnboarding" }
+                "schema": {
+                  "$ref": "#/components/schemas/UserOnboarding"
+                }
               }
             }
           },
@@ -7248,7 +9171,11 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       },
       "patch": {
         "tags": ["v1", "onboarding"],
@@ -7257,7 +9184,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/UserOnboardingUpdate" }
+              "schema": {
+                "$ref": "#/components/schemas/UserOnboardingUpdate"
+              }
             }
           },
           "required": true
@@ -7267,7 +9196,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/UserOnboarding" }
+                "schema": {
+                  "$ref": "#/components/schemas/UserOnboarding"
+                }
               }
             }
           },
@@ -7278,12 +9209,18 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/onboarding/agents": {
@@ -7297,7 +9234,9 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "items": { "$ref": "#/components/schemas/StoreAgentDetails" },
+                  "items": {
+                    "$ref": "#/components/schemas/StoreAgentDetails"
+                  },
                   "type": "array",
                   "title": "Response Getv1Recommended Onboarding Agents"
                 }
@@ -7308,7 +9247,11 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/onboarding/completed": {
@@ -7331,7 +9274,11 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/onboarding/profile": {
@@ -7352,7 +9299,11 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": { "application/json": { "schema": {} } }
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
@@ -7361,12 +9312,18 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/onboarding/reset": {
@@ -7379,7 +9336,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/UserOnboarding" }
+                "schema": {
+                  "$ref": "#/components/schemas/UserOnboarding"
+                }
               }
             }
           },
@@ -7387,7 +9346,11 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/onboarding/step": {
@@ -7395,7 +9358,11 @@
         "tags": ["v1", "onboarding"],
         "summary": "Complete onboarding step",
         "operationId": "postV1Complete onboarding step",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "step",
@@ -7421,7 +9388,11 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": { "application/json": { "schema": {} } }
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
@@ -7430,7 +9401,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -7446,7 +9419,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/ChatRequest" }
+              "schema": {
+                "$ref": "#/components/schemas/ChatRequest"
+              }
             }
           },
           "required": true
@@ -7456,7 +9431,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ApiResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
               }
             }
           },
@@ -7467,12 +9444,18 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/platform-linking/links": {
@@ -7486,7 +9469,9 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "items": { "$ref": "#/components/schemas/PlatformLinkInfo" },
+                  "items": {
+                    "$ref": "#/components/schemas/PlatformLinkInfo"
+                  },
                   "type": "array",
                   "title": "Response Getplatform-Linkinglist All Platform Servers Linked To The Authenticated User"
                 }
@@ -7497,7 +9482,11 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/platform-linking/links/{link_id}": {
@@ -7505,13 +9494,20 @@
         "tags": ["platform-linking"],
         "summary": "Unlink a platform server",
         "operationId": "deletePlatform-linkingUnlink a platform server",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "link_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Link Id" }
+            "schema": {
+              "type": "string",
+              "title": "Link Id"
+            }
           }
         ],
         "responses": {
@@ -7519,7 +9515,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/DeleteLinkResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteLinkResponse"
+                }
               }
             }
           },
@@ -7530,11 +9528,44 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         }
+      }
+    },
+    "/api/platform-linking/platforms": {
+      "get": {
+        "tags": ["platform-linking"],
+        "summary": "List bot platforms enabled on this deployment plus the caller's links",
+        "operationId": "list_bot_platforms",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/BotPlatformInfo"
+                  },
+                  "type": "array",
+                  "title": "Response List Bot Platforms"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/platform-linking/tokens/{token}/confirm": {
@@ -7542,7 +9573,11 @@
         "tags": ["platform-linking"],
         "summary": "Confirm a SERVER link token (user must be authenticated)",
         "operationId": "postPlatform-linkingConfirm a server link token (user must be authenticated)",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "token",
@@ -7561,7 +9596,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ConfirmLinkResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ConfirmLinkResponse"
+                }
               }
             }
           },
@@ -7572,7 +9609,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -7584,7 +9623,11 @@
         "tags": ["platform-linking"],
         "summary": "Get display info for a link token",
         "operationId": "getPlatform-linkingGet display info for a link token",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "token",
@@ -7616,7 +9659,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -7647,7 +9692,11 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/platform-linking/user-links/{link_id}": {
@@ -7655,13 +9704,20 @@
         "tags": ["platform-linking"],
         "summary": "Unlink a DM / user link",
         "operationId": "deletePlatform-linkingUnlink a dm / user link",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "link_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Link Id" }
+            "schema": {
+              "type": "string",
+              "title": "Link Id"
+            }
           }
         ],
         "responses": {
@@ -7669,7 +9725,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/DeleteLinkResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteLinkResponse"
+                }
               }
             }
           },
@@ -7680,7 +9738,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -7692,7 +9752,11 @@
         "tags": ["platform-linking"],
         "summary": "Confirm a USER link token (user must be authenticated)",
         "operationId": "postPlatform-linkingConfirm a user link token (user must be authenticated)",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "token",
@@ -7724,7 +9788,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -7764,7 +9830,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -7802,13 +9870,19 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": { "application/json": { "schema": {} } }
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
           },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -7823,13 +9897,17 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/PushSubscribeRequest" }
+              "schema": {
+                "$ref": "#/components/schemas/PushSubscribeRequest"
+              }
             }
           },
           "required": true
         },
         "responses": {
-          "204": { "description": "Successful Response" },
+          "204": {
+            "description": "Successful Response"
+          },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
@@ -7837,12 +9915,18 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/push/unsubscribe": {
@@ -7861,7 +9945,9 @@
           "required": true
         },
         "responses": {
-          "204": { "description": "Successful Response" },
+          "204": {
+            "description": "Successful Response"
+          },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
@@ -7869,12 +9955,18 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/push/vapid-key": {
@@ -7905,7 +9997,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/ReviewRequest" }
+              "schema": {
+                "$ref": "#/components/schemas/ReviewRequest"
+              }
             }
           },
           "required": true
@@ -7915,7 +10009,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ReviewResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ReviewResponse"
+                }
               }
             }
           },
@@ -7926,12 +10022,18 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/review/execution/{graph_exec_id}": {
@@ -7940,13 +10042,20 @@
         "summary": "Get Pending Reviews for Execution",
         "description": "Get all pending reviews for a specific graph execution.\n\nRetrieves all reviews with status \"WAITING\" for the specified graph execution\nthat belong to the authenticated user. Results are ordered by creation time\n(oldest first) to preserve review order within the execution.\n\nArgs:\n    graph_exec_id: ID of the graph execution to get reviews for\n    user_id: Authenticated user ID from security dependency\n\nReturns:\n    List of pending review objects for the specified execution\n\nRaises:\n    HTTPException:\n        - 404: If the graph execution doesn't exist or isn't owned by this user\n        - 500: If authentication fails or database error occurs\n\nNote:\n    Only returns reviews owned by the authenticated user for security.\n    Reviews with invalid status are excluded with warning logs.",
         "operationId": "getV2Get pending reviews for execution",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "graph_exec_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Graph Exec Id" }
+            "schema": {
+              "type": "string",
+              "title": "Graph Exec Id"
+            }
           }
         ],
         "responses": {
@@ -7967,18 +10076,24 @@
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
-          "404": { "description": "Graph execution not found" },
+          "404": {
+            "description": "Graph execution not found"
+          },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           },
           "500": {
             "description": "Server error",
-            "content": { "application/json": {} }
+            "content": {
+              "application/json": {}
+            }
           }
         }
       }
@@ -7989,7 +10104,11 @@
         "summary": "Get Pending Reviews",
         "description": "Get all pending reviews for the current user.\n\nRetrieves all reviews with status \"WAITING\" that belong to the authenticated user.\nResults are ordered by creation time (newest first).\n\nArgs:\n    user_id: Authenticated user ID from security dependency\n\nReturns:\n    List of pending review objects with status converted to typed literals\n\nRaises:\n    HTTPException: If authentication fails or database error occurs\n\nNote:\n    Reviews with invalid status values are logged as warnings but excluded\n    from results rather than failing the entire request.",
         "operationId": "getV2Get pending reviews",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "page",
@@ -8041,13 +10160,17 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           },
           "500": {
             "description": "Server error",
-            "content": { "application/json": {} }
+            "content": {
+              "application/json": {}
+            }
           }
         }
       }
@@ -8076,7 +10199,11 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/schedules/followups": {
@@ -8104,7 +10231,11 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/schedules/{schedule_id}": {
@@ -8112,7 +10243,11 @@
         "tags": ["v1", "schedules"],
         "summary": "Delete execution schedule",
         "operationId": "deleteV1Delete execution schedule",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "schedule_id",
@@ -8146,7 +10281,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -8165,7 +10302,9 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "items": { "$ref": "#/components/schemas/CopilotSkillInfo" },
+                  "items": {
+                    "$ref": "#/components/schemas/CopilotSkillInfo"
+                  },
                   "type": "array",
                   "title": "Response Listcopilotskills"
                 }
@@ -8176,7 +10315,11 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/skills/{name}": {
@@ -8185,7 +10328,11 @@
         "summary": "Delete a user-distilled copilot skill",
         "description": "Delete a user-distilled skill by slug.\n\nBuilt-in defaults are not user-deletable — attempting to delete one\nreturns 400.  Missing skills return 404 so the UI can reconcile a\nstale list.",
         "operationId": "deleteCopilotSkill",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "name",
@@ -8206,7 +10353,9 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "additionalProperties": { "type": "string" },
+                  "additionalProperties": {
+                    "type": "string"
+                  },
                   "title": "Response Deletecopilotskill"
                 }
               }
@@ -8219,7 +10368,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -8230,7 +10381,11 @@
         "summary": "Read a single copilot skill with its full SKILL.md body",
         "description": "Return full SKILL.md content (name, description, triggers, body)\nfor the library UI's expand-to-view dialog.\n\nBuilt-in default skills are returned with ``is_default=True`` so the\nUI can hide destructive affordances; missing user skills return 404.",
         "operationId": "readCopilotSkill",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "name",
@@ -8249,19 +10404,25 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/CopilotSkillDetail" }
+                "schema": {
+                  "$ref": "#/components/schemas/CopilotSkillDetail"
+                }
               }
             }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
-          "404": { "description": "Skill not found" },
+          "404": {
+            "description": "Skill not found"
+          },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -8274,7 +10435,11 @@
         "summary": "Get Admin Listings History",
         "description": "Get store listings with their version history for admins.\n\nThis provides a consolidated view of listings with their versions,\nallowing for an expandable UI in the admin dashboard.\n\nArgs:\n    status: Filter by submission status (PENDING, APPROVED, REJECTED)\n    search: Search by name, description, or user email\n    page: Page number for pagination\n    page_size: Number of items per page\n\nReturns:\n    Paginated listings with their versions",
         "operationId": "getV2Get admin listings history",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "status",
@@ -8282,8 +10447,12 @@
             "required": false,
             "schema": {
               "anyOf": [
-                { "$ref": "#/components/schemas/SubmissionStatus" },
-                { "type": "null" }
+                {
+                  "$ref": "#/components/schemas/SubmissionStatus"
+                },
+                {
+                  "type": "null"
+                }
               ],
               "title": "Status"
             }
@@ -8293,7 +10462,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "Search"
             }
           },
@@ -8301,13 +10477,21 @@
             "name": "page",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "default": 1, "title": "Page" }
+            "schema": {
+              "type": "integer",
+              "default": 1,
+              "title": "Page"
+            }
           },
           {
             "name": "page_size",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "default": 20, "title": "Page Size" }
+            "schema": {
+              "type": "integer",
+              "default": 20,
+              "title": "Page Size"
+            }
           }
         ],
         "responses": {
@@ -8328,7 +10512,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -8341,7 +10527,11 @@
         "summary": "Admin Download Agent File",
         "description": "Download the agent file by streaming its content.\n\nArgs:\n    store_listing_version_id (str): The ID of the agent to download\n\nReturns:\n    StreamingResponse: A streaming response containing the agent's graph data.\n\nRaises:\n    HTTPException: If the agent is not found or an unexpected error occurs.",
         "operationId": "getV2Admin download agent file",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "store_listing_version_id",
@@ -8358,7 +10548,11 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": { "application/json": { "schema": {} } }
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
@@ -8367,7 +10561,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -8380,13 +10576,20 @@
         "summary": "Admin Add Pending Agent to Library",
         "description": "Add a pending marketplace agent to the admin's library for review.\nUses admin-level access to bypass marketplace APPROVED-only checks.\n\nThe builder can load the graph because get_graph() checks library\nmembership as a fallback: \"you added it, you keep it.\"",
         "operationId": "postV2Admin add pending agent to library",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "store_listing_version_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Store Listing Version Id" }
+            "schema": {
+              "type": "string",
+              "title": "Store Listing Version Id"
+            }
           }
         ],
         "responses": {
@@ -8394,7 +10597,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/LibraryAgent" }
+                "schema": {
+                  "$ref": "#/components/schemas/LibraryAgent"
+                }
               }
             }
           },
@@ -8405,7 +10610,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -8418,13 +10625,20 @@
         "summary": "Admin Preview Submission Listing",
         "description": "Preview a marketplace submission as it would appear on the listing page.\nBypasses the APPROVED-only StoreAgent view so admins can preview pending\nsubmissions before approving.",
         "operationId": "getV2Admin preview submission listing",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "store_listing_version_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Store Listing Version Id" }
+            "schema": {
+              "type": "string",
+              "title": "Store Listing Version Id"
+            }
           }
         ],
         "responses": {
@@ -8432,7 +10646,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/StoreAgentDetails" }
+                "schema": {
+                  "$ref": "#/components/schemas/StoreAgentDetails"
+                }
               }
             }
           },
@@ -8443,7 +10659,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -8456,13 +10674,20 @@
         "summary": "Review Store Submission",
         "description": "Review a store listing submission.\n\nArgs:\n    store_listing_version_id: ID of the submission to review\n    request: Review details including approval status and comments\n    user_id: Authenticated admin user performing the review\n\nReturns:\n    StoreSubmissionAdminView with updated review information",
         "operationId": "postV2Review store submission",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "store_listing_version_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Store Listing Version Id" }
+            "schema": {
+              "type": "string",
+              "title": "Store Listing Version Id"
+            }
           }
         ],
         "requestBody": {
@@ -8493,7 +10718,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -8524,7 +10751,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "description": "Filter agents by creator username",
               "title": "Creator"
             },
@@ -8535,7 +10769,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "description": "Filter agents by category",
               "title": "Category"
             },
@@ -8546,7 +10787,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "description": "Literal + semantic search on names and descriptions",
               "title": "Search Query"
             },
@@ -8558,8 +10806,12 @@
             "required": false,
             "schema": {
               "anyOf": [
-                { "$ref": "#/components/schemas/StoreAgentsSortOptions" },
-                { "type": "null" }
+                {
+                  "$ref": "#/components/schemas/StoreAgentsSortOptions"
+                },
+                {
+                  "type": "null"
+                }
               ],
               "description": "Property to sort results by. Ignored if search_query is provided.",
               "title": "Sorted By"
@@ -8594,7 +10846,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/StoreAgentsResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/StoreAgentsResponse"
+                }
               }
             }
           },
@@ -8602,7 +10856,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -8620,13 +10876,19 @@
             "name": "username",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Username" }
+            "schema": {
+              "type": "string",
+              "title": "Username"
+            }
           },
           {
             "name": "agent_name",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Agent Name" }
+            "schema": {
+              "type": "string",
+              "title": "Agent Name"
+            }
           },
           {
             "name": "include_changelog",
@@ -8644,7 +10906,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/StoreAgentDetails" }
+                "schema": {
+                  "$ref": "#/components/schemas/StoreAgentDetails"
+                }
               }
             }
           },
@@ -8652,7 +10916,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -8665,26 +10931,38 @@
         "summary": "Create agent review",
         "description": "Post a user review on a marketplace agent listing",
         "operationId": "postV2Create agent review",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "username",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Username" }
+            "schema": {
+              "type": "string",
+              "title": "Username"
+            }
           },
           {
             "name": "agent_name",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Agent Name" }
+            "schema": {
+              "type": "string",
+              "title": "Agent Name"
+            }
           }
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/StoreReviewCreate" }
+              "schema": {
+                "$ref": "#/components/schemas/StoreReviewCreate"
+              }
             }
           }
         },
@@ -8693,7 +10971,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/StoreReview" }
+                "schema": {
+                  "$ref": "#/components/schemas/StoreReview"
+                }
               }
             }
           },
@@ -8704,7 +10984,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -8735,7 +11017,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "description": "Literal + semantic search on names and descriptions",
               "title": "Search Query"
             },
@@ -8747,8 +11036,12 @@
             "required": false,
             "schema": {
               "anyOf": [
-                { "$ref": "#/components/schemas/StoreCreatorsSortOptions" },
-                { "type": "null" }
+                {
+                  "$ref": "#/components/schemas/StoreCreatorsSortOptions"
+                },
+                {
+                  "type": "null"
+                }
               ],
               "title": "Sorted By"
             }
@@ -8781,7 +11074,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/CreatorsResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/CreatorsResponse"
+                }
               }
             }
           },
@@ -8789,7 +11084,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -8807,7 +11104,10 @@
             "name": "username",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Username" }
+            "schema": {
+              "type": "string",
+              "title": "Username"
+            }
           }
         ],
         "responses": {
@@ -8815,7 +11115,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/CreatorDetails" }
+                "schema": {
+                  "$ref": "#/components/schemas/CreatorDetails"
+                }
               }
             }
           },
@@ -8823,7 +11125,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -8835,13 +11139,20 @@
         "tags": ["v2", "store"],
         "summary": "Get agent by version",
         "operationId": "getV2Get agent by version",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "store_listing_version_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Store Listing Version Id" }
+            "schema": {
+              "type": "string",
+              "title": "Store Listing Version Id"
+            }
           }
         ],
         "responses": {
@@ -8849,7 +11160,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/StoreAgentDetails" }
+                "schema": {
+                  "$ref": "#/components/schemas/StoreAgentDetails"
+                }
               }
             }
           },
@@ -8860,7 +11173,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -8873,13 +11188,20 @@
         "summary": "Get agent graph",
         "description": "Get outline of graph belonging to a specific marketplace listing version",
         "operationId": "getV2Get agent graph",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "store_listing_version_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Store Listing Version Id" }
+            "schema": {
+              "type": "string",
+              "title": "Store Listing Version Id"
+            }
           }
         ],
         "responses": {
@@ -8900,7 +11222,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -8918,19 +11242,28 @@
             "name": "store_listing_version_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Store Listing Version Id" }
+            "schema": {
+              "type": "string",
+              "title": "Store Listing Version Id"
+            }
           }
         ],
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": { "application/json": { "schema": {} } }
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
           },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -8946,7 +11279,13 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": { "text/plain": { "schema": { "type": "string" } } }
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           }
         }
       }
@@ -8957,7 +11296,11 @@
         "summary": "Get my agents",
         "description": "List the authenticated user's unpublished agents",
         "operationId": "getV2Get my agents",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "page",
@@ -9009,7 +11352,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -9027,7 +11372,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ProfileDetails" }
+                "schema": {
+                  "$ref": "#/components/schemas/ProfileDetails"
+                }
               }
             }
           },
@@ -9035,7 +11382,11 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       },
       "post": {
         "tags": ["v2", "store", "private"],
@@ -9045,7 +11396,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/Profile" }
+              "schema": {
+                "$ref": "#/components/schemas/Profile"
+              }
             }
           },
           "required": true
@@ -9055,7 +11408,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ProfileDetails" }
+                "schema": {
+                  "$ref": "#/components/schemas/ProfileDetails"
+                }
               }
             }
           },
@@ -9066,12 +11421,18 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/store/search": {
@@ -9080,13 +11441,20 @@
         "summary": "Unified search across all content types",
         "description": "Search across all content types (marketplace agents, blocks, documentation)\nusing hybrid search.\n\nCombines semantic (embedding-based) and lexical (text-based) search for best results.",
         "operationId": "getV2Unified search across all content types",
-        "security": [{ "HTTPBearer": [] }],
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
         "parameters": [
           {
             "name": "query",
             "in": "query",
             "required": true,
-            "schema": { "type": "string", "title": "Query" }
+            "schema": {
+              "type": "string",
+              "title": "Query"
+            }
           },
           {
             "name": "content_types",
@@ -9096,9 +11464,13 @@
               "anyOf": [
                 {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/ContentType" }
+                  "items": {
+                    "$ref": "#/components/schemas/ContentType"
+                  }
                 },
-                { "type": "null" }
+                {
+                  "type": "null"
+                }
               ],
               "description": "Content types to search. If not specified, searches all.",
               "title": "Content Types"
@@ -9143,7 +11515,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -9156,7 +11530,11 @@
         "summary": "List my submissions",
         "description": "List the authenticated user's marketplace listing submissions",
         "operationId": "getV2List my submissions",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "page",
@@ -9199,7 +11577,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -9210,7 +11590,11 @@
         "summary": "Create store submission",
         "description": "Submit a new marketplace listing for review",
         "operationId": "postV2Create store submission",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -9226,7 +11610,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/StoreSubmission" }
+                "schema": {
+                  "$ref": "#/components/schemas/StoreSubmission"
+                }
               }
             }
           },
@@ -9237,7 +11623,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -9250,13 +11638,20 @@
         "summary": "Generate submission image",
         "description": "Generate an image for a marketplace listing submission based on the properties\nof a given graph.",
         "operationId": "postV2Generate submission image",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "graph_id",
             "in": "query",
             "required": true,
-            "schema": { "type": "string", "title": "Graph Id" }
+            "schema": {
+              "type": "string",
+              "title": "Graph Id"
+            }
           }
         ],
         "responses": {
@@ -9264,7 +11659,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ImageURLResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ImageURLResponse"
+                }
               }
             }
           },
@@ -9275,7 +11672,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -9317,12 +11716,18 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/store/submissions/{store_listing_version_id}": {
@@ -9331,13 +11736,20 @@
         "summary": "Edit store submission",
         "description": "Update a pending marketplace listing submission",
         "operationId": "putV2Edit store submission",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "store_listing_version_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Store Listing Version Id" }
+            "schema": {
+              "type": "string",
+              "title": "Store Listing Version Id"
+            }
           }
         ],
         "requestBody": {
@@ -9355,7 +11767,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/StoreSubmission" }
+                "schema": {
+                  "$ref": "#/components/schemas/StoreSubmission"
+                }
               }
             }
           },
@@ -9366,7 +11780,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -9379,13 +11795,20 @@
         "summary": "Delete store submission",
         "description": "Delete a marketplace listing submission",
         "operationId": "deleteV2Delete store submission",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "submission_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Submission Id" }
+            "schema": {
+              "type": "string",
+              "title": "Submission Id"
+            }
           }
         ],
         "responses": {
@@ -9407,7 +11830,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -9420,14 +11845,25 @@
         "summary": "List workspace files",
         "description": "List files in the user's workspace.\n\nWhen session_id is provided, only files for that session are returned.\nOtherwise, all files across sessions are listed. Results are paginated\nvia `limit`/`offset`; `has_more` indicates whether additional pages exist.",
         "operationId": "listWorkspaceFiles",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "session_id",
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "Session Id"
             }
           },
@@ -9460,7 +11896,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ListFilesResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ListFilesResponse"
+                }
               }
             }
           },
@@ -9471,7 +11909,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -9484,14 +11924,25 @@
         "summary": "Upload file to workspace",
         "description": "Upload a file to the user's workspace.\n\nFiles are stored in session-scoped paths when session_id is provided,\nso the agent's session-scoped tools can discover them automatically.",
         "operationId": "uploadWorkspaceFile",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "session_id",
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "Session Id"
             }
           },
@@ -9534,7 +11985,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -9547,13 +12000,20 @@
         "summary": "Delete a workspace file",
         "description": "Soft-delete a workspace file and attempt to remove it from storage.\n\nUsed when a user clears a file input in the builder.",
         "operationId": "deleteWorkspaceFile",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "file_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "File Id" }
+            "schema": {
+              "type": "string",
+              "title": "File Id"
+            }
           }
         ],
         "responses": {
@@ -9561,7 +12021,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/DeleteFileResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteFileResponse"
+                }
               }
             }
           },
@@ -9572,7 +12034,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -9585,19 +12049,30 @@
         "summary": "Download file by ID",
         "description": "Download a file by its ID.\n\nReturns the file content directly or redirects to a signed URL for GCS.",
         "operationId": "getWorkspaceDownloadFileById",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "file_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "File Id" }
+            "schema": {
+              "type": "string",
+              "title": "File Id"
+            }
           }
         ],
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": { "application/json": { "schema": {} } }
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
@@ -9606,7 +12081,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -9634,7 +12111,11 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/health": {
@@ -9645,7 +12126,11 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": { "application/json": { "schema": {} } }
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
           }
         }
       }
@@ -9655,10 +12140,23 @@
     "schemas": {
       "APIKeyCredentials": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "provider": { "type": "string", "title": "Provider" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "provider": {
+            "type": "string",
+            "title": "Provider"
+          },
           "title": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Title"
           },
           "is_managed": {
@@ -9684,7 +12182,14 @@
             "writeOnly": true
           },
           "expires_at": {
-            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Expires At",
             "description": "Unix timestamp (seconds) indicating when the API key expires (if at all)"
           }
@@ -9695,9 +12200,14 @@
       },
       "APIKeyInfo": {
         "properties": {
-          "user_id": { "type": "string", "title": "User Id" },
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
           "scopes": {
-            "items": { "$ref": "#/components/schemas/APIKeyPermission" },
+            "items": {
+              "$ref": "#/components/schemas/APIKeyPermission"
+            },
             "type": "array",
             "title": "Scopes"
           },
@@ -9714,27 +12224,48 @@
           },
           "expires_at": {
             "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Expires At"
           },
           "last_used_at": {
             "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Last Used At"
           },
           "revoked_at": {
             "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Revoked At"
           },
-          "id": { "type": "string", "title": "Id" },
-          "name": { "type": "string", "title": "Name" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
           "head": {
             "type": "string",
             "title": "Head",
@@ -9745,9 +12276,18 @@
             "title": "Tail",
             "description": "The last 8 characters of the key"
           },
-          "status": { "$ref": "#/components/schemas/APIKeyStatus" },
+          "status": {
+            "$ref": "#/components/schemas/APIKeyStatus"
+          },
           "description": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Description"
           }
         },
@@ -9789,14 +12329,33 @@
       },
       "AccuracyAlertData": {
         "properties": {
-          "graph_id": { "type": "string", "title": "Graph Id" },
+          "graph_id": {
+            "type": "string",
+            "title": "Graph Id"
+          },
           "user_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "User Id"
           },
-          "drop_percent": { "type": "number", "title": "Drop Percent" },
-          "three_day_avg": { "type": "number", "title": "Three Day Avg" },
-          "seven_day_avg": { "type": "number", "title": "Seven Day Avg" },
+          "drop_percent": {
+            "type": "number",
+            "title": "Drop Percent"
+          },
+          "three_day_avg": {
+            "type": "number",
+            "title": "Three Day Avg"
+          },
+          "seven_day_avg": {
+            "type": "number",
+            "title": "Seven Day Avg"
+          },
           "detected_at": {
             "type": "string",
             "format": "date-time",
@@ -9817,21 +12376,53 @@
       },
       "AccuracyLatestData": {
         "properties": {
-          "date": { "type": "string", "format": "date-time", "title": "Date" },
+          "date": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Date"
+          },
           "daily_score": {
-            "anyOf": [{ "type": "number" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Daily Score"
           },
           "three_day_avg": {
-            "anyOf": [{ "type": "number" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Three Day Avg"
           },
           "seven_day_avg": {
-            "anyOf": [{ "type": "number" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Seven Day Avg"
           },
           "fourteen_day_avg": {
-            "anyOf": [{ "type": "number" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Fourteen Day Avg"
           }
         },
@@ -9848,20 +12439,30 @@
       },
       "AccuracyTrendsResponse": {
         "properties": {
-          "latest_data": { "$ref": "#/components/schemas/AccuracyLatestData" },
+          "latest_data": {
+            "$ref": "#/components/schemas/AccuracyLatestData"
+          },
           "alert": {
             "anyOf": [
-              { "$ref": "#/components/schemas/AccuracyAlertData" },
-              { "type": "null" }
+              {
+                "$ref": "#/components/schemas/AccuracyAlertData"
+              },
+              {
+                "type": "null"
+              }
             ]
           },
           "historical_data": {
             "anyOf": [
               {
-                "items": { "$ref": "#/components/schemas/AccuracyLatestData" },
+                "items": {
+                  "$ref": "#/components/schemas/AccuracyLatestData"
+                },
                 "type": "array"
               },
-              { "type": "null" }
+              {
+                "type": "null"
+              }
             ],
             "title": "Historical Data"
           }
@@ -9873,10 +12474,23 @@
       },
       "ActiveStreamInfo": {
         "properties": {
-          "turn_id": { "type": "string", "title": "Turn Id" },
-          "last_message_id": { "type": "string", "title": "Last Message Id" },
+          "turn_id": {
+            "type": "string",
+            "title": "Turn Id"
+          },
+          "last_message_id": {
+            "type": "string",
+            "title": "Last Message Id"
+          },
           "started_at": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Started At"
           }
         },
@@ -9887,8 +12501,14 @@
       },
       "AddUserCreditsResponse": {
         "properties": {
-          "new_balance": { "type": "integer", "title": "New Balance" },
-          "transaction_key": { "type": "string", "title": "Transaction Key" }
+          "new_balance": {
+            "type": "integer",
+            "title": "New Balance"
+          },
+          "transaction_key": {
+            "type": "string",
+            "title": "Transaction Key"
+          }
         },
         "type": "object",
         "required": ["new_balance", "transaction_key"],
@@ -9896,9 +12516,18 @@
       },
       "AgentDetails": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "name": { "type": "string", "title": "Name" },
-          "description": { "type": "string", "title": "Description" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
           "in_library": {
             "type": "boolean",
             "title": "In Library",
@@ -9911,7 +12540,9 @@
             "default": {}
           },
           "credentials": {
-            "items": { "$ref": "#/components/schemas/CredentialsMetaInput" },
+            "items": {
+              "$ref": "#/components/schemas/CredentialsMetaInput"
+            },
             "type": "array",
             "title": "Credentials",
             "default": []
@@ -9921,8 +12552,13 @@
           },
           "trigger_info": {
             "anyOf": [
-              { "additionalProperties": true, "type": "object" },
-              { "type": "null" }
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Trigger Info"
           }
@@ -9938,23 +12574,49 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "agent_details"
           },
-          "message": { "type": "string", "title": "Message" },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
           "session_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Session Id"
           },
-          "agent": { "$ref": "#/components/schemas/AgentDetails" },
+          "agent": {
+            "$ref": "#/components/schemas/AgentDetails"
+          },
           "user_authenticated": {
             "type": "boolean",
             "title": "User Authenticated",
             "default": false
           },
           "graph_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Graph Id"
           },
           "graph_version": {
-            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Graph Version"
           }
         },
@@ -9969,7 +12631,10 @@
             "type": "integer",
             "title": "Agents With Active Executions"
           },
-          "timestamp": { "type": "string", "title": "Timestamp" }
+          "timestamp": {
+            "type": "string",
+            "title": "Timestamp"
+          }
         },
         "type": "object",
         "required": ["agents_with_active_executions", "timestamp"],
@@ -9991,9 +12656,18 @@
       },
       "AgentInfo": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "name": { "type": "string", "title": "Name" },
-          "description": { "type": "string", "title": "Description" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
           "source": {
             "type": "string",
             "title": "Source",
@@ -10005,82 +12679,185 @@
             "default": false
           },
           "creator": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Creator"
           },
           "category": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Category"
           },
           "rating": {
-            "anyOf": [{ "type": "number" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Rating"
           },
           "runs": {
-            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Runs"
           },
           "is_featured": {
-            "anyOf": [{ "type": "boolean" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Is Featured"
           },
           "status": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Status"
           },
           "can_access_graph": {
-            "anyOf": [{ "type": "boolean" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Can Access Graph"
           },
           "has_external_trigger": {
-            "anyOf": [{ "type": "boolean" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Has External Trigger"
           },
           "new_output": {
-            "anyOf": [{ "type": "boolean" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "New Output"
           },
           "graph_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Graph Id"
           },
           "graph_version": {
-            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Graph Version"
           },
           "match_score": {
-            "anyOf": [{ "type": "number" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Match Score",
             "description": "Combined relevance score in [0, 1] when this agent was returned from a similarity search (e.g. the create-time library check). Null for non-similarity sources."
           },
           "input_schema": {
             "anyOf": [
-              { "additionalProperties": true, "type": "object" },
-              { "type": "null" }
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Input Schema",
             "description": "JSON Schema for the agent's inputs (for AgentExecutorBlock)"
           },
           "output_schema": {
             "anyOf": [
-              { "additionalProperties": true, "type": "object" },
-              { "type": "null" }
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Output Schema",
             "description": "JSON Schema for the agent's outputs (for AgentExecutorBlock)"
           },
           "inputs": {
             "anyOf": [
-              { "additionalProperties": true, "type": "object" },
-              { "type": "null" }
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Inputs",
             "description": "Input schema for the agent, including field names, types, and defaults"
           },
           "graph": {
             "anyOf": [
-              { "$ref": "#/components/schemas/BaseGraph-Output" },
-              { "type": "null" }
+              {
+                "$ref": "#/components/schemas/BaseGraph-Output"
+              },
+              {
+                "type": "null"
+              }
             ],
             "description": "Full graph structure (nodes + links) when include_graph is requested"
           }
@@ -10096,34 +12873,73 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "agent_output"
           },
-          "message": { "type": "string", "title": "Message" },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
           "session_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Session Id"
           },
-          "agent_name": { "type": "string", "title": "Agent Name" },
-          "agent_id": { "type": "string", "title": "Agent Id" },
+          "agent_name": {
+            "type": "string",
+            "title": "Agent Name"
+          },
+          "agent_id": {
+            "type": "string",
+            "title": "Agent Id"
+          },
           "library_agent_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Library Agent Id"
           },
           "library_agent_link": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Library Agent Link"
           },
           "execution": {
             "anyOf": [
-              { "$ref": "#/components/schemas/ExecutionOutputInfo" },
-              { "type": "null" }
+              {
+                "$ref": "#/components/schemas/ExecutionOutputInfo"
+              },
+              {
+                "type": "null"
+              }
             ]
           },
           "available_executions": {
             "anyOf": [
               {
-                "items": { "additionalProperties": true, "type": "object" },
+                "items": {
+                  "additionalProperties": true,
+                  "type": "object"
+                },
                 "type": "array"
               },
-              { "type": "null" }
+              {
+                "type": "null"
+              }
             ],
             "title": "Available Executions"
           },
@@ -10144,9 +12960,19 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "agent_builder_preview"
           },
-          "message": { "type": "string", "title": "Message" },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
           "session_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Session Id"
           },
           "agent_json": {
@@ -10154,9 +12980,18 @@
             "type": "object",
             "title": "Agent Json"
           },
-          "agent_name": { "type": "string", "title": "Agent Name" },
-          "description": { "type": "string", "title": "Description" },
-          "node_count": { "type": "integer", "title": "Node Count" },
+          "agent_name": {
+            "type": "string",
+            "title": "Agent Name"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
+          "node_count": {
+            "type": "integer",
+            "title": "Node Count"
+          },
           "link_count": {
             "type": "integer",
             "title": "Link Count",
@@ -10180,23 +13015,52 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "agent_builder_saved"
           },
-          "message": { "type": "string", "title": "Message" },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
           "session_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Session Id"
           },
-          "agent_id": { "type": "string", "title": "Agent Id" },
-          "agent_name": { "type": "string", "title": "Agent Name" },
+          "agent_id": {
+            "type": "string",
+            "title": "Agent Id"
+          },
+          "agent_name": {
+            "type": "string",
+            "title": "Agent Name"
+          },
           "graph_version": {
-            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Graph Version"
           },
-          "library_agent_id": { "type": "string", "title": "Library Agent Id" },
+          "library_agent_id": {
+            "type": "string",
+            "title": "Library Agent Id"
+          },
           "library_agent_link": {
             "type": "string",
             "title": "Library Agent Link"
           },
-          "agent_page_link": { "type": "string", "title": "Agent Page Link" }
+          "agent_page_link": {
+            "type": "string",
+            "title": "Agent Page Link"
+          }
         },
         "type": "object",
         "required": [
@@ -10216,9 +13080,19 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "agents_found"
           },
-          "message": { "type": "string", "title": "Message" },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
           "session_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Session Id"
           },
           "title": {
@@ -10227,11 +13101,16 @@
             "default": "Available Agents"
           },
           "agents": {
-            "items": { "$ref": "#/components/schemas/AgentInfo" },
+            "items": {
+              "$ref": "#/components/schemas/AgentInfo"
+            },
             "type": "array",
             "title": "Agents"
           },
-          "count": { "type": "integer", "title": "Count" },
+          "count": {
+            "type": "integer",
+            "title": "Count"
+          },
           "name": {
             "type": "string",
             "title": "Name",
@@ -10245,13 +13124,21 @@
       },
       "ApiResponse": {
         "properties": {
-          "answer": { "type": "string", "title": "Answer" },
+          "answer": {
+            "type": "string",
+            "title": "Answer"
+          },
           "documents": {
-            "items": { "$ref": "#/components/schemas/Document" },
+            "items": {
+              "$ref": "#/components/schemas/Document"
+            },
             "type": "array",
             "title": "Documents"
           },
-          "success": { "type": "boolean", "title": "Success" }
+          "success": {
+            "type": "boolean",
+            "title": "Success"
+          }
         },
         "type": "object",
         "required": ["answer", "documents", "success"],
@@ -10270,7 +13157,9 @@
             "description": "Redirect URI"
           },
           "scopes": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Scopes",
             "description": "List of scopes"
@@ -10325,8 +13214,14 @@
       },
       "AutoTopUpConfig": {
         "properties": {
-          "amount": { "type": "integer", "title": "Amount" },
-          "threshold": { "type": "integer", "title": "Threshold" }
+          "amount": {
+            "type": "integer",
+            "title": "Amount"
+          },
+          "threshold": {
+            "type": "integer",
+            "title": "Threshold"
+          }
         },
         "type": "object",
         "required": ["amount", "threshold"],
@@ -10352,38 +13247,83 @@
       },
       "BaseGraph-Input": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "version": { "type": "integer", "title": "Version", "default": 1 },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "version": {
+            "type": "integer",
+            "title": "Version",
+            "default": 1
+          },
           "is_active": {
             "type": "boolean",
             "title": "Is Active",
             "default": true
           },
-          "name": { "type": "string", "title": "Name" },
-          "description": { "type": "string", "title": "Description" },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
           "instructions": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Instructions"
           },
           "recommended_schedule_cron": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Recommended Schedule Cron"
           },
           "forked_from_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Forked From Id"
           },
           "forked_from_version": {
-            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Forked From Version"
           },
           "nodes": {
-            "items": { "$ref": "#/components/schemas/Node" },
+            "items": {
+              "$ref": "#/components/schemas/Node"
+            },
             "type": "array",
             "title": "Nodes"
           },
           "links": {
-            "items": { "$ref": "#/components/schemas/Link" },
+            "items": {
+              "$ref": "#/components/schemas/Link"
+            },
             "type": "array",
             "title": "Links"
           }
@@ -10395,38 +13335,83 @@
       },
       "BaseGraph-Output": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "version": { "type": "integer", "title": "Version", "default": 1 },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "version": {
+            "type": "integer",
+            "title": "Version",
+            "default": 1
+          },
           "is_active": {
             "type": "boolean",
             "title": "Is Active",
             "default": true
           },
-          "name": { "type": "string", "title": "Name" },
-          "description": { "type": "string", "title": "Description" },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
           "instructions": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Instructions"
           },
           "recommended_schedule_cron": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Recommended Schedule Cron"
           },
           "forked_from_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Forked From Id"
           },
           "forked_from_version": {
-            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Forked From Version"
           },
           "nodes": {
-            "items": { "$ref": "#/components/schemas/Node" },
+            "items": {
+              "$ref": "#/components/schemas/Node"
+            },
             "type": "array",
             "title": "Nodes"
           },
           "links": {
-            "items": { "$ref": "#/components/schemas/Link" },
+            "items": {
+              "$ref": "#/components/schemas/Link"
+            },
             "type": "array",
             "title": "Links"
           },
@@ -10459,8 +13444,12 @@
           },
           "trigger_setup_info": {
             "anyOf": [
-              { "$ref": "#/components/schemas/GraphTriggerInfo" },
-              { "type": "null" }
+              {
+                "$ref": "#/components/schemas/GraphTriggerInfo"
+              },
+              {
+                "type": "null"
+              }
             ],
             "readOnly": true
           }
@@ -10481,10 +13470,18 @@
       },
       "BlockCategoryResponse": {
         "properties": {
-          "name": { "type": "string", "title": "Name" },
-          "total_blocks": { "type": "integer", "title": "Total Blocks" },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "total_blocks": {
+            "type": "integer",
+            "title": "Total Blocks"
+          },
           "blocks": {
-            "items": { "$ref": "#/components/schemas/BlockInfo" },
+            "items": {
+              "$ref": "#/components/schemas/BlockInfo"
+            },
             "type": "array",
             "title": "Blocks"
           }
@@ -10495,13 +13492,18 @@
       },
       "BlockCost": {
         "properties": {
-          "cost_amount": { "type": "integer", "title": "Cost Amount" },
+          "cost_amount": {
+            "type": "integer",
+            "title": "Cost Amount"
+          },
           "cost_filter": {
             "additionalProperties": true,
             "type": "object",
             "title": "Cost Filter"
           },
-          "cost_type": { "$ref": "#/components/schemas/BlockCostType" },
+          "cost_type": {
+            "$ref": "#/components/schemas/BlockCostType"
+          },
           "cost_divisor": {
             "type": "integer",
             "title": "Cost Divisor",
@@ -10509,8 +13511,12 @@
           },
           "token_rate": {
             "anyOf": [
-              { "$ref": "#/components/schemas/TokenRateDisplay" },
-              { "type": "null" }
+              {
+                "$ref": "#/components/schemas/TokenRateDisplay"
+              },
+              {
+                "type": "null"
+              }
             ]
           }
         },
@@ -10520,13 +13526,34 @@
       },
       "BlockCostEstimateRow": {
         "properties": {
-          "block_id": { "type": "string", "title": "Block Id" },
-          "block_name": { "type": "string", "title": "Block Name" },
-          "cost_type": { "type": "string", "title": "Cost Type" },
-          "samples": { "type": "integer", "title": "Samples" },
-          "mean_credits": { "type": "integer", "title": "Mean Credits" },
-          "p50_credits": { "type": "integer", "title": "P50 Credits" },
-          "p95_credits": { "type": "integer", "title": "P95 Credits" }
+          "block_id": {
+            "type": "string",
+            "title": "Block Id"
+          },
+          "block_name": {
+            "type": "string",
+            "title": "Block Name"
+          },
+          "cost_type": {
+            "type": "string",
+            "title": "Cost Type"
+          },
+          "samples": {
+            "type": "integer",
+            "title": "Samples"
+          },
+          "mean_credits": {
+            "type": "integer",
+            "title": "Mean Credits"
+          },
+          "p50_credits": {
+            "type": "integer",
+            "title": "P50 Credits"
+          },
+          "p95_credits": {
+            "type": "integer",
+            "title": "P95 Credits"
+          }
         },
         "type": "object",
         "required": [
@@ -10543,14 +13570,28 @@
       "BlockCostEstimatesResponse": {
         "properties": {
           "estimates": {
-            "items": { "$ref": "#/components/schemas/BlockCostEstimateRow" },
+            "items": {
+              "$ref": "#/components/schemas/BlockCostEstimateRow"
+            },
             "type": "array",
             "title": "Estimates"
           },
-          "total_rows": { "type": "integer", "title": "Total Rows" },
-          "window_days": { "type": "integer", "title": "Window Days" },
-          "max_window_days": { "type": "integer", "title": "Max Window Days" },
-          "min_samples": { "type": "integer", "title": "Min Samples" },
+          "total_rows": {
+            "type": "integer",
+            "title": "Total Rows"
+          },
+          "window_days": {
+            "type": "integer",
+            "title": "Window Days"
+          },
+          "max_window_days": {
+            "type": "integer",
+            "title": "Max Window Days"
+          },
+          "min_samples": {
+            "type": "integer",
+            "title": "Min Samples"
+          },
           "generated_at": {
             "type": "string",
             "format": "date-time",
@@ -10575,9 +13616,18 @@
       },
       "BlockDetails": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "name": { "type": "string", "title": "Name" },
-          "description": { "type": "string", "title": "Description" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
           "inputs": {
             "additionalProperties": true,
             "type": "object",
@@ -10591,7 +13641,9 @@
             "default": {}
           },
           "credentials": {
-            "items": { "$ref": "#/components/schemas/CredentialsMetaInput" },
+            "items": {
+              "$ref": "#/components/schemas/CredentialsMetaInput"
+            },
             "type": "array",
             "title": "Credentials",
             "default": []
@@ -10608,12 +13660,24 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "block_details"
           },
-          "message": { "type": "string", "title": "Message" },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
           "session_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Session Id"
           },
-          "block": { "$ref": "#/components/schemas/BlockDetails" },
+          "block": {
+            "$ref": "#/components/schemas/BlockDetails"
+          },
           "user_authenticated": {
             "type": "boolean",
             "title": "User Authenticated",
@@ -10627,8 +13691,14 @@
       },
       "BlockInfo": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "name": { "type": "string", "title": "Name" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
           "inputSchema": {
             "additionalProperties": true,
             "type": "object",
@@ -10640,26 +13710,42 @@
             "title": "Outputschema"
           },
           "costs": {
-            "items": { "$ref": "#/components/schemas/BlockCost" },
+            "items": {
+              "$ref": "#/components/schemas/BlockCost"
+            },
             "type": "array",
             "title": "Costs"
           },
-          "description": { "type": "string", "title": "Description" },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
           "categories": {
             "items": {
-              "additionalProperties": { "type": "string" },
+              "additionalProperties": {
+                "type": "string"
+              },
               "type": "object"
             },
             "type": "array",
             "title": "Categories"
           },
           "contributors": {
-            "items": { "additionalProperties": true, "type": "object" },
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
             "type": "array",
             "title": "Contributors"
           },
-          "staticOutput": { "type": "boolean", "title": "Staticoutput" },
-          "uiType": { "type": "string", "title": "Uitype" }
+          "staticOutput": {
+            "type": "boolean",
+            "title": "Staticoutput"
+          },
+          "uiType": {
+            "type": "string",
+            "title": "Uitype"
+          }
         },
         "type": "object",
         "required": [
@@ -10678,11 +13764,22 @@
       },
       "BlockInfoSummary": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "name": { "type": "string", "title": "Name" },
-          "description": { "type": "string", "title": "Description" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
           "categories": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Categories"
           },
@@ -10705,7 +13802,9 @@
             "default": false
           },
           "required_inputs": {
-            "items": { "$ref": "#/components/schemas/BlockInputFieldInfo" },
+            "items": {
+              "$ref": "#/components/schemas/BlockInputFieldInfo"
+            },
             "type": "array",
             "title": "Required Inputs",
             "description": "List of input fields for this block"
@@ -10718,8 +13817,14 @@
       },
       "BlockInputFieldInfo": {
         "properties": {
-          "name": { "type": "string", "title": "Name" },
-          "type": { "type": "string", "title": "Type" },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "type": {
+            "type": "string",
+            "title": "Type"
+          },
           "description": {
             "type": "string",
             "title": "Description",
@@ -10730,7 +13835,15 @@
             "title": "Required",
             "default": false
           },
-          "default": { "anyOf": [{}, { "type": "null" }], "title": "Default" }
+          "default": {
+            "anyOf": [
+              {},
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Default"
+          }
         },
         "type": "object",
         "required": ["name", "type"],
@@ -10743,18 +13856,36 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "block_list"
           },
-          "message": { "type": "string", "title": "Message" },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
           "session_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Session Id"
           },
           "blocks": {
-            "items": { "$ref": "#/components/schemas/BlockInfoSummary" },
+            "items": {
+              "$ref": "#/components/schemas/BlockInfoSummary"
+            },
             "type": "array",
             "title": "Blocks"
           },
-          "count": { "type": "integer", "title": "Count" },
-          "query": { "type": "string", "title": "Query" },
+          "count": {
+            "type": "integer",
+            "title": "Count"
+          },
+          "query": {
+            "type": "string",
+            "title": "Query"
+          },
           "usage_hint": {
             "type": "string",
             "title": "Usage Hint",
@@ -10772,21 +13903,51 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "block_output"
           },
-          "message": { "type": "string", "title": "Message" },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
           "session_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Session Id"
           },
-          "block_id": { "type": "string", "title": "Block Id" },
-          "block_name": { "type": "string", "title": "Block Name" },
+          "block_id": {
+            "type": "string",
+            "title": "Block Id"
+          },
+          "block_name": {
+            "type": "string",
+            "title": "Block Name"
+          },
           "outputs": {
-            "additionalProperties": { "items": {}, "type": "array" },
+            "additionalProperties": {
+              "items": {},
+              "type": "array"
+            },
             "type": "object",
             "title": "Outputs"
           },
-          "success": { "type": "boolean", "title": "Success", "default": true },
+          "success": {
+            "type": "boolean",
+            "title": "Success",
+            "default": true
+          },
           "is_dry_run": {
-            "anyOf": [{ "type": "boolean" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Is Dry Run"
           }
         },
@@ -10798,11 +13959,15 @@
       "BlockResponse": {
         "properties": {
           "blocks": {
-            "items": { "$ref": "#/components/schemas/BlockInfo" },
+            "items": {
+              "$ref": "#/components/schemas/BlockInfo"
+            },
             "type": "array",
             "title": "Blocks"
           },
-          "pagination": { "$ref": "#/components/schemas/Pagination" }
+          "pagination": {
+            "$ref": "#/components/schemas/Pagination"
+          }
         },
         "type": "object",
         "required": ["blocks", "pagination"],
@@ -10822,7 +13987,10 @@
       },
       "Body_postAnalyticsLogRawAnalytics": {
         "properties": {
-          "type": { "type": "string", "title": "Type" },
+          "type": {
+            "type": "string",
+            "title": "Type"
+          },
           "data": {
             "additionalProperties": true,
             "type": "object",
@@ -10848,8 +14016,13 @@
           },
           "token_type_hint": {
             "anyOf": [
-              { "type": "string", "enum": ["access_token", "refresh_token"] },
-              { "type": "null" }
+              {
+                "type": "string",
+                "enum": ["access_token", "refresh_token"]
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Token Type Hint",
             "description": "Hint about token type ('access_token' or 'refresh_token')"
@@ -10878,8 +14051,13 @@
           },
           "token_type_hint": {
             "anyOf": [
-              { "type": "string", "enum": ["access_token", "refresh_token"] },
-              { "type": "null" }
+              {
+                "type": "string",
+                "enum": ["access_token", "refresh_token"]
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Token Type Hint",
             "description": "Hint about token type ('access_token' or 'refresh_token')"
@@ -10901,7 +14079,11 @@
       },
       "Body_postOauthUploadAppLogo": {
         "properties": {
-          "file": { "type": "string", "format": "binary", "title": "File" }
+          "file": {
+            "type": "string",
+            "format": "binary",
+            "title": "File"
+          }
         },
         "type": "object",
         "required": ["file"],
@@ -10913,7 +14095,10 @@
             "type": "string",
             "title": "Authorization code acquired by user login"
           },
-          "state_token": { "type": "string", "title": "Anti-CSRF nonce" }
+          "state_token": {
+            "type": "string",
+            "title": "Anti-CSRF nonce"
+          }
         },
         "type": "object",
         "required": ["code", "state_token"],
@@ -10939,18 +14124,28 @@
                 "type": "string",
                 "enum": ["builder", "library", "onboarding"]
               },
-              { "type": "null" }
+              {
+                "type": "null"
+              }
             ],
             "title": "Source"
           },
-          "dry_run": { "type": "boolean", "title": "Dry Run", "default": false }
+          "dry_run": {
+            "type": "boolean",
+            "title": "Dry Run",
+            "default": false
+          }
         },
         "type": "object",
         "title": "Body_postV1Execute graph agent"
       },
       "Body_postV1Upload_file_to_cloud_storage": {
         "properties": {
-          "file": { "type": "string", "format": "binary", "title": "File" }
+          "file": {
+            "type": "string",
+            "format": "binary",
+            "title": "File"
+          }
         },
         "type": "object",
         "required": ["file"],
@@ -10958,9 +14153,18 @@
       },
       "Body_postV2Add_credits_to_user": {
         "properties": {
-          "user_id": { "type": "string", "title": "User Id" },
-          "amount": { "type": "integer", "title": "Amount" },
-          "comments": { "type": "string", "title": "Comments" }
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
+          "amount": {
+            "type": "integer",
+            "title": "Amount"
+          },
+          "comments": {
+            "type": "string",
+            "title": "Comments"
+          }
         },
         "type": "object",
         "required": ["user_id", "amount", "comments"],
@@ -11003,7 +14207,10 @@
       },
       "Body_postV2Reset_user_rate_limit_usage": {
         "properties": {
-          "user_id": { "type": "string", "title": "User Id" },
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
           "reset_weekly": {
             "type": "boolean",
             "title": "Reset Weekly",
@@ -11016,7 +14223,11 @@
       },
       "Body_postV2Upload_submission_media": {
         "properties": {
-          "file": { "type": "string", "format": "binary", "title": "File" }
+          "file": {
+            "type": "string",
+            "format": "binary",
+            "title": "File"
+          }
         },
         "type": "object",
         "required": ["file"],
@@ -11024,21 +14235,82 @@
       },
       "Body_uploadWorkspaceFile": {
         "properties": {
-          "file": { "type": "string", "format": "binary", "title": "File" }
+          "file": {
+            "type": "string",
+            "format": "binary",
+            "title": "File"
+          }
         },
         "type": "object",
         "required": ["file"],
         "title": "Body_uploadWorkspaceFile"
       },
+      "BotPlatformInfo": {
+        "properties": {
+          "platform": {
+            "type": "string",
+            "title": "Platform"
+          },
+          "display_name": {
+            "type": "string",
+            "title": "Display Name"
+          },
+          "icon": {
+            "type": "string",
+            "title": "Icon"
+          },
+          "add_bot_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Add Bot Url"
+          },
+          "dm_link": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PlatformUserLinkInfo"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "server_links": {
+            "items": {
+              "$ref": "#/components/schemas/PlatformLinkInfo"
+            },
+            "type": "array",
+            "title": "Server Links"
+          }
+        },
+        "type": "object",
+        "required": ["platform", "display_name", "icon"],
+        "title": "BotPlatformInfo",
+        "description": "A bot platform enabled on this deployment plus the caller's links to it.\n\nPlatforms whose adapter isn't configured (missing token/credentials) are\nomitted from the response entirely — the Bots settings page hides them."
+      },
       "BulkMoveAgentsRequest": {
         "properties": {
           "agent_ids": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Agent Ids"
           },
           "folder_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Folder Id"
           }
         },
@@ -11049,9 +14321,19 @@
       },
       "CancelSessionResponse": {
         "properties": {
-          "cancelled": { "type": "boolean", "title": "Cancelled" },
+          "cancelled": {
+            "type": "boolean",
+            "title": "Cancelled"
+          },
           "reason": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Reason"
           }
         },
@@ -11062,9 +14344,19 @@
       },
       "ChangelogEntry": {
         "properties": {
-          "version": { "type": "string", "title": "Version" },
-          "changes_summary": { "type": "string", "title": "Changes Summary" },
-          "date": { "type": "string", "format": "date-time", "title": "Date" }
+          "version": {
+            "type": "string",
+            "title": "Version"
+          },
+          "changes_summary": {
+            "type": "string",
+            "title": "Changes Summary"
+          },
+          "date": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Date"
+          }
         },
         "type": "object",
         "required": ["version", "changes_summary", "date"],
@@ -11072,20 +14364,35 @@
       },
       "ChatRequest": {
         "properties": {
-          "query": { "type": "string", "title": "Query" },
+          "query": {
+            "type": "string",
+            "title": "Query"
+          },
           "conversation_history": {
-            "items": { "$ref": "#/components/schemas/Message" },
+            "items": {
+              "$ref": "#/components/schemas/Message"
+            },
             "type": "array",
             "title": "Conversation History"
           },
-          "message_id": { "type": "string", "title": "Message Id" },
+          "message_id": {
+            "type": "string",
+            "title": "Message Id"
+          },
           "include_graph_data": {
             "type": "boolean",
             "title": "Include Graph Data",
             "default": false
           },
           "graph_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Graph Id"
           }
         },
@@ -11101,11 +14408,25 @@
             "default": false
           },
           "builder_graph_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Builder Graph Id"
           },
           "source_platform": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Source Platform"
           }
         },
@@ -11119,13 +14440,25 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "agent_builder_clarification_needed"
           },
-          "message": { "type": "string", "title": "Message" },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
           "session_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Session Id"
           },
           "questions": {
-            "items": { "$ref": "#/components/schemas/ClarifyingQuestion" },
+            "items": {
+              "$ref": "#/components/schemas/ClarifyingQuestion"
+            },
             "type": "array",
             "title": "Questions"
           }
@@ -11137,10 +14470,23 @@
       },
       "ClarifyingQuestion": {
         "properties": {
-          "question": { "type": "string", "title": "Question" },
-          "keyword": { "type": "string", "title": "Keyword" },
+          "question": {
+            "type": "string",
+            "title": "Question"
+          },
+          "keyword": {
+            "type": "string",
+            "title": "Keyword"
+          },
           "example": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Example"
           }
         },
@@ -11153,15 +14499,23 @@
         "properties": {
           "daily": {
             "anyOf": [
-              { "$ref": "#/components/schemas/UsageWindowPublic" },
-              { "type": "null" }
+              {
+                "$ref": "#/components/schemas/UsageWindowPublic"
+              },
+              {
+                "type": "null"
+              }
             ],
             "description": "Null when no daily cap is configured (unlimited)."
           },
           "weekly": {
             "anyOf": [
-              { "$ref": "#/components/schemas/UsageWindowPublic" },
-              { "type": "null" }
+              {
+                "$ref": "#/components/schemas/UsageWindowPublic"
+              },
+              {
+                "type": "null"
+              }
             ],
             "description": "Null when no weekly cap is configured (unlimited)."
           },
@@ -11182,18 +14536,31 @@
       },
       "ConfirmLinkResponse": {
         "properties": {
-          "success": { "type": "boolean", "title": "Success" },
+          "success": {
+            "type": "boolean",
+            "title": "Success"
+          },
           "link_type": {
             "$ref": "#/components/schemas/LinkType",
             "default": "SERVER"
           },
-          "platform": { "type": "string", "title": "Platform" },
+          "platform": {
+            "type": "string",
+            "title": "Platform"
+          },
           "platform_server_id": {
             "type": "string",
             "title": "Platform Server Id"
           },
           "server_name": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Server Name"
           }
         },
@@ -11208,13 +14575,22 @@
       },
       "ConfirmUserLinkResponse": {
         "properties": {
-          "success": { "type": "boolean", "title": "Success" },
+          "success": {
+            "type": "boolean",
+            "title": "Success"
+          },
           "link_type": {
             "$ref": "#/components/schemas/LinkType",
             "default": "USER"
           },
-          "platform": { "type": "string", "title": "Platform" },
-          "platform_user_id": { "type": "string", "title": "Platform User Id" }
+          "platform": {
+            "type": "string",
+            "title": "Platform"
+          },
+          "platform_user_id": {
+            "type": "string",
+            "title": "Platform User Id"
+          }
         },
         "type": "object",
         "required": ["success", "platform", "platform_user_id"],
@@ -11233,17 +14609,35 @@
       },
       "CopilotSkillDetail": {
         "properties": {
-          "name": { "type": "string", "title": "Name" },
-          "description": { "type": "string", "title": "Description" },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
           "triggers": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Triggers",
             "default": []
           },
-          "body": { "type": "string", "title": "Body" },
+          "body": {
+            "type": "string",
+            "title": "Body"
+          },
           "version": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Version"
           },
           "is_default": {
@@ -11252,7 +14646,9 @@
             "default": false
           },
           "sibling_files": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Sibling Files",
             "default": []
@@ -11265,10 +14661,18 @@
       },
       "CopilotSkillInfo": {
         "properties": {
-          "name": { "type": "string", "title": "Name" },
-          "description": { "type": "string", "title": "Description" },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
           "triggers": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Triggers",
             "default": []
@@ -11288,23 +14692,55 @@
             "default": "copilot_turn"
           },
           "schedule_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Schedule Id"
           },
-          "user_id": { "type": "string", "title": "User Id" },
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
           "session_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Session Id"
           },
-          "message": { "type": "string", "title": "Message" },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
           "cron": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Cron"
           },
           "run_at": {
             "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Run At"
           },
@@ -11314,12 +14750,28 @@
             "default": 0
           },
           "user_timezone": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "User Timezone"
           },
-          "id": { "type": "string", "title": "Id" },
-          "name": { "type": "string", "title": "Name" },
-          "next_run_time": { "type": "string", "title": "Next Run Time" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "next_run_time": {
+            "type": "string",
+            "title": "Next Run Time"
+          },
           "timezone": {
             "type": "string",
             "title": "Timezone",
@@ -11334,13 +14786,24 @@
       "CopilotUsageExportResponse": {
         "properties": {
           "rows": {
-            "items": { "$ref": "#/components/schemas/CopilotWeeklyUsageRow" },
+            "items": {
+              "$ref": "#/components/schemas/CopilotWeeklyUsageRow"
+            },
             "type": "array",
             "title": "Rows"
           },
-          "total_rows": { "type": "integer", "title": "Total Rows" },
-          "window_days": { "type": "integer", "title": "Window Days" },
-          "max_window_days": { "type": "integer", "title": "Max Window Days" }
+          "total_rows": {
+            "type": "integer",
+            "title": "Total Rows"
+          },
+          "window_days": {
+            "type": "integer",
+            "title": "Window Days"
+          },
+          "max_window_days": {
+            "type": "integer",
+            "title": "Max Window Days"
+          }
         },
         "type": "object",
         "required": ["rows", "total_rows", "window_days", "max_window_days"],
@@ -11348,9 +14811,19 @@
       },
       "CopilotWeeklyUsageRow": {
         "properties": {
-          "user_id": { "type": "string", "title": "User Id" },
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
           "user_email": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "User Email"
           },
           "week_start": {
@@ -11367,12 +14840,18 @@
             "type": "integer",
             "title": "Copilot Cost Microdollars"
           },
-          "tier": { "type": "string", "title": "Tier" },
+          "tier": {
+            "type": "string",
+            "title": "Tier"
+          },
           "weekly_limit_microdollars": {
             "type": "integer",
             "title": "Weekly Limit Microdollars"
           },
-          "percent_used": { "type": "number", "title": "Percent Used" }
+          "percent_used": {
+            "type": "number",
+            "title": "Percent Used"
+          }
         },
         "type": "object",
         "required": [
@@ -11388,8 +14867,14 @@
       },
       "CostBucket": {
         "properties": {
-          "bucket": { "type": "string", "title": "Bucket" },
-          "count": { "type": "integer", "title": "Count" }
+          "bucket": {
+            "type": "string",
+            "title": "Bucket"
+          },
+          "count": {
+            "type": "integer",
+            "title": "Count"
+          }
         },
         "type": "object",
         "required": ["bucket", "count"],
@@ -11397,60 +14882,153 @@
       },
       "CostLogRow": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
           "created_at": {
             "type": "string",
             "format": "date-time",
             "title": "Created At"
           },
           "user_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "User Id"
           },
           "email": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Email"
           },
           "graph_exec_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Graph Exec Id"
           },
           "node_exec_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Node Exec Id"
           },
-          "block_name": { "type": "string", "title": "Block Name" },
-          "provider": { "type": "string", "title": "Provider" },
+          "block_name": {
+            "type": "string",
+            "title": "Block Name"
+          },
+          "provider": {
+            "type": "string",
+            "title": "Provider"
+          },
           "tracking_type": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Tracking Type"
           },
           "cost_microdollars": {
-            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Cost Microdollars"
           },
           "input_tokens": {
-            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Input Tokens"
           },
           "output_tokens": {
-            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Output Tokens"
           },
           "duration": {
-            "anyOf": [{ "type": "number" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Duration"
           },
           "model": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Model"
           },
           "cache_read_tokens": {
-            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Cache Read Tokens"
           },
           "cache_creation_tokens": {
-            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Cache Creation Tokens"
           }
         },
@@ -11460,16 +15038,34 @@
       },
       "CountResponse": {
         "properties": {
-          "all_blocks": { "type": "integer", "title": "All Blocks" },
-          "input_blocks": { "type": "integer", "title": "Input Blocks" },
-          "action_blocks": { "type": "integer", "title": "Action Blocks" },
-          "output_blocks": { "type": "integer", "title": "Output Blocks" },
-          "integrations": { "type": "integer", "title": "Integrations" },
+          "all_blocks": {
+            "type": "integer",
+            "title": "All Blocks"
+          },
+          "input_blocks": {
+            "type": "integer",
+            "title": "Input Blocks"
+          },
+          "action_blocks": {
+            "type": "integer",
+            "title": "Action Blocks"
+          },
+          "output_blocks": {
+            "type": "integer",
+            "title": "Output Blocks"
+          },
+          "integrations": {
+            "type": "integer",
+            "title": "Integrations"
+          },
           "marketplace_agents": {
             "type": "integer",
             "title": "Marketplace Agents"
           },
-          "my_agents": { "type": "integer", "title": "My Agents" }
+          "my_agents": {
+            "type": "integer",
+            "title": "My Agents"
+          }
         },
         "type": "object",
         "required": [
@@ -11485,14 +15081,26 @@
       },
       "CreateAPIKeyRequest": {
         "properties": {
-          "name": { "type": "string", "title": "Name" },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
           "permissions": {
-            "items": { "$ref": "#/components/schemas/APIKeyPermission" },
+            "items": {
+              "$ref": "#/components/schemas/APIKeyPermission"
+            },
             "type": "array",
             "title": "Permissions"
           },
           "description": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Description"
           }
         },
@@ -11502,8 +15110,13 @@
       },
       "CreateAPIKeyResponse": {
         "properties": {
-          "api_key": { "$ref": "#/components/schemas/APIKeyInfo" },
-          "plain_text_key": { "type": "string", "title": "Plain Text Key" }
+          "api_key": {
+            "$ref": "#/components/schemas/APIKeyInfo"
+          },
+          "plain_text_key": {
+            "type": "string",
+            "title": "Plain Text Key"
+          }
         },
         "type": "object",
         "required": ["api_key", "plain_text_key"],
@@ -11511,11 +15124,18 @@
       },
       "CreateGraph": {
         "properties": {
-          "graph": { "$ref": "#/components/schemas/Graph" },
+          "graph": {
+            "$ref": "#/components/schemas/Graph"
+          },
           "source": {
             "anyOf": [
-              { "type": "string", "enum": ["builder", "upload"] },
-              { "type": "null" }
+              {
+                "type": "string",
+                "enum": ["builder", "upload"]
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Source"
           }
@@ -11533,8 +15153,13 @@
           },
           "builder_graph_id": {
             "anyOf": [
-              { "type": "string", "maxLength": 128 },
-              { "type": "null" }
+              {
+                "type": "string",
+                "maxLength": 128
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Builder Graph Id"
           }
@@ -11546,15 +15171,30 @@
       },
       "CreateSessionResponse": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "created_at": { "type": "string", "title": "Created At" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "created_at": {
+            "type": "string",
+            "title": "Created At"
+          },
           "user_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "User Id"
           },
           "metadata": {
             "$ref": "#/components/schemas/ChatSessionMetadata",
-            "default": { "dry_run": false }
+            "default": {
+              "dry_run": false
+            }
           }
         },
         "type": "object",
@@ -11564,24 +15204,56 @@
       },
       "CreatorDetails": {
         "properties": {
-          "username": { "type": "string", "title": "Username" },
-          "name": { "type": "string", "title": "Name" },
-          "description": { "type": "string", "title": "Description" },
+          "username": {
+            "type": "string",
+            "title": "Username"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
           "avatar_url": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Avatar Url"
           },
           "links": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Links"
           },
-          "is_featured": { "type": "boolean", "title": "Is Featured" },
-          "num_agents": { "type": "integer", "title": "Num Agents" },
-          "agent_runs": { "type": "integer", "title": "Agent Runs" },
-          "agent_rating": { "type": "number", "title": "Agent Rating" },
+          "is_featured": {
+            "type": "boolean",
+            "title": "Is Featured"
+          },
+          "num_agents": {
+            "type": "integer",
+            "title": "Num Agents"
+          },
+          "agent_runs": {
+            "type": "integer",
+            "title": "Agent Runs"
+          },
+          "agent_rating": {
+            "type": "number",
+            "title": "Agent Rating"
+          },
           "top_categories": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Top Categories"
           }
@@ -11605,11 +15277,15 @@
       "CreatorsResponse": {
         "properties": {
           "creators": {
-            "items": { "$ref": "#/components/schemas/CreatorDetails" },
+            "items": {
+              "$ref": "#/components/schemas/CreatorDetails"
+            },
             "type": "array",
             "title": "Creators"
           },
-          "pagination": { "$ref": "#/components/schemas/Pagination" }
+          "pagination": {
+            "$ref": "#/components/schemas/Pagination"
+          }
         },
         "type": "object",
         "required": ["creators", "pagination"],
@@ -11629,7 +15305,10 @@
             "title": "Need Confirmation",
             "default": true
           },
-          "message": { "type": "string", "title": "Message" }
+          "message": {
+            "type": "string",
+            "title": "Message"
+          }
         },
         "type": "object",
         "required": ["message"],
@@ -11644,7 +15323,14 @@
             "default": true
           },
           "revoked": {
-            "anyOf": [{ "type": "boolean" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Revoked",
             "description": "Indicates whether the credentials were also revoked by their provider. `None`/`null` if not applicable, e.g. when deleting non-revocable credentials such as API keys."
           }
@@ -11655,9 +15341,19 @@
       },
       "CredentialsMetaInput": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
           "title": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Title"
           },
           "provider": {
@@ -11679,30 +15375,64 @@
       },
       "CredentialsMetaResponse": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "provider": { "type": "string", "title": "Provider" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "provider": {
+            "type": "string",
+            "title": "Provider"
+          },
           "type": {
             "type": "string",
             "enum": ["api_key", "oauth2", "user_password", "host_scoped"],
             "title": "Type"
           },
           "title": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Title"
           },
           "scopes": {
             "anyOf": [
-              { "items": { "type": "string" }, "type": "array" },
-              { "type": "null" }
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Scopes"
           },
           "username": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Username"
           },
           "host": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Host",
             "description": "Host pattern for host-scoped or MCP server URL for MCP credentials"
           },
@@ -11731,13 +15461,24 @@
       "CreditTransactionsExportResponse": {
         "properties": {
           "transactions": {
-            "items": { "$ref": "#/components/schemas/UserTransaction" },
+            "items": {
+              "$ref": "#/components/schemas/UserTransaction"
+            },
             "type": "array",
             "title": "Transactions"
           },
-          "total_rows": { "type": "integer", "title": "Total Rows" },
-          "window_days": { "type": "integer", "title": "Window Days" },
-          "max_window_days": { "type": "integer", "title": "Max Window Days" }
+          "total_rows": {
+            "type": "integer",
+            "title": "Total Rows"
+          },
+          "window_days": {
+            "type": "integer",
+            "title": "Window Days"
+          },
+          "max_window_days": {
+            "type": "integer",
+            "title": "Max Window Days"
+          }
         },
         "type": "object",
         "required": [
@@ -11749,21 +15490,34 @@
         "title": "CreditTransactionsExportResponse"
       },
       "DeleteFileResponse": {
-        "properties": { "deleted": { "type": "boolean", "title": "Deleted" } },
+        "properties": {
+          "deleted": {
+            "type": "boolean",
+            "title": "Deleted"
+          }
+        },
         "type": "object",
         "required": ["deleted"],
         "title": "DeleteFileResponse"
       },
       "DeleteGraphResponse": {
         "properties": {
-          "version_counts": { "type": "integer", "title": "Version Counts" }
+          "version_counts": {
+            "type": "integer",
+            "title": "Version Counts"
+          }
         },
         "type": "object",
         "required": ["version_counts"],
         "title": "DeleteGraphResponse"
       },
       "DeleteLinkResponse": {
-        "properties": { "success": { "type": "boolean", "title": "Success" } },
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "title": "Success"
+          }
+        },
         "type": "object",
         "required": ["success"],
         "title": "DeleteLinkResponse"
@@ -11776,7 +15530,14 @@
             "description": "URL of the MCP server"
           },
           "auth_token": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Auth Token",
             "description": "Optional Bearer token for authenticated MCP servers"
           }
@@ -11789,16 +15550,32 @@
       "DiscoverToolsResponse": {
         "properties": {
           "tools": {
-            "items": { "$ref": "#/components/schemas/MCPToolResponse" },
+            "items": {
+              "$ref": "#/components/schemas/MCPToolResponse"
+            },
             "type": "array",
             "title": "Tools"
           },
           "server_name": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Server Name"
           },
           "protocol_version": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Protocol Version"
           }
         },
@@ -11813,16 +15590,42 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "doc_page"
           },
-          "message": { "type": "string", "title": "Message" },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
           "session_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Session Id"
           },
-          "title": { "type": "string", "title": "Title" },
-          "path": { "type": "string", "title": "Path" },
-          "content": { "type": "string", "title": "Content" },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "path": {
+            "type": "string",
+            "title": "Path"
+          },
+          "content": {
+            "type": "string",
+            "title": "Content"
+          },
           "doc_url": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Doc Url"
           }
         },
@@ -11833,13 +15636,35 @@
       },
       "DocSearchResult": {
         "properties": {
-          "title": { "type": "string", "title": "Title" },
-          "path": { "type": "string", "title": "Path" },
-          "section": { "type": "string", "title": "Section" },
-          "snippet": { "type": "string", "title": "Snippet" },
-          "score": { "type": "number", "title": "Score" },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "path": {
+            "type": "string",
+            "title": "Path"
+          },
+          "section": {
+            "type": "string",
+            "title": "Section"
+          },
+          "snippet": {
+            "type": "string",
+            "title": "Snippet"
+          },
+          "score": {
+            "type": "number",
+            "title": "Score"
+          },
           "doc_url": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Doc Url"
           }
         },
@@ -11854,18 +15679,36 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "doc_search_results"
           },
-          "message": { "type": "string", "title": "Message" },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
           "session_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Session Id"
           },
           "results": {
-            "items": { "$ref": "#/components/schemas/DocSearchResult" },
+            "items": {
+              "$ref": "#/components/schemas/DocSearchResult"
+            },
             "type": "array",
             "title": "Results"
           },
-          "count": { "type": "integer", "title": "Count" },
-          "query": { "type": "string", "title": "Query" }
+          "count": {
+            "type": "integer",
+            "title": "Count"
+          },
+          "query": {
+            "type": "string",
+            "title": "Query"
+          }
         },
         "type": "object",
         "required": ["message", "results", "count", "query"],
@@ -11874,8 +15717,14 @@
       },
       "Document": {
         "properties": {
-          "url": { "type": "string", "title": "Url" },
-          "relevance_score": { "type": "number", "title": "Relevance Score" }
+          "url": {
+            "type": "string",
+            "title": "Url"
+          },
+          "relevance_score": {
+            "type": "number",
+            "title": "Relevance Score"
+          }
         },
         "type": "object",
         "required": ["url", "relevance_score"],
@@ -11887,19 +15736,41 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "error"
           },
-          "message": { "type": "string", "title": "Message" },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
           "session_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Session Id"
           },
           "error": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Error"
           },
           "details": {
             "anyOf": [
-              { "additionalProperties": true, "type": "object" },
-              { "type": "null" }
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Details"
           }
@@ -11912,7 +15783,9 @@
       "ExecutionAnalyticsConfig": {
         "properties": {
           "available_models": {
-            "items": { "$ref": "#/components/schemas/ModelInfo" },
+            "items": {
+              "$ref": "#/components/schemas/ModelInfo"
+            },
             "type": "array",
             "title": "Available Models"
           },
@@ -11946,19 +15819,38 @@
             "description": "Graph ID to analyze"
           },
           "graph_version": {
-            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Graph Version",
             "description": "Optional graph version"
           },
           "user_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "User Id",
             "description": "Optional user ID filter"
           },
           "created_after": {
             "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Created After",
             "description": "Optional created date lower bound"
@@ -11978,12 +15870,26 @@
             "default": 10
           },
           "system_prompt": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "System Prompt",
             "description": "Custom system prompt (default: built-in prompt)"
           },
           "user_prompt": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "User Prompt",
             "description": "Custom user prompt with {{GRAPH_NAME}} and {{EXECUTION_DATA}} placeholders (default: built-in prompt)"
           },
@@ -12041,34 +15947,80 @@
       },
       "ExecutionAnalyticsResult": {
         "properties": {
-          "agent_id": { "type": "string", "title": "Agent Id" },
-          "version_id": { "type": "integer", "title": "Version Id" },
-          "user_id": { "type": "string", "title": "User Id" },
-          "exec_id": { "type": "string", "title": "Exec Id" },
+          "agent_id": {
+            "type": "string",
+            "title": "Agent Id"
+          },
+          "version_id": {
+            "type": "integer",
+            "title": "Version Id"
+          },
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
+          "exec_id": {
+            "type": "string",
+            "title": "Exec Id"
+          },
           "summary_text": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Summary Text"
           },
           "score": {
-            "anyOf": [{ "type": "number" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Score"
           },
-          "status": { "type": "string", "title": "Status" },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
           "error_message": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Error Message"
           },
           "started_at": {
             "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Started At"
           },
           "ended_at": {
             "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Ended At"
           }
@@ -12107,13 +16059,22 @@
             "type": "integer",
             "title": "Orphaned Running"
           },
-          "orphaned_queued": { "type": "integer", "title": "Orphaned Queued" },
-          "failed_count_1h": { "type": "integer", "title": "Failed Count 1H" },
+          "orphaned_queued": {
+            "type": "integer",
+            "title": "Orphaned Queued"
+          },
+          "failed_count_1h": {
+            "type": "integer",
+            "title": "Failed Count 1H"
+          },
           "failed_count_24h": {
             "type": "integer",
             "title": "Failed Count 24H"
           },
-          "failure_rate_24h": { "type": "number", "title": "Failure Rate 24H" },
+          "failure_rate_24h": {
+            "type": "number",
+            "title": "Failure Rate 24H"
+          },
           "stuck_running_24h": {
             "type": "integer",
             "title": "Stuck Running 24H"
@@ -12123,10 +16084,20 @@
             "title": "Stuck Running 1H"
           },
           "oldest_running_hours": {
-            "anyOf": [{ "type": "number" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Oldest Running Hours"
           },
-          "stuck_queued_1h": { "type": "integer", "title": "Stuck Queued 1H" },
+          "stuck_queued_1h": {
+            "type": "integer",
+            "title": "Stuck Queued 1H"
+          },
           "queued_never_started": {
             "type": "integer",
             "title": "Queued Never Started"
@@ -12139,13 +16110,22 @@
             "type": "integer",
             "title": "Invalid Running Without Start"
           },
-          "completed_1h": { "type": "integer", "title": "Completed 1H" },
-          "completed_24h": { "type": "integer", "title": "Completed 24H" },
+          "completed_1h": {
+            "type": "integer",
+            "title": "Completed 1H"
+          },
+          "completed_24h": {
+            "type": "integer",
+            "title": "Completed 24H"
+          },
           "throughput_per_hour": {
             "type": "number",
             "title": "Throughput Per Hour"
           },
-          "timestamp": { "type": "string", "title": "Timestamp" }
+          "timestamp": {
+            "type": "string",
+            "title": "Timestamp"
+          }
         },
         "type": "object",
         "required": [
@@ -12175,13 +16155,21 @@
       },
       "ExecutionOptions": {
         "properties": {
-          "manual": { "type": "boolean", "title": "Manual", "default": true },
+          "manual": {
+            "type": "boolean",
+            "title": "Manual",
+            "default": true
+          },
           "scheduled": {
             "type": "boolean",
             "title": "Scheduled",
             "default": true
           },
-          "webhook": { "type": "boolean", "title": "Webhook", "default": false }
+          "webhook": {
+            "type": "boolean",
+            "title": "Webhook",
+            "default": false
+          }
         },
         "type": "object",
         "title": "ExecutionOptions",
@@ -12189,41 +16177,70 @@
       },
       "ExecutionOutputInfo": {
         "properties": {
-          "execution_id": { "type": "string", "title": "Execution Id" },
-          "status": { "type": "string", "title": "Status" },
+          "execution_id": {
+            "type": "string",
+            "title": "Execution Id"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
           "started_at": {
             "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Started At"
           },
           "ended_at": {
             "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Ended At"
           },
           "outputs": {
-            "additionalProperties": { "items": {}, "type": "array" },
+            "additionalProperties": {
+              "items": {},
+              "type": "array"
+            },
             "type": "object",
             "title": "Outputs"
           },
           "inputs_summary": {
             "anyOf": [
-              { "additionalProperties": true, "type": "object" },
-              { "type": "null" }
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Inputs Summary"
           },
           "node_executions": {
             "anyOf": [
               {
-                "items": { "additionalProperties": true, "type": "object" },
+                "items": {
+                  "additionalProperties": true,
+                  "type": "object"
+                },
                 "type": "array"
               },
-              { "type": "null" }
+              {
+                "type": "null"
+              }
             ],
             "title": "Node Executions"
           }
@@ -12239,23 +16256,60 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "execution_started"
           },
-          "message": { "type": "string", "title": "Message" },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
           "session_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Session Id"
           },
-          "execution_id": { "type": "string", "title": "Execution Id" },
-          "graph_id": { "type": "string", "title": "Graph Id" },
-          "graph_name": { "type": "string", "title": "Graph Name" },
+          "execution_id": {
+            "type": "string",
+            "title": "Execution Id"
+          },
+          "graph_id": {
+            "type": "string",
+            "title": "Graph Id"
+          },
+          "graph_name": {
+            "type": "string",
+            "title": "Graph Name"
+          },
           "library_agent_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Library Agent Id"
           },
           "library_agent_link": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Library Agent Link"
           },
-          "status": { "type": "string", "title": "Status", "default": "QUEUED" }
+          "status": {
+            "type": "string",
+            "title": "Status",
+            "default": "QUEUED"
+          }
         },
         "type": "object",
         "required": ["message", "execution_id", "graph_id", "graph_name"],
@@ -12264,16 +16318,41 @@
       },
       "FailedExecutionDetail": {
         "properties": {
-          "execution_id": { "type": "string", "title": "Execution Id" },
-          "graph_id": { "type": "string", "title": "Graph Id" },
-          "graph_name": { "type": "string", "title": "Graph Name" },
-          "graph_version": { "type": "integer", "title": "Graph Version" },
-          "user_id": { "type": "string", "title": "User Id" },
+          "execution_id": {
+            "type": "string",
+            "title": "Execution Id"
+          },
+          "graph_id": {
+            "type": "string",
+            "title": "Graph Id"
+          },
+          "graph_name": {
+            "type": "string",
+            "title": "Graph Name"
+          },
+          "graph_version": {
+            "type": "integer",
+            "title": "Graph Version"
+          },
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
           "user_email": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "User Email"
           },
-          "status": { "type": "string", "title": "Status" },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
           "created_at": {
             "type": "string",
             "format": "date-time",
@@ -12281,20 +16360,37 @@
           },
           "started_at": {
             "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Started At"
           },
           "failed_at": {
             "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Failed At"
           },
           "error_message": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Error Message"
           }
         },
@@ -12318,11 +16414,16 @@
       "FailedExecutionsListResponse": {
         "properties": {
           "executions": {
-            "items": { "$ref": "#/components/schemas/FailedExecutionDetail" },
+            "items": {
+              "$ref": "#/components/schemas/FailedExecutionDetail"
+            },
             "type": "array",
             "title": "Executions"
           },
-          "total": { "type": "integer", "title": "Total" }
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          }
         },
         "type": "object",
         "required": ["executions", "total"],
@@ -12338,19 +16439,38 @@
             "title": "Name"
           },
           "icon": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Icon"
           },
           "color": {
             "anyOf": [
-              { "type": "string", "pattern": "^#[0-9A-Fa-f]{6}$" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "pattern": "^#[0-9A-Fa-f]{6}$"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Color",
             "description": "Hex color code (#RRGGBB)"
           },
           "parent_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Parent Id"
           }
         },
@@ -12362,11 +16482,15 @@
       "FolderListResponse": {
         "properties": {
           "folders": {
-            "items": { "$ref": "#/components/schemas/LibraryFolder" },
+            "items": {
+              "$ref": "#/components/schemas/LibraryFolder"
+            },
             "type": "array",
             "title": "Folders"
           },
-          "pagination": { "$ref": "#/components/schemas/Pagination" }
+          "pagination": {
+            "$ref": "#/components/schemas/Pagination"
+          }
         },
         "type": "object",
         "required": ["folders", "pagination"],
@@ -12376,7 +16500,14 @@
       "FolderMoveRequest": {
         "properties": {
           "target_parent_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Target Parent Id"
           }
         },
@@ -12387,7 +16518,9 @@
       "FolderTreeResponse": {
         "properties": {
           "tree": {
-            "items": { "$ref": "#/components/schemas/LibraryFolderTree" },
+            "items": {
+              "$ref": "#/components/schemas/LibraryFolderTree"
+            },
             "type": "array",
             "title": "Tree"
           }
@@ -12401,17 +16534,37 @@
         "properties": {
           "name": {
             "anyOf": [
-              { "type": "string", "maxLength": 100, "minLength": 1 },
-              { "type": "null" }
+              {
+                "type": "string",
+                "maxLength": 100,
+                "minLength": 1
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Name"
           },
           "icon": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Icon"
           },
           "color": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Color"
           }
         },
@@ -12421,43 +16574,90 @@
       },
       "Graph": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "version": { "type": "integer", "title": "Version", "default": 1 },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "version": {
+            "type": "integer",
+            "title": "Version",
+            "default": 1
+          },
           "is_active": {
             "type": "boolean",
             "title": "Is Active",
             "default": true
           },
-          "name": { "type": "string", "title": "Name" },
-          "description": { "type": "string", "title": "Description" },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
           "instructions": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Instructions"
           },
           "recommended_schedule_cron": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Recommended Schedule Cron"
           },
           "forked_from_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Forked From Id"
           },
           "forked_from_version": {
-            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Forked From Version"
           },
           "nodes": {
-            "items": { "$ref": "#/components/schemas/Node" },
+            "items": {
+              "$ref": "#/components/schemas/Node"
+            },
             "type": "array",
             "title": "Nodes"
           },
           "links": {
-            "items": { "$ref": "#/components/schemas/Link" },
+            "items": {
+              "$ref": "#/components/schemas/Link"
+            },
             "type": "array",
             "title": "Links"
           },
           "sub_graphs": {
-            "items": { "$ref": "#/components/schemas/BaseGraph-Input" },
+            "items": {
+              "$ref": "#/components/schemas/BaseGraph-Input"
+            },
             "type": "array",
             "title": "Sub Graphs"
           }
@@ -12469,10 +16669,22 @@
       },
       "GraphExecution": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "user_id": { "type": "string", "title": "User Id" },
-          "graph_id": { "type": "string", "title": "Graph Id" },
-          "graph_version": { "type": "integer", "title": "Graph Version" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
+          "graph_id": {
+            "type": "string",
+            "title": "Graph Id"
+          },
+          "graph_version": {
+            "type": "integer",
+            "title": "Graph Version"
+          },
           "inputs": {
             "additionalProperties": true,
             "type": "object",
@@ -12486,7 +16698,9 @@
                 },
                 "type": "object"
               },
-              { "type": "null" }
+              {
+                "type": "null"
+              }
             ],
             "title": "Credential Inputs"
           },
@@ -12499,27 +16713,48 @@
                 },
                 "type": "object"
               },
-              { "type": "null" }
+              {
+                "type": "null"
+              }
             ],
             "title": "Nodes Input Masks"
           },
           "preset_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Preset Id"
           },
-          "status": { "$ref": "#/components/schemas/AgentExecutionStatus" },
+          "status": {
+            "$ref": "#/components/schemas/AgentExecutionStatus"
+          },
           "started_at": {
             "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Started At",
             "description": "When execution started running. Null if not yet started (QUEUED)."
           },
           "ended_at": {
             "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Ended At",
             "description": "When execution finished. Null if not yet completed (QUEUED, RUNNING, INCOMPLETE, REVIEW)."
@@ -12530,7 +16765,14 @@
             "default": false
           },
           "share_token": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Share Token"
           },
           "is_dry_run": {
@@ -12540,12 +16782,19 @@
           },
           "stats": {
             "anyOf": [
-              { "$ref": "#/components/schemas/Stats" },
-              { "type": "null" }
+              {
+                "$ref": "#/components/schemas/Stats"
+              },
+              {
+                "type": "null"
+              }
             ]
           },
           "outputs": {
-            "additionalProperties": { "items": {}, "type": "array" },
+            "additionalProperties": {
+              "items": {},
+              "type": "array"
+            },
             "type": "object",
             "title": "Outputs"
           }
@@ -12575,17 +16824,43 @@
             "default": "graph"
           },
           "schedule_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Schedule Id"
           },
-          "user_id": { "type": "string", "title": "User Id" },
-          "graph_id": { "type": "string", "title": "Graph Id" },
-          "graph_version": { "type": "integer", "title": "Graph Version" },
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
+          "graph_id": {
+            "type": "string",
+            "title": "Graph Id"
+          },
+          "graph_version": {
+            "type": "integer",
+            "title": "Graph Version"
+          },
           "agent_name": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Agent Name"
           },
-          "cron": { "type": "string", "title": "Cron" },
+          "cron": {
+            "type": "string",
+            "title": "Cron"
+          },
           "input_data": {
             "additionalProperties": true,
             "type": "object",
@@ -12598,9 +16873,18 @@
             "type": "object",
             "title": "Input Credentials"
           },
-          "id": { "type": "string", "title": "Id" },
-          "name": { "type": "string", "title": "Name" },
-          "next_run_time": { "type": "string", "title": "Next Run Time" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "next_run_time": {
+            "type": "string",
+            "title": "Next Run Time"
+          },
           "timezone": {
             "type": "string",
             "title": "Timezone",
@@ -12623,14 +16907,31 @@
       },
       "GraphExecutionMeta": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "user_id": { "type": "string", "title": "User Id" },
-          "graph_id": { "type": "string", "title": "Graph Id" },
-          "graph_version": { "type": "integer", "title": "Graph Version" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
+          "graph_id": {
+            "type": "string",
+            "title": "Graph Id"
+          },
+          "graph_version": {
+            "type": "integer",
+            "title": "Graph Version"
+          },
           "inputs": {
             "anyOf": [
-              { "additionalProperties": true, "type": "object" },
-              { "type": "null" }
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Inputs"
           },
@@ -12642,7 +16943,9 @@
                 },
                 "type": "object"
               },
-              { "type": "null" }
+              {
+                "type": "null"
+              }
             ],
             "title": "Credential Inputs"
           },
@@ -12655,27 +16958,48 @@
                 },
                 "type": "object"
               },
-              { "type": "null" }
+              {
+                "type": "null"
+              }
             ],
             "title": "Nodes Input Masks"
           },
           "preset_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Preset Id"
           },
-          "status": { "$ref": "#/components/schemas/AgentExecutionStatus" },
+          "status": {
+            "$ref": "#/components/schemas/AgentExecutionStatus"
+          },
           "started_at": {
             "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Started At",
             "description": "When execution started running. Null if not yet started (QUEUED)."
           },
           "ended_at": {
             "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Ended At",
             "description": "When execution finished. Null if not yet completed (QUEUED, RUNNING, INCOMPLETE, REVIEW)."
@@ -12686,7 +17010,14 @@
             "default": false
           },
           "share_token": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Share Token"
           },
           "is_dry_run": {
@@ -12696,8 +17027,12 @@
           },
           "stats": {
             "anyOf": [
-              { "$ref": "#/components/schemas/Stats" },
-              { "type": "null" }
+              {
+                "$ref": "#/components/schemas/Stats"
+              },
+              {
+                "type": "null"
+              }
             ]
           }
         },
@@ -12718,10 +17053,22 @@
       },
       "GraphExecutionWithNodes": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "user_id": { "type": "string", "title": "User Id" },
-          "graph_id": { "type": "string", "title": "Graph Id" },
-          "graph_version": { "type": "integer", "title": "Graph Version" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
+          "graph_id": {
+            "type": "string",
+            "title": "Graph Id"
+          },
+          "graph_version": {
+            "type": "integer",
+            "title": "Graph Version"
+          },
           "inputs": {
             "additionalProperties": true,
             "type": "object",
@@ -12735,7 +17082,9 @@
                 },
                 "type": "object"
               },
-              { "type": "null" }
+              {
+                "type": "null"
+              }
             ],
             "title": "Credential Inputs"
           },
@@ -12748,27 +17097,48 @@
                 },
                 "type": "object"
               },
-              { "type": "null" }
+              {
+                "type": "null"
+              }
             ],
             "title": "Nodes Input Masks"
           },
           "preset_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Preset Id"
           },
-          "status": { "$ref": "#/components/schemas/AgentExecutionStatus" },
+          "status": {
+            "$ref": "#/components/schemas/AgentExecutionStatus"
+          },
           "started_at": {
             "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Started At",
             "description": "When execution started running. Null if not yet started (QUEUED)."
           },
           "ended_at": {
             "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Ended At",
             "description": "When execution finished. Null if not yet completed (QUEUED, RUNNING, INCOMPLETE, REVIEW)."
@@ -12779,7 +17149,14 @@
             "default": false
           },
           "share_token": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Share Token"
           },
           "is_dry_run": {
@@ -12789,17 +17166,26 @@
           },
           "stats": {
             "anyOf": [
-              { "$ref": "#/components/schemas/Stats" },
-              { "type": "null" }
+              {
+                "$ref": "#/components/schemas/Stats"
+              },
+              {
+                "type": "null"
+              }
             ]
           },
           "outputs": {
-            "additionalProperties": { "items": {}, "type": "array" },
+            "additionalProperties": {
+              "items": {},
+              "type": "array"
+            },
             "type": "object",
             "title": "Outputs"
           },
           "node_executions": {
-            "items": { "$ref": "#/components/schemas/NodeExecutionResult" },
+            "items": {
+              "$ref": "#/components/schemas/NodeExecutionResult"
+            },
             "type": "array",
             "title": "Node Executions"
           }
@@ -12824,11 +17210,15 @@
       "GraphExecutionsPaginated": {
         "properties": {
           "executions": {
-            "items": { "$ref": "#/components/schemas/GraphExecutionMeta" },
+            "items": {
+              "$ref": "#/components/schemas/GraphExecutionMeta"
+            },
             "type": "array",
             "title": "Executions"
           },
-          "pagination": { "$ref": "#/components/schemas/Pagination" }
+          "pagination": {
+            "$ref": "#/components/schemas/Pagination"
+          }
         },
         "type": "object",
         "required": ["executions", "pagination"],
@@ -12837,32 +17227,75 @@
       },
       "GraphMeta": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "version": { "type": "integer", "title": "Version" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "version": {
+            "type": "integer",
+            "title": "Version"
+          },
           "is_active": {
             "type": "boolean",
             "title": "Is Active",
             "default": true
           },
-          "name": { "type": "string", "title": "Name" },
-          "description": { "type": "string", "title": "Description" },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
           "instructions": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Instructions"
           },
           "recommended_schedule_cron": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Recommended Schedule Cron"
           },
           "forked_from_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Forked From Id"
           },
           "forked_from_version": {
-            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Forked From Version"
           },
-          "user_id": { "type": "string", "title": "User Id" },
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
           "created_at": {
             "type": "string",
             "format": "date-time",
@@ -12883,49 +17316,99 @@
       },
       "GraphModel": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "version": { "type": "integer", "title": "Version", "default": 1 },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "version": {
+            "type": "integer",
+            "title": "Version",
+            "default": 1
+          },
           "is_active": {
             "type": "boolean",
             "title": "Is Active",
             "default": true
           },
-          "name": { "type": "string", "title": "Name" },
-          "description": { "type": "string", "title": "Description" },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
           "instructions": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Instructions"
           },
           "recommended_schedule_cron": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Recommended Schedule Cron"
           },
           "forked_from_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Forked From Id"
           },
           "forked_from_version": {
-            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Forked From Version"
           },
-          "user_id": { "type": "string", "title": "User Id" },
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
           "created_at": {
             "type": "string",
             "format": "date-time",
             "title": "Created At"
           },
           "nodes": {
-            "items": { "$ref": "#/components/schemas/NodeModel" },
+            "items": {
+              "$ref": "#/components/schemas/NodeModel"
+            },
             "type": "array",
             "title": "Nodes"
           },
           "links": {
-            "items": { "$ref": "#/components/schemas/Link" },
+            "items": {
+              "$ref": "#/components/schemas/Link"
+            },
             "type": "array",
             "title": "Links"
           },
           "sub_graphs": {
-            "items": { "$ref": "#/components/schemas/BaseGraph-Output" },
+            "items": {
+              "$ref": "#/components/schemas/BaseGraph-Output"
+            },
             "type": "array",
             "title": "Sub Graphs"
           },
@@ -12958,8 +17441,12 @@
           },
           "trigger_setup_info": {
             "anyOf": [
-              { "$ref": "#/components/schemas/GraphTriggerInfo" },
-              { "type": "null" }
+              {
+                "$ref": "#/components/schemas/GraphTriggerInfo"
+              },
+              {
+                "type": "null"
+              }
             ],
             "readOnly": true
           },
@@ -12989,32 +17476,76 @@
       },
       "GraphModelWithoutNodes": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "version": { "type": "integer", "title": "Version", "default": 1 },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "version": {
+            "type": "integer",
+            "title": "Version",
+            "default": 1
+          },
           "is_active": {
             "type": "boolean",
             "title": "Is Active",
             "default": true
           },
-          "name": { "type": "string", "title": "Name" },
-          "description": { "type": "string", "title": "Description" },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
           "instructions": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Instructions"
           },
           "recommended_schedule_cron": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Recommended Schedule Cron"
           },
           "forked_from_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Forked From Id"
           },
           "forked_from_version": {
-            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Forked From Version"
           },
-          "user_id": { "type": "string", "title": "User Id" },
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
           "created_at": {
             "type": "string",
             "format": "date-time",
@@ -13049,8 +17580,12 @@
           },
           "trigger_setup_info": {
             "anyOf": [
-              { "$ref": "#/components/schemas/GraphTriggerInfo" },
-              { "type": "null" }
+              {
+                "$ref": "#/components/schemas/GraphTriggerInfo"
+              },
+              {
+                "type": "null"
+              }
             ],
             "readOnly": true
           },
@@ -13091,7 +17626,14 @@
             "default": false
           },
           "builder_chat_session_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Builder Chat Session Id"
           }
         },
@@ -13112,7 +17654,14 @@
             "description": "Input schema for the trigger block"
           },
           "credentials_input_name": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Credentials Input Name"
           }
         },
@@ -13123,7 +17672,9 @@
       "HTTPValidationError": {
         "properties": {
           "detail": {
-            "items": { "$ref": "#/components/schemas/ValidationError" },
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
             "type": "array",
             "title": "Detail"
           }
@@ -13133,10 +17684,23 @@
       },
       "HostScopedCredentials": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "provider": { "type": "string", "title": "Provider" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "provider": {
+            "type": "string",
+            "title": "Provider"
+          },
           "title": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Title"
           },
           "is_managed": {
@@ -13177,7 +17741,10 @@
       },
       "ImageURLResponse": {
         "properties": {
-          "image_url": { "type": "string", "title": "Image Url" }
+          "image_url": {
+            "type": "string",
+            "title": "Image Url"
+          }
         },
         "type": "object",
         "required": ["image_url"],
@@ -13189,13 +17756,25 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "input_validation_error"
           },
-          "message": { "type": "string", "title": "Message" },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
           "session_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Session Id"
           },
           "unrecognized_fields": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Unrecognized Fields",
             "description": "List of input field names that were not recognized"
@@ -13207,11 +17786,25 @@
             "description": "The agent's valid input schema for reference"
           },
           "graph_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Graph Id"
           },
           "graph_version": {
-            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Graph Version"
           }
         },
@@ -13222,9 +17815,19 @@
       },
       "InvoiceListItem": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
           "number": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Number"
           },
           "created_at": {
@@ -13232,7 +17835,10 @@
             "format": "date-time",
             "title": "Created At"
           },
-          "total_cents": { "type": "integer", "title": "Total Cents" },
+          "total_cents": {
+            "type": "integer",
+            "title": "Total Cents"
+          },
           "amount_paid_cents": {
             "type": "integer",
             "title": "Amount Paid Cents"
@@ -13242,17 +17848,41 @@
             "title": "Currency",
             "default": "usd"
           },
-          "status": { "type": "string", "title": "Status" },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
           "description": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Description"
           },
           "hosted_invoice_url": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Hosted Invoice Url"
           },
           "invoice_pdf_url": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Invoice Pdf Url"
           }
         },
@@ -13269,19 +17899,40 @@
       },
       "LibraryAgent": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "graph_id": { "type": "string", "title": "Graph Id" },
-          "graph_version": { "type": "integer", "title": "Graph Version" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "graph_id": {
+            "type": "string",
+            "title": "Graph Id"
+          },
+          "graph_version": {
+            "type": "integer",
+            "title": "Graph Version"
+          },
           "image_url": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Image Url"
           },
-          "creator_name": { "type": "string", "title": "Creator Name" },
+          "creator_name": {
+            "type": "string",
+            "title": "Creator Name"
+          },
           "creator_image_url": {
             "type": "string",
             "title": "Creator Image Url"
           },
-          "status": { "$ref": "#/components/schemas/LibraryAgentStatus" },
+          "status": {
+            "$ref": "#/components/schemas/LibraryAgentStatus"
+          },
           "created_at": {
             "type": "string",
             "format": "date-time",
@@ -13292,10 +17943,23 @@
             "format": "date-time",
             "title": "Updated At"
           },
-          "name": { "type": "string", "title": "Name" },
-          "description": { "type": "string", "title": "Description" },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
           "instructions": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Instructions"
           },
           "input_schema": {
@@ -13310,8 +17974,13 @@
           },
           "credentials_input_schema": {
             "anyOf": [
-              { "additionalProperties": true, "type": "object" },
-              { "type": "null" }
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Credentials Input Schema",
             "description": "Input schema for credentials required by the agent"
@@ -13333,26 +18002,49 @@
           },
           "trigger_setup_info": {
             "anyOf": [
-              { "$ref": "#/components/schemas/GraphTriggerInfo" },
-              { "type": "null" }
+              {
+                "$ref": "#/components/schemas/GraphTriggerInfo"
+              },
+              {
+                "type": "null"
+              }
             ]
           },
-          "new_output": { "type": "boolean", "title": "New Output" },
+          "new_output": {
+            "type": "boolean",
+            "title": "New Output"
+          },
           "execution_count": {
             "type": "integer",
             "title": "Execution Count",
             "default": 0
           },
           "success_rate": {
-            "anyOf": [{ "type": "number" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Success Rate"
           },
           "avg_correctness_score": {
-            "anyOf": [{ "type": "number" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Avg Correctness Score"
           },
           "recent_executions": {
-            "items": { "$ref": "#/components/schemas/RecentExecution" },
+            "items": {
+              "$ref": "#/components/schemas/RecentExecution"
+            },
             "type": "array",
             "title": "Recent Executions",
             "description": "List of recent executions with status, score, and summary"
@@ -13366,13 +18058,30 @@
             "type": "boolean",
             "title": "Is Latest Version"
           },
-          "is_favorite": { "type": "boolean", "title": "Is Favorite" },
+          "is_favorite": {
+            "type": "boolean",
+            "title": "Is Favorite"
+          },
           "folder_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Folder Id"
           },
           "folder_name": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Folder Name"
           },
           "is_hidden": {
@@ -13381,7 +18090,14 @@
             "default": false
           },
           "recommended_schedule_cron": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Recommended Schedule Cron"
           },
           "is_scheduled": {
@@ -13391,15 +18107,28 @@
             "default": false
           },
           "next_scheduled_run": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Next Scheduled Run",
             "description": "ISO 8601 timestamp of the next scheduled run, if any"
           },
-          "settings": { "$ref": "#/components/schemas/GraphSettings" },
+          "settings": {
+            "$ref": "#/components/schemas/GraphSettings"
+          },
           "marketplace_listing": {
             "anyOf": [
-              { "$ref": "#/components/schemas/MarketplaceListing" },
-              { "type": "null" }
+              {
+                "$ref": "#/components/schemas/MarketplaceListing"
+              },
+              {
+                "type": "null"
+              }
             ]
           }
         },
@@ -13432,8 +18161,14 @@
       },
       "LibraryAgentPreset": {
         "properties": {
-          "graph_id": { "type": "string", "title": "Graph Id" },
-          "graph_version": { "type": "integer", "title": "Graph Version" },
+          "graph_id": {
+            "type": "string",
+            "title": "Graph Id"
+          },
+          "graph_version": {
+            "type": "integer",
+            "title": "Graph Version"
+          },
           "inputs": {
             "additionalProperties": true,
             "type": "object",
@@ -13446,19 +18181,38 @@
             "type": "object",
             "title": "Credentials"
           },
-          "name": { "type": "string", "title": "Name" },
-          "description": { "type": "string", "title": "Description" },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
           "is_active": {
             "type": "boolean",
             "title": "Is Active",
             "default": true
           },
           "webhook_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Webhook Id"
           },
-          "id": { "type": "string", "title": "Id" },
-          "user_id": { "type": "string", "title": "User Id" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
           "created_at": {
             "type": "string",
             "format": "date-time",
@@ -13471,8 +18225,12 @@
           },
           "webhook": {
             "anyOf": [
-              { "$ref": "#/components/schemas/Webhook" },
-              { "type": "null" }
+              {
+                "$ref": "#/components/schemas/Webhook"
+              },
+              {
+                "type": "null"
+              }
             ]
           }
         },
@@ -13495,8 +18253,14 @@
       },
       "LibraryAgentPresetCreatable": {
         "properties": {
-          "graph_id": { "type": "string", "title": "Graph Id" },
-          "graph_version": { "type": "integer", "title": "Graph Version" },
+          "graph_id": {
+            "type": "string",
+            "title": "Graph Id"
+          },
+          "graph_version": {
+            "type": "integer",
+            "title": "Graph Version"
+          },
           "inputs": {
             "additionalProperties": true,
             "type": "object",
@@ -13509,15 +18273,28 @@
             "type": "object",
             "title": "Credentials"
           },
-          "name": { "type": "string", "title": "Name" },
-          "description": { "type": "string", "title": "Description" },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
           "is_active": {
             "type": "boolean",
             "title": "Is Active",
             "default": true
           },
           "webhook_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Webhook Id"
           }
         },
@@ -13539,8 +18316,14 @@
             "type": "string",
             "title": "Graph Execution Id"
           },
-          "name": { "type": "string", "title": "Name" },
-          "description": { "type": "string", "title": "Description" },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
           "is_active": {
             "type": "boolean",
             "title": "Is Active",
@@ -13555,11 +18338,15 @@
       "LibraryAgentPresetResponse": {
         "properties": {
           "presets": {
-            "items": { "$ref": "#/components/schemas/LibraryAgentPreset" },
+            "items": {
+              "$ref": "#/components/schemas/LibraryAgentPreset"
+            },
             "type": "array",
             "title": "Presets"
           },
-          "pagination": { "$ref": "#/components/schemas/Pagination" }
+          "pagination": {
+            "$ref": "#/components/schemas/Pagination"
+          }
         },
         "type": "object",
         "required": ["presets", "pagination"],
@@ -13570,8 +18357,13 @@
         "properties": {
           "inputs": {
             "anyOf": [
-              { "additionalProperties": true, "type": "object" },
-              { "type": "null" }
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Inputs"
           },
@@ -13583,20 +18375,43 @@
                 },
                 "type": "object"
               },
-              { "type": "null" }
+              {
+                "type": "null"
+              }
             ],
             "title": "Credentials"
           },
           "name": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Name"
           },
           "description": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Description"
           },
           "is_active": {
-            "anyOf": [{ "type": "boolean" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Is Active"
           }
         },
@@ -13607,11 +18422,15 @@
       "LibraryAgentResponse": {
         "properties": {
           "agents": {
-            "items": { "$ref": "#/components/schemas/LibraryAgent" },
+            "items": {
+              "$ref": "#/components/schemas/LibraryAgent"
+            },
             "type": "array",
             "title": "Agents"
           },
-          "pagination": { "$ref": "#/components/schemas/Pagination" }
+          "pagination": {
+            "$ref": "#/components/schemas/Pagination"
+          }
         },
         "type": "object",
         "required": ["agents", "pagination"],
@@ -13632,39 +18451,85 @@
       "LibraryAgentUpdateRequest": {
         "properties": {
           "auto_update_version": {
-            "anyOf": [{ "type": "boolean" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Auto Update Version",
             "description": "Auto-update the agent version"
           },
           "graph_version": {
-            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Graph Version",
             "description": "Specific graph version to update to"
           },
           "is_favorite": {
-            "anyOf": [{ "type": "boolean" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Is Favorite",
             "description": "Mark the agent as a favorite"
           },
           "is_archived": {
-            "anyOf": [{ "type": "boolean" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Is Archived",
             "description": "Archive the agent"
           },
           "is_hidden": {
-            "anyOf": [{ "type": "boolean" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Is Hidden",
             "description": "Whether to hide the agent from the library listing"
           },
           "settings": {
             "anyOf": [
-              { "$ref": "#/components/schemas/GraphSettings" },
-              { "type": "null" }
+              {
+                "$ref": "#/components/schemas/GraphSettings"
+              },
+              {
+                "type": "null"
+              }
             ],
             "description": "User-specific settings for this library agent"
           },
           "folder_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Folder Id",
             "description": "Folder ID to move agent to (None to move to root)"
           }
@@ -13675,19 +18540,49 @@
       },
       "LibraryFolder": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "user_id": { "type": "string", "title": "User Id" },
-          "name": { "type": "string", "title": "Name" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
           "icon": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Icon"
           },
           "color": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Color"
           },
           "parent_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Parent Id"
           },
           "created_at": {
@@ -13718,19 +18613,49 @@
       },
       "LibraryFolderTree": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "user_id": { "type": "string", "title": "User Id" },
-          "name": { "type": "string", "title": "Name" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
           "icon": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Icon"
           },
           "color": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Color"
           },
           "parent_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Parent Id"
           },
           "created_at": {
@@ -13754,7 +18679,9 @@
             "default": 0
           },
           "children": {
-            "items": { "$ref": "#/components/schemas/LibraryFolderTree" },
+            "items": {
+              "$ref": "#/components/schemas/LibraryFolderTree"
+            },
             "type": "array",
             "title": "Children",
             "default": []
@@ -13767,11 +18694,26 @@
       },
       "Link": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "source_id": { "type": "string", "title": "Source Id" },
-          "sink_id": { "type": "string", "title": "Sink Id" },
-          "source_name": { "type": "string", "title": "Source Name" },
-          "sink_name": { "type": "string", "title": "Sink Name" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "source_id": {
+            "type": "string",
+            "title": "Source Id"
+          },
+          "sink_id": {
+            "type": "string",
+            "title": "Sink Id"
+          },
+          "source_name": {
+            "type": "string",
+            "title": "Source Name"
+          },
+          "sink_name": {
+            "type": "string",
+            "title": "Sink Name"
+          },
           "is_static": {
             "type": "boolean",
             "title": "Is Static",
@@ -13784,10 +18726,22 @@
       },
       "LinkTokenInfoResponse": {
         "properties": {
-          "platform": { "type": "string", "title": "Platform" },
-          "link_type": { "$ref": "#/components/schemas/LinkType" },
+          "platform": {
+            "type": "string",
+            "title": "Platform"
+          },
+          "link_type": {
+            "$ref": "#/components/schemas/LinkType"
+          },
           "server_name": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Server Name"
           }
         },
@@ -13803,11 +18757,17 @@
       "ListFilesResponse": {
         "properties": {
           "files": {
-            "items": { "$ref": "#/components/schemas/WorkspaceFileItem" },
+            "items": {
+              "$ref": "#/components/schemas/WorkspaceFileItem"
+            },
             "type": "array",
             "title": "Files"
           },
-          "offset": { "type": "integer", "title": "Offset", "default": 0 },
+          "offset": {
+            "type": "integer",
+            "title": "Offset",
+            "default": 0
+          },
           "has_more": {
             "type": "boolean",
             "title": "Has More",
@@ -13821,11 +18781,16 @@
       "ListSessionsResponse": {
         "properties": {
           "sessions": {
-            "items": { "$ref": "#/components/schemas/SessionSummaryResponse" },
+            "items": {
+              "$ref": "#/components/schemas/SessionSummaryResponse"
+            },
             "type": "array",
             "title": "Sessions"
           },
-          "total": { "type": "integer", "title": "Total" }
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          }
         },
         "type": "object",
         "required": ["sessions", "total"],
@@ -13839,7 +18804,10 @@
             "minLength": 1,
             "title": "Metric Name"
           },
-          "metric_value": { "type": "number", "title": "Metric Value" },
+          "metric_value": {
+            "type": "number",
+            "title": "Metric Value"
+          },
           "data_string": {
             "type": "string",
             "minLength": 1,
@@ -13852,8 +18820,14 @@
       },
       "LoginResponse": {
         "properties": {
-          "login_url": { "type": "string", "title": "Login Url" },
-          "state_token": { "type": "string", "title": "State Token" }
+          "login_url": {
+            "type": "string",
+            "title": "Login Url"
+          },
+          "state_token": {
+            "type": "string",
+            "title": "State Token"
+          }
         },
         "type": "object",
         "required": ["login_url", "state_token"],
@@ -13892,8 +18866,14 @@
       },
       "MCPOAuthLoginResponse": {
         "properties": {
-          "login_url": { "type": "string", "title": "Login Url" },
-          "state_token": { "type": "string", "title": "State Token" }
+          "login_url": {
+            "type": "string",
+            "title": "Login Url"
+          },
+          "state_token": {
+            "type": "string",
+            "title": "State Token"
+          }
         },
         "type": "object",
         "required": ["login_url", "state_token"],
@@ -13923,8 +18903,14 @@
       },
       "MCPToolInfo": {
         "properties": {
-          "name": { "type": "string", "title": "Name" },
-          "description": { "type": "string", "title": "Description" },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
           "input_schema": {
             "additionalProperties": true,
             "type": "object",
@@ -13942,15 +18928,37 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "mcp_tool_output"
           },
-          "message": { "type": "string", "title": "Message" },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
           "session_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Session Id"
           },
-          "server_url": { "type": "string", "title": "Server Url" },
-          "tool_name": { "type": "string", "title": "Tool Name" },
-          "result": { "title": "Result" },
-          "success": { "type": "boolean", "title": "Success", "default": true }
+          "server_url": {
+            "type": "string",
+            "title": "Server Url"
+          },
+          "tool_name": {
+            "type": "string",
+            "title": "Tool Name"
+          },
+          "result": {
+            "title": "Result"
+          },
+          "success": {
+            "type": "boolean",
+            "title": "Success",
+            "default": true
+          }
         },
         "type": "object",
         "required": ["message", "server_url", "tool_name"],
@@ -13959,8 +18967,14 @@
       },
       "MCPToolResponse": {
         "properties": {
-          "name": { "type": "string", "title": "Name" },
-          "description": { "type": "string", "title": "Description" },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
           "input_schema": {
             "additionalProperties": true,
             "type": "object",
@@ -13978,14 +18992,29 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "mcp_tools_discovered"
           },
-          "message": { "type": "string", "title": "Message" },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
           "session_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Session Id"
           },
-          "server_url": { "type": "string", "title": "Server Url" },
+          "server_url": {
+            "type": "string",
+            "title": "Server Url"
+          },
           "tools": {
-            "items": { "$ref": "#/components/schemas/MCPToolInfo" },
+            "items": {
+              "$ref": "#/components/schemas/MCPToolInfo"
+            },
             "type": "array",
             "title": "Tools"
           }
@@ -13997,9 +19026,18 @@
       },
       "MarketplaceListing": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "name": { "type": "string", "title": "Name" },
-          "slug": { "type": "string", "title": "Slug" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "slug": {
+            "type": "string",
+            "title": "Slug"
+          },
           "creator": {
             "$ref": "#/components/schemas/MarketplaceListingCreator"
           }
@@ -14011,9 +19049,18 @@
       },
       "MarketplaceListingCreator": {
         "properties": {
-          "name": { "type": "string", "title": "Name" },
-          "id": { "type": "string", "title": "Id" },
-          "slug": { "type": "string", "title": "Slug" }
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "slug": {
+            "type": "string",
+            "title": "Slug"
+          }
         },
         "type": "object",
         "required": ["name", "id", "slug"],
@@ -14026,14 +19073,26 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "memory_forget_candidates"
           },
-          "message": { "type": "string", "title": "Message" },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
           "session_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Session Id"
           },
           "candidates": {
             "items": {
-              "additionalProperties": { "type": "string" },
+              "additionalProperties": {
+                "type": "string"
+              },
               "type": "object"
             },
             "type": "array",
@@ -14051,18 +19110,32 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "memory_forget_confirm"
           },
-          "message": { "type": "string", "title": "Message" },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
           "session_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Session Id"
           },
           "deleted_uuids": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Deleted Uuids"
           },
           "failed_uuids": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Failed Uuids"
           }
@@ -14078,18 +19151,32 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "memory_search"
           },
-          "message": { "type": "string", "title": "Message" },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
           "session_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Session Id"
           },
           "facts": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Facts"
           },
           "recent_episodes": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Recent Episodes"
           }
@@ -14105,12 +19192,25 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "memory_store"
           },
-          "message": { "type": "string", "title": "Message" },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
           "session_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Session Id"
           },
-          "memory_name": { "type": "string", "title": "Memory Name" }
+          "memory_name": {
+            "type": "string",
+            "title": "Memory Name"
+          }
         },
         "type": "object",
         "required": ["message", "memory_name"],
@@ -14119,8 +19219,14 @@
       },
       "Message": {
         "properties": {
-          "query": { "type": "string", "title": "Query" },
-          "response": { "type": "string", "title": "Response" }
+          "query": {
+            "type": "string",
+            "title": "Query"
+          },
+          "response": {
+            "type": "string",
+            "title": "Response"
+          }
         },
         "type": "object",
         "required": ["query", "response"],
@@ -14128,9 +19234,18 @@
       },
       "ModelInfo": {
         "properties": {
-          "value": { "type": "string", "title": "Value" },
-          "label": { "type": "string", "title": "Label" },
-          "provider": { "type": "string", "title": "Provider" }
+          "value": {
+            "type": "string",
+            "title": "Value"
+          },
+          "label": {
+            "type": "string",
+            "title": "Label"
+          },
+          "provider": {
+            "type": "string",
+            "title": "Provider"
+          }
         },
         "type": "object",
         "required": ["value", "label", "provider"],
@@ -14143,21 +19258,47 @@
       },
       "MyUnpublishedAgent": {
         "properties": {
-          "graph_id": { "type": "string", "title": "Graph Id" },
-          "graph_version": { "type": "integer", "title": "Graph Version" },
-          "agent_name": { "type": "string", "title": "Agent Name" },
+          "graph_id": {
+            "type": "string",
+            "title": "Graph Id"
+          },
+          "graph_version": {
+            "type": "integer",
+            "title": "Graph Version"
+          },
+          "agent_name": {
+            "type": "string",
+            "title": "Agent Name"
+          },
           "agent_image": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Agent Image"
           },
-          "description": { "type": "string", "title": "Description" },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
           "last_edited": {
             "type": "string",
             "format": "date-time",
             "title": "Last Edited"
           },
           "recommended_schedule_cron": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Recommended Schedule Cron"
           }
         },
@@ -14174,11 +19315,15 @@
       "MyUnpublishedAgentsResponse": {
         "properties": {
           "agents": {
-            "items": { "$ref": "#/components/schemas/MyUnpublishedAgent" },
+            "items": {
+              "$ref": "#/components/schemas/MyUnpublishedAgent"
+            },
             "type": "array",
             "title": "Agents"
           },
-          "pagination": { "$ref": "#/components/schemas/Pagination" }
+          "pagination": {
+            "$ref": "#/components/schemas/Pagination"
+          }
         },
         "type": "object",
         "required": ["agents", "pagination"],
@@ -14190,15 +19335,30 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "need_login"
           },
-          "message": { "type": "string", "title": "Message" },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
           "session_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Session Id"
           },
           "agent_info": {
             "anyOf": [
-              { "additionalProperties": true, "type": "object" },
-              { "type": "null" }
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Agent Info"
           }
@@ -14214,18 +19374,34 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "no_results"
           },
-          "message": { "type": "string", "title": "Message" },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
           "session_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Session Id"
           },
           "suggestions": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Suggestions",
             "default": []
           },
-          "name": { "type": "string", "title": "Name", "default": "no_results" }
+          "name": {
+            "type": "string",
+            "title": "Name",
+            "default": "no_results"
+          }
         },
         "type": "object",
         "required": ["message"],
@@ -14234,8 +19410,14 @@
       },
       "Node": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "block_id": { "type": "string", "title": "Block Id" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "block_id": {
+            "type": "string",
+            "title": "Block Id"
+          },
           "input_default": {
             "additionalProperties": true,
             "type": "object",
@@ -14247,12 +19429,16 @@
             "title": "Metadata"
           },
           "input_links": {
-            "items": { "$ref": "#/components/schemas/Link" },
+            "items": {
+              "$ref": "#/components/schemas/Link"
+            },
             "type": "array",
             "title": "Input Links"
           },
           "output_links": {
-            "items": { "$ref": "#/components/schemas/Link" },
+            "items": {
+              "$ref": "#/components/schemas/Link"
+            },
             "type": "array",
             "title": "Output Links"
           }
@@ -14263,21 +19449,47 @@
       },
       "NodeExecutionResult": {
         "properties": {
-          "user_id": { "type": "string", "title": "User Id" },
-          "graph_id": { "type": "string", "title": "Graph Id" },
-          "graph_version": { "type": "integer", "title": "Graph Version" },
-          "graph_exec_id": { "type": "string", "title": "Graph Exec Id" },
-          "node_exec_id": { "type": "string", "title": "Node Exec Id" },
-          "node_id": { "type": "string", "title": "Node Id" },
-          "block_id": { "type": "string", "title": "Block Id" },
-          "status": { "$ref": "#/components/schemas/AgentExecutionStatus" },
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
+          "graph_id": {
+            "type": "string",
+            "title": "Graph Id"
+          },
+          "graph_version": {
+            "type": "integer",
+            "title": "Graph Version"
+          },
+          "graph_exec_id": {
+            "type": "string",
+            "title": "Graph Exec Id"
+          },
+          "node_exec_id": {
+            "type": "string",
+            "title": "Node Exec Id"
+          },
+          "node_id": {
+            "type": "string",
+            "title": "Node Id"
+          },
+          "block_id": {
+            "type": "string",
+            "title": "Block Id"
+          },
+          "status": {
+            "$ref": "#/components/schemas/AgentExecutionStatus"
+          },
           "input_data": {
             "additionalProperties": true,
             "type": "object",
             "title": "Input Data"
           },
           "output_data": {
-            "additionalProperties": { "items": {}, "type": "array" },
+            "additionalProperties": {
+              "items": {},
+              "type": "array"
+            },
             "type": "object",
             "title": "Output Data"
           },
@@ -14288,22 +19500,37 @@
           },
           "queue_time": {
             "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Queue Time"
           },
           "start_time": {
             "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Start Time"
           },
           "end_time": {
             "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "End Time"
           }
@@ -14329,8 +19556,14 @@
       },
       "NodeModel": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "block_id": { "type": "string", "title": "Block Id" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "block_id": {
+            "type": "string",
+            "title": "Block Id"
+          },
           "input_default": {
             "additionalProperties": true,
             "type": "object",
@@ -14342,19 +19575,36 @@
             "title": "Metadata"
           },
           "input_links": {
-            "items": { "$ref": "#/components/schemas/Link" },
+            "items": {
+              "$ref": "#/components/schemas/Link"
+            },
             "type": "array",
             "title": "Input Links"
           },
           "output_links": {
-            "items": { "$ref": "#/components/schemas/Link" },
+            "items": {
+              "$ref": "#/components/schemas/Link"
+            },
             "type": "array",
             "title": "Output Links"
           },
-          "graph_id": { "type": "string", "title": "Graph Id" },
-          "graph_version": { "type": "integer", "title": "Graph Version" },
+          "graph_id": {
+            "type": "string",
+            "title": "Graph Id"
+          },
+          "graph_version": {
+            "type": "integer",
+            "title": "Graph Version"
+          },
           "webhook_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Webhook Id"
           }
         },
@@ -14364,10 +19614,19 @@
       },
       "NotificationPreference": {
         "properties": {
-          "user_id": { "type": "string", "title": "User Id" },
-          "email": { "type": "string", "format": "email", "title": "Email" },
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
+          "email": {
+            "type": "string",
+            "format": "email",
+            "title": "Email"
+          },
           "preferences": {
-            "additionalProperties": { "type": "boolean" },
+            "additionalProperties": {
+              "type": "boolean"
+            },
             "propertyNames": {
               "$ref": "#/components/schemas/NotificationType"
             },
@@ -14404,7 +19663,9 @@
             "description": "User's email address"
           },
           "preferences": {
-            "additionalProperties": { "type": "boolean" },
+            "additionalProperties": {
+              "type": "boolean"
+            },
             "propertyNames": {
               "$ref": "#/components/schemas/NotificationType"
             },
@@ -14442,10 +19703,23 @@
       },
       "OAuth2Credentials": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "provider": { "type": "string", "title": "Provider" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "provider": {
+            "type": "string",
+            "title": "Provider"
+          },
           "title": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Title"
           },
           "is_managed": {
@@ -14465,7 +19739,14 @@
             "default": "oauth2"
           },
           "username": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Username"
           },
           "access_token": {
@@ -14475,22 +19756,44 @@
             "writeOnly": true
           },
           "access_token_expires_at": {
-            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Access Token Expires At"
           },
           "refresh_token": {
             "anyOf": [
-              { "type": "string", "format": "password", "writeOnly": true },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "password",
+                "writeOnly": true
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Refresh Token"
           },
           "refresh_token_expires_at": {
-            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Refresh Token Expires At"
           },
           "scopes": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Scopes"
           }
@@ -14501,34 +19804,69 @@
       },
       "OAuthApplicationInfo": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "name": { "type": "string", "title": "Name" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
           "description": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Description"
           },
           "logo_url": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Logo Url"
           },
-          "client_id": { "type": "string", "title": "Client Id" },
+          "client_id": {
+            "type": "string",
+            "title": "Client Id"
+          },
           "redirect_uris": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Redirect Uris"
           },
           "grant_types": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Grant Types"
           },
           "scopes": {
-            "items": { "$ref": "#/components/schemas/APIKeyPermission" },
+            "items": {
+              "$ref": "#/components/schemas/APIKeyPermission"
+            },
             "type": "array",
             "title": "Scopes"
           },
-          "owner_id": { "type": "string", "title": "Owner Id" },
-          "is_active": { "type": "boolean", "title": "Is Active" },
+          "owner_id": {
+            "type": "string",
+            "title": "Owner Id"
+          },
+          "is_active": {
+            "type": "boolean",
+            "title": "Is Active"
+          },
           "created_at": {
             "type": "string",
             "format": "date-time",
@@ -14558,17 +19896,36 @@
       },
       "OAuthApplicationPublicInfo": {
         "properties": {
-          "name": { "type": "string", "title": "Name" },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
           "description": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Description"
           },
           "logo_url": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Logo Url"
           },
           "scopes": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Scopes"
           }
@@ -14593,7 +19950,9 @@
             "title": "User Role"
           },
           "pain_points": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "maxItems": 20,
             "title": "Pain Points"
@@ -14606,7 +19965,10 @@
       },
       "OnboardingStatusResponse": {
         "properties": {
-          "is_completed": { "type": "boolean", "title": "Is Completed" }
+          "is_completed": {
+            "type": "boolean",
+            "title": "Is Completed"
+          }
         },
         "type": "object",
         "required": ["is_completed"],
@@ -14643,17 +20005,45 @@
       },
       "OrphanedScheduleDetail": {
         "properties": {
-          "schedule_id": { "type": "string", "title": "Schedule Id" },
-          "schedule_name": { "type": "string", "title": "Schedule Name" },
-          "graph_id": { "type": "string", "title": "Graph Id" },
-          "graph_version": { "type": "integer", "title": "Graph Version" },
-          "user_id": { "type": "string", "title": "User Id" },
-          "orphan_reason": { "type": "string", "title": "Orphan Reason" },
+          "schedule_id": {
+            "type": "string",
+            "title": "Schedule Id"
+          },
+          "schedule_name": {
+            "type": "string",
+            "title": "Schedule Name"
+          },
+          "graph_id": {
+            "type": "string",
+            "title": "Graph Id"
+          },
+          "graph_version": {
+            "type": "integer",
+            "title": "Graph Version"
+          },
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
+          "orphan_reason": {
+            "type": "string",
+            "title": "Orphan Reason"
+          },
           "error_detail": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Error Detail"
           },
-          "next_run_time": { "type": "string", "title": "Next Run Time" }
+          "next_run_time": {
+            "type": "string",
+            "title": "Next Run Time"
+          }
         },
         "type": "object",
         "required": [
@@ -14672,11 +20062,16 @@
       "OrphanedSchedulesListResponse": {
         "properties": {
           "schedules": {
-            "items": { "$ref": "#/components/schemas/OrphanedScheduleDetail" },
+            "items": {
+              "$ref": "#/components/schemas/OrphanedScheduleDetail"
+            },
             "type": "array",
             "title": "Schedules"
           },
-          "total": { "type": "integer", "title": "Total" }
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          }
         },
         "type": "object",
         "required": ["schedules", "total"],
@@ -14717,11 +20112,16 @@
       "PeekPendingMessagesResponse": {
         "properties": {
           "messages": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Messages"
           },
-          "count": { "type": "integer", "title": "Count" }
+          "count": {
+            "type": "integer",
+            "title": "Count"
+          }
         },
         "type": "object",
         "required": ["messages", "count"],
@@ -14763,19 +20163,42 @@
           },
           "payload": {
             "anyOf": [
-              { "additionalProperties": true, "type": "object" },
-              { "items": {}, "type": "array" },
-              { "type": "string" },
-              { "type": "integer" },
-              { "type": "number" },
-              { "type": "boolean" },
-              { "type": "null" }
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "items": {},
+                "type": "array"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Payload",
             "description": "The actual data payload awaiting review"
           },
           "instructions": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Instructions",
             "description": "Instructions or message for the reviewer"
           },
@@ -14789,12 +20212,26 @@
             "description": "Review status"
           },
           "review_message": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Review Message",
             "description": "Optional message from the reviewer"
           },
           "was_edited": {
-            "anyOf": [{ "type": "boolean" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Was Edited",
             "description": "Whether the data was modified during review"
           },
@@ -14812,16 +20249,26 @@
           },
           "updated_at": {
             "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Updated At",
             "description": "When the review was last updated"
           },
           "reviewed_at": {
             "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Reviewed At",
             "description": "When the review was completed"
@@ -14850,7 +20297,14 @@
             "description": "OAuth access token suitable for the picker SDK call."
           },
           "access_token_expires_at": {
-            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Access Token Expires At",
             "description": "Unix timestamp at which the access token expires, if known."
           }
@@ -14863,12 +20317,16 @@
       "PlatformCostDashboard": {
         "properties": {
           "by_provider": {
-            "items": { "$ref": "#/components/schemas/ProviderCostSummary" },
+            "items": {
+              "$ref": "#/components/schemas/ProviderCostSummary"
+            },
             "type": "array",
             "title": "By Provider"
           },
           "by_user": {
-            "items": { "$ref": "#/components/schemas/UserCostSummary" },
+            "items": {
+              "$ref": "#/components/schemas/UserCostSummary"
+            },
             "type": "array",
             "title": "By User"
           },
@@ -14876,8 +20334,14 @@
             "type": "integer",
             "title": "Total Cost Microdollars"
           },
-          "total_requests": { "type": "integer", "title": "Total Requests" },
-          "total_users": { "type": "integer", "title": "Total Users" },
+          "total_requests": {
+            "type": "integer",
+            "title": "Total Requests"
+          },
+          "total_users": {
+            "type": "integer",
+            "title": "Total Users"
+          },
           "total_input_tokens": {
             "type": "integer",
             "title": "Total Input Tokens",
@@ -14924,7 +20388,9 @@
             "default": 0.0
           },
           "cost_buckets": {
-            "items": { "$ref": "#/components/schemas/CostBucket" },
+            "items": {
+              "$ref": "#/components/schemas/CostBucket"
+            },
             "type": "array",
             "title": "Cost Buckets",
             "default": []
@@ -14943,12 +20409,20 @@
       "PlatformCostExportResponse": {
         "properties": {
           "logs": {
-            "items": { "$ref": "#/components/schemas/CostLogRow" },
+            "items": {
+              "$ref": "#/components/schemas/CostLogRow"
+            },
             "type": "array",
             "title": "Logs"
           },
-          "total_rows": { "type": "integer", "title": "Total Rows" },
-          "truncated": { "type": "boolean", "title": "Truncated" }
+          "total_rows": {
+            "type": "integer",
+            "title": "Total Rows"
+          },
+          "truncated": {
+            "type": "boolean",
+            "title": "Truncated"
+          }
         },
         "type": "object",
         "required": ["logs", "total_rows", "truncated"],
@@ -14957,11 +20431,15 @@
       "PlatformCostLogsResponse": {
         "properties": {
           "logs": {
-            "items": { "$ref": "#/components/schemas/CostLogRow" },
+            "items": {
+              "$ref": "#/components/schemas/CostLogRow"
+            },
             "type": "array",
             "title": "Logs"
           },
-          "pagination": { "$ref": "#/components/schemas/Pagination" }
+          "pagination": {
+            "$ref": "#/components/schemas/Pagination"
+          }
         },
         "type": "object",
         "required": ["logs", "pagination"],
@@ -14969,8 +20447,14 @@
       },
       "PlatformLinkInfo": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "platform": { "type": "string", "title": "Platform" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "platform": {
+            "type": "string",
+            "title": "Platform"
+          },
           "platform_server_id": {
             "type": "string",
             "title": "Platform Server Id"
@@ -14980,7 +20464,14 @@
             "title": "Owner Platform User Id"
           },
           "server_name": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Server Name"
           },
           "linked_at": {
@@ -15002,11 +20493,27 @@
       },
       "PlatformUserLinkInfo": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "platform": { "type": "string", "title": "Platform" },
-          "platform_user_id": { "type": "string", "title": "Platform User Id" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "platform": {
+            "type": "string",
+            "title": "Platform"
+          },
+          "platform_user_id": {
+            "type": "string",
+            "title": "Platform User Id"
+          },
           "platform_username": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Platform Username"
           },
           "linked_at": {
@@ -15041,26 +20548,81 @@
             "title": "Recordtype",
             "default": "Bounce"
           },
-          "ID": { "type": "integer", "title": "Id" },
-          "Type": { "type": "string", "title": "Type" },
-          "TypeCode": { "$ref": "#/components/schemas/PostmarkBounceEnum" },
-          "Tag": { "type": "string", "title": "Tag" },
-          "MessageID": { "type": "string", "title": "Messageid" },
-          "Details": { "type": "string", "title": "Details" },
-          "Email": { "type": "string", "title": "Email" },
-          "From": { "type": "string", "title": "From" },
-          "BouncedAt": { "type": "string", "title": "Bouncedat" },
-          "Inactive": { "type": "boolean", "title": "Inactive" },
-          "DumpAvailable": { "type": "boolean", "title": "Dumpavailable" },
-          "CanActivate": { "type": "boolean", "title": "Canactivate" },
-          "Subject": { "type": "string", "title": "Subject" },
-          "ServerID": { "type": "integer", "title": "Serverid" },
-          "MessageStream": { "type": "string", "title": "Messagestream" },
-          "Content": { "type": "string", "title": "Content" },
-          "Name": { "type": "string", "title": "Name" },
-          "Description": { "type": "string", "title": "Description" },
+          "ID": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "Type": {
+            "type": "string",
+            "title": "Type"
+          },
+          "TypeCode": {
+            "$ref": "#/components/schemas/PostmarkBounceEnum"
+          },
+          "Tag": {
+            "type": "string",
+            "title": "Tag"
+          },
+          "MessageID": {
+            "type": "string",
+            "title": "Messageid"
+          },
+          "Details": {
+            "type": "string",
+            "title": "Details"
+          },
+          "Email": {
+            "type": "string",
+            "title": "Email"
+          },
+          "From": {
+            "type": "string",
+            "title": "From"
+          },
+          "BouncedAt": {
+            "type": "string",
+            "title": "Bouncedat"
+          },
+          "Inactive": {
+            "type": "boolean",
+            "title": "Inactive"
+          },
+          "DumpAvailable": {
+            "type": "boolean",
+            "title": "Dumpavailable"
+          },
+          "CanActivate": {
+            "type": "boolean",
+            "title": "Canactivate"
+          },
+          "Subject": {
+            "type": "string",
+            "title": "Subject"
+          },
+          "ServerID": {
+            "type": "integer",
+            "title": "Serverid"
+          },
+          "MessageStream": {
+            "type": "string",
+            "title": "Messagestream"
+          },
+          "Content": {
+            "type": "string",
+            "title": "Content"
+          },
+          "Name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "Description": {
+            "type": "string",
+            "title": "Description"
+          },
           "Metadata": {
-            "additionalProperties": { "type": "string" },
+            "additionalProperties": {
+              "type": "string"
+            },
             "type": "object",
             "title": "Metadata"
           }
@@ -15097,32 +20659,67 @@
             "title": "Recordtype",
             "default": "Click"
           },
-          "MessageStream": { "type": "string", "title": "Messagestream" },
+          "MessageStream": {
+            "type": "string",
+            "title": "Messagestream"
+          },
           "Metadata": {
-            "additionalProperties": { "type": "string" },
+            "additionalProperties": {
+              "type": "string"
+            },
             "type": "object",
             "title": "Metadata"
           },
-          "Recipient": { "type": "string", "title": "Recipient" },
-          "MessageID": { "type": "string", "title": "Messageid" },
-          "ReceivedAt": { "type": "string", "title": "Receivedat" },
-          "Platform": { "type": "string", "title": "Platform" },
-          "ClickLocation": { "type": "string", "title": "Clicklocation" },
-          "OriginalLink": { "type": "string", "title": "Originallink" },
-          "Tag": { "type": "string", "title": "Tag" },
-          "UserAgent": { "type": "string", "title": "Useragent" },
+          "Recipient": {
+            "type": "string",
+            "title": "Recipient"
+          },
+          "MessageID": {
+            "type": "string",
+            "title": "Messageid"
+          },
+          "ReceivedAt": {
+            "type": "string",
+            "title": "Receivedat"
+          },
+          "Platform": {
+            "type": "string",
+            "title": "Platform"
+          },
+          "ClickLocation": {
+            "type": "string",
+            "title": "Clicklocation"
+          },
+          "OriginalLink": {
+            "type": "string",
+            "title": "Originallink"
+          },
+          "Tag": {
+            "type": "string",
+            "title": "Tag"
+          },
+          "UserAgent": {
+            "type": "string",
+            "title": "Useragent"
+          },
           "OS": {
-            "additionalProperties": { "type": "string" },
+            "additionalProperties": {
+              "type": "string"
+            },
             "type": "object",
             "title": "Os"
           },
           "Client": {
-            "additionalProperties": { "type": "string" },
+            "additionalProperties": {
+              "type": "string"
+            },
             "type": "object",
             "title": "Client"
           },
           "Geo": {
-            "additionalProperties": { "type": "string" },
+            "additionalProperties": {
+              "type": "string"
+            },
             "type": "object",
             "title": "Geo"
           }
@@ -15153,15 +20750,38 @@
             "title": "Recordtype",
             "default": "Delivery"
           },
-          "ServerID": { "type": "integer", "title": "Serverid" },
-          "MessageStream": { "type": "string", "title": "Messagestream" },
-          "MessageID": { "type": "string", "title": "Messageid" },
-          "Recipient": { "type": "string", "title": "Recipient" },
-          "Tag": { "type": "string", "title": "Tag" },
-          "DeliveredAt": { "type": "string", "title": "Deliveredat" },
-          "Details": { "type": "string", "title": "Details" },
+          "ServerID": {
+            "type": "integer",
+            "title": "Serverid"
+          },
+          "MessageStream": {
+            "type": "string",
+            "title": "Messagestream"
+          },
+          "MessageID": {
+            "type": "string",
+            "title": "Messageid"
+          },
+          "Recipient": {
+            "type": "string",
+            "title": "Recipient"
+          },
+          "Tag": {
+            "type": "string",
+            "title": "Tag"
+          },
+          "DeliveredAt": {
+            "type": "string",
+            "title": "Deliveredat"
+          },
+          "Details": {
+            "type": "string",
+            "title": "Details"
+          },
           "Metadata": {
-            "additionalProperties": { "type": "string" },
+            "additionalProperties": {
+              "type": "string"
+            },
             "type": "object",
             "title": "Metadata"
           }
@@ -15187,32 +20807,67 @@
             "title": "Recordtype",
             "default": "Open"
           },
-          "MessageStream": { "type": "string", "title": "Messagestream" },
+          "MessageStream": {
+            "type": "string",
+            "title": "Messagestream"
+          },
           "Metadata": {
-            "additionalProperties": { "type": "string" },
+            "additionalProperties": {
+              "type": "string"
+            },
             "type": "object",
             "title": "Metadata"
           },
-          "FirstOpen": { "type": "boolean", "title": "Firstopen" },
-          "Recipient": { "type": "string", "title": "Recipient" },
-          "MessageID": { "type": "string", "title": "Messageid" },
-          "ReceivedAt": { "type": "string", "title": "Receivedat" },
-          "Platform": { "type": "string", "title": "Platform" },
-          "ReadSeconds": { "type": "integer", "title": "Readseconds" },
-          "Tag": { "type": "string", "title": "Tag" },
-          "UserAgent": { "type": "string", "title": "Useragent" },
+          "FirstOpen": {
+            "type": "boolean",
+            "title": "Firstopen"
+          },
+          "Recipient": {
+            "type": "string",
+            "title": "Recipient"
+          },
+          "MessageID": {
+            "type": "string",
+            "title": "Messageid"
+          },
+          "ReceivedAt": {
+            "type": "string",
+            "title": "Receivedat"
+          },
+          "Platform": {
+            "type": "string",
+            "title": "Platform"
+          },
+          "ReadSeconds": {
+            "type": "integer",
+            "title": "Readseconds"
+          },
+          "Tag": {
+            "type": "string",
+            "title": "Tag"
+          },
+          "UserAgent": {
+            "type": "string",
+            "title": "Useragent"
+          },
           "OS": {
-            "additionalProperties": { "type": "string" },
+            "additionalProperties": {
+              "type": "string"
+            },
             "type": "object",
             "title": "Os"
           },
           "Client": {
-            "additionalProperties": { "type": "string" },
+            "additionalProperties": {
+              "type": "string"
+            },
             "type": "object",
             "title": "Client"
           },
           "Geo": {
-            "additionalProperties": { "type": "string" },
+            "additionalProperties": {
+              "type": "string"
+            },
             "type": "object",
             "title": "Geo"
           }
@@ -15243,26 +20898,82 @@
             "title": "Recordtype",
             "default": "SpamComplaint"
           },
-          "ID": { "type": "integer", "title": "Id" },
-          "Type": { "type": "string", "title": "Type" },
-          "TypeCode": { "type": "integer", "title": "Typecode" },
-          "Tag": { "type": "string", "title": "Tag" },
-          "MessageID": { "type": "string", "title": "Messageid" },
-          "Details": { "type": "string", "title": "Details" },
-          "Email": { "type": "string", "title": "Email" },
-          "From": { "type": "string", "title": "From" },
-          "BouncedAt": { "type": "string", "title": "Bouncedat" },
-          "Inactive": { "type": "boolean", "title": "Inactive" },
-          "DumpAvailable": { "type": "boolean", "title": "Dumpavailable" },
-          "CanActivate": { "type": "boolean", "title": "Canactivate" },
-          "Subject": { "type": "string", "title": "Subject" },
-          "ServerID": { "type": "integer", "title": "Serverid" },
-          "MessageStream": { "type": "string", "title": "Messagestream" },
-          "Content": { "type": "string", "title": "Content" },
-          "Name": { "type": "string", "title": "Name" },
-          "Description": { "type": "string", "title": "Description" },
+          "ID": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "Type": {
+            "type": "string",
+            "title": "Type"
+          },
+          "TypeCode": {
+            "type": "integer",
+            "title": "Typecode"
+          },
+          "Tag": {
+            "type": "string",
+            "title": "Tag"
+          },
+          "MessageID": {
+            "type": "string",
+            "title": "Messageid"
+          },
+          "Details": {
+            "type": "string",
+            "title": "Details"
+          },
+          "Email": {
+            "type": "string",
+            "title": "Email"
+          },
+          "From": {
+            "type": "string",
+            "title": "From"
+          },
+          "BouncedAt": {
+            "type": "string",
+            "title": "Bouncedat"
+          },
+          "Inactive": {
+            "type": "boolean",
+            "title": "Inactive"
+          },
+          "DumpAvailable": {
+            "type": "boolean",
+            "title": "Dumpavailable"
+          },
+          "CanActivate": {
+            "type": "boolean",
+            "title": "Canactivate"
+          },
+          "Subject": {
+            "type": "string",
+            "title": "Subject"
+          },
+          "ServerID": {
+            "type": "integer",
+            "title": "Serverid"
+          },
+          "MessageStream": {
+            "type": "string",
+            "title": "Messagestream"
+          },
+          "Content": {
+            "type": "string",
+            "title": "Content"
+          },
+          "Name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "Description": {
+            "type": "string",
+            "title": "Description"
+          },
           "Metadata": {
-            "additionalProperties": { "type": "string" },
+            "additionalProperties": {
+              "type": "string"
+            },
             "type": "object",
             "title": "Metadata"
           }
@@ -15299,20 +21010,46 @@
             "title": "Recordtype",
             "default": "SubscriptionChange"
           },
-          "MessageID": { "type": "string", "title": "Messageid" },
-          "ServerID": { "type": "integer", "title": "Serverid" },
-          "MessageStream": { "type": "string", "title": "Messagestream" },
-          "ChangedAt": { "type": "string", "title": "Changedat" },
-          "Recipient": { "type": "string", "title": "Recipient" },
-          "Origin": { "type": "string", "title": "Origin" },
-          "SuppressSending": { "type": "boolean", "title": "Suppresssending" },
+          "MessageID": {
+            "type": "string",
+            "title": "Messageid"
+          },
+          "ServerID": {
+            "type": "integer",
+            "title": "Serverid"
+          },
+          "MessageStream": {
+            "type": "string",
+            "title": "Messagestream"
+          },
+          "ChangedAt": {
+            "type": "string",
+            "title": "Changedat"
+          },
+          "Recipient": {
+            "type": "string",
+            "title": "Recipient"
+          },
+          "Origin": {
+            "type": "string",
+            "title": "Origin"
+          },
+          "SuppressSending": {
+            "type": "boolean",
+            "title": "Suppresssending"
+          },
           "SuppressionReason": {
             "type": "string",
             "title": "Suppressionreason"
           },
-          "Tag": { "type": "string", "title": "Tag" },
+          "Tag": {
+            "type": "string",
+            "title": "Tag"
+          },
           "Metadata": {
-            "additionalProperties": { "type": "string" },
+            "additionalProperties": {
+              "type": "string"
+            },
             "type": "object",
             "title": "Metadata"
           }
@@ -15334,15 +21071,33 @@
       },
       "Profile": {
         "properties": {
-          "username": { "type": "string", "title": "Username" },
-          "name": { "type": "string", "title": "Name" },
-          "description": { "type": "string", "title": "Description" },
+          "username": {
+            "type": "string",
+            "title": "Username"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
           "avatar_url": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Avatar Url"
           },
           "links": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Links"
           }
@@ -15354,19 +21109,40 @@
       },
       "ProfileDetails": {
         "properties": {
-          "username": { "type": "string", "title": "Username" },
-          "name": { "type": "string", "title": "Name" },
-          "description": { "type": "string", "title": "Description" },
+          "username": {
+            "type": "string",
+            "title": "Username"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
           "avatar_url": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Avatar Url"
           },
           "links": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Links"
           },
-          "is_featured": { "type": "boolean", "title": "Is Featured" }
+          "is_featured": {
+            "type": "boolean",
+            "title": "Is Featured"
+          }
         },
         "type": "object",
         "required": [
@@ -15387,7 +21163,10 @@
             "title": "Name",
             "description": "Provider name for integrations. Can be any string value, including custom provider names."
           },
-          "description": { "type": "string", "title": "Description" },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
           "integration_count": {
             "type": "integer",
             "title": "Integration Count"
@@ -15400,7 +21179,9 @@
       "ProviderConstants": {
         "properties": {
           "PROVIDER_NAMES": {
-            "additionalProperties": { "type": "string" },
+            "additionalProperties": {
+              "type": "string"
+            },
             "type": "object",
             "title": "Provider Names",
             "description": "All available provider names as a constant mapping",
@@ -15421,13 +21202,30 @@
       },
       "ProviderCostSummary": {
         "properties": {
-          "provider": { "type": "string", "title": "Provider" },
+          "provider": {
+            "type": "string",
+            "title": "Provider"
+          },
           "tracking_type": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Tracking Type"
           },
           "model": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Model"
           },
           "total_cost_microdollars": {
@@ -15462,7 +21260,10 @@
             "title": "Total Tracking Amount",
             "default": 0.0
           },
-          "request_count": { "type": "integer", "title": "Request Count" }
+          "request_count": {
+            "type": "integer",
+            "title": "Request Count"
+          }
         },
         "type": "object",
         "required": [
@@ -15495,7 +21296,14 @@
             "description": "Provider slug (e.g. ``github``)"
           },
           "description": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Description",
             "description": "One-line human-readable summary of what the provider does. Declared via ``ProviderBuilder.with_description(...)`` in the provider's ``_config.py``. ``None`` if not set."
           },
@@ -15517,7 +21325,9 @@
       "ProviderNamesResponse": {
         "properties": {
           "providers": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Providers",
             "description": "List of all available provider names"
@@ -15530,11 +21340,15 @@
       "ProviderResponse": {
         "properties": {
           "providers": {
-            "items": { "$ref": "#/components/schemas/Provider" },
+            "items": {
+              "$ref": "#/components/schemas/Provider"
+            },
             "type": "array",
             "title": "Providers"
           },
-          "pagination": { "$ref": "#/components/schemas/Pagination" }
+          "pagination": {
+            "$ref": "#/components/schemas/Pagination"
+          }
         },
         "type": "object",
         "required": ["providers", "pagination"],
@@ -15548,11 +21362,18 @@
             "minLength": 1,
             "title": "Endpoint"
           },
-          "keys": { "$ref": "#/components/schemas/PushSubscriptionKeys" },
+          "keys": {
+            "$ref": "#/components/schemas/PushSubscriptionKeys"
+          },
           "user_agent": {
             "anyOf": [
-              { "type": "string", "maxLength": 512 },
-              { "type": "null" }
+              {
+                "type": "string",
+                "maxLength": 512
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "User Agent"
           }
@@ -15603,21 +21424,29 @@
           "context": {
             "anyOf": [
               {
-                "additionalProperties": { "type": "string" },
+                "additionalProperties": {
+                  "type": "string"
+                },
                 "type": "object"
               },
-              { "type": "null" }
+              {
+                "type": "null"
+              }
             ],
             "title": "Context"
           },
           "file_ids": {
             "anyOf": [
               {
-                "items": { "type": "string" },
+                "items": {
+                  "type": "string"
+                },
                 "type": "array",
                 "maxItems": 20
               },
-              { "type": "null" }
+              {
+                "type": "null"
+              }
             ],
             "title": "File Ids"
           }
@@ -15629,12 +21458,18 @@
       },
       "QueuePendingMessageResponse": {
         "properties": {
-          "buffer_length": { "type": "integer", "title": "Buffer Length" },
+          "buffer_length": {
+            "type": "integer",
+            "title": "Buffer Length"
+          },
           "max_buffer_length": {
             "type": "integer",
             "title": "Max Buffer Length"
           },
-          "turn_in_flight": { "type": "boolean", "title": "Turn In Flight" }
+          "turn_in_flight": {
+            "type": "boolean",
+            "title": "Turn In Flight"
+          }
         },
         "type": "object",
         "required": ["buffer_length", "max_buffer_length", "turn_in_flight"],
@@ -15643,7 +21478,10 @@
       },
       "RateLimitResetResponse": {
         "properties": {
-          "success": { "type": "boolean", "title": "Success" },
+          "success": {
+            "type": "boolean",
+            "title": "Success"
+          },
           "credits_charged": {
             "type": "integer",
             "title": "Credits Charged",
@@ -15671,13 +21509,30 @@
       },
       "RecentExecution": {
         "properties": {
-          "status": { "type": "string", "title": "Status" },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
           "correctness_score": {
-            "anyOf": [{ "type": "number" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Correctness Score"
           },
           "activity_summary": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Activity Summary"
           }
         },
@@ -15688,16 +21543,41 @@
       },
       "RefundRequest": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "user_id": { "type": "string", "title": "User Id" },
-          "transaction_key": { "type": "string", "title": "Transaction Key" },
-          "amount": { "type": "integer", "title": "Amount" },
-          "reason": { "type": "string", "title": "Reason" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
+          "transaction_key": {
+            "type": "string",
+            "title": "Transaction Key"
+          },
+          "amount": {
+            "type": "integer",
+            "title": "Amount"
+          },
+          "reason": {
+            "type": "string",
+            "title": "Reason"
+          },
           "result": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Result"
           },
-          "status": { "type": "string", "title": "Status" },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
           "created_at": {
             "type": "string",
             "format": "date-time",
@@ -15724,7 +21604,10 @@
       },
       "RequestTopUp": {
         "properties": {
-          "credit_amount": { "type": "integer", "title": "Credit Amount" }
+          "credit_amount": {
+            "type": "integer",
+            "title": "Credit Amount"
+          }
         },
         "type": "object",
         "required": ["credit_amount"],
@@ -15732,13 +21615,19 @@
       },
       "RequeueExecutionResponse": {
         "properties": {
-          "success": { "type": "boolean", "title": "Success" },
+          "success": {
+            "type": "boolean",
+            "title": "Success"
+          },
           "requeued_count": {
             "type": "integer",
             "title": "Requeued Count",
             "default": 0
           },
-          "message": { "type": "string", "title": "Message" }
+          "message": {
+            "type": "string",
+            "title": "Message"
+          }
         },
         "type": "object",
         "required": ["success", "message"],
@@ -15825,21 +21714,42 @@
           },
           "message": {
             "anyOf": [
-              { "type": "string", "maxLength": 2000 },
-              { "type": "null" }
+              {
+                "type": "string",
+                "maxLength": 2000
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Message",
             "description": "Optional review message"
           },
           "reviewed_data": {
             "anyOf": [
-              { "additionalProperties": true, "type": "object" },
-              { "items": {}, "type": "array" },
-              { "type": "string" },
-              { "type": "integer" },
-              { "type": "number" },
-              { "type": "boolean" },
-              { "type": "null" }
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "items": {},
+                "type": "array"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Reviewed Data",
             "description": "Optional edited data (ignored if approved=False)"
@@ -15859,7 +21769,9 @@
       "ReviewRequest": {
         "properties": {
           "reviews": {
-            "items": { "$ref": "#/components/schemas/ReviewItem" },
+            "items": {
+              "$ref": "#/components/schemas/ReviewItem"
+            },
             "type": "array",
             "title": "Reviews",
             "description": "All reviews with their approval status, data, and messages"
@@ -15888,7 +21800,14 @@
             "description": "Number of reviews that failed processing"
           },
           "error": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Error",
             "description": "Error message if operation failed"
           }
@@ -15909,10 +21828,23 @@
             "type": "string",
             "title": "Store Listing Version Id"
           },
-          "is_approved": { "type": "boolean", "title": "Is Approved" },
-          "comments": { "type": "string", "title": "Comments" },
+          "is_approved": {
+            "type": "boolean",
+            "title": "Is Approved"
+          },
+          "comments": {
+            "type": "string",
+            "title": "Comments"
+          },
           "internal_comments": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Internal Comments"
           }
         },
@@ -15922,16 +21854,41 @@
       },
       "RunningExecutionDetail": {
         "properties": {
-          "execution_id": { "type": "string", "title": "Execution Id" },
-          "graph_id": { "type": "string", "title": "Graph Id" },
-          "graph_name": { "type": "string", "title": "Graph Name" },
-          "graph_version": { "type": "integer", "title": "Graph Version" },
-          "user_id": { "type": "string", "title": "User Id" },
+          "execution_id": {
+            "type": "string",
+            "title": "Execution Id"
+          },
+          "graph_id": {
+            "type": "string",
+            "title": "Graph Id"
+          },
+          "graph_name": {
+            "type": "string",
+            "title": "Graph Name"
+          },
+          "graph_version": {
+            "type": "integer",
+            "title": "Graph Version"
+          },
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
           "user_email": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "User Email"
           },
-          "status": { "type": "string", "title": "Status" },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
           "created_at": {
             "type": "string",
             "format": "date-time",
@@ -15939,13 +21896,25 @@
           },
           "started_at": {
             "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Started At"
           },
           "queue_status": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Queue Status"
           }
         },
@@ -15967,11 +21936,16 @@
       "RunningExecutionsListResponse": {
         "properties": {
           "executions": {
-            "items": { "$ref": "#/components/schemas/RunningExecutionDetail" },
+            "items": {
+              "$ref": "#/components/schemas/RunningExecutionDetail"
+            },
             "type": "array",
             "title": "Executions"
           },
-          "total": { "type": "integer", "title": "Total" }
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          }
         },
         "type": "object",
         "required": ["executions", "total"],
@@ -15981,7 +21955,9 @@
       "ScheduleCleanupRequest": {
         "properties": {
           "schedule_ids": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Schedule Ids"
           }
@@ -15993,13 +21969,19 @@
       },
       "ScheduleCleanupResponse": {
         "properties": {
-          "success": { "type": "boolean", "title": "Success" },
+          "success": {
+            "type": "boolean",
+            "title": "Success"
+          },
           "deleted_count": {
             "type": "integer",
             "title": "Deleted Count",
             "default": 0
           },
-          "message": { "type": "string", "title": "Message" }
+          "message": {
+            "type": "string",
+            "title": "Message"
+          }
         },
         "type": "object",
         "required": ["success", "message"],
@@ -16009,11 +21991,24 @@
       "ScheduleCreationRequest": {
         "properties": {
           "graph_version": {
-            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Graph Version"
           },
-          "name": { "type": "string", "title": "Name" },
-          "cron": { "type": "string", "title": "Cron" },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "cron": {
+            "type": "string",
+            "title": "Cron"
+          },
           "inputs": {
             "additionalProperties": true,
             "type": "object",
@@ -16027,7 +22022,14 @@
             "title": "Credentials"
           },
           "timezone": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Timezone",
             "description": "User's timezone for scheduling (e.g., 'America/New_York'). If not provided, will use user's saved timezone or UTC."
           }
@@ -16042,12 +22044,25 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "schedule_deleted"
           },
-          "message": { "type": "string", "title": "Message" },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
           "session_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Session Id"
           },
-          "schedule_id": { "type": "string", "title": "Schedule Id" }
+          "schedule_id": {
+            "type": "string",
+            "title": "Schedule Id"
+          }
         },
         "type": "object",
         "required": ["message", "schedule_id"],
@@ -16056,23 +22071,62 @@
       },
       "ScheduleDetail": {
         "properties": {
-          "schedule_id": { "type": "string", "title": "Schedule Id" },
-          "schedule_name": { "type": "string", "title": "Schedule Name" },
-          "graph_id": { "type": "string", "title": "Graph Id" },
-          "graph_name": { "type": "string", "title": "Graph Name" },
-          "graph_version": { "type": "integer", "title": "Graph Version" },
-          "user_id": { "type": "string", "title": "User Id" },
+          "schedule_id": {
+            "type": "string",
+            "title": "Schedule Id"
+          },
+          "schedule_name": {
+            "type": "string",
+            "title": "Schedule Name"
+          },
+          "graph_id": {
+            "type": "string",
+            "title": "Graph Id"
+          },
+          "graph_name": {
+            "type": "string",
+            "title": "Graph Name"
+          },
+          "graph_version": {
+            "type": "integer",
+            "title": "Graph Version"
+          },
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
           "user_email": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "User Email"
           },
-          "cron": { "type": "string", "title": "Cron" },
-          "timezone": { "type": "string", "title": "Timezone" },
-          "next_run_time": { "type": "string", "title": "Next Run Time" },
+          "cron": {
+            "type": "string",
+            "title": "Cron"
+          },
+          "timezone": {
+            "type": "string",
+            "title": "Timezone"
+          },
+          "next_run_time": {
+            "type": "string",
+            "title": "Next Run Time"
+          },
           "created_at": {
             "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Created At"
           }
@@ -16095,8 +22149,14 @@
       },
       "ScheduleHealthMetrics": {
         "properties": {
-          "total_schedules": { "type": "integer", "title": "Total Schedules" },
-          "user_schedules": { "type": "integer", "title": "User Schedules" },
+          "total_schedules": {
+            "type": "integer",
+            "title": "Total Schedules"
+          },
+          "user_schedules": {
+            "type": "integer",
+            "title": "User Schedules"
+          },
           "system_schedules": {
             "type": "integer",
             "title": "System Schedules"
@@ -16117,7 +22177,10 @@
             "type": "integer",
             "title": "Orphaned Validation Failed"
           },
-          "total_orphaned": { "type": "integer", "title": "Total Orphaned" },
+          "total_orphaned": {
+            "type": "integer",
+            "title": "Total Orphaned"
+          },
           "schedules_next_hour": {
             "type": "integer",
             "title": "Schedules Next Hour"
@@ -16134,7 +22197,10 @@
             "type": "integer",
             "title": "Total Runs Next 24H"
           },
-          "timestamp": { "type": "string", "title": "Timestamp" }
+          "timestamp": {
+            "type": "string",
+            "title": "Timestamp"
+          }
         },
         "type": "object",
         "required": [
@@ -16161,13 +22227,25 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "schedule_list"
           },
-          "message": { "type": "string", "title": "Message" },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
           "session_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Session Id"
           },
           "schedules": {
-            "items": { "$ref": "#/components/schemas/ScheduleSummary" },
+            "items": {
+              "$ref": "#/components/schemas/ScheduleSummary"
+            },
             "type": "array",
             "title": "Schedules"
           }
@@ -16179,37 +22257,91 @@
       },
       "ScheduleSummary": {
         "properties": {
-          "schedule_id": { "type": "string", "title": "Schedule Id" },
+          "schedule_id": {
+            "type": "string",
+            "title": "Schedule Id"
+          },
           "kind": {
             "type": "string",
             "enum": ["graph", "copilot_turn"],
             "title": "Kind"
           },
-          "name": { "type": "string", "title": "Name" },
-          "timezone": { "type": "string", "title": "Timezone" },
-          "next_run_time": { "type": "string", "title": "Next Run Time" },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "timezone": {
+            "type": "string",
+            "title": "Timezone"
+          },
+          "next_run_time": {
+            "type": "string",
+            "title": "Next Run Time"
+          },
           "cron": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Cron"
           },
           "run_at": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Run At"
           },
           "graph_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Graph Id"
           },
           "graph_version": {
-            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Graph Version"
           },
           "session_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Session Id"
           },
           "message": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Message"
           }
         },
@@ -16227,11 +22359,16 @@
       "SchedulesListResponse": {
         "properties": {
           "schedules": {
-            "items": { "$ref": "#/components/schemas/ScheduleDetail" },
+            "items": {
+              "$ref": "#/components/schemas/ScheduleDetail"
+            },
             "type": "array",
             "title": "Schedules"
           },
-          "total": { "type": "integer", "title": "Total" }
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          }
         },
         "type": "object",
         "required": ["schedules", "total"],
@@ -16241,7 +22378,14 @@
       "SearchEntry": {
         "properties": {
           "search_query": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Search Query"
           },
           "filter": {
@@ -16258,19 +22402,35 @@
                 },
                 "type": "array"
               },
-              { "type": "null" }
+              {
+                "type": "null"
+              }
             ],
             "title": "Filter"
           },
           "by_creator": {
             "anyOf": [
-              { "items": { "type": "string" }, "type": "array" },
-              { "type": "null" }
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "By Creator"
           },
           "search_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Search Id"
           }
         },
@@ -16282,17 +22442,28 @@
           "items": {
             "items": {
               "anyOf": [
-                { "$ref": "#/components/schemas/BlockInfo" },
-                { "$ref": "#/components/schemas/LibraryAgent" },
-                { "$ref": "#/components/schemas/StoreAgent" }
+                {
+                  "$ref": "#/components/schemas/BlockInfo"
+                },
+                {
+                  "$ref": "#/components/schemas/LibraryAgent"
+                },
+                {
+                  "$ref": "#/components/schemas/StoreAgent"
+                }
               ]
             },
             "type": "array",
             "title": "Items"
           },
-          "search_id": { "type": "string", "title": "Search Id" },
+          "search_id": {
+            "type": "string",
+            "title": "Search Id"
+          },
           "total_items": {
-            "additionalProperties": { "type": "integer" },
+            "additionalProperties": {
+              "type": "integer"
+            },
             "propertyNames": {
               "enum": [
                 "blocks",
@@ -16304,7 +22475,9 @@
             "type": "object",
             "title": "Total Items"
           },
-          "pagination": { "$ref": "#/components/schemas/Pagination" }
+          "pagination": {
+            "$ref": "#/components/schemas/Pagination"
+          }
         },
         "type": "object",
         "required": ["items", "search_id", "total_items", "pagination"],
@@ -16312,11 +22485,27 @@
       },
       "SessionDetailResponse": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "created_at": { "type": "string", "title": "Created At" },
-          "updated_at": { "type": "string", "title": "Updated At" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "created_at": {
+            "type": "string",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "type": "string",
+            "title": "Updated At"
+          },
           "user_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "User Id"
           },
           "chat_status": {
@@ -16325,14 +22514,21 @@
             "default": "idle"
           },
           "messages": {
-            "items": { "additionalProperties": true, "type": "object" },
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
             "type": "array",
             "title": "Messages"
           },
           "active_stream": {
             "anyOf": [
-              { "$ref": "#/components/schemas/ActiveStreamInfo" },
-              { "type": "null" }
+              {
+                "$ref": "#/components/schemas/ActiveStreamInfo"
+              },
+              {
+                "type": "null"
+              }
             ]
           },
           "has_more_messages": {
@@ -16341,7 +22537,14 @@
             "default": false
           },
           "oldest_sequence": {
-            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Oldest Sequence"
           },
           "total_prompt_tokens": {
@@ -16356,7 +22559,9 @@
           },
           "metadata": {
             "$ref": "#/components/schemas/ChatSessionMetadata",
-            "default": { "dry_run": false }
+            "default": {
+              "dry_run": false
+            }
           }
         },
         "type": "object",
@@ -16366,11 +22571,27 @@
       },
       "SessionSummaryResponse": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "created_at": { "type": "string", "title": "Created At" },
-          "updated_at": { "type": "string", "title": "Updated At" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "created_at": {
+            "type": "string",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "type": "string",
+            "title": "Updated At"
+          },
           "title": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Title"
           },
           "chat_status": {
@@ -16378,9 +22599,19 @@
             "title": "Chat Status",
             "default": "idle"
           },
-          "is_processing": { "type": "boolean", "title": "Is Processing" },
+          "is_processing": {
+            "type": "boolean",
+            "title": "Is Processing"
+          },
           "source_platform": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Source Platform"
           }
         },
@@ -16402,8 +22633,13 @@
       },
       "SetUserTierRequest": {
         "properties": {
-          "user_id": { "type": "string", "title": "User Id" },
-          "tier": { "$ref": "#/components/schemas/SubscriptionTier" }
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
+          "tier": {
+            "$ref": "#/components/schemas/SubscriptionTier"
+          }
         },
         "type": "object",
         "required": ["user_id", "tier"],
@@ -16411,14 +22647,25 @@
       },
       "SetupInfo": {
         "properties": {
-          "agent_id": { "type": "string", "title": "Agent Id" },
-          "agent_name": { "type": "string", "title": "Agent Name" },
+          "agent_id": {
+            "type": "string",
+            "title": "Agent Id"
+          },
+          "agent_name": {
+            "type": "string",
+            "title": "Agent Name"
+          },
           "requirements": {
-            "additionalProperties": { "items": {}, "type": "array" },
+            "additionalProperties": {
+              "items": {},
+              "type": "array"
+            },
             "type": "object",
             "title": "Requirements"
           },
-          "user_readiness": { "$ref": "#/components/schemas/UserReadiness" }
+          "user_readiness": {
+            "$ref": "#/components/schemas/UserReadiness"
+          }
         },
         "type": "object",
         "required": ["agent_id", "agent_name"],
@@ -16431,18 +22678,44 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "setup_requirements"
           },
-          "message": { "type": "string", "title": "Message" },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
           "session_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Session Id"
           },
-          "setup_info": { "$ref": "#/components/schemas/SetupInfo" },
+          "setup_info": {
+            "$ref": "#/components/schemas/SetupInfo"
+          },
           "graph_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Graph Id"
           },
           "graph_version": {
-            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Graph Version"
           }
         },
@@ -16459,8 +22732,14 @@
       },
       "ShareResponse": {
         "properties": {
-          "share_url": { "type": "string", "title": "Share Url" },
-          "share_token": { "type": "string", "title": "Share Token" }
+          "share_url": {
+            "type": "string",
+            "title": "Share Url"
+          },
+          "share_token": {
+            "type": "string",
+            "title": "Share Token"
+          }
         },
         "type": "object",
         "required": ["share_url", "share_token"],
@@ -16469,20 +22748,38 @@
       },
       "SharedExecutionResponse": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "graph_name": { "type": "string", "title": "Graph Name" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "graph_name": {
+            "type": "string",
+            "title": "Graph Name"
+          },
           "graph_description": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Graph Description"
           },
-          "status": { "$ref": "#/components/schemas/AgentExecutionStatus" },
+          "status": {
+            "$ref": "#/components/schemas/AgentExecutionStatus"
+          },
           "created_at": {
             "type": "string",
             "format": "date-time",
             "title": "Created At"
           },
           "outputs": {
-            "additionalProperties": { "items": {}, "type": "array" },
+            "additionalProperties": {
+              "items": {},
+              "type": "array"
+            },
             "type": "object",
             "title": "Outputs"
           }
@@ -16544,17 +22841,38 @@
             "default": 0
           },
           "error": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Error",
             "description": "Error message if any"
           },
           "activity_status": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Activity Status",
             "description": "AI-generated summary of what the agent did"
           },
           "correctness_score": {
-            "anyOf": [{ "type": "number" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Correctness Score",
             "description": "AI-generated score (0.0-1.0) indicating how well the execution achieved its intended purpose"
           }
@@ -16565,7 +22883,10 @@
       },
       "StopExecutionRequest": {
         "properties": {
-          "execution_id": { "type": "string", "title": "Execution Id" }
+          "execution_id": {
+            "type": "string",
+            "title": "Execution Id"
+          }
         },
         "type": "object",
         "required": ["execution_id"],
@@ -16574,13 +22895,19 @@
       },
       "StopExecutionResponse": {
         "properties": {
-          "success": { "type": "boolean", "title": "Success" },
+          "success": {
+            "type": "boolean",
+            "title": "Success"
+          },
           "stopped_count": {
             "type": "integer",
             "title": "Stopped Count",
             "default": 0
           },
-          "message": { "type": "string", "title": "Message" }
+          "message": {
+            "type": "string",
+            "title": "Message"
+          }
         },
         "type": "object",
         "required": ["success", "message"],
@@ -16590,7 +22917,9 @@
       "StopExecutionsRequest": {
         "properties": {
           "execution_ids": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Execution Ids"
           }
@@ -16602,10 +22931,22 @@
       },
       "StorageUsageResponse": {
         "properties": {
-          "used_bytes": { "type": "integer", "title": "Used Bytes" },
-          "limit_bytes": { "type": "integer", "title": "Limit Bytes" },
-          "used_percent": { "type": "number", "title": "Used Percent" },
-          "file_count": { "type": "integer", "title": "File Count" }
+          "used_bytes": {
+            "type": "integer",
+            "title": "Used Bytes"
+          },
+          "limit_bytes": {
+            "type": "integer",
+            "title": "Limit Bytes"
+          },
+          "used_percent": {
+            "type": "number",
+            "title": "Used Percent"
+          },
+          "file_count": {
+            "type": "integer",
+            "title": "File Count"
+          }
         },
         "type": "object",
         "required": ["used_bytes", "limit_bytes", "used_percent", "file_count"],
@@ -16613,16 +22954,46 @@
       },
       "StoreAgent": {
         "properties": {
-          "slug": { "type": "string", "title": "Slug" },
-          "agent_name": { "type": "string", "title": "Agent Name" },
-          "agent_image": { "type": "string", "title": "Agent Image" },
-          "creator": { "type": "string", "title": "Creator" },
-          "creator_avatar": { "type": "string", "title": "Creator Avatar" },
-          "sub_heading": { "type": "string", "title": "Sub Heading" },
-          "description": { "type": "string", "title": "Description" },
-          "runs": { "type": "integer", "title": "Runs" },
-          "rating": { "type": "number", "title": "Rating" },
-          "agent_graph_id": { "type": "string", "title": "Agent Graph Id" }
+          "slug": {
+            "type": "string",
+            "title": "Slug"
+          },
+          "agent_name": {
+            "type": "string",
+            "title": "Agent Name"
+          },
+          "agent_image": {
+            "type": "string",
+            "title": "Agent Image"
+          },
+          "creator": {
+            "type": "string",
+            "title": "Creator"
+          },
+          "creator_avatar": {
+            "type": "string",
+            "title": "Creator Avatar"
+          },
+          "sub_heading": {
+            "type": "string",
+            "title": "Sub Heading"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
+          "runs": {
+            "type": "integer",
+            "title": "Runs"
+          },
+          "rating": {
+            "type": "number",
+            "title": "Rating"
+          },
+          "agent_graph_id": {
+            "type": "string",
+            "title": "Agent Graph Id"
+          }
         },
         "type": "object",
         "required": [
@@ -16645,41 +23016,86 @@
             "type": "string",
             "title": "Store Listing Version Id"
           },
-          "slug": { "type": "string", "title": "Slug" },
-          "agent_name": { "type": "string", "title": "Agent Name" },
-          "agent_video": { "type": "string", "title": "Agent Video" },
+          "slug": {
+            "type": "string",
+            "title": "Slug"
+          },
+          "agent_name": {
+            "type": "string",
+            "title": "Agent Name"
+          },
+          "agent_video": {
+            "type": "string",
+            "title": "Agent Video"
+          },
           "agent_output_demo": {
             "type": "string",
             "title": "Agent Output Demo"
           },
           "agent_image": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Agent Image"
           },
-          "creator": { "type": "string", "title": "Creator" },
-          "creator_avatar": { "type": "string", "title": "Creator Avatar" },
-          "sub_heading": { "type": "string", "title": "Sub Heading" },
-          "description": { "type": "string", "title": "Description" },
+          "creator": {
+            "type": "string",
+            "title": "Creator"
+          },
+          "creator_avatar": {
+            "type": "string",
+            "title": "Creator Avatar"
+          },
+          "sub_heading": {
+            "type": "string",
+            "title": "Sub Heading"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
           "instructions": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Instructions"
           },
           "categories": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Categories"
           },
-          "runs": { "type": "integer", "title": "Runs" },
-          "rating": { "type": "number", "title": "Rating" },
+          "runs": {
+            "type": "integer",
+            "title": "Runs"
+          },
+          "rating": {
+            "type": "number",
+            "title": "Rating"
+          },
           "versions": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Versions"
           },
-          "graph_id": { "type": "string", "title": "Graph Id" },
+          "graph_id": {
+            "type": "string",
+            "title": "Graph Id"
+          },
           "graph_versions": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Graph Versions"
           },
@@ -16689,7 +23105,14 @@
             "title": "Last Updated"
           },
           "recommended_schedule_cron": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Recommended Schedule Cron"
           },
           "active_version_id": {
@@ -16703,10 +23126,14 @@
           "changelog": {
             "anyOf": [
               {
-                "items": { "$ref": "#/components/schemas/ChangelogEntry" },
+                "items": {
+                  "$ref": "#/components/schemas/ChangelogEntry"
+                },
                 "type": "array"
               },
-              { "type": "null" }
+              {
+                "type": "null"
+              }
             ],
             "title": "Changelog"
           }
@@ -16738,11 +23165,15 @@
       "StoreAgentsResponse": {
         "properties": {
           "agents": {
-            "items": { "$ref": "#/components/schemas/StoreAgent" },
+            "items": {
+              "$ref": "#/components/schemas/StoreAgent"
+            },
             "type": "array",
             "title": "Agents"
           },
-          "pagination": { "$ref": "#/components/schemas/Pagination" }
+          "pagination": {
+            "$ref": "#/components/schemas/Pagination"
+          }
         },
         "type": "object",
         "required": ["agents", "pagination"],
@@ -16760,11 +23191,27 @@
       },
       "StoreListingWithVersionsAdminView": {
         "properties": {
-          "listing_id": { "type": "string", "title": "Listing Id" },
-          "graph_id": { "type": "string", "title": "Graph Id" },
-          "slug": { "type": "string", "title": "Slug" },
+          "listing_id": {
+            "type": "string",
+            "title": "Listing Id"
+          },
+          "graph_id": {
+            "type": "string",
+            "title": "Graph Id"
+          },
+          "slug": {
+            "type": "string",
+            "title": "Slug"
+          },
           "active_listing_version_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Active Listing Version Id"
           },
           "has_approved_version": {
@@ -16773,13 +23220,24 @@
             "default": false
           },
           "creator_email": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Creator Email"
           },
           "latest_version": {
             "anyOf": [
-              { "$ref": "#/components/schemas/StoreSubmissionAdminView" },
-              { "type": "null" }
+              {
+                "$ref": "#/components/schemas/StoreSubmissionAdminView"
+              },
+              {
+                "type": "null"
+              }
             ]
           },
           "versions": {
@@ -16805,7 +23263,9 @@
             "type": "array",
             "title": "Listings"
           },
-          "pagination": { "$ref": "#/components/schemas/Pagination" }
+          "pagination": {
+            "$ref": "#/components/schemas/Pagination"
+          }
         },
         "type": "object",
         "required": ["listings", "pagination"],
@@ -16814,9 +23274,19 @@
       },
       "StoreReview": {
         "properties": {
-          "score": { "type": "integer", "title": "Score" },
+          "score": {
+            "type": "integer",
+            "title": "Score"
+          },
           "comments": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Comments"
           }
         },
@@ -16830,9 +23300,19 @@
             "type": "string",
             "title": "Store Listing Version Id"
           },
-          "score": { "type": "integer", "title": "Score" },
+          "score": {
+            "type": "integer",
+            "title": "Score"
+          },
           "comments": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Comments"
           }
         },
@@ -16842,66 +23322,151 @@
       },
       "StoreSubmission": {
         "properties": {
-          "listing_id": { "type": "string", "title": "Listing Id" },
-          "user_id": { "type": "string", "title": "User Id" },
-          "slug": { "type": "string", "title": "Slug" },
+          "listing_id": {
+            "type": "string",
+            "title": "Listing Id"
+          },
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
+          "slug": {
+            "type": "string",
+            "title": "Slug"
+          },
           "listing_version_id": {
             "type": "string",
             "title": "Listing Version Id"
           },
-          "listing_version": { "type": "integer", "title": "Listing Version" },
-          "graph_id": { "type": "string", "title": "Graph Id" },
-          "graph_version": { "type": "integer", "title": "Graph Version" },
-          "name": { "type": "string", "title": "Name" },
-          "sub_heading": { "type": "string", "title": "Sub Heading" },
-          "description": { "type": "string", "title": "Description" },
+          "listing_version": {
+            "type": "integer",
+            "title": "Listing Version"
+          },
+          "graph_id": {
+            "type": "string",
+            "title": "Graph Id"
+          },
+          "graph_version": {
+            "type": "integer",
+            "title": "Graph Version"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "sub_heading": {
+            "type": "string",
+            "title": "Sub Heading"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
           "instructions": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Instructions"
           },
           "categories": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Categories"
           },
           "image_urls": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Image Urls"
           },
           "video_url": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Video Url"
           },
           "agent_output_demo_url": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Agent Output Demo Url"
           },
           "submitted_at": {
             "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Submitted At"
           },
           "changes_summary": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Changes Summary"
           },
-          "status": { "$ref": "#/components/schemas/SubmissionStatus" },
+          "status": {
+            "$ref": "#/components/schemas/SubmissionStatus"
+          },
           "reviewed_at": {
             "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Reviewed At"
           },
           "reviewer_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Reviewer Id"
           },
           "review_comments": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Review Comments"
           },
           "run_count": {
@@ -16945,66 +23510,151 @@
       },
       "StoreSubmissionAdminView": {
         "properties": {
-          "listing_id": { "type": "string", "title": "Listing Id" },
-          "user_id": { "type": "string", "title": "User Id" },
-          "slug": { "type": "string", "title": "Slug" },
+          "listing_id": {
+            "type": "string",
+            "title": "Listing Id"
+          },
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
+          "slug": {
+            "type": "string",
+            "title": "Slug"
+          },
           "listing_version_id": {
             "type": "string",
             "title": "Listing Version Id"
           },
-          "listing_version": { "type": "integer", "title": "Listing Version" },
-          "graph_id": { "type": "string", "title": "Graph Id" },
-          "graph_version": { "type": "integer", "title": "Graph Version" },
-          "name": { "type": "string", "title": "Name" },
-          "sub_heading": { "type": "string", "title": "Sub Heading" },
-          "description": { "type": "string", "title": "Description" },
+          "listing_version": {
+            "type": "integer",
+            "title": "Listing Version"
+          },
+          "graph_id": {
+            "type": "string",
+            "title": "Graph Id"
+          },
+          "graph_version": {
+            "type": "integer",
+            "title": "Graph Version"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "sub_heading": {
+            "type": "string",
+            "title": "Sub Heading"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
           "instructions": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Instructions"
           },
           "categories": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Categories"
           },
           "image_urls": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Image Urls"
           },
           "video_url": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Video Url"
           },
           "agent_output_demo_url": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Agent Output Demo Url"
           },
           "submitted_at": {
             "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Submitted At"
           },
           "changes_summary": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Changes Summary"
           },
-          "status": { "$ref": "#/components/schemas/SubmissionStatus" },
+          "status": {
+            "$ref": "#/components/schemas/SubmissionStatus"
+          },
           "reviewed_at": {
             "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Reviewed At"
           },
           "reviewer_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Reviewer Id"
           },
           "review_comments": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Review Comments"
           },
           "run_count": {
@@ -17023,7 +23673,14 @@
             "default": 0.0
           },
           "internal_comments": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Internal Comments"
           }
         },
@@ -17053,18 +23710,40 @@
       },
       "StoreSubmissionEditRequest": {
         "properties": {
-          "name": { "type": "string", "title": "Name" },
-          "sub_heading": { "type": "string", "title": "Sub Heading" },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "sub_heading": {
+            "type": "string",
+            "title": "Sub Heading"
+          },
           "video_url": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Video Url"
           },
           "agent_output_demo_url": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Agent Output Demo Url"
           },
           "image_urls": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Image Urls",
             "default": []
@@ -17075,21 +23754,44 @@
             "default": ""
           },
           "instructions": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Instructions"
           },
           "categories": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Categories",
             "default": []
           },
           "changes_summary": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Changes Summary"
           },
           "recommended_schedule_cron": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Recommended Schedule Cron"
           }
         },
@@ -17111,19 +23813,44 @@
             "title": "Graph Version",
             "description": "Graph version must be greater than 0"
           },
-          "slug": { "type": "string", "title": "Slug" },
-          "name": { "type": "string", "title": "Name" },
-          "sub_heading": { "type": "string", "title": "Sub Heading" },
+          "slug": {
+            "type": "string",
+            "title": "Slug"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "sub_heading": {
+            "type": "string",
+            "title": "Sub Heading"
+          },
           "video_url": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Video Url"
           },
           "agent_output_demo_url": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Agent Output Demo Url"
           },
           "image_urls": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Image Urls",
             "default": []
@@ -17134,21 +23861,44 @@
             "default": ""
           },
           "instructions": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Instructions"
           },
           "categories": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Categories",
             "default": []
           },
           "changes_summary": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Changes Summary"
           },
           "recommended_schedule_cron": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Recommended Schedule Cron"
           }
         },
@@ -17165,12 +23915,18 @@
       "StoreSubmissionsResponse": {
         "properties": {
           "submissions": {
-            "items": { "$ref": "#/components/schemas/StoreSubmission" },
+            "items": {
+              "$ref": "#/components/schemas/StoreSubmission"
+            },
             "type": "array",
             "title": "Submissions"
           },
-          "pagination": { "$ref": "#/components/schemas/Pagination" },
-          "stats": { "$ref": "#/components/schemas/SubmissionStats" }
+          "pagination": {
+            "$ref": "#/components/schemas/Pagination"
+          },
+          "stats": {
+            "$ref": "#/components/schemas/SubmissionStats"
+          }
         },
         "type": "object",
         "required": ["submissions", "pagination", "stats"],
@@ -17191,44 +23947,67 @@
           "context": {
             "anyOf": [
               {
-                "additionalProperties": { "type": "string" },
+                "additionalProperties": {
+                  "type": "string"
+                },
                 "type": "object"
               },
-              { "type": "null" }
+              {
+                "type": "null"
+              }
             ],
             "title": "Context"
           },
           "file_ids": {
             "anyOf": [
               {
-                "items": { "type": "string" },
+                "items": {
+                  "type": "string"
+                },
                 "type": "array",
                 "maxItems": 20
               },
-              { "type": "null" }
+              {
+                "type": "null"
+              }
             ],
             "title": "File Ids"
           },
           "mode": {
             "anyOf": [
-              { "type": "string", "enum": ["fast", "extended_thinking"] },
-              { "type": "null" }
+              {
+                "type": "string",
+                "enum": ["fast", "extended_thinking"]
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Mode",
             "description": "Autopilot mode: 'fast' for baseline LLM, 'extended_thinking' for Claude Agent SDK. If None, uses the server default (extended_thinking)."
           },
           "model": {
             "anyOf": [
-              { "type": "string", "enum": ["standard", "advanced"] },
-              { "type": "null" }
+              {
+                "type": "string",
+                "enum": ["standard", "advanced"]
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Model",
             "description": "Model tier: 'standard' for the default model, 'advanced' for the highest-capability model. If None, the server applies per-user LD targeting then falls back to config."
           },
           "message_id": {
             "anyOf": [
-              { "type": "string", "maxLength": 64 },
-              { "type": "null" }
+              {
+                "type": "string",
+                "maxLength": 64
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Message Id",
             "description": "Optional per-click UUID generated by the frontend.  Becomes the persisted ``ChatMessage.id`` (PK).  Frontend / network / RMQ-redelivery retransmits of the same logical send reuse the id, so the Postgres unique-constraint on the PK is the atomic dedup primitive: a duplicate INSERT returns a subscribe-only response without creating a parallel turn.  Distinct user clicks (even with identical text) MUST send different ids — the frontend's per-click ``crypto.randomUUID()`` guarantees that."
@@ -17241,12 +24020,31 @@
       },
       "SubmissionStats": {
         "properties": {
-          "total": { "type": "integer", "title": "Total" },
-          "approved": { "type": "integer", "title": "Approved" },
-          "pending": { "type": "integer", "title": "Pending" },
-          "total_runs": { "type": "integer", "title": "Total Runs" },
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          },
+          "approved": {
+            "type": "integer",
+            "title": "Approved"
+          },
+          "pending": {
+            "type": "integer",
+            "title": "Pending"
+          },
+          "total_runs": {
+            "type": "integer",
+            "title": "Total Runs"
+          },
           "average_rating": {
-            "anyOf": [{ "type": "number" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Average Rating"
           }
         },
@@ -17280,14 +24078,21 @@
             ],
             "title": "Tier"
           },
-          "monthly_cost": { "type": "integer", "title": "Monthly Cost" },
+          "monthly_cost": {
+            "type": "integer",
+            "title": "Monthly Cost"
+          },
           "tier_costs": {
-            "additionalProperties": { "type": "integer" },
+            "additionalProperties": {
+              "type": "integer"
+            },
             "type": "object",
             "title": "Tier Costs"
           },
           "tier_costs_yearly": {
-            "additionalProperties": { "type": "integer" },
+            "additionalProperties": {
+              "type": "integer"
+            },
             "type": "object",
             "title": "Tier Costs Yearly",
             "description": "Tier → yearly amount in cents. Populated only for tiers with a yearly Stripe price configured in LaunchDarkly. Empty for monthly-only configurations."
@@ -17300,7 +24105,9 @@
             "default": "monthly"
           },
           "tier_multipliers": {
-            "additionalProperties": { "type": "number" },
+            "additionalProperties": {
+              "type": "number"
+            },
             "type": "object",
             "title": "Tier Multipliers",
             "description": "Tier → rate-limit multiplier. Covers the same tiers listed in ``tier_costs`` so the frontend can render rate-limit badges relative to the lowest visible tier without knowing backend defaults."
@@ -17316,7 +24123,14 @@
             "default": false
           },
           "current_period_end": {
-            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Current Period End",
             "description": "Unix timestamp of the active subscription's current_period_end. Used to show the date Stripe will issue the next invoice (with prorated upgrade charges, if any). None when no active sub."
           },
@@ -17326,21 +24140,33 @@
                 "type": "string",
                 "enum": ["NO_TIER", "BASIC", "PRO", "MAX", "BUSINESS"]
               },
-              { "type": "null" }
+              {
+                "type": "null"
+              }
             ],
             "title": "Pending Tier"
           },
           "pending_tier_effective_at": {
             "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Pending Tier Effective At"
           },
           "pending_billing_cycle": {
             "anyOf": [
-              { "type": "string", "enum": ["monthly", "yearly"] },
-              { "type": "null" }
+              {
+                "type": "string",
+                "enum": ["monthly", "yearly"]
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Pending Billing Cycle",
             "description": "Billing cycle of the queued change, when resolvable. Set alongside ``pending_tier`` for tier downgrades and same-tier cycle switches (yearly→monthly). The frontend uses this to differentiate a cycle-only schedule (``pending_tier == current tier``) from a real tier downgrade so the UI copy can describe the actual change. ``None`` for cancellations and unconfigured legacy prices."
@@ -17401,9 +24227,19 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "suggested_goal"
           },
-          "message": { "type": "string", "title": "Message" },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
           "session_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Session Id"
           },
           "suggested_goal": {
@@ -17439,7 +24275,9 @@
       "SuggestedPromptsResponse": {
         "properties": {
           "themes": {
-            "items": { "$ref": "#/components/schemas/SuggestedTheme" },
+            "items": {
+              "$ref": "#/components/schemas/SuggestedTheme"
+            },
             "type": "array",
             "title": "Themes"
           }
@@ -17451,9 +24289,14 @@
       },
       "SuggestedTheme": {
         "properties": {
-          "name": { "type": "string", "title": "Name" },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
           "prompts": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Prompts"
           }
@@ -17466,7 +24309,9 @@
       "SuggestionsResponse": {
         "properties": {
           "recent_searches": {
-            "items": { "$ref": "#/components/schemas/SearchEntry" },
+            "items": {
+              "$ref": "#/components/schemas/SearchEntry"
+            },
             "type": "array",
             "title": "Recent Searches"
           },
@@ -17479,7 +24324,9 @@
             "title": "Providers"
           },
           "top_blocks": {
-            "items": { "$ref": "#/components/schemas/BlockInfo" },
+            "items": {
+              "$ref": "#/components/schemas/BlockInfo"
+            },
             "type": "array",
             "title": "Top Blocks"
           }
@@ -18095,7 +24942,9 @@
                 ],
                 "minLength": 1
               },
-              { "type": "string" }
+              {
+                "type": "string"
+              }
             ],
             "title": "Timezone"
           }
@@ -18134,13 +24983,25 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "todo_write"
           },
-          "message": { "type": "string", "title": "Message" },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
           "session_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Session Id"
           },
           "todos": {
-            "items": { "$ref": "#/components/schemas/TodoItem" },
+            "items": {
+              "$ref": "#/components/schemas/TodoItem"
+            },
             "type": "array",
             "title": "Todos"
           }
@@ -18152,30 +25013,66 @@
       },
       "TokenIntrospectionResult": {
         "properties": {
-          "active": { "type": "boolean", "title": "Active" },
+          "active": {
+            "type": "boolean",
+            "title": "Active"
+          },
           "scopes": {
             "anyOf": [
-              { "items": { "type": "string" }, "type": "array" },
-              { "type": "null" }
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Scopes"
           },
           "client_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Client Id"
           },
           "user_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "User Id"
           },
           "exp": {
-            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Exp"
           },
           "token_type": {
             "anyOf": [
-              { "type": "string", "enum": ["access_token", "refresh_token"] },
-              { "type": "null" }
+              {
+                "type": "string",
+                "enum": ["access_token", "refresh_token"]
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Token Type"
           }
@@ -18198,11 +25095,27 @@
             "title": "Output Usd Per 1M"
           },
           "cache_read_usd_per_1m": {
-            "anyOf": [{ "type": "number", "minimum": 0.0 }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "number",
+                "minimum": 0.0
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Cache Read Usd Per 1M"
           },
           "cache_creation_usd_per_1m": {
-            "anyOf": [{ "type": "number", "minimum": 0.0 }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "number",
+                "minimum": 0.0
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Cache Creation Usd Per 1M"
           }
         },
@@ -18228,8 +25141,14 @@
             "title": "Redirect Uri",
             "description": "Redirect URI (must match authorization request)"
           },
-          "client_id": { "type": "string", "title": "Client Id" },
-          "client_secret": { "type": "string", "title": "Client Secret" },
+          "client_id": {
+            "type": "string",
+            "title": "Client Id"
+          },
+          "client_secret": {
+            "type": "string",
+            "title": "Client Secret"
+          },
           "code_verifier": {
             "type": "string",
             "title": "Code Verifier",
@@ -18254,9 +25173,18 @@
             "const": "refresh_token",
             "title": "Grant Type"
           },
-          "refresh_token": { "type": "string", "title": "Refresh Token" },
-          "client_id": { "type": "string", "title": "Client Id" },
-          "client_secret": { "type": "string", "title": "Client Secret" }
+          "refresh_token": {
+            "type": "string",
+            "title": "Refresh Token"
+          },
+          "client_id": {
+            "type": "string",
+            "title": "Client Id"
+          },
+          "client_secret": {
+            "type": "string",
+            "title": "Client Secret"
+          }
         },
         "type": "object",
         "required": [
@@ -18275,20 +25203,28 @@
             "title": "Token Type",
             "default": "Bearer"
           },
-          "access_token": { "type": "string", "title": "Access Token" },
+          "access_token": {
+            "type": "string",
+            "title": "Access Token"
+          },
           "access_token_expires_at": {
             "type": "string",
             "format": "date-time",
             "title": "Access Token Expires At"
           },
-          "refresh_token": { "type": "string", "title": "Refresh Token" },
+          "refresh_token": {
+            "type": "string",
+            "title": "Refresh Token"
+          },
           "refresh_token_expires_at": {
             "type": "string",
             "format": "date-time",
             "title": "Refresh Token Expires At"
           },
           "scopes": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Scopes"
           }
@@ -18307,14 +25243,21 @@
       "TransactionHistory": {
         "properties": {
           "transactions": {
-            "items": { "$ref": "#/components/schemas/UserTransaction" },
+            "items": {
+              "$ref": "#/components/schemas/UserTransaction"
+            },
             "type": "array",
             "title": "Transactions"
           },
           "next_transaction_time": {
             "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Next Transaction Time"
           }
@@ -18325,14 +25268,23 @@
       },
       "TriggeredPresetSetupRequest": {
         "properties": {
-          "name": { "type": "string", "title": "Name" },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
           "description": {
             "type": "string",
             "title": "Description",
             "default": ""
           },
-          "graph_id": { "type": "string", "title": "Graph Id" },
-          "graph_version": { "type": "integer", "title": "Graph Version" },
+          "graph_id": {
+            "type": "string",
+            "title": "Graph Id"
+          },
+          "graph_version": {
+            "type": "integer",
+            "title": "Graph Version"
+          },
           "trigger_config": {
             "additionalProperties": true,
             "type": "object",
@@ -18356,13 +25308,25 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "understanding_updated"
           },
-          "message": { "type": "string", "title": "Message" },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
           "session_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Session Id"
           },
           "updated_fields": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Updated Fields"
           },
@@ -18380,11 +25344,15 @@
       "UnifiedSearchResponse": {
         "properties": {
           "results": {
-            "items": { "$ref": "#/components/schemas/UnifiedSearchResult" },
+            "items": {
+              "$ref": "#/components/schemas/UnifiedSearchResult"
+            },
             "type": "array",
             "title": "Results"
           },
-          "pagination": { "$ref": "#/components/schemas/Pagination" }
+          "pagination": {
+            "$ref": "#/components/schemas/Pagination"
+          }
         },
         "type": "object",
         "required": ["results", "pagination"],
@@ -18393,33 +25361,73 @@
       },
       "UnifiedSearchResult": {
         "properties": {
-          "content_type": { "type": "string", "title": "Content Type" },
-          "content_id": { "type": "string", "title": "Content Id" },
-          "searchable_text": { "type": "string", "title": "Searchable Text" },
+          "content_type": {
+            "type": "string",
+            "title": "Content Type"
+          },
+          "content_id": {
+            "type": "string",
+            "title": "Content Id"
+          },
+          "searchable_text": {
+            "type": "string",
+            "title": "Searchable Text"
+          },
           "metadata": {
             "anyOf": [
-              { "additionalProperties": true, "type": "object" },
-              { "type": "null" }
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Metadata"
           },
           "updated_at": {
             "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Updated At"
           },
           "combined_score": {
-            "anyOf": [{ "type": "number" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Combined Score"
           },
           "semantic_score": {
-            "anyOf": [{ "type": "number" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Semantic Score"
           },
           "lexical_score": {
-            "anyOf": [{ "type": "number" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Lexical Score"
           }
         },
@@ -18443,7 +25451,9 @@
       "UpdatePermissionsRequest": {
         "properties": {
           "permissions": {
-            "items": { "$ref": "#/components/schemas/APIKeyPermission" },
+            "items": {
+              "$ref": "#/components/schemas/APIKeyPermission"
+            },
             "type": "array",
             "title": "Permissions"
           }
@@ -18453,7 +25463,12 @@
         "title": "UpdatePermissionsRequest"
       },
       "UpdateSessionTitleRequest": {
-        "properties": { "title": { "type": "string", "title": "Title" } },
+        "properties": {
+          "title": {
+            "type": "string",
+            "title": "Title"
+          }
+        },
         "type": "object",
         "required": ["title"],
         "title": "UpdateSessionTitleRequest",
@@ -19092,9 +26107,18 @@
       },
       "UserAgentCostRollup": {
         "properties": {
-          "graph_id": { "type": "string", "title": "Graph Id" },
-          "cost_cents": { "type": "integer", "title": "Cost Cents" },
-          "run_count": { "type": "integer", "title": "Run Count" }
+          "graph_id": {
+            "type": "string",
+            "title": "Graph Id"
+          },
+          "cost_cents": {
+            "type": "integer",
+            "title": "Cost Cents"
+          },
+          "run_count": {
+            "type": "integer",
+            "title": "Run Count"
+          }
         },
         "type": "object",
         "required": ["graph_id", "cost_cents", "run_count"],
@@ -19103,11 +26127,25 @@
       "UserCostSummary": {
         "properties": {
           "user_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "User Id"
           },
           "email": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Email"
           },
           "total_cost_microdollars": {
@@ -19132,7 +26170,10 @@
             "title": "Total Cache Creation Tokens",
             "default": 0
           },
-          "request_count": { "type": "integer", "title": "Request Count" },
+          "request_count": {
+            "type": "integer",
+            "title": "Request Count"
+          },
           "cost_bearing_request_count": {
             "type": "integer",
             "title": "Cost Bearing Request Count",
@@ -19150,9 +26191,19 @@
       },
       "UserDailyCost": {
         "properties": {
-          "date": { "type": "string", "format": "date", "title": "Date" },
-          "cost_cents": { "type": "integer", "title": "Cost Cents" },
-          "run_count": { "type": "integer", "title": "Run Count" }
+          "date": {
+            "type": "string",
+            "format": "date",
+            "title": "Date"
+          },
+          "cost_cents": {
+            "type": "integer",
+            "title": "Cost Cents"
+          },
+          "run_count": {
+            "type": "integer",
+            "title": "Run Count"
+          }
         },
         "type": "object",
         "required": ["date", "cost_cents", "run_count"],
@@ -19160,8 +26211,14 @@
       },
       "UserExecutionCostSummary": {
         "properties": {
-          "total_cents": { "type": "integer", "title": "Total Cents" },
-          "run_count": { "type": "integer", "title": "Run Count" },
+          "total_cents": {
+            "type": "integer",
+            "title": "Total Cents"
+          },
+          "run_count": {
+            "type": "integer",
+            "title": "Run Count"
+          },
           "billable_run_count": {
             "type": "integer",
             "title": "Billable Run Count"
@@ -19171,17 +26228,23 @@
             "title": "Failed Cost Cents"
           },
           "by_agent": {
-            "items": { "$ref": "#/components/schemas/UserAgentCostRollup" },
+            "items": {
+              "$ref": "#/components/schemas/UserAgentCostRollup"
+            },
             "type": "array",
             "title": "By Agent"
           },
           "top_runs": {
-            "items": { "$ref": "#/components/schemas/UserTopRun" },
+            "items": {
+              "$ref": "#/components/schemas/UserTopRun"
+            },
             "type": "array",
             "title": "Top Runs"
           },
           "daily": {
-            "items": { "$ref": "#/components/schemas/UserDailyCost" },
+            "items": {
+              "$ref": "#/components/schemas/UserDailyCost"
+            },
             "type": "array",
             "title": "Daily"
           }
@@ -19201,11 +26264,15 @@
       "UserHistoryResponse": {
         "properties": {
           "history": {
-            "items": { "$ref": "#/components/schemas/UserTransaction" },
+            "items": {
+              "$ref": "#/components/schemas/UserTransaction"
+            },
             "type": "array",
             "title": "History"
           },
-          "pagination": { "$ref": "#/components/schemas/Pagination" }
+          "pagination": {
+            "$ref": "#/components/schemas/Pagination"
+          }
         },
         "type": "object",
         "required": ["history", "pagination"],
@@ -19214,56 +26281,111 @@
       },
       "UserOnboarding": {
         "properties": {
-          "userId": { "type": "string", "title": "Userid" },
+          "userId": {
+            "type": "string",
+            "title": "Userid"
+          },
           "completedSteps": {
-            "items": { "$ref": "#/components/schemas/OnboardingStep" },
+            "items": {
+              "$ref": "#/components/schemas/OnboardingStep"
+            },
             "type": "array",
             "title": "Completedsteps"
           },
-          "walletShown": { "type": "boolean", "title": "Walletshown" },
+          "walletShown": {
+            "type": "boolean",
+            "title": "Walletshown"
+          },
           "notified": {
-            "items": { "$ref": "#/components/schemas/OnboardingStep" },
+            "items": {
+              "$ref": "#/components/schemas/OnboardingStep"
+            },
             "type": "array",
             "title": "Notified"
           },
           "rewardedFor": {
-            "items": { "$ref": "#/components/schemas/OnboardingStep" },
+            "items": {
+              "$ref": "#/components/schemas/OnboardingStep"
+            },
             "type": "array",
             "title": "Rewardedfor"
           },
           "usageReason": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Usagereason"
           },
           "integrations": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Integrations"
           },
           "otherIntegrations": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Otherintegrations"
           },
           "selectedStoreListingVersionId": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Selectedstorelistingversionid"
           },
           "agentInput": {
             "anyOf": [
-              { "additionalProperties": true, "type": "object" },
-              { "type": "null" }
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Agentinput"
           },
           "onboardingAgentExecutionId": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Onboardingagentexecutionid"
           },
-          "agentRuns": { "type": "integer", "title": "Agentruns" },
+          "agentRuns": {
+            "type": "integer",
+            "title": "Agentruns"
+          },
           "lastRunAt": {
             "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Lastrunat"
           },
@@ -19294,47 +26416,98 @@
       "UserOnboardingUpdate": {
         "properties": {
           "walletShown": {
-            "anyOf": [{ "type": "boolean" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Walletshown"
           },
           "notified": {
             "anyOf": [
               {
-                "items": { "$ref": "#/components/schemas/OnboardingStep" },
+                "items": {
+                  "$ref": "#/components/schemas/OnboardingStep"
+                },
                 "type": "array"
               },
-              { "type": "null" }
+              {
+                "type": "null"
+              }
             ],
             "title": "Notified"
           },
           "usageReason": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Usagereason"
           },
           "integrations": {
             "anyOf": [
-              { "items": { "type": "string" }, "type": "array" },
-              { "type": "null" }
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Integrations"
           },
           "otherIntegrations": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Otherintegrations"
           },
           "selectedStoreListingVersionId": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Selectedstorelistingversionid"
           },
           "agentInput": {
             "anyOf": [
-              { "additionalProperties": true, "type": "object" },
-              { "type": "null" }
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Agentinput"
           },
           "onboardingAgentExecutionId": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Onboardingagentexecutionid"
           }
         },
@@ -19343,10 +26516,23 @@
       },
       "UserPasswordCredentials": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "provider": { "type": "string", "title": "Provider" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "provider": {
+            "type": "string",
+            "title": "Provider"
+          },
           "title": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Title"
           },
           "is_managed": {
@@ -19384,9 +26570,19 @@
       },
       "UserRateLimitResponse": {
         "properties": {
-          "user_id": { "type": "string", "title": "User Id" },
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
           "user_email": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "User Email"
           },
           "daily_cost_limit_microdollars": {
@@ -19405,7 +26601,9 @@
             "type": "integer",
             "title": "Weekly Cost Used Microdollars"
           },
-          "tier": { "$ref": "#/components/schemas/SubscriptionTier" }
+          "tier": {
+            "$ref": "#/components/schemas/SubscriptionTier"
+          }
         },
         "type": "object",
         "required": [
@@ -19443,9 +26641,19 @@
       },
       "UserSearchResult": {
         "properties": {
-          "user_id": { "type": "string", "title": "User Id" },
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
           "user_email": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "User Email"
           }
         },
@@ -19455,8 +26663,13 @@
       },
       "UserTierResponse": {
         "properties": {
-          "user_id": { "type": "string", "title": "User Id" },
-          "tier": { "$ref": "#/components/schemas/SubscriptionTier" }
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
+          "tier": {
+            "$ref": "#/components/schemas/SubscriptionTier"
+          }
         },
         "type": "object",
         "required": ["user_id", "tier"],
@@ -19464,17 +26677,34 @@
       },
       "UserTopRun": {
         "properties": {
-          "execution_id": { "type": "string", "title": "Execution Id" },
-          "graph_id": { "type": "string", "title": "Graph Id" },
-          "cost_cents": { "type": "integer", "title": "Cost Cents" },
+          "execution_id": {
+            "type": "string",
+            "title": "Execution Id"
+          },
+          "graph_id": {
+            "type": "string",
+            "title": "Graph Id"
+          },
+          "cost_cents": {
+            "type": "integer",
+            "title": "Cost Cents"
+          },
           "started_at": {
             "type": "string",
             "format": "date-time",
             "title": "Started At"
           },
-          "status": { "$ref": "#/components/schemas/AgentExecutionStatus" },
-          "duration_seconds": { "type": "number", "title": "Duration Seconds" },
-          "node_error_count": { "type": "integer", "title": "Node Error Count" }
+          "status": {
+            "$ref": "#/components/schemas/AgentExecutionStatus"
+          },
+          "duration_seconds": {
+            "type": "number",
+            "title": "Duration Seconds"
+          },
+          "node_error_count": {
+            "type": "integer",
+            "title": "Node Error Count"
+          }
         },
         "type": "object",
         "required": [
@@ -19505,7 +26735,11 @@
             "$ref": "#/components/schemas/CreditTransactionType",
             "default": "USAGE"
           },
-          "amount": { "type": "integer", "title": "Amount", "default": 0 },
+          "amount": {
+            "type": "integer",
+            "title": "Amount",
+            "default": 0
+          },
           "running_balance": {
             "type": "integer",
             "title": "Running Balance",
@@ -19517,15 +26751,36 @@
             "default": 0
           },
           "description": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Description"
           },
           "usage_graph_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Usage Graph Id"
           },
           "usage_execution_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Usage Execution Id"
           },
           "usage_node_count": {
@@ -19539,21 +26794,52 @@
             "title": "Usage Start Time",
             "default": "9999-12-31T23:59:59.999999Z"
           },
-          "user_id": { "type": "string", "title": "User Id" },
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
           "user_email": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "User Email"
           },
           "reason": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Reason"
           },
           "admin_email": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Admin Email"
           },
           "extra_data": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Extra Data"
           }
         },
@@ -19564,14 +26850,34 @@
       "ValidationError": {
         "properties": {
           "loc": {
-            "items": { "anyOf": [{ "type": "string" }, { "type": "integer" }] },
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
             "type": "array",
             "title": "Location"
           },
-          "msg": { "type": "string", "title": "Message" },
-          "type": { "type": "string", "title": "Error Type" },
-          "input": { "title": "Input" },
-          "ctx": { "type": "object", "title": "Context" }
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          },
+          "input": {
+            "title": "Input"
+          },
+          "ctx": {
+            "type": "object",
+            "title": "Context"
+          }
         },
         "type": "object",
         "required": ["loc", "msg", "type"],
@@ -19579,7 +26885,10 @@
       },
       "VapidPublicKeyResponse": {
         "properties": {
-          "public_key": { "type": "string", "title": "Public Key" }
+          "public_key": {
+            "type": "string",
+            "title": "Public Key"
+          }
         },
         "type": "object",
         "required": ["public_key"],
@@ -19587,18 +26896,35 @@
       },
       "Webhook": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "user_id": { "type": "string", "title": "User Id" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
           "provider": {
             "type": "string",
             "title": "Provider",
             "description": "Provider name for integrations. Can be any string value, including custom provider names."
           },
-          "credentials_id": { "type": "string", "title": "Credentials Id" },
-          "webhook_type": { "type": "string", "title": "Webhook Type" },
-          "resource": { "type": "string", "title": "Resource" },
+          "credentials_id": {
+            "type": "string",
+            "title": "Credentials Id"
+          },
+          "webhook_type": {
+            "type": "string",
+            "title": "Webhook Type"
+          },
+          "resource": {
+            "type": "string",
+            "title": "Resource"
+          },
           "events": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Events"
           },
@@ -19607,12 +26933,19 @@
             "type": "object",
             "title": "Config"
           },
-          "secret": { "type": "string", "title": "Secret" },
+          "secret": {
+            "type": "string",
+            "title": "Secret"
+          },
           "provider_webhook_id": {
             "type": "string",
             "title": "Provider Webhook Id"
           },
-          "url": { "type": "string", "title": "Url", "readOnly": true }
+          "url": {
+            "type": "string",
+            "title": "Url",
+            "readOnly": true
+          }
         },
         "type": "object",
         "required": [
@@ -19630,17 +26963,35 @@
       },
       "WorkspaceFileItem": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "name": { "type": "string", "title": "Name" },
-          "path": { "type": "string", "title": "Path" },
-          "mime_type": { "type": "string", "title": "Mime Type" },
-          "size_bytes": { "type": "integer", "title": "Size Bytes" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "path": {
+            "type": "string",
+            "title": "Path"
+          },
+          "mime_type": {
+            "type": "string",
+            "title": "Mime Type"
+          },
+          "size_bytes": {
+            "type": "integer",
+            "title": "Size Bytes"
+          },
           "metadata": {
             "additionalProperties": true,
             "type": "object",
             "title": "Metadata"
           },
-          "created_at": { "type": "string", "title": "Created At" }
+          "created_at": {
+            "type": "string",
+            "title": "Created At"
+          }
         },
         "type": "object",
         "required": [
@@ -19655,11 +27006,26 @@
       },
       "backend__api__features__workspace__routes__UploadFileResponse": {
         "properties": {
-          "file_id": { "type": "string", "title": "File Id" },
-          "name": { "type": "string", "title": "Name" },
-          "path": { "type": "string", "title": "Path" },
-          "mime_type": { "type": "string", "title": "Mime Type" },
-          "size_bytes": { "type": "integer", "title": "Size Bytes" }
+          "file_id": {
+            "type": "string",
+            "title": "File Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "path": {
+            "type": "string",
+            "title": "Path"
+          },
+          "mime_type": {
+            "type": "string",
+            "title": "Mime Type"
+          },
+          "size_bytes": {
+            "type": "integer",
+            "title": "Size Bytes"
+          }
         },
         "type": "object",
         "required": ["file_id", "name", "path", "mime_type", "size_bytes"],
@@ -19667,11 +27033,26 @@
       },
       "backend__api__model__UploadFileResponse": {
         "properties": {
-          "file_uri": { "type": "string", "title": "File Uri" },
-          "file_name": { "type": "string", "title": "File Name" },
-          "size": { "type": "integer", "title": "Size" },
-          "content_type": { "type": "string", "title": "Content Type" },
-          "expires_in_hours": { "type": "integer", "title": "Expires In Hours" }
+          "file_uri": {
+            "type": "string",
+            "title": "File Uri"
+          },
+          "file_name": {
+            "type": "string",
+            "title": "File Name"
+          },
+          "size": {
+            "type": "integer",
+            "title": "Size"
+          },
+          "content_type": {
+            "type": "string",
+            "title": "Content Type"
+          },
+          "expires_in_hours": {
+            "type": "integer",
+            "title": "Expires In Hours"
+          }
         },
         "type": "object",
         "required": [
@@ -19690,7 +27071,10 @@
         "in": "header",
         "name": "X-Postmark-Webhook-Token"
       },
-      "HTTPBearer": { "type": "http", "scheme": "bearer" },
+      "HTTPBearer": {
+        "type": "http",
+        "scheme": "bearer"
+      },
       "HTTPBearerJWT": {
         "type": "http",
         "scheme": "bearer",
@@ -19704,7 +27088,11 @@
           "application/json": {
             "schema": {
               "type": "object",
-              "properties": { "detail": { "type": "string" } }
+              "properties": {
+                "detail": {
+                  "type": "string"
+                }
+              }
             }
           }
         }

--- a/autogpt_platform/frontend/src/app/api/openapi.json
+++ b/autogpt_platform/frontend/src/app/api/openapi.json
@@ -13,11 +13,7 @@
         "summary": "Export Block Cost Estimates",
         "description": "Aggregate per-block average credits-per-execution over [start, end].\n\nCapped at ANALYTICS_MAX_DAYS days. Returns only blocks whose current cost\ntype is dynamic (SECOND/ITEMS/COST_USD) — static-cost blocks already\ncharge correctly pre-flight and don't need an estimate override. TOKENS\nis excluded because `compute_token_credits` already supplies a per-model\nfloor at pre-flight; a per-block historical mean would lose that\ngranularity.",
         "operationId": "getV2Export block cost estimates",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "start",
@@ -25,13 +21,8 @@
             "required": false,
             "schema": {
               "anyOf": [
-                {
-                  "type": "string",
-                  "format": "date-time"
-                },
-                {
-                  "type": "null"
-                }
+                { "type": "string", "format": "date-time" },
+                { "type": "null" }
               ],
               "description": "ISO timestamp (inclusive)",
               "title": "Start"
@@ -44,13 +35,8 @@
             "required": false,
             "schema": {
               "anyOf": [
-                {
-                  "type": "string",
-                  "format": "date-time"
-                },
-                {
-                  "type": "null"
-                }
+                { "type": "string", "format": "date-time" },
+                { "type": "null" }
               ],
               "description": "ISO timestamp (inclusive)",
               "title": "End"
@@ -89,9 +75,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -119,11 +103,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/admin/diagnostics/executions": {
@@ -147,11 +127,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/admin/diagnostics/executions/cleanup-all-orphaned": {
@@ -175,11 +151,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/admin/diagnostics/executions/cleanup-all-stuck-queued": {
@@ -203,11 +175,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/admin/diagnostics/executions/cleanup-orphaned": {
@@ -219,9 +187,7 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/StopExecutionsRequest"
-              }
+              "schema": { "$ref": "#/components/schemas/StopExecutionsRequest" }
             }
           },
           "required": true
@@ -244,18 +210,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/admin/diagnostics/executions/failed": {
@@ -264,41 +224,25 @@
         "summary": "List Failed Executions",
         "description": "Get detailed list of failed executions.\n\nArgs:\n    limit: Maximum number of executions to return (default 100)\n    offset: Number of executions to skip (default 0)\n    hours: Number of hours to look back (default 24)\n\nReturns:\n    List of failed executions with error details",
         "operationId": "getV2List failed executions",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "limit",
             "in": "query",
             "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 100,
-              "title": "Limit"
-            }
+            "schema": { "type": "integer", "default": 100, "title": "Limit" }
           },
           {
             "name": "offset",
             "in": "query",
             "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 0,
-              "title": "Offset"
-            }
+            "schema": { "type": "integer", "default": 0, "title": "Offset" }
           },
           {
             "name": "hours",
             "in": "query",
             "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 24,
-              "title": "Hours"
-            }
+            "schema": { "type": "integer", "default": 24, "title": "Hours" }
           }
         ],
         "responses": {
@@ -319,9 +263,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -334,31 +276,19 @@
         "summary": "List Invalid Executions",
         "description": "Get detailed list of executions in invalid states (READ-ONLY).\n\nInvalid states indicate data corruption and require manual investigation:\n- QUEUED but has startedAt (impossible - can't start while queued)\n- RUNNING but no startedAt (impossible - can't run without starting)\n\n⚠️ NO BULK ACTIONS PROVIDED - These need case-by-case investigation.\n\nEach invalid execution likely has a different root cause (crashes, race conditions,\nDB corruption). Investigate the execution history and logs to determine appropriate\naction (manual cleanup, status fix, or leave as-is if system recovered).\n\nArgs:\n    limit: Maximum number of executions to return (default 100)\n    offset: Number of executions to skip (default 0)\n\nReturns:\n    List of invalid state executions with details",
         "operationId": "getV2List invalid executions",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "limit",
             "in": "query",
             "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 100,
-              "title": "Limit"
-            }
+            "schema": { "type": "integer", "default": 100, "title": "Limit" }
           },
           {
             "name": "offset",
             "in": "query",
             "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 0,
-              "title": "Offset"
-            }
+            "schema": { "type": "integer", "default": 0, "title": "Offset" }
           }
         ],
         "responses": {
@@ -379,9 +309,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -394,31 +322,19 @@
         "summary": "List Long-Running Executions",
         "description": "Get detailed list of long-running executions (RUNNING status >24h).\n\nArgs:\n    limit: Maximum number of executions to return (default 100)\n    offset: Number of executions to skip (default 0)\n\nReturns:\n    List of long-running executions with details",
         "operationId": "getV2List long-running executions",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "limit",
             "in": "query",
             "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 100,
-              "title": "Limit"
-            }
+            "schema": { "type": "integer", "default": 100, "title": "Limit" }
           },
           {
             "name": "offset",
             "in": "query",
             "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 0,
-              "title": "Offset"
-            }
+            "schema": { "type": "integer", "default": 0, "title": "Offset" }
           }
         ],
         "responses": {
@@ -439,9 +355,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -454,31 +368,19 @@
         "summary": "List Orphaned Executions",
         "description": "Get detailed list of orphaned executions (>24h old, likely not in executor).\n\nArgs:\n    limit: Maximum number of executions to return (default 100)\n    offset: Number of executions to skip (default 0)\n\nReturns:\n    List of orphaned executions with details",
         "operationId": "getV2List orphaned executions",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "limit",
             "in": "query",
             "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 100,
-              "title": "Limit"
-            }
+            "schema": { "type": "integer", "default": 100, "title": "Limit" }
           },
           {
             "name": "offset",
             "in": "query",
             "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 0,
-              "title": "Offset"
-            }
+            "schema": { "type": "integer", "default": 0, "title": "Offset" }
           }
         ],
         "responses": {
@@ -499,9 +401,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -517,9 +417,7 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/StopExecutionRequest"
-              }
+              "schema": { "$ref": "#/components/schemas/StopExecutionRequest" }
             }
           },
           "required": true
@@ -542,18 +440,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/admin/diagnostics/executions/requeue-all-stuck": {
@@ -577,11 +469,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/admin/diagnostics/executions/requeue-bulk": {
@@ -593,9 +481,7 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/StopExecutionsRequest"
-              }
+              "schema": { "$ref": "#/components/schemas/StopExecutionsRequest" }
             }
           },
           "required": true
@@ -618,18 +504,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/admin/diagnostics/executions/running": {
@@ -638,31 +518,19 @@
         "summary": "List Running Executions",
         "description": "Get detailed list of running and queued executions (recent, likely active).\n\nArgs:\n    limit: Maximum number of executions to return (default 100)\n    offset: Number of executions to skip (default 0)\n\nReturns:\n    List of running executions with details",
         "operationId": "getV2List running executions",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "limit",
             "in": "query",
             "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 100,
-              "title": "Limit"
-            }
+            "schema": { "type": "integer", "default": 100, "title": "Limit" }
           },
           {
             "name": "offset",
             "in": "query",
             "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 0,
-              "title": "Offset"
-            }
+            "schema": { "type": "integer", "default": 0, "title": "Offset" }
           }
         ],
         "responses": {
@@ -683,9 +551,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -701,9 +567,7 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/StopExecutionRequest"
-              }
+              "schema": { "$ref": "#/components/schemas/StopExecutionRequest" }
             }
           },
           "required": true
@@ -726,18 +590,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/admin/diagnostics/executions/stop-all-long-running": {
@@ -761,11 +619,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/admin/diagnostics/executions/stop-bulk": {
@@ -777,9 +631,7 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/StopExecutionsRequest"
-              }
+              "schema": { "$ref": "#/components/schemas/StopExecutionsRequest" }
             }
           },
           "required": true
@@ -802,18 +654,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/admin/diagnostics/executions/stuck-queued": {
@@ -822,31 +668,19 @@
         "summary": "List Stuck Queued Executions",
         "description": "Get detailed list of stuck queued executions (QUEUED >1h, never started).\n\nArgs:\n    limit: Maximum number of executions to return (default 100)\n    offset: Number of executions to skip (default 0)\n\nReturns:\n    List of stuck queued executions with details",
         "operationId": "getV2List stuck queued executions",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "limit",
             "in": "query",
             "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 100,
-              "title": "Limit"
-            }
+            "schema": { "type": "integer", "default": 100, "title": "Limit" }
           },
           {
             "name": "offset",
             "in": "query",
             "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 0,
-              "title": "Offset"
-            }
+            "schema": { "type": "integer", "default": 0, "title": "Offset" }
           }
         ],
         "responses": {
@@ -867,9 +701,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -897,11 +729,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/admin/diagnostics/schedules/all": {
@@ -910,31 +738,19 @@
         "summary": "List All User Schedules",
         "description": "Get detailed list of all user schedules (excludes system monitoring jobs).\n\nArgs:\n    limit: Maximum number of schedules to return (default 100)\n    offset: Number of schedules to skip (default 0)\n\nReturns:\n    List of schedules with details",
         "operationId": "getV2List all user schedules",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "limit",
             "in": "query",
             "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 100,
-              "title": "Limit"
-            }
+            "schema": { "type": "integer", "default": 100, "title": "Limit" }
           },
           {
             "name": "offset",
             "in": "query",
             "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 0,
-              "title": "Offset"
-            }
+            "schema": { "type": "integer", "default": 0, "title": "Offset" }
           }
         ],
         "responses": {
@@ -955,9 +771,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -998,18 +812,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/admin/diagnostics/schedules/orphaned": {
@@ -1033,11 +841,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/admin/platform-costs/dashboard": {
@@ -1045,11 +849,7 @@
         "tags": ["v2", "admin", "platform-cost", "admin"],
         "summary": "Get Platform Cost Dashboard",
         "operationId": "getV2Get platform cost dashboard",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "start",
@@ -1057,13 +857,8 @@
             "required": false,
             "schema": {
               "anyOf": [
-                {
-                  "type": "string",
-                  "format": "date-time"
-                },
-                {
-                  "type": "null"
-                }
+                { "type": "string", "format": "date-time" },
+                { "type": "null" }
               ],
               "title": "Start"
             }
@@ -1074,13 +869,8 @@
             "required": false,
             "schema": {
               "anyOf": [
-                {
-                  "type": "string",
-                  "format": "date-time"
-                },
-                {
-                  "type": "null"
-                }
+                { "type": "string", "format": "date-time" },
+                { "type": "null" }
               ],
               "title": "End"
             }
@@ -1090,14 +880,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "Provider"
             }
           },
@@ -1106,14 +889,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "User Id"
             }
           },
@@ -1122,14 +898,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "Model"
             }
           },
@@ -1138,14 +907,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "Block Name"
             }
           },
@@ -1154,14 +916,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "Tracking Type"
             }
           },
@@ -1170,14 +925,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "Graph Exec Id"
             }
           }
@@ -1200,9 +948,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -1214,11 +960,7 @@
         "tags": ["v2", "admin", "platform-cost", "admin"],
         "summary": "Get Platform Cost Logs",
         "operationId": "getV2Get platform cost logs",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "start",
@@ -1226,13 +968,8 @@
             "required": false,
             "schema": {
               "anyOf": [
-                {
-                  "type": "string",
-                  "format": "date-time"
-                },
-                {
-                  "type": "null"
-                }
+                { "type": "string", "format": "date-time" },
+                { "type": "null" }
               ],
               "title": "Start"
             }
@@ -1243,13 +980,8 @@
             "required": false,
             "schema": {
               "anyOf": [
-                {
-                  "type": "string",
-                  "format": "date-time"
-                },
-                {
-                  "type": "null"
-                }
+                { "type": "string", "format": "date-time" },
+                { "type": "null" }
               ],
               "title": "End"
             }
@@ -1259,14 +991,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "Provider"
             }
           },
@@ -1275,14 +1000,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "User Id"
             }
           },
@@ -1314,14 +1032,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "Model"
             }
           },
@@ -1330,14 +1041,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "Block Name"
             }
           },
@@ -1346,14 +1050,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "Tracking Type"
             }
           },
@@ -1362,14 +1059,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "Graph Exec Id"
             }
           }
@@ -1392,9 +1082,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -1406,11 +1094,7 @@
         "tags": ["v2", "admin", "platform-cost", "admin"],
         "summary": "Export Platform Cost Logs",
         "operationId": "getV2Export platform cost logs",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "start",
@@ -1418,13 +1102,8 @@
             "required": false,
             "schema": {
               "anyOf": [
-                {
-                  "type": "string",
-                  "format": "date-time"
-                },
-                {
-                  "type": "null"
-                }
+                { "type": "string", "format": "date-time" },
+                { "type": "null" }
               ],
               "title": "Start"
             }
@@ -1435,13 +1114,8 @@
             "required": false,
             "schema": {
               "anyOf": [
-                {
-                  "type": "string",
-                  "format": "date-time"
-                },
-                {
-                  "type": "null"
-                }
+                { "type": "string", "format": "date-time" },
+                { "type": "null" }
               ],
               "title": "End"
             }
@@ -1451,14 +1125,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "Provider"
             }
           },
@@ -1467,14 +1134,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "User Id"
             }
           },
@@ -1483,14 +1143,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "Model"
             }
           },
@@ -1499,14 +1152,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "Block Name"
             }
           },
@@ -1515,14 +1161,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "Tracking Type"
             }
           },
@@ -1531,14 +1170,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "Graph Exec Id"
             }
           }
@@ -1561,9 +1193,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -1588,11 +1218,7 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+            "content": { "application/json": { "schema": {} } }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
@@ -1601,18 +1227,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/analytics/log_raw_metric": {
@@ -1623,9 +1243,7 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/LogRawMetricRequest"
-              }
+              "schema": { "$ref": "#/components/schemas/LogRawMetricRequest" }
             }
           },
           "required": true
@@ -1633,11 +1251,7 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+            "content": { "application/json": { "schema": {} } }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
@@ -1646,18 +1260,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/api-keys": {
@@ -1672,9 +1280,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/APIKeyInfo"
-                  },
+                  "items": { "$ref": "#/components/schemas/APIKeyInfo" },
                   "type": "array",
                   "title": "Response Getv1List User Api Keys"
                 }
@@ -1685,11 +1291,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       },
       "post": {
         "tags": ["v1", "api-keys"],
@@ -1699,9 +1301,7 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateAPIKeyRequest"
-              }
+              "schema": { "$ref": "#/components/schemas/CreateAPIKeyRequest" }
             }
           },
           "required": true
@@ -1724,18 +1324,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/api-keys/{key_id}": {
@@ -1744,20 +1338,13 @@
         "summary": "Revoke API key",
         "description": "Revoke an API key",
         "operationId": "deleteV1Revoke api key",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "key_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Key Id"
-            }
+            "schema": { "type": "string", "title": "Key Id" }
           }
         ],
         "responses": {
@@ -1765,9 +1352,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/APIKeyInfo"
-                }
+                "schema": { "$ref": "#/components/schemas/APIKeyInfo" }
               }
             }
           },
@@ -1778,9 +1363,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -1791,20 +1374,13 @@
         "summary": "Get specific API key",
         "description": "Get a specific API key",
         "operationId": "getV1Get specific api key",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "key_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Key Id"
-            }
+            "schema": { "type": "string", "title": "Key Id" }
           }
         ],
         "responses": {
@@ -1812,9 +1388,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/APIKeyInfo"
-                }
+                "schema": { "$ref": "#/components/schemas/APIKeyInfo" }
               }
             }
           },
@@ -1825,9 +1399,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -1840,20 +1412,13 @@
         "summary": "Update key permissions",
         "description": "Update API key permissions",
         "operationId": "putV1Update key permissions",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "key_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Key Id"
-            }
+            "schema": { "type": "string", "title": "Key Id" }
           }
         ],
         "requestBody": {
@@ -1871,9 +1436,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/APIKeyInfo"
-                }
+                "schema": { "$ref": "#/components/schemas/APIKeyInfo" }
               }
             }
           },
@@ -1884,9 +1447,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -1899,20 +1460,13 @@
         "summary": "Suspend API key",
         "description": "Suspend an API key",
         "operationId": "postV1Suspend api key",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "key_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Key Id"
-            }
+            "schema": { "type": "string", "title": "Key Id" }
           }
         ],
         "responses": {
@@ -1920,9 +1474,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/APIKeyInfo"
-                }
+                "schema": { "$ref": "#/components/schemas/APIKeyInfo" }
               }
             }
           },
@@ -1933,9 +1485,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -1950,21 +1500,13 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+            "content": { "application/json": { "schema": {} } }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/auth/user/email": {
@@ -1975,10 +1517,7 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "type": "string",
-                "title": "Email"
-              }
+              "schema": { "type": "string", "title": "Email" }
             }
           },
           "required": true
@@ -1989,9 +1528,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": {
-                    "type": "string"
-                  },
+                  "additionalProperties": { "type": "string" },
                   "type": "object",
                   "title": "Response Postv1Update User Email"
                 }
@@ -2005,18 +1542,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/auth/user/preferences": {
@@ -2039,11 +1570,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       },
       "post": {
         "tags": ["v1", "auth"],
@@ -2077,18 +1604,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/auth/user/timezone": {
@@ -2102,9 +1623,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TimezoneResponse"
-                }
+                "schema": { "$ref": "#/components/schemas/TimezoneResponse" }
               }
             }
           },
@@ -2112,11 +1631,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       },
       "post": {
         "tags": ["v1", "auth"],
@@ -2126,9 +1641,7 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateTimezoneRequest"
-              }
+              "schema": { "$ref": "#/components/schemas/UpdateTimezoneRequest" }
             }
           },
           "required": true
@@ -2138,9 +1651,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TimezoneResponse"
-                }
+                "schema": { "$ref": "#/components/schemas/TimezoneResponse" }
               }
             }
           },
@@ -2151,18 +1662,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/blocks": {
@@ -2176,10 +1681,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "items": {
-                    "additionalProperties": true,
-                    "type": "object"
-                  },
+                  "items": { "additionalProperties": true, "type": "object" },
                   "type": "array",
                   "title": "Response Getv1List Available Blocks"
                 }
@@ -2190,11 +1692,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/blocks/{block_id}/execute": {
@@ -2202,20 +1700,13 @@
         "tags": ["v1", "blocks"],
         "summary": "Execute graph block",
         "operationId": "postV1Execute graph block",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "block_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Block Id"
-            }
+            "schema": { "type": "string", "title": "Block Id" }
           }
         ],
         "requestBody": {
@@ -2237,10 +1728,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "additionalProperties": {
-                    "type": "array",
-                    "items": {}
-                  },
+                  "additionalProperties": { "type": "array", "items": {} },
                   "title": "Response Postv1Execute Graph Block"
                 }
               }
@@ -2256,9 +1744,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -2271,25 +1757,14 @@
         "summary": "Get Builder blocks",
         "description": "Get blocks based on either category, type, or provider.",
         "operationId": "getV2Get builder blocks",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "category",
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "Category"
             }
           },
@@ -2303,9 +1778,7 @@
                   "enum": ["all", "input", "action", "output"],
                   "type": "string"
                 },
-                {
-                  "type": "null"
-                }
+                { "type": "null" }
               ],
               "title": "Type"
             }
@@ -2320,9 +1793,7 @@
                   "type": "string",
                   "description": "Provider name for integrations. Can be any string value, including custom provider names."
                 },
-                {
-                  "type": "null"
-                }
+                { "type": "null" }
               ],
               "title": "Provider"
             }
@@ -2331,21 +1802,13 @@
             "name": "page",
             "in": "query",
             "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 1,
-              "title": "Page"
-            }
+            "schema": { "type": "integer", "default": 1, "title": "Page" }
           },
           {
             "name": "page_size",
             "in": "query",
             "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 50,
-              "title": "Page Size"
-            }
+            "schema": { "type": "integer", "default": 50, "title": "Page Size" }
           }
         ],
         "responses": {
@@ -2353,9 +1816,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BlockResponse"
-                }
+                "schema": { "$ref": "#/components/schemas/BlockResponse" }
               }
             }
           },
@@ -2366,9 +1827,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -2381,11 +1840,7 @@
         "summary": "Get specific blocks",
         "description": "Get specific blocks by their IDs.",
         "operationId": "getV2Get specific blocks",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "block_ids",
@@ -2393,9 +1848,7 @@
             "required": true,
             "schema": {
               "type": "array",
-              "items": {
-                "type": "string"
-              },
+              "items": { "type": "string" },
               "title": "Block Ids"
             }
           }
@@ -2407,9 +1860,7 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/BlockInfo"
-                  },
+                  "items": { "$ref": "#/components/schemas/BlockInfo" },
                   "title": "Response Getv2Get Specific Blocks"
                 }
               }
@@ -2422,9 +1873,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -2437,11 +1886,7 @@
         "summary": "Get Builder block categories",
         "description": "Get all block categories with a specified number of blocks per category.",
         "operationId": "getV2Get builder block categories",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "blocks_per_category",
@@ -2476,9 +1921,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -2496,9 +1939,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CountResponse"
-                }
+                "schema": { "$ref": "#/components/schemas/CountResponse" }
               }
             }
           },
@@ -2506,11 +1947,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/builder/providers": {
@@ -2519,31 +1956,19 @@
         "summary": "Get Builder integration providers",
         "description": "Get all integration providers with their block counts.",
         "operationId": "getV2Get builder integration providers",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "page",
             "in": "query",
             "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 1,
-              "title": "Page"
-            }
+            "schema": { "type": "integer", "default": 1, "title": "Page" }
           },
           {
             "name": "page_size",
             "in": "query",
             "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 50,
-              "title": "Page Size"
-            }
+            "schema": { "type": "integer", "default": 50, "title": "Page Size" }
           }
         ],
         "responses": {
@@ -2551,9 +1976,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProviderResponse"
-                }
+                "schema": { "$ref": "#/components/schemas/ProviderResponse" }
               }
             }
           },
@@ -2564,9 +1987,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -2579,25 +2000,14 @@
         "summary": "Builder search",
         "description": "Search for blocks (including integrations), marketplace agents, and user library agents.",
         "operationId": "getV2Builder search",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "search_query",
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "Search Query"
             }
           },
@@ -2606,14 +2016,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "Filter"
             }
           },
@@ -2622,14 +2025,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "Search Id"
             }
           },
@@ -2639,15 +2035,8 @@
             "required": false,
             "schema": {
               "anyOf": [
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                {
-                  "type": "null"
-                }
+                { "type": "array", "items": { "type": "string" } },
+                { "type": "null" }
               ],
               "title": "By Creator"
             }
@@ -2656,21 +2045,13 @@
             "name": "page",
             "in": "query",
             "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 1,
-              "title": "Page"
-            }
+            "schema": { "type": "integer", "default": 1, "title": "Page" }
           },
           {
             "name": "page_size",
             "in": "query",
             "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 50,
-              "title": "Page Size"
-            }
+            "schema": { "type": "integer", "default": 50, "title": "Page Size" }
           }
         ],
         "responses": {
@@ -2678,9 +2059,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SearchResponse"
-                }
+                "schema": { "$ref": "#/components/schemas/SearchResponse" }
               }
             }
           },
@@ -2691,9 +2070,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -2711,9 +2088,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SuggestionsResponse"
-                }
+                "schema": { "$ref": "#/components/schemas/SuggestionsResponse" }
               }
             }
           },
@@ -2721,11 +2096,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/chat/config/ttl": {
@@ -2785,90 +2156,48 @@
               "application/json": {
                 "schema": {
                   "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/AgentsFoundResponse"
-                    },
-                    {
-                      "$ref": "#/components/schemas/NoResultsResponse"
-                    },
-                    {
-                      "$ref": "#/components/schemas/AgentDetailsResponse"
-                    },
+                    { "$ref": "#/components/schemas/AgentsFoundResponse" },
+                    { "$ref": "#/components/schemas/NoResultsResponse" },
+                    { "$ref": "#/components/schemas/AgentDetailsResponse" },
                     {
                       "$ref": "#/components/schemas/SetupRequirementsResponse"
                     },
-                    {
-                      "$ref": "#/components/schemas/ExecutionStartedResponse"
-                    },
-                    {
-                      "$ref": "#/components/schemas/NeedLoginResponse"
-                    },
-                    {
-                      "$ref": "#/components/schemas/ErrorResponse"
-                    },
+                    { "$ref": "#/components/schemas/ExecutionStartedResponse" },
+                    { "$ref": "#/components/schemas/NeedLoginResponse" },
+                    { "$ref": "#/components/schemas/ErrorResponse" },
                     {
                       "$ref": "#/components/schemas/InputValidationErrorResponse"
                     },
-                    {
-                      "$ref": "#/components/schemas/AgentOutputResponse"
-                    },
+                    { "$ref": "#/components/schemas/AgentOutputResponse" },
                     {
                       "$ref": "#/components/schemas/UnderstandingUpdatedResponse"
                     },
-                    {
-                      "$ref": "#/components/schemas/AgentPreviewResponse"
-                    },
-                    {
-                      "$ref": "#/components/schemas/AgentSavedResponse"
-                    },
+                    { "$ref": "#/components/schemas/AgentPreviewResponse" },
+                    { "$ref": "#/components/schemas/AgentSavedResponse" },
                     {
                       "$ref": "#/components/schemas/ClarificationNeededResponse"
                     },
-                    {
-                      "$ref": "#/components/schemas/SuggestedGoalResponse"
-                    },
-                    {
-                      "$ref": "#/components/schemas/BlockListResponse"
-                    },
-                    {
-                      "$ref": "#/components/schemas/BlockDetailsResponse"
-                    },
-                    {
-                      "$ref": "#/components/schemas/BlockOutputResponse"
-                    },
-                    {
-                      "$ref": "#/components/schemas/DocSearchResultsResponse"
-                    },
-                    {
-                      "$ref": "#/components/schemas/DocPageResponse"
-                    },
+                    { "$ref": "#/components/schemas/SuggestedGoalResponse" },
+                    { "$ref": "#/components/schemas/BlockListResponse" },
+                    { "$ref": "#/components/schemas/BlockDetailsResponse" },
+                    { "$ref": "#/components/schemas/BlockOutputResponse" },
+                    { "$ref": "#/components/schemas/DocSearchResultsResponse" },
+                    { "$ref": "#/components/schemas/DocPageResponse" },
                     {
                       "$ref": "#/components/schemas/MCPToolsDiscoveredResponse"
                     },
-                    {
-                      "$ref": "#/components/schemas/MCPToolOutputResponse"
-                    },
-                    {
-                      "$ref": "#/components/schemas/ScheduleListResponse"
-                    },
-                    {
-                      "$ref": "#/components/schemas/ScheduleDeletedResponse"
-                    },
-                    {
-                      "$ref": "#/components/schemas/MemoryStoreResponse"
-                    },
-                    {
-                      "$ref": "#/components/schemas/MemorySearchResponse"
-                    },
+                    { "$ref": "#/components/schemas/MCPToolOutputResponse" },
+                    { "$ref": "#/components/schemas/ScheduleListResponse" },
+                    { "$ref": "#/components/schemas/ScheduleDeletedResponse" },
+                    { "$ref": "#/components/schemas/MemoryStoreResponse" },
+                    { "$ref": "#/components/schemas/MemorySearchResponse" },
                     {
                       "$ref": "#/components/schemas/MemoryForgetCandidatesResponse"
                     },
                     {
                       "$ref": "#/components/schemas/MemoryForgetConfirmResponse"
                     },
-                    {
-                      "$ref": "#/components/schemas/TodoWriteResponse"
-                    }
+                    { "$ref": "#/components/schemas/TodoWriteResponse" }
                   ],
                   "title": "Response Getv2[Dummy] Tool Response Type Export For Codegen"
                 }
@@ -2884,11 +2213,7 @@
         "summary": "List Sessions",
         "description": "List chat sessions for the authenticated user.\n\nReturns a paginated list of chat sessions belonging to the current user,\nordered by most recently updated.\n\nArgs:\n    user_id: The authenticated user's ID.\n    limit: Maximum number of sessions to return (1-100).\n    offset: Number of sessions to skip for pagination.\n\nReturns:\n    ListSessionsResponse: List of session summaries and total count.",
         "operationId": "getV2ListSessions",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "limit",
@@ -2932,9 +2257,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -2945,22 +2268,14 @@
         "summary": "Create Session",
         "description": "Create (or get-or-create) a chat session.\n\nTwo modes, selected by the request body:\n\n- Default: create a fresh session for the user. ``dry_run=True`` forces\n  run_block and run_agent calls to use dry-run simulation.\n- Builder-bound: when ``builder_graph_id`` is set, get-or-create keyed\n  on ``(user_id, builder_graph_id)``. Returns the existing session for\n  that graph or creates one locked to it.  Graph ownership is validated\n  inside :func:`get_or_create_builder_session`; raises 404 on\n  unauthorized access.  Write-side scope is enforced per-tool\n  (``edit_agent`` / ``run_agent`` reject any ``agent_id`` other than\n  the bound graph) and a small blacklist hides tools that conflict\n  with the panel's scope (see :data:`BUILDER_BLOCKED_TOOLS`).\n\nArgs:\n    user_id: The authenticated user ID parsed from the JWT (required).\n    request: Optional request body with ``dry_run`` and/or\n        ``builder_graph_id``.\n\nReturns:\n    CreateSessionResponse: Details of the resulting session.",
         "operationId": "postV2CreateSession",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
                 "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/CreateSessionRequest"
-                  },
-                  {
-                    "type": "null"
-                  }
+                  { "$ref": "#/components/schemas/CreateSessionRequest" },
+                  { "type": "null" }
                 ],
                 "title": "Request"
               }
@@ -2985,9 +2300,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -3000,39 +2313,26 @@
         "summary": "Delete Session",
         "description": "Delete a chat session.\n\nPermanently removes a chat session and all its messages.\nOnly the owner can delete their sessions.\n\nArgs:\n    session_id: The session ID to delete.\n    user_id: The authenticated user's ID.\n\nReturns:\n    204 No Content on success.\n\nRaises:\n    HTTPException: 404 if session not found or not owned by user.",
         "operationId": "deleteV2DeleteSession",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "session_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Session Id"
-            }
+            "schema": { "type": "string", "title": "Session Id" }
           }
         ],
         "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
+          "204": { "description": "Successful Response" },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
-          "404": {
-            "description": "Session not found or access denied"
-          },
+          "404": { "description": "Session not found or access denied" },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -3043,20 +2343,13 @@
         "summary": "Get Session",
         "description": "Retrieve the details of a specific chat session.\n\nSupports cursor-based pagination via ``limit`` and ``before_sequence``.\nWhen no pagination params are provided, returns the most recent messages.",
         "operationId": "getV2GetSession",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "session_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Session Id"
-            }
+            "schema": { "type": "string", "title": "Session Id" }
           },
           {
             "name": "limit",
@@ -3076,13 +2369,8 @@
             "required": false,
             "schema": {
               "anyOf": [
-                {
-                  "type": "integer",
-                  "minimum": 0
-                },
-                {
-                  "type": "null"
-                }
+                { "type": "integer", "minimum": 0 },
+                { "type": "null" }
               ],
               "title": "Before Sequence"
             }
@@ -3106,9 +2394,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -3121,20 +2407,13 @@
         "summary": "Session Assign User",
         "description": "Assign an authenticated user to a chat session.\n\nUsed (typically post-login) to claim an existing anonymous session as the current authenticated user.\n\nArgs:\n    session_id: The identifier for the (previously anonymous) session.\n    user_id: The authenticated user's ID to associate with the session.\n\nReturns:\n    dict: Status of the assignment.",
         "operationId": "patchV2SessionAssignUser",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "session_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Session Id"
-            }
+            "schema": { "type": "string", "title": "Session Id" }
           }
         ],
         "responses": {
@@ -3157,9 +2436,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -3172,20 +2449,13 @@
         "summary": "Cancel Session Task",
         "description": "Cancel an in-flight task for a session.\n\nHandles both lifecycle states uniformly:\n\n* **Queued** (``chatStatus='queued'``) — the dispatcher hasn't\n  claimed the row yet.  Flip the session back to ``idle`` and\n  return; no executor cancel event needed.\n* **Running** (``chatStatus='running'``) — publish a cancel event\n  to the executor via RabbitMQ FANOUT, then poll Redis until the\n  task status flips out of ``running`` or a 5 s timeout is hit.",
         "operationId": "postV2CancelSessionTask",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "session_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Session Id"
-            }
+            "schema": { "type": "string", "title": "Session Id" }
           }
         ],
         "responses": {
@@ -3206,9 +2476,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -3221,20 +2489,13 @@
         "summary": "Get Pending Messages",
         "description": "Peek at the pending-message buffer without consuming it.\n\nReturns the current contents of the session's pending message buffer\nso the frontend can restore the queued-message indicator after a page\nrefresh and clear it correctly once a turn drains the buffer.",
         "operationId": "getV2GetPendingMessages",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "session_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Session Id"
-            }
+            "schema": { "type": "string", "title": "Session Id" }
           }
         ],
         "responses": {
@@ -3251,16 +2512,12 @@
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
-          "404": {
-            "description": "Session not found or access denied"
-          },
+          "404": { "description": "Session not found or access denied" },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -3271,20 +2528,13 @@
         "summary": "Queue Pending Message",
         "description": "Queue a follow-up message while the session has an active turn.",
         "operationId": "postV2QueuePendingMessage",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "session_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Session Id"
-            }
+            "schema": { "type": "string", "title": "Session Id" }
           }
         ],
         "requestBody": {
@@ -3311,9 +2561,7 @@
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
-          "404": {
-            "description": "Session not found or access denied"
-          },
+          "404": { "description": "Session not found or access denied" },
           "409": {
             "description": "Session has no active turn to receive pending messages"
           },
@@ -3321,15 +2569,11 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           },
-          "429": {
-            "description": "Call-frequency cap exceeded"
-          },
+          "429": { "description": "Call-frequency cap exceeded" },
           "503": {
             "description": "Chat service degraded (Redis unavailable); client should honour the Retry-After header before retrying."
           }
@@ -3342,26 +2586,17 @@
         "summary": "Disconnect Session Stream",
         "description": "Disconnect all active SSE listeners for a session.\n\nCalled by the frontend when the user switches away from a chat so the\nbackend releases XREAD listeners immediately rather than waiting for\nthe 5-10 s timeout.",
         "operationId": "deleteV2DisconnectSessionStream",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "session_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Session Id"
-            }
+            "schema": { "type": "string", "title": "Session Id" }
           }
         ],
         "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
+          "204": { "description": "Successful Response" },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
@@ -3369,9 +2604,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -3382,30 +2615,19 @@
         "summary": "Resume Session Stream",
         "description": "Resume an active stream for a session.\n\nCalled by the AI SDK's ``useChat(resume: true)`` on page load.\nChecks for an active (in-progress) task on the session and either replays\nthe full SSE stream or returns 204 No Content if nothing is running.\n\nAlways replays the active turn from ``0-0``. The AI SDK UI-message parser\nkeeps text/reasoning part state inside a single parser instance; resuming\nfrom a Redis cursor can skip the ``*-start`` events required by later\n``*-delta`` chunks.",
         "operationId": "getV2ResumeSessionStream",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "session_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Session Id"
-            }
+            "schema": { "type": "string", "title": "Session Id" }
           }
         ],
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+            "content": { "application/json": { "schema": {} } }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
@@ -3414,9 +2636,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -3427,40 +2647,27 @@
         "summary": "Stream Chat Post",
         "description": "Start a new turn and return an AI SDK UI message stream.\n\nReturns an SSE stream (``text/event-stream``) with Vercel AI SDK chunks\n(text fragments, tool-call UI, tool results). The generation runs in a\nbackground task that survives client disconnects; reconnect via\n``GET /sessions/{session_id}/stream`` to resume.\n\nFollow-up messages typed while a turn is already running should use\n``POST /sessions/{session_id}/messages/pending``. If an older client still\nposts that follow-up here, we queue it defensively but still return a valid\nempty UI-message stream so AI SDK transports never receive a JSON body from\nthe stream endpoint.\n\nArgs:\n    session_id: The chat session identifier.\n    request: Request body with message, is_user_message, and optional context.\n    user_id: Authenticated user ID.",
         "operationId": "postV2StreamChatPost",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "session_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Session Id"
-            }
+            "schema": { "type": "string", "title": "Session Id" }
           }
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/StreamChatRequest"
-              }
+              "schema": { "$ref": "#/components/schemas/StreamChatRequest" }
             }
           }
         },
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+            "content": { "application/json": { "schema": {} } }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
@@ -3468,16 +2675,12 @@
           "402": {
             "description": "Subscription required (NO_TIER user, paywall on)"
           },
-          "404": {
-            "description": "Session not found or access denied"
-          },
+          "404": { "description": "Session not found or access denied" },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           },
@@ -3496,20 +2699,13 @@
         "summary": "Update session title",
         "description": "Update the title of a chat session.\n\nAllows the user to rename their chat session.\n\nArgs:\n    session_id: The session ID to update.\n    request: Request body containing the new title.\n    user_id: The authenticated user's ID.\n\nReturns:\n    dict: Status of the update.\n\nRaises:\n    HTTPException: 404 if session not found or not owned by user.",
         "operationId": "patchV2Update session title",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "session_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Session Id"
-            }
+            "schema": { "type": "string", "title": "Session Id" }
           }
         ],
         "requestBody": {
@@ -3538,16 +2734,12 @@
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
-          "404": {
-            "description": "Session not found or access denied"
-          },
+          "404": { "description": "Session not found or access denied" },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -3575,11 +2767,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/chat/usage": {
@@ -3593,9 +2781,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CoPilotUsagePublic"
-                }
+                "schema": { "$ref": "#/components/schemas/CoPilotUsagePublic" }
               }
             }
           },
@@ -3603,11 +2789,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/chat/usage/reset": {
@@ -3633,9 +2815,7 @@
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
-          "402": {
-            "description": "Payment Required (insufficient credits)"
-          },
+          "402": { "description": "Payment Required (insufficient credits)" },
           "429": {
             "description": "Too Many Requests (max daily resets exceeded or reset in progress)"
           },
@@ -3643,11 +2823,7 @@
             "description": "Service Unavailable (Redis reset failed; credits refunded or support needed)"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/copilot/admin/rate_limit": {
@@ -3656,25 +2832,14 @@
         "summary": "Get User Rate Limit",
         "description": "Get a user's current usage and effective rate limits. Admin-only.\n\nAccepts either ``user_id`` or ``email`` as a query parameter.\nWhen ``email`` is provided the user is looked up by email first.",
         "operationId": "getV2Get user rate limit",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "user_id",
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "User Id"
             }
           },
@@ -3683,14 +2848,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "Email"
             }
           }
@@ -3713,9 +2871,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -3756,18 +2912,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/copilot/admin/rate_limit/search_users": {
@@ -3776,30 +2926,19 @@
         "summary": "Search Users by Name or Email",
         "description": "Search users by partial email or name. Admin-only.\n\nQueries the User table directly — returns results even for users\nwithout credit transaction history.",
         "operationId": "getV2Search users by name or email",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "query",
             "in": "query",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Query"
-            }
+            "schema": { "type": "string", "title": "Query" }
           },
           {
             "name": "limit",
             "in": "query",
             "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 20,
-              "title": "Limit"
-            }
+            "schema": { "type": "integer", "default": 20, "title": "Limit" }
           }
         ],
         "responses": {
@@ -3809,9 +2948,7 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/UserSearchResult"
-                  },
+                  "items": { "$ref": "#/components/schemas/UserSearchResult" },
                   "title": "Response Getv2Search Users By Name Or Email"
                 }
               }
@@ -3824,9 +2961,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -3839,20 +2974,13 @@
         "summary": "Get User Rate Limit Tier",
         "description": "Get a user's current rate-limit tier. Admin-only.\n\nReturns 404 if the user does not exist in the database.",
         "operationId": "getV2Get user rate limit tier",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "user_id",
             "in": "query",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "User Id"
-            }
+            "schema": { "type": "string", "title": "User Id" }
           }
         ],
         "responses": {
@@ -3860,9 +2988,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UserTierResponse"
-                }
+                "schema": { "$ref": "#/components/schemas/UserTierResponse" }
               }
             }
           },
@@ -3873,9 +2999,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -3886,18 +3010,12 @@
         "summary": "Set User Rate Limit Tier",
         "description": "Set a user's rate-limit tier. Admin-only.\n\nReturns 404 if the user does not exist in the database.",
         "operationId": "postV2Set user rate limit tier",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SetUserTierRequest"
-              }
+              "schema": { "$ref": "#/components/schemas/SetUserTierRequest" }
             }
           }
         },
@@ -3906,9 +3024,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UserTierResponse"
-                }
+                "schema": { "$ref": "#/components/schemas/UserTierResponse" }
               }
             }
           },
@@ -3919,9 +3035,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -3939,9 +3053,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": {
-                    "type": "integer"
-                  },
+                  "additionalProperties": { "type": "integer" },
                   "type": "object",
                   "title": "Response Getv1Get User Credits"
                 }
@@ -3952,11 +3064,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       },
       "patch": {
         "tags": ["v1", "credits"],
@@ -3965,21 +3073,13 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+            "content": { "application/json": { "schema": {} } }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       },
       "post": {
         "tags": ["v1", "credits"],
@@ -3988,9 +3088,7 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/RequestTopUp"
-              }
+              "schema": { "$ref": "#/components/schemas/RequestTopUp" }
             }
           },
           "required": true
@@ -3998,11 +3096,7 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+            "content": { "application/json": { "schema": {} } }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
@@ -4011,18 +3105,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/credits/admin/add_credits": {
@@ -4058,18 +3146,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/credits/admin/copilot-usage/export": {
@@ -4078,11 +3160,7 @@
         "summary": "Export Copilot Weekly Usage vs Rate Limit",
         "description": "Export per-(user, ISO week) copilot spend with the user's tier limit.\n\nUses the same 90-day window cap and 100k row cap as the credit export.",
         "operationId": "getV2Export copilot weekly usage vs rate limit",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "start",
@@ -4090,13 +3168,8 @@
             "required": false,
             "schema": {
               "anyOf": [
-                {
-                  "type": "string",
-                  "format": "date-time"
-                },
-                {
-                  "type": "null"
-                }
+                { "type": "string", "format": "date-time" },
+                { "type": "null" }
               ],
               "description": "ISO timestamp (inclusive)",
               "title": "Start"
@@ -4109,13 +3182,8 @@
             "required": false,
             "schema": {
               "anyOf": [
-                {
-                  "type": "string",
-                  "format": "date-time"
-                },
-                {
-                  "type": "null"
-                }
+                { "type": "string", "format": "date-time" },
+                { "type": "null" }
               ],
               "description": "ISO timestamp (inclusive)",
               "title": "End"
@@ -4141,9 +3209,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -4156,11 +3222,7 @@
         "summary": "Export Credit Transactions",
         "description": "Export CreditTransaction rows in [start, end].\n\nCapped at CREDIT_EXPORT_MAX_DAYS days and CREDIT_EXPORT_MAX_ROWS rows;\nover-cap requests fail fast with 400 so callers narrow the window\ninstead of receiving silently truncated data.",
         "operationId": "getV2Export credit transactions",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "start",
@@ -4168,13 +3230,8 @@
             "required": false,
             "schema": {
               "anyOf": [
-                {
-                  "type": "string",
-                  "format": "date-time"
-                },
-                {
-                  "type": "null"
-                }
+                { "type": "string", "format": "date-time" },
+                { "type": "null" }
               ],
               "description": "ISO timestamp (inclusive)",
               "title": "Start"
@@ -4187,13 +3244,8 @@
             "required": false,
             "schema": {
               "anyOf": [
-                {
-                  "type": "string",
-                  "format": "date-time"
-                },
-                {
-                  "type": "null"
-                }
+                { "type": "string", "format": "date-time" },
+                { "type": "null" }
               ],
               "description": "ISO timestamp (inclusive)",
               "title": "End"
@@ -4206,12 +3258,8 @@
             "required": false,
             "schema": {
               "anyOf": [
-                {
-                  "$ref": "#/components/schemas/CreditTransactionType"
-                },
-                {
-                  "type": "null"
-                }
+                { "$ref": "#/components/schemas/CreditTransactionType" },
+                { "type": "null" }
               ],
               "title": "Transaction Type"
             }
@@ -4221,14 +3269,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "User Id"
             }
           },
@@ -4263,9 +3304,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -4277,25 +3316,14 @@
         "tags": ["v2", "admin", "credits", "admin"],
         "summary": "Get All Users History",
         "operationId": "getV2Get all users history",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "search",
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "Search"
             }
           },
@@ -4303,21 +3331,13 @@
             "name": "page",
             "in": "query",
             "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 1,
-              "title": "Page"
-            }
+            "schema": { "type": "integer", "default": 1, "title": "Page" }
           },
           {
             "name": "page_size",
             "in": "query",
             "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 20,
-              "title": "Page Size"
-            }
+            "schema": { "type": "integer", "default": 20, "title": "Page Size" }
           },
           {
             "name": "transaction_filter",
@@ -4325,12 +3345,8 @@
             "required": false,
             "schema": {
               "anyOf": [
-                {
-                  "$ref": "#/components/schemas/CreditTransactionType"
-                },
-                {
-                  "type": "null"
-                }
+                { "$ref": "#/components/schemas/CreditTransactionType" },
+                { "type": "null" }
               ],
               "title": "Transaction Filter"
             }
@@ -4351,9 +3367,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UserHistoryResponse"
-                }
+                "schema": { "$ref": "#/components/schemas/UserHistoryResponse" }
               }
             }
           },
@@ -4364,9 +3378,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -4383,9 +3395,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AutoTopUpConfig"
-                }
+                "schema": { "$ref": "#/components/schemas/AutoTopUpConfig" }
               }
             }
           },
@@ -4393,11 +3403,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       },
       "post": {
         "tags": ["v1", "credits"],
@@ -4407,9 +3413,7 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AutoTopUpConfig"
-              }
+              "schema": { "$ref": "#/components/schemas/AutoTopUpConfig" }
             }
           },
           "required": true
@@ -4433,18 +3437,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/credits/invoices": {
@@ -4453,11 +3451,7 @@
         "summary": "List Stripe invoices",
         "description": "Recent Stripe invoices for the current user.\n\nEach item includes ``hosted_invoice_url`` (Stripe-hosted view) and\n``invoice_pdf_url`` (direct PDF download). Returns an empty list when\nthe credit system is disabled or the user has no Stripe customer yet.",
         "operationId": "getV1List stripe invoices",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "limit",
@@ -4479,9 +3473,7 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/InvoiceListItem"
-                  },
+                  "items": { "$ref": "#/components/schemas/InvoiceListItem" },
                   "title": "Response Getv1List Stripe Invoices"
                 }
               }
@@ -4494,9 +3486,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -4514,9 +3504,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": {
-                    "type": "string"
-                  },
+                  "additionalProperties": { "type": "string" },
                   "type": "object",
                   "title": "Response Getv1Manage Payment Methods"
                 }
@@ -4527,11 +3515,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/credits/refunds": {
@@ -4545,9 +3529,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/RefundRequest"
-                  },
+                  "items": { "$ref": "#/components/schemas/RefundRequest" },
                   "type": "array",
                   "title": "Response Getv1Get Refund Requests"
                 }
@@ -4558,11 +3540,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/credits/stripe_webhook": {
@@ -4573,11 +3551,7 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+            "content": { "application/json": { "schema": {} } }
           }
         }
       }
@@ -4602,11 +3576,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       },
       "post": {
         "tags": ["v1", "credits"],
@@ -4640,18 +3610,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/credits/transactions": {
@@ -4659,11 +3623,7 @@
         "tags": ["v1", "credits"],
         "summary": "Get credit history",
         "operationId": "getV1Get credit history",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "transaction_time",
@@ -4671,13 +3631,8 @@
             "required": false,
             "schema": {
               "anyOf": [
-                {
-                  "type": "string",
-                  "format": "date-time"
-                },
-                {
-                  "type": "null"
-                }
+                { "type": "string", "format": "date-time" },
+                { "type": "null" }
               ],
               "title": "Transaction Time"
             }
@@ -4687,14 +3642,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "Transaction Type"
             }
           },
@@ -4714,9 +3662,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TransactionHistory"
-                }
+                "schema": { "$ref": "#/components/schemas/TransactionHistory" }
               }
             }
           },
@@ -4727,9 +3673,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -4741,20 +3685,13 @@
         "tags": ["v1", "credits"],
         "summary": "Refund credit transaction",
         "operationId": "postV1Refund credit transaction",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "transaction_key",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Transaction Key"
-            }
+            "schema": { "type": "string", "title": "Transaction Key" }
           }
         ],
         "requestBody": {
@@ -4763,9 +3700,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "additionalProperties": {
-                  "type": "string"
-                },
+                "additionalProperties": { "type": "string" },
                 "title": "Metadata"
               }
             }
@@ -4790,9 +3725,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -4809,21 +3742,13 @@
             "application/json": {
               "schema": {
                 "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/PostmarkDeliveryWebhook"
-                  },
-                  {
-                    "$ref": "#/components/schemas/PostmarkBounceWebhook"
-                  },
+                  { "$ref": "#/components/schemas/PostmarkDeliveryWebhook" },
+                  { "$ref": "#/components/schemas/PostmarkBounceWebhook" },
                   {
                     "$ref": "#/components/schemas/PostmarkSpamComplaintWebhook"
                   },
-                  {
-                    "$ref": "#/components/schemas/PostmarkOpenWebhook"
-                  },
-                  {
-                    "$ref": "#/components/schemas/PostmarkClickWebhook"
-                  },
+                  { "$ref": "#/components/schemas/PostmarkOpenWebhook" },
+                  { "$ref": "#/components/schemas/PostmarkClickWebhook" },
                   {
                     "$ref": "#/components/schemas/PostmarkSubscriptionChangeWebhook"
                   }
@@ -4848,28 +3773,18 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+            "content": { "application/json": { "schema": {} } }
           },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "APIKeyAuthenticator-X-Postmark-Webhook-Token": []
-          }
-        ]
+        "security": [{ "APIKeyAuthenticator-X-Postmark-Webhook-Token": [] }]
       }
     },
     "/api/email/unsubscribe": {
@@ -4882,28 +3797,19 @@
             "name": "token",
             "in": "query",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Token"
-            }
+            "schema": { "type": "string", "title": "Token" }
           }
         ],
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+            "content": { "application/json": { "schema": {} } }
           },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -4934,11 +3840,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/executions/admin/execution_accuracy_trends": {
@@ -4947,34 +3849,20 @@
         "summary": "Get Execution Accuracy Trends and Alerts",
         "description": "Get execution accuracy trends with moving averages and alert detection.\nSimple single-query approach.",
         "operationId": "getV2Get execution accuracy trends and alerts",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "graph_id",
             "in": "query",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Graph Id"
-            }
+            "schema": { "type": "string", "title": "Graph Id" }
           },
           {
             "name": "user_id",
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "User Id"
             }
           },
@@ -4982,11 +3870,7 @@
             "name": "days_back",
             "in": "query",
             "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 30,
-              "title": "Days Back"
-            }
+            "schema": { "type": "integer", "default": 30, "title": "Days Back" }
           },
           {
             "name": "drop_threshold",
@@ -5027,9 +3911,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -5070,18 +3952,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/executions/admin/execution_analytics/config": {
@@ -5105,11 +3981,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/executions/cost-summary": {
@@ -5118,11 +3990,7 @@
         "summary": "User cost summary",
         "description": "Aggregated cost breakdown for the calling user's graph executions.",
         "operationId": "getV1User cost summary",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "since",
@@ -5130,13 +3998,8 @@
             "required": false,
             "schema": {
               "anyOf": [
-                {
-                  "type": "string",
-                  "format": "date-time"
-                },
-                {
-                  "type": "null"
-                }
+                { "type": "string", "format": "date-time" },
+                { "type": "null" }
               ],
               "description": "Window start (UTC). Defaults to start of current calendar month.",
               "title": "Since"
@@ -5149,13 +4012,8 @@
             "required": false,
             "schema": {
               "anyOf": [
-                {
-                  "type": "string",
-                  "format": "date-time"
-                },
-                {
-                  "type": "null"
-                }
+                { "type": "string", "format": "date-time" },
+                { "type": "null" }
               ],
               "description": "Window end (UTC). Defaults to now.",
               "title": "Until"
@@ -5195,9 +4053,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -5209,26 +4065,17 @@
         "tags": ["v1", "graphs"],
         "summary": "Delete graph execution",
         "operationId": "deleteV1Delete graph execution",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "graph_exec_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Graph Exec Id"
-            }
+            "schema": { "type": "string", "title": "Graph Exec Id" }
           }
         ],
         "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
+          "204": { "description": "Successful Response" },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
@@ -5236,9 +4083,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -5251,11 +4096,7 @@
         "summary": "Upload file to cloud storage",
         "description": "Upload a file to cloud storage and return a storage key that can be used\nwith FileStoreBlock and AgentFileInputBlock.\n\nArgs:\n    file: The file to upload\n    user_id: The user ID\n    provider: Cloud storage provider (\"gcs\", \"s3\", \"azure\")\n    expiration_hours: Hours until file expires (1-48)\n\nReturns:\n    Dict containing the cloud storage path and signed URL",
         "operationId": "postV1Upload file to cloud storage",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "expiration_hours",
@@ -5296,9 +4137,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -5316,9 +4155,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/GraphMeta"
-                  },
+                  "items": { "$ref": "#/components/schemas/GraphMeta" },
                   "type": "array",
                   "title": "Response Getv1List User Graphs"
                 }
@@ -5329,11 +4166,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       },
       "post": {
         "tags": ["v1", "graphs"],
@@ -5342,9 +4175,7 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateGraph"
-              }
+              "schema": { "$ref": "#/components/schemas/CreateGraph" }
             }
           },
           "required": true
@@ -5354,9 +4185,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GraphModel"
-                }
+                "schema": { "$ref": "#/components/schemas/GraphModel" }
               }
             }
           },
@@ -5367,18 +4196,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/graphs/{graph_id}": {
@@ -5386,20 +4209,13 @@
         "tags": ["v1", "graphs"],
         "summary": "Delete graph permanently",
         "operationId": "deleteV1Delete graph permanently",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "graph_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Graph Id"
-            }
+            "schema": { "type": "string", "title": "Graph Id" }
           }
         ],
         "responses": {
@@ -5407,9 +4223,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/DeleteGraphResponse"
-                }
+                "schema": { "$ref": "#/components/schemas/DeleteGraphResponse" }
               }
             }
           },
@@ -5420,9 +4234,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -5432,34 +4244,20 @@
         "tags": ["v1", "graphs"],
         "summary": "Get specific graph",
         "operationId": "getV1Get specific graph",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "graph_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Graph Id"
-            }
+            "schema": { "type": "string", "title": "Graph Id" }
           },
           {
             "name": "version",
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "integer" }, { "type": "null" }],
               "title": "Version"
             }
           },
@@ -5479,9 +4277,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GraphModel"
-                }
+                "schema": { "$ref": "#/components/schemas/GraphModel" }
               }
             }
           },
@@ -5492,9 +4288,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -5504,29 +4298,20 @@
         "tags": ["v1", "graphs"],
         "summary": "Update graph version",
         "operationId": "putV1Update graph version",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "graph_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Graph Id"
-            }
+            "schema": { "type": "string", "title": "Graph Id" }
           }
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Graph"
-              }
+              "schema": { "$ref": "#/components/schemas/Graph" }
             }
           }
         },
@@ -5535,9 +4320,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GraphModel"
-                }
+                "schema": { "$ref": "#/components/schemas/GraphModel" }
               }
             }
           },
@@ -5548,9 +4331,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -5562,34 +4343,20 @@
         "tags": ["v1", "graphs"],
         "summary": "Execute graph agent",
         "operationId": "postV1Execute graph agent",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "graph_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Graph Id"
-            }
+            "schema": { "type": "string", "title": "Graph Id" }
           },
           {
             "name": "graph_version",
             "in": "path",
             "required": true,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "integer" }, { "type": "null" }],
               "title": "Graph Version"
             }
           },
@@ -5598,14 +4365,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "Preset Id"
             }
           }
@@ -5624,9 +4384,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GraphExecutionMeta"
-                }
+                "schema": { "$ref": "#/components/schemas/GraphExecutionMeta" }
               }
             }
           },
@@ -5640,15 +4398,11 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           },
-          "503": {
-            "description": "Subscription state temporarily unavailable"
-          }
+          "503": { "description": "Subscription state temporarily unavailable" }
         }
       }
     },
@@ -5657,20 +4411,13 @@
         "tags": ["v1", "graphs"],
         "summary": "List graph executions",
         "operationId": "getV1List graph executions",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "graph_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Graph Id"
-            }
+            "schema": { "type": "string", "title": "Graph Id" }
           },
           {
             "name": "page",
@@ -5718,9 +4465,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -5732,29 +4477,19 @@
         "tags": ["v1", "graphs"],
         "summary": "Get execution details",
         "operationId": "getV1Get execution details",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "graph_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Graph Id"
-            }
+            "schema": { "type": "string", "title": "Graph Id" }
           },
           {
             "name": "graph_exec_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Graph Exec Id"
-            }
+            "schema": { "type": "string", "title": "Graph Exec Id" }
           }
         ],
         "responses": {
@@ -5764,12 +4499,8 @@
               "application/json": {
                 "schema": {
                   "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/GraphExecution"
-                    },
-                    {
-                      "$ref": "#/components/schemas/GraphExecutionWithNodes"
-                    }
+                    { "$ref": "#/components/schemas/GraphExecution" },
+                    { "$ref": "#/components/schemas/GraphExecutionWithNodes" }
                   ],
                   "title": "Response Getv1Get Execution Details"
                 }
@@ -5783,9 +4514,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -5798,35 +4527,23 @@
         "summary": "Disable Execution Sharing",
         "description": "Disable sharing for a graph execution.",
         "operationId": "deleteV1DisableExecutionSharing",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "graph_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Graph Id"
-            }
+            "schema": { "type": "string", "title": "Graph Id" }
           },
           {
             "name": "graph_exec_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Graph Exec Id"
-            }
+            "schema": { "type": "string", "title": "Graph Exec Id" }
           }
         ],
         "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
+          "204": { "description": "Successful Response" },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
@@ -5834,9 +4551,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -5847,29 +4562,19 @@
         "summary": "Enable Execution Sharing",
         "description": "Enable sharing for a graph execution.",
         "operationId": "postV1EnableExecutionSharing",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "graph_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Graph Id"
-            }
+            "schema": { "type": "string", "title": "Graph Id" }
           },
           {
             "name": "graph_exec_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Graph Exec Id"
-            }
+            "schema": { "type": "string", "title": "Graph Exec Id" }
           }
         ],
         "requestBody": {
@@ -5887,9 +4592,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ShareResponse"
-                }
+                "schema": { "$ref": "#/components/schemas/ShareResponse" }
               }
             }
           },
@@ -5900,9 +4603,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -5914,29 +4615,19 @@
         "tags": ["v1", "graphs"],
         "summary": "Stop graph execution",
         "operationId": "postV1Stop graph execution",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "graph_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Graph Id"
-            }
+            "schema": { "type": "string", "title": "Graph Id" }
           },
           {
             "name": "graph_exec_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Graph Exec Id"
-            }
+            "schema": { "type": "string", "title": "Graph Exec Id" }
           }
         ],
         "responses": {
@@ -5946,12 +4637,8 @@
               "application/json": {
                 "schema": {
                   "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/GraphExecutionMeta"
-                    },
-                    {
-                      "type": "null"
-                    }
+                    { "$ref": "#/components/schemas/GraphExecutionMeta" },
+                    { "type": "null" }
                   ],
                   "title": "Response Postv1Stop Graph Execution"
                 }
@@ -5965,9 +4652,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -5979,20 +4664,13 @@
         "tags": ["v1", "schedules"],
         "summary": "List execution schedules for a graph",
         "operationId": "getV1List execution schedules for a graph",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "graph_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Graph Id"
-            }
+            "schema": { "type": "string", "title": "Graph Id" }
           }
         ],
         "responses": {
@@ -6017,9 +4695,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -6029,11 +4705,7 @@
         "tags": ["v1", "schedules"],
         "summary": "Create execution schedule",
         "operationId": "postV1Create execution schedule",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "graph_id",
@@ -6075,9 +4747,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -6090,29 +4760,20 @@
         "summary": "Update graph settings",
         "description": "Update graph settings for the user's library agent.",
         "operationId": "patchV1Update graph settings",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "graph_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Graph Id"
-            }
+            "schema": { "type": "string", "title": "Graph Id" }
           }
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/GraphSettings"
-              }
+              "schema": { "$ref": "#/components/schemas/GraphSettings" }
             }
           }
         },
@@ -6121,9 +4782,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GraphSettings"
-                }
+                "schema": { "$ref": "#/components/schemas/GraphSettings" }
               }
             }
           },
@@ -6134,9 +4793,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -6148,20 +4805,13 @@
         "tags": ["v1", "graphs"],
         "summary": "Get all graph versions",
         "operationId": "getV1Get all graph versions",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "graph_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Graph Id"
-            }
+            "schema": { "type": "string", "title": "Graph Id" }
           }
         ],
         "responses": {
@@ -6171,9 +4821,7 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/GraphModel"
-                  },
+                  "items": { "$ref": "#/components/schemas/GraphModel" },
                   "title": "Response Getv1Get All Graph Versions"
                 }
               }
@@ -6186,9 +4834,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -6200,40 +4846,27 @@
         "tags": ["v1", "graphs"],
         "summary": "Set active graph version",
         "operationId": "putV1Set active graph version",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "graph_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Graph Id"
-            }
+            "schema": { "type": "string", "title": "Graph Id" }
           }
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SetGraphActiveVersion"
-              }
+              "schema": { "$ref": "#/components/schemas/SetGraphActiveVersion" }
             }
           }
         },
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+            "content": { "application/json": { "schema": {} } }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
@@ -6242,9 +4875,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -6256,34 +4887,20 @@
         "tags": ["v1", "graphs"],
         "summary": "Get graph version",
         "operationId": "getV1Get graph version",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "graph_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Graph Id"
-            }
+            "schema": { "type": "string", "title": "Graph Id" }
           },
           {
             "name": "version",
             "in": "path",
             "required": true,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "integer" }, { "type": "null" }],
               "title": "Version"
             }
           },
@@ -6303,9 +4920,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GraphModel"
-                }
+                "schema": { "$ref": "#/components/schemas/GraphModel" }
               }
             }
           },
@@ -6316,9 +4931,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -6336,9 +4949,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AyrshareSSOResponse"
-                }
+                "schema": { "$ref": "#/components/schemas/AyrshareSSOResponse" }
               }
             }
           },
@@ -6346,11 +4957,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/integrations/credentials": {
@@ -6377,11 +4984,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/integrations/providers": {
@@ -6396,9 +4999,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/ProviderMetadata"
-                  },
+                  "items": { "$ref": "#/components/schemas/ProviderMetadata" },
                   "type": "array",
                   "title": "Response Getv1Listproviders"
                 }
@@ -6419,9 +5020,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProviderConstants"
-                }
+                "schema": { "$ref": "#/components/schemas/ProviderConstants" }
               }
             }
           }
@@ -6480,9 +5079,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "items": {
-                    "type": "string"
-                  },
+                  "items": { "type": "string" },
                   "type": "array",
                   "title": "Response Getv1Listsystemproviders"
                 }
@@ -6497,30 +5094,19 @@
         "tags": ["v1", "integrations"],
         "summary": "Webhook Ping",
         "operationId": "postV1WebhookPing",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "webhook_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Our ID for the webhook"
-            }
+            "schema": { "type": "string", "title": "Our ID for the webhook" }
           }
         ],
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+            "content": { "application/json": { "schema": {} } }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
@@ -6529,9 +5115,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -6543,11 +5127,7 @@
         "tags": ["v1", "integrations"],
         "summary": "Exchange OAuth code for tokens",
         "operationId": "postV1Exchange oauth code for tokens",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "provider",
@@ -6588,9 +5168,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -6602,11 +5180,7 @@
         "tags": ["v1", "integrations"],
         "summary": "List Credentials By Provider",
         "operationId": "getV1ListCredentialsByProvider",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "provider",
@@ -6641,9 +5215,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -6653,11 +5225,7 @@
         "tags": ["v1", "integrations"],
         "summary": "Create Credentials",
         "operationId": "postV1Create credentials",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "provider",
@@ -6676,18 +5244,10 @@
             "application/json": {
               "schema": {
                 "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/OAuth2Credentials"
-                  },
-                  {
-                    "$ref": "#/components/schemas/APIKeyCredentials"
-                  },
-                  {
-                    "$ref": "#/components/schemas/UserPasswordCredentials"
-                  },
-                  {
-                    "$ref": "#/components/schemas/HostScopedCredentials"
-                  }
+                  { "$ref": "#/components/schemas/OAuth2Credentials" },
+                  { "$ref": "#/components/schemas/APIKeyCredentials" },
+                  { "$ref": "#/components/schemas/UserPasswordCredentials" },
+                  { "$ref": "#/components/schemas/HostScopedCredentials" }
                 ],
                 "discriminator": {
                   "propertyName": "type",
@@ -6721,9 +5281,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -6735,11 +5293,7 @@
         "tags": ["v1", "integrations"],
         "summary": "Delete Credentials",
         "operationId": "deleteV1DeleteCredentials",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "provider",
@@ -6797,9 +5351,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -6809,11 +5361,7 @@
         "tags": ["v1", "integrations"],
         "summary": "Get Specific Credential By ID",
         "operationId": "getV1Get specific credential by id",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "provider",
@@ -6853,9 +5401,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -6868,11 +5414,7 @@
         "summary": "Issue a short-lived access token for a provider-hosted picker",
         "description": "Return the raw access token for an OAuth2 credential so the frontend\ncan initialize a provider-hosted picker (e.g. Google Drive Picker).\n\n`GET /{provider}/credentials/{cred_id}` deliberately strips secrets (see\n`CredentialsMetaResponse` + `TestGetCredentialReturnsMetaOnly` in\n`router_test.py`). That hardening broke the Drive picker, which needs the\nraw access token to call `google.picker.Builder.setOAuthToken(...)`. This\nendpoint carves a narrow, explicit hole: the caller must own the\ncredential, it must be OAuth2, and the endpoint returns only the access\ntoken + its expiry — nothing else about the credential. SDK-default\ncredentials are excluded for the same reason as `get_credential`.",
         "operationId": "postV1GetPickerToken",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "provider",
@@ -6899,9 +5441,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PickerTokenResponse"
-                }
+                "schema": { "$ref": "#/components/schemas/PickerTokenResponse" }
               }
             }
           },
@@ -6912,9 +5452,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -6926,11 +5464,7 @@
         "tags": ["v1", "integrations"],
         "summary": "Initiate OAuth flow",
         "operationId": "getV1Initiate oauth flow",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "provider",
@@ -6957,14 +5491,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "ID of existing credential to upgrade scopes for"
             }
           }
@@ -6974,9 +5501,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LoginResponse"
-                }
+                "schema": { "$ref": "#/components/schemas/LoginResponse" }
               }
             }
           },
@@ -6987,9 +5512,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -7016,28 +5539,19 @@
             "name": "webhook_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Our ID for the webhook"
-            }
+            "schema": { "type": "string", "title": "Our ID for the webhook" }
           }
         ],
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+            "content": { "application/json": { "schema": {} } }
           },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -7050,25 +5564,14 @@
         "summary": "List Library Agents",
         "description": "Get all agents in the user's library (both created and saved).",
         "operationId": "getV2List library agents",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "search_term",
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "description": "Search term to filter agents",
               "title": "Search Term"
             },
@@ -7116,14 +5619,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "description": "Filter by folder ID",
               "title": "Folder Id"
             },
@@ -7146,14 +5642,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "boolean" }, { "type": "null" }],
               "description": "Filter by hidden status. True = only hidden, False = only non-hidden, omit = all agents.",
               "title": "Is Hidden"
             },
@@ -7178,9 +5667,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -7191,11 +5678,7 @@
         "summary": "Add Marketplace Agent",
         "description": "Add an agent from the marketplace to the user's library.",
         "operationId": "postV2Add marketplace agent",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "requestBody": {
           "required": true,
           "content": {
@@ -7211,9 +5694,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LibraryAgent"
-                }
+                "schema": { "$ref": "#/components/schemas/LibraryAgent" }
               }
             }
           },
@@ -7224,9 +5705,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -7238,34 +5717,20 @@
         "tags": ["v2", "library", "private"],
         "summary": "Get Library Agent By Graph Id",
         "operationId": "getV2GetLibraryAgentByGraphId",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "graph_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Graph Id"
-            }
+            "schema": { "type": "string", "title": "Graph Id" }
           },
           {
             "name": "version",
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "integer" }, { "type": "null" }],
               "title": "Version"
             }
           }
@@ -7275,9 +5740,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LibraryAgent"
-                }
+                "schema": { "$ref": "#/components/schemas/LibraryAgent" }
               }
             }
           },
@@ -7288,9 +5751,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -7303,11 +5764,7 @@
         "summary": "List Favorite Library Agents",
         "description": "Get all favorite agents in the user's library.",
         "operationId": "getV2List favorite library agents",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "page",
@@ -7354,9 +5811,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -7369,20 +5824,13 @@
         "summary": "Get Agent By Store ID",
         "description": "Get Library Agent from Store Listing Version ID.",
         "operationId": "getV2Get agent by store id",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "store_listing_version_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Store Listing Version Id"
-            }
+            "schema": { "type": "string", "title": "Store Listing Version Id" }
           }
         ],
         "responses": {
@@ -7392,12 +5840,8 @@
               "application/json": {
                 "schema": {
                   "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/LibraryAgent"
-                    },
-                    {
-                      "type": "null"
-                    }
+                    { "$ref": "#/components/schemas/LibraryAgent" },
+                    { "type": "null" }
                   ],
                   "title": "Response Getv2Get Agent By Store Id"
                 }
@@ -7411,9 +5855,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -7426,30 +5868,19 @@
         "summary": "Delete Library Agent",
         "description": "Soft-delete the specified library agent.",
         "operationId": "deleteV2Delete library agent",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "library_agent_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Library Agent Id"
-            }
+            "schema": { "type": "string", "title": "Library Agent Id" }
           }
         ],
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+            "content": { "application/json": { "schema": {} } }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
@@ -7458,9 +5889,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -7470,20 +5899,13 @@
         "tags": ["v2", "library", "private"],
         "summary": "Get Library Agent",
         "operationId": "getV2Get library agent",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "library_agent_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Library Agent Id"
-            }
+            "schema": { "type": "string", "title": "Library Agent Id" }
           }
         ],
         "responses": {
@@ -7491,9 +5913,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LibraryAgent"
-                }
+                "schema": { "$ref": "#/components/schemas/LibraryAgent" }
               }
             }
           },
@@ -7504,9 +5924,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -7517,20 +5935,13 @@
         "summary": "Update Library Agent",
         "description": "Update the library agent with the given fields.",
         "operationId": "patchV2Update library agent",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "library_agent_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Library Agent Id"
-            }
+            "schema": { "type": "string", "title": "Library Agent Id" }
           }
         ],
         "requestBody": {
@@ -7548,9 +5959,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LibraryAgent"
-                }
+                "schema": { "$ref": "#/components/schemas/LibraryAgent" }
               }
             }
           },
@@ -7561,9 +5970,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -7575,20 +5982,13 @@
         "tags": ["v2", "library", "private"],
         "summary": "Fork Library Agent",
         "operationId": "postV2Fork library agent",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "library_agent_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Library Agent Id"
-            }
+            "schema": { "type": "string", "title": "Library Agent Id" }
           }
         ],
         "responses": {
@@ -7596,9 +5996,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LibraryAgent"
-                }
+                "schema": { "$ref": "#/components/schemas/LibraryAgent" }
               }
             }
           },
@@ -7609,9 +6007,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -7624,20 +6020,13 @@
         "summary": "List Trigger Agents",
         "description": "List trigger agents linked to the given parent agent.",
         "operationId": "getV2List trigger agents",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "library_agent_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Library Agent Id"
-            }
+            "schema": { "type": "string", "title": "Library Agent Id" }
           }
         ],
         "responses": {
@@ -7647,9 +6036,7 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/LibraryAgent"
-                  },
+                  "items": { "$ref": "#/components/schemas/LibraryAgent" },
                   "title": "Response Getv2List Trigger Agents"
                 }
               }
@@ -7662,9 +6049,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -7677,25 +6062,14 @@
         "summary": "List Library Folders",
         "description": "List folders for the authenticated user.\n\nArgs:\n    user_id: ID of the authenticated user.\n    parent_id: Optional parent folder ID to filter by.\n    include_relations: Whether to include agent and subfolder relations for counts.\n\nReturns:\n    A FolderListResponse containing folders.",
         "operationId": "getV2List library folders",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "parent_id",
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "description": "Filter by parent folder ID. If not provided, returns root-level folders.",
               "title": "Parent Id"
             },
@@ -7719,9 +6093,7 @@
             "description": "List of folders",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FolderListResponse"
-                }
+                "schema": { "$ref": "#/components/schemas/FolderListResponse" }
               }
             }
           },
@@ -7732,15 +6104,11 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           },
-          "500": {
-            "description": "Server error"
-          }
+          "500": { "description": "Server error" }
         }
       },
       "post": {
@@ -7748,18 +6116,12 @@
         "summary": "Create Folder",
         "description": "Create a new folder.\n\nArgs:\n    payload: The folder creation request.\n    user_id: ID of the authenticated user.\n\nReturns:\n    The created LibraryFolder.",
         "operationId": "postV2Create folder",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/FolderCreateRequest"
-              }
+              "schema": { "$ref": "#/components/schemas/FolderCreateRequest" }
             }
           }
         },
@@ -7768,37 +6130,25 @@
             "description": "Folder created successfully",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LibraryFolder"
-                }
+                "schema": { "$ref": "#/components/schemas/LibraryFolder" }
               }
             }
           },
-          "400": {
-            "description": "Validation error"
-          },
+          "400": { "description": "Validation error" },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
-          "404": {
-            "description": "Parent folder not found"
-          },
-          "409": {
-            "description": "Folder name conflict"
-          },
+          "404": { "description": "Parent folder not found" },
+          "409": { "description": "Folder name conflict" },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           },
-          "500": {
-            "description": "Server error"
-          }
+          "500": { "description": "Server error" }
         }
       }
     },
@@ -7811,9 +6161,7 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/BulkMoveAgentsRequest"
-              }
+              "schema": { "$ref": "#/components/schemas/BulkMoveAgentsRequest" }
             }
           },
           "required": true
@@ -7824,9 +6172,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/LibraryAgent"
-                  },
+                  "items": { "$ref": "#/components/schemas/LibraryAgent" },
                   "type": "array",
                   "title": "Response Postv2Bulk Move Agents"
                 }
@@ -7836,28 +6182,18 @@
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
-          "404": {
-            "description": "Folder not found"
-          },
+          "404": { "description": "Folder not found" },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           },
-          "500": {
-            "description": "Server error"
-          }
+          "500": { "description": "Server error" }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/library/folders/tree": {
@@ -7871,24 +6207,16 @@
             "description": "Folder tree structure",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FolderTreeResponse"
-                }
+                "schema": { "$ref": "#/components/schemas/FolderTreeResponse" }
               }
             }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
-          "500": {
-            "description": "Server error"
-          }
+          "500": { "description": "Server error" }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/library/folders/{folder_id}": {
@@ -7897,45 +6225,30 @@
         "summary": "Delete Folder",
         "description": "Soft-delete a folder and all its contents.\n\nArgs:\n    folder_id: ID of the folder to delete.\n    user_id: ID of the authenticated user.\n\nReturns:\n    204 No Content if successful.",
         "operationId": "deleteV2Delete folder",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "folder_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Folder Id"
-            }
+            "schema": { "type": "string", "title": "Folder Id" }
           }
         ],
         "responses": {
-          "204": {
-            "description": "Folder deleted successfully"
-          },
+          "204": { "description": "Folder deleted successfully" },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
-          "404": {
-            "description": "Folder not found"
-          },
+          "404": { "description": "Folder not found" },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           },
-          "500": {
-            "description": "Server error"
-          }
+          "500": { "description": "Server error" }
         }
       },
       "get": {
@@ -7943,20 +6256,13 @@
         "summary": "Get Folder",
         "description": "Get a specific folder.\n\nArgs:\n    folder_id: ID of the folder to retrieve.\n    user_id: ID of the authenticated user.\n\nReturns:\n    The requested LibraryFolder.",
         "operationId": "getV2Get folder",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "folder_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Folder Id"
-            }
+            "schema": { "type": "string", "title": "Folder Id" }
           }
         ],
         "responses": {
@@ -7964,31 +6270,23 @@
             "description": "Folder details",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LibraryFolder"
-                }
+                "schema": { "$ref": "#/components/schemas/LibraryFolder" }
               }
             }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
-          "404": {
-            "description": "Folder not found"
-          },
+          "404": { "description": "Folder not found" },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           },
-          "500": {
-            "description": "Server error"
-          }
+          "500": { "description": "Server error" }
         }
       },
       "patch": {
@@ -7996,29 +6294,20 @@
         "summary": "Update Folder",
         "description": "Update a folder's properties.\n\nArgs:\n    folder_id: ID of the folder to update.\n    payload: The folder update request.\n    user_id: ID of the authenticated user.\n\nReturns:\n    The updated LibraryFolder.",
         "operationId": "patchV2Update folder",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "folder_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Folder Id"
-            }
+            "schema": { "type": "string", "title": "Folder Id" }
           }
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/FolderUpdateRequest"
-              }
+              "schema": { "$ref": "#/components/schemas/FolderUpdateRequest" }
             }
           }
         },
@@ -8027,37 +6316,25 @@
             "description": "Folder updated successfully",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LibraryFolder"
-                }
+                "schema": { "$ref": "#/components/schemas/LibraryFolder" }
               }
             }
           },
-          "400": {
-            "description": "Validation error"
-          },
+          "400": { "description": "Validation error" },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
-          "404": {
-            "description": "Folder not found"
-          },
-          "409": {
-            "description": "Folder name conflict"
-          },
+          "404": { "description": "Folder not found" },
+          "409": { "description": "Folder name conflict" },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           },
-          "500": {
-            "description": "Server error"
-          }
+          "500": { "description": "Server error" }
         }
       }
     },
@@ -8067,29 +6344,20 @@
         "summary": "Move Folder",
         "description": "Move a folder to a new parent.\n\nArgs:\n    folder_id: ID of the folder to move.\n    payload: The move request with target parent.\n    user_id: ID of the authenticated user.\n\nReturns:\n    The moved LibraryFolder.",
         "operationId": "postV2Move folder",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "folder_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Folder Id"
-            }
+            "schema": { "type": "string", "title": "Folder Id" }
           }
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/FolderMoveRequest"
-              }
+              "schema": { "$ref": "#/components/schemas/FolderMoveRequest" }
             }
           }
         },
@@ -8098,37 +6366,25 @@
             "description": "Folder moved successfully",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LibraryFolder"
-                }
+                "schema": { "$ref": "#/components/schemas/LibraryFolder" }
               }
             }
           },
-          "400": {
-            "description": "Validation error (circular reference)"
-          },
+          "400": { "description": "Validation error (circular reference)" },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
-          "404": {
-            "description": "Folder or target parent not found"
-          },
-          "409": {
-            "description": "Folder name conflict in target location"
-          },
+          "404": { "description": "Folder or target parent not found" },
+          "409": { "description": "Folder name conflict in target location" },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           },
-          "500": {
-            "description": "Server error"
-          }
+          "500": { "description": "Server error" }
         }
       }
     },
@@ -8138,11 +6394,7 @@
         "summary": "List presets",
         "description": "Retrieve a paginated list of presets for the current user.",
         "operationId": "getV2List presets",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "page",
@@ -8171,14 +6423,7 @@
             "in": "query",
             "required": true,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "description": "Allows to filter presets by a specific agent graph",
               "title": "Graph Id"
             },
@@ -8203,9 +6448,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -8216,11 +6459,7 @@
         "summary": "Create a new preset",
         "description": "Create a new preset for the current user.",
         "operationId": "postV2Create a new preset",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "requestBody": {
           "required": true,
           "content": {
@@ -8244,9 +6483,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LibraryAgentPreset"
-                }
+                "schema": { "$ref": "#/components/schemas/LibraryAgentPreset" }
               }
             }
           },
@@ -8257,9 +6494,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -8287,9 +6522,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LibraryAgentPreset"
-                }
+                "schema": { "$ref": "#/components/schemas/LibraryAgentPreset" }
               }
             }
           },
@@ -8300,18 +6533,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/library/presets/{preset_id}": {
@@ -8320,26 +6547,17 @@
         "summary": "Delete a preset",
         "description": "Delete an existing preset by its ID.",
         "operationId": "deleteV2Delete a preset",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "preset_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Preset Id"
-            }
+            "schema": { "type": "string", "title": "Preset Id" }
           }
         ],
         "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
+          "204": { "description": "Successful Response" },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
@@ -8347,9 +6565,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -8360,20 +6576,13 @@
         "summary": "Get a specific preset",
         "description": "Retrieve details for a specific preset by its ID.",
         "operationId": "getV2Get a specific preset",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "preset_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Preset Id"
-            }
+            "schema": { "type": "string", "title": "Preset Id" }
           }
         ],
         "responses": {
@@ -8381,9 +6590,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LibraryAgentPreset"
-                }
+                "schema": { "$ref": "#/components/schemas/LibraryAgentPreset" }
               }
             }
           },
@@ -8394,9 +6601,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -8407,20 +6612,13 @@
         "summary": "Update an existing preset",
         "description": "Update an existing preset by its ID.",
         "operationId": "patchV2Update an existing preset",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "preset_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Preset Id"
-            }
+            "schema": { "type": "string", "title": "Preset Id" }
           }
         ],
         "requestBody": {
@@ -8438,9 +6636,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LibraryAgentPreset"
-                }
+                "schema": { "$ref": "#/components/schemas/LibraryAgentPreset" }
               }
             }
           },
@@ -8451,9 +6647,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -8466,20 +6660,13 @@
         "summary": "Execute a preset",
         "description": "Execute a preset with the given graph and node input for the current user.",
         "operationId": "postV2Execute a preset",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "preset_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Preset Id"
-            }
+            "schema": { "type": "string", "title": "Preset Id" }
           }
         ],
         "requestBody": {
@@ -8496,9 +6683,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GraphExecutionMeta"
-                }
+                "schema": { "$ref": "#/components/schemas/GraphExecutionMeta" }
               }
             }
           },
@@ -8512,15 +6697,11 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           },
-          "503": {
-            "description": "Subscription state temporarily unavailable"
-          }
+          "503": { "description": "Subscription state temporarily unavailable" }
         }
       }
     },
@@ -8533,9 +6714,7 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/DiscoverToolsRequest"
-              }
+              "schema": { "$ref": "#/components/schemas/DiscoverToolsRequest" }
             }
           },
           "required": true
@@ -8558,18 +6737,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/mcp/oauth/callback": {
@@ -8606,18 +6779,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/mcp/oauth/login": {
@@ -8629,9 +6796,7 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/MCPOAuthLoginRequest"
-              }
+              "schema": { "$ref": "#/components/schemas/MCPOAuthLoginRequest" }
             }
           },
           "required": true
@@ -8654,18 +6819,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/mcp/token": {
@@ -8677,9 +6836,7 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/MCPStoreTokenRequest"
-              }
+              "schema": { "$ref": "#/components/schemas/MCPStoreTokenRequest" }
             }
           },
           "required": true
@@ -8702,18 +6859,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/oauth/app/{client_id}": {
@@ -8722,20 +6873,13 @@
         "summary": "Get Oauth App Info",
         "description": "Get public information about an OAuth application.\n\nThis endpoint is used by the consent screen to display application details\nto the user before they authorize access.\n\nReturns:\n- name: Application name\n- description: Application description (if provided)\n- scopes: List of scopes the application is allowed to request",
         "operationId": "getOauthGetOauthAppInfo",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "client_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Client Id"
-            }
+            "schema": { "type": "string", "title": "Client Id" }
           }
         ],
         "responses": {
@@ -8752,16 +6896,12 @@
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
-          "404": {
-            "description": "Application not found or disabled"
-          },
+          "404": { "description": "Application not found or disabled" },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -8793,11 +6933,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/oauth/apps/{app_id}/logo": {
@@ -8806,29 +6942,20 @@
         "summary": "Update App Logo",
         "description": "Update the logo URL for an OAuth application.\n\nOnly the application owner can update the logo.\nThe logo should be uploaded first using the media upload endpoint,\nthen this endpoint is called with the resulting URL.\n\nLogo requirements:\n- Must be square (1:1 aspect ratio)\n- Minimum 512x512 pixels\n- Maximum 2048x2048 pixels\n\nReturns the updated application info.",
         "operationId": "patchOauthUpdateAppLogo",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "app_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "App Id"
-            }
+            "schema": { "type": "string", "title": "App Id" }
           }
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateAppLogoRequest"
-              }
+              "schema": { "$ref": "#/components/schemas/UpdateAppLogoRequest" }
             }
           }
         },
@@ -8850,9 +6977,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -8865,20 +6990,13 @@
         "summary": "Upload App Logo",
         "description": "Upload a logo image for an OAuth application.\n\nRequirements:\n- Image must be square (1:1 aspect ratio)\n- Minimum 512x512 pixels\n- Maximum 2048x2048 pixels\n- Allowed formats: JPEG, PNG, WebP\n- Maximum file size: 3MB\n\nThe image is uploaded to cloud storage and the app's logoUrl is updated.\nReturns the updated application info.",
         "operationId": "postOauthUploadAppLogo",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "app_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "App Id"
-            }
+            "schema": { "type": "string", "title": "App Id" }
           }
         ],
         "requestBody": {
@@ -8909,9 +7027,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -8924,20 +7040,13 @@
         "summary": "Update App Status",
         "description": "Enable or disable an OAuth application.\n\nOnly the application owner can update the status.\nWhen disabled, the application cannot be used for new authorizations\nand existing access tokens will fail validation.\n\nReturns the updated application info.",
         "operationId": "patchOauthUpdateAppStatus",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "app_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "App Id"
-            }
+            "schema": { "type": "string", "title": "App Id" }
           }
         ],
         "requestBody": {
@@ -8968,9 +7077,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -8986,9 +7093,7 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AuthorizeRequest"
-              }
+              "schema": { "$ref": "#/components/schemas/AuthorizeRequest" }
             }
           },
           "required": true
@@ -8998,9 +7103,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AuthorizeResponse"
-                }
+                "schema": { "$ref": "#/components/schemas/AuthorizeResponse" }
               }
             }
           },
@@ -9011,18 +7114,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/oauth/introspect": {
@@ -9056,9 +7153,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -9074,9 +7169,7 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Body_postOauthRevoke"
-              }
+              "schema": { "$ref": "#/components/schemas/Body_postOauthRevoke" }
             }
           },
           "required": true
@@ -9084,19 +7177,13 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+            "content": { "application/json": { "schema": {} } }
           },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -9114,12 +7201,8 @@
             "application/json": {
               "schema": {
                 "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/TokenRequestByCode"
-                  },
-                  {
-                    "$ref": "#/components/schemas/TokenRequestByRefreshToken"
-                  }
+                  { "$ref": "#/components/schemas/TokenRequestByCode" },
+                  { "$ref": "#/components/schemas/TokenRequestByRefreshToken" }
                 ],
                 "title": "Request"
               }
@@ -9132,9 +7215,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TokenResponse"
-                }
+                "schema": { "$ref": "#/components/schemas/TokenResponse" }
               }
             }
           },
@@ -9142,9 +7223,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -9161,9 +7240,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UserOnboarding"
-                }
+                "schema": { "$ref": "#/components/schemas/UserOnboarding" }
               }
             }
           },
@@ -9171,11 +7248,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       },
       "patch": {
         "tags": ["v1", "onboarding"],
@@ -9184,9 +7257,7 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UserOnboardingUpdate"
-              }
+              "schema": { "$ref": "#/components/schemas/UserOnboardingUpdate" }
             }
           },
           "required": true
@@ -9196,9 +7267,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UserOnboarding"
-                }
+                "schema": { "$ref": "#/components/schemas/UserOnboarding" }
               }
             }
           },
@@ -9209,18 +7278,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/onboarding/agents": {
@@ -9234,9 +7297,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/StoreAgentDetails"
-                  },
+                  "items": { "$ref": "#/components/schemas/StoreAgentDetails" },
                   "type": "array",
                   "title": "Response Getv1Recommended Onboarding Agents"
                 }
@@ -9247,11 +7308,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/onboarding/completed": {
@@ -9274,11 +7331,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/onboarding/profile": {
@@ -9299,11 +7352,7 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+            "content": { "application/json": { "schema": {} } }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
@@ -9312,18 +7361,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/onboarding/reset": {
@@ -9336,9 +7379,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UserOnboarding"
-                }
+                "schema": { "$ref": "#/components/schemas/UserOnboarding" }
               }
             }
           },
@@ -9346,11 +7387,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/onboarding/step": {
@@ -9358,11 +7395,7 @@
         "tags": ["v1", "onboarding"],
         "summary": "Complete onboarding step",
         "operationId": "postV1Complete onboarding step",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "step",
@@ -9388,11 +7421,7 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+            "content": { "application/json": { "schema": {} } }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
@@ -9401,9 +7430,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -9419,9 +7446,7 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ChatRequest"
-              }
+              "schema": { "$ref": "#/components/schemas/ChatRequest" }
             }
           },
           "required": true
@@ -9431,9 +7456,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
+                "schema": { "$ref": "#/components/schemas/ApiResponse" }
               }
             }
           },
@@ -9444,18 +7467,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/platform-linking/links": {
@@ -9469,9 +7486,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/PlatformLinkInfo"
-                  },
+                  "items": { "$ref": "#/components/schemas/PlatformLinkInfo" },
                   "type": "array",
                   "title": "Response Getplatform-Linkinglist All Platform Servers Linked To The Authenticated User"
                 }
@@ -9482,11 +7497,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/platform-linking/links/{link_id}": {
@@ -9494,20 +7505,13 @@
         "tags": ["platform-linking"],
         "summary": "Unlink a platform server",
         "operationId": "deletePlatform-linkingUnlink a platform server",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "link_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Link Id"
-            }
+            "schema": { "type": "string", "title": "Link Id" }
           }
         ],
         "responses": {
@@ -9515,9 +7519,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/DeleteLinkResponse"
-                }
+                "schema": { "$ref": "#/components/schemas/DeleteLinkResponse" }
               }
             }
           },
@@ -9528,9 +7530,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -9548,9 +7548,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/BotPlatformInfo"
-                  },
+                  "items": { "$ref": "#/components/schemas/BotPlatformInfo" },
                   "type": "array",
                   "title": "Response List Bot Platforms"
                 }
@@ -9561,11 +7559,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/platform-linking/tokens/{token}/confirm": {
@@ -9573,11 +7567,7 @@
         "tags": ["platform-linking"],
         "summary": "Confirm a SERVER link token (user must be authenticated)",
         "operationId": "postPlatform-linkingConfirm a server link token (user must be authenticated)",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "token",
@@ -9596,9 +7586,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ConfirmLinkResponse"
-                }
+                "schema": { "$ref": "#/components/schemas/ConfirmLinkResponse" }
               }
             }
           },
@@ -9609,9 +7597,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -9623,11 +7609,7 @@
         "tags": ["platform-linking"],
         "summary": "Get display info for a link token",
         "operationId": "getPlatform-linkingGet display info for a link token",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "token",
@@ -9659,9 +7641,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -9692,11 +7672,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/platform-linking/user-links/{link_id}": {
@@ -9704,20 +7680,13 @@
         "tags": ["platform-linking"],
         "summary": "Unlink a DM / user link",
         "operationId": "deletePlatform-linkingUnlink a dm / user link",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "link_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Link Id"
-            }
+            "schema": { "type": "string", "title": "Link Id" }
           }
         ],
         "responses": {
@@ -9725,9 +7694,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/DeleteLinkResponse"
-                }
+                "schema": { "$ref": "#/components/schemas/DeleteLinkResponse" }
               }
             }
           },
@@ -9738,9 +7705,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -9752,11 +7717,7 @@
         "tags": ["platform-linking"],
         "summary": "Confirm a USER link token (user must be authenticated)",
         "operationId": "postPlatform-linkingConfirm a user link token (user must be authenticated)",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "token",
@@ -9788,9 +7749,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -9830,9 +7789,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -9870,19 +7827,13 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+            "content": { "application/json": { "schema": {} } }
           },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -9897,17 +7848,13 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PushSubscribeRequest"
-              }
+              "schema": { "$ref": "#/components/schemas/PushSubscribeRequest" }
             }
           },
           "required": true
         },
         "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
+          "204": { "description": "Successful Response" },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
@@ -9915,18 +7862,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/push/unsubscribe": {
@@ -9945,9 +7886,7 @@
           "required": true
         },
         "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
+          "204": { "description": "Successful Response" },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
@@ -9955,18 +7894,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/push/vapid-key": {
@@ -9997,9 +7930,7 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ReviewRequest"
-              }
+              "schema": { "$ref": "#/components/schemas/ReviewRequest" }
             }
           },
           "required": true
@@ -10009,9 +7940,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ReviewResponse"
-                }
+                "schema": { "$ref": "#/components/schemas/ReviewResponse" }
               }
             }
           },
@@ -10022,18 +7951,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/review/execution/{graph_exec_id}": {
@@ -10042,20 +7965,13 @@
         "summary": "Get Pending Reviews for Execution",
         "description": "Get all pending reviews for a specific graph execution.\n\nRetrieves all reviews with status \"WAITING\" for the specified graph execution\nthat belong to the authenticated user. Results are ordered by creation time\n(oldest first) to preserve review order within the execution.\n\nArgs:\n    graph_exec_id: ID of the graph execution to get reviews for\n    user_id: Authenticated user ID from security dependency\n\nReturns:\n    List of pending review objects for the specified execution\n\nRaises:\n    HTTPException:\n        - 404: If the graph execution doesn't exist or isn't owned by this user\n        - 500: If authentication fails or database error occurs\n\nNote:\n    Only returns reviews owned by the authenticated user for security.\n    Reviews with invalid status are excluded with warning logs.",
         "operationId": "getV2Get pending reviews for execution",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "graph_exec_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Graph Exec Id"
-            }
+            "schema": { "type": "string", "title": "Graph Exec Id" }
           }
         ],
         "responses": {
@@ -10076,24 +7992,18 @@
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
-          "404": {
-            "description": "Graph execution not found"
-          },
+          "404": { "description": "Graph execution not found" },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           },
           "500": {
             "description": "Server error",
-            "content": {
-              "application/json": {}
-            }
+            "content": { "application/json": {} }
           }
         }
       }
@@ -10104,11 +8014,7 @@
         "summary": "Get Pending Reviews",
         "description": "Get all pending reviews for the current user.\n\nRetrieves all reviews with status \"WAITING\" that belong to the authenticated user.\nResults are ordered by creation time (newest first).\n\nArgs:\n    user_id: Authenticated user ID from security dependency\n\nReturns:\n    List of pending review objects with status converted to typed literals\n\nRaises:\n    HTTPException: If authentication fails or database error occurs\n\nNote:\n    Reviews with invalid status values are logged as warnings but excluded\n    from results rather than failing the entire request.",
         "operationId": "getV2Get pending reviews",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "page",
@@ -10160,17 +8066,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           },
           "500": {
             "description": "Server error",
-            "content": {
-              "application/json": {}
-            }
+            "content": { "application/json": {} }
           }
         }
       }
@@ -10199,11 +8101,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/schedules/followups": {
@@ -10231,11 +8129,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/schedules/{schedule_id}": {
@@ -10243,11 +8137,7 @@
         "tags": ["v1", "schedules"],
         "summary": "Delete execution schedule",
         "operationId": "deleteV1Delete execution schedule",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "schedule_id",
@@ -10281,9 +8171,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -10302,9 +8190,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/CopilotSkillInfo"
-                  },
+                  "items": { "$ref": "#/components/schemas/CopilotSkillInfo" },
                   "type": "array",
                   "title": "Response Listcopilotskills"
                 }
@@ -10315,11 +8201,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/skills/{name}": {
@@ -10328,11 +8210,7 @@
         "summary": "Delete a user-distilled copilot skill",
         "description": "Delete a user-distilled skill by slug.\n\nBuilt-in defaults are not user-deletable — attempting to delete one\nreturns 400.  Missing skills return 404 so the UI can reconcile a\nstale list.",
         "operationId": "deleteCopilotSkill",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "name",
@@ -10353,9 +8231,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "additionalProperties": {
-                    "type": "string"
-                  },
+                  "additionalProperties": { "type": "string" },
                   "title": "Response Deletecopilotskill"
                 }
               }
@@ -10368,9 +8244,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -10381,11 +8255,7 @@
         "summary": "Read a single copilot skill with its full SKILL.md body",
         "description": "Return full SKILL.md content (name, description, triggers, body)\nfor the library UI's expand-to-view dialog.\n\nBuilt-in default skills are returned with ``is_default=True`` so the\nUI can hide destructive affordances; missing user skills return 404.",
         "operationId": "readCopilotSkill",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "name",
@@ -10404,25 +8274,19 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CopilotSkillDetail"
-                }
+                "schema": { "$ref": "#/components/schemas/CopilotSkillDetail" }
               }
             }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
-          "404": {
-            "description": "Skill not found"
-          },
+          "404": { "description": "Skill not found" },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -10435,11 +8299,7 @@
         "summary": "Get Admin Listings History",
         "description": "Get store listings with their version history for admins.\n\nThis provides a consolidated view of listings with their versions,\nallowing for an expandable UI in the admin dashboard.\n\nArgs:\n    status: Filter by submission status (PENDING, APPROVED, REJECTED)\n    search: Search by name, description, or user email\n    page: Page number for pagination\n    page_size: Number of items per page\n\nReturns:\n    Paginated listings with their versions",
         "operationId": "getV2Get admin listings history",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "status",
@@ -10447,12 +8307,8 @@
             "required": false,
             "schema": {
               "anyOf": [
-                {
-                  "$ref": "#/components/schemas/SubmissionStatus"
-                },
-                {
-                  "type": "null"
-                }
+                { "$ref": "#/components/schemas/SubmissionStatus" },
+                { "type": "null" }
               ],
               "title": "Status"
             }
@@ -10462,14 +8318,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "Search"
             }
           },
@@ -10477,21 +8326,13 @@
             "name": "page",
             "in": "query",
             "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 1,
-              "title": "Page"
-            }
+            "schema": { "type": "integer", "default": 1, "title": "Page" }
           },
           {
             "name": "page_size",
             "in": "query",
             "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 20,
-              "title": "Page Size"
-            }
+            "schema": { "type": "integer", "default": 20, "title": "Page Size" }
           }
         ],
         "responses": {
@@ -10512,9 +8353,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -10527,11 +8366,7 @@
         "summary": "Admin Download Agent File",
         "description": "Download the agent file by streaming its content.\n\nArgs:\n    store_listing_version_id (str): The ID of the agent to download\n\nReturns:\n    StreamingResponse: A streaming response containing the agent's graph data.\n\nRaises:\n    HTTPException: If the agent is not found or an unexpected error occurs.",
         "operationId": "getV2Admin download agent file",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "store_listing_version_id",
@@ -10548,11 +8383,7 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+            "content": { "application/json": { "schema": {} } }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
@@ -10561,9 +8392,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -10576,20 +8405,13 @@
         "summary": "Admin Add Pending Agent to Library",
         "description": "Add a pending marketplace agent to the admin's library for review.\nUses admin-level access to bypass marketplace APPROVED-only checks.\n\nThe builder can load the graph because get_graph() checks library\nmembership as a fallback: \"you added it, you keep it.\"",
         "operationId": "postV2Admin add pending agent to library",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "store_listing_version_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Store Listing Version Id"
-            }
+            "schema": { "type": "string", "title": "Store Listing Version Id" }
           }
         ],
         "responses": {
@@ -10597,9 +8419,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LibraryAgent"
-                }
+                "schema": { "$ref": "#/components/schemas/LibraryAgent" }
               }
             }
           },
@@ -10610,9 +8430,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -10625,20 +8443,13 @@
         "summary": "Admin Preview Submission Listing",
         "description": "Preview a marketplace submission as it would appear on the listing page.\nBypasses the APPROVED-only StoreAgent view so admins can preview pending\nsubmissions before approving.",
         "operationId": "getV2Admin preview submission listing",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "store_listing_version_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Store Listing Version Id"
-            }
+            "schema": { "type": "string", "title": "Store Listing Version Id" }
           }
         ],
         "responses": {
@@ -10646,9 +8457,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/StoreAgentDetails"
-                }
+                "schema": { "$ref": "#/components/schemas/StoreAgentDetails" }
               }
             }
           },
@@ -10659,9 +8468,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -10674,20 +8481,13 @@
         "summary": "Review Store Submission",
         "description": "Review a store listing submission.\n\nArgs:\n    store_listing_version_id: ID of the submission to review\n    request: Review details including approval status and comments\n    user_id: Authenticated admin user performing the review\n\nReturns:\n    StoreSubmissionAdminView with updated review information",
         "operationId": "postV2Review store submission",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "store_listing_version_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Store Listing Version Id"
-            }
+            "schema": { "type": "string", "title": "Store Listing Version Id" }
           }
         ],
         "requestBody": {
@@ -10718,9 +8518,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -10751,14 +8549,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "description": "Filter agents by creator username",
               "title": "Creator"
             },
@@ -10769,14 +8560,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "description": "Filter agents by category",
               "title": "Category"
             },
@@ -10787,14 +8571,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "description": "Literal + semantic search on names and descriptions",
               "title": "Search Query"
             },
@@ -10806,12 +8583,8 @@
             "required": false,
             "schema": {
               "anyOf": [
-                {
-                  "$ref": "#/components/schemas/StoreAgentsSortOptions"
-                },
-                {
-                  "type": "null"
-                }
+                { "$ref": "#/components/schemas/StoreAgentsSortOptions" },
+                { "type": "null" }
               ],
               "description": "Property to sort results by. Ignored if search_query is provided.",
               "title": "Sorted By"
@@ -10846,9 +8619,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/StoreAgentsResponse"
-                }
+                "schema": { "$ref": "#/components/schemas/StoreAgentsResponse" }
               }
             }
           },
@@ -10856,9 +8627,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -10876,19 +8645,13 @@
             "name": "username",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Username"
-            }
+            "schema": { "type": "string", "title": "Username" }
           },
           {
             "name": "agent_name",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Agent Name"
-            }
+            "schema": { "type": "string", "title": "Agent Name" }
           },
           {
             "name": "include_changelog",
@@ -10906,9 +8669,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/StoreAgentDetails"
-                }
+                "schema": { "$ref": "#/components/schemas/StoreAgentDetails" }
               }
             }
           },
@@ -10916,9 +8677,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -10931,38 +8690,26 @@
         "summary": "Create agent review",
         "description": "Post a user review on a marketplace agent listing",
         "operationId": "postV2Create agent review",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "username",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Username"
-            }
+            "schema": { "type": "string", "title": "Username" }
           },
           {
             "name": "agent_name",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Agent Name"
-            }
+            "schema": { "type": "string", "title": "Agent Name" }
           }
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/StoreReviewCreate"
-              }
+              "schema": { "$ref": "#/components/schemas/StoreReviewCreate" }
             }
           }
         },
@@ -10971,9 +8718,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/StoreReview"
-                }
+                "schema": { "$ref": "#/components/schemas/StoreReview" }
               }
             }
           },
@@ -10984,9 +8729,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -11017,14 +8760,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "description": "Literal + semantic search on names and descriptions",
               "title": "Search Query"
             },
@@ -11036,12 +8772,8 @@
             "required": false,
             "schema": {
               "anyOf": [
-                {
-                  "$ref": "#/components/schemas/StoreCreatorsSortOptions"
-                },
-                {
-                  "type": "null"
-                }
+                { "$ref": "#/components/schemas/StoreCreatorsSortOptions" },
+                { "type": "null" }
               ],
               "title": "Sorted By"
             }
@@ -11074,9 +8806,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CreatorsResponse"
-                }
+                "schema": { "$ref": "#/components/schemas/CreatorsResponse" }
               }
             }
           },
@@ -11084,9 +8814,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -11104,10 +8832,7 @@
             "name": "username",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Username"
-            }
+            "schema": { "type": "string", "title": "Username" }
           }
         ],
         "responses": {
@@ -11115,9 +8840,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CreatorDetails"
-                }
+                "schema": { "$ref": "#/components/schemas/CreatorDetails" }
               }
             }
           },
@@ -11125,9 +8848,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -11139,20 +8860,13 @@
         "tags": ["v2", "store"],
         "summary": "Get agent by version",
         "operationId": "getV2Get agent by version",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "store_listing_version_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Store Listing Version Id"
-            }
+            "schema": { "type": "string", "title": "Store Listing Version Id" }
           }
         ],
         "responses": {
@@ -11160,9 +8874,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/StoreAgentDetails"
-                }
+                "schema": { "$ref": "#/components/schemas/StoreAgentDetails" }
               }
             }
           },
@@ -11173,9 +8885,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -11188,20 +8898,13 @@
         "summary": "Get agent graph",
         "description": "Get outline of graph belonging to a specific marketplace listing version",
         "operationId": "getV2Get agent graph",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "store_listing_version_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Store Listing Version Id"
-            }
+            "schema": { "type": "string", "title": "Store Listing Version Id" }
           }
         ],
         "responses": {
@@ -11222,9 +8925,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -11242,28 +8943,19 @@
             "name": "store_listing_version_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Store Listing Version Id"
-            }
+            "schema": { "type": "string", "title": "Store Listing Version Id" }
           }
         ],
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+            "content": { "application/json": { "schema": {} } }
           },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -11279,13 +8971,7 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
+            "content": { "text/plain": { "schema": { "type": "string" } } }
           }
         }
       }
@@ -11296,11 +8982,7 @@
         "summary": "Get my agents",
         "description": "List the authenticated user's unpublished agents",
         "operationId": "getV2Get my agents",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "page",
@@ -11352,9 +9034,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -11372,9 +9052,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProfileDetails"
-                }
+                "schema": { "$ref": "#/components/schemas/ProfileDetails" }
               }
             }
           },
@@ -11382,11 +9060,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       },
       "post": {
         "tags": ["v2", "store", "private"],
@@ -11396,9 +9070,7 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Profile"
-              }
+              "schema": { "$ref": "#/components/schemas/Profile" }
             }
           },
           "required": true
@@ -11408,9 +9080,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProfileDetails"
-                }
+                "schema": { "$ref": "#/components/schemas/ProfileDetails" }
               }
             }
           },
@@ -11421,18 +9091,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/store/search": {
@@ -11441,20 +9105,13 @@
         "summary": "Unified search across all content types",
         "description": "Search across all content types (marketplace agents, blocks, documentation)\nusing hybrid search.\n\nCombines semantic (embedding-based) and lexical (text-based) search for best results.",
         "operationId": "getV2Unified search across all content types",
-        "security": [
-          {
-            "HTTPBearer": []
-          }
-        ],
+        "security": [{ "HTTPBearer": [] }],
         "parameters": [
           {
             "name": "query",
             "in": "query",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Query"
-            }
+            "schema": { "type": "string", "title": "Query" }
           },
           {
             "name": "content_types",
@@ -11464,13 +9121,9 @@
               "anyOf": [
                 {
                   "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ContentType"
-                  }
+                  "items": { "$ref": "#/components/schemas/ContentType" }
                 },
-                {
-                  "type": "null"
-                }
+                { "type": "null" }
               ],
               "description": "Content types to search. If not specified, searches all.",
               "title": "Content Types"
@@ -11515,9 +9168,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -11530,11 +9181,7 @@
         "summary": "List my submissions",
         "description": "List the authenticated user's marketplace listing submissions",
         "operationId": "getV2List my submissions",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "page",
@@ -11577,9 +9224,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -11590,11 +9235,7 @@
         "summary": "Create store submission",
         "description": "Submit a new marketplace listing for review",
         "operationId": "postV2Create store submission",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "requestBody": {
           "required": true,
           "content": {
@@ -11610,9 +9251,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/StoreSubmission"
-                }
+                "schema": { "$ref": "#/components/schemas/StoreSubmission" }
               }
             }
           },
@@ -11623,9 +9262,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -11638,20 +9275,13 @@
         "summary": "Generate submission image",
         "description": "Generate an image for a marketplace listing submission based on the properties\nof a given graph.",
         "operationId": "postV2Generate submission image",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "graph_id",
             "in": "query",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Graph Id"
-            }
+            "schema": { "type": "string", "title": "Graph Id" }
           }
         ],
         "responses": {
@@ -11659,9 +9289,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ImageURLResponse"
-                }
+                "schema": { "$ref": "#/components/schemas/ImageURLResponse" }
               }
             }
           },
@@ -11672,9 +9300,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -11716,18 +9342,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/store/submissions/{store_listing_version_id}": {
@@ -11736,20 +9356,13 @@
         "summary": "Edit store submission",
         "description": "Update a pending marketplace listing submission",
         "operationId": "putV2Edit store submission",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "store_listing_version_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Store Listing Version Id"
-            }
+            "schema": { "type": "string", "title": "Store Listing Version Id" }
           }
         ],
         "requestBody": {
@@ -11767,9 +9380,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/StoreSubmission"
-                }
+                "schema": { "$ref": "#/components/schemas/StoreSubmission" }
               }
             }
           },
@@ -11780,9 +9391,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -11795,20 +9404,13 @@
         "summary": "Delete store submission",
         "description": "Delete a marketplace listing submission",
         "operationId": "deleteV2Delete store submission",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "submission_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Submission Id"
-            }
+            "schema": { "type": "string", "title": "Submission Id" }
           }
         ],
         "responses": {
@@ -11830,9 +9432,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -11845,25 +9445,14 @@
         "summary": "List workspace files",
         "description": "List files in the user's workspace.\n\nWhen session_id is provided, only files for that session are returned.\nOtherwise, all files across sessions are listed. Results are paginated\nvia `limit`/`offset`; `has_more` indicates whether additional pages exist.",
         "operationId": "listWorkspaceFiles",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "session_id",
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "Session Id"
             }
           },
@@ -11896,9 +9485,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ListFilesResponse"
-                }
+                "schema": { "$ref": "#/components/schemas/ListFilesResponse" }
               }
             }
           },
@@ -11909,9 +9496,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -11924,25 +9509,14 @@
         "summary": "Upload file to workspace",
         "description": "Upload a file to the user's workspace.\n\nFiles are stored in session-scoped paths when session_id is provided,\nso the agent's session-scoped tools can discover them automatically.",
         "operationId": "uploadWorkspaceFile",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "session_id",
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "Session Id"
             }
           },
@@ -11985,9 +9559,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -12000,20 +9572,13 @@
         "summary": "Delete a workspace file",
         "description": "Soft-delete a workspace file and attempt to remove it from storage.\n\nUsed when a user clears a file input in the builder.",
         "operationId": "deleteWorkspaceFile",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "file_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "File Id"
-            }
+            "schema": { "type": "string", "title": "File Id" }
           }
         ],
         "responses": {
@@ -12021,9 +9586,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/DeleteFileResponse"
-                }
+                "schema": { "$ref": "#/components/schemas/DeleteFileResponse" }
               }
             }
           },
@@ -12034,9 +9597,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -12049,30 +9610,19 @@
         "summary": "Download file by ID",
         "description": "Download a file by its ID.\n\nReturns the file content directly or redirects to a signed URL for GCS.",
         "operationId": "getWorkspaceDownloadFileById",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "file_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "File Id"
-            }
+            "schema": { "type": "string", "title": "File Id" }
           }
         ],
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+            "content": { "application/json": { "schema": {} } }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
@@ -12081,9 +9631,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -12111,11 +9659,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/health": {
@@ -12126,11 +9670,7 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+            "content": { "application/json": { "schema": {} } }
           }
         }
       }
@@ -12140,23 +9680,10 @@
     "schemas": {
       "APIKeyCredentials": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "provider": {
-            "type": "string",
-            "title": "Provider"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "provider": { "type": "string", "title": "Provider" },
           "title": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Title"
           },
           "is_managed": {
@@ -12182,14 +9709,7 @@
             "writeOnly": true
           },
           "expires_at": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
             "title": "Expires At",
             "description": "Unix timestamp (seconds) indicating when the API key expires (if at all)"
           }
@@ -12200,14 +9720,9 @@
       },
       "APIKeyInfo": {
         "properties": {
-          "user_id": {
-            "type": "string",
-            "title": "User Id"
-          },
+          "user_id": { "type": "string", "title": "User Id" },
           "scopes": {
-            "items": {
-              "$ref": "#/components/schemas/APIKeyPermission"
-            },
+            "items": { "$ref": "#/components/schemas/APIKeyPermission" },
             "type": "array",
             "title": "Scopes"
           },
@@ -12224,48 +9739,27 @@
           },
           "expires_at": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
             ],
             "title": "Expires At"
           },
           "last_used_at": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
             ],
             "title": "Last Used At"
           },
           "revoked_at": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
             ],
             "title": "Revoked At"
           },
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "name": { "type": "string", "title": "Name" },
           "head": {
             "type": "string",
             "title": "Head",
@@ -12276,18 +9770,9 @@
             "title": "Tail",
             "description": "The last 8 characters of the key"
           },
-          "status": {
-            "$ref": "#/components/schemas/APIKeyStatus"
-          },
+          "status": { "$ref": "#/components/schemas/APIKeyStatus" },
           "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Description"
           }
         },
@@ -12329,33 +9814,14 @@
       },
       "AccuracyAlertData": {
         "properties": {
-          "graph_id": {
-            "type": "string",
-            "title": "Graph Id"
-          },
+          "graph_id": { "type": "string", "title": "Graph Id" },
           "user_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "User Id"
           },
-          "drop_percent": {
-            "type": "number",
-            "title": "Drop Percent"
-          },
-          "three_day_avg": {
-            "type": "number",
-            "title": "Three Day Avg"
-          },
-          "seven_day_avg": {
-            "type": "number",
-            "title": "Seven Day Avg"
-          },
+          "drop_percent": { "type": "number", "title": "Drop Percent" },
+          "three_day_avg": { "type": "number", "title": "Three Day Avg" },
+          "seven_day_avg": { "type": "number", "title": "Seven Day Avg" },
           "detected_at": {
             "type": "string",
             "format": "date-time",
@@ -12376,53 +9842,21 @@
       },
       "AccuracyLatestData": {
         "properties": {
-          "date": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Date"
-          },
+          "date": { "type": "string", "format": "date-time", "title": "Date" },
           "daily_score": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "number" }, { "type": "null" }],
             "title": "Daily Score"
           },
           "three_day_avg": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "number" }, { "type": "null" }],
             "title": "Three Day Avg"
           },
           "seven_day_avg": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "number" }, { "type": "null" }],
             "title": "Seven Day Avg"
           },
           "fourteen_day_avg": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "number" }, { "type": "null" }],
             "title": "Fourteen Day Avg"
           }
         },
@@ -12439,30 +9873,20 @@
       },
       "AccuracyTrendsResponse": {
         "properties": {
-          "latest_data": {
-            "$ref": "#/components/schemas/AccuracyLatestData"
-          },
+          "latest_data": { "$ref": "#/components/schemas/AccuracyLatestData" },
           "alert": {
             "anyOf": [
-              {
-                "$ref": "#/components/schemas/AccuracyAlertData"
-              },
-              {
-                "type": "null"
-              }
+              { "$ref": "#/components/schemas/AccuracyAlertData" },
+              { "type": "null" }
             ]
           },
           "historical_data": {
             "anyOf": [
               {
-                "items": {
-                  "$ref": "#/components/schemas/AccuracyLatestData"
-                },
+                "items": { "$ref": "#/components/schemas/AccuracyLatestData" },
                 "type": "array"
               },
-              {
-                "type": "null"
-              }
+              { "type": "null" }
             ],
             "title": "Historical Data"
           }
@@ -12474,23 +9898,10 @@
       },
       "ActiveStreamInfo": {
         "properties": {
-          "turn_id": {
-            "type": "string",
-            "title": "Turn Id"
-          },
-          "last_message_id": {
-            "type": "string",
-            "title": "Last Message Id"
-          },
+          "turn_id": { "type": "string", "title": "Turn Id" },
+          "last_message_id": { "type": "string", "title": "Last Message Id" },
           "started_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Started At"
           }
         },
@@ -12501,14 +9912,8 @@
       },
       "AddUserCreditsResponse": {
         "properties": {
-          "new_balance": {
-            "type": "integer",
-            "title": "New Balance"
-          },
-          "transaction_key": {
-            "type": "string",
-            "title": "Transaction Key"
-          }
+          "new_balance": { "type": "integer", "title": "New Balance" },
+          "transaction_key": { "type": "string", "title": "Transaction Key" }
         },
         "type": "object",
         "required": ["new_balance", "transaction_key"],
@@ -12516,18 +9921,9 @@
       },
       "AgentDetails": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "name": { "type": "string", "title": "Name" },
+          "description": { "type": "string", "title": "Description" },
           "in_library": {
             "type": "boolean",
             "title": "In Library",
@@ -12540,9 +9936,7 @@
             "default": {}
           },
           "credentials": {
-            "items": {
-              "$ref": "#/components/schemas/CredentialsMetaInput"
-            },
+            "items": { "$ref": "#/components/schemas/CredentialsMetaInput" },
             "type": "array",
             "title": "Credentials",
             "default": []
@@ -12552,13 +9946,8 @@
           },
           "trigger_info": {
             "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
+              { "additionalProperties": true, "type": "object" },
+              { "type": "null" }
             ],
             "title": "Trigger Info"
           }
@@ -12574,49 +9963,23 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "agent_details"
           },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          },
+          "message": { "type": "string", "title": "Message" },
           "session_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Session Id"
           },
-          "agent": {
-            "$ref": "#/components/schemas/AgentDetails"
-          },
+          "agent": { "$ref": "#/components/schemas/AgentDetails" },
           "user_authenticated": {
             "type": "boolean",
             "title": "User Authenticated",
             "default": false
           },
           "graph_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Graph Id"
           },
           "graph_version": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
             "title": "Graph Version"
           }
         },
@@ -12631,10 +9994,7 @@
             "type": "integer",
             "title": "Agents With Active Executions"
           },
-          "timestamp": {
-            "type": "string",
-            "title": "Timestamp"
-          }
+          "timestamp": { "type": "string", "title": "Timestamp" }
         },
         "type": "object",
         "required": ["agents_with_active_executions", "timestamp"],
@@ -12656,18 +10016,9 @@
       },
       "AgentInfo": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "name": { "type": "string", "title": "Name" },
+          "description": { "type": "string", "title": "Description" },
           "source": {
             "type": "string",
             "title": "Source",
@@ -12679,185 +10030,82 @@
             "default": false
           },
           "creator": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Creator"
           },
           "category": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Category"
           },
           "rating": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "number" }, { "type": "null" }],
             "title": "Rating"
           },
           "runs": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
             "title": "Runs"
           },
           "is_featured": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "boolean" }, { "type": "null" }],
             "title": "Is Featured"
           },
           "status": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Status"
           },
           "can_access_graph": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "boolean" }, { "type": "null" }],
             "title": "Can Access Graph"
           },
           "has_external_trigger": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "boolean" }, { "type": "null" }],
             "title": "Has External Trigger"
           },
           "new_output": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "boolean" }, { "type": "null" }],
             "title": "New Output"
           },
           "graph_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Graph Id"
           },
           "graph_version": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
             "title": "Graph Version"
           },
           "match_score": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "number" }, { "type": "null" }],
             "title": "Match Score",
             "description": "Combined relevance score in [0, 1] when this agent was returned from a similarity search (e.g. the create-time library check). Null for non-similarity sources."
           },
           "input_schema": {
             "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
+              { "additionalProperties": true, "type": "object" },
+              { "type": "null" }
             ],
             "title": "Input Schema",
             "description": "JSON Schema for the agent's inputs (for AgentExecutorBlock)"
           },
           "output_schema": {
             "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
+              { "additionalProperties": true, "type": "object" },
+              { "type": "null" }
             ],
             "title": "Output Schema",
             "description": "JSON Schema for the agent's outputs (for AgentExecutorBlock)"
           },
           "inputs": {
             "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
+              { "additionalProperties": true, "type": "object" },
+              { "type": "null" }
             ],
             "title": "Inputs",
             "description": "Input schema for the agent, including field names, types, and defaults"
           },
           "graph": {
             "anyOf": [
-              {
-                "$ref": "#/components/schemas/BaseGraph-Output"
-              },
-              {
-                "type": "null"
-              }
+              { "$ref": "#/components/schemas/BaseGraph-Output" },
+              { "type": "null" }
             ],
             "description": "Full graph structure (nodes + links) when include_graph is requested"
           }
@@ -12873,73 +10121,34 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "agent_output"
           },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          },
+          "message": { "type": "string", "title": "Message" },
           "session_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Session Id"
           },
-          "agent_name": {
-            "type": "string",
-            "title": "Agent Name"
-          },
-          "agent_id": {
-            "type": "string",
-            "title": "Agent Id"
-          },
+          "agent_name": { "type": "string", "title": "Agent Name" },
+          "agent_id": { "type": "string", "title": "Agent Id" },
           "library_agent_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Library Agent Id"
           },
           "library_agent_link": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Library Agent Link"
           },
           "execution": {
             "anyOf": [
-              {
-                "$ref": "#/components/schemas/ExecutionOutputInfo"
-              },
-              {
-                "type": "null"
-              }
+              { "$ref": "#/components/schemas/ExecutionOutputInfo" },
+              { "type": "null" }
             ]
           },
           "available_executions": {
             "anyOf": [
               {
-                "items": {
-                  "additionalProperties": true,
-                  "type": "object"
-                },
+                "items": { "additionalProperties": true, "type": "object" },
                 "type": "array"
               },
-              {
-                "type": "null"
-              }
+              { "type": "null" }
             ],
             "title": "Available Executions"
           },
@@ -12960,19 +10169,9 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "agent_builder_preview"
           },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          },
+          "message": { "type": "string", "title": "Message" },
           "session_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Session Id"
           },
           "agent_json": {
@@ -12980,18 +10179,9 @@
             "type": "object",
             "title": "Agent Json"
           },
-          "agent_name": {
-            "type": "string",
-            "title": "Agent Name"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
-          "node_count": {
-            "type": "integer",
-            "title": "Node Count"
-          },
+          "agent_name": { "type": "string", "title": "Agent Name" },
+          "description": { "type": "string", "title": "Description" },
+          "node_count": { "type": "integer", "title": "Node Count" },
           "link_count": {
             "type": "integer",
             "title": "Link Count",
@@ -13015,52 +10205,23 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "agent_builder_saved"
           },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          },
+          "message": { "type": "string", "title": "Message" },
           "session_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Session Id"
           },
-          "agent_id": {
-            "type": "string",
-            "title": "Agent Id"
-          },
-          "agent_name": {
-            "type": "string",
-            "title": "Agent Name"
-          },
+          "agent_id": { "type": "string", "title": "Agent Id" },
+          "agent_name": { "type": "string", "title": "Agent Name" },
           "graph_version": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
             "title": "Graph Version"
           },
-          "library_agent_id": {
-            "type": "string",
-            "title": "Library Agent Id"
-          },
+          "library_agent_id": { "type": "string", "title": "Library Agent Id" },
           "library_agent_link": {
             "type": "string",
             "title": "Library Agent Link"
           },
-          "agent_page_link": {
-            "type": "string",
-            "title": "Agent Page Link"
-          }
+          "agent_page_link": { "type": "string", "title": "Agent Page Link" }
         },
         "type": "object",
         "required": [
@@ -13080,19 +10241,9 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "agents_found"
           },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          },
+          "message": { "type": "string", "title": "Message" },
           "session_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Session Id"
           },
           "title": {
@@ -13101,16 +10252,11 @@
             "default": "Available Agents"
           },
           "agents": {
-            "items": {
-              "$ref": "#/components/schemas/AgentInfo"
-            },
+            "items": { "$ref": "#/components/schemas/AgentInfo" },
             "type": "array",
             "title": "Agents"
           },
-          "count": {
-            "type": "integer",
-            "title": "Count"
-          },
+          "count": { "type": "integer", "title": "Count" },
           "name": {
             "type": "string",
             "title": "Name",
@@ -13124,21 +10270,13 @@
       },
       "ApiResponse": {
         "properties": {
-          "answer": {
-            "type": "string",
-            "title": "Answer"
-          },
+          "answer": { "type": "string", "title": "Answer" },
           "documents": {
-            "items": {
-              "$ref": "#/components/schemas/Document"
-            },
+            "items": { "$ref": "#/components/schemas/Document" },
             "type": "array",
             "title": "Documents"
           },
-          "success": {
-            "type": "boolean",
-            "title": "Success"
-          }
+          "success": { "type": "boolean", "title": "Success" }
         },
         "type": "object",
         "required": ["answer", "documents", "success"],
@@ -13157,9 +10295,7 @@
             "description": "Redirect URI"
           },
           "scopes": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Scopes",
             "description": "List of scopes"
@@ -13214,14 +10350,8 @@
       },
       "AutoTopUpConfig": {
         "properties": {
-          "amount": {
-            "type": "integer",
-            "title": "Amount"
-          },
-          "threshold": {
-            "type": "integer",
-            "title": "Threshold"
-          }
+          "amount": { "type": "integer", "title": "Amount" },
+          "threshold": { "type": "integer", "title": "Threshold" }
         },
         "type": "object",
         "required": ["amount", "threshold"],
@@ -13247,83 +10377,38 @@
       },
       "BaseGraph-Input": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "version": {
-            "type": "integer",
-            "title": "Version",
-            "default": 1
-          },
+          "id": { "type": "string", "title": "Id" },
+          "version": { "type": "integer", "title": "Version", "default": 1 },
           "is_active": {
             "type": "boolean",
             "title": "Is Active",
             "default": true
           },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
+          "name": { "type": "string", "title": "Name" },
+          "description": { "type": "string", "title": "Description" },
           "instructions": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Instructions"
           },
           "recommended_schedule_cron": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Recommended Schedule Cron"
           },
           "forked_from_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Forked From Id"
           },
           "forked_from_version": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
             "title": "Forked From Version"
           },
           "nodes": {
-            "items": {
-              "$ref": "#/components/schemas/Node"
-            },
+            "items": { "$ref": "#/components/schemas/Node" },
             "type": "array",
             "title": "Nodes"
           },
           "links": {
-            "items": {
-              "$ref": "#/components/schemas/Link"
-            },
+            "items": { "$ref": "#/components/schemas/Link" },
             "type": "array",
             "title": "Links"
           }
@@ -13335,83 +10420,38 @@
       },
       "BaseGraph-Output": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "version": {
-            "type": "integer",
-            "title": "Version",
-            "default": 1
-          },
+          "id": { "type": "string", "title": "Id" },
+          "version": { "type": "integer", "title": "Version", "default": 1 },
           "is_active": {
             "type": "boolean",
             "title": "Is Active",
             "default": true
           },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
+          "name": { "type": "string", "title": "Name" },
+          "description": { "type": "string", "title": "Description" },
           "instructions": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Instructions"
           },
           "recommended_schedule_cron": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Recommended Schedule Cron"
           },
           "forked_from_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Forked From Id"
           },
           "forked_from_version": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
             "title": "Forked From Version"
           },
           "nodes": {
-            "items": {
-              "$ref": "#/components/schemas/Node"
-            },
+            "items": { "$ref": "#/components/schemas/Node" },
             "type": "array",
             "title": "Nodes"
           },
           "links": {
-            "items": {
-              "$ref": "#/components/schemas/Link"
-            },
+            "items": { "$ref": "#/components/schemas/Link" },
             "type": "array",
             "title": "Links"
           },
@@ -13444,12 +10484,8 @@
           },
           "trigger_setup_info": {
             "anyOf": [
-              {
-                "$ref": "#/components/schemas/GraphTriggerInfo"
-              },
-              {
-                "type": "null"
-              }
+              { "$ref": "#/components/schemas/GraphTriggerInfo" },
+              { "type": "null" }
             ],
             "readOnly": true
           }
@@ -13470,18 +10506,10 @@
       },
       "BlockCategoryResponse": {
         "properties": {
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "total_blocks": {
-            "type": "integer",
-            "title": "Total Blocks"
-          },
+          "name": { "type": "string", "title": "Name" },
+          "total_blocks": { "type": "integer", "title": "Total Blocks" },
           "blocks": {
-            "items": {
-              "$ref": "#/components/schemas/BlockInfo"
-            },
+            "items": { "$ref": "#/components/schemas/BlockInfo" },
             "type": "array",
             "title": "Blocks"
           }
@@ -13492,18 +10520,13 @@
       },
       "BlockCost": {
         "properties": {
-          "cost_amount": {
-            "type": "integer",
-            "title": "Cost Amount"
-          },
+          "cost_amount": { "type": "integer", "title": "Cost Amount" },
           "cost_filter": {
             "additionalProperties": true,
             "type": "object",
             "title": "Cost Filter"
           },
-          "cost_type": {
-            "$ref": "#/components/schemas/BlockCostType"
-          },
+          "cost_type": { "$ref": "#/components/schemas/BlockCostType" },
           "cost_divisor": {
             "type": "integer",
             "title": "Cost Divisor",
@@ -13511,12 +10534,8 @@
           },
           "token_rate": {
             "anyOf": [
-              {
-                "$ref": "#/components/schemas/TokenRateDisplay"
-              },
-              {
-                "type": "null"
-              }
+              { "$ref": "#/components/schemas/TokenRateDisplay" },
+              { "type": "null" }
             ]
           }
         },
@@ -13526,34 +10545,13 @@
       },
       "BlockCostEstimateRow": {
         "properties": {
-          "block_id": {
-            "type": "string",
-            "title": "Block Id"
-          },
-          "block_name": {
-            "type": "string",
-            "title": "Block Name"
-          },
-          "cost_type": {
-            "type": "string",
-            "title": "Cost Type"
-          },
-          "samples": {
-            "type": "integer",
-            "title": "Samples"
-          },
-          "mean_credits": {
-            "type": "integer",
-            "title": "Mean Credits"
-          },
-          "p50_credits": {
-            "type": "integer",
-            "title": "P50 Credits"
-          },
-          "p95_credits": {
-            "type": "integer",
-            "title": "P95 Credits"
-          }
+          "block_id": { "type": "string", "title": "Block Id" },
+          "block_name": { "type": "string", "title": "Block Name" },
+          "cost_type": { "type": "string", "title": "Cost Type" },
+          "samples": { "type": "integer", "title": "Samples" },
+          "mean_credits": { "type": "integer", "title": "Mean Credits" },
+          "p50_credits": { "type": "integer", "title": "P50 Credits" },
+          "p95_credits": { "type": "integer", "title": "P95 Credits" }
         },
         "type": "object",
         "required": [
@@ -13570,28 +10568,14 @@
       "BlockCostEstimatesResponse": {
         "properties": {
           "estimates": {
-            "items": {
-              "$ref": "#/components/schemas/BlockCostEstimateRow"
-            },
+            "items": { "$ref": "#/components/schemas/BlockCostEstimateRow" },
             "type": "array",
             "title": "Estimates"
           },
-          "total_rows": {
-            "type": "integer",
-            "title": "Total Rows"
-          },
-          "window_days": {
-            "type": "integer",
-            "title": "Window Days"
-          },
-          "max_window_days": {
-            "type": "integer",
-            "title": "Max Window Days"
-          },
-          "min_samples": {
-            "type": "integer",
-            "title": "Min Samples"
-          },
+          "total_rows": { "type": "integer", "title": "Total Rows" },
+          "window_days": { "type": "integer", "title": "Window Days" },
+          "max_window_days": { "type": "integer", "title": "Max Window Days" },
+          "min_samples": { "type": "integer", "title": "Min Samples" },
           "generated_at": {
             "type": "string",
             "format": "date-time",
@@ -13616,18 +10600,9 @@
       },
       "BlockDetails": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "name": { "type": "string", "title": "Name" },
+          "description": { "type": "string", "title": "Description" },
           "inputs": {
             "additionalProperties": true,
             "type": "object",
@@ -13641,9 +10616,7 @@
             "default": {}
           },
           "credentials": {
-            "items": {
-              "$ref": "#/components/schemas/CredentialsMetaInput"
-            },
+            "items": { "$ref": "#/components/schemas/CredentialsMetaInput" },
             "type": "array",
             "title": "Credentials",
             "default": []
@@ -13660,24 +10633,12 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "block_details"
           },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          },
+          "message": { "type": "string", "title": "Message" },
           "session_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Session Id"
           },
-          "block": {
-            "$ref": "#/components/schemas/BlockDetails"
-          },
+          "block": { "$ref": "#/components/schemas/BlockDetails" },
           "user_authenticated": {
             "type": "boolean",
             "title": "User Authenticated",
@@ -13691,14 +10652,8 @@
       },
       "BlockInfo": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "name": { "type": "string", "title": "Name" },
           "inputSchema": {
             "additionalProperties": true,
             "type": "object",
@@ -13710,42 +10665,26 @@
             "title": "Outputschema"
           },
           "costs": {
-            "items": {
-              "$ref": "#/components/schemas/BlockCost"
-            },
+            "items": { "$ref": "#/components/schemas/BlockCost" },
             "type": "array",
             "title": "Costs"
           },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
+          "description": { "type": "string", "title": "Description" },
           "categories": {
             "items": {
-              "additionalProperties": {
-                "type": "string"
-              },
+              "additionalProperties": { "type": "string" },
               "type": "object"
             },
             "type": "array",
             "title": "Categories"
           },
           "contributors": {
-            "items": {
-              "additionalProperties": true,
-              "type": "object"
-            },
+            "items": { "additionalProperties": true, "type": "object" },
             "type": "array",
             "title": "Contributors"
           },
-          "staticOutput": {
-            "type": "boolean",
-            "title": "Staticoutput"
-          },
-          "uiType": {
-            "type": "string",
-            "title": "Uitype"
-          }
+          "staticOutput": { "type": "boolean", "title": "Staticoutput" },
+          "uiType": { "type": "string", "title": "Uitype" }
         },
         "type": "object",
         "required": [
@@ -13764,22 +10703,11 @@
       },
       "BlockInfoSummary": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "name": { "type": "string", "title": "Name" },
+          "description": { "type": "string", "title": "Description" },
           "categories": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Categories"
           },
@@ -13802,9 +10730,7 @@
             "default": false
           },
           "required_inputs": {
-            "items": {
-              "$ref": "#/components/schemas/BlockInputFieldInfo"
-            },
+            "items": { "$ref": "#/components/schemas/BlockInputFieldInfo" },
             "type": "array",
             "title": "Required Inputs",
             "description": "List of input fields for this block"
@@ -13817,14 +10743,8 @@
       },
       "BlockInputFieldInfo": {
         "properties": {
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "type": {
-            "type": "string",
-            "title": "Type"
-          },
+          "name": { "type": "string", "title": "Name" },
+          "type": { "type": "string", "title": "Type" },
           "description": {
             "type": "string",
             "title": "Description",
@@ -13835,15 +10755,7 @@
             "title": "Required",
             "default": false
           },
-          "default": {
-            "anyOf": [
-              {},
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Default"
-          }
+          "default": { "anyOf": [{}, { "type": "null" }], "title": "Default" }
         },
         "type": "object",
         "required": ["name", "type"],
@@ -13856,36 +10768,18 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "block_list"
           },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          },
+          "message": { "type": "string", "title": "Message" },
           "session_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Session Id"
           },
           "blocks": {
-            "items": {
-              "$ref": "#/components/schemas/BlockInfoSummary"
-            },
+            "items": { "$ref": "#/components/schemas/BlockInfoSummary" },
             "type": "array",
             "title": "Blocks"
           },
-          "count": {
-            "type": "integer",
-            "title": "Count"
-          },
-          "query": {
-            "type": "string",
-            "title": "Query"
-          },
+          "count": { "type": "integer", "title": "Count" },
+          "query": { "type": "string", "title": "Query" },
           "usage_hint": {
             "type": "string",
             "title": "Usage Hint",
@@ -13903,51 +10797,21 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "block_output"
           },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          },
+          "message": { "type": "string", "title": "Message" },
           "session_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Session Id"
           },
-          "block_id": {
-            "type": "string",
-            "title": "Block Id"
-          },
-          "block_name": {
-            "type": "string",
-            "title": "Block Name"
-          },
+          "block_id": { "type": "string", "title": "Block Id" },
+          "block_name": { "type": "string", "title": "Block Name" },
           "outputs": {
-            "additionalProperties": {
-              "items": {},
-              "type": "array"
-            },
+            "additionalProperties": { "items": {}, "type": "array" },
             "type": "object",
             "title": "Outputs"
           },
-          "success": {
-            "type": "boolean",
-            "title": "Success",
-            "default": true
-          },
+          "success": { "type": "boolean", "title": "Success", "default": true },
           "is_dry_run": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "boolean" }, { "type": "null" }],
             "title": "Is Dry Run"
           }
         },
@@ -13959,15 +10823,11 @@
       "BlockResponse": {
         "properties": {
           "blocks": {
-            "items": {
-              "$ref": "#/components/schemas/BlockInfo"
-            },
+            "items": { "$ref": "#/components/schemas/BlockInfo" },
             "type": "array",
             "title": "Blocks"
           },
-          "pagination": {
-            "$ref": "#/components/schemas/Pagination"
-          }
+          "pagination": { "$ref": "#/components/schemas/Pagination" }
         },
         "type": "object",
         "required": ["blocks", "pagination"],
@@ -13987,10 +10847,7 @@
       },
       "Body_postAnalyticsLogRawAnalytics": {
         "properties": {
-          "type": {
-            "type": "string",
-            "title": "Type"
-          },
+          "type": { "type": "string", "title": "Type" },
           "data": {
             "additionalProperties": true,
             "type": "object",
@@ -14016,13 +10873,8 @@
           },
           "token_type_hint": {
             "anyOf": [
-              {
-                "type": "string",
-                "enum": ["access_token", "refresh_token"]
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "enum": ["access_token", "refresh_token"] },
+              { "type": "null" }
             ],
             "title": "Token Type Hint",
             "description": "Hint about token type ('access_token' or 'refresh_token')"
@@ -14051,13 +10903,8 @@
           },
           "token_type_hint": {
             "anyOf": [
-              {
-                "type": "string",
-                "enum": ["access_token", "refresh_token"]
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "enum": ["access_token", "refresh_token"] },
+              { "type": "null" }
             ],
             "title": "Token Type Hint",
             "description": "Hint about token type ('access_token' or 'refresh_token')"
@@ -14079,11 +10926,7 @@
       },
       "Body_postOauthUploadAppLogo": {
         "properties": {
-          "file": {
-            "type": "string",
-            "format": "binary",
-            "title": "File"
-          }
+          "file": { "type": "string", "format": "binary", "title": "File" }
         },
         "type": "object",
         "required": ["file"],
@@ -14095,10 +10938,7 @@
             "type": "string",
             "title": "Authorization code acquired by user login"
           },
-          "state_token": {
-            "type": "string",
-            "title": "Anti-CSRF nonce"
-          }
+          "state_token": { "type": "string", "title": "Anti-CSRF nonce" }
         },
         "type": "object",
         "required": ["code", "state_token"],
@@ -14124,28 +10964,18 @@
                 "type": "string",
                 "enum": ["builder", "library", "onboarding"]
               },
-              {
-                "type": "null"
-              }
+              { "type": "null" }
             ],
             "title": "Source"
           },
-          "dry_run": {
-            "type": "boolean",
-            "title": "Dry Run",
-            "default": false
-          }
+          "dry_run": { "type": "boolean", "title": "Dry Run", "default": false }
         },
         "type": "object",
         "title": "Body_postV1Execute graph agent"
       },
       "Body_postV1Upload_file_to_cloud_storage": {
         "properties": {
-          "file": {
-            "type": "string",
-            "format": "binary",
-            "title": "File"
-          }
+          "file": { "type": "string", "format": "binary", "title": "File" }
         },
         "type": "object",
         "required": ["file"],
@@ -14153,18 +10983,9 @@
       },
       "Body_postV2Add_credits_to_user": {
         "properties": {
-          "user_id": {
-            "type": "string",
-            "title": "User Id"
-          },
-          "amount": {
-            "type": "integer",
-            "title": "Amount"
-          },
-          "comments": {
-            "type": "string",
-            "title": "Comments"
-          }
+          "user_id": { "type": "string", "title": "User Id" },
+          "amount": { "type": "integer", "title": "Amount" },
+          "comments": { "type": "string", "title": "Comments" }
         },
         "type": "object",
         "required": ["user_id", "amount", "comments"],
@@ -14207,10 +11028,7 @@
       },
       "Body_postV2Reset_user_rate_limit_usage": {
         "properties": {
-          "user_id": {
-            "type": "string",
-            "title": "User Id"
-          },
+          "user_id": { "type": "string", "title": "User Id" },
           "reset_weekly": {
             "type": "boolean",
             "title": "Reset Weekly",
@@ -14223,11 +11041,7 @@
       },
       "Body_postV2Upload_submission_media": {
         "properties": {
-          "file": {
-            "type": "string",
-            "format": "binary",
-            "title": "File"
-          }
+          "file": { "type": "string", "format": "binary", "title": "File" }
         },
         "type": "object",
         "required": ["file"],
@@ -14235,11 +11049,7 @@
       },
       "Body_uploadWorkspaceFile": {
         "properties": {
-          "file": {
-            "type": "string",
-            "format": "binary",
-            "title": "File"
-          }
+          "file": { "type": "string", "format": "binary", "title": "File" }
         },
         "type": "object",
         "required": ["file"],
@@ -14247,43 +11057,21 @@
       },
       "BotPlatformInfo": {
         "properties": {
-          "platform": {
-            "type": "string",
-            "title": "Platform"
-          },
-          "display_name": {
-            "type": "string",
-            "title": "Display Name"
-          },
-          "icon": {
-            "type": "string",
-            "title": "Icon"
-          },
+          "platform": { "type": "string", "title": "Platform" },
+          "display_name": { "type": "string", "title": "Display Name" },
+          "icon": { "type": "string", "title": "Icon" },
           "add_bot_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Add Bot Url"
           },
           "dm_link": {
             "anyOf": [
-              {
-                "$ref": "#/components/schemas/PlatformUserLinkInfo"
-              },
-              {
-                "type": "null"
-              }
+              { "$ref": "#/components/schemas/PlatformUserLinkInfo" },
+              { "type": "null" }
             ]
           },
           "server_links": {
-            "items": {
-              "$ref": "#/components/schemas/PlatformLinkInfo"
-            },
+            "items": { "$ref": "#/components/schemas/PlatformLinkInfo" },
             "type": "array",
             "title": "Server Links"
           }
@@ -14296,21 +11084,12 @@
       "BulkMoveAgentsRequest": {
         "properties": {
           "agent_ids": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Agent Ids"
           },
           "folder_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Folder Id"
           }
         },
@@ -14321,19 +11100,9 @@
       },
       "CancelSessionResponse": {
         "properties": {
-          "cancelled": {
-            "type": "boolean",
-            "title": "Cancelled"
-          },
+          "cancelled": { "type": "boolean", "title": "Cancelled" },
           "reason": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Reason"
           }
         },
@@ -14344,19 +11113,9 @@
       },
       "ChangelogEntry": {
         "properties": {
-          "version": {
-            "type": "string",
-            "title": "Version"
-          },
-          "changes_summary": {
-            "type": "string",
-            "title": "Changes Summary"
-          },
-          "date": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Date"
-          }
+          "version": { "type": "string", "title": "Version" },
+          "changes_summary": { "type": "string", "title": "Changes Summary" },
+          "date": { "type": "string", "format": "date-time", "title": "Date" }
         },
         "type": "object",
         "required": ["version", "changes_summary", "date"],
@@ -14364,35 +11123,20 @@
       },
       "ChatRequest": {
         "properties": {
-          "query": {
-            "type": "string",
-            "title": "Query"
-          },
+          "query": { "type": "string", "title": "Query" },
           "conversation_history": {
-            "items": {
-              "$ref": "#/components/schemas/Message"
-            },
+            "items": { "$ref": "#/components/schemas/Message" },
             "type": "array",
             "title": "Conversation History"
           },
-          "message_id": {
-            "type": "string",
-            "title": "Message Id"
-          },
+          "message_id": { "type": "string", "title": "Message Id" },
           "include_graph_data": {
             "type": "boolean",
             "title": "Include Graph Data",
             "default": false
           },
           "graph_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Graph Id"
           }
         },
@@ -14408,25 +11152,11 @@
             "default": false
           },
           "builder_graph_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Builder Graph Id"
           },
           "source_platform": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Source Platform"
           }
         },
@@ -14440,25 +11170,13 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "agent_builder_clarification_needed"
           },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          },
+          "message": { "type": "string", "title": "Message" },
           "session_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Session Id"
           },
           "questions": {
-            "items": {
-              "$ref": "#/components/schemas/ClarifyingQuestion"
-            },
+            "items": { "$ref": "#/components/schemas/ClarifyingQuestion" },
             "type": "array",
             "title": "Questions"
           }
@@ -14470,23 +11188,10 @@
       },
       "ClarifyingQuestion": {
         "properties": {
-          "question": {
-            "type": "string",
-            "title": "Question"
-          },
-          "keyword": {
-            "type": "string",
-            "title": "Keyword"
-          },
+          "question": { "type": "string", "title": "Question" },
+          "keyword": { "type": "string", "title": "Keyword" },
           "example": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Example"
           }
         },
@@ -14499,23 +11204,15 @@
         "properties": {
           "daily": {
             "anyOf": [
-              {
-                "$ref": "#/components/schemas/UsageWindowPublic"
-              },
-              {
-                "type": "null"
-              }
+              { "$ref": "#/components/schemas/UsageWindowPublic" },
+              { "type": "null" }
             ],
             "description": "Null when no daily cap is configured (unlimited)."
           },
           "weekly": {
             "anyOf": [
-              {
-                "$ref": "#/components/schemas/UsageWindowPublic"
-              },
-              {
-                "type": "null"
-              }
+              { "$ref": "#/components/schemas/UsageWindowPublic" },
+              { "type": "null" }
             ],
             "description": "Null when no weekly cap is configured (unlimited)."
           },
@@ -14536,31 +11233,18 @@
       },
       "ConfirmLinkResponse": {
         "properties": {
-          "success": {
-            "type": "boolean",
-            "title": "Success"
-          },
+          "success": { "type": "boolean", "title": "Success" },
           "link_type": {
             "$ref": "#/components/schemas/LinkType",
             "default": "SERVER"
           },
-          "platform": {
-            "type": "string",
-            "title": "Platform"
-          },
+          "platform": { "type": "string", "title": "Platform" },
           "platform_server_id": {
             "type": "string",
             "title": "Platform Server Id"
           },
           "server_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Server Name"
           }
         },
@@ -14575,22 +11259,13 @@
       },
       "ConfirmUserLinkResponse": {
         "properties": {
-          "success": {
-            "type": "boolean",
-            "title": "Success"
-          },
+          "success": { "type": "boolean", "title": "Success" },
           "link_type": {
             "$ref": "#/components/schemas/LinkType",
             "default": "USER"
           },
-          "platform": {
-            "type": "string",
-            "title": "Platform"
-          },
-          "platform_user_id": {
-            "type": "string",
-            "title": "Platform User Id"
-          }
+          "platform": { "type": "string", "title": "Platform" },
+          "platform_user_id": { "type": "string", "title": "Platform User Id" }
         },
         "type": "object",
         "required": ["success", "platform", "platform_user_id"],
@@ -14609,35 +11284,17 @@
       },
       "CopilotSkillDetail": {
         "properties": {
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
+          "name": { "type": "string", "title": "Name" },
+          "description": { "type": "string", "title": "Description" },
           "triggers": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Triggers",
             "default": []
           },
-          "body": {
-            "type": "string",
-            "title": "Body"
-          },
+          "body": { "type": "string", "title": "Body" },
           "version": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Version"
           },
           "is_default": {
@@ -14646,9 +11303,7 @@
             "default": false
           },
           "sibling_files": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Sibling Files",
             "default": []
@@ -14661,18 +11316,10 @@
       },
       "CopilotSkillInfo": {
         "properties": {
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
+          "name": { "type": "string", "title": "Name" },
+          "description": { "type": "string", "title": "Description" },
           "triggers": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Triggers",
             "default": []
@@ -14692,55 +11339,23 @@
             "default": "copilot_turn"
           },
           "schedule_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Schedule Id"
           },
-          "user_id": {
-            "type": "string",
-            "title": "User Id"
-          },
+          "user_id": { "type": "string", "title": "User Id" },
           "session_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Session Id"
           },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          },
+          "message": { "type": "string", "title": "Message" },
           "cron": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Cron"
           },
           "run_at": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
             ],
             "title": "Run At"
           },
@@ -14750,28 +11365,12 @@
             "default": 0
           },
           "user_timezone": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "User Timezone"
           },
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "next_run_time": {
-            "type": "string",
-            "title": "Next Run Time"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "name": { "type": "string", "title": "Name" },
+          "next_run_time": { "type": "string", "title": "Next Run Time" },
           "timezone": {
             "type": "string",
             "title": "Timezone",
@@ -14786,24 +11385,13 @@
       "CopilotUsageExportResponse": {
         "properties": {
           "rows": {
-            "items": {
-              "$ref": "#/components/schemas/CopilotWeeklyUsageRow"
-            },
+            "items": { "$ref": "#/components/schemas/CopilotWeeklyUsageRow" },
             "type": "array",
             "title": "Rows"
           },
-          "total_rows": {
-            "type": "integer",
-            "title": "Total Rows"
-          },
-          "window_days": {
-            "type": "integer",
-            "title": "Window Days"
-          },
-          "max_window_days": {
-            "type": "integer",
-            "title": "Max Window Days"
-          }
+          "total_rows": { "type": "integer", "title": "Total Rows" },
+          "window_days": { "type": "integer", "title": "Window Days" },
+          "max_window_days": { "type": "integer", "title": "Max Window Days" }
         },
         "type": "object",
         "required": ["rows", "total_rows", "window_days", "max_window_days"],
@@ -14811,19 +11399,9 @@
       },
       "CopilotWeeklyUsageRow": {
         "properties": {
-          "user_id": {
-            "type": "string",
-            "title": "User Id"
-          },
+          "user_id": { "type": "string", "title": "User Id" },
           "user_email": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "User Email"
           },
           "week_start": {
@@ -14840,18 +11418,12 @@
             "type": "integer",
             "title": "Copilot Cost Microdollars"
           },
-          "tier": {
-            "type": "string",
-            "title": "Tier"
-          },
+          "tier": { "type": "string", "title": "Tier" },
           "weekly_limit_microdollars": {
             "type": "integer",
             "title": "Weekly Limit Microdollars"
           },
-          "percent_used": {
-            "type": "number",
-            "title": "Percent Used"
-          }
+          "percent_used": { "type": "number", "title": "Percent Used" }
         },
         "type": "object",
         "required": [
@@ -14867,14 +11439,8 @@
       },
       "CostBucket": {
         "properties": {
-          "bucket": {
-            "type": "string",
-            "title": "Bucket"
-          },
-          "count": {
-            "type": "integer",
-            "title": "Count"
-          }
+          "bucket": { "type": "string", "title": "Bucket" },
+          "count": { "type": "integer", "title": "Count" }
         },
         "type": "object",
         "required": ["bucket", "count"],
@@ -14882,153 +11448,60 @@
       },
       "CostLogRow": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
+          "id": { "type": "string", "title": "Id" },
           "created_at": {
             "type": "string",
             "format": "date-time",
             "title": "Created At"
           },
           "user_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "User Id"
           },
           "email": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Email"
           },
           "graph_exec_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Graph Exec Id"
           },
           "node_exec_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Node Exec Id"
           },
-          "block_name": {
-            "type": "string",
-            "title": "Block Name"
-          },
-          "provider": {
-            "type": "string",
-            "title": "Provider"
-          },
+          "block_name": { "type": "string", "title": "Block Name" },
+          "provider": { "type": "string", "title": "Provider" },
           "tracking_type": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Tracking Type"
           },
           "cost_microdollars": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
             "title": "Cost Microdollars"
           },
           "input_tokens": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
             "title": "Input Tokens"
           },
           "output_tokens": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
             "title": "Output Tokens"
           },
           "duration": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "number" }, { "type": "null" }],
             "title": "Duration"
           },
           "model": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Model"
           },
           "cache_read_tokens": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
             "title": "Cache Read Tokens"
           },
           "cache_creation_tokens": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
             "title": "Cache Creation Tokens"
           }
         },
@@ -15038,34 +11511,16 @@
       },
       "CountResponse": {
         "properties": {
-          "all_blocks": {
-            "type": "integer",
-            "title": "All Blocks"
-          },
-          "input_blocks": {
-            "type": "integer",
-            "title": "Input Blocks"
-          },
-          "action_blocks": {
-            "type": "integer",
-            "title": "Action Blocks"
-          },
-          "output_blocks": {
-            "type": "integer",
-            "title": "Output Blocks"
-          },
-          "integrations": {
-            "type": "integer",
-            "title": "Integrations"
-          },
+          "all_blocks": { "type": "integer", "title": "All Blocks" },
+          "input_blocks": { "type": "integer", "title": "Input Blocks" },
+          "action_blocks": { "type": "integer", "title": "Action Blocks" },
+          "output_blocks": { "type": "integer", "title": "Output Blocks" },
+          "integrations": { "type": "integer", "title": "Integrations" },
           "marketplace_agents": {
             "type": "integer",
             "title": "Marketplace Agents"
           },
-          "my_agents": {
-            "type": "integer",
-            "title": "My Agents"
-          }
+          "my_agents": { "type": "integer", "title": "My Agents" }
         },
         "type": "object",
         "required": [
@@ -15081,26 +11536,14 @@
       },
       "CreateAPIKeyRequest": {
         "properties": {
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
+          "name": { "type": "string", "title": "Name" },
           "permissions": {
-            "items": {
-              "$ref": "#/components/schemas/APIKeyPermission"
-            },
+            "items": { "$ref": "#/components/schemas/APIKeyPermission" },
             "type": "array",
             "title": "Permissions"
           },
           "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Description"
           }
         },
@@ -15110,13 +11553,8 @@
       },
       "CreateAPIKeyResponse": {
         "properties": {
-          "api_key": {
-            "$ref": "#/components/schemas/APIKeyInfo"
-          },
-          "plain_text_key": {
-            "type": "string",
-            "title": "Plain Text Key"
-          }
+          "api_key": { "$ref": "#/components/schemas/APIKeyInfo" },
+          "plain_text_key": { "type": "string", "title": "Plain Text Key" }
         },
         "type": "object",
         "required": ["api_key", "plain_text_key"],
@@ -15124,18 +11562,11 @@
       },
       "CreateGraph": {
         "properties": {
-          "graph": {
-            "$ref": "#/components/schemas/Graph"
-          },
+          "graph": { "$ref": "#/components/schemas/Graph" },
           "source": {
             "anyOf": [
-              {
-                "type": "string",
-                "enum": ["builder", "upload"]
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "enum": ["builder", "upload"] },
+              { "type": "null" }
             ],
             "title": "Source"
           }
@@ -15153,13 +11584,8 @@
           },
           "builder_graph_id": {
             "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 128
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "maxLength": 128 },
+              { "type": "null" }
             ],
             "title": "Builder Graph Id"
           }
@@ -15171,30 +11597,15 @@
       },
       "CreateSessionResponse": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "created_at": {
-            "type": "string",
-            "title": "Created At"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "created_at": { "type": "string", "title": "Created At" },
           "user_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "User Id"
           },
           "metadata": {
             "$ref": "#/components/schemas/ChatSessionMetadata",
-            "default": {
-              "dry_run": false
-            }
+            "default": { "dry_run": false }
           }
         },
         "type": "object",
@@ -15204,56 +11615,24 @@
       },
       "CreatorDetails": {
         "properties": {
-          "username": {
-            "type": "string",
-            "title": "Username"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
+          "username": { "type": "string", "title": "Username" },
+          "name": { "type": "string", "title": "Name" },
+          "description": { "type": "string", "title": "Description" },
           "avatar_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Avatar Url"
           },
           "links": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Links"
           },
-          "is_featured": {
-            "type": "boolean",
-            "title": "Is Featured"
-          },
-          "num_agents": {
-            "type": "integer",
-            "title": "Num Agents"
-          },
-          "agent_runs": {
-            "type": "integer",
-            "title": "Agent Runs"
-          },
-          "agent_rating": {
-            "type": "number",
-            "title": "Agent Rating"
-          },
+          "is_featured": { "type": "boolean", "title": "Is Featured" },
+          "num_agents": { "type": "integer", "title": "Num Agents" },
+          "agent_runs": { "type": "integer", "title": "Agent Runs" },
+          "agent_rating": { "type": "number", "title": "Agent Rating" },
           "top_categories": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Top Categories"
           }
@@ -15277,15 +11656,11 @@
       "CreatorsResponse": {
         "properties": {
           "creators": {
-            "items": {
-              "$ref": "#/components/schemas/CreatorDetails"
-            },
+            "items": { "$ref": "#/components/schemas/CreatorDetails" },
             "type": "array",
             "title": "Creators"
           },
-          "pagination": {
-            "$ref": "#/components/schemas/Pagination"
-          }
+          "pagination": { "$ref": "#/components/schemas/Pagination" }
         },
         "type": "object",
         "required": ["creators", "pagination"],
@@ -15305,10 +11680,7 @@
             "title": "Need Confirmation",
             "default": true
           },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          }
+          "message": { "type": "string", "title": "Message" }
         },
         "type": "object",
         "required": ["message"],
@@ -15323,14 +11695,7 @@
             "default": true
           },
           "revoked": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "boolean" }, { "type": "null" }],
             "title": "Revoked",
             "description": "Indicates whether the credentials were also revoked by their provider. `None`/`null` if not applicable, e.g. when deleting non-revocable credentials such as API keys."
           }
@@ -15341,19 +11706,9 @@
       },
       "CredentialsMetaInput": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
+          "id": { "type": "string", "title": "Id" },
           "title": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Title"
           },
           "provider": {
@@ -15375,64 +11730,30 @@
       },
       "CredentialsMetaResponse": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "provider": {
-            "type": "string",
-            "title": "Provider"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "provider": { "type": "string", "title": "Provider" },
           "type": {
             "type": "string",
             "enum": ["api_key", "oauth2", "user_password", "host_scoped"],
             "title": "Type"
           },
           "title": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Title"
           },
           "scopes": {
             "anyOf": [
-              {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
+              { "items": { "type": "string" }, "type": "array" },
+              { "type": "null" }
             ],
             "title": "Scopes"
           },
           "username": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Username"
           },
           "host": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Host",
             "description": "Host pattern for host-scoped or MCP server URL for MCP credentials"
           },
@@ -15461,24 +11782,13 @@
       "CreditTransactionsExportResponse": {
         "properties": {
           "transactions": {
-            "items": {
-              "$ref": "#/components/schemas/UserTransaction"
-            },
+            "items": { "$ref": "#/components/schemas/UserTransaction" },
             "type": "array",
             "title": "Transactions"
           },
-          "total_rows": {
-            "type": "integer",
-            "title": "Total Rows"
-          },
-          "window_days": {
-            "type": "integer",
-            "title": "Window Days"
-          },
-          "max_window_days": {
-            "type": "integer",
-            "title": "Max Window Days"
-          }
+          "total_rows": { "type": "integer", "title": "Total Rows" },
+          "window_days": { "type": "integer", "title": "Window Days" },
+          "max_window_days": { "type": "integer", "title": "Max Window Days" }
         },
         "type": "object",
         "required": [
@@ -15490,34 +11800,21 @@
         "title": "CreditTransactionsExportResponse"
       },
       "DeleteFileResponse": {
-        "properties": {
-          "deleted": {
-            "type": "boolean",
-            "title": "Deleted"
-          }
-        },
+        "properties": { "deleted": { "type": "boolean", "title": "Deleted" } },
         "type": "object",
         "required": ["deleted"],
         "title": "DeleteFileResponse"
       },
       "DeleteGraphResponse": {
         "properties": {
-          "version_counts": {
-            "type": "integer",
-            "title": "Version Counts"
-          }
+          "version_counts": { "type": "integer", "title": "Version Counts" }
         },
         "type": "object",
         "required": ["version_counts"],
         "title": "DeleteGraphResponse"
       },
       "DeleteLinkResponse": {
-        "properties": {
-          "success": {
-            "type": "boolean",
-            "title": "Success"
-          }
-        },
+        "properties": { "success": { "type": "boolean", "title": "Success" } },
         "type": "object",
         "required": ["success"],
         "title": "DeleteLinkResponse"
@@ -15530,14 +11827,7 @@
             "description": "URL of the MCP server"
           },
           "auth_token": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Auth Token",
             "description": "Optional Bearer token for authenticated MCP servers"
           }
@@ -15550,32 +11840,16 @@
       "DiscoverToolsResponse": {
         "properties": {
           "tools": {
-            "items": {
-              "$ref": "#/components/schemas/MCPToolResponse"
-            },
+            "items": { "$ref": "#/components/schemas/MCPToolResponse" },
             "type": "array",
             "title": "Tools"
           },
           "server_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Server Name"
           },
           "protocol_version": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Protocol Version"
           }
         },
@@ -15590,42 +11864,16 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "doc_page"
           },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          },
+          "message": { "type": "string", "title": "Message" },
           "session_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Session Id"
           },
-          "title": {
-            "type": "string",
-            "title": "Title"
-          },
-          "path": {
-            "type": "string",
-            "title": "Path"
-          },
-          "content": {
-            "type": "string",
-            "title": "Content"
-          },
+          "title": { "type": "string", "title": "Title" },
+          "path": { "type": "string", "title": "Path" },
+          "content": { "type": "string", "title": "Content" },
           "doc_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Doc Url"
           }
         },
@@ -15636,35 +11884,13 @@
       },
       "DocSearchResult": {
         "properties": {
-          "title": {
-            "type": "string",
-            "title": "Title"
-          },
-          "path": {
-            "type": "string",
-            "title": "Path"
-          },
-          "section": {
-            "type": "string",
-            "title": "Section"
-          },
-          "snippet": {
-            "type": "string",
-            "title": "Snippet"
-          },
-          "score": {
-            "type": "number",
-            "title": "Score"
-          },
+          "title": { "type": "string", "title": "Title" },
+          "path": { "type": "string", "title": "Path" },
+          "section": { "type": "string", "title": "Section" },
+          "snippet": { "type": "string", "title": "Snippet" },
+          "score": { "type": "number", "title": "Score" },
           "doc_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Doc Url"
           }
         },
@@ -15679,36 +11905,18 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "doc_search_results"
           },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          },
+          "message": { "type": "string", "title": "Message" },
           "session_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Session Id"
           },
           "results": {
-            "items": {
-              "$ref": "#/components/schemas/DocSearchResult"
-            },
+            "items": { "$ref": "#/components/schemas/DocSearchResult" },
             "type": "array",
             "title": "Results"
           },
-          "count": {
-            "type": "integer",
-            "title": "Count"
-          },
-          "query": {
-            "type": "string",
-            "title": "Query"
-          }
+          "count": { "type": "integer", "title": "Count" },
+          "query": { "type": "string", "title": "Query" }
         },
         "type": "object",
         "required": ["message", "results", "count", "query"],
@@ -15717,14 +11925,8 @@
       },
       "Document": {
         "properties": {
-          "url": {
-            "type": "string",
-            "title": "Url"
-          },
-          "relevance_score": {
-            "type": "number",
-            "title": "Relevance Score"
-          }
+          "url": { "type": "string", "title": "Url" },
+          "relevance_score": { "type": "number", "title": "Relevance Score" }
         },
         "type": "object",
         "required": ["url", "relevance_score"],
@@ -15736,41 +11938,19 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "error"
           },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          },
+          "message": { "type": "string", "title": "Message" },
           "session_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Session Id"
           },
           "error": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Error"
           },
           "details": {
             "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
+              { "additionalProperties": true, "type": "object" },
+              { "type": "null" }
             ],
             "title": "Details"
           }
@@ -15783,9 +11963,7 @@
       "ExecutionAnalyticsConfig": {
         "properties": {
           "available_models": {
-            "items": {
-              "$ref": "#/components/schemas/ModelInfo"
-            },
+            "items": { "$ref": "#/components/schemas/ModelInfo" },
             "type": "array",
             "title": "Available Models"
           },
@@ -15819,38 +11997,19 @@
             "description": "Graph ID to analyze"
           },
           "graph_version": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
             "title": "Graph Version",
             "description": "Optional graph version"
           },
           "user_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "User Id",
             "description": "Optional user ID filter"
           },
           "created_after": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
             ],
             "title": "Created After",
             "description": "Optional created date lower bound"
@@ -15870,26 +12029,12 @@
             "default": 10
           },
           "system_prompt": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "System Prompt",
             "description": "Custom system prompt (default: built-in prompt)"
           },
           "user_prompt": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "User Prompt",
             "description": "Custom user prompt with {{GRAPH_NAME}} and {{EXECUTION_DATA}} placeholders (default: built-in prompt)"
           },
@@ -15947,80 +12092,34 @@
       },
       "ExecutionAnalyticsResult": {
         "properties": {
-          "agent_id": {
-            "type": "string",
-            "title": "Agent Id"
-          },
-          "version_id": {
-            "type": "integer",
-            "title": "Version Id"
-          },
-          "user_id": {
-            "type": "string",
-            "title": "User Id"
-          },
-          "exec_id": {
-            "type": "string",
-            "title": "Exec Id"
-          },
+          "agent_id": { "type": "string", "title": "Agent Id" },
+          "version_id": { "type": "integer", "title": "Version Id" },
+          "user_id": { "type": "string", "title": "User Id" },
+          "exec_id": { "type": "string", "title": "Exec Id" },
           "summary_text": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Summary Text"
           },
           "score": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "number" }, { "type": "null" }],
             "title": "Score"
           },
-          "status": {
-            "type": "string",
-            "title": "Status"
-          },
+          "status": { "type": "string", "title": "Status" },
           "error_message": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Error Message"
           },
           "started_at": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
             ],
             "title": "Started At"
           },
           "ended_at": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
             ],
             "title": "Ended At"
           }
@@ -16059,22 +12158,13 @@
             "type": "integer",
             "title": "Orphaned Running"
           },
-          "orphaned_queued": {
-            "type": "integer",
-            "title": "Orphaned Queued"
-          },
-          "failed_count_1h": {
-            "type": "integer",
-            "title": "Failed Count 1H"
-          },
+          "orphaned_queued": { "type": "integer", "title": "Orphaned Queued" },
+          "failed_count_1h": { "type": "integer", "title": "Failed Count 1H" },
           "failed_count_24h": {
             "type": "integer",
             "title": "Failed Count 24H"
           },
-          "failure_rate_24h": {
-            "type": "number",
-            "title": "Failure Rate 24H"
-          },
+          "failure_rate_24h": { "type": "number", "title": "Failure Rate 24H" },
           "stuck_running_24h": {
             "type": "integer",
             "title": "Stuck Running 24H"
@@ -16084,20 +12174,10 @@
             "title": "Stuck Running 1H"
           },
           "oldest_running_hours": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "number" }, { "type": "null" }],
             "title": "Oldest Running Hours"
           },
-          "stuck_queued_1h": {
-            "type": "integer",
-            "title": "Stuck Queued 1H"
-          },
+          "stuck_queued_1h": { "type": "integer", "title": "Stuck Queued 1H" },
           "queued_never_started": {
             "type": "integer",
             "title": "Queued Never Started"
@@ -16110,22 +12190,13 @@
             "type": "integer",
             "title": "Invalid Running Without Start"
           },
-          "completed_1h": {
-            "type": "integer",
-            "title": "Completed 1H"
-          },
-          "completed_24h": {
-            "type": "integer",
-            "title": "Completed 24H"
-          },
+          "completed_1h": { "type": "integer", "title": "Completed 1H" },
+          "completed_24h": { "type": "integer", "title": "Completed 24H" },
           "throughput_per_hour": {
             "type": "number",
             "title": "Throughput Per Hour"
           },
-          "timestamp": {
-            "type": "string",
-            "title": "Timestamp"
-          }
+          "timestamp": { "type": "string", "title": "Timestamp" }
         },
         "type": "object",
         "required": [
@@ -16155,21 +12226,13 @@
       },
       "ExecutionOptions": {
         "properties": {
-          "manual": {
-            "type": "boolean",
-            "title": "Manual",
-            "default": true
-          },
+          "manual": { "type": "boolean", "title": "Manual", "default": true },
           "scheduled": {
             "type": "boolean",
             "title": "Scheduled",
             "default": true
           },
-          "webhook": {
-            "type": "boolean",
-            "title": "Webhook",
-            "default": false
-          }
+          "webhook": { "type": "boolean", "title": "Webhook", "default": false }
         },
         "type": "object",
         "title": "ExecutionOptions",
@@ -16177,70 +12240,41 @@
       },
       "ExecutionOutputInfo": {
         "properties": {
-          "execution_id": {
-            "type": "string",
-            "title": "Execution Id"
-          },
-          "status": {
-            "type": "string",
-            "title": "Status"
-          },
+          "execution_id": { "type": "string", "title": "Execution Id" },
+          "status": { "type": "string", "title": "Status" },
           "started_at": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
             ],
             "title": "Started At"
           },
           "ended_at": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
             ],
             "title": "Ended At"
           },
           "outputs": {
-            "additionalProperties": {
-              "items": {},
-              "type": "array"
-            },
+            "additionalProperties": { "items": {}, "type": "array" },
             "type": "object",
             "title": "Outputs"
           },
           "inputs_summary": {
             "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
+              { "additionalProperties": true, "type": "object" },
+              { "type": "null" }
             ],
             "title": "Inputs Summary"
           },
           "node_executions": {
             "anyOf": [
               {
-                "items": {
-                  "additionalProperties": true,
-                  "type": "object"
-                },
+                "items": { "additionalProperties": true, "type": "object" },
                 "type": "array"
               },
-              {
-                "type": "null"
-              }
+              { "type": "null" }
             ],
             "title": "Node Executions"
           }
@@ -16256,60 +12290,23 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "execution_started"
           },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          },
+          "message": { "type": "string", "title": "Message" },
           "session_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Session Id"
           },
-          "execution_id": {
-            "type": "string",
-            "title": "Execution Id"
-          },
-          "graph_id": {
-            "type": "string",
-            "title": "Graph Id"
-          },
-          "graph_name": {
-            "type": "string",
-            "title": "Graph Name"
-          },
+          "execution_id": { "type": "string", "title": "Execution Id" },
+          "graph_id": { "type": "string", "title": "Graph Id" },
+          "graph_name": { "type": "string", "title": "Graph Name" },
           "library_agent_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Library Agent Id"
           },
           "library_agent_link": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Library Agent Link"
           },
-          "status": {
-            "type": "string",
-            "title": "Status",
-            "default": "QUEUED"
-          }
+          "status": { "type": "string", "title": "Status", "default": "QUEUED" }
         },
         "type": "object",
         "required": ["message", "execution_id", "graph_id", "graph_name"],
@@ -16318,41 +12315,16 @@
       },
       "FailedExecutionDetail": {
         "properties": {
-          "execution_id": {
-            "type": "string",
-            "title": "Execution Id"
-          },
-          "graph_id": {
-            "type": "string",
-            "title": "Graph Id"
-          },
-          "graph_name": {
-            "type": "string",
-            "title": "Graph Name"
-          },
-          "graph_version": {
-            "type": "integer",
-            "title": "Graph Version"
-          },
-          "user_id": {
-            "type": "string",
-            "title": "User Id"
-          },
+          "execution_id": { "type": "string", "title": "Execution Id" },
+          "graph_id": { "type": "string", "title": "Graph Id" },
+          "graph_name": { "type": "string", "title": "Graph Name" },
+          "graph_version": { "type": "integer", "title": "Graph Version" },
+          "user_id": { "type": "string", "title": "User Id" },
           "user_email": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "User Email"
           },
-          "status": {
-            "type": "string",
-            "title": "Status"
-          },
+          "status": { "type": "string", "title": "Status" },
           "created_at": {
             "type": "string",
             "format": "date-time",
@@ -16360,37 +12332,20 @@
           },
           "started_at": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
             ],
             "title": "Started At"
           },
           "failed_at": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
             ],
             "title": "Failed At"
           },
           "error_message": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Error Message"
           }
         },
@@ -16414,16 +12369,11 @@
       "FailedExecutionsListResponse": {
         "properties": {
           "executions": {
-            "items": {
-              "$ref": "#/components/schemas/FailedExecutionDetail"
-            },
+            "items": { "$ref": "#/components/schemas/FailedExecutionDetail" },
             "type": "array",
             "title": "Executions"
           },
-          "total": {
-            "type": "integer",
-            "title": "Total"
-          }
+          "total": { "type": "integer", "title": "Total" }
         },
         "type": "object",
         "required": ["executions", "total"],
@@ -16439,38 +12389,19 @@
             "title": "Name"
           },
           "icon": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Icon"
           },
           "color": {
             "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^#[0-9A-Fa-f]{6}$"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "pattern": "^#[0-9A-Fa-f]{6}$" },
+              { "type": "null" }
             ],
             "title": "Color",
             "description": "Hex color code (#RRGGBB)"
           },
           "parent_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Parent Id"
           }
         },
@@ -16482,15 +12413,11 @@
       "FolderListResponse": {
         "properties": {
           "folders": {
-            "items": {
-              "$ref": "#/components/schemas/LibraryFolder"
-            },
+            "items": { "$ref": "#/components/schemas/LibraryFolder" },
             "type": "array",
             "title": "Folders"
           },
-          "pagination": {
-            "$ref": "#/components/schemas/Pagination"
-          }
+          "pagination": { "$ref": "#/components/schemas/Pagination" }
         },
         "type": "object",
         "required": ["folders", "pagination"],
@@ -16500,14 +12427,7 @@
       "FolderMoveRequest": {
         "properties": {
           "target_parent_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Target Parent Id"
           }
         },
@@ -16518,9 +12438,7 @@
       "FolderTreeResponse": {
         "properties": {
           "tree": {
-            "items": {
-              "$ref": "#/components/schemas/LibraryFolderTree"
-            },
+            "items": { "$ref": "#/components/schemas/LibraryFolderTree" },
             "type": "array",
             "title": "Tree"
           }
@@ -16534,37 +12452,17 @@
         "properties": {
           "name": {
             "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 100,
-                "minLength": 1
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "maxLength": 100, "minLength": 1 },
+              { "type": "null" }
             ],
             "title": "Name"
           },
           "icon": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Icon"
           },
           "color": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Color"
           }
         },
@@ -16574,90 +12472,43 @@
       },
       "Graph": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "version": {
-            "type": "integer",
-            "title": "Version",
-            "default": 1
-          },
+          "id": { "type": "string", "title": "Id" },
+          "version": { "type": "integer", "title": "Version", "default": 1 },
           "is_active": {
             "type": "boolean",
             "title": "Is Active",
             "default": true
           },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
+          "name": { "type": "string", "title": "Name" },
+          "description": { "type": "string", "title": "Description" },
           "instructions": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Instructions"
           },
           "recommended_schedule_cron": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Recommended Schedule Cron"
           },
           "forked_from_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Forked From Id"
           },
           "forked_from_version": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
             "title": "Forked From Version"
           },
           "nodes": {
-            "items": {
-              "$ref": "#/components/schemas/Node"
-            },
+            "items": { "$ref": "#/components/schemas/Node" },
             "type": "array",
             "title": "Nodes"
           },
           "links": {
-            "items": {
-              "$ref": "#/components/schemas/Link"
-            },
+            "items": { "$ref": "#/components/schemas/Link" },
             "type": "array",
             "title": "Links"
           },
           "sub_graphs": {
-            "items": {
-              "$ref": "#/components/schemas/BaseGraph-Input"
-            },
+            "items": { "$ref": "#/components/schemas/BaseGraph-Input" },
             "type": "array",
             "title": "Sub Graphs"
           }
@@ -16669,22 +12520,10 @@
       },
       "GraphExecution": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "user_id": {
-            "type": "string",
-            "title": "User Id"
-          },
-          "graph_id": {
-            "type": "string",
-            "title": "Graph Id"
-          },
-          "graph_version": {
-            "type": "integer",
-            "title": "Graph Version"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "user_id": { "type": "string", "title": "User Id" },
+          "graph_id": { "type": "string", "title": "Graph Id" },
+          "graph_version": { "type": "integer", "title": "Graph Version" },
           "inputs": {
             "additionalProperties": true,
             "type": "object",
@@ -16698,9 +12537,7 @@
                 },
                 "type": "object"
               },
-              {
-                "type": "null"
-              }
+              { "type": "null" }
             ],
             "title": "Credential Inputs"
           },
@@ -16713,48 +12550,27 @@
                 },
                 "type": "object"
               },
-              {
-                "type": "null"
-              }
+              { "type": "null" }
             ],
             "title": "Nodes Input Masks"
           },
           "preset_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Preset Id"
           },
-          "status": {
-            "$ref": "#/components/schemas/AgentExecutionStatus"
-          },
+          "status": { "$ref": "#/components/schemas/AgentExecutionStatus" },
           "started_at": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
             ],
             "title": "Started At",
             "description": "When execution started running. Null if not yet started (QUEUED)."
           },
           "ended_at": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
             ],
             "title": "Ended At",
             "description": "When execution finished. Null if not yet completed (QUEUED, RUNNING, INCOMPLETE, REVIEW)."
@@ -16765,14 +12581,7 @@
             "default": false
           },
           "share_token": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Share Token"
           },
           "is_dry_run": {
@@ -16782,19 +12591,12 @@
           },
           "stats": {
             "anyOf": [
-              {
-                "$ref": "#/components/schemas/Stats"
-              },
-              {
-                "type": "null"
-              }
+              { "$ref": "#/components/schemas/Stats" },
+              { "type": "null" }
             ]
           },
           "outputs": {
-            "additionalProperties": {
-              "items": {},
-              "type": "array"
-            },
+            "additionalProperties": { "items": {}, "type": "array" },
             "type": "object",
             "title": "Outputs"
           }
@@ -16824,43 +12626,17 @@
             "default": "graph"
           },
           "schedule_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Schedule Id"
           },
-          "user_id": {
-            "type": "string",
-            "title": "User Id"
-          },
-          "graph_id": {
-            "type": "string",
-            "title": "Graph Id"
-          },
-          "graph_version": {
-            "type": "integer",
-            "title": "Graph Version"
-          },
+          "user_id": { "type": "string", "title": "User Id" },
+          "graph_id": { "type": "string", "title": "Graph Id" },
+          "graph_version": { "type": "integer", "title": "Graph Version" },
           "agent_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Agent Name"
           },
-          "cron": {
-            "type": "string",
-            "title": "Cron"
-          },
+          "cron": { "type": "string", "title": "Cron" },
           "input_data": {
             "additionalProperties": true,
             "type": "object",
@@ -16873,18 +12649,9 @@
             "type": "object",
             "title": "Input Credentials"
           },
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "next_run_time": {
-            "type": "string",
-            "title": "Next Run Time"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "name": { "type": "string", "title": "Name" },
+          "next_run_time": { "type": "string", "title": "Next Run Time" },
           "timezone": {
             "type": "string",
             "title": "Timezone",
@@ -16907,31 +12674,14 @@
       },
       "GraphExecutionMeta": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "user_id": {
-            "type": "string",
-            "title": "User Id"
-          },
-          "graph_id": {
-            "type": "string",
-            "title": "Graph Id"
-          },
-          "graph_version": {
-            "type": "integer",
-            "title": "Graph Version"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "user_id": { "type": "string", "title": "User Id" },
+          "graph_id": { "type": "string", "title": "Graph Id" },
+          "graph_version": { "type": "integer", "title": "Graph Version" },
           "inputs": {
             "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
+              { "additionalProperties": true, "type": "object" },
+              { "type": "null" }
             ],
             "title": "Inputs"
           },
@@ -16943,9 +12693,7 @@
                 },
                 "type": "object"
               },
-              {
-                "type": "null"
-              }
+              { "type": "null" }
             ],
             "title": "Credential Inputs"
           },
@@ -16958,48 +12706,27 @@
                 },
                 "type": "object"
               },
-              {
-                "type": "null"
-              }
+              { "type": "null" }
             ],
             "title": "Nodes Input Masks"
           },
           "preset_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Preset Id"
           },
-          "status": {
-            "$ref": "#/components/schemas/AgentExecutionStatus"
-          },
+          "status": { "$ref": "#/components/schemas/AgentExecutionStatus" },
           "started_at": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
             ],
             "title": "Started At",
             "description": "When execution started running. Null if not yet started (QUEUED)."
           },
           "ended_at": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
             ],
             "title": "Ended At",
             "description": "When execution finished. Null if not yet completed (QUEUED, RUNNING, INCOMPLETE, REVIEW)."
@@ -17010,14 +12737,7 @@
             "default": false
           },
           "share_token": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Share Token"
           },
           "is_dry_run": {
@@ -17027,12 +12747,8 @@
           },
           "stats": {
             "anyOf": [
-              {
-                "$ref": "#/components/schemas/Stats"
-              },
-              {
-                "type": "null"
-              }
+              { "$ref": "#/components/schemas/Stats" },
+              { "type": "null" }
             ]
           }
         },
@@ -17053,22 +12769,10 @@
       },
       "GraphExecutionWithNodes": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "user_id": {
-            "type": "string",
-            "title": "User Id"
-          },
-          "graph_id": {
-            "type": "string",
-            "title": "Graph Id"
-          },
-          "graph_version": {
-            "type": "integer",
-            "title": "Graph Version"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "user_id": { "type": "string", "title": "User Id" },
+          "graph_id": { "type": "string", "title": "Graph Id" },
+          "graph_version": { "type": "integer", "title": "Graph Version" },
           "inputs": {
             "additionalProperties": true,
             "type": "object",
@@ -17082,9 +12786,7 @@
                 },
                 "type": "object"
               },
-              {
-                "type": "null"
-              }
+              { "type": "null" }
             ],
             "title": "Credential Inputs"
           },
@@ -17097,48 +12799,27 @@
                 },
                 "type": "object"
               },
-              {
-                "type": "null"
-              }
+              { "type": "null" }
             ],
             "title": "Nodes Input Masks"
           },
           "preset_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Preset Id"
           },
-          "status": {
-            "$ref": "#/components/schemas/AgentExecutionStatus"
-          },
+          "status": { "$ref": "#/components/schemas/AgentExecutionStatus" },
           "started_at": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
             ],
             "title": "Started At",
             "description": "When execution started running. Null if not yet started (QUEUED)."
           },
           "ended_at": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
             ],
             "title": "Ended At",
             "description": "When execution finished. Null if not yet completed (QUEUED, RUNNING, INCOMPLETE, REVIEW)."
@@ -17149,14 +12830,7 @@
             "default": false
           },
           "share_token": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Share Token"
           },
           "is_dry_run": {
@@ -17166,26 +12840,17 @@
           },
           "stats": {
             "anyOf": [
-              {
-                "$ref": "#/components/schemas/Stats"
-              },
-              {
-                "type": "null"
-              }
+              { "$ref": "#/components/schemas/Stats" },
+              { "type": "null" }
             ]
           },
           "outputs": {
-            "additionalProperties": {
-              "items": {},
-              "type": "array"
-            },
+            "additionalProperties": { "items": {}, "type": "array" },
             "type": "object",
             "title": "Outputs"
           },
           "node_executions": {
-            "items": {
-              "$ref": "#/components/schemas/NodeExecutionResult"
-            },
+            "items": { "$ref": "#/components/schemas/NodeExecutionResult" },
             "type": "array",
             "title": "Node Executions"
           }
@@ -17210,15 +12875,11 @@
       "GraphExecutionsPaginated": {
         "properties": {
           "executions": {
-            "items": {
-              "$ref": "#/components/schemas/GraphExecutionMeta"
-            },
+            "items": { "$ref": "#/components/schemas/GraphExecutionMeta" },
             "type": "array",
             "title": "Executions"
           },
-          "pagination": {
-            "$ref": "#/components/schemas/Pagination"
-          }
+          "pagination": { "$ref": "#/components/schemas/Pagination" }
         },
         "type": "object",
         "required": ["executions", "pagination"],
@@ -17227,75 +12888,32 @@
       },
       "GraphMeta": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "version": {
-            "type": "integer",
-            "title": "Version"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "version": { "type": "integer", "title": "Version" },
           "is_active": {
             "type": "boolean",
             "title": "Is Active",
             "default": true
           },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
+          "name": { "type": "string", "title": "Name" },
+          "description": { "type": "string", "title": "Description" },
           "instructions": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Instructions"
           },
           "recommended_schedule_cron": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Recommended Schedule Cron"
           },
           "forked_from_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Forked From Id"
           },
           "forked_from_version": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
             "title": "Forked From Version"
           },
-          "user_id": {
-            "type": "string",
-            "title": "User Id"
-          },
+          "user_id": { "type": "string", "title": "User Id" },
           "created_at": {
             "type": "string",
             "format": "date-time",
@@ -17316,99 +12934,49 @@
       },
       "GraphModel": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "version": {
-            "type": "integer",
-            "title": "Version",
-            "default": 1
-          },
+          "id": { "type": "string", "title": "Id" },
+          "version": { "type": "integer", "title": "Version", "default": 1 },
           "is_active": {
             "type": "boolean",
             "title": "Is Active",
             "default": true
           },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
+          "name": { "type": "string", "title": "Name" },
+          "description": { "type": "string", "title": "Description" },
           "instructions": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Instructions"
           },
           "recommended_schedule_cron": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Recommended Schedule Cron"
           },
           "forked_from_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Forked From Id"
           },
           "forked_from_version": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
             "title": "Forked From Version"
           },
-          "user_id": {
-            "type": "string",
-            "title": "User Id"
-          },
+          "user_id": { "type": "string", "title": "User Id" },
           "created_at": {
             "type": "string",
             "format": "date-time",
             "title": "Created At"
           },
           "nodes": {
-            "items": {
-              "$ref": "#/components/schemas/NodeModel"
-            },
+            "items": { "$ref": "#/components/schemas/NodeModel" },
             "type": "array",
             "title": "Nodes"
           },
           "links": {
-            "items": {
-              "$ref": "#/components/schemas/Link"
-            },
+            "items": { "$ref": "#/components/schemas/Link" },
             "type": "array",
             "title": "Links"
           },
           "sub_graphs": {
-            "items": {
-              "$ref": "#/components/schemas/BaseGraph-Output"
-            },
+            "items": { "$ref": "#/components/schemas/BaseGraph-Output" },
             "type": "array",
             "title": "Sub Graphs"
           },
@@ -17441,12 +13009,8 @@
           },
           "trigger_setup_info": {
             "anyOf": [
-              {
-                "$ref": "#/components/schemas/GraphTriggerInfo"
-              },
-              {
-                "type": "null"
-              }
+              { "$ref": "#/components/schemas/GraphTriggerInfo" },
+              { "type": "null" }
             ],
             "readOnly": true
           },
@@ -17476,76 +13040,32 @@
       },
       "GraphModelWithoutNodes": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "version": {
-            "type": "integer",
-            "title": "Version",
-            "default": 1
-          },
+          "id": { "type": "string", "title": "Id" },
+          "version": { "type": "integer", "title": "Version", "default": 1 },
           "is_active": {
             "type": "boolean",
             "title": "Is Active",
             "default": true
           },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
+          "name": { "type": "string", "title": "Name" },
+          "description": { "type": "string", "title": "Description" },
           "instructions": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Instructions"
           },
           "recommended_schedule_cron": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Recommended Schedule Cron"
           },
           "forked_from_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Forked From Id"
           },
           "forked_from_version": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
             "title": "Forked From Version"
           },
-          "user_id": {
-            "type": "string",
-            "title": "User Id"
-          },
+          "user_id": { "type": "string", "title": "User Id" },
           "created_at": {
             "type": "string",
             "format": "date-time",
@@ -17580,12 +13100,8 @@
           },
           "trigger_setup_info": {
             "anyOf": [
-              {
-                "$ref": "#/components/schemas/GraphTriggerInfo"
-              },
-              {
-                "type": "null"
-              }
+              { "$ref": "#/components/schemas/GraphTriggerInfo" },
+              { "type": "null" }
             ],
             "readOnly": true
           },
@@ -17626,14 +13142,7 @@
             "default": false
           },
           "builder_chat_session_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Builder Chat Session Id"
           }
         },
@@ -17654,14 +13163,7 @@
             "description": "Input schema for the trigger block"
           },
           "credentials_input_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Credentials Input Name"
           }
         },
@@ -17672,9 +13174,7 @@
       "HTTPValidationError": {
         "properties": {
           "detail": {
-            "items": {
-              "$ref": "#/components/schemas/ValidationError"
-            },
+            "items": { "$ref": "#/components/schemas/ValidationError" },
             "type": "array",
             "title": "Detail"
           }
@@ -17684,23 +13184,10 @@
       },
       "HostScopedCredentials": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "provider": {
-            "type": "string",
-            "title": "Provider"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "provider": { "type": "string", "title": "Provider" },
           "title": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Title"
           },
           "is_managed": {
@@ -17741,10 +13228,7 @@
       },
       "ImageURLResponse": {
         "properties": {
-          "image_url": {
-            "type": "string",
-            "title": "Image Url"
-          }
+          "image_url": { "type": "string", "title": "Image Url" }
         },
         "type": "object",
         "required": ["image_url"],
@@ -17756,25 +13240,13 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "input_validation_error"
           },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          },
+          "message": { "type": "string", "title": "Message" },
           "session_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Session Id"
           },
           "unrecognized_fields": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Unrecognized Fields",
             "description": "List of input field names that were not recognized"
@@ -17786,25 +13258,11 @@
             "description": "The agent's valid input schema for reference"
           },
           "graph_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Graph Id"
           },
           "graph_version": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
             "title": "Graph Version"
           }
         },
@@ -17815,19 +13273,9 @@
       },
       "InvoiceListItem": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
+          "id": { "type": "string", "title": "Id" },
           "number": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Number"
           },
           "created_at": {
@@ -17835,10 +13283,7 @@
             "format": "date-time",
             "title": "Created At"
           },
-          "total_cents": {
-            "type": "integer",
-            "title": "Total Cents"
-          },
+          "total_cents": { "type": "integer", "title": "Total Cents" },
           "amount_paid_cents": {
             "type": "integer",
             "title": "Amount Paid Cents"
@@ -17848,41 +13293,17 @@
             "title": "Currency",
             "default": "usd"
           },
-          "status": {
-            "type": "string",
-            "title": "Status"
-          },
+          "status": { "type": "string", "title": "Status" },
           "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Description"
           },
           "hosted_invoice_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Hosted Invoice Url"
           },
           "invoice_pdf_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Invoice Pdf Url"
           }
         },
@@ -17899,40 +13320,19 @@
       },
       "LibraryAgent": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "graph_id": {
-            "type": "string",
-            "title": "Graph Id"
-          },
-          "graph_version": {
-            "type": "integer",
-            "title": "Graph Version"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "graph_id": { "type": "string", "title": "Graph Id" },
+          "graph_version": { "type": "integer", "title": "Graph Version" },
           "image_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Image Url"
           },
-          "creator_name": {
-            "type": "string",
-            "title": "Creator Name"
-          },
+          "creator_name": { "type": "string", "title": "Creator Name" },
           "creator_image_url": {
             "type": "string",
             "title": "Creator Image Url"
           },
-          "status": {
-            "$ref": "#/components/schemas/LibraryAgentStatus"
-          },
+          "status": { "$ref": "#/components/schemas/LibraryAgentStatus" },
           "created_at": {
             "type": "string",
             "format": "date-time",
@@ -17943,23 +13343,10 @@
             "format": "date-time",
             "title": "Updated At"
           },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
+          "name": { "type": "string", "title": "Name" },
+          "description": { "type": "string", "title": "Description" },
           "instructions": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Instructions"
           },
           "input_schema": {
@@ -17974,13 +13361,8 @@
           },
           "credentials_input_schema": {
             "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
+              { "additionalProperties": true, "type": "object" },
+              { "type": "null" }
             ],
             "title": "Credentials Input Schema",
             "description": "Input schema for credentials required by the agent"
@@ -18002,49 +13384,26 @@
           },
           "trigger_setup_info": {
             "anyOf": [
-              {
-                "$ref": "#/components/schemas/GraphTriggerInfo"
-              },
-              {
-                "type": "null"
-              }
+              { "$ref": "#/components/schemas/GraphTriggerInfo" },
+              { "type": "null" }
             ]
           },
-          "new_output": {
-            "type": "boolean",
-            "title": "New Output"
-          },
+          "new_output": { "type": "boolean", "title": "New Output" },
           "execution_count": {
             "type": "integer",
             "title": "Execution Count",
             "default": 0
           },
           "success_rate": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "number" }, { "type": "null" }],
             "title": "Success Rate"
           },
           "avg_correctness_score": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "number" }, { "type": "null" }],
             "title": "Avg Correctness Score"
           },
           "recent_executions": {
-            "items": {
-              "$ref": "#/components/schemas/RecentExecution"
-            },
+            "items": { "$ref": "#/components/schemas/RecentExecution" },
             "type": "array",
             "title": "Recent Executions",
             "description": "List of recent executions with status, score, and summary"
@@ -18058,30 +13417,13 @@
             "type": "boolean",
             "title": "Is Latest Version"
           },
-          "is_favorite": {
-            "type": "boolean",
-            "title": "Is Favorite"
-          },
+          "is_favorite": { "type": "boolean", "title": "Is Favorite" },
           "folder_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Folder Id"
           },
           "folder_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Folder Name"
           },
           "is_hidden": {
@@ -18090,14 +13432,7 @@
             "default": false
           },
           "recommended_schedule_cron": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Recommended Schedule Cron"
           },
           "is_scheduled": {
@@ -18107,28 +13442,15 @@
             "default": false
           },
           "next_scheduled_run": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Next Scheduled Run",
             "description": "ISO 8601 timestamp of the next scheduled run, if any"
           },
-          "settings": {
-            "$ref": "#/components/schemas/GraphSettings"
-          },
+          "settings": { "$ref": "#/components/schemas/GraphSettings" },
           "marketplace_listing": {
             "anyOf": [
-              {
-                "$ref": "#/components/schemas/MarketplaceListing"
-              },
-              {
-                "type": "null"
-              }
+              { "$ref": "#/components/schemas/MarketplaceListing" },
+              { "type": "null" }
             ]
           }
         },
@@ -18161,14 +13483,8 @@
       },
       "LibraryAgentPreset": {
         "properties": {
-          "graph_id": {
-            "type": "string",
-            "title": "Graph Id"
-          },
-          "graph_version": {
-            "type": "integer",
-            "title": "Graph Version"
-          },
+          "graph_id": { "type": "string", "title": "Graph Id" },
+          "graph_version": { "type": "integer", "title": "Graph Version" },
           "inputs": {
             "additionalProperties": true,
             "type": "object",
@@ -18181,38 +13497,19 @@
             "type": "object",
             "title": "Credentials"
           },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
+          "name": { "type": "string", "title": "Name" },
+          "description": { "type": "string", "title": "Description" },
           "is_active": {
             "type": "boolean",
             "title": "Is Active",
             "default": true
           },
           "webhook_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Webhook Id"
           },
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "user_id": {
-            "type": "string",
-            "title": "User Id"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "user_id": { "type": "string", "title": "User Id" },
           "created_at": {
             "type": "string",
             "format": "date-time",
@@ -18225,12 +13522,8 @@
           },
           "webhook": {
             "anyOf": [
-              {
-                "$ref": "#/components/schemas/Webhook"
-              },
-              {
-                "type": "null"
-              }
+              { "$ref": "#/components/schemas/Webhook" },
+              { "type": "null" }
             ]
           }
         },
@@ -18253,14 +13546,8 @@
       },
       "LibraryAgentPresetCreatable": {
         "properties": {
-          "graph_id": {
-            "type": "string",
-            "title": "Graph Id"
-          },
-          "graph_version": {
-            "type": "integer",
-            "title": "Graph Version"
-          },
+          "graph_id": { "type": "string", "title": "Graph Id" },
+          "graph_version": { "type": "integer", "title": "Graph Version" },
           "inputs": {
             "additionalProperties": true,
             "type": "object",
@@ -18273,28 +13560,15 @@
             "type": "object",
             "title": "Credentials"
           },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
+          "name": { "type": "string", "title": "Name" },
+          "description": { "type": "string", "title": "Description" },
           "is_active": {
             "type": "boolean",
             "title": "Is Active",
             "default": true
           },
           "webhook_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Webhook Id"
           }
         },
@@ -18316,14 +13590,8 @@
             "type": "string",
             "title": "Graph Execution Id"
           },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
+          "name": { "type": "string", "title": "Name" },
+          "description": { "type": "string", "title": "Description" },
           "is_active": {
             "type": "boolean",
             "title": "Is Active",
@@ -18338,15 +13606,11 @@
       "LibraryAgentPresetResponse": {
         "properties": {
           "presets": {
-            "items": {
-              "$ref": "#/components/schemas/LibraryAgentPreset"
-            },
+            "items": { "$ref": "#/components/schemas/LibraryAgentPreset" },
             "type": "array",
             "title": "Presets"
           },
-          "pagination": {
-            "$ref": "#/components/schemas/Pagination"
-          }
+          "pagination": { "$ref": "#/components/schemas/Pagination" }
         },
         "type": "object",
         "required": ["presets", "pagination"],
@@ -18357,13 +13621,8 @@
         "properties": {
           "inputs": {
             "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
+              { "additionalProperties": true, "type": "object" },
+              { "type": "null" }
             ],
             "title": "Inputs"
           },
@@ -18375,43 +13634,20 @@
                 },
                 "type": "object"
               },
-              {
-                "type": "null"
-              }
+              { "type": "null" }
             ],
             "title": "Credentials"
           },
           "name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Name"
           },
           "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Description"
           },
           "is_active": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "boolean" }, { "type": "null" }],
             "title": "Is Active"
           }
         },
@@ -18422,15 +13658,11 @@
       "LibraryAgentResponse": {
         "properties": {
           "agents": {
-            "items": {
-              "$ref": "#/components/schemas/LibraryAgent"
-            },
+            "items": { "$ref": "#/components/schemas/LibraryAgent" },
             "type": "array",
             "title": "Agents"
           },
-          "pagination": {
-            "$ref": "#/components/schemas/Pagination"
-          }
+          "pagination": { "$ref": "#/components/schemas/Pagination" }
         },
         "type": "object",
         "required": ["agents", "pagination"],
@@ -18451,85 +13683,39 @@
       "LibraryAgentUpdateRequest": {
         "properties": {
           "auto_update_version": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "boolean" }, { "type": "null" }],
             "title": "Auto Update Version",
             "description": "Auto-update the agent version"
           },
           "graph_version": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
             "title": "Graph Version",
             "description": "Specific graph version to update to"
           },
           "is_favorite": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "boolean" }, { "type": "null" }],
             "title": "Is Favorite",
             "description": "Mark the agent as a favorite"
           },
           "is_archived": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "boolean" }, { "type": "null" }],
             "title": "Is Archived",
             "description": "Archive the agent"
           },
           "is_hidden": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "boolean" }, { "type": "null" }],
             "title": "Is Hidden",
             "description": "Whether to hide the agent from the library listing"
           },
           "settings": {
             "anyOf": [
-              {
-                "$ref": "#/components/schemas/GraphSettings"
-              },
-              {
-                "type": "null"
-              }
+              { "$ref": "#/components/schemas/GraphSettings" },
+              { "type": "null" }
             ],
             "description": "User-specific settings for this library agent"
           },
           "folder_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Folder Id",
             "description": "Folder ID to move agent to (None to move to root)"
           }
@@ -18540,49 +13726,19 @@
       },
       "LibraryFolder": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "user_id": {
-            "type": "string",
-            "title": "User Id"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "user_id": { "type": "string", "title": "User Id" },
+          "name": { "type": "string", "title": "Name" },
           "icon": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Icon"
           },
           "color": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Color"
           },
           "parent_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Parent Id"
           },
           "created_at": {
@@ -18613,49 +13769,19 @@
       },
       "LibraryFolderTree": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "user_id": {
-            "type": "string",
-            "title": "User Id"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "user_id": { "type": "string", "title": "User Id" },
+          "name": { "type": "string", "title": "Name" },
           "icon": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Icon"
           },
           "color": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Color"
           },
           "parent_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Parent Id"
           },
           "created_at": {
@@ -18679,9 +13805,7 @@
             "default": 0
           },
           "children": {
-            "items": {
-              "$ref": "#/components/schemas/LibraryFolderTree"
-            },
+            "items": { "$ref": "#/components/schemas/LibraryFolderTree" },
             "type": "array",
             "title": "Children",
             "default": []
@@ -18694,26 +13818,11 @@
       },
       "Link": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "source_id": {
-            "type": "string",
-            "title": "Source Id"
-          },
-          "sink_id": {
-            "type": "string",
-            "title": "Sink Id"
-          },
-          "source_name": {
-            "type": "string",
-            "title": "Source Name"
-          },
-          "sink_name": {
-            "type": "string",
-            "title": "Sink Name"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "source_id": { "type": "string", "title": "Source Id" },
+          "sink_id": { "type": "string", "title": "Sink Id" },
+          "source_name": { "type": "string", "title": "Source Name" },
+          "sink_name": { "type": "string", "title": "Sink Name" },
           "is_static": {
             "type": "boolean",
             "title": "Is Static",
@@ -18726,22 +13835,10 @@
       },
       "LinkTokenInfoResponse": {
         "properties": {
-          "platform": {
-            "type": "string",
-            "title": "Platform"
-          },
-          "link_type": {
-            "$ref": "#/components/schemas/LinkType"
-          },
+          "platform": { "type": "string", "title": "Platform" },
+          "link_type": { "$ref": "#/components/schemas/LinkType" },
           "server_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Server Name"
           }
         },
@@ -18757,17 +13854,11 @@
       "ListFilesResponse": {
         "properties": {
           "files": {
-            "items": {
-              "$ref": "#/components/schemas/WorkspaceFileItem"
-            },
+            "items": { "$ref": "#/components/schemas/WorkspaceFileItem" },
             "type": "array",
             "title": "Files"
           },
-          "offset": {
-            "type": "integer",
-            "title": "Offset",
-            "default": 0
-          },
+          "offset": { "type": "integer", "title": "Offset", "default": 0 },
           "has_more": {
             "type": "boolean",
             "title": "Has More",
@@ -18781,16 +13872,11 @@
       "ListSessionsResponse": {
         "properties": {
           "sessions": {
-            "items": {
-              "$ref": "#/components/schemas/SessionSummaryResponse"
-            },
+            "items": { "$ref": "#/components/schemas/SessionSummaryResponse" },
             "type": "array",
             "title": "Sessions"
           },
-          "total": {
-            "type": "integer",
-            "title": "Total"
-          }
+          "total": { "type": "integer", "title": "Total" }
         },
         "type": "object",
         "required": ["sessions", "total"],
@@ -18804,10 +13890,7 @@
             "minLength": 1,
             "title": "Metric Name"
           },
-          "metric_value": {
-            "type": "number",
-            "title": "Metric Value"
-          },
+          "metric_value": { "type": "number", "title": "Metric Value" },
           "data_string": {
             "type": "string",
             "minLength": 1,
@@ -18820,14 +13903,8 @@
       },
       "LoginResponse": {
         "properties": {
-          "login_url": {
-            "type": "string",
-            "title": "Login Url"
-          },
-          "state_token": {
-            "type": "string",
-            "title": "State Token"
-          }
+          "login_url": { "type": "string", "title": "Login Url" },
+          "state_token": { "type": "string", "title": "State Token" }
         },
         "type": "object",
         "required": ["login_url", "state_token"],
@@ -18866,14 +13943,8 @@
       },
       "MCPOAuthLoginResponse": {
         "properties": {
-          "login_url": {
-            "type": "string",
-            "title": "Login Url"
-          },
-          "state_token": {
-            "type": "string",
-            "title": "State Token"
-          }
+          "login_url": { "type": "string", "title": "Login Url" },
+          "state_token": { "type": "string", "title": "State Token" }
         },
         "type": "object",
         "required": ["login_url", "state_token"],
@@ -18903,14 +13974,8 @@
       },
       "MCPToolInfo": {
         "properties": {
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
+          "name": { "type": "string", "title": "Name" },
+          "description": { "type": "string", "title": "Description" },
           "input_schema": {
             "additionalProperties": true,
             "type": "object",
@@ -18928,37 +13993,15 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "mcp_tool_output"
           },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          },
+          "message": { "type": "string", "title": "Message" },
           "session_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Session Id"
           },
-          "server_url": {
-            "type": "string",
-            "title": "Server Url"
-          },
-          "tool_name": {
-            "type": "string",
-            "title": "Tool Name"
-          },
-          "result": {
-            "title": "Result"
-          },
-          "success": {
-            "type": "boolean",
-            "title": "Success",
-            "default": true
-          }
+          "server_url": { "type": "string", "title": "Server Url" },
+          "tool_name": { "type": "string", "title": "Tool Name" },
+          "result": { "title": "Result" },
+          "success": { "type": "boolean", "title": "Success", "default": true }
         },
         "type": "object",
         "required": ["message", "server_url", "tool_name"],
@@ -18967,14 +14010,8 @@
       },
       "MCPToolResponse": {
         "properties": {
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
+          "name": { "type": "string", "title": "Name" },
+          "description": { "type": "string", "title": "Description" },
           "input_schema": {
             "additionalProperties": true,
             "type": "object",
@@ -18992,29 +14029,14 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "mcp_tools_discovered"
           },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          },
+          "message": { "type": "string", "title": "Message" },
           "session_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Session Id"
           },
-          "server_url": {
-            "type": "string",
-            "title": "Server Url"
-          },
+          "server_url": { "type": "string", "title": "Server Url" },
           "tools": {
-            "items": {
-              "$ref": "#/components/schemas/MCPToolInfo"
-            },
+            "items": { "$ref": "#/components/schemas/MCPToolInfo" },
             "type": "array",
             "title": "Tools"
           }
@@ -19026,18 +14048,9 @@
       },
       "MarketplaceListing": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "slug": {
-            "type": "string",
-            "title": "Slug"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "name": { "type": "string", "title": "Name" },
+          "slug": { "type": "string", "title": "Slug" },
           "creator": {
             "$ref": "#/components/schemas/MarketplaceListingCreator"
           }
@@ -19049,18 +14062,9 @@
       },
       "MarketplaceListingCreator": {
         "properties": {
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "slug": {
-            "type": "string",
-            "title": "Slug"
-          }
+          "name": { "type": "string", "title": "Name" },
+          "id": { "type": "string", "title": "Id" },
+          "slug": { "type": "string", "title": "Slug" }
         },
         "type": "object",
         "required": ["name", "id", "slug"],
@@ -19073,26 +14077,14 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "memory_forget_candidates"
           },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          },
+          "message": { "type": "string", "title": "Message" },
           "session_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Session Id"
           },
           "candidates": {
             "items": {
-              "additionalProperties": {
-                "type": "string"
-              },
+              "additionalProperties": { "type": "string" },
               "type": "object"
             },
             "type": "array",
@@ -19110,32 +14102,18 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "memory_forget_confirm"
           },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          },
+          "message": { "type": "string", "title": "Message" },
           "session_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Session Id"
           },
           "deleted_uuids": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Deleted Uuids"
           },
           "failed_uuids": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Failed Uuids"
           }
@@ -19151,32 +14129,18 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "memory_search"
           },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          },
+          "message": { "type": "string", "title": "Message" },
           "session_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Session Id"
           },
           "facts": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Facts"
           },
           "recent_episodes": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Recent Episodes"
           }
@@ -19192,25 +14156,12 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "memory_store"
           },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          },
+          "message": { "type": "string", "title": "Message" },
           "session_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Session Id"
           },
-          "memory_name": {
-            "type": "string",
-            "title": "Memory Name"
-          }
+          "memory_name": { "type": "string", "title": "Memory Name" }
         },
         "type": "object",
         "required": ["message", "memory_name"],
@@ -19219,14 +14170,8 @@
       },
       "Message": {
         "properties": {
-          "query": {
-            "type": "string",
-            "title": "Query"
-          },
-          "response": {
-            "type": "string",
-            "title": "Response"
-          }
+          "query": { "type": "string", "title": "Query" },
+          "response": { "type": "string", "title": "Response" }
         },
         "type": "object",
         "required": ["query", "response"],
@@ -19234,18 +14179,9 @@
       },
       "ModelInfo": {
         "properties": {
-          "value": {
-            "type": "string",
-            "title": "Value"
-          },
-          "label": {
-            "type": "string",
-            "title": "Label"
-          },
-          "provider": {
-            "type": "string",
-            "title": "Provider"
-          }
+          "value": { "type": "string", "title": "Value" },
+          "label": { "type": "string", "title": "Label" },
+          "provider": { "type": "string", "title": "Provider" }
         },
         "type": "object",
         "required": ["value", "label", "provider"],
@@ -19258,47 +14194,21 @@
       },
       "MyUnpublishedAgent": {
         "properties": {
-          "graph_id": {
-            "type": "string",
-            "title": "Graph Id"
-          },
-          "graph_version": {
-            "type": "integer",
-            "title": "Graph Version"
-          },
-          "agent_name": {
-            "type": "string",
-            "title": "Agent Name"
-          },
+          "graph_id": { "type": "string", "title": "Graph Id" },
+          "graph_version": { "type": "integer", "title": "Graph Version" },
+          "agent_name": { "type": "string", "title": "Agent Name" },
           "agent_image": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Agent Image"
           },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
+          "description": { "type": "string", "title": "Description" },
           "last_edited": {
             "type": "string",
             "format": "date-time",
             "title": "Last Edited"
           },
           "recommended_schedule_cron": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Recommended Schedule Cron"
           }
         },
@@ -19315,15 +14225,11 @@
       "MyUnpublishedAgentsResponse": {
         "properties": {
           "agents": {
-            "items": {
-              "$ref": "#/components/schemas/MyUnpublishedAgent"
-            },
+            "items": { "$ref": "#/components/schemas/MyUnpublishedAgent" },
             "type": "array",
             "title": "Agents"
           },
-          "pagination": {
-            "$ref": "#/components/schemas/Pagination"
-          }
+          "pagination": { "$ref": "#/components/schemas/Pagination" }
         },
         "type": "object",
         "required": ["agents", "pagination"],
@@ -19335,30 +14241,15 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "need_login"
           },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          },
+          "message": { "type": "string", "title": "Message" },
           "session_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Session Id"
           },
           "agent_info": {
             "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
+              { "additionalProperties": true, "type": "object" },
+              { "type": "null" }
             ],
             "title": "Agent Info"
           }
@@ -19374,34 +14265,18 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "no_results"
           },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          },
+          "message": { "type": "string", "title": "Message" },
           "session_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Session Id"
           },
           "suggestions": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Suggestions",
             "default": []
           },
-          "name": {
-            "type": "string",
-            "title": "Name",
-            "default": "no_results"
-          }
+          "name": { "type": "string", "title": "Name", "default": "no_results" }
         },
         "type": "object",
         "required": ["message"],
@@ -19410,14 +14285,8 @@
       },
       "Node": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "block_id": {
-            "type": "string",
-            "title": "Block Id"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "block_id": { "type": "string", "title": "Block Id" },
           "input_default": {
             "additionalProperties": true,
             "type": "object",
@@ -19429,16 +14298,12 @@
             "title": "Metadata"
           },
           "input_links": {
-            "items": {
-              "$ref": "#/components/schemas/Link"
-            },
+            "items": { "$ref": "#/components/schemas/Link" },
             "type": "array",
             "title": "Input Links"
           },
           "output_links": {
-            "items": {
-              "$ref": "#/components/schemas/Link"
-            },
+            "items": { "$ref": "#/components/schemas/Link" },
             "type": "array",
             "title": "Output Links"
           }
@@ -19449,47 +14314,21 @@
       },
       "NodeExecutionResult": {
         "properties": {
-          "user_id": {
-            "type": "string",
-            "title": "User Id"
-          },
-          "graph_id": {
-            "type": "string",
-            "title": "Graph Id"
-          },
-          "graph_version": {
-            "type": "integer",
-            "title": "Graph Version"
-          },
-          "graph_exec_id": {
-            "type": "string",
-            "title": "Graph Exec Id"
-          },
-          "node_exec_id": {
-            "type": "string",
-            "title": "Node Exec Id"
-          },
-          "node_id": {
-            "type": "string",
-            "title": "Node Id"
-          },
-          "block_id": {
-            "type": "string",
-            "title": "Block Id"
-          },
-          "status": {
-            "$ref": "#/components/schemas/AgentExecutionStatus"
-          },
+          "user_id": { "type": "string", "title": "User Id" },
+          "graph_id": { "type": "string", "title": "Graph Id" },
+          "graph_version": { "type": "integer", "title": "Graph Version" },
+          "graph_exec_id": { "type": "string", "title": "Graph Exec Id" },
+          "node_exec_id": { "type": "string", "title": "Node Exec Id" },
+          "node_id": { "type": "string", "title": "Node Id" },
+          "block_id": { "type": "string", "title": "Block Id" },
+          "status": { "$ref": "#/components/schemas/AgentExecutionStatus" },
           "input_data": {
             "additionalProperties": true,
             "type": "object",
             "title": "Input Data"
           },
           "output_data": {
-            "additionalProperties": {
-              "items": {},
-              "type": "array"
-            },
+            "additionalProperties": { "items": {}, "type": "array" },
             "type": "object",
             "title": "Output Data"
           },
@@ -19500,37 +14339,22 @@
           },
           "queue_time": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
             ],
             "title": "Queue Time"
           },
           "start_time": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
             ],
             "title": "Start Time"
           },
           "end_time": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
             ],
             "title": "End Time"
           }
@@ -19556,14 +14380,8 @@
       },
       "NodeModel": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "block_id": {
-            "type": "string",
-            "title": "Block Id"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "block_id": { "type": "string", "title": "Block Id" },
           "input_default": {
             "additionalProperties": true,
             "type": "object",
@@ -19575,36 +14393,19 @@
             "title": "Metadata"
           },
           "input_links": {
-            "items": {
-              "$ref": "#/components/schemas/Link"
-            },
+            "items": { "$ref": "#/components/schemas/Link" },
             "type": "array",
             "title": "Input Links"
           },
           "output_links": {
-            "items": {
-              "$ref": "#/components/schemas/Link"
-            },
+            "items": { "$ref": "#/components/schemas/Link" },
             "type": "array",
             "title": "Output Links"
           },
-          "graph_id": {
-            "type": "string",
-            "title": "Graph Id"
-          },
-          "graph_version": {
-            "type": "integer",
-            "title": "Graph Version"
-          },
+          "graph_id": { "type": "string", "title": "Graph Id" },
+          "graph_version": { "type": "integer", "title": "Graph Version" },
           "webhook_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Webhook Id"
           }
         },
@@ -19614,19 +14415,10 @@
       },
       "NotificationPreference": {
         "properties": {
-          "user_id": {
-            "type": "string",
-            "title": "User Id"
-          },
-          "email": {
-            "type": "string",
-            "format": "email",
-            "title": "Email"
-          },
+          "user_id": { "type": "string", "title": "User Id" },
+          "email": { "type": "string", "format": "email", "title": "Email" },
           "preferences": {
-            "additionalProperties": {
-              "type": "boolean"
-            },
+            "additionalProperties": { "type": "boolean" },
             "propertyNames": {
               "$ref": "#/components/schemas/NotificationType"
             },
@@ -19663,9 +14455,7 @@
             "description": "User's email address"
           },
           "preferences": {
-            "additionalProperties": {
-              "type": "boolean"
-            },
+            "additionalProperties": { "type": "boolean" },
             "propertyNames": {
               "$ref": "#/components/schemas/NotificationType"
             },
@@ -19703,23 +14493,10 @@
       },
       "OAuth2Credentials": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "provider": {
-            "type": "string",
-            "title": "Provider"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "provider": { "type": "string", "title": "Provider" },
           "title": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Title"
           },
           "is_managed": {
@@ -19739,14 +14516,7 @@
             "default": "oauth2"
           },
           "username": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Username"
           },
           "access_token": {
@@ -19756,44 +14526,22 @@
             "writeOnly": true
           },
           "access_token_expires_at": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
             "title": "Access Token Expires At"
           },
           "refresh_token": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "password",
-                "writeOnly": true
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "password", "writeOnly": true },
+              { "type": "null" }
             ],
             "title": "Refresh Token"
           },
           "refresh_token_expires_at": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
             "title": "Refresh Token Expires At"
           },
           "scopes": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Scopes"
           }
@@ -19804,69 +14552,34 @@
       },
       "OAuthApplicationInfo": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "name": { "type": "string", "title": "Name" },
           "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Description"
           },
           "logo_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Logo Url"
           },
-          "client_id": {
-            "type": "string",
-            "title": "Client Id"
-          },
+          "client_id": { "type": "string", "title": "Client Id" },
           "redirect_uris": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Redirect Uris"
           },
           "grant_types": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Grant Types"
           },
           "scopes": {
-            "items": {
-              "$ref": "#/components/schemas/APIKeyPermission"
-            },
+            "items": { "$ref": "#/components/schemas/APIKeyPermission" },
             "type": "array",
             "title": "Scopes"
           },
-          "owner_id": {
-            "type": "string",
-            "title": "Owner Id"
-          },
-          "is_active": {
-            "type": "boolean",
-            "title": "Is Active"
-          },
+          "owner_id": { "type": "string", "title": "Owner Id" },
+          "is_active": { "type": "boolean", "title": "Is Active" },
           "created_at": {
             "type": "string",
             "format": "date-time",
@@ -19896,36 +14609,17 @@
       },
       "OAuthApplicationPublicInfo": {
         "properties": {
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
+          "name": { "type": "string", "title": "Name" },
           "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Description"
           },
           "logo_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Logo Url"
           },
           "scopes": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Scopes"
           }
@@ -19950,9 +14644,7 @@
             "title": "User Role"
           },
           "pain_points": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "maxItems": 20,
             "title": "Pain Points"
@@ -19965,10 +14657,7 @@
       },
       "OnboardingStatusResponse": {
         "properties": {
-          "is_completed": {
-            "type": "boolean",
-            "title": "Is Completed"
-          }
+          "is_completed": { "type": "boolean", "title": "Is Completed" }
         },
         "type": "object",
         "required": ["is_completed"],
@@ -20005,45 +14694,17 @@
       },
       "OrphanedScheduleDetail": {
         "properties": {
-          "schedule_id": {
-            "type": "string",
-            "title": "Schedule Id"
-          },
-          "schedule_name": {
-            "type": "string",
-            "title": "Schedule Name"
-          },
-          "graph_id": {
-            "type": "string",
-            "title": "Graph Id"
-          },
-          "graph_version": {
-            "type": "integer",
-            "title": "Graph Version"
-          },
-          "user_id": {
-            "type": "string",
-            "title": "User Id"
-          },
-          "orphan_reason": {
-            "type": "string",
-            "title": "Orphan Reason"
-          },
+          "schedule_id": { "type": "string", "title": "Schedule Id" },
+          "schedule_name": { "type": "string", "title": "Schedule Name" },
+          "graph_id": { "type": "string", "title": "Graph Id" },
+          "graph_version": { "type": "integer", "title": "Graph Version" },
+          "user_id": { "type": "string", "title": "User Id" },
+          "orphan_reason": { "type": "string", "title": "Orphan Reason" },
           "error_detail": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Error Detail"
           },
-          "next_run_time": {
-            "type": "string",
-            "title": "Next Run Time"
-          }
+          "next_run_time": { "type": "string", "title": "Next Run Time" }
         },
         "type": "object",
         "required": [
@@ -20062,16 +14723,11 @@
       "OrphanedSchedulesListResponse": {
         "properties": {
           "schedules": {
-            "items": {
-              "$ref": "#/components/schemas/OrphanedScheduleDetail"
-            },
+            "items": { "$ref": "#/components/schemas/OrphanedScheduleDetail" },
             "type": "array",
             "title": "Schedules"
           },
-          "total": {
-            "type": "integer",
-            "title": "Total"
-          }
+          "total": { "type": "integer", "title": "Total" }
         },
         "type": "object",
         "required": ["schedules", "total"],
@@ -20112,16 +14768,11 @@
       "PeekPendingMessagesResponse": {
         "properties": {
           "messages": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Messages"
           },
-          "count": {
-            "type": "integer",
-            "title": "Count"
-          }
+          "count": { "type": "integer", "title": "Count" }
         },
         "type": "object",
         "required": ["messages", "count"],
@@ -20163,42 +14814,19 @@
           },
           "payload": {
             "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "items": {},
-                "type": "array"
-              },
-              {
-                "type": "string"
-              },
-              {
-                "type": "integer"
-              },
-              {
-                "type": "number"
-              },
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
+              { "additionalProperties": true, "type": "object" },
+              { "items": {}, "type": "array" },
+              { "type": "string" },
+              { "type": "integer" },
+              { "type": "number" },
+              { "type": "boolean" },
+              { "type": "null" }
             ],
             "title": "Payload",
             "description": "The actual data payload awaiting review"
           },
           "instructions": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Instructions",
             "description": "Instructions or message for the reviewer"
           },
@@ -20212,26 +14840,12 @@
             "description": "Review status"
           },
           "review_message": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Review Message",
             "description": "Optional message from the reviewer"
           },
           "was_edited": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "boolean" }, { "type": "null" }],
             "title": "Was Edited",
             "description": "Whether the data was modified during review"
           },
@@ -20249,26 +14863,16 @@
           },
           "updated_at": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
             ],
             "title": "Updated At",
             "description": "When the review was last updated"
           },
           "reviewed_at": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
             ],
             "title": "Reviewed At",
             "description": "When the review was completed"
@@ -20297,14 +14901,7 @@
             "description": "OAuth access token suitable for the picker SDK call."
           },
           "access_token_expires_at": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
             "title": "Access Token Expires At",
             "description": "Unix timestamp at which the access token expires, if known."
           }
@@ -20317,16 +14914,12 @@
       "PlatformCostDashboard": {
         "properties": {
           "by_provider": {
-            "items": {
-              "$ref": "#/components/schemas/ProviderCostSummary"
-            },
+            "items": { "$ref": "#/components/schemas/ProviderCostSummary" },
             "type": "array",
             "title": "By Provider"
           },
           "by_user": {
-            "items": {
-              "$ref": "#/components/schemas/UserCostSummary"
-            },
+            "items": { "$ref": "#/components/schemas/UserCostSummary" },
             "type": "array",
             "title": "By User"
           },
@@ -20334,14 +14927,8 @@
             "type": "integer",
             "title": "Total Cost Microdollars"
           },
-          "total_requests": {
-            "type": "integer",
-            "title": "Total Requests"
-          },
-          "total_users": {
-            "type": "integer",
-            "title": "Total Users"
-          },
+          "total_requests": { "type": "integer", "title": "Total Requests" },
+          "total_users": { "type": "integer", "title": "Total Users" },
           "total_input_tokens": {
             "type": "integer",
             "title": "Total Input Tokens",
@@ -20388,9 +14975,7 @@
             "default": 0.0
           },
           "cost_buckets": {
-            "items": {
-              "$ref": "#/components/schemas/CostBucket"
-            },
+            "items": { "$ref": "#/components/schemas/CostBucket" },
             "type": "array",
             "title": "Cost Buckets",
             "default": []
@@ -20409,20 +14994,12 @@
       "PlatformCostExportResponse": {
         "properties": {
           "logs": {
-            "items": {
-              "$ref": "#/components/schemas/CostLogRow"
-            },
+            "items": { "$ref": "#/components/schemas/CostLogRow" },
             "type": "array",
             "title": "Logs"
           },
-          "total_rows": {
-            "type": "integer",
-            "title": "Total Rows"
-          },
-          "truncated": {
-            "type": "boolean",
-            "title": "Truncated"
-          }
+          "total_rows": { "type": "integer", "title": "Total Rows" },
+          "truncated": { "type": "boolean", "title": "Truncated" }
         },
         "type": "object",
         "required": ["logs", "total_rows", "truncated"],
@@ -20431,15 +15008,11 @@
       "PlatformCostLogsResponse": {
         "properties": {
           "logs": {
-            "items": {
-              "$ref": "#/components/schemas/CostLogRow"
-            },
+            "items": { "$ref": "#/components/schemas/CostLogRow" },
             "type": "array",
             "title": "Logs"
           },
-          "pagination": {
-            "$ref": "#/components/schemas/Pagination"
-          }
+          "pagination": { "$ref": "#/components/schemas/Pagination" }
         },
         "type": "object",
         "required": ["logs", "pagination"],
@@ -20447,14 +15020,8 @@
       },
       "PlatformLinkInfo": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "platform": {
-            "type": "string",
-            "title": "Platform"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "platform": { "type": "string", "title": "Platform" },
           "platform_server_id": {
             "type": "string",
             "title": "Platform Server Id"
@@ -20464,14 +15031,7 @@
             "title": "Owner Platform User Id"
           },
           "server_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Server Name"
           },
           "linked_at": {
@@ -20493,27 +15053,11 @@
       },
       "PlatformUserLinkInfo": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "platform": {
-            "type": "string",
-            "title": "Platform"
-          },
-          "platform_user_id": {
-            "type": "string",
-            "title": "Platform User Id"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "platform": { "type": "string", "title": "Platform" },
+          "platform_user_id": { "type": "string", "title": "Platform User Id" },
           "platform_username": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Platform Username"
           },
           "linked_at": {
@@ -20548,81 +15092,26 @@
             "title": "Recordtype",
             "default": "Bounce"
           },
-          "ID": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "Type": {
-            "type": "string",
-            "title": "Type"
-          },
-          "TypeCode": {
-            "$ref": "#/components/schemas/PostmarkBounceEnum"
-          },
-          "Tag": {
-            "type": "string",
-            "title": "Tag"
-          },
-          "MessageID": {
-            "type": "string",
-            "title": "Messageid"
-          },
-          "Details": {
-            "type": "string",
-            "title": "Details"
-          },
-          "Email": {
-            "type": "string",
-            "title": "Email"
-          },
-          "From": {
-            "type": "string",
-            "title": "From"
-          },
-          "BouncedAt": {
-            "type": "string",
-            "title": "Bouncedat"
-          },
-          "Inactive": {
-            "type": "boolean",
-            "title": "Inactive"
-          },
-          "DumpAvailable": {
-            "type": "boolean",
-            "title": "Dumpavailable"
-          },
-          "CanActivate": {
-            "type": "boolean",
-            "title": "Canactivate"
-          },
-          "Subject": {
-            "type": "string",
-            "title": "Subject"
-          },
-          "ServerID": {
-            "type": "integer",
-            "title": "Serverid"
-          },
-          "MessageStream": {
-            "type": "string",
-            "title": "Messagestream"
-          },
-          "Content": {
-            "type": "string",
-            "title": "Content"
-          },
-          "Name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "Description": {
-            "type": "string",
-            "title": "Description"
-          },
+          "ID": { "type": "integer", "title": "Id" },
+          "Type": { "type": "string", "title": "Type" },
+          "TypeCode": { "$ref": "#/components/schemas/PostmarkBounceEnum" },
+          "Tag": { "type": "string", "title": "Tag" },
+          "MessageID": { "type": "string", "title": "Messageid" },
+          "Details": { "type": "string", "title": "Details" },
+          "Email": { "type": "string", "title": "Email" },
+          "From": { "type": "string", "title": "From" },
+          "BouncedAt": { "type": "string", "title": "Bouncedat" },
+          "Inactive": { "type": "boolean", "title": "Inactive" },
+          "DumpAvailable": { "type": "boolean", "title": "Dumpavailable" },
+          "CanActivate": { "type": "boolean", "title": "Canactivate" },
+          "Subject": { "type": "string", "title": "Subject" },
+          "ServerID": { "type": "integer", "title": "Serverid" },
+          "MessageStream": { "type": "string", "title": "Messagestream" },
+          "Content": { "type": "string", "title": "Content" },
+          "Name": { "type": "string", "title": "Name" },
+          "Description": { "type": "string", "title": "Description" },
           "Metadata": {
-            "additionalProperties": {
-              "type": "string"
-            },
+            "additionalProperties": { "type": "string" },
             "type": "object",
             "title": "Metadata"
           }
@@ -20659,67 +15148,32 @@
             "title": "Recordtype",
             "default": "Click"
           },
-          "MessageStream": {
-            "type": "string",
-            "title": "Messagestream"
-          },
+          "MessageStream": { "type": "string", "title": "Messagestream" },
           "Metadata": {
-            "additionalProperties": {
-              "type": "string"
-            },
+            "additionalProperties": { "type": "string" },
             "type": "object",
             "title": "Metadata"
           },
-          "Recipient": {
-            "type": "string",
-            "title": "Recipient"
-          },
-          "MessageID": {
-            "type": "string",
-            "title": "Messageid"
-          },
-          "ReceivedAt": {
-            "type": "string",
-            "title": "Receivedat"
-          },
-          "Platform": {
-            "type": "string",
-            "title": "Platform"
-          },
-          "ClickLocation": {
-            "type": "string",
-            "title": "Clicklocation"
-          },
-          "OriginalLink": {
-            "type": "string",
-            "title": "Originallink"
-          },
-          "Tag": {
-            "type": "string",
-            "title": "Tag"
-          },
-          "UserAgent": {
-            "type": "string",
-            "title": "Useragent"
-          },
+          "Recipient": { "type": "string", "title": "Recipient" },
+          "MessageID": { "type": "string", "title": "Messageid" },
+          "ReceivedAt": { "type": "string", "title": "Receivedat" },
+          "Platform": { "type": "string", "title": "Platform" },
+          "ClickLocation": { "type": "string", "title": "Clicklocation" },
+          "OriginalLink": { "type": "string", "title": "Originallink" },
+          "Tag": { "type": "string", "title": "Tag" },
+          "UserAgent": { "type": "string", "title": "Useragent" },
           "OS": {
-            "additionalProperties": {
-              "type": "string"
-            },
+            "additionalProperties": { "type": "string" },
             "type": "object",
             "title": "Os"
           },
           "Client": {
-            "additionalProperties": {
-              "type": "string"
-            },
+            "additionalProperties": { "type": "string" },
             "type": "object",
             "title": "Client"
           },
           "Geo": {
-            "additionalProperties": {
-              "type": "string"
-            },
+            "additionalProperties": { "type": "string" },
             "type": "object",
             "title": "Geo"
           }
@@ -20750,38 +15204,15 @@
             "title": "Recordtype",
             "default": "Delivery"
           },
-          "ServerID": {
-            "type": "integer",
-            "title": "Serverid"
-          },
-          "MessageStream": {
-            "type": "string",
-            "title": "Messagestream"
-          },
-          "MessageID": {
-            "type": "string",
-            "title": "Messageid"
-          },
-          "Recipient": {
-            "type": "string",
-            "title": "Recipient"
-          },
-          "Tag": {
-            "type": "string",
-            "title": "Tag"
-          },
-          "DeliveredAt": {
-            "type": "string",
-            "title": "Deliveredat"
-          },
-          "Details": {
-            "type": "string",
-            "title": "Details"
-          },
+          "ServerID": { "type": "integer", "title": "Serverid" },
+          "MessageStream": { "type": "string", "title": "Messagestream" },
+          "MessageID": { "type": "string", "title": "Messageid" },
+          "Recipient": { "type": "string", "title": "Recipient" },
+          "Tag": { "type": "string", "title": "Tag" },
+          "DeliveredAt": { "type": "string", "title": "Deliveredat" },
+          "Details": { "type": "string", "title": "Details" },
           "Metadata": {
-            "additionalProperties": {
-              "type": "string"
-            },
+            "additionalProperties": { "type": "string" },
             "type": "object",
             "title": "Metadata"
           }
@@ -20807,67 +15238,32 @@
             "title": "Recordtype",
             "default": "Open"
           },
-          "MessageStream": {
-            "type": "string",
-            "title": "Messagestream"
-          },
+          "MessageStream": { "type": "string", "title": "Messagestream" },
           "Metadata": {
-            "additionalProperties": {
-              "type": "string"
-            },
+            "additionalProperties": { "type": "string" },
             "type": "object",
             "title": "Metadata"
           },
-          "FirstOpen": {
-            "type": "boolean",
-            "title": "Firstopen"
-          },
-          "Recipient": {
-            "type": "string",
-            "title": "Recipient"
-          },
-          "MessageID": {
-            "type": "string",
-            "title": "Messageid"
-          },
-          "ReceivedAt": {
-            "type": "string",
-            "title": "Receivedat"
-          },
-          "Platform": {
-            "type": "string",
-            "title": "Platform"
-          },
-          "ReadSeconds": {
-            "type": "integer",
-            "title": "Readseconds"
-          },
-          "Tag": {
-            "type": "string",
-            "title": "Tag"
-          },
-          "UserAgent": {
-            "type": "string",
-            "title": "Useragent"
-          },
+          "FirstOpen": { "type": "boolean", "title": "Firstopen" },
+          "Recipient": { "type": "string", "title": "Recipient" },
+          "MessageID": { "type": "string", "title": "Messageid" },
+          "ReceivedAt": { "type": "string", "title": "Receivedat" },
+          "Platform": { "type": "string", "title": "Platform" },
+          "ReadSeconds": { "type": "integer", "title": "Readseconds" },
+          "Tag": { "type": "string", "title": "Tag" },
+          "UserAgent": { "type": "string", "title": "Useragent" },
           "OS": {
-            "additionalProperties": {
-              "type": "string"
-            },
+            "additionalProperties": { "type": "string" },
             "type": "object",
             "title": "Os"
           },
           "Client": {
-            "additionalProperties": {
-              "type": "string"
-            },
+            "additionalProperties": { "type": "string" },
             "type": "object",
             "title": "Client"
           },
           "Geo": {
-            "additionalProperties": {
-              "type": "string"
-            },
+            "additionalProperties": { "type": "string" },
             "type": "object",
             "title": "Geo"
           }
@@ -20898,82 +15294,26 @@
             "title": "Recordtype",
             "default": "SpamComplaint"
           },
-          "ID": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "Type": {
-            "type": "string",
-            "title": "Type"
-          },
-          "TypeCode": {
-            "type": "integer",
-            "title": "Typecode"
-          },
-          "Tag": {
-            "type": "string",
-            "title": "Tag"
-          },
-          "MessageID": {
-            "type": "string",
-            "title": "Messageid"
-          },
-          "Details": {
-            "type": "string",
-            "title": "Details"
-          },
-          "Email": {
-            "type": "string",
-            "title": "Email"
-          },
-          "From": {
-            "type": "string",
-            "title": "From"
-          },
-          "BouncedAt": {
-            "type": "string",
-            "title": "Bouncedat"
-          },
-          "Inactive": {
-            "type": "boolean",
-            "title": "Inactive"
-          },
-          "DumpAvailable": {
-            "type": "boolean",
-            "title": "Dumpavailable"
-          },
-          "CanActivate": {
-            "type": "boolean",
-            "title": "Canactivate"
-          },
-          "Subject": {
-            "type": "string",
-            "title": "Subject"
-          },
-          "ServerID": {
-            "type": "integer",
-            "title": "Serverid"
-          },
-          "MessageStream": {
-            "type": "string",
-            "title": "Messagestream"
-          },
-          "Content": {
-            "type": "string",
-            "title": "Content"
-          },
-          "Name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "Description": {
-            "type": "string",
-            "title": "Description"
-          },
+          "ID": { "type": "integer", "title": "Id" },
+          "Type": { "type": "string", "title": "Type" },
+          "TypeCode": { "type": "integer", "title": "Typecode" },
+          "Tag": { "type": "string", "title": "Tag" },
+          "MessageID": { "type": "string", "title": "Messageid" },
+          "Details": { "type": "string", "title": "Details" },
+          "Email": { "type": "string", "title": "Email" },
+          "From": { "type": "string", "title": "From" },
+          "BouncedAt": { "type": "string", "title": "Bouncedat" },
+          "Inactive": { "type": "boolean", "title": "Inactive" },
+          "DumpAvailable": { "type": "boolean", "title": "Dumpavailable" },
+          "CanActivate": { "type": "boolean", "title": "Canactivate" },
+          "Subject": { "type": "string", "title": "Subject" },
+          "ServerID": { "type": "integer", "title": "Serverid" },
+          "MessageStream": { "type": "string", "title": "Messagestream" },
+          "Content": { "type": "string", "title": "Content" },
+          "Name": { "type": "string", "title": "Name" },
+          "Description": { "type": "string", "title": "Description" },
           "Metadata": {
-            "additionalProperties": {
-              "type": "string"
-            },
+            "additionalProperties": { "type": "string" },
             "type": "object",
             "title": "Metadata"
           }
@@ -21010,46 +15350,20 @@
             "title": "Recordtype",
             "default": "SubscriptionChange"
           },
-          "MessageID": {
-            "type": "string",
-            "title": "Messageid"
-          },
-          "ServerID": {
-            "type": "integer",
-            "title": "Serverid"
-          },
-          "MessageStream": {
-            "type": "string",
-            "title": "Messagestream"
-          },
-          "ChangedAt": {
-            "type": "string",
-            "title": "Changedat"
-          },
-          "Recipient": {
-            "type": "string",
-            "title": "Recipient"
-          },
-          "Origin": {
-            "type": "string",
-            "title": "Origin"
-          },
-          "SuppressSending": {
-            "type": "boolean",
-            "title": "Suppresssending"
-          },
+          "MessageID": { "type": "string", "title": "Messageid" },
+          "ServerID": { "type": "integer", "title": "Serverid" },
+          "MessageStream": { "type": "string", "title": "Messagestream" },
+          "ChangedAt": { "type": "string", "title": "Changedat" },
+          "Recipient": { "type": "string", "title": "Recipient" },
+          "Origin": { "type": "string", "title": "Origin" },
+          "SuppressSending": { "type": "boolean", "title": "Suppresssending" },
           "SuppressionReason": {
             "type": "string",
             "title": "Suppressionreason"
           },
-          "Tag": {
-            "type": "string",
-            "title": "Tag"
-          },
+          "Tag": { "type": "string", "title": "Tag" },
           "Metadata": {
-            "additionalProperties": {
-              "type": "string"
-            },
+            "additionalProperties": { "type": "string" },
             "type": "object",
             "title": "Metadata"
           }
@@ -21071,33 +15385,15 @@
       },
       "Profile": {
         "properties": {
-          "username": {
-            "type": "string",
-            "title": "Username"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
+          "username": { "type": "string", "title": "Username" },
+          "name": { "type": "string", "title": "Name" },
+          "description": { "type": "string", "title": "Description" },
           "avatar_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Avatar Url"
           },
           "links": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Links"
           }
@@ -21109,40 +15405,19 @@
       },
       "ProfileDetails": {
         "properties": {
-          "username": {
-            "type": "string",
-            "title": "Username"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
+          "username": { "type": "string", "title": "Username" },
+          "name": { "type": "string", "title": "Name" },
+          "description": { "type": "string", "title": "Description" },
           "avatar_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Avatar Url"
           },
           "links": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Links"
           },
-          "is_featured": {
-            "type": "boolean",
-            "title": "Is Featured"
-          }
+          "is_featured": { "type": "boolean", "title": "Is Featured" }
         },
         "type": "object",
         "required": [
@@ -21163,10 +15438,7 @@
             "title": "Name",
             "description": "Provider name for integrations. Can be any string value, including custom provider names."
           },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
+          "description": { "type": "string", "title": "Description" },
           "integration_count": {
             "type": "integer",
             "title": "Integration Count"
@@ -21179,9 +15451,7 @@
       "ProviderConstants": {
         "properties": {
           "PROVIDER_NAMES": {
-            "additionalProperties": {
-              "type": "string"
-            },
+            "additionalProperties": { "type": "string" },
             "type": "object",
             "title": "Provider Names",
             "description": "All available provider names as a constant mapping",
@@ -21202,30 +15472,13 @@
       },
       "ProviderCostSummary": {
         "properties": {
-          "provider": {
-            "type": "string",
-            "title": "Provider"
-          },
+          "provider": { "type": "string", "title": "Provider" },
           "tracking_type": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Tracking Type"
           },
           "model": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Model"
           },
           "total_cost_microdollars": {
@@ -21260,10 +15513,7 @@
             "title": "Total Tracking Amount",
             "default": 0.0
           },
-          "request_count": {
-            "type": "integer",
-            "title": "Request Count"
-          }
+          "request_count": { "type": "integer", "title": "Request Count" }
         },
         "type": "object",
         "required": [
@@ -21296,14 +15546,7 @@
             "description": "Provider slug (e.g. ``github``)"
           },
           "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Description",
             "description": "One-line human-readable summary of what the provider does. Declared via ``ProviderBuilder.with_description(...)`` in the provider's ``_config.py``. ``None`` if not set."
           },
@@ -21325,9 +15568,7 @@
       "ProviderNamesResponse": {
         "properties": {
           "providers": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Providers",
             "description": "List of all available provider names"
@@ -21340,15 +15581,11 @@
       "ProviderResponse": {
         "properties": {
           "providers": {
-            "items": {
-              "$ref": "#/components/schemas/Provider"
-            },
+            "items": { "$ref": "#/components/schemas/Provider" },
             "type": "array",
             "title": "Providers"
           },
-          "pagination": {
-            "$ref": "#/components/schemas/Pagination"
-          }
+          "pagination": { "$ref": "#/components/schemas/Pagination" }
         },
         "type": "object",
         "required": ["providers", "pagination"],
@@ -21362,18 +15599,11 @@
             "minLength": 1,
             "title": "Endpoint"
           },
-          "keys": {
-            "$ref": "#/components/schemas/PushSubscriptionKeys"
-          },
+          "keys": { "$ref": "#/components/schemas/PushSubscriptionKeys" },
           "user_agent": {
             "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 512
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "maxLength": 512 },
+              { "type": "null" }
             ],
             "title": "User Agent"
           }
@@ -21424,29 +15654,21 @@
           "context": {
             "anyOf": [
               {
-                "additionalProperties": {
-                  "type": "string"
-                },
+                "additionalProperties": { "type": "string" },
                 "type": "object"
               },
-              {
-                "type": "null"
-              }
+              { "type": "null" }
             ],
             "title": "Context"
           },
           "file_ids": {
             "anyOf": [
               {
-                "items": {
-                  "type": "string"
-                },
+                "items": { "type": "string" },
                 "type": "array",
                 "maxItems": 20
               },
-              {
-                "type": "null"
-              }
+              { "type": "null" }
             ],
             "title": "File Ids"
           }
@@ -21458,18 +15680,12 @@
       },
       "QueuePendingMessageResponse": {
         "properties": {
-          "buffer_length": {
-            "type": "integer",
-            "title": "Buffer Length"
-          },
+          "buffer_length": { "type": "integer", "title": "Buffer Length" },
           "max_buffer_length": {
             "type": "integer",
             "title": "Max Buffer Length"
           },
-          "turn_in_flight": {
-            "type": "boolean",
-            "title": "Turn In Flight"
-          }
+          "turn_in_flight": { "type": "boolean", "title": "Turn In Flight" }
         },
         "type": "object",
         "required": ["buffer_length", "max_buffer_length", "turn_in_flight"],
@@ -21478,10 +15694,7 @@
       },
       "RateLimitResetResponse": {
         "properties": {
-          "success": {
-            "type": "boolean",
-            "title": "Success"
-          },
+          "success": { "type": "boolean", "title": "Success" },
           "credits_charged": {
             "type": "integer",
             "title": "Credits Charged",
@@ -21509,30 +15722,13 @@
       },
       "RecentExecution": {
         "properties": {
-          "status": {
-            "type": "string",
-            "title": "Status"
-          },
+          "status": { "type": "string", "title": "Status" },
           "correctness_score": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "number" }, { "type": "null" }],
             "title": "Correctness Score"
           },
           "activity_summary": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Activity Summary"
           }
         },
@@ -21543,41 +15739,16 @@
       },
       "RefundRequest": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "user_id": {
-            "type": "string",
-            "title": "User Id"
-          },
-          "transaction_key": {
-            "type": "string",
-            "title": "Transaction Key"
-          },
-          "amount": {
-            "type": "integer",
-            "title": "Amount"
-          },
-          "reason": {
-            "type": "string",
-            "title": "Reason"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "user_id": { "type": "string", "title": "User Id" },
+          "transaction_key": { "type": "string", "title": "Transaction Key" },
+          "amount": { "type": "integer", "title": "Amount" },
+          "reason": { "type": "string", "title": "Reason" },
           "result": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Result"
           },
-          "status": {
-            "type": "string",
-            "title": "Status"
-          },
+          "status": { "type": "string", "title": "Status" },
           "created_at": {
             "type": "string",
             "format": "date-time",
@@ -21604,10 +15775,7 @@
       },
       "RequestTopUp": {
         "properties": {
-          "credit_amount": {
-            "type": "integer",
-            "title": "Credit Amount"
-          }
+          "credit_amount": { "type": "integer", "title": "Credit Amount" }
         },
         "type": "object",
         "required": ["credit_amount"],
@@ -21615,19 +15783,13 @@
       },
       "RequeueExecutionResponse": {
         "properties": {
-          "success": {
-            "type": "boolean",
-            "title": "Success"
-          },
+          "success": { "type": "boolean", "title": "Success" },
           "requeued_count": {
             "type": "integer",
             "title": "Requeued Count",
             "default": 0
           },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          }
+          "message": { "type": "string", "title": "Message" }
         },
         "type": "object",
         "required": ["success", "message"],
@@ -21714,42 +15876,21 @@
           },
           "message": {
             "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 2000
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "maxLength": 2000 },
+              { "type": "null" }
             ],
             "title": "Message",
             "description": "Optional review message"
           },
           "reviewed_data": {
             "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "items": {},
-                "type": "array"
-              },
-              {
-                "type": "string"
-              },
-              {
-                "type": "integer"
-              },
-              {
-                "type": "number"
-              },
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
+              { "additionalProperties": true, "type": "object" },
+              { "items": {}, "type": "array" },
+              { "type": "string" },
+              { "type": "integer" },
+              { "type": "number" },
+              { "type": "boolean" },
+              { "type": "null" }
             ],
             "title": "Reviewed Data",
             "description": "Optional edited data (ignored if approved=False)"
@@ -21769,9 +15910,7 @@
       "ReviewRequest": {
         "properties": {
           "reviews": {
-            "items": {
-              "$ref": "#/components/schemas/ReviewItem"
-            },
+            "items": { "$ref": "#/components/schemas/ReviewItem" },
             "type": "array",
             "title": "Reviews",
             "description": "All reviews with their approval status, data, and messages"
@@ -21800,14 +15939,7 @@
             "description": "Number of reviews that failed processing"
           },
           "error": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Error",
             "description": "Error message if operation failed"
           }
@@ -21828,23 +15960,10 @@
             "type": "string",
             "title": "Store Listing Version Id"
           },
-          "is_approved": {
-            "type": "boolean",
-            "title": "Is Approved"
-          },
-          "comments": {
-            "type": "string",
-            "title": "Comments"
-          },
+          "is_approved": { "type": "boolean", "title": "Is Approved" },
+          "comments": { "type": "string", "title": "Comments" },
           "internal_comments": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Internal Comments"
           }
         },
@@ -21854,41 +15973,16 @@
       },
       "RunningExecutionDetail": {
         "properties": {
-          "execution_id": {
-            "type": "string",
-            "title": "Execution Id"
-          },
-          "graph_id": {
-            "type": "string",
-            "title": "Graph Id"
-          },
-          "graph_name": {
-            "type": "string",
-            "title": "Graph Name"
-          },
-          "graph_version": {
-            "type": "integer",
-            "title": "Graph Version"
-          },
-          "user_id": {
-            "type": "string",
-            "title": "User Id"
-          },
+          "execution_id": { "type": "string", "title": "Execution Id" },
+          "graph_id": { "type": "string", "title": "Graph Id" },
+          "graph_name": { "type": "string", "title": "Graph Name" },
+          "graph_version": { "type": "integer", "title": "Graph Version" },
+          "user_id": { "type": "string", "title": "User Id" },
           "user_email": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "User Email"
           },
-          "status": {
-            "type": "string",
-            "title": "Status"
-          },
+          "status": { "type": "string", "title": "Status" },
           "created_at": {
             "type": "string",
             "format": "date-time",
@@ -21896,25 +15990,13 @@
           },
           "started_at": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
             ],
             "title": "Started At"
           },
           "queue_status": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Queue Status"
           }
         },
@@ -21936,16 +16018,11 @@
       "RunningExecutionsListResponse": {
         "properties": {
           "executions": {
-            "items": {
-              "$ref": "#/components/schemas/RunningExecutionDetail"
-            },
+            "items": { "$ref": "#/components/schemas/RunningExecutionDetail" },
             "type": "array",
             "title": "Executions"
           },
-          "total": {
-            "type": "integer",
-            "title": "Total"
-          }
+          "total": { "type": "integer", "title": "Total" }
         },
         "type": "object",
         "required": ["executions", "total"],
@@ -21955,9 +16032,7 @@
       "ScheduleCleanupRequest": {
         "properties": {
           "schedule_ids": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Schedule Ids"
           }
@@ -21969,19 +16044,13 @@
       },
       "ScheduleCleanupResponse": {
         "properties": {
-          "success": {
-            "type": "boolean",
-            "title": "Success"
-          },
+          "success": { "type": "boolean", "title": "Success" },
           "deleted_count": {
             "type": "integer",
             "title": "Deleted Count",
             "default": 0
           },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          }
+          "message": { "type": "string", "title": "Message" }
         },
         "type": "object",
         "required": ["success", "message"],
@@ -21991,24 +16060,11 @@
       "ScheduleCreationRequest": {
         "properties": {
           "graph_version": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
             "title": "Graph Version"
           },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "cron": {
-            "type": "string",
-            "title": "Cron"
-          },
+          "name": { "type": "string", "title": "Name" },
+          "cron": { "type": "string", "title": "Cron" },
           "inputs": {
             "additionalProperties": true,
             "type": "object",
@@ -22022,14 +16078,7 @@
             "title": "Credentials"
           },
           "timezone": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Timezone",
             "description": "User's timezone for scheduling (e.g., 'America/New_York'). If not provided, will use user's saved timezone or UTC."
           }
@@ -22044,25 +16093,12 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "schedule_deleted"
           },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          },
+          "message": { "type": "string", "title": "Message" },
           "session_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Session Id"
           },
-          "schedule_id": {
-            "type": "string",
-            "title": "Schedule Id"
-          }
+          "schedule_id": { "type": "string", "title": "Schedule Id" }
         },
         "type": "object",
         "required": ["message", "schedule_id"],
@@ -22071,62 +16107,23 @@
       },
       "ScheduleDetail": {
         "properties": {
-          "schedule_id": {
-            "type": "string",
-            "title": "Schedule Id"
-          },
-          "schedule_name": {
-            "type": "string",
-            "title": "Schedule Name"
-          },
-          "graph_id": {
-            "type": "string",
-            "title": "Graph Id"
-          },
-          "graph_name": {
-            "type": "string",
-            "title": "Graph Name"
-          },
-          "graph_version": {
-            "type": "integer",
-            "title": "Graph Version"
-          },
-          "user_id": {
-            "type": "string",
-            "title": "User Id"
-          },
+          "schedule_id": { "type": "string", "title": "Schedule Id" },
+          "schedule_name": { "type": "string", "title": "Schedule Name" },
+          "graph_id": { "type": "string", "title": "Graph Id" },
+          "graph_name": { "type": "string", "title": "Graph Name" },
+          "graph_version": { "type": "integer", "title": "Graph Version" },
+          "user_id": { "type": "string", "title": "User Id" },
           "user_email": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "User Email"
           },
-          "cron": {
-            "type": "string",
-            "title": "Cron"
-          },
-          "timezone": {
-            "type": "string",
-            "title": "Timezone"
-          },
-          "next_run_time": {
-            "type": "string",
-            "title": "Next Run Time"
-          },
+          "cron": { "type": "string", "title": "Cron" },
+          "timezone": { "type": "string", "title": "Timezone" },
+          "next_run_time": { "type": "string", "title": "Next Run Time" },
           "created_at": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
             ],
             "title": "Created At"
           }
@@ -22149,14 +16146,8 @@
       },
       "ScheduleHealthMetrics": {
         "properties": {
-          "total_schedules": {
-            "type": "integer",
-            "title": "Total Schedules"
-          },
-          "user_schedules": {
-            "type": "integer",
-            "title": "User Schedules"
-          },
+          "total_schedules": { "type": "integer", "title": "Total Schedules" },
+          "user_schedules": { "type": "integer", "title": "User Schedules" },
           "system_schedules": {
             "type": "integer",
             "title": "System Schedules"
@@ -22177,10 +16168,7 @@
             "type": "integer",
             "title": "Orphaned Validation Failed"
           },
-          "total_orphaned": {
-            "type": "integer",
-            "title": "Total Orphaned"
-          },
+          "total_orphaned": { "type": "integer", "title": "Total Orphaned" },
           "schedules_next_hour": {
             "type": "integer",
             "title": "Schedules Next Hour"
@@ -22197,10 +16185,7 @@
             "type": "integer",
             "title": "Total Runs Next 24H"
           },
-          "timestamp": {
-            "type": "string",
-            "title": "Timestamp"
-          }
+          "timestamp": { "type": "string", "title": "Timestamp" }
         },
         "type": "object",
         "required": [
@@ -22227,25 +16212,13 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "schedule_list"
           },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          },
+          "message": { "type": "string", "title": "Message" },
           "session_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Session Id"
           },
           "schedules": {
-            "items": {
-              "$ref": "#/components/schemas/ScheduleSummary"
-            },
+            "items": { "$ref": "#/components/schemas/ScheduleSummary" },
             "type": "array",
             "title": "Schedules"
           }
@@ -22257,91 +16230,37 @@
       },
       "ScheduleSummary": {
         "properties": {
-          "schedule_id": {
-            "type": "string",
-            "title": "Schedule Id"
-          },
+          "schedule_id": { "type": "string", "title": "Schedule Id" },
           "kind": {
             "type": "string",
             "enum": ["graph", "copilot_turn"],
             "title": "Kind"
           },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "timezone": {
-            "type": "string",
-            "title": "Timezone"
-          },
-          "next_run_time": {
-            "type": "string",
-            "title": "Next Run Time"
-          },
+          "name": { "type": "string", "title": "Name" },
+          "timezone": { "type": "string", "title": "Timezone" },
+          "next_run_time": { "type": "string", "title": "Next Run Time" },
           "cron": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Cron"
           },
           "run_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Run At"
           },
           "graph_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Graph Id"
           },
           "graph_version": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
             "title": "Graph Version"
           },
           "session_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Session Id"
           },
           "message": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Message"
           }
         },
@@ -22359,16 +16278,11 @@
       "SchedulesListResponse": {
         "properties": {
           "schedules": {
-            "items": {
-              "$ref": "#/components/schemas/ScheduleDetail"
-            },
+            "items": { "$ref": "#/components/schemas/ScheduleDetail" },
             "type": "array",
             "title": "Schedules"
           },
-          "total": {
-            "type": "integer",
-            "title": "Total"
-          }
+          "total": { "type": "integer", "title": "Total" }
         },
         "type": "object",
         "required": ["schedules", "total"],
@@ -22378,14 +16292,7 @@
       "SearchEntry": {
         "properties": {
           "search_query": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Search Query"
           },
           "filter": {
@@ -22402,35 +16309,19 @@
                 },
                 "type": "array"
               },
-              {
-                "type": "null"
-              }
+              { "type": "null" }
             ],
             "title": "Filter"
           },
           "by_creator": {
             "anyOf": [
-              {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
+              { "items": { "type": "string" }, "type": "array" },
+              { "type": "null" }
             ],
             "title": "By Creator"
           },
           "search_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Search Id"
           }
         },
@@ -22442,28 +16333,17 @@
           "items": {
             "items": {
               "anyOf": [
-                {
-                  "$ref": "#/components/schemas/BlockInfo"
-                },
-                {
-                  "$ref": "#/components/schemas/LibraryAgent"
-                },
-                {
-                  "$ref": "#/components/schemas/StoreAgent"
-                }
+                { "$ref": "#/components/schemas/BlockInfo" },
+                { "$ref": "#/components/schemas/LibraryAgent" },
+                { "$ref": "#/components/schemas/StoreAgent" }
               ]
             },
             "type": "array",
             "title": "Items"
           },
-          "search_id": {
-            "type": "string",
-            "title": "Search Id"
-          },
+          "search_id": { "type": "string", "title": "Search Id" },
           "total_items": {
-            "additionalProperties": {
-              "type": "integer"
-            },
+            "additionalProperties": { "type": "integer" },
             "propertyNames": {
               "enum": [
                 "blocks",
@@ -22475,9 +16355,7 @@
             "type": "object",
             "title": "Total Items"
           },
-          "pagination": {
-            "$ref": "#/components/schemas/Pagination"
-          }
+          "pagination": { "$ref": "#/components/schemas/Pagination" }
         },
         "type": "object",
         "required": ["items", "search_id", "total_items", "pagination"],
@@ -22485,27 +16363,11 @@
       },
       "SessionDetailResponse": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "created_at": {
-            "type": "string",
-            "title": "Created At"
-          },
-          "updated_at": {
-            "type": "string",
-            "title": "Updated At"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "created_at": { "type": "string", "title": "Created At" },
+          "updated_at": { "type": "string", "title": "Updated At" },
           "user_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "User Id"
           },
           "chat_status": {
@@ -22514,21 +16376,14 @@
             "default": "idle"
           },
           "messages": {
-            "items": {
-              "additionalProperties": true,
-              "type": "object"
-            },
+            "items": { "additionalProperties": true, "type": "object" },
             "type": "array",
             "title": "Messages"
           },
           "active_stream": {
             "anyOf": [
-              {
-                "$ref": "#/components/schemas/ActiveStreamInfo"
-              },
-              {
-                "type": "null"
-              }
+              { "$ref": "#/components/schemas/ActiveStreamInfo" },
+              { "type": "null" }
             ]
           },
           "has_more_messages": {
@@ -22537,14 +16392,7 @@
             "default": false
           },
           "oldest_sequence": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
             "title": "Oldest Sequence"
           },
           "total_prompt_tokens": {
@@ -22559,9 +16407,7 @@
           },
           "metadata": {
             "$ref": "#/components/schemas/ChatSessionMetadata",
-            "default": {
-              "dry_run": false
-            }
+            "default": { "dry_run": false }
           }
         },
         "type": "object",
@@ -22571,27 +16417,11 @@
       },
       "SessionSummaryResponse": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "created_at": {
-            "type": "string",
-            "title": "Created At"
-          },
-          "updated_at": {
-            "type": "string",
-            "title": "Updated At"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "created_at": { "type": "string", "title": "Created At" },
+          "updated_at": { "type": "string", "title": "Updated At" },
           "title": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Title"
           },
           "chat_status": {
@@ -22599,19 +16429,9 @@
             "title": "Chat Status",
             "default": "idle"
           },
-          "is_processing": {
-            "type": "boolean",
-            "title": "Is Processing"
-          },
+          "is_processing": { "type": "boolean", "title": "Is Processing" },
           "source_platform": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Source Platform"
           }
         },
@@ -22633,13 +16453,8 @@
       },
       "SetUserTierRequest": {
         "properties": {
-          "user_id": {
-            "type": "string",
-            "title": "User Id"
-          },
-          "tier": {
-            "$ref": "#/components/schemas/SubscriptionTier"
-          }
+          "user_id": { "type": "string", "title": "User Id" },
+          "tier": { "$ref": "#/components/schemas/SubscriptionTier" }
         },
         "type": "object",
         "required": ["user_id", "tier"],
@@ -22647,25 +16462,14 @@
       },
       "SetupInfo": {
         "properties": {
-          "agent_id": {
-            "type": "string",
-            "title": "Agent Id"
-          },
-          "agent_name": {
-            "type": "string",
-            "title": "Agent Name"
-          },
+          "agent_id": { "type": "string", "title": "Agent Id" },
+          "agent_name": { "type": "string", "title": "Agent Name" },
           "requirements": {
-            "additionalProperties": {
-              "items": {},
-              "type": "array"
-            },
+            "additionalProperties": { "items": {}, "type": "array" },
             "type": "object",
             "title": "Requirements"
           },
-          "user_readiness": {
-            "$ref": "#/components/schemas/UserReadiness"
-          }
+          "user_readiness": { "$ref": "#/components/schemas/UserReadiness" }
         },
         "type": "object",
         "required": ["agent_id", "agent_name"],
@@ -22678,44 +16482,18 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "setup_requirements"
           },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          },
+          "message": { "type": "string", "title": "Message" },
           "session_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Session Id"
           },
-          "setup_info": {
-            "$ref": "#/components/schemas/SetupInfo"
-          },
+          "setup_info": { "$ref": "#/components/schemas/SetupInfo" },
           "graph_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Graph Id"
           },
           "graph_version": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
             "title": "Graph Version"
           }
         },
@@ -22732,14 +16510,8 @@
       },
       "ShareResponse": {
         "properties": {
-          "share_url": {
-            "type": "string",
-            "title": "Share Url"
-          },
-          "share_token": {
-            "type": "string",
-            "title": "Share Token"
-          }
+          "share_url": { "type": "string", "title": "Share Url" },
+          "share_token": { "type": "string", "title": "Share Token" }
         },
         "type": "object",
         "required": ["share_url", "share_token"],
@@ -22748,38 +16520,20 @@
       },
       "SharedExecutionResponse": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "graph_name": {
-            "type": "string",
-            "title": "Graph Name"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "graph_name": { "type": "string", "title": "Graph Name" },
           "graph_description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Graph Description"
           },
-          "status": {
-            "$ref": "#/components/schemas/AgentExecutionStatus"
-          },
+          "status": { "$ref": "#/components/schemas/AgentExecutionStatus" },
           "created_at": {
             "type": "string",
             "format": "date-time",
             "title": "Created At"
           },
           "outputs": {
-            "additionalProperties": {
-              "items": {},
-              "type": "array"
-            },
+            "additionalProperties": { "items": {}, "type": "array" },
             "type": "object",
             "title": "Outputs"
           }
@@ -22841,38 +16595,17 @@
             "default": 0
           },
           "error": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Error",
             "description": "Error message if any"
           },
           "activity_status": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Activity Status",
             "description": "AI-generated summary of what the agent did"
           },
           "correctness_score": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "number" }, { "type": "null" }],
             "title": "Correctness Score",
             "description": "AI-generated score (0.0-1.0) indicating how well the execution achieved its intended purpose"
           }
@@ -22883,10 +16616,7 @@
       },
       "StopExecutionRequest": {
         "properties": {
-          "execution_id": {
-            "type": "string",
-            "title": "Execution Id"
-          }
+          "execution_id": { "type": "string", "title": "Execution Id" }
         },
         "type": "object",
         "required": ["execution_id"],
@@ -22895,19 +16625,13 @@
       },
       "StopExecutionResponse": {
         "properties": {
-          "success": {
-            "type": "boolean",
-            "title": "Success"
-          },
+          "success": { "type": "boolean", "title": "Success" },
           "stopped_count": {
             "type": "integer",
             "title": "Stopped Count",
             "default": 0
           },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          }
+          "message": { "type": "string", "title": "Message" }
         },
         "type": "object",
         "required": ["success", "message"],
@@ -22917,9 +16641,7 @@
       "StopExecutionsRequest": {
         "properties": {
           "execution_ids": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Execution Ids"
           }
@@ -22931,22 +16653,10 @@
       },
       "StorageUsageResponse": {
         "properties": {
-          "used_bytes": {
-            "type": "integer",
-            "title": "Used Bytes"
-          },
-          "limit_bytes": {
-            "type": "integer",
-            "title": "Limit Bytes"
-          },
-          "used_percent": {
-            "type": "number",
-            "title": "Used Percent"
-          },
-          "file_count": {
-            "type": "integer",
-            "title": "File Count"
-          }
+          "used_bytes": { "type": "integer", "title": "Used Bytes" },
+          "limit_bytes": { "type": "integer", "title": "Limit Bytes" },
+          "used_percent": { "type": "number", "title": "Used Percent" },
+          "file_count": { "type": "integer", "title": "File Count" }
         },
         "type": "object",
         "required": ["used_bytes", "limit_bytes", "used_percent", "file_count"],
@@ -22954,46 +16664,16 @@
       },
       "StoreAgent": {
         "properties": {
-          "slug": {
-            "type": "string",
-            "title": "Slug"
-          },
-          "agent_name": {
-            "type": "string",
-            "title": "Agent Name"
-          },
-          "agent_image": {
-            "type": "string",
-            "title": "Agent Image"
-          },
-          "creator": {
-            "type": "string",
-            "title": "Creator"
-          },
-          "creator_avatar": {
-            "type": "string",
-            "title": "Creator Avatar"
-          },
-          "sub_heading": {
-            "type": "string",
-            "title": "Sub Heading"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
-          "runs": {
-            "type": "integer",
-            "title": "Runs"
-          },
-          "rating": {
-            "type": "number",
-            "title": "Rating"
-          },
-          "agent_graph_id": {
-            "type": "string",
-            "title": "Agent Graph Id"
-          }
+          "slug": { "type": "string", "title": "Slug" },
+          "agent_name": { "type": "string", "title": "Agent Name" },
+          "agent_image": { "type": "string", "title": "Agent Image" },
+          "creator": { "type": "string", "title": "Creator" },
+          "creator_avatar": { "type": "string", "title": "Creator Avatar" },
+          "sub_heading": { "type": "string", "title": "Sub Heading" },
+          "description": { "type": "string", "title": "Description" },
+          "runs": { "type": "integer", "title": "Runs" },
+          "rating": { "type": "number", "title": "Rating" },
+          "agent_graph_id": { "type": "string", "title": "Agent Graph Id" }
         },
         "type": "object",
         "required": [
@@ -23016,86 +16696,41 @@
             "type": "string",
             "title": "Store Listing Version Id"
           },
-          "slug": {
-            "type": "string",
-            "title": "Slug"
-          },
-          "agent_name": {
-            "type": "string",
-            "title": "Agent Name"
-          },
-          "agent_video": {
-            "type": "string",
-            "title": "Agent Video"
-          },
+          "slug": { "type": "string", "title": "Slug" },
+          "agent_name": { "type": "string", "title": "Agent Name" },
+          "agent_video": { "type": "string", "title": "Agent Video" },
           "agent_output_demo": {
             "type": "string",
             "title": "Agent Output Demo"
           },
           "agent_image": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Agent Image"
           },
-          "creator": {
-            "type": "string",
-            "title": "Creator"
-          },
-          "creator_avatar": {
-            "type": "string",
-            "title": "Creator Avatar"
-          },
-          "sub_heading": {
-            "type": "string",
-            "title": "Sub Heading"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
+          "creator": { "type": "string", "title": "Creator" },
+          "creator_avatar": { "type": "string", "title": "Creator Avatar" },
+          "sub_heading": { "type": "string", "title": "Sub Heading" },
+          "description": { "type": "string", "title": "Description" },
           "instructions": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Instructions"
           },
           "categories": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Categories"
           },
-          "runs": {
-            "type": "integer",
-            "title": "Runs"
-          },
-          "rating": {
-            "type": "number",
-            "title": "Rating"
-          },
+          "runs": { "type": "integer", "title": "Runs" },
+          "rating": { "type": "number", "title": "Rating" },
           "versions": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Versions"
           },
-          "graph_id": {
-            "type": "string",
-            "title": "Graph Id"
-          },
+          "graph_id": { "type": "string", "title": "Graph Id" },
           "graph_versions": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Graph Versions"
           },
@@ -23105,14 +16740,7 @@
             "title": "Last Updated"
           },
           "recommended_schedule_cron": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Recommended Schedule Cron"
           },
           "active_version_id": {
@@ -23126,14 +16754,10 @@
           "changelog": {
             "anyOf": [
               {
-                "items": {
-                  "$ref": "#/components/schemas/ChangelogEntry"
-                },
+                "items": { "$ref": "#/components/schemas/ChangelogEntry" },
                 "type": "array"
               },
-              {
-                "type": "null"
-              }
+              { "type": "null" }
             ],
             "title": "Changelog"
           }
@@ -23165,15 +16789,11 @@
       "StoreAgentsResponse": {
         "properties": {
           "agents": {
-            "items": {
-              "$ref": "#/components/schemas/StoreAgent"
-            },
+            "items": { "$ref": "#/components/schemas/StoreAgent" },
             "type": "array",
             "title": "Agents"
           },
-          "pagination": {
-            "$ref": "#/components/schemas/Pagination"
-          }
+          "pagination": { "$ref": "#/components/schemas/Pagination" }
         },
         "type": "object",
         "required": ["agents", "pagination"],
@@ -23191,27 +16811,11 @@
       },
       "StoreListingWithVersionsAdminView": {
         "properties": {
-          "listing_id": {
-            "type": "string",
-            "title": "Listing Id"
-          },
-          "graph_id": {
-            "type": "string",
-            "title": "Graph Id"
-          },
-          "slug": {
-            "type": "string",
-            "title": "Slug"
-          },
+          "listing_id": { "type": "string", "title": "Listing Id" },
+          "graph_id": { "type": "string", "title": "Graph Id" },
+          "slug": { "type": "string", "title": "Slug" },
           "active_listing_version_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Active Listing Version Id"
           },
           "has_approved_version": {
@@ -23220,24 +16824,13 @@
             "default": false
           },
           "creator_email": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Creator Email"
           },
           "latest_version": {
             "anyOf": [
-              {
-                "$ref": "#/components/schemas/StoreSubmissionAdminView"
-              },
-              {
-                "type": "null"
-              }
+              { "$ref": "#/components/schemas/StoreSubmissionAdminView" },
+              { "type": "null" }
             ]
           },
           "versions": {
@@ -23263,9 +16856,7 @@
             "type": "array",
             "title": "Listings"
           },
-          "pagination": {
-            "$ref": "#/components/schemas/Pagination"
-          }
+          "pagination": { "$ref": "#/components/schemas/Pagination" }
         },
         "type": "object",
         "required": ["listings", "pagination"],
@@ -23274,19 +16865,9 @@
       },
       "StoreReview": {
         "properties": {
-          "score": {
-            "type": "integer",
-            "title": "Score"
-          },
+          "score": { "type": "integer", "title": "Score" },
           "comments": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Comments"
           }
         },
@@ -23300,19 +16881,9 @@
             "type": "string",
             "title": "Store Listing Version Id"
           },
-          "score": {
-            "type": "integer",
-            "title": "Score"
-          },
+          "score": { "type": "integer", "title": "Score" },
           "comments": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Comments"
           }
         },
@@ -23322,151 +16893,66 @@
       },
       "StoreSubmission": {
         "properties": {
-          "listing_id": {
-            "type": "string",
-            "title": "Listing Id"
-          },
-          "user_id": {
-            "type": "string",
-            "title": "User Id"
-          },
-          "slug": {
-            "type": "string",
-            "title": "Slug"
-          },
+          "listing_id": { "type": "string", "title": "Listing Id" },
+          "user_id": { "type": "string", "title": "User Id" },
+          "slug": { "type": "string", "title": "Slug" },
           "listing_version_id": {
             "type": "string",
             "title": "Listing Version Id"
           },
-          "listing_version": {
-            "type": "integer",
-            "title": "Listing Version"
-          },
-          "graph_id": {
-            "type": "string",
-            "title": "Graph Id"
-          },
-          "graph_version": {
-            "type": "integer",
-            "title": "Graph Version"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "sub_heading": {
-            "type": "string",
-            "title": "Sub Heading"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
+          "listing_version": { "type": "integer", "title": "Listing Version" },
+          "graph_id": { "type": "string", "title": "Graph Id" },
+          "graph_version": { "type": "integer", "title": "Graph Version" },
+          "name": { "type": "string", "title": "Name" },
+          "sub_heading": { "type": "string", "title": "Sub Heading" },
+          "description": { "type": "string", "title": "Description" },
           "instructions": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Instructions"
           },
           "categories": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Categories"
           },
           "image_urls": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Image Urls"
           },
           "video_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Video Url"
           },
           "agent_output_demo_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Agent Output Demo Url"
           },
           "submitted_at": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
             ],
             "title": "Submitted At"
           },
           "changes_summary": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Changes Summary"
           },
-          "status": {
-            "$ref": "#/components/schemas/SubmissionStatus"
-          },
+          "status": { "$ref": "#/components/schemas/SubmissionStatus" },
           "reviewed_at": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
             ],
             "title": "Reviewed At"
           },
           "reviewer_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Reviewer Id"
           },
           "review_comments": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Review Comments"
           },
           "run_count": {
@@ -23510,151 +16996,66 @@
       },
       "StoreSubmissionAdminView": {
         "properties": {
-          "listing_id": {
-            "type": "string",
-            "title": "Listing Id"
-          },
-          "user_id": {
-            "type": "string",
-            "title": "User Id"
-          },
-          "slug": {
-            "type": "string",
-            "title": "Slug"
-          },
+          "listing_id": { "type": "string", "title": "Listing Id" },
+          "user_id": { "type": "string", "title": "User Id" },
+          "slug": { "type": "string", "title": "Slug" },
           "listing_version_id": {
             "type": "string",
             "title": "Listing Version Id"
           },
-          "listing_version": {
-            "type": "integer",
-            "title": "Listing Version"
-          },
-          "graph_id": {
-            "type": "string",
-            "title": "Graph Id"
-          },
-          "graph_version": {
-            "type": "integer",
-            "title": "Graph Version"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "sub_heading": {
-            "type": "string",
-            "title": "Sub Heading"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
+          "listing_version": { "type": "integer", "title": "Listing Version" },
+          "graph_id": { "type": "string", "title": "Graph Id" },
+          "graph_version": { "type": "integer", "title": "Graph Version" },
+          "name": { "type": "string", "title": "Name" },
+          "sub_heading": { "type": "string", "title": "Sub Heading" },
+          "description": { "type": "string", "title": "Description" },
           "instructions": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Instructions"
           },
           "categories": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Categories"
           },
           "image_urls": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Image Urls"
           },
           "video_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Video Url"
           },
           "agent_output_demo_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Agent Output Demo Url"
           },
           "submitted_at": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
             ],
             "title": "Submitted At"
           },
           "changes_summary": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Changes Summary"
           },
-          "status": {
-            "$ref": "#/components/schemas/SubmissionStatus"
-          },
+          "status": { "$ref": "#/components/schemas/SubmissionStatus" },
           "reviewed_at": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
             ],
             "title": "Reviewed At"
           },
           "reviewer_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Reviewer Id"
           },
           "review_comments": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Review Comments"
           },
           "run_count": {
@@ -23673,14 +17074,7 @@
             "default": 0.0
           },
           "internal_comments": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Internal Comments"
           }
         },
@@ -23710,40 +17104,18 @@
       },
       "StoreSubmissionEditRequest": {
         "properties": {
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "sub_heading": {
-            "type": "string",
-            "title": "Sub Heading"
-          },
+          "name": { "type": "string", "title": "Name" },
+          "sub_heading": { "type": "string", "title": "Sub Heading" },
           "video_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Video Url"
           },
           "agent_output_demo_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Agent Output Demo Url"
           },
           "image_urls": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Image Urls",
             "default": []
@@ -23754,44 +17126,21 @@
             "default": ""
           },
           "instructions": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Instructions"
           },
           "categories": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Categories",
             "default": []
           },
           "changes_summary": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Changes Summary"
           },
           "recommended_schedule_cron": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Recommended Schedule Cron"
           }
         },
@@ -23813,44 +17162,19 @@
             "title": "Graph Version",
             "description": "Graph version must be greater than 0"
           },
-          "slug": {
-            "type": "string",
-            "title": "Slug"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "sub_heading": {
-            "type": "string",
-            "title": "Sub Heading"
-          },
+          "slug": { "type": "string", "title": "Slug" },
+          "name": { "type": "string", "title": "Name" },
+          "sub_heading": { "type": "string", "title": "Sub Heading" },
           "video_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Video Url"
           },
           "agent_output_demo_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Agent Output Demo Url"
           },
           "image_urls": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Image Urls",
             "default": []
@@ -23861,44 +17185,21 @@
             "default": ""
           },
           "instructions": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Instructions"
           },
           "categories": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Categories",
             "default": []
           },
           "changes_summary": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Changes Summary"
           },
           "recommended_schedule_cron": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Recommended Schedule Cron"
           }
         },
@@ -23915,18 +17216,12 @@
       "StoreSubmissionsResponse": {
         "properties": {
           "submissions": {
-            "items": {
-              "$ref": "#/components/schemas/StoreSubmission"
-            },
+            "items": { "$ref": "#/components/schemas/StoreSubmission" },
             "type": "array",
             "title": "Submissions"
           },
-          "pagination": {
-            "$ref": "#/components/schemas/Pagination"
-          },
-          "stats": {
-            "$ref": "#/components/schemas/SubmissionStats"
-          }
+          "pagination": { "$ref": "#/components/schemas/Pagination" },
+          "stats": { "$ref": "#/components/schemas/SubmissionStats" }
         },
         "type": "object",
         "required": ["submissions", "pagination", "stats"],
@@ -23947,67 +17242,44 @@
           "context": {
             "anyOf": [
               {
-                "additionalProperties": {
-                  "type": "string"
-                },
+                "additionalProperties": { "type": "string" },
                 "type": "object"
               },
-              {
-                "type": "null"
-              }
+              { "type": "null" }
             ],
             "title": "Context"
           },
           "file_ids": {
             "anyOf": [
               {
-                "items": {
-                  "type": "string"
-                },
+                "items": { "type": "string" },
                 "type": "array",
                 "maxItems": 20
               },
-              {
-                "type": "null"
-              }
+              { "type": "null" }
             ],
             "title": "File Ids"
           },
           "mode": {
             "anyOf": [
-              {
-                "type": "string",
-                "enum": ["fast", "extended_thinking"]
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "enum": ["fast", "extended_thinking"] },
+              { "type": "null" }
             ],
             "title": "Mode",
             "description": "Autopilot mode: 'fast' for baseline LLM, 'extended_thinking' for Claude Agent SDK. If None, uses the server default (extended_thinking)."
           },
           "model": {
             "anyOf": [
-              {
-                "type": "string",
-                "enum": ["standard", "advanced"]
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "enum": ["standard", "advanced"] },
+              { "type": "null" }
             ],
             "title": "Model",
             "description": "Model tier: 'standard' for the default model, 'advanced' for the highest-capability model. If None, the server applies per-user LD targeting then falls back to config."
           },
           "message_id": {
             "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 64
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "maxLength": 64 },
+              { "type": "null" }
             ],
             "title": "Message Id",
             "description": "Optional per-click UUID generated by the frontend.  Becomes the persisted ``ChatMessage.id`` (PK).  Frontend / network / RMQ-redelivery retransmits of the same logical send reuse the id, so the Postgres unique-constraint on the PK is the atomic dedup primitive: a duplicate INSERT returns a subscribe-only response without creating a parallel turn.  Distinct user clicks (even with identical text) MUST send different ids — the frontend's per-click ``crypto.randomUUID()`` guarantees that."
@@ -24020,31 +17292,12 @@
       },
       "SubmissionStats": {
         "properties": {
-          "total": {
-            "type": "integer",
-            "title": "Total"
-          },
-          "approved": {
-            "type": "integer",
-            "title": "Approved"
-          },
-          "pending": {
-            "type": "integer",
-            "title": "Pending"
-          },
-          "total_runs": {
-            "type": "integer",
-            "title": "Total Runs"
-          },
+          "total": { "type": "integer", "title": "Total" },
+          "approved": { "type": "integer", "title": "Approved" },
+          "pending": { "type": "integer", "title": "Pending" },
+          "total_runs": { "type": "integer", "title": "Total Runs" },
           "average_rating": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "number" }, { "type": "null" }],
             "title": "Average Rating"
           }
         },
@@ -24078,21 +17331,14 @@
             ],
             "title": "Tier"
           },
-          "monthly_cost": {
-            "type": "integer",
-            "title": "Monthly Cost"
-          },
+          "monthly_cost": { "type": "integer", "title": "Monthly Cost" },
           "tier_costs": {
-            "additionalProperties": {
-              "type": "integer"
-            },
+            "additionalProperties": { "type": "integer" },
             "type": "object",
             "title": "Tier Costs"
           },
           "tier_costs_yearly": {
-            "additionalProperties": {
-              "type": "integer"
-            },
+            "additionalProperties": { "type": "integer" },
             "type": "object",
             "title": "Tier Costs Yearly",
             "description": "Tier → yearly amount in cents. Populated only for tiers with a yearly Stripe price configured in LaunchDarkly. Empty for monthly-only configurations."
@@ -24105,9 +17351,7 @@
             "default": "monthly"
           },
           "tier_multipliers": {
-            "additionalProperties": {
-              "type": "number"
-            },
+            "additionalProperties": { "type": "number" },
             "type": "object",
             "title": "Tier Multipliers",
             "description": "Tier → rate-limit multiplier. Covers the same tiers listed in ``tier_costs`` so the frontend can render rate-limit badges relative to the lowest visible tier without knowing backend defaults."
@@ -24123,14 +17367,7 @@
             "default": false
           },
           "current_period_end": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
             "title": "Current Period End",
             "description": "Unix timestamp of the active subscription's current_period_end. Used to show the date Stripe will issue the next invoice (with prorated upgrade charges, if any). None when no active sub."
           },
@@ -24140,33 +17377,21 @@
                 "type": "string",
                 "enum": ["NO_TIER", "BASIC", "PRO", "MAX", "BUSINESS"]
               },
-              {
-                "type": "null"
-              }
+              { "type": "null" }
             ],
             "title": "Pending Tier"
           },
           "pending_tier_effective_at": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
             ],
             "title": "Pending Tier Effective At"
           },
           "pending_billing_cycle": {
             "anyOf": [
-              {
-                "type": "string",
-                "enum": ["monthly", "yearly"]
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "enum": ["monthly", "yearly"] },
+              { "type": "null" }
             ],
             "title": "Pending Billing Cycle",
             "description": "Billing cycle of the queued change, when resolvable. Set alongside ``pending_tier`` for tier downgrades and same-tier cycle switches (yearly→monthly). The frontend uses this to differentiate a cycle-only schedule (``pending_tier == current tier``) from a real tier downgrade so the UI copy can describe the actual change. ``None`` for cancellations and unconfigured legacy prices."
@@ -24227,19 +17452,9 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "suggested_goal"
           },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          },
+          "message": { "type": "string", "title": "Message" },
           "session_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Session Id"
           },
           "suggested_goal": {
@@ -24275,9 +17490,7 @@
       "SuggestedPromptsResponse": {
         "properties": {
           "themes": {
-            "items": {
-              "$ref": "#/components/schemas/SuggestedTheme"
-            },
+            "items": { "$ref": "#/components/schemas/SuggestedTheme" },
             "type": "array",
             "title": "Themes"
           }
@@ -24289,14 +17502,9 @@
       },
       "SuggestedTheme": {
         "properties": {
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
+          "name": { "type": "string", "title": "Name" },
           "prompts": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Prompts"
           }
@@ -24309,9 +17517,7 @@
       "SuggestionsResponse": {
         "properties": {
           "recent_searches": {
-            "items": {
-              "$ref": "#/components/schemas/SearchEntry"
-            },
+            "items": { "$ref": "#/components/schemas/SearchEntry" },
             "type": "array",
             "title": "Recent Searches"
           },
@@ -24324,9 +17530,7 @@
             "title": "Providers"
           },
           "top_blocks": {
-            "items": {
-              "$ref": "#/components/schemas/BlockInfo"
-            },
+            "items": { "$ref": "#/components/schemas/BlockInfo" },
             "type": "array",
             "title": "Top Blocks"
           }
@@ -24942,9 +18146,7 @@
                 ],
                 "minLength": 1
               },
-              {
-                "type": "string"
-              }
+              { "type": "string" }
             ],
             "title": "Timezone"
           }
@@ -24983,25 +18185,13 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "todo_write"
           },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          },
+          "message": { "type": "string", "title": "Message" },
           "session_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Session Id"
           },
           "todos": {
-            "items": {
-              "$ref": "#/components/schemas/TodoItem"
-            },
+            "items": { "$ref": "#/components/schemas/TodoItem" },
             "type": "array",
             "title": "Todos"
           }
@@ -25013,66 +18203,30 @@
       },
       "TokenIntrospectionResult": {
         "properties": {
-          "active": {
-            "type": "boolean",
-            "title": "Active"
-          },
+          "active": { "type": "boolean", "title": "Active" },
           "scopes": {
             "anyOf": [
-              {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
+              { "items": { "type": "string" }, "type": "array" },
+              { "type": "null" }
             ],
             "title": "Scopes"
           },
           "client_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Client Id"
           },
           "user_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "User Id"
           },
           "exp": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
             "title": "Exp"
           },
           "token_type": {
             "anyOf": [
-              {
-                "type": "string",
-                "enum": ["access_token", "refresh_token"]
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "enum": ["access_token", "refresh_token"] },
+              { "type": "null" }
             ],
             "title": "Token Type"
           }
@@ -25095,27 +18249,11 @@
             "title": "Output Usd Per 1M"
           },
           "cache_read_usd_per_1m": {
-            "anyOf": [
-              {
-                "type": "number",
-                "minimum": 0.0
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "number", "minimum": 0.0 }, { "type": "null" }],
             "title": "Cache Read Usd Per 1M"
           },
           "cache_creation_usd_per_1m": {
-            "anyOf": [
-              {
-                "type": "number",
-                "minimum": 0.0
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "number", "minimum": 0.0 }, { "type": "null" }],
             "title": "Cache Creation Usd Per 1M"
           }
         },
@@ -25141,14 +18279,8 @@
             "title": "Redirect Uri",
             "description": "Redirect URI (must match authorization request)"
           },
-          "client_id": {
-            "type": "string",
-            "title": "Client Id"
-          },
-          "client_secret": {
-            "type": "string",
-            "title": "Client Secret"
-          },
+          "client_id": { "type": "string", "title": "Client Id" },
+          "client_secret": { "type": "string", "title": "Client Secret" },
           "code_verifier": {
             "type": "string",
             "title": "Code Verifier",
@@ -25173,18 +18305,9 @@
             "const": "refresh_token",
             "title": "Grant Type"
           },
-          "refresh_token": {
-            "type": "string",
-            "title": "Refresh Token"
-          },
-          "client_id": {
-            "type": "string",
-            "title": "Client Id"
-          },
-          "client_secret": {
-            "type": "string",
-            "title": "Client Secret"
-          }
+          "refresh_token": { "type": "string", "title": "Refresh Token" },
+          "client_id": { "type": "string", "title": "Client Id" },
+          "client_secret": { "type": "string", "title": "Client Secret" }
         },
         "type": "object",
         "required": [
@@ -25203,28 +18326,20 @@
             "title": "Token Type",
             "default": "Bearer"
           },
-          "access_token": {
-            "type": "string",
-            "title": "Access Token"
-          },
+          "access_token": { "type": "string", "title": "Access Token" },
           "access_token_expires_at": {
             "type": "string",
             "format": "date-time",
             "title": "Access Token Expires At"
           },
-          "refresh_token": {
-            "type": "string",
-            "title": "Refresh Token"
-          },
+          "refresh_token": { "type": "string", "title": "Refresh Token" },
           "refresh_token_expires_at": {
             "type": "string",
             "format": "date-time",
             "title": "Refresh Token Expires At"
           },
           "scopes": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Scopes"
           }
@@ -25243,21 +18358,14 @@
       "TransactionHistory": {
         "properties": {
           "transactions": {
-            "items": {
-              "$ref": "#/components/schemas/UserTransaction"
-            },
+            "items": { "$ref": "#/components/schemas/UserTransaction" },
             "type": "array",
             "title": "Transactions"
           },
           "next_transaction_time": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
             ],
             "title": "Next Transaction Time"
           }
@@ -25268,23 +18376,14 @@
       },
       "TriggeredPresetSetupRequest": {
         "properties": {
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
+          "name": { "type": "string", "title": "Name" },
           "description": {
             "type": "string",
             "title": "Description",
             "default": ""
           },
-          "graph_id": {
-            "type": "string",
-            "title": "Graph Id"
-          },
-          "graph_version": {
-            "type": "integer",
-            "title": "Graph Version"
-          },
+          "graph_id": { "type": "string", "title": "Graph Id" },
+          "graph_version": { "type": "integer", "title": "Graph Version" },
           "trigger_config": {
             "additionalProperties": true,
             "type": "object",
@@ -25308,25 +18407,13 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "understanding_updated"
           },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          },
+          "message": { "type": "string", "title": "Message" },
           "session_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Session Id"
           },
           "updated_fields": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Updated Fields"
           },
@@ -25344,15 +18431,11 @@
       "UnifiedSearchResponse": {
         "properties": {
           "results": {
-            "items": {
-              "$ref": "#/components/schemas/UnifiedSearchResult"
-            },
+            "items": { "$ref": "#/components/schemas/UnifiedSearchResult" },
             "type": "array",
             "title": "Results"
           },
-          "pagination": {
-            "$ref": "#/components/schemas/Pagination"
-          }
+          "pagination": { "$ref": "#/components/schemas/Pagination" }
         },
         "type": "object",
         "required": ["results", "pagination"],
@@ -25361,73 +18444,33 @@
       },
       "UnifiedSearchResult": {
         "properties": {
-          "content_type": {
-            "type": "string",
-            "title": "Content Type"
-          },
-          "content_id": {
-            "type": "string",
-            "title": "Content Id"
-          },
-          "searchable_text": {
-            "type": "string",
-            "title": "Searchable Text"
-          },
+          "content_type": { "type": "string", "title": "Content Type" },
+          "content_id": { "type": "string", "title": "Content Id" },
+          "searchable_text": { "type": "string", "title": "Searchable Text" },
           "metadata": {
             "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
+              { "additionalProperties": true, "type": "object" },
+              { "type": "null" }
             ],
             "title": "Metadata"
           },
           "updated_at": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
             ],
             "title": "Updated At"
           },
           "combined_score": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "number" }, { "type": "null" }],
             "title": "Combined Score"
           },
           "semantic_score": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "number" }, { "type": "null" }],
             "title": "Semantic Score"
           },
           "lexical_score": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "number" }, { "type": "null" }],
             "title": "Lexical Score"
           }
         },
@@ -25451,9 +18494,7 @@
       "UpdatePermissionsRequest": {
         "properties": {
           "permissions": {
-            "items": {
-              "$ref": "#/components/schemas/APIKeyPermission"
-            },
+            "items": { "$ref": "#/components/schemas/APIKeyPermission" },
             "type": "array",
             "title": "Permissions"
           }
@@ -25463,12 +18504,7 @@
         "title": "UpdatePermissionsRequest"
       },
       "UpdateSessionTitleRequest": {
-        "properties": {
-          "title": {
-            "type": "string",
-            "title": "Title"
-          }
-        },
+        "properties": { "title": { "type": "string", "title": "Title" } },
         "type": "object",
         "required": ["title"],
         "title": "UpdateSessionTitleRequest",
@@ -26107,18 +19143,9 @@
       },
       "UserAgentCostRollup": {
         "properties": {
-          "graph_id": {
-            "type": "string",
-            "title": "Graph Id"
-          },
-          "cost_cents": {
-            "type": "integer",
-            "title": "Cost Cents"
-          },
-          "run_count": {
-            "type": "integer",
-            "title": "Run Count"
-          }
+          "graph_id": { "type": "string", "title": "Graph Id" },
+          "cost_cents": { "type": "integer", "title": "Cost Cents" },
+          "run_count": { "type": "integer", "title": "Run Count" }
         },
         "type": "object",
         "required": ["graph_id", "cost_cents", "run_count"],
@@ -26127,25 +19154,11 @@
       "UserCostSummary": {
         "properties": {
           "user_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "User Id"
           },
           "email": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Email"
           },
           "total_cost_microdollars": {
@@ -26170,10 +19183,7 @@
             "title": "Total Cache Creation Tokens",
             "default": 0
           },
-          "request_count": {
-            "type": "integer",
-            "title": "Request Count"
-          },
+          "request_count": { "type": "integer", "title": "Request Count" },
           "cost_bearing_request_count": {
             "type": "integer",
             "title": "Cost Bearing Request Count",
@@ -26191,19 +19201,9 @@
       },
       "UserDailyCost": {
         "properties": {
-          "date": {
-            "type": "string",
-            "format": "date",
-            "title": "Date"
-          },
-          "cost_cents": {
-            "type": "integer",
-            "title": "Cost Cents"
-          },
-          "run_count": {
-            "type": "integer",
-            "title": "Run Count"
-          }
+          "date": { "type": "string", "format": "date", "title": "Date" },
+          "cost_cents": { "type": "integer", "title": "Cost Cents" },
+          "run_count": { "type": "integer", "title": "Run Count" }
         },
         "type": "object",
         "required": ["date", "cost_cents", "run_count"],
@@ -26211,14 +19211,8 @@
       },
       "UserExecutionCostSummary": {
         "properties": {
-          "total_cents": {
-            "type": "integer",
-            "title": "Total Cents"
-          },
-          "run_count": {
-            "type": "integer",
-            "title": "Run Count"
-          },
+          "total_cents": { "type": "integer", "title": "Total Cents" },
+          "run_count": { "type": "integer", "title": "Run Count" },
           "billable_run_count": {
             "type": "integer",
             "title": "Billable Run Count"
@@ -26228,23 +19222,17 @@
             "title": "Failed Cost Cents"
           },
           "by_agent": {
-            "items": {
-              "$ref": "#/components/schemas/UserAgentCostRollup"
-            },
+            "items": { "$ref": "#/components/schemas/UserAgentCostRollup" },
             "type": "array",
             "title": "By Agent"
           },
           "top_runs": {
-            "items": {
-              "$ref": "#/components/schemas/UserTopRun"
-            },
+            "items": { "$ref": "#/components/schemas/UserTopRun" },
             "type": "array",
             "title": "Top Runs"
           },
           "daily": {
-            "items": {
-              "$ref": "#/components/schemas/UserDailyCost"
-            },
+            "items": { "$ref": "#/components/schemas/UserDailyCost" },
             "type": "array",
             "title": "Daily"
           }
@@ -26264,15 +19252,11 @@
       "UserHistoryResponse": {
         "properties": {
           "history": {
-            "items": {
-              "$ref": "#/components/schemas/UserTransaction"
-            },
+            "items": { "$ref": "#/components/schemas/UserTransaction" },
             "type": "array",
             "title": "History"
           },
-          "pagination": {
-            "$ref": "#/components/schemas/Pagination"
-          }
+          "pagination": { "$ref": "#/components/schemas/Pagination" }
         },
         "type": "object",
         "required": ["history", "pagination"],
@@ -26281,111 +19265,56 @@
       },
       "UserOnboarding": {
         "properties": {
-          "userId": {
-            "type": "string",
-            "title": "Userid"
-          },
+          "userId": { "type": "string", "title": "Userid" },
           "completedSteps": {
-            "items": {
-              "$ref": "#/components/schemas/OnboardingStep"
-            },
+            "items": { "$ref": "#/components/schemas/OnboardingStep" },
             "type": "array",
             "title": "Completedsteps"
           },
-          "walletShown": {
-            "type": "boolean",
-            "title": "Walletshown"
-          },
+          "walletShown": { "type": "boolean", "title": "Walletshown" },
           "notified": {
-            "items": {
-              "$ref": "#/components/schemas/OnboardingStep"
-            },
+            "items": { "$ref": "#/components/schemas/OnboardingStep" },
             "type": "array",
             "title": "Notified"
           },
           "rewardedFor": {
-            "items": {
-              "$ref": "#/components/schemas/OnboardingStep"
-            },
+            "items": { "$ref": "#/components/schemas/OnboardingStep" },
             "type": "array",
             "title": "Rewardedfor"
           },
           "usageReason": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Usagereason"
           },
           "integrations": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Integrations"
           },
           "otherIntegrations": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Otherintegrations"
           },
           "selectedStoreListingVersionId": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Selectedstorelistingversionid"
           },
           "agentInput": {
             "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
+              { "additionalProperties": true, "type": "object" },
+              { "type": "null" }
             ],
             "title": "Agentinput"
           },
           "onboardingAgentExecutionId": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Onboardingagentexecutionid"
           },
-          "agentRuns": {
-            "type": "integer",
-            "title": "Agentruns"
-          },
+          "agentRuns": { "type": "integer", "title": "Agentruns" },
           "lastRunAt": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
             ],
             "title": "Lastrunat"
           },
@@ -26416,98 +19345,47 @@
       "UserOnboardingUpdate": {
         "properties": {
           "walletShown": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "boolean" }, { "type": "null" }],
             "title": "Walletshown"
           },
           "notified": {
             "anyOf": [
               {
-                "items": {
-                  "$ref": "#/components/schemas/OnboardingStep"
-                },
+                "items": { "$ref": "#/components/schemas/OnboardingStep" },
                 "type": "array"
               },
-              {
-                "type": "null"
-              }
+              { "type": "null" }
             ],
             "title": "Notified"
           },
           "usageReason": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Usagereason"
           },
           "integrations": {
             "anyOf": [
-              {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
+              { "items": { "type": "string" }, "type": "array" },
+              { "type": "null" }
             ],
             "title": "Integrations"
           },
           "otherIntegrations": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Otherintegrations"
           },
           "selectedStoreListingVersionId": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Selectedstorelistingversionid"
           },
           "agentInput": {
             "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
+              { "additionalProperties": true, "type": "object" },
+              { "type": "null" }
             ],
             "title": "Agentinput"
           },
           "onboardingAgentExecutionId": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Onboardingagentexecutionid"
           }
         },
@@ -26516,23 +19394,10 @@
       },
       "UserPasswordCredentials": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "provider": {
-            "type": "string",
-            "title": "Provider"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "provider": { "type": "string", "title": "Provider" },
           "title": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Title"
           },
           "is_managed": {
@@ -26570,19 +19435,9 @@
       },
       "UserRateLimitResponse": {
         "properties": {
-          "user_id": {
-            "type": "string",
-            "title": "User Id"
-          },
+          "user_id": { "type": "string", "title": "User Id" },
           "user_email": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "User Email"
           },
           "daily_cost_limit_microdollars": {
@@ -26601,9 +19456,7 @@
             "type": "integer",
             "title": "Weekly Cost Used Microdollars"
           },
-          "tier": {
-            "$ref": "#/components/schemas/SubscriptionTier"
-          }
+          "tier": { "$ref": "#/components/schemas/SubscriptionTier" }
         },
         "type": "object",
         "required": [
@@ -26641,19 +19494,9 @@
       },
       "UserSearchResult": {
         "properties": {
-          "user_id": {
-            "type": "string",
-            "title": "User Id"
-          },
+          "user_id": { "type": "string", "title": "User Id" },
           "user_email": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "User Email"
           }
         },
@@ -26663,13 +19506,8 @@
       },
       "UserTierResponse": {
         "properties": {
-          "user_id": {
-            "type": "string",
-            "title": "User Id"
-          },
-          "tier": {
-            "$ref": "#/components/schemas/SubscriptionTier"
-          }
+          "user_id": { "type": "string", "title": "User Id" },
+          "tier": { "$ref": "#/components/schemas/SubscriptionTier" }
         },
         "type": "object",
         "required": ["user_id", "tier"],
@@ -26677,34 +19515,17 @@
       },
       "UserTopRun": {
         "properties": {
-          "execution_id": {
-            "type": "string",
-            "title": "Execution Id"
-          },
-          "graph_id": {
-            "type": "string",
-            "title": "Graph Id"
-          },
-          "cost_cents": {
-            "type": "integer",
-            "title": "Cost Cents"
-          },
+          "execution_id": { "type": "string", "title": "Execution Id" },
+          "graph_id": { "type": "string", "title": "Graph Id" },
+          "cost_cents": { "type": "integer", "title": "Cost Cents" },
           "started_at": {
             "type": "string",
             "format": "date-time",
             "title": "Started At"
           },
-          "status": {
-            "$ref": "#/components/schemas/AgentExecutionStatus"
-          },
-          "duration_seconds": {
-            "type": "number",
-            "title": "Duration Seconds"
-          },
-          "node_error_count": {
-            "type": "integer",
-            "title": "Node Error Count"
-          }
+          "status": { "$ref": "#/components/schemas/AgentExecutionStatus" },
+          "duration_seconds": { "type": "number", "title": "Duration Seconds" },
+          "node_error_count": { "type": "integer", "title": "Node Error Count" }
         },
         "type": "object",
         "required": [
@@ -26735,11 +19556,7 @@
             "$ref": "#/components/schemas/CreditTransactionType",
             "default": "USAGE"
           },
-          "amount": {
-            "type": "integer",
-            "title": "Amount",
-            "default": 0
-          },
+          "amount": { "type": "integer", "title": "Amount", "default": 0 },
           "running_balance": {
             "type": "integer",
             "title": "Running Balance",
@@ -26751,36 +19568,15 @@
             "default": 0
           },
           "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Description"
           },
           "usage_graph_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Usage Graph Id"
           },
           "usage_execution_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Usage Execution Id"
           },
           "usage_node_count": {
@@ -26794,52 +19590,21 @@
             "title": "Usage Start Time",
             "default": "9999-12-31T23:59:59.999999Z"
           },
-          "user_id": {
-            "type": "string",
-            "title": "User Id"
-          },
+          "user_id": { "type": "string", "title": "User Id" },
           "user_email": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "User Email"
           },
           "reason": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Reason"
           },
           "admin_email": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Admin Email"
           },
           "extra_data": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Extra Data"
           }
         },
@@ -26850,34 +19615,14 @@
       "ValidationError": {
         "properties": {
           "loc": {
-            "items": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "integer"
-                }
-              ]
-            },
+            "items": { "anyOf": [{ "type": "string" }, { "type": "integer" }] },
             "type": "array",
             "title": "Location"
           },
-          "msg": {
-            "type": "string",
-            "title": "Message"
-          },
-          "type": {
-            "type": "string",
-            "title": "Error Type"
-          },
-          "input": {
-            "title": "Input"
-          },
-          "ctx": {
-            "type": "object",
-            "title": "Context"
-          }
+          "msg": { "type": "string", "title": "Message" },
+          "type": { "type": "string", "title": "Error Type" },
+          "input": { "title": "Input" },
+          "ctx": { "type": "object", "title": "Context" }
         },
         "type": "object",
         "required": ["loc", "msg", "type"],
@@ -26885,10 +19630,7 @@
       },
       "VapidPublicKeyResponse": {
         "properties": {
-          "public_key": {
-            "type": "string",
-            "title": "Public Key"
-          }
+          "public_key": { "type": "string", "title": "Public Key" }
         },
         "type": "object",
         "required": ["public_key"],
@@ -26896,35 +19638,18 @@
       },
       "Webhook": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "user_id": {
-            "type": "string",
-            "title": "User Id"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "user_id": { "type": "string", "title": "User Id" },
           "provider": {
             "type": "string",
             "title": "Provider",
             "description": "Provider name for integrations. Can be any string value, including custom provider names."
           },
-          "credentials_id": {
-            "type": "string",
-            "title": "Credentials Id"
-          },
-          "webhook_type": {
-            "type": "string",
-            "title": "Webhook Type"
-          },
-          "resource": {
-            "type": "string",
-            "title": "Resource"
-          },
+          "credentials_id": { "type": "string", "title": "Credentials Id" },
+          "webhook_type": { "type": "string", "title": "Webhook Type" },
+          "resource": { "type": "string", "title": "Resource" },
           "events": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Events"
           },
@@ -26933,19 +19658,12 @@
             "type": "object",
             "title": "Config"
           },
-          "secret": {
-            "type": "string",
-            "title": "Secret"
-          },
+          "secret": { "type": "string", "title": "Secret" },
           "provider_webhook_id": {
             "type": "string",
             "title": "Provider Webhook Id"
           },
-          "url": {
-            "type": "string",
-            "title": "Url",
-            "readOnly": true
-          }
+          "url": { "type": "string", "title": "Url", "readOnly": true }
         },
         "type": "object",
         "required": [
@@ -26963,35 +19681,17 @@
       },
       "WorkspaceFileItem": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "path": {
-            "type": "string",
-            "title": "Path"
-          },
-          "mime_type": {
-            "type": "string",
-            "title": "Mime Type"
-          },
-          "size_bytes": {
-            "type": "integer",
-            "title": "Size Bytes"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "name": { "type": "string", "title": "Name" },
+          "path": { "type": "string", "title": "Path" },
+          "mime_type": { "type": "string", "title": "Mime Type" },
+          "size_bytes": { "type": "integer", "title": "Size Bytes" },
           "metadata": {
             "additionalProperties": true,
             "type": "object",
             "title": "Metadata"
           },
-          "created_at": {
-            "type": "string",
-            "title": "Created At"
-          }
+          "created_at": { "type": "string", "title": "Created At" }
         },
         "type": "object",
         "required": [
@@ -27006,26 +19706,11 @@
       },
       "backend__api__features__workspace__routes__UploadFileResponse": {
         "properties": {
-          "file_id": {
-            "type": "string",
-            "title": "File Id"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "path": {
-            "type": "string",
-            "title": "Path"
-          },
-          "mime_type": {
-            "type": "string",
-            "title": "Mime Type"
-          },
-          "size_bytes": {
-            "type": "integer",
-            "title": "Size Bytes"
-          }
+          "file_id": { "type": "string", "title": "File Id" },
+          "name": { "type": "string", "title": "Name" },
+          "path": { "type": "string", "title": "Path" },
+          "mime_type": { "type": "string", "title": "Mime Type" },
+          "size_bytes": { "type": "integer", "title": "Size Bytes" }
         },
         "type": "object",
         "required": ["file_id", "name", "path", "mime_type", "size_bytes"],
@@ -27033,26 +19718,11 @@
       },
       "backend__api__model__UploadFileResponse": {
         "properties": {
-          "file_uri": {
-            "type": "string",
-            "title": "File Uri"
-          },
-          "file_name": {
-            "type": "string",
-            "title": "File Name"
-          },
-          "size": {
-            "type": "integer",
-            "title": "Size"
-          },
-          "content_type": {
-            "type": "string",
-            "title": "Content Type"
-          },
-          "expires_in_hours": {
-            "type": "integer",
-            "title": "Expires In Hours"
-          }
+          "file_uri": { "type": "string", "title": "File Uri" },
+          "file_name": { "type": "string", "title": "File Name" },
+          "size": { "type": "integer", "title": "Size" },
+          "content_type": { "type": "string", "title": "Content Type" },
+          "expires_in_hours": { "type": "integer", "title": "Expires In Hours" }
         },
         "type": "object",
         "required": [
@@ -27071,10 +19741,7 @@
         "in": "header",
         "name": "X-Postmark-Webhook-Token"
       },
-      "HTTPBearer": {
-        "type": "http",
-        "scheme": "bearer"
-      },
+      "HTTPBearer": { "type": "http", "scheme": "bearer" },
       "HTTPBearerJWT": {
         "type": "http",
         "scheme": "bearer",
@@ -27088,11 +19755,7 @@
           "application/json": {
             "schema": {
               "type": "object",
-              "properties": {
-                "detail": {
-                  "type": "string"
-                }
-              }
+              "properties": { "detail": { "type": "string" } }
             }
           }
         }


### PR DESCRIPTION
## Why

Users had no way to see which chat-bot platforms they'd connected AutoGPT to, what their DM link looked like, or which servers their bots were linked to. The existing `/settings/integrations` covers third-party API integrations (Gmail, GitHub, etc.) but doesn't surface chat-bot connections, which behave differently — they're per-deployment, can be unlinked, and have an "add bot to server" entry point.

## What

A new **Bots** tab under Settings that dynamically lists every bot platform enabled on this deployment (Discord today, more later as their adapters land). For each platform: an "Add bot to X" button, a DM tile showing your linked DM channel, and a list of linked servers each with its own Unlink action.

## How

- `GET /api/platform-linking/platforms` returns one `BotPlatformInfo` per enabled platform + caller's DM/server links. Platforms whose adapter isn't configured are omitted, so future platforms stay hidden until they're wired up.
- A small `registry.py` is the source of truth for which platforms exist. Adding a new platform = adding one `PlatformMeta` row.
- Discord invite URL is built from a new `AUTOPILOT_BOT_DISCORD_CLIENT_ID` secret + a hardcoded sensible permissions default (`377957124928`) that can be overridden via `AUTOPILOT_BOT_DISCORD_PERMISSIONS`.
- Frontend: standard `src/app/(platform)/settings/bots/` layout (page + hooks + sub-components, render functions under 50 lines). Orval generates the React Query hook.
- The server list distinguishes "server name unknown" (bot can't see the server) with an amber indicator + tooltip, rather than rendering a raw ID as if it were the name. Relies on the bot's name-refresh events from the stacked PR underneath.

> ⚠️ **Stacked on #13221** (the bot-side name-refresh path). Merge that first or servers the bot can see will appear as IDs until the bot reconnects.

## Test plan

- [x] Backend: `poetry run pytest backend/api/features/platform_linking/ backend/platform_linking/ backend/copilot/bot/` — 217 pass
- [x] Frontend: `pnpm exec vitest run src/app/\(platform\)/settings/bots` — 8 pass
- [x] Frontend: `pnpm format && pnpm exec next lint && pnpm exec prettier --check src/app/api/openapi.json`
- [x] Manual: visited `/settings/bots`, confirmed Add bot button, DM tile, server list with both happy-path and "Bot not in server" indicator


<img width="1142" height="556" alt="image" src="https://github.com/user-attachments/assets/e30c5045-c7e2-45cd-b470-90458eb46344" />
<img width="377" height="104" alt="image" src="https://github.com/user-attachments/assets/fdb8ba1e-c21e-48b7-86f1-8c951361c3a1" />
