### PR TITLE
fix(infra): add libatomic1 to backend image so Prisma migrate boots

### DIFF
--- a/autogpt_platform/backend/Dockerfile
+++ b/autogpt_platform/backend/Dockerfile
@@ -63,10 +63,14 @@ WORKDIR /app/autogpt_platform/backend
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install only what's needed for prisma migrate: Node.js and minimal Python for prisma-python
+# libatomic1: debian:13-slim no longer ships it, but the Prisma CLI's bundled
+# Node (copied from the builder, which had it via build-essential) dynamically
+# links libatomic.so.1 — without it `node` exits 127 and migrate crash-loops.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     python3.13 \
     python3-pip \
     ca-certificates \
+    libatomic1 \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy Node.js from builder (needed for Prisma CLI)
@@ -106,6 +110,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ripgrep \
     tree \
     bubblewrap \
+    libatomic1 \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy poetry (build-time only, for `poetry install --only-root` to create entry points)


### PR DESCRIPTION
## Why

A fresh `docker compose build` of the backend currently produces a stack that **never starts**: the `migrate` container crash-loops with

```
/root/.cache/prisma-python/nodeenv/bin/node: error while loading shared libraries:
libatomic.so.1: cannot open shared object file: No such file or directory
```

so migrations never run and every app service stays in `created`/restarting. This reproduces on a clean build on any host (found while testing on Windows 11 + Docker Desktop).

## Root cause

The base image is `debian:13-slim` (trixie), which **no longer ships `libatomic1`** in its default package set. The `builder` stage happens to have it transitively (via `build-essential`), so `prisma generate` works there. But the **`migrate`** and **`server`** stages copy the Prisma CLI's bundled Node from the builder onto a fresh `debian:13-slim` that lacks `libatomic1` — and that Node binary dynamically links `libatomic.so.1`, so it exits 127 the moment `prisma migrate` / `prisma generate` invokes it.

## What

Add `libatomic1` explicitly to the `apt-get install` in both stages that run Node without `build-essential`:
- the `migrate` stage (runs `prisma migrate deploy`)
- the `server` stage (runs `prisma` at build, plus `agent-browser`/Node at runtime)

## Validation

On a clean Windows 11 + Docker Desktop build: before the change the `migrate` container crash-loops (exit 127); after it, **`migrate` exits 0**, migrations apply, and the backend comes up (verified the full stack + AutoPilot booting).

## Notes

Found while E2E-testing #12993, but this is independent of that PR (base-image regression affecting `dev`) — splitting it out per review feedback.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small Dockerfile dependency addition for missing runtime libs; no application logic or security surface changes.
> 
> **Overview**
> Fixes backend Docker images that **fail to start on a clean build** because copied Prisma/Node binaries need **`libatomic.so.1`**, which **`debian:13-slim` no longer provides** by default (the builder stage still had it via `build-essential`).
> 
> The change **adds `libatomic1` to `apt-get install`** in the **`migrate`** and **`server`** stages of `autogpt_platform/backend/Dockerfile`, with a short comment on **`migrate`** explaining the exit-127 / crash-loop behavior when Node is invoked without that library.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cea5b0bcf8e75e81b282a474b59bbf385bc4734b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->