### PR TITLE
feat(frontend): capture marketing-site triggerprompt into sessionStorage

### DIFF
--- a/autogpt_platform/frontend/src/app/(no-navbar)/login/useLoginPage.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/login/useLoginPage.ts
@@ -1,4 +1,5 @@
 import { useToast } from "@/components/molecules/Toast/use-toast";
+import { useCaptureMarketingPrompt } from "@/hooks/useCaptureMarketingPrompt";
 import { sanitizeAuthNext } from "@/lib/auth-redirect";
 import { useSupabase } from "@/lib/supabase/hooks/useSupabase";
 import { environment } from "@/services/environment";
@@ -11,6 +12,8 @@ import z from "zod";
 import { login as loginAction } from "./actions";
 
 export function useLoginPage() {
+  useCaptureMarketingPrompt();
+
   const { supabase, user, isUserLoading, isLoggedIn } = useSupabase();
   const [feedback, setFeedback] = useState<string | null>(null);
   const router = useRouter();

--- a/autogpt_platform/frontend/src/app/(no-navbar)/signup/useSignupPage.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/signup/useSignupPage.ts
@@ -1,4 +1,5 @@
 import { useToast } from "@/components/molecules/Toast/use-toast";
+import { useCaptureMarketingPrompt } from "@/hooks/useCaptureMarketingPrompt";
 import { sanitizeAuthNext } from "@/lib/auth-redirect";
 import { useSupabase } from "@/lib/supabase/hooks/useSupabase";
 import { environment } from "@/services/environment";
@@ -11,6 +12,8 @@ import z from "zod";
 import { signup as signupAction } from "./actions";
 
 export function useSignupPage() {
+  useCaptureMarketingPrompt();
+
   const { supabase, user, isUserLoading, isLoggedIn } = useSupabase();
   const [feedback, setFeedback] = useState<string | null>(null);
   const { toast } = useToast();

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/useWorkflowImportAutoSubmit.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/useWorkflowImportAutoSubmit.ts
@@ -16,12 +16,20 @@ function extractPromptFromUrl(): {
   if (typeof window === "undefined") return null;
 
   const searchParams = new URLSearchParams(window.location.search);
-  const autosubmit = searchParams.get("autosubmit") === "true";
+  const autosubmitFromUrl = searchParams.get("autosubmit") === "true";
 
-  // Check sessionStorage first (used by workflow import for large prompts)
+  // Check sessionStorage first (used by workflow import for large prompts
+  // and by the marketing-site CTA handoff via useCaptureMarketingPrompt).
   const storedPrompt = sessionStorage.getItem("importWorkflowPrompt");
   if (storedPrompt) {
     sessionStorage.removeItem("importWorkflowPrompt");
+
+    // Onboarding wipes URL params before we reach /copilot, so the
+    // marketing handoff stashes its autosubmit intent alongside the prompt.
+    const autosubmitFromStorage =
+      sessionStorage.getItem("importWorkflowAutosubmit") === "true";
+    sessionStorage.removeItem("importWorkflowAutosubmit");
+    const autosubmit = autosubmitFromUrl || autosubmitFromStorage;
 
     // Check for a pre-uploaded workflow file attached to this import
     let filePart: FileUIPart | undefined;
@@ -77,7 +85,7 @@ function extractPromptFromUrl(): {
     `${cleanURL.pathname}${cleanURL.search}`,
   );
 
-  return { prompt: prompt.trim(), autosubmit };
+  return { prompt: prompt.trim(), autosubmit: autosubmitFromUrl };
 }
 
 /**

--- a/autogpt_platform/frontend/src/hooks/useCaptureMarketingPrompt.ts
+++ b/autogpt_platform/frontend/src/hooks/useCaptureMarketingPrompt.ts
@@ -1,0 +1,31 @@
+import { useMountEffect } from "./useMountEffect";
+
+const PROMPT_KEY = "importWorkflowPrompt";
+const AUTOSUBMIT_KEY = "importWorkflowAutosubmit";
+const PARAM = "triggerprompt";
+
+/**
+ * Capture a `?triggerprompt=` value handed off from the marketing site and
+ * stash it into sessionStorage so it survives the signup → onboarding →
+ * /copilot redirect chain (which would otherwise strip the URL). The /copilot
+ * page picks it up via `useWorkflowImportAutoSubmit` and auto-submits.
+ */
+export function useCaptureMarketingPrompt() {
+  useMountEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const url = new URL(window.location.href);
+    const prompt = url.searchParams.get(PARAM);
+    if (!prompt || !prompt.trim()) return;
+
+    sessionStorage.setItem(PROMPT_KEY, prompt.trim());
+    sessionStorage.setItem(AUTOSUBMIT_KEY, "true");
+
+    url.searchParams.delete(PARAM);
+    window.history.replaceState(
+      null,
+      "",
+      `${url.pathname}${url.search}${url.hash}`,
+    );
+  });
+}


### PR DESCRIPTION
### Why / What / How

**Why.** The marketing site hero CTA hands a user-entered prompt to the platform so the chat starts with it pre-submitted. The previous handoff used `https://platform.agpt.co/copilot?autosubmit=true#prompt=...`. URL hashes are never sent to the server, so when the Supabase middleware redirects an unauthenticated visitor from `/copilot` to `/login?next=/copilot?autosubmit=true`, the `#prompt=` fragment is dropped. New users always lost their prompt before reaching the chat.

**What.** Switch the handoff to a `?triggerprompt=` query param read on `/signup` and `/login` mount. A small `useCaptureMarketingPrompt` hook stashes the value into sessionStorage and strips it from the URL. The existing `useWorkflowImportAutoSubmit` on `/copilot` already consumes that sessionStorage key, so the prompt survives the auth → onboarding → `/copilot` redirect chain and auto-submits once the user lands in the chat.

**How.**
- `useCaptureMarketingPrompt` (new): mount-once effect that reads `?triggerprompt=` from the URL, writes `importWorkflowPrompt` + `importWorkflowAutosubmit` to sessionStorage, and uses `history.replaceState` to remove the param so subsequent navigations are clean.
- Wired into `useSignupPage` and `useLoginPage` as the first hook call, so capture happens before any logged-in short-circuit, password-form submit, or OAuth redirect (sessionStorage survives the OAuth round-trip since the user returns to the same origin).
- `useWorkflowImportAutoSubmit` now also reads the autosubmit flag from sessionStorage. URL `?autosubmit=true` continues to win when explicitly set (workflow import path), but the marketing handoff needs the storage-side flag because onboarding wipes URL params before we reach `/copilot`.

Marketing-site change (`/signup?triggerprompt=...` instead of `/copilot?autosubmit=true#prompt=...`) shipped separately in the marketing repo.

### Changes 🏗️

- New `src/hooks/useCaptureMarketingPrompt.ts`
- `useSignupPage` and `useLoginPage` call the new hook on mount
- `useWorkflowImportAutoSubmit` consumes the `importWorkflowAutosubmit` sessionStorage flag in addition to the URL param

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [ ] New unauthenticated user: open `https://platform.agpt.co/signup?triggerprompt=Hello%20world`, complete email + password signup, finish onboarding, confirm `/copilot` auto-submits "Hello world" as the first message.
  - [ ] Same flow via Google OAuth.
  - [ ] Existing logged-in user: open `https://platform.agpt.co/signup?triggerprompt=Hello`, confirm OnboardingProvider routes through to `/copilot` and the prompt auto-submits.
  - [ ] Existing logged-in user with onboarding incomplete: same URL, confirm onboarding completes then `/copilot` auto-submits.
  - [ ] Refreshing `/signup?triggerprompt=...` after the URL is stripped does not lose the prompt (sessionStorage persists until consumed on `/copilot`).
  - [ ] Existing workflow-import flow (`/copilot?source=import&autosubmit=true` + sessionStorage) still auto-submits the imported workflow prompt.
  - [ ] Existing `/copilot#prompt=...&autosubmit=true` deep link (e.g. SitrepItem, LibraryAgentCard) still works.

#### For configuration changes:

- [x] `.env.default` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes
- [x] I have included a list of my configuration changes in the PR description (under **Changes**)

_No configuration changes._
