### PR TITLE
fix(backend/copilot): plumb user_timezone in run_block ExecutionContext

### DIFF
--- a/autogpt_platform/backend/backend/copilot/tools/conftest.py
+++ b/autogpt_platform/backend/backend/copilot/tools/conftest.py
@@ -5,6 +5,9 @@ backend/conftest.py so that integration tests in this directory do not trigger
 the full SpinTestServer startup (which requires Postgres + RabbitMQ).
 """
 
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
 import pytest_asyncio
 
 
@@ -18,3 +21,20 @@ async def server():  # type: ignore[override]
 async def graph_cleanup():  # type: ignore[override]
     """No-op graph cleanup stub."""
     yield
+
+
+@pytest.fixture(autouse=True)
+def stub_user_lookup(monkeypatch):
+    """Stub ``user_db.get_user_by_id`` for every test in this dir.
+
+    ``prepare_block_for_execution`` reads the user record to plumb
+    ``user_timezone`` into ``ExecutionContext``. The existing tests don't
+    need a real DB — return a minimal user with ``timezone='UTC'`` so the
+    timezone resolves to UTC (matches `ExecutionContext`'s default).
+    """
+    user = MagicMock()
+    user.timezone = "UTC"
+    monkeypatch.setattr(
+        "backend.copilot.tools.helpers.user_db.get_user_by_id",
+        AsyncMock(return_value=user),
+    )

--- a/autogpt_platform/backend/backend/copilot/tools/conftest.py
+++ b/autogpt_platform/backend/backend/copilot/tools/conftest.py
@@ -24,17 +24,22 @@ async def graph_cleanup():  # type: ignore[override]
 
 
 @pytest.fixture(autouse=True)
-def stub_user_lookup(monkeypatch):
-    """Stub ``user_db.get_user_by_id`` for every test in this dir.
+def stub_user_lookup_in_helpers(monkeypatch):
+    """Stub ``user_db.get_user_by_id`` ONLY for the helpers.py-local binding.
 
     ``prepare_block_for_execution`` reads the user record to plumb
     ``user_timezone`` into ``ExecutionContext``. The existing tests don't
-    need a real DB — return a minimal user with ``timezone='UTC'`` so the
-    timezone resolves to UTC (matches `ExecutionContext`'s default).
+    need a real DB for that.
+
+    ⚠️ We must patch the ``user_db`` name on the helpers module itself,
+    NOT ``helpers.user_db.get_user_by_id`` — the latter resolves through
+    the module reference and mutates ``backend.data.user.get_user_by_id``
+    globally, which leaks into unrelated callers (e.g. ``rate_limit``'s
+    ``user_db().get_user_by_id`` in ``run_agent_test``) and clobbers
+    their real-DB test users with our MagicMock.
     """
     user = MagicMock()
     user.timezone = "UTC"
-    monkeypatch.setattr(
-        "backend.copilot.tools.helpers.user_db.get_user_by_id",
-        AsyncMock(return_value=user),
-    )
+    stub = MagicMock()
+    stub.get_user_by_id = AsyncMock(return_value=user)
+    monkeypatch.setattr("backend.copilot.tools.helpers.user_db", stub)

--- a/autogpt_platform/backend/backend/copilot/tools/helpers.py
+++ b/autogpt_platform/backend/backend/copilot/tools/helpers.py
@@ -20,6 +20,7 @@ from backend.copilot.constants import (
 )
 from backend.copilot.model import ChatSession
 from backend.copilot.sdk.file_ref import FileRefExpansionError, expand_file_refs_in_args
+from backend.data import user as user_db
 from backend.data.credit import UsageTransactionMetadata
 from backend.data.db_accessors import credit_db, review_db, workspace_db
 from backend.data.execution import ExecutionContext
@@ -32,6 +33,7 @@ from backend.executor.simulator import simulate_block
 from backend.executor.utils import block_usage_cost
 from backend.integrations.creds_manager import IntegrationCredentialsManager
 from backend.util.exceptions import BlockError, InsufficientBalanceError
+from backend.util.timezone_utils import get_user_timezone_or_utc
 from backend.util.type import coerce_inputs_to_schema
 
 from .models import (
@@ -227,6 +229,7 @@ async def execute_block(
 
     try:
         workspace = await workspace_db().get_or_create_workspace(user_id)
+        user = await user_db.get_user_by_id(user_id)
 
         synthetic_graph_id = f"{COPILOT_SESSION_PREFIX}{session_id}"
         synthetic_node_id = f"{COPILOT_NODE_PREFIX}{block_id}"
@@ -241,6 +244,7 @@ async def execute_block(
             workspace_id=workspace.id,
             session_id=session_id,
             sensitive_action_safe_mode=sensitive_action_safe_mode,
+            user_timezone=get_user_timezone_or_utc(user.timezone if user else None),
         )
 
         exec_kwargs: dict[str, Any] = {

--- a/autogpt_platform/backend/backend/copilot/tools/helpers.py
+++ b/autogpt_platform/backend/backend/copilot/tools/helpers.py
@@ -229,7 +229,14 @@ async def execute_block(
 
     try:
         workspace = await workspace_db().get_or_create_workspace(user_id)
-        user = await user_db.get_user_by_id(user_id)
+        # get_user_by_id raises ValueError on missing user; fall back to UTC
+        # so an orphaned-session block call still runs instead of crashing.
+        try:
+            user_timezone = get_user_timezone_or_utc(
+                (await user_db.get_user_by_id(user_id)).timezone
+            )
+        except ValueError:
+            user_timezone = "UTC"
 
         synthetic_graph_id = f"{COPILOT_SESSION_PREFIX}{session_id}"
         synthetic_node_id = f"{COPILOT_NODE_PREFIX}{block_id}"
@@ -244,7 +251,7 @@ async def execute_block(
             workspace_id=workspace.id,
             session_id=session_id,
             sensitive_action_safe_mode=sensitive_action_safe_mode,
-            user_timezone=get_user_timezone_or_utc(user.timezone if user else None),
+            user_timezone=user_timezone,
         )
 
         exec_kwargs: dict[str, Any] = {


### PR DESCRIPTION
### Why / What / How

**Why**: Follow-up to #13236. That PR plumbed `ExecutionContext` (with `user_id` + `user_timezone`) at the direct-block-execute REST boundary so time blocks invoked via `POST /api/blocks/{id}/execute` use the user's profile timezone. The same logical bug existed — and still exists post-#13236 — at the copilot/autopilot `run_block` tool boundary: `backend/copilot/tools/helpers.py::prepare_block_for_execution` constructs an `ExecutionContext` for every block invoked by autopilot, but never set `user_timezone`. Time blocks called from autopilot with `use_user_timezone=true` therefore returned UTC time regardless of the user's profile.

**What**: Set `user_timezone` on the `ExecutionContext` built for copilot block execution, sourced from the live user record (same helper as the REST routes use).

**How**:

- Add `user_db.get_user_by_id(user_id)` next to the existing `workspace_db().get_or_create_workspace(user_id)` call.
- Pass `user_timezone=get_user_timezone_or_utc(user.timezone if user else None)` into the `ExecutionContext(...)` construction.
- The unrelated `review_context` further down only flows into `is_block_exec_need_review` (which reads `sensitive_action_safe_mode`, not timezone) and doesn't need the same change.

### Changes 🏗️

- `backend/copilot/tools/helpers.py::prepare_block_for_execution`: add user lookup + `user_timezone` to the `ExecutionContext`.
- No schema, migration, or env changes.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `poetry run format && poetry run lint --skip-pyright`
  - [x] Manual E2E via `/pr-test --fix` (queued)
