### PR TITLE
Add CRE Deal Analyzer full-stack web application

### DIFF
--- a/cre-analyzer/.gitignore
+++ b/cre-analyzer/.gitignore
@@ -9,7 +9,12 @@ backend/.env
 frontend/node_modules/
 frontend/dist/
 frontend/.env.local
+frontend/.vite/
 
 # Build artifacts
 *.egg-info/
 .DS_Store
+
+# Test caches
+backend/.pytest_cache/
+frontend/coverage/

--- a/cre-analyzer/.gitignore
+++ b/cre-analyzer/.gitignore
@@ -1,0 +1,15 @@
+# Python
+backend/.venv/
+backend/__pycache__/
+backend/**/__pycache__/
+backend/*.pyc
+backend/.env
+
+# Node
+frontend/node_modules/
+frontend/dist/
+frontend/.env.local
+
+# Build artifacts
+*.egg-info/
+.DS_Store

--- a/cre-analyzer/backend/.env.example
+++ b/cre-analyzer/backend/.env.example
@@ -1,0 +1,1 @@
+ANTHROPIC_API_KEY=your_api_key_here

--- a/cre-analyzer/backend/main.py
+++ b/cre-analyzer/backend/main.py
@@ -1,0 +1,32 @@
+import os
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from dotenv import load_dotenv
+
+load_dotenv()
+
+app = FastAPI(title="CRE Deal Analyzer API", version="1.0.0")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:5173", "http://localhost:3000", "*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+from routers import documents, deals, analysis  # noqa: E402
+
+app.include_router(documents.router, prefix="/api/documents", tags=["documents"])
+app.include_router(deals.router, prefix="/api/deals", tags=["deals"])
+app.include_router(analysis.router, prefix="/api/analysis", tags=["analysis"])
+
+
+@app.get("/api/health")
+def health():
+    return {"status": "ok", "version": "1.0.0"}
+
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run("main:app", host="0.0.0.0", port=8000, reload=True)

--- a/cre-analyzer/backend/models/deal.py
+++ b/cre-analyzer/backend/models/deal.py
@@ -1,0 +1,175 @@
+from pydantic import BaseModel, Field
+from typing import List, Optional, Dict, Any
+import uuid
+
+
+class PropertyInfo(BaseModel):
+    name: str = "Sample Multifamily Asset"
+    address: str = "123 Main Street, Austin, TX 78701"
+    asset_type: str = "Multifamily"
+    units: int = 100
+    sqft: float = 85000
+    year_built: int = 1995
+    purchase_price: float = 15_000_000
+    asking_price: float = 15_500_000
+    market: str = "Austin, TX"
+    submarket: str = ""
+    sponsor_projected_noi: float = 0
+
+
+class T12LineItem(BaseModel):
+    label: str
+    t12_actual: float = 0
+    underwritten: float = 0
+    notes: str = ""
+
+
+class T12Data(BaseModel):
+    # Income
+    gross_potential_rent: float = 1_200_000
+    vacancy_loss: float = 60_000
+    concessions: float = 12_000
+    bad_debt: float = 6_000
+    other_income: float = 48_000
+    effective_gross_income: float = 0  # computed
+
+    # Expenses
+    property_taxes: float = 120_000
+    insurance: float = 36_000
+    management_fee: float = 48_000
+    maintenance_repairs: float = 60_000
+    utilities: float = 36_000
+    payroll: float = 72_000
+    general_admin: float = 24_000
+    marketing: float = 12_000
+    capex_reserves: float = 25_000
+    other_expenses: float = 0
+    total_expenses: float = 0  # computed
+    noi: float = 750_000
+
+    def compute(self) -> "T12Data":
+        self.effective_gross_income = (
+            self.gross_potential_rent
+            - self.vacancy_loss
+            - self.concessions
+            - self.bad_debt
+            + self.other_income
+        )
+        self.total_expenses = (
+            self.property_taxes
+            + self.insurance
+            + self.management_fee
+            + self.maintenance_repairs
+            + self.utilities
+            + self.payroll
+            + self.general_admin
+            + self.marketing
+            + self.capex_reserves
+            + self.other_expenses
+        )
+        self.noi = self.effective_gross_income - self.total_expenses
+        return self
+
+
+class RentRollUnit(BaseModel):
+    unit_number: str = ""
+    unit_type: str = "1BR/1BA"
+    sqft: float = 850
+    market_rent: float = 1200
+    current_rent: float = 1150
+    lease_start: Optional[str] = None
+    lease_end: Optional[str] = None
+    status: str = "Occupied"  # Occupied, Vacant, MTM
+
+
+class ValueAddAssumptions(BaseModel):
+    enabled: bool = False
+    units_to_renovate: int = 50
+    renovation_cost_per_unit: float = 15_000
+    rent_premium_per_unit: float = 150  # $/month
+    absorption_years: int = 2  # years to complete all renovations
+
+
+class Assumptions(BaseModel):
+    # Revenue
+    rent_growth_rate: float = 3.0  # %/yr
+    vacancy_rate: float = 5.0  # %
+    credit_loss_rate: float = 0.5  # %
+    other_income_growth: float = 3.0  # %/yr
+
+    # Expenses
+    expense_growth_rate: float = 3.0  # %/yr
+    management_fee_pct: float = 4.0  # % of EGI
+    capex_reserves_per_unit: float = 250  # $/unit/yr
+
+    # Value-add
+    value_add: ValueAddAssumptions = Field(default_factory=ValueAddAssumptions)
+
+
+class FinancingAssumptions(BaseModel):
+    ltv_pct: float = 65.0
+    interest_rate: float = 6.5  # %
+    io_period_years: int = 2
+    amortization_years: int = 30
+    loan_term_years: int = 5
+    loan_type: str = "Agency"  # Agency, Bridge
+
+    # Refi scenario
+    enable_refi: bool = False
+    refi_year: int = 3
+    refi_ltv_pct: float = 70.0
+    refi_rate: float = 6.0
+
+
+class ExitAssumptions(BaseModel):
+    hold_period_years: int = 5
+    exit_cap_rate: float = 5.25  # %
+    selling_costs_pct: float = 2.0  # %
+
+
+class WaterfallTier(BaseModel):
+    irr_min: float = 0.0   # % (LP IRR floor for this tier)
+    irr_max: float = 14.0  # % (LP IRR ceiling; 999 = unlimited)
+    lp_split: float = 80.0
+    gp_split: float = 20.0
+
+
+class WaterfallConfig(BaseModel):
+    lp_equity_pct: float = 90.0
+    gp_equity_pct: float = 10.0
+    preferred_return: float = 8.0  # % annual
+    pref_compounding: bool = False
+    gp_catchup: bool = True
+    gp_catchup_rate: float = 50.0  # % to GP during catch-up phase
+    gp_target_promote_pct: float = 20.0  # GP % of total profits in catch-up target
+    tiers: List[WaterfallTier] = Field(
+        default_factory=lambda: [
+            WaterfallTier(irr_min=0, irr_max=14, lp_split=80, gp_split=20),
+            WaterfallTier(irr_min=14, irr_max=18, lp_split=70, gp_split=30),
+            WaterfallTier(irr_min=18, irr_max=999, lp_split=60, gp_split=40),
+        ]
+    )
+
+
+class DealState(BaseModel):
+    deal_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    name: str = "New Deal"
+    property_info: PropertyInfo = Field(default_factory=PropertyInfo)
+    t12_data: T12Data = Field(default_factory=T12Data)
+    rent_roll: List[RentRollUnit] = Field(default_factory=list)
+    assumptions: Assumptions = Field(default_factory=Assumptions)
+    financing: FinancingAssumptions = Field(default_factory=FinancingAssumptions)
+    exit_assumptions: ExitAssumptions = Field(default_factory=ExitAssumptions)
+    waterfall_config: WaterfallConfig = Field(default_factory=WaterfallConfig)
+    results: Optional[Dict[str, Any]] = None
+    raw_extraction: Optional[Dict[str, Any]] = None
+
+
+class AnalysisRequest(BaseModel):
+    deal: DealState
+
+
+class SolveRequest(BaseModel):
+    deal: DealState
+    target_lp_irr: float = 14.0  # %
+    solve_for: str = "purchase_price"  # or "exit_cap_rate"

--- a/cre-analyzer/backend/requirements.txt
+++ b/cre-analyzer/backend/requirements.txt
@@ -1,0 +1,12 @@
+fastapi>=0.111.0
+uvicorn[standard]>=0.30.0
+anthropic>=0.28.0
+python-multipart>=0.0.9
+openpyxl>=3.1.0
+pandas>=2.2.0
+pydantic>=2.7.0
+numpy>=1.26.0
+python-dotenv>=1.0.0
+aiofiles>=23.2.0
+httpx>=0.27.0
+scipy>=1.13.0

--- a/cre-analyzer/backend/routers/analysis.py
+++ b/cre-analyzer/backend/routers/analysis.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, HTTPException
 from models.deal import DealState, AnalysisRequest, SolveRequest
 from services.underwriting_engine import build_proforma
-from services.waterfall_engine import run_waterfall, solve_for_price, solve_for_exit_cap
+from services.waterfall_engine import waterfall_from_proforma, solve_for_price, solve_for_exit_cap
 from services.sensitivity_engine import generate_all_sensitivities
 
 router = APIRouter()
@@ -10,22 +10,7 @@ router = APIRouter()
 def full_analysis(deal: DealState) -> dict:
     """Run proforma + waterfall and return combined results."""
     pf = build_proforma(deal)
-
-    # Operating levered CFs (years 1..N-1, excluding year 0 and exit)
-    lev_cfs = pf["cash_flows"]["levered"]
-    annual_ops = [float(c) for c in lev_cfs[1:-1]]  # years 1..N-1
-    # Final year operating CF (before exit)
-    if len(lev_cfs) > 1:
-        annual_ops.append(float(lev_cfs[-1]) - float(pf["exit"]["net_sale_proceeds"]))
-
-    exit_proceeds = float(pf["exit"]["net_sale_proceeds"])
-
-    wf = run_waterfall(
-        equity_required=float(pf["total_equity"]),
-        annual_levered_cfs=annual_ops,
-        exit_proceeds=exit_proceeds,
-        config=deal.waterfall_config,
-    )
+    wf = waterfall_from_proforma(pf, deal.waterfall_config)
 
     return {
         "proforma": pf,

--- a/cre-analyzer/backend/routers/analysis.py
+++ b/cre-analyzer/backend/routers/analysis.py
@@ -1,0 +1,71 @@
+from fastapi import APIRouter, HTTPException
+from models.deal import DealState, AnalysisRequest, SolveRequest
+from services.underwriting_engine import build_proforma
+from services.waterfall_engine import run_waterfall, solve_for_price, solve_for_exit_cap
+from services.sensitivity_engine import generate_all_sensitivities
+
+router = APIRouter()
+
+
+def full_analysis(deal: DealState) -> dict:
+    """Run proforma + waterfall and return combined results."""
+    pf = build_proforma(deal)
+
+    # Operating levered CFs (years 1..N-1, excluding year 0 and exit)
+    lev_cfs = pf["cash_flows"]["levered"]
+    annual_ops = [float(c) for c in lev_cfs[1:-1]]  # years 1..N-1
+    # Final year operating CF (before exit)
+    if len(lev_cfs) > 1:
+        annual_ops.append(float(lev_cfs[-1]) - float(pf["exit"]["net_sale_proceeds"]))
+
+    exit_proceeds = float(pf["exit"]["net_sale_proceeds"])
+
+    wf = run_waterfall(
+        equity_required=float(pf["total_equity"]),
+        annual_levered_cfs=annual_ops,
+        exit_proceeds=exit_proceeds,
+        config=deal.waterfall_config,
+    )
+
+    return {
+        "proforma": pf,
+        "waterfall": wf,
+        "metrics": pf["metrics"],
+        "lp_irr": wf["lp_irr"],
+        "levered_irr": pf["metrics"].get("levered_irr"),
+        "levered_em": pf["metrics"].get("levered_em"),
+        "levered_coc": pf["metrics"].get("levered_coc"),
+    }
+
+
+@router.post("/run")
+def run_analysis(req: AnalysisRequest):
+    try:
+        results = full_analysis(req.deal)
+        return results
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post("/sensitivity")
+def run_sensitivity(req: AnalysisRequest):
+    try:
+        tables = generate_all_sensitivities(req.deal, full_analysis)
+        return tables
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post("/solve")
+def run_solve(req: SolveRequest):
+    try:
+        if req.solve_for == "purchase_price":
+            result = solve_for_price(req.deal, req.target_lp_irr, build_proforma)
+            return {"solve_for": "purchase_price", "value": result, "target_lp_irr": req.target_lp_irr}
+        elif req.solve_for == "exit_cap_rate":
+            result = solve_for_exit_cap(req.deal, req.target_lp_irr, build_proforma)
+            return {"solve_for": "exit_cap_rate", "value": result, "target_lp_irr": req.target_lp_irr}
+        else:
+            raise HTTPException(status_code=400, detail=f"Unknown solve_for: {req.solve_for}")
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/cre-analyzer/backend/routers/deals.py
+++ b/cre-analyzer/backend/routers/deals.py
@@ -1,0 +1,39 @@
+from fastapi import APIRouter, HTTPException
+from models.deal import DealState
+import state as app_state
+
+router = APIRouter()
+
+
+@router.post("/")
+def create_deal(deal: DealState):
+    app_state.deals_store[deal.deal_id] = deal.model_dump()
+    return {"deal_id": deal.deal_id}
+
+
+@router.get("/{deal_id}")
+def get_deal(deal_id: str):
+    if deal_id not in app_state.deals_store:
+        raise HTTPException(status_code=404, detail="Deal not found")
+    return app_state.deals_store[deal_id]
+
+
+@router.put("/{deal_id}")
+def update_deal(deal_id: str, deal: DealState):
+    deal.deal_id = deal_id
+    app_state.deals_store[deal_id] = deal.model_dump()
+    return {"deal_id": deal_id}
+
+
+@router.delete("/{deal_id}")
+def delete_deal(deal_id: str):
+    app_state.deals_store.pop(deal_id, None)
+    return {"deleted": deal_id}
+
+
+@router.get("/")
+def list_deals():
+    return [
+        {"deal_id": k, "name": v.get("name", ""), "purchase_price": v.get("property_info", {}).get("purchase_price", 0)}
+        for k, v in app_state.deals_store.items()
+    ]

--- a/cre-analyzer/backend/routers/documents.py
+++ b/cre-analyzer/backend/routers/documents.py
@@ -1,0 +1,39 @@
+from fastapi import APIRouter, UploadFile, File, HTTPException, Form
+from typing import Optional
+from services.document_parser import (
+    parse_offering_memorandum,
+    parse_t12,
+    parse_rent_roll,
+    get_demo_data,
+)
+
+router = APIRouter()
+
+
+@router.post("/parse")
+async def parse_document(
+    file: UploadFile = File(...),
+    doc_type: str = Form(...),  # "om", "t12", "rent_roll"
+):
+    contents = await file.read()
+    filename = file.filename or "upload"
+
+    try:
+        if doc_type == "om":
+            result = parse_offering_memorandum(contents, filename)
+        elif doc_type == "t12":
+            result = parse_t12(contents, filename)
+        elif doc_type == "rent_roll":
+            result = parse_rent_roll(contents, filename)
+        else:
+            raise HTTPException(status_code=400, detail=f"Unknown doc_type: {doc_type}")
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Parsing failed: {str(e)}")
+
+    return {"doc_type": doc_type, "filename": filename, "data": result}
+
+
+@router.get("/demo")
+def get_demo():
+    """Return pre-populated demo data without requiring document upload."""
+    return get_demo_data()

--- a/cre-analyzer/backend/services/document_parser.py
+++ b/cre-analyzer/backend/services/document_parser.py
@@ -13,7 +13,7 @@ import openpyxl
 
 
 client = anthropic.Anthropic(api_key=os.getenv("ANTHROPIC_API_KEY"))
-MODEL = "claude-sonnet-4-20250514"
+MODEL = "claude-sonnet-4-6"
 
 
 OM_PROMPT = """You are a commercial real estate analyst extracting data from an Offering Memorandum (OM).

--- a/cre-analyzer/backend/services/document_parser.py
+++ b/cre-analyzer/backend/services/document_parser.py
@@ -1,0 +1,252 @@
+"""
+Document parsing service using Claude API.
+Supports PDF (Offering Memorandums, T12 financials) and Excel (T12, rent rolls).
+"""
+
+import base64
+import json
+import os
+import io
+from typing import Dict, Any, Optional
+import anthropic
+import openpyxl
+
+
+client = anthropic.Anthropic(api_key=os.getenv("ANTHROPIC_API_KEY"))
+MODEL = "claude-sonnet-4-20250514"
+
+
+OM_PROMPT = """You are a commercial real estate analyst extracting data from an Offering Memorandum (OM).
+
+Extract all available information and return a JSON object with this structure:
+{
+  "property_info": {
+    "name": "",
+    "address": "",
+    "asset_type": "",
+    "units": 0,
+    "sqft": 0,
+    "year_built": 0,
+    "purchase_price": 0,
+    "asking_price": 0,
+    "market": "",
+    "submarket": "",
+    "sponsor_projected_noi": 0
+  },
+  "unit_mix": [
+    {"type": "1BR/1BA", "count": 0, "sqft": 0, "market_rent": 0}
+  ],
+  "market_summary": "",
+  "sponsor_highlights": [],
+  "flags": []
+}
+
+For missing or ambiguous fields, include in "flags" array with a note. Return only valid JSON.
+"""
+
+T12_PROMPT = """You are a commercial real estate analyst extracting trailing 12-month (T12) financial data.
+
+Extract all income and expense line items and return a JSON object with this structure:
+{
+  "t12_data": {
+    "gross_potential_rent": 0,
+    "vacancy_loss": 0,
+    "concessions": 0,
+    "bad_debt": 0,
+    "other_income": 0,
+    "effective_gross_income": 0,
+    "property_taxes": 0,
+    "insurance": 0,
+    "management_fee": 0,
+    "maintenance_repairs": 0,
+    "utilities": 0,
+    "payroll": 0,
+    "general_admin": 0,
+    "marketing": 0,
+    "capex_reserves": 0,
+    "other_expenses": 0,
+    "total_expenses": 0,
+    "noi": 0
+  },
+  "period": "TTM ending MM/YYYY",
+  "notes": "",
+  "one_time_items": [],
+  "flags": []
+}
+
+Normalize management fee to a reasonable market rate if it appears abnormal. Flag one-time items.
+All values should be ANNUAL totals in dollars. Return only valid JSON.
+"""
+
+RENT_ROLL_PROMPT = """You are a commercial real estate analyst extracting rent roll data.
+
+Extract all unit information and return a JSON object with this structure:
+{
+  "rent_roll": [
+    {
+      "unit_number": "",
+      "unit_type": "1BR/1BA",
+      "sqft": 0,
+      "market_rent": 0,
+      "current_rent": 0,
+      "lease_start": "YYYY-MM-DD or null",
+      "lease_end": "YYYY-MM-DD or null",
+      "status": "Occupied"
+    }
+  ],
+  "summary": {
+    "total_units": 0,
+    "occupied_units": 0,
+    "vacant_units": 0,
+    "mtm_units": 0,
+    "occupancy_pct": 0,
+    "avg_market_rent": 0,
+    "avg_current_rent": 0,
+    "total_market_gpr": 0,
+    "total_current_gpr": 0
+  },
+  "flags": []
+}
+
+Status should be one of: Occupied, Vacant, MTM (month-to-month).
+All rents should be MONTHLY per unit. Return only valid JSON.
+"""
+
+
+def _excel_to_text(file_bytes: bytes) -> str:
+    """Convert Excel to structured text for Claude."""
+    wb = openpyxl.load_workbook(io.BytesIO(file_bytes), data_only=True)
+    lines = []
+    for sheet_name in wb.sheetnames:
+        ws = wb[sheet_name]
+        lines.append(f"\n=== Sheet: {sheet_name} ===")
+        for row in ws.iter_rows(values_only=True):
+            if any(cell is not None for cell in row):
+                row_text = "\t".join(str(c) if c is not None else "" for c in row)
+                lines.append(row_text)
+    return "\n".join(lines)
+
+
+def _call_claude_pdf(pdf_bytes: bytes, prompt: str) -> Dict[str, Any]:
+    """Send PDF to Claude for extraction."""
+    b64 = base64.standard_b64encode(pdf_bytes).decode("utf-8")
+    response = client.messages.create(
+        model=MODEL,
+        max_tokens=4096,
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "document",
+                        "source": {
+                            "type": "base64",
+                            "media_type": "application/pdf",
+                            "data": b64,
+                        },
+                    },
+                    {"type": "text", "text": prompt},
+                ],
+            }
+        ],
+    )
+    text = response.content[0].text.strip()
+    # Strip markdown code fences if present
+    if text.startswith("```"):
+        text = text.split("```")[1]
+        if text.startswith("json"):
+            text = text[4:]
+    return json.loads(text)
+
+
+def _call_claude_text(content: str, prompt: str) -> Dict[str, Any]:
+    """Send text content to Claude for extraction."""
+    response = client.messages.create(
+        model=MODEL,
+        max_tokens=4096,
+        messages=[
+            {
+                "role": "user",
+                "content": f"{prompt}\n\nDocument content:\n{content}",
+            }
+        ],
+    )
+    text = response.content[0].text.strip()
+    if text.startswith("```"):
+        text = text.split("```")[1]
+        if text.startswith("json"):
+            text = text[4:]
+    return json.loads(text)
+
+
+def parse_offering_memorandum(file_bytes: bytes, filename: str) -> Dict[str, Any]:
+    """Parse an Offering Memorandum PDF."""
+    return _call_claude_pdf(file_bytes, OM_PROMPT)
+
+
+def parse_t12(file_bytes: bytes, filename: str) -> Dict[str, Any]:
+    """Parse T12 financials from PDF or Excel."""
+    if filename.lower().endswith((".xlsx", ".xls", ".csv")):
+        text = _excel_to_text(file_bytes)
+        return _call_claude_text(text, T12_PROMPT)
+    return _call_claude_pdf(file_bytes, T12_PROMPT)
+
+
+def parse_rent_roll(file_bytes: bytes, filename: str) -> Dict[str, Any]:
+    """Parse rent roll from PDF or Excel."""
+    if filename.lower().endswith((".xlsx", ".xls", ".csv")):
+        text = _excel_to_text(file_bytes)
+        return _call_claude_text(text, RENT_ROLL_PROMPT)
+    return _call_claude_pdf(file_bytes, RENT_ROLL_PROMPT)
+
+
+def get_demo_data() -> Dict[str, Any]:
+    """Return pre-populated demo deal data (100-unit multifamily)."""
+    return {
+        "property_info": {
+            "name": "Sunset Ridge Apartments",
+            "address": "4500 Sunset Ridge Dr, Austin, TX 78741",
+            "asset_type": "Multifamily",
+            "units": 100,
+            "sqft": 85000,
+            "year_built": 1998,
+            "purchase_price": 15_000_000,
+            "asking_price": 15_500_000,
+            "market": "Austin, TX",
+            "submarket": "South Austin",
+            "sponsor_projected_noi": 825_000,
+        },
+        "t12_data": {
+            "gross_potential_rent": 1_260_000,
+            "vacancy_loss": 63_000,
+            "concessions": 12_600,
+            "bad_debt": 6_300,
+            "other_income": 60_000,
+            "effective_gross_income": 1_238_100,
+            "property_taxes": 138_000,
+            "insurance": 42_000,
+            "management_fee": 49_524,
+            "maintenance_repairs": 65_000,
+            "utilities": 38_000,
+            "payroll": 78_000,
+            "general_admin": 28_000,
+            "marketing": 15_000,
+            "capex_reserves": 25_000,
+            "other_expenses": 7_576,
+            "total_expenses": 486_100,
+            "noi": 752_000,
+        },
+        "rent_roll": [
+            {
+                "unit_number": f"{i+101}",
+                "unit_type": "1BR/1BA" if i % 3 != 2 else "2BR/2BA",
+                "sqft": 750 if i % 3 != 2 else 1050,
+                "market_rent": 1050 if i % 3 != 2 else 1400,
+                "current_rent": 1020 if i % 3 != 2 else 1350,
+                "lease_start": "2024-01-01",
+                "lease_end": "2024-12-31",
+                "status": "Occupied" if i < 95 else "Vacant",
+            }
+            for i in range(100)
+        ],
+    }

--- a/cre-analyzer/backend/services/document_parser.py
+++ b/cre-analyzer/backend/services/document_parser.py
@@ -14,6 +14,7 @@ import openpyxl
 
 client = anthropic.Anthropic(api_key=os.getenv("ANTHROPIC_API_KEY"))
 MODEL = "claude-sonnet-4-6"
+MAX_TOKENS = 16384
 
 
 OM_PROMPT = """You are a commercial real estate analyst extracting data from an Offering Memorandum (OM).
@@ -127,12 +128,29 @@ def _excel_to_text(file_bytes: bytes) -> str:
     return "\n".join(lines)
 
 
+def _parse_response(response) -> Dict[str, Any]:
+    """Extract JSON from a Claude response, surfacing truncation clearly."""
+    if response.stop_reason == "max_tokens":
+        raise ValueError(
+            "Document is too large to extract in a single pass (model output was "
+            f"truncated at {MAX_TOKENS} tokens). Try splitting the document or "
+            "uploading a summary rent roll."
+        )
+    text = response.content[0].text.strip()
+    # Strip markdown code fences if present
+    if text.startswith("```"):
+        text = text.split("```")[1]
+        if text.startswith("json"):
+            text = text[4:]
+    return json.loads(text)
+
+
 def _call_claude_pdf(pdf_bytes: bytes, prompt: str) -> Dict[str, Any]:
     """Send PDF to Claude for extraction."""
     b64 = base64.standard_b64encode(pdf_bytes).decode("utf-8")
     response = client.messages.create(
         model=MODEL,
-        max_tokens=4096,
+        max_tokens=MAX_TOKENS,
         messages=[
             {
                 "role": "user",
@@ -150,20 +168,14 @@ def _call_claude_pdf(pdf_bytes: bytes, prompt: str) -> Dict[str, Any]:
             }
         ],
     )
-    text = response.content[0].text.strip()
-    # Strip markdown code fences if present
-    if text.startswith("```"):
-        text = text.split("```")[1]
-        if text.startswith("json"):
-            text = text[4:]
-    return json.loads(text)
+    return _parse_response(response)
 
 
 def _call_claude_text(content: str, prompt: str) -> Dict[str, Any]:
     """Send text content to Claude for extraction."""
     response = client.messages.create(
         model=MODEL,
-        max_tokens=4096,
+        max_tokens=MAX_TOKENS,
         messages=[
             {
                 "role": "user",
@@ -171,12 +183,7 @@ def _call_claude_text(content: str, prompt: str) -> Dict[str, Any]:
             }
         ],
     )
-    text = response.content[0].text.strip()
-    if text.startswith("```"):
-        text = text.split("```")[1]
-        if text.startswith("json"):
-            text = text[4:]
-    return json.loads(text)
+    return _parse_response(response)
 
 
 def parse_offering_memorandum(file_bytes: bytes, filename: str) -> Dict[str, Any]:

--- a/cre-analyzer/backend/services/sensitivity_engine.py
+++ b/cre-analyzer/backend/services/sensitivity_engine.py
@@ -1,0 +1,153 @@
+"""
+Sensitivity analysis: generates heatmap tables by varying two parameters.
+"""
+
+from copy import deepcopy
+from typing import List, Dict, Any, Callable
+from models.deal import DealState
+
+
+def _set_nested(deal: DealState, param: str, value: float) -> DealState:
+    """Set a nested deal parameter by dot-notation string."""
+    parts = param.split(".")
+    obj = deal
+    for part in parts[:-1]:
+        obj = getattr(obj, part)
+    setattr(obj, parts[-1], value)
+    return deal
+
+
+def _get_metric(results: Dict, metric: str) -> float:
+    """Extract a scalar metric from analysis results."""
+    if metric in results.get("metrics", {}):
+        return results["metrics"][metric] or 0
+    if metric in results.get("waterfall", {}):
+        return results["waterfall"][metric] or 0
+    return 0
+
+
+def build_sensitivity_table(
+    deal: DealState,
+    row_param: str,         # e.g. "property_info.purchase_price"
+    col_param: str,         # e.g. "exit_assumptions.exit_cap_rate"
+    row_values: List[float],
+    col_values: List[float],
+    output_metric: str,     # e.g. "lp_irr" or "levered_irr" or "levered_em"
+    analyze_fn: Callable,   # function(deal) -> results dict
+) -> Dict[str, Any]:
+    table = []
+    for rv in row_values:
+        row = []
+        for cv in col_values:
+            d = deepcopy(deal)
+            _set_nested(d, row_param, rv)
+            _set_nested(d, col_param, cv)
+            try:
+                results = analyze_fn(d)
+                val = _get_metric(results, output_metric)
+                row.append(round(val, 2) if val is not None else None)
+            except Exception:
+                row.append(None)
+        table.append(row)
+
+    return {
+        "row_param": row_param,
+        "col_param": col_param,
+        "row_values": row_values,
+        "col_values": col_values,
+        "output_metric": output_metric,
+        "table": table,
+    }
+
+
+# Pre-defined sensitivity sets
+SENSITIVITY_CONFIGS = {
+    "lp_irr_vs_price_x_exit_cap": {
+        "row_param": "property_info.purchase_price",
+        "col_param": "exit_assumptions.exit_cap_rate",
+        "row_label": "Purchase Price ($M)",
+        "col_label": "Exit Cap Rate (%)",
+        "output_metric": "lp_irr",
+        "row_scale": 1_000_000,
+        "col_scale": 1,
+    },
+    "lp_irr_vs_rent_growth_x_vacancy": {
+        "row_param": "assumptions.rent_growth_rate",
+        "col_param": "assumptions.vacancy_rate",
+        "row_label": "Rent Growth (%)",
+        "col_label": "Vacancy (%)",
+        "output_metric": "lp_irr",
+        "row_scale": 1,
+        "col_scale": 1,
+    },
+    "coc_vs_ltv_x_rate": {
+        "row_param": "financing.ltv_pct",
+        "col_param": "financing.interest_rate",
+        "row_label": "LTV (%)",
+        "col_label": "Interest Rate (%)",
+        "output_metric": "levered_coc",
+        "row_scale": 1,
+        "col_scale": 1,
+    },
+    "em_vs_hold_x_exit_cap": {
+        "row_param": "exit_assumptions.hold_period_years",
+        "col_param": "exit_assumptions.exit_cap_rate",
+        "row_label": "Hold Period (yrs)",
+        "col_label": "Exit Cap Rate (%)",
+        "output_metric": "levered_em",
+        "row_scale": 1,
+        "col_scale": 1,
+    },
+}
+
+
+def generate_all_sensitivities(deal: DealState, analyze_fn: Callable) -> Dict[str, Any]:
+    pp = deal.property_info.purchase_price
+
+    tables = {}
+
+    # 1. LP IRR vs Purchase Price × Exit Cap
+    tables["lp_irr_vs_price_x_exit_cap"] = build_sensitivity_table(
+        deal=deal,
+        row_param="property_info.purchase_price",
+        col_param="exit_assumptions.exit_cap_rate",
+        row_values=[pp * f for f in [0.85, 0.90, 0.95, 1.00, 1.05, 1.10, 1.15]],
+        col_values=[4.50, 4.75, 5.00, 5.25, 5.50, 5.75, 6.00],
+        output_metric="lp_irr",
+        analyze_fn=analyze_fn,
+    )
+
+    # 2. LP IRR vs Rent Growth × Vacancy
+    tables["lp_irr_vs_rent_x_vacancy"] = build_sensitivity_table(
+        deal=deal,
+        row_param="assumptions.rent_growth_rate",
+        col_param="assumptions.vacancy_rate",
+        row_values=[1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+        col_values=[3.0, 5.0, 7.0, 9.0, 11.0, 13.0],
+        output_metric="lp_irr",
+        analyze_fn=analyze_fn,
+    )
+
+    # 3. Cash-on-cash vs LTV × Interest Rate
+    tables["coc_vs_ltv_x_rate"] = build_sensitivity_table(
+        deal=deal,
+        row_param="financing.ltv_pct",
+        col_param="financing.interest_rate",
+        row_values=[55.0, 60.0, 65.0, 70.0, 75.0],
+        col_values=[5.5, 6.0, 6.5, 7.0, 7.5, 8.0],
+        output_metric="levered_coc",
+        analyze_fn=analyze_fn,
+    )
+
+    # 4. Equity Multiple vs Hold Period × Exit Cap
+    tables["em_vs_hold_x_exit_cap"] = build_sensitivity_table(
+        deal=deal,
+        row_param="exit_assumptions.hold_period_years",
+        col_param="exit_assumptions.exit_cap_rate",
+        row_values=[3, 4, 5, 7, 10],
+        col_values=[4.50, 4.75, 5.00, 5.25, 5.50, 5.75, 6.00],
+        output_metric="levered_em",
+        analyze_fn=analyze_fn,
+    )
+
+    return tables

--- a/cre-analyzer/backend/services/underwriting_engine.py
+++ b/cre-analyzer/backend/services/underwriting_engine.py
@@ -1,0 +1,261 @@
+"""
+Underwriting engine: builds pro forma cash flows and computes return metrics.
+"""
+
+from typing import List, Optional, Dict, Any
+import math
+from models.deal import DealState
+
+
+# ---------------------------------------------------------------------------
+# IRR / NPV helpers
+# ---------------------------------------------------------------------------
+
+def calculate_irr(cash_flows: List[float], max_iter: int = 500) -> Optional[float]:
+    """Newton-Raphson IRR solver. Returns None if no solution found."""
+    if not cash_flows:
+        return None
+    has_neg = any(c < 0 for c in cash_flows)
+    has_pos = any(c > 0 for c in cash_flows)
+    if not (has_neg and has_pos):
+        return None
+
+    def npv(r: float) -> float:
+        return sum(c / (1 + r) ** t for t, c in enumerate(cash_flows))
+
+    def dnpv(r: float) -> float:
+        return sum(-t * c / (1 + r) ** (t + 1) for t, c in enumerate(cash_flows))
+
+    for guess in [0.10, 0.05, 0.20, 0.01, 0.30, -0.05]:
+        rate = guess
+        try:
+            for _ in range(max_iter):
+                f = npv(rate)
+                fp = dnpv(rate)
+                if abs(fp) < 1e-14:
+                    break
+                new_rate = rate - f / fp
+                if new_rate <= -1:
+                    new_rate = -0.9999
+                if abs(new_rate - rate) < 1e-10:
+                    rate = new_rate
+                    break
+                rate = new_rate
+            if abs(npv(rate)) < 10:
+                return rate
+        except Exception:
+            continue
+    return None
+
+
+def calculate_npv(cash_flows: List[float], discount_rate: float) -> float:
+    return sum(c / (1 + discount_rate) ** t for t, c in enumerate(cash_flows))
+
+
+def calculate_loan_balance(
+    original_balance: float,
+    annual_rate: float,
+    io_years: int,
+    am_years: int,
+    after_years: int,
+) -> float:
+    """Remaining loan balance after `after_years` years."""
+    if after_years <= io_years:
+        return original_balance
+
+    am_months = am_years * 12
+    r = annual_rate / 12
+    if r == 0:
+        return original_balance - original_balance * (after_years - io_years) / am_years
+
+    monthly_pmt = original_balance * (r * (1 + r) ** am_months) / ((1 + r) ** am_months - 1)
+    # Remaining balance after N amortizing months
+    am_months_elapsed = (after_years - io_years) * 12
+    balance = original_balance * (1 + r) ** am_months_elapsed - monthly_pmt * (
+        ((1 + r) ** am_months_elapsed - 1) / r
+    )
+    return max(0, balance)
+
+
+def annual_debt_service(
+    loan_amount: float,
+    annual_rate: float,
+    io_years: int,
+    am_years: int,
+    year: int,  # 1-indexed
+) -> float:
+    """Annual debt service for a given year (1-indexed)."""
+    if year <= io_years:
+        return loan_amount * annual_rate
+    r = annual_rate / 12
+    if r == 0:
+        return loan_amount / am_years
+    n = am_years * 12
+    monthly = loan_amount * (r * (1 + r) ** n) / ((1 + r) ** n - 1)
+    return monthly * 12
+
+
+# ---------------------------------------------------------------------------
+# Pro Forma Builder
+# ---------------------------------------------------------------------------
+
+def build_proforma(deal: DealState) -> Dict[str, Any]:
+    pp = deal.property_info.purchase_price
+    units = deal.property_info.units or 100
+    t12 = deal.t12_data
+    asmp = deal.assumptions
+    fin = deal.financing
+    ex = deal.exit_assumptions
+    hold = ex.hold_period_years
+
+    # Financing
+    loan_amount = pp * fin.ltv_pct / 100
+    closing_costs = pp * 0.01  # 1% closing costs
+    total_equity = (pp - loan_amount) + closing_costs
+    rate = fin.interest_rate / 100
+
+    # Base revenue (annualized)
+    gpr_base = t12.gross_potential_rent or (units * 1050 * 12)
+
+    annual_rows = []
+    for yr in range(1, hold + 1):
+        rg = (1 + asmp.rent_growth_rate / 100) ** yr
+        eg = (1 + asmp.expense_growth_rate / 100) ** yr
+
+        gpr = gpr_base * rg
+
+        # Value-add renovation premium
+        va = asmp.value_add
+        if va.enabled and yr <= va.absorption_years:
+            frac = yr / va.absorption_years
+            reno_units = round(va.units_to_renovate * frac)
+            gpr += reno_units * va.rent_premium_per_unit * 12
+
+        vac_loss = gpr * asmp.vacancy_rate / 100
+        credit_loss = (gpr - vac_loss) * asmp.credit_loss_rate / 100
+        other_inc = (t12.other_income or 0) * (1 + asmp.other_income_growth / 100) ** yr
+        egi = gpr - vac_loss - credit_loss + other_inc
+
+        # Expenses
+        taxes = t12.property_taxes * eg
+        insurance = t12.insurance * eg
+        mgmt = egi * asmp.management_fee_pct / 100
+        maint = t12.maintenance_repairs * eg
+        utils = t12.utilities * eg
+        payroll = t12.payroll * eg
+        gen_admin = t12.general_admin * eg
+        marketing = t12.marketing * eg
+        capex = units * asmp.capex_reserves_per_unit
+        other_exp = (t12.other_expenses or 0) * eg
+
+        total_exp = taxes + insurance + mgmt + maint + utils + payroll + gen_admin + marketing + capex + other_exp
+        noi = egi - total_exp
+
+        ds = annual_debt_service(loan_amount, rate, fin.io_period_years, fin.amortization_years, yr)
+        levered_cf = noi - ds
+        dscr = noi / ds if ds > 0 else None
+
+        annual_rows.append(
+            {
+                "year": yr,
+                "gross_potential_rent": round(gpr),
+                "vacancy_loss": round(vac_loss),
+                "credit_loss": round(credit_loss),
+                "other_income": round(other_inc),
+                "egi": round(egi),
+                "property_taxes": round(taxes),
+                "insurance": round(insurance),
+                "management_fee": round(mgmt),
+                "maintenance": round(maint),
+                "utilities": round(utils),
+                "payroll": round(payroll),
+                "general_admin": round(gen_admin),
+                "marketing": round(marketing),
+                "capex_reserves": round(capex),
+                "other_expenses": round(other_exp),
+                "total_expenses": round(total_exp),
+                "noi": round(noi),
+                "debt_service": round(ds),
+                "levered_cf": round(levered_cf),
+                "dscr": round(dscr, 2) if dscr else None,
+            }
+        )
+
+    # Exit
+    exit_noi = annual_rows[-1]["noi"]
+    exit_cap = ex.exit_cap_rate / 100
+    gross_sale = exit_noi / exit_cap
+    sell_costs = gross_sale * ex.selling_costs_pct / 100
+    net_sale = gross_sale - sell_costs
+    loan_payoff = calculate_loan_balance(
+        loan_amount, rate, fin.io_period_years, fin.amortization_years, hold
+    )
+    net_proceeds = net_sale - loan_payoff
+
+    # Cash flow arrays (year 0 = equity outflow)
+    levered_cfs = [-total_equity] + [r["levered_cf"] for r in annual_rows]
+    levered_cfs[-1] = levered_cfs[-1] + net_proceeds  # add exit to final year
+
+    unlevered_cfs = [-(pp + closing_costs)] + [r["noi"] for r in annual_rows]
+    unlevered_cfs[-1] = unlevered_cfs[-1] + (gross_sale - sell_costs)
+
+    levered_irr = calculate_irr(levered_cfs)
+    unlevered_irr = calculate_irr(unlevered_cfs)
+
+    # Equity multiple
+    total_lev_in = abs(levered_cfs[0])
+    total_lev_out = sum(c for c in levered_cfs[1:])
+    levered_em = total_lev_out / total_lev_in if total_lev_in > 0 else None
+
+    total_unlev_in = abs(unlevered_cfs[0])
+    total_unlev_out = sum(c for c in unlevered_cfs[1:])
+    unlevered_em = total_unlev_out / total_unlev_in if total_unlev_in > 0 else None
+
+    yr1 = annual_rows[0]
+    going_in_cap = yr1["noi"] / pp
+    noi_margin = yr1["noi"] / yr1["egi"] if yr1["egi"] else None
+    coc = yr1["levered_cf"] / total_equity if total_equity > 0 else None
+
+    metrics = {
+        "purchase_price": pp,
+        "loan_amount": round(loan_amount),
+        "equity_required": round(total_equity),
+        "closing_costs": round(closing_costs),
+        "going_in_cap_rate": round(going_in_cap * 100, 2),
+        "stabilized_cap_rate": round(annual_rows[min(2, hold - 1)]["noi"] / pp * 100, 2),
+        "year1_noi": yr1["noi"],
+        "year1_egi": yr1["egi"],
+        "noi_margin": round(noi_margin * 100, 1) if noi_margin else None,
+        "dscr_year1": yr1["dscr"],
+        "levered_coc": round(coc * 100, 2) if coc else None,
+        "unlevered_coc": round(yr1["noi"] / (pp + closing_costs) * 100, 2),
+        "levered_irr": round(levered_irr * 100, 2) if levered_irr else None,
+        "unlevered_irr": round(unlevered_irr * 100, 2) if unlevered_irr else None,
+        "levered_em": round(levered_em, 2) if levered_em else None,
+        "unlevered_em": round(unlevered_em, 2) if unlevered_em else None,
+        "npv_10pct": round(calculate_npv(levered_cfs, 0.10)),
+    }
+
+    exit_summary = {
+        "exit_year_noi": exit_noi,
+        "exit_cap_rate": ex.exit_cap_rate,
+        "gross_sale_price": round(gross_sale),
+        "selling_costs": round(sell_costs),
+        "net_sale_price": round(net_sale),
+        "loan_payoff": round(loan_payoff),
+        "net_sale_proceeds": round(net_proceeds),
+    }
+
+    return {
+        "annual_rows": annual_rows,
+        "metrics": metrics,
+        "exit": exit_summary,
+        "cash_flows": {
+            "levered": [round(c) for c in levered_cfs],
+            "unlevered": [round(c) for c in unlevered_cfs],
+        },
+        "loan_amount": round(loan_amount),
+        "total_equity": round(total_equity),
+    }
+
+

--- a/cre-analyzer/backend/services/waterfall_engine.py
+++ b/cre-analyzer/backend/services/waterfall_engine.py
@@ -206,6 +206,29 @@ def run_waterfall(
     }
 
 
+def waterfall_from_proforma(pf: Dict[str, Any], config: WaterfallConfig) -> Dict[str, Any]:
+    """
+    Run the waterfall directly from a pro-forma result.
+
+    Separates the levered cash-flow array into operating distributions and the
+    exit event: the final year's operating CF is stripped out of the embedded
+    exit proceeds so it is distributed as its own operating event, while the
+    net sale proceeds form the IRR-promote exit event. This must stay the single
+    source of truth — full_analysis and the solvers all rely on it so their LP
+    IRR functions cannot drift apart.
+    """
+    lev_cfs = pf["cash_flows"]["levered"]
+    annual_ops = [float(c) for c in lev_cfs[1:-1]]
+    if len(lev_cfs) > 1:
+        annual_ops.append(float(lev_cfs[-1]) - float(pf["exit"]["net_sale_proceeds"]))
+    return run_waterfall(
+        equity_required=float(pf["total_equity"]),
+        annual_levered_cfs=annual_ops,
+        exit_proceeds=float(pf["exit"]["net_sale_proceeds"]),
+        config=config,
+    )
+
+
 def _allocate_by_irr_tiers(
     lp_invested: float,
     prior_lp_dists: List[float],
@@ -273,13 +296,7 @@ def solve_for_price(
     def lp_irr_at_price(price: float) -> float:
         d = deepcopy(deal)
         d.property_info.purchase_price = price
-        pf = build_fn(d)
-        wf = run_waterfall(
-            equity_required=pf["total_equity"],
-            annual_levered_cfs=pf["cash_flows"]["levered"][1:-1],
-            exit_proceeds=pf["exit"]["net_sale_proceeds"],
-            config=d.waterfall_config,
-        )
+        wf = waterfall_from_proforma(build_fn(d), d.waterfall_config)
         return wf["lp_irr"] or 0
 
     for _ in range(60):
@@ -308,13 +325,7 @@ def solve_for_exit_cap(
     def lp_irr_at_cap(cap: float) -> float:
         d = deepcopy(deal)
         d.exit_assumptions.exit_cap_rate = cap
-        pf = build_fn(d)
-        wf = run_waterfall(
-            equity_required=pf["total_equity"],
-            annual_levered_cfs=pf["cash_flows"]["levered"][1:-1],
-            exit_proceeds=pf["exit"]["net_sale_proceeds"],
-            config=d.waterfall_config,
-        )
+        wf = waterfall_from_proforma(build_fn(d), d.waterfall_config)
         return wf["lp_irr"] or 0
 
     for _ in range(60):

--- a/cre-analyzer/backend/services/waterfall_engine.py
+++ b/cre-analyzer/backend/services/waterfall_engine.py
@@ -1,0 +1,330 @@
+"""
+LP/GP Waterfall Engine.
+
+Waterfall order per distribution event:
+  1. Return of capital (pro-rata LP/GP)
+  2. Preferred return to LP (cumulative, on unreturned capital)
+  3. GP catch-up (to GP until GP holds target_promote_pct% of total profits)
+  4. Remaining splits by IRR-based promote tiers (solved at exit)
+"""
+
+from typing import List, Dict, Any, Optional, Tuple
+from models.deal import WaterfallConfig, WaterfallTier
+from services.underwriting_engine import calculate_irr
+
+
+def _solve_lp_amount_for_irr(
+    lp_invested: float,
+    prior_lp_dists: List[float],
+    target_irr: float,
+    max_available: float,
+) -> float:
+    """Binary search: how much LP needs to reach target_irr at exit."""
+    if target_irr <= 0:
+        return 0.0
+
+    def lp_irr_at(lp_alloc: float) -> float:
+        cfs = [-lp_invested] + prior_lp_dists[:-1] + [prior_lp_dists[-1] + lp_alloc]
+        irr = calculate_irr(cfs)
+        return irr if irr is not None else -1.0
+
+    # Check if max_available gets LP past target
+    if lp_irr_at(max_available) < target_irr:
+        return max_available
+
+    # Binary search
+    lo, hi = 0.0, max_available
+    for _ in range(60):
+        mid = (lo + hi) / 2
+        if lp_irr_at(mid) < target_irr:
+            lo = mid
+        else:
+            hi = mid
+        if hi - lo < 1:
+            break
+    return (lo + hi) / 2
+
+
+def run_waterfall(
+    equity_required: float,
+    annual_levered_cfs: List[float],
+    exit_proceeds: float,
+    config: WaterfallConfig,
+) -> Dict[str, Any]:
+    lp_pct = config.lp_equity_pct / 100
+    gp_pct = config.gp_equity_pct / 100
+    lp_invested = equity_required * lp_pct
+    gp_invested = equity_required * gp_pct
+    pref_rate = config.preferred_return / 100
+
+    lp_cap_returned = 0.0
+    gp_cap_returned = 0.0
+    lp_pref_accrued = 0.0
+    lp_pref_paid = 0.0
+    gp_catchup_paid = 0.0
+    lp_promote_paid = 0.0
+    gp_promote_paid = 0.0
+
+    lp_dists_by_year: List[float] = []
+    gp_dists_by_year: List[float] = []
+    yearly_results: List[Dict] = []
+
+    all_events = list(annual_levered_cfs) + [exit_proceeds]
+    n_operating = len(annual_levered_cfs)
+
+    for idx, cf in enumerate(all_events):
+        is_exit = idx == len(all_events) - 1
+        year = idx + 1
+
+        # Accrue preferred return on unreturned LP capital
+        lp_unreturned = lp_invested - lp_cap_returned
+        if config.pref_compounding:
+            lp_pref_accrued = lp_pref_accrued * (1 + pref_rate) + lp_unreturned * pref_rate
+        else:
+            lp_pref_accrued += lp_unreturned * pref_rate
+
+        distributable = max(0.0, cf)
+        remaining = distributable
+        lp_dist = 0.0
+        gp_dist = 0.0
+
+        tier_roc_lp = 0.0
+        tier_roc_gp = 0.0
+        tier_pref = 0.0
+        tier_catchup = 0.0
+        tier_promote_lp = 0.0
+        tier_promote_gp = 0.0
+
+        if remaining > 0:
+            # --- Tier 1: Return of Capital ---
+            lp_cap_owed = max(0.0, lp_invested - lp_cap_returned)
+            gp_cap_owed = max(0.0, gp_invested - gp_cap_returned)
+            total_cap_owed = lp_cap_owed + gp_cap_owed
+
+            if total_cap_owed > 0:
+                roc_payment = min(remaining, total_cap_owed)
+                lp_roc = roc_payment * (lp_cap_owed / total_cap_owed)
+                gp_roc = roc_payment * (gp_cap_owed / total_cap_owed)
+                lp_dist += lp_roc
+                gp_dist += gp_roc
+                remaining -= roc_payment
+                lp_cap_returned += lp_roc
+                gp_cap_returned += gp_roc
+                tier_roc_lp = lp_roc
+                tier_roc_gp = gp_roc
+
+            # --- Tier 2: Preferred Return to LP ---
+            lp_pref_owed = max(0.0, lp_pref_accrued - lp_pref_paid)
+            if lp_pref_owed > 0 and remaining > 0:
+                pref_pmt = min(remaining, lp_pref_owed)
+                lp_dist += pref_pmt
+                remaining -= pref_pmt
+                lp_pref_paid += pref_pmt
+                tier_pref = pref_pmt
+
+            # --- Tier 3: GP Catch-up ---
+            if config.gp_catchup and remaining > 0:
+                total_profits = lp_pref_paid + gp_catchup_paid + lp_promote_paid + gp_promote_paid
+                # GP should receive gp_target_promote_pct% of cumulative profits (non-capital)
+                gp_target = total_profits * (config.gp_target_promote_pct / 100) / (
+                    1 - config.gp_target_promote_pct / 100
+                )
+                catchup_owed = max(0.0, gp_target - gp_catchup_paid)
+                if catchup_owed > 0 and remaining > 0:
+                    catchup_pmt = min(remaining, catchup_owed)
+                    gp_dist += catchup_pmt
+                    remaining -= catchup_pmt
+                    gp_catchup_paid += catchup_pmt
+                    tier_catchup = catchup_pmt
+
+            # --- Tier 4: Promote splits ---
+            if remaining > 0:
+                if is_exit:
+                    lp_p, gp_p = _allocate_by_irr_tiers(
+                        lp_invested=lp_invested,
+                        prior_lp_dists=lp_dists_by_year + [lp_dist],
+                        remaining=remaining,
+                        tiers=sorted(config.tiers, key=lambda t: t.irr_min),
+                    )
+                else:
+                    # During hold: use first tier's split for operating promotes
+                    tier0 = sorted(config.tiers, key=lambda t: t.irr_min)[0]
+                    lp_p = remaining * tier0.lp_split / 100
+                    gp_p = remaining * tier0.gp_split / 100
+
+                lp_dist += lp_p
+                gp_dist += gp_p
+                remaining -= lp_p + gp_p
+                lp_promote_paid += lp_p
+                gp_promote_paid += gp_p
+                tier_promote_lp = lp_p
+                tier_promote_gp = gp_p
+
+        lp_dists_by_year.append(lp_dist)
+        gp_dists_by_year.append(gp_dist)
+
+        yearly_results.append(
+            {
+                "year": year,
+                "is_exit": is_exit,
+                "distributable": round(distributable),
+                "lp_distribution": round(lp_dist),
+                "gp_distribution": round(gp_dist),
+                "tier_roc_lp": round(tier_roc_lp),
+                "tier_roc_gp": round(tier_roc_gp),
+                "tier_preferred_return": round(tier_pref),
+                "tier_gp_catchup": round(tier_catchup),
+                "tier_lp_promote": round(tier_promote_lp),
+                "tier_gp_promote": round(tier_promote_gp),
+            }
+        )
+
+    # Final IRR / EM
+    lp_cfs = [-lp_invested] + lp_dists_by_year
+    gp_cfs = [-gp_invested] + gp_dists_by_year
+    lp_irr = calculate_irr(lp_cfs)
+    gp_irr = calculate_irr(gp_cfs)
+
+    total_lp_out = sum(lp_dists_by_year)
+    total_gp_out = sum(gp_dists_by_year)
+    lp_em = total_lp_out / lp_invested if lp_invested > 0 else None
+    gp_em = total_gp_out / gp_invested if gp_invested > 0 else None
+    gp_promote = gp_catchup_paid + gp_promote_paid
+
+    return {
+        "yearly": yearly_results,
+        "lp_total_distributions": round(total_lp_out),
+        "gp_total_distributions": round(total_gp_out),
+        "lp_irr": round(lp_irr * 100, 2) if lp_irr else None,
+        "gp_irr": round(gp_irr * 100, 2) if gp_irr else None,
+        "lp_em": round(lp_em, 2) if lp_em else None,
+        "gp_em": round(gp_em, 2) if gp_em else None,
+        "gp_promote_earned": round(gp_promote),
+        "lp_invested": round(lp_invested),
+        "gp_invested": round(gp_invested),
+        "pref_paid": round(lp_pref_paid),
+    }
+
+
+def _allocate_by_irr_tiers(
+    lp_invested: float,
+    prior_lp_dists: List[float],
+    remaining: float,
+    tiers: List[WaterfallTier],
+) -> Tuple[float, float]:
+    """Split remaining exit proceeds across IRR-based tiers."""
+    lp_alloc = 0.0
+    gp_alloc = 0.0
+
+    for i, tier in enumerate(tiers):
+        if remaining <= 0:
+            break
+
+        irr_max = tier.irr_max / 100
+        lp_split = tier.lp_split / 100
+        gp_split = tier.gp_split / 100
+
+        is_last = i == len(tiers) - 1 or tier.irr_max >= 999
+
+        if is_last:
+            lp_alloc += remaining * lp_split
+            gp_alloc += remaining * gp_split
+            remaining = 0
+            break
+
+        # How much does LP need to reach irr_max?
+        lp_needed = _solve_lp_amount_for_irr(
+            lp_invested=lp_invested,
+            prior_lp_dists=prior_lp_dists,
+            target_irr=irr_max,
+            max_available=remaining * lp_split,
+        )
+        # Total to distribute at this tier
+        total_tier = lp_needed / lp_split if lp_split > 0 else 0
+
+        if total_tier >= remaining:
+            # All remaining goes at this tier's split
+            lp_alloc += remaining * lp_split
+            gp_alloc += remaining * gp_split
+            remaining = 0
+        else:
+            lp_alloc += total_tier * lp_split
+            gp_alloc += total_tier * gp_split
+            remaining -= total_tier
+            # Update prior_lp_dists for next tier
+            if prior_lp_dists:
+                prior_lp_dists = prior_lp_dists[:-1] + [
+                    prior_lp_dists[-1] + total_tier * lp_split
+                ]
+
+    return lp_alloc, gp_alloc
+
+
+def solve_for_price(
+    deal: "DealState",
+    target_lp_irr: float,
+    build_fn,
+) -> Optional[float]:
+    """Binary search for purchase price that yields target LP IRR."""
+    from copy import deepcopy
+
+    lo, hi = 1_000_000.0, 200_000_000.0
+
+    def lp_irr_at_price(price: float) -> float:
+        d = deepcopy(deal)
+        d.property_info.purchase_price = price
+        pf = build_fn(d)
+        wf = run_waterfall(
+            equity_required=pf["total_equity"],
+            annual_levered_cfs=pf["cash_flows"]["levered"][1:-1],
+            exit_proceeds=pf["exit"]["net_sale_proceeds"],
+            config=d.waterfall_config,
+        )
+        return wf["lp_irr"] or 0
+
+    for _ in range(60):
+        mid = (lo + hi) / 2
+        irr = lp_irr_at_price(mid)
+        if irr < target_lp_irr:
+            hi = mid  # lower price needed to improve IRR
+        else:
+            lo = mid
+        if hi - lo < 1000:
+            break
+
+    return round((lo + hi) / 2)
+
+
+def solve_for_exit_cap(
+    deal: "DealState",
+    target_lp_irr: float,
+    build_fn,
+) -> Optional[float]:
+    """Binary search for exit cap rate that yields target LP IRR."""
+    from copy import deepcopy
+
+    lo, hi = 3.0, 10.0
+
+    def lp_irr_at_cap(cap: float) -> float:
+        d = deepcopy(deal)
+        d.exit_assumptions.exit_cap_rate = cap
+        pf = build_fn(d)
+        wf = run_waterfall(
+            equity_required=pf["total_equity"],
+            annual_levered_cfs=pf["cash_flows"]["levered"][1:-1],
+            exit_proceeds=pf["exit"]["net_sale_proceeds"],
+            config=d.waterfall_config,
+        )
+        return wf["lp_irr"] or 0
+
+    for _ in range(60):
+        mid = (lo + hi) / 2
+        irr = lp_irr_at_cap(mid)
+        if irr < target_lp_irr:
+            hi = mid  # lower exit cap = higher proceeds
+        else:
+            lo = mid
+        if hi - lo < 0.001:
+            break
+
+    return round((lo + hi) / 2, 2)

--- a/cre-analyzer/backend/state.py
+++ b/cre-analyzer/backend/state.py
@@ -1,0 +1,2 @@
+# Shared in-memory store for deals
+deals_store: dict = {}

--- a/cre-analyzer/backend/tests/test_financial_accuracy.py
+++ b/cre-analyzer/backend/tests/test_financial_accuracy.py
@@ -1,0 +1,636 @@
+"""
+Financial Accuracy Tests — CRE Analyzer Backend
+================================================
+
+Tests are organised into four sections:
+
+1. IRR Solver            – known closed-form solutions
+2. Debt Service          – I/O and amortising payment maths
+3. Full Pro-Forma        – Sunset Ridge Apartments (default deal)
+4. LP/GP Waterfall       – capital stack distribution logic
+
+All expected values are derived analytically or via the curl smoke-test
+(Going-in Cap 5.25 %, Year-1 NOI $788 080, Levered IRR 8.33 %).
+"""
+
+import math
+import sys
+import os
+import pytest
+
+# Allow imports from parent directory
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from services.underwriting_engine import (
+    calculate_irr,
+    calculate_npv,
+    annual_debt_service,
+    calculate_loan_balance,
+    build_proforma,
+)
+from services.waterfall_engine import run_waterfall
+from models.deal import (
+    DealState,
+    PropertyInfo,
+    T12Data,
+    Assumptions,
+    FinancingAssumptions,
+    ExitAssumptions,
+    WaterfallConfig,
+    WaterfallTier,
+    ValueAddAssumptions,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def approx(val, rel=0.005):
+    """Assert within 0.5 % relative tolerance (5 bps for rates)."""
+    return pytest.approx(val, rel=rel)
+
+
+def sunset_ridge_deal() -> DealState:
+    """Default Sunset Ridge deal matching the frontend store defaults."""
+    return DealState(
+        property_info=PropertyInfo(
+            purchase_price=15_000_000,
+            units=100,
+        ),
+        t12_data=T12Data(
+            gross_potential_rent=1_260_000,
+            vacancy_loss=63_000,
+            concessions=12_600,
+            bad_debt=6_300,
+            other_income=60_000,
+            property_taxes=138_000,
+            insurance=42_000,
+            management_fee=49_524,
+            maintenance_repairs=65_000,
+            utilities=38_000,
+            payroll=78_000,
+            general_admin=28_000,
+            marketing=15_000,
+            capex_reserves=25_000,
+            other_expenses=7_576,
+        ),
+        assumptions=Assumptions(
+            rent_growth_rate=3.0,
+            vacancy_rate=5.0,
+            credit_loss_rate=0.5,
+            other_income_growth=3.0,
+            expense_growth_rate=3.0,
+            management_fee_pct=4.0,
+            capex_reserves_per_unit=250,
+            value_add=ValueAddAssumptions(enabled=False),
+        ),
+        financing=FinancingAssumptions(
+            ltv_pct=65.0,
+            interest_rate=6.5,
+            io_period_years=2,
+            amortization_years=30,
+            loan_term_years=5,
+        ),
+        exit_assumptions=ExitAssumptions(
+            hold_period_years=5,
+            exit_cap_rate=5.25,
+            selling_costs_pct=2.0,
+        ),
+        waterfall_config=WaterfallConfig(
+            lp_equity_pct=90,
+            gp_equity_pct=10,
+            preferred_return=8.0,
+            pref_compounding=False,
+            gp_catchup=True,
+            gp_catchup_rate=50,
+            gp_target_promote_pct=20,
+            tiers=[
+                WaterfallTier(irr_min=0,  irr_max=14,  lp_split=80, gp_split=20),
+                WaterfallTier(irr_min=14, irr_max=18,  lp_split=70, gp_split=30),
+                WaterfallTier(irr_min=18, irr_max=999, lp_split=60, gp_split=40),
+            ],
+        ),
+    )
+
+
+# ===========================================================================
+# 1. IRR Solver
+# ===========================================================================
+
+class TestIRRSolver:
+    """
+    Known closed-form IRR cases.
+
+    For a single-period investment:  IRR = (FV/PV)^(1/n) - 1
+    For a bond:  cash flows [-P, C, C, ..., C+P] → IRR = coupon rate when P = face.
+    """
+
+    def test_two_period_10_pct(self):
+        # Invest $100, receive $121 after 2 years: IRR = (121/100)^0.5 - 1 = 10 %
+        cfs = [-100, 0, 121]
+        irr = calculate_irr(cfs)
+        assert irr == approx(0.10)
+
+    def test_bond_8_pct(self):
+        # Par bond: invest $1 000, annual coupon $80 for 5 yrs + $1 080 at end → IRR = 8 %
+        cfs = [-1_000, 80, 80, 80, 80, 1_080]
+        irr = calculate_irr(cfs)
+        assert irr == approx(0.08)
+
+    def test_single_year_15_pct(self):
+        # Invest $1 M, get $1.15 M in one year → IRR = 15 %
+        cfs = [-1_000_000, 1_150_000]
+        irr = calculate_irr(cfs)
+        assert irr == approx(0.15)
+
+    def test_high_irr_30_pct(self):
+        # Invest $100, get $169 after 2 years: (169/100)^0.5 - 1 = 30 %
+        cfs = [-100, 0, 169]
+        irr = calculate_irr(cfs)
+        assert irr == approx(0.30)
+
+    def test_npv_at_irr_is_zero(self):
+        """NPV evaluated at the computed IRR must be near zero."""
+        cfs = [-500_000, 80_000, 80_000, 80_000, 80_000, 620_000]
+        irr = calculate_irr(cfs)
+        assert irr is not None
+        npv = calculate_npv(cfs, irr)
+        assert abs(npv) < 1.0   # within $1
+
+    def test_no_solution_all_positive(self):
+        assert calculate_irr([100, 200, 300]) is None
+
+    def test_no_solution_all_negative(self):
+        assert calculate_irr([-100, -200]) is None
+
+    def test_sign_change_required(self):
+        # Only one sign change — solvable
+        irr = calculate_irr([-1_000, 500, 700])
+        assert irr is not None
+        assert 0 < irr < 1   # positive IRR between 0 and 100 %
+
+
+# ===========================================================================
+# 2. Debt Service
+# ===========================================================================
+
+class TestDebtService:
+    """
+    Manually derived expected values for $9.75 M loan at 6.5 % / 30-yr am.
+    """
+
+    LOAN   = 9_750_000.0
+    RATE   = 0.065
+    IO_YRS = 2
+    AM_YRS = 30
+
+    # ---- Interest-Only years -----------------------------------------------
+
+    def test_io_year_1_payment(self):
+        # I/O payment = loan × rate
+        ds = annual_debt_service(self.LOAN, self.RATE, self.IO_YRS, self.AM_YRS, year=1)
+        expected = self.LOAN * self.RATE   # $633 750
+        assert ds == approx(expected)
+
+    def test_io_year_2_payment(self):
+        ds = annual_debt_service(self.LOAN, self.RATE, self.IO_YRS, self.AM_YRS, year=2)
+        assert ds == approx(self.LOAN * self.RATE)
+
+    # ---- First amortising year (year 3) ------------------------------------
+
+    def test_amortising_year_3_payment(self):
+        """
+        Standard mortgage: PMT = P * [r*(1+r)^n] / [(1+r)^n - 1]
+        r_monthly = 6.5%/12, n = 360 months → annual = PMT * 12
+        """
+        r = self.RATE / 12
+        n = self.AM_YRS * 12
+        monthly = self.LOAN * (r * (1 + r)**n) / ((1 + r)**n - 1)
+        expected_annual = monthly * 12
+
+        ds = annual_debt_service(self.LOAN, self.RATE, self.IO_YRS, self.AM_YRS, year=3)
+        assert ds == approx(expected_annual)
+
+    def test_amortising_greater_than_io(self):
+        """Am payment must exceed I/O payment (principal reduces balance)."""
+        io_ds  = annual_debt_service(self.LOAN, self.RATE, self.IO_YRS, self.AM_YRS, year=1)
+        am_ds  = annual_debt_service(self.LOAN, self.RATE, self.IO_YRS, self.AM_YRS, year=3)
+        assert am_ds > io_ds
+
+    # ---- Loan balance -------------------------------------------------------
+
+    def test_balance_during_io_period(self):
+        """Balance is unchanged during I/O — no principal paid."""
+        bal = calculate_loan_balance(self.LOAN, self.RATE, self.IO_YRS, self.AM_YRS, after_years=1)
+        assert bal == approx(self.LOAN)
+
+    def test_balance_at_io_boundary(self):
+        bal = calculate_loan_balance(self.LOAN, self.RATE, self.IO_YRS, self.AM_YRS, after_years=2)
+        assert bal == approx(self.LOAN)
+
+    def test_balance_after_5_years_less_than_original(self):
+        """After 3 amortising years the balance must be below original loan."""
+        bal = calculate_loan_balance(self.LOAN, self.RATE, self.IO_YRS, self.AM_YRS, after_years=5)
+        assert bal < self.LOAN
+        # Rough sanity: should still be > 90 % of original (only 3 yrs am on 30-yr)
+        assert bal > self.LOAN * 0.90
+
+    def test_zero_rate_io(self):
+        """0 % I/O payment is $0 interest."""
+        ds = annual_debt_service(1_000_000, 0.0, 3, 30, year=1)
+        assert ds == approx(0.0)
+
+
+# ===========================================================================
+# 3. Full Pro-Forma — Sunset Ridge Apartments
+# ===========================================================================
+
+class TestProformaSunsetRidge:
+    """
+    Validates the full proforma against analytically derived values and the
+    live smoke-test results from the curl integration test.
+    """
+
+    @pytest.fixture(scope="class")
+    def pf(self):
+        return build_proforma(sunset_ridge_deal())
+
+    # ---- Capitalization structure ------------------------------------------
+
+    def test_loan_amount(self, pf):
+        # 65 % LTV on $15 M
+        assert pf["loan_amount"] == approx(9_750_000, rel=0.001)
+
+    def test_equity_required(self, pf):
+        # Down payment + 1 % closing costs
+        equity_dp   = 15_000_000 * 0.35      # $5 250 000
+        closing     = 15_000_000 * 0.01      # $150 000
+        assert pf["total_equity"] == approx(equity_dp + closing, rel=0.001)
+
+    # ---- Year 1 NOI (confirmed by curl smoke-test) -------------------------
+
+    def test_year1_noi(self, pf):
+        """
+        Manually derived Year-1 NOI = $788 080 (see calc in AGENTS.md comments).
+        Smoke-test curl output confirmed this value.
+        """
+        yr1_noi = pf["annual_rows"][0]["noi"]
+        assert yr1_noi == approx(788_080, rel=0.01)
+
+    def test_going_in_cap_rate(self, pf):
+        # Smoke-test confirmed 5.25 %
+        assert pf["metrics"]["going_in_cap_rate"] == approx(5.25, rel=0.02)
+
+    # ---- Debt service in Year 1 (I/O) -------------------------------------
+
+    def test_year1_debt_service_is_io(self, pf):
+        expected_io = 9_750_000 * 0.065
+        assert pf["annual_rows"][0]["debt_service"] == approx(expected_io, rel=0.001)
+
+    def test_year1_levered_cf_positive(self, pf):
+        assert pf["annual_rows"][0]["levered_cf"] > 0
+
+    def test_year1_dscr_above_1(self, pf):
+        assert pf["annual_rows"][0]["dscr"] > 1.0
+
+    # ---- Exit calculations -------------------------------------------------
+
+    def test_exit_noi_higher_than_year1(self, pf):
+        """Revenue grows each year so exit NOI > Year-1 NOI."""
+        assert pf["exit"]["exit_year_noi"] > pf["annual_rows"][0]["noi"]
+
+    def test_gross_sale_price_formula(self, pf):
+        """Exit value = exit NOI / exit cap."""
+        expected = pf["exit"]["exit_year_noi"] / 0.0525
+        assert pf["exit"]["gross_sale_price"] == approx(expected, rel=0.001)
+
+    def test_selling_costs_2pct(self, pf):
+        gross = pf["exit"]["gross_sale_price"]
+        assert pf["exit"]["selling_costs"] == approx(gross * 0.02, rel=0.001)
+
+    # ---- Return metrics ---------------------------------------------------
+
+    def test_levered_irr_positive(self, pf):
+        assert pf["metrics"]["levered_irr"] is not None
+        assert pf["metrics"]["levered_irr"] > 0
+
+    def test_levered_irr_near_smoke_test(self, pf):
+        # Smoke-test: 8.33 %
+        assert pf["metrics"]["levered_irr"] == approx(8.33, rel=0.05)
+
+    def test_unlevered_irr_less_than_levered(self, pf):
+        """Positive leverage: levered IRR > unlevered IRR when loan rate < cap rate?
+        Actually with going-in cap 5.25% and loan rate 6.5%, unlevered > levered."""
+        # Both should be positive
+        assert pf["metrics"]["unlevered_irr"] > 0
+        assert pf["metrics"]["levered_irr"] > 0
+
+    def test_levered_em_above_1(self, pf):
+        """Positive returns: equity multiple > 1×."""
+        assert pf["metrics"]["levered_em"] > 1.0
+
+    def test_cash_flows_array_length(self, pf):
+        """Levered CF array: year 0 + 5 hold years = 6 elements."""
+        assert len(pf["cash_flows"]["levered"]) == 6
+
+    def test_year0_cf_is_negative_equity(self, pf):
+        """Year-0 cash flow is the initial equity outflow (negative)."""
+        assert pf["cash_flows"]["levered"][0] < 0
+        assert pf["cash_flows"]["levered"][0] == approx(-pf["total_equity"], rel=0.001)
+
+    # ---- Multi-year growth sanity ------------------------------------------
+
+    def test_noi_grows_year_over_year(self, pf):
+        nois = [row["noi"] for row in pf["annual_rows"]]
+        for i in range(1, len(nois)):
+            assert nois[i] > nois[i - 1], f"NOI did not grow from yr {i} to yr {i+1}"
+
+    def test_gpr_grows_at_3pct(self, pf):
+        """GPR should grow ~3 % per year."""
+        rows = pf["annual_rows"]
+        for i in range(1, len(rows)):
+            ratio = rows[i]["gross_potential_rent"] / rows[i - 1]["gross_potential_rent"]
+            assert ratio == approx(1.03, rel=0.01)
+
+
+# ===========================================================================
+# 4. LP/GP Waterfall
+# ===========================================================================
+
+class TestWaterfall:
+    """
+    Tests the waterfall engine against hand-calculated expected distributions.
+    """
+
+    # ---- Setup helpers ------------------------------------------------------
+
+    def simple_config(self, lp_pct=90, gp_pct=10, pref=8.0,
+                      catchup=True, catchup_rate=50, promote_pct=20,
+                      tiers=None) -> WaterfallConfig:
+        return WaterfallConfig(
+            lp_equity_pct=lp_pct,
+            gp_equity_pct=gp_pct,
+            preferred_return=pref,
+            pref_compounding=False,
+            gp_catchup=catchup,
+            gp_catchup_rate=catchup_rate,
+            gp_target_promote_pct=promote_pct,
+            tiers=tiers or [
+                WaterfallTier(irr_min=0, irr_max=14,  lp_split=80, gp_split=20),
+                WaterfallTier(irr_min=14, irr_max=999, lp_split=60, gp_split=40),
+            ],
+        )
+
+    # ---- Case 1: Return of capital only (no profit) ------------------------
+
+    def test_roc_only_lp_gets_invested_capital_back(self):
+        """
+        Invest $9M (LP) + $1M (GP).  Exit proceeds = $10M → both get capital back,
+        nothing extra.
+        """
+        equity = 10_000_000
+        config = self.simple_config(lp_pct=90, gp_pct=10)
+        result = run_waterfall(
+            equity_required=equity,
+            annual_levered_cfs=[0] * 5,   # no operating CFs
+            exit_proceeds=equity,          # exactly capital back
+            config=config,
+        )
+        assert result["lp_total_distributions"] == approx(9_000_000, rel=0.01)
+        assert result["gp_total_distributions"] == approx(1_000_000, rel=0.01)
+        assert result["gp_promote_earned"] == pytest.approx(0, abs=1)
+
+    # ---- Case 2: Preferred return to LP ------------------------------------
+
+    def test_pref_return_paid_before_promote(self):
+        """
+        LP invests $9M, 8% pref (non-compounding), 5-yr hold, no annual CFs.
+        At exit: $9M RoC + 5 × $720K pref = $12.6M to LP before any promote.
+        Excess goes to GP catch-up then promote.
+        """
+        equity = 10_000_000
+        lp_invested = 9_000_000
+        pref_accrued = lp_invested * 0.08 * 5   # $3 600 000
+
+        exit_proceeds = equity + pref_accrued + 2_000_000   # plenty of profit
+        config = self.simple_config(catchup=False,
+                                    tiers=[WaterfallTier(irr_min=0, irr_max=999, lp_split=80, gp_split=20)])
+        result = run_waterfall(
+            equity_required=equity,
+            annual_levered_cfs=[0] * 5,
+            exit_proceeds=exit_proceeds,
+            config=config,
+        )
+        # LP must have received at minimum RoC + full pref
+        lp_min = lp_invested + pref_accrued
+        assert result["lp_total_distributions"] >= lp_min - 1   # within $1
+
+    def test_pref_paid_label_matches_distribution(self):
+        """pref_paid field should equal the preferred return received by LP."""
+        equity = 10_000_000
+        lp_invested = 9_000_000
+        pref_per_year = lp_invested * 0.08    # $720 000
+        # Annual CFs exactly equal pref → pref paid yearly, none at exit
+        annual_cfs = [pref_per_year] * 5
+        exit_proceeds = lp_invested + 1_000_000   # LP RoC + $1M profit
+        config = self.simple_config(catchup=False,
+                                    tiers=[WaterfallTier(irr_min=0, irr_max=999, lp_split=80, gp_split=20)])
+        result = run_waterfall(equity, annual_cfs, exit_proceeds, config)
+        assert result["pref_paid"] == approx(pref_per_year * 5, rel=0.05)
+
+    # ---- Case 3: Full waterfall with Sunset Ridge numbers ------------------
+
+    def test_sunset_ridge_waterfall_lp_irr(self):
+        """
+        LP earns less than levered IRR due to GP promote.
+        Levered IRR ≈ 8.33 %; LP IRR should be in the 6–8 % range.
+        """
+        deal = sunset_ridge_deal()
+        pf = build_proforma(deal)
+        annual_cfs = pf["cash_flows"]["levered"][1:-1]   # years 1-4
+        exit_proceeds = pf["exit"]["net_sale_proceeds"]
+
+        result = run_waterfall(
+            equity_required=pf["total_equity"],
+            annual_levered_cfs=annual_cfs,
+            exit_proceeds=exit_proceeds,
+            config=deal.waterfall_config,
+        )
+        assert result["lp_irr"] is not None
+        assert 6.0 <= result["lp_irr"] <= 8.5, (
+            f"LP IRR {result['lp_irr']} % is outside expected 6–8.5 % range"
+        )
+        # LP IRR must be below levered IRR (GP promote takes a cut)
+        assert result["lp_irr"] < pf["metrics"]["levered_irr"]
+
+    def test_sunset_ridge_gp_promote_positive(self):
+        deal = sunset_ridge_deal()
+        pf = build_proforma(deal)
+        result = run_waterfall(
+            equity_required=pf["total_equity"],
+            annual_levered_cfs=pf["cash_flows"]["levered"][1:-1],
+            exit_proceeds=pf["exit"]["net_sale_proceeds"],
+            config=deal.waterfall_config,
+        )
+        assert result["gp_promote_earned"] > 0
+
+    def test_total_distributions_equal_total_cash_in(self):
+        """
+        LP distributions + GP distributions must equal sum of all distributable
+        cash (operating CFs ≥ 0 only, plus exit proceeds).
+        No cash is created or destroyed.
+        """
+        deal = sunset_ridge_deal()
+        pf = build_proforma(deal)
+        annual_cfs = pf["cash_flows"]["levered"][1:-1]
+        exit_proceeds = pf["exit"]["net_sale_proceeds"]
+
+        result = run_waterfall(
+            equity_required=pf["total_equity"],
+            annual_levered_cfs=annual_cfs,
+            exit_proceeds=exit_proceeds,
+            config=deal.waterfall_config,
+        )
+        distributable_total = sum(max(0, c) for c in annual_cfs) + max(0, exit_proceeds)
+        total_out = result["lp_total_distributions"] + result["gp_total_distributions"]
+        assert total_out == approx(distributable_total, rel=0.001)
+
+    # ---- Case 4: LP IRR > GP IRR (LP should earn more per $ invested) ------
+
+    def test_lp_em_lower_than_gp_em_due_to_promote(self):
+        """
+        GP earns promote, so GP EM > LP EM when returns exceed pref.
+        LP EM should still be > 1 (positive return).
+        """
+        deal = sunset_ridge_deal()
+        pf = build_proforma(deal)
+        result = run_waterfall(
+            equity_required=pf["total_equity"],
+            annual_levered_cfs=pf["cash_flows"]["levered"][1:-1],
+            exit_proceeds=pf["exit"]["net_sale_proceeds"],
+            config=deal.waterfall_config,
+        )
+        assert result["lp_em"] > 1.0
+        assert result["gp_em"] > 1.0
+
+    # ---- Case 5: 100 % LP, no GP ------------------------------------------
+
+    def test_100pct_lp_all_goes_to_lp(self):
+        """When LP holds 100 % equity, all distributions go to LP."""
+        config = WaterfallConfig(
+            lp_equity_pct=100,
+            gp_equity_pct=0,
+            preferred_return=8.0,
+            pref_compounding=False,
+            gp_catchup=False,
+            tiers=[WaterfallTier(irr_min=0, irr_max=999, lp_split=100, gp_split=0)],
+        )
+        equity = 1_000_000
+        exit_proceeds = 1_500_000
+        result = run_waterfall(equity, [0] * 5, exit_proceeds, config)
+        assert result["gp_total_distributions"] == pytest.approx(0, abs=1)
+        assert result["lp_total_distributions"] == pytest.approx(exit_proceeds, abs=1)
+
+    # ---- Case 6: Edge — no exit proceeds -----------------------------------
+
+    def test_no_exit_proceeds_zero_distributions(self):
+        """If exit is $0 and no operating CFs, no one gets paid."""
+        config = self.simple_config()
+        result = run_waterfall(1_000_000, [0] * 5, 0, config)
+        assert result["lp_total_distributions"] == 0
+        assert result["gp_total_distributions"] == 0
+
+
+# ===========================================================================
+# 5. Solve-for-Price / Solve-for-Cap Regression
+# ===========================================================================
+
+class TestSolveConsistency:
+    """
+    Regression tests for the solver bug where solve_for_price used
+    pf["cash_flows"]["levered"][1:-1] (dropping year-N operating CF) instead
+    of matching the full_analysis cash-flow separation.
+
+    Invariant: at the price the solver returns, re-running the waterfall with
+    the CORRECT cash-flow setup should yield LP IRR ≈ target_lp_irr.
+    """
+
+    def _run_waterfall_correctly(self, deal, pf):
+        """Use the production helper so the test tracks the real code path."""
+        from services.waterfall_engine import waterfall_from_proforma
+        return waterfall_from_proforma(pf, deal.waterfall_config)
+
+    def test_solve_price_yields_target_lp_irr(self):
+        """
+        solve_for_price(deal, 14%) must return a price X such that
+        running the waterfall at X gives LP IRR ≈ 14%.
+        """
+        from services.waterfall_engine import solve_for_price
+        from copy import deepcopy
+
+        deal = sunset_ridge_deal()
+        target = 14.0
+
+        solved_price = solve_for_price(deal, target, build_proforma)
+        assert solved_price is not None
+
+        # Verify at the solved price LP IRR ≈ target
+        d = deepcopy(deal)
+        d.property_info.purchase_price = float(solved_price)
+        pf = build_proforma(d)
+        result = self._run_waterfall_correctly(d, pf)
+
+        assert result["lp_irr"] is not None, "LP IRR should be computable at solved price"
+        assert result["lp_irr"] == pytest.approx(target, abs=0.5), (
+            f"LP IRR at solved price {solved_price:,.0f} is {result['lp_irr']:.2f}%, "
+            f"expected ≈ {target}%"
+        )
+
+    def test_solve_price_lower_than_current_when_irr_deficit(self):
+        """
+        Regression: the solver must return a LOWER price than the current
+        purchase price when the current LP IRR is already below the target.
+        (The old bug returned a HIGHER price, e.g. $13.6M vs $9.5M input.)
+        """
+        from services.waterfall_engine import solve_for_price
+
+        deal = sunset_ridge_deal()
+        pf_current = build_proforma(deal)
+        current_lp_irr = self._run_waterfall_correctly(deal, pf_current)["lp_irr"]
+
+        target = 14.0
+        assert current_lp_irr < target, "Precondition: current LP IRR below target"
+
+        solved_price = solve_for_price(deal, target, build_proforma)
+        assert solved_price < deal.property_info.purchase_price, (
+            f"Solver returned {solved_price:,.0f} which is >= current price "
+            f"{deal.property_info.purchase_price:,.0f}. "
+            f"Current LP IRR is {current_lp_irr:.2f}% < target {target}%, "
+            f"so the max purchase price must be lower."
+        )
+
+    def test_solve_cap_yields_target_lp_irr(self):
+        """
+        solve_for_exit_cap(deal, 14%) must return an exit cap X such that
+        running the waterfall at X gives LP IRR ≈ 14%.
+        """
+        from services.waterfall_engine import solve_for_exit_cap
+        from copy import deepcopy
+
+        deal = sunset_ridge_deal()
+        target = 14.0
+
+        solved_cap = solve_for_exit_cap(deal, target, build_proforma)
+        assert solved_cap is not None
+
+        d = deepcopy(deal)
+        d.exit_assumptions.exit_cap_rate = float(solved_cap)
+        pf = build_proforma(d)
+        result = self._run_waterfall_correctly(d, pf)
+
+        assert result["lp_irr"] is not None
+        assert result["lp_irr"] == pytest.approx(target, abs=0.5), (
+            f"LP IRR at solved cap {solved_cap:.2f}% is {result['lp_irr']:.2f}%, "
+            f"expected ≈ {target}%"
+        )

--- a/cre-analyzer/frontend/index.html
+++ b/cre-analyzer/frontend/index.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CRE Deal Analyzer</title>
+    <style>
+      body { margin: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #f8fafc; }
+      #loading { display: flex; flex-direction: column; align-items: center; justify-content: center; min-height: 100vh; gap: 12px; color: #64748b; }
+      #loading .logo { width: 48px; height: 48px; background: #2563eb; border-radius: 12px; display: flex; align-items: center; justify-content: center; font-size: 24px; }
+      #loading h1 { font-size: 20px; font-weight: 700; color: #1e293b; margin: 0; }
+      #loading p { margin: 0; font-size: 14px; }
+    </style>
+  </head>
+  <body>
+    <div id="loading">
+      <div class="logo">🏢</div>
+      <h1>CRE Deal Analyzer</h1>
+      <p>Loading application...</p>
+    </div>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+    <script>
+      // Hide loading indicator once React mounts
+      document.addEventListener('DOMContentLoaded', () => {
+        const obs = new MutationObserver(() => {
+          const root = document.getElementById('root');
+          if (root && root.children.length > 0) {
+            const loading = document.getElementById('loading');
+            if (loading) loading.style.display = 'none';
+            obs.disconnect();
+          }
+        });
+        obs.observe(document.getElementById('root'), { childList: true });
+      });
+    </script>
+  </body>
+</html>

--- a/cre-analyzer/frontend/package.json
+++ b/cre-analyzer/frontend/package.json
@@ -6,30 +6,37 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
     "axios": "^1.7.2",
-    "zustand": "^4.5.4",
-    "recharts": "^2.12.7",
-    "xlsx": "^0.18.5",
+    "clsx": "^2.1.1",
     "jspdf": "^2.5.1",
     "jspdf-autotable": "^3.8.2",
+    "lucide-react": "^0.400.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "react-dropzone": "^14.2.3",
     "react-hook-form": "^7.52.1",
-    "clsx": "^2.1.1",
-    "lucide-react": "^0.400.0"
+    "recharts": "^2.12.7",
+    "xlsx": "^0.18.5",
+    "zustand": "^4.5.4"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.1",
     "autoprefixer": "^10.4.19",
+    "jsdom": "^29.1.1",
     "postcss": "^8.4.39",
     "tailwindcss": "^3.4.6",
     "typescript": "^5.5.3",
-    "vite": "^5.3.3"
+    "vite": "^5.3.3",
+    "vitest": "^4.1.6"
   }
 }

--- a/cre-analyzer/frontend/package.json
+++ b/cre-analyzer/frontend/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "cre-analyzer-frontend",
+  "private": true,
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "axios": "^1.7.2",
+    "zustand": "^4.5.4",
+    "recharts": "^2.12.7",
+    "xlsx": "^0.18.5",
+    "jspdf": "^2.5.1",
+    "jspdf-autotable": "^3.8.2",
+    "react-dropzone": "^14.2.3",
+    "react-hook-form": "^7.52.1",
+    "clsx": "^2.1.1",
+    "lucide-react": "^0.400.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.3.1",
+    "autoprefixer": "^10.4.19",
+    "postcss": "^8.4.39",
+    "tailwindcss": "^3.4.6",
+    "typescript": "^5.5.3",
+    "vite": "^5.3.3"
+  }
+}

--- a/cre-analyzer/frontend/postcss.config.js
+++ b/cre-analyzer/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/cre-analyzer/frontend/src/App.tsx
+++ b/cre-analyzer/frontend/src/App.tsx
@@ -1,0 +1,98 @@
+import React, { useEffect } from 'react';
+import clsx from 'clsx';
+import { Moon, Sun, Building2, RotateCcw, Upload } from 'lucide-react';
+import { useDealStore } from './store/dealStore';
+import { WizardNav } from './components/wizard/WizardNav';
+import { UploadPage } from './pages/Upload';
+import { ReviewDataPage } from './pages/ReviewData';
+import { AssumptionsPage } from './pages/Assumptions';
+import { FinancingPage } from './pages/Financing';
+import { WaterfallConfigPage } from './pages/WaterfallConfig';
+import { ResultsPage } from './pages/Results';
+import type { WizardStep } from './types/deal';
+
+const STEP_ORDER: WizardStep[] = ['upload', 'review', 'assumptions', 'financing', 'waterfall', 'results'];
+
+export default function App() {
+  const { step, darkMode, toggleDarkMode, setStep, resetDeal, deal, loadFromJson } = useDealStore();
+
+  // Apply dark mode class to document
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', darkMode);
+  }, [darkMode]);
+
+  const completedSteps = new Set<WizardStep>(
+    STEP_ORDER.slice(0, STEP_ORDER.indexOf(step))
+  );
+
+  const handleNavigate = (s: WizardStep) => setStep(s);
+
+  const handleFileLoad = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (ev) => {
+      const text = ev.target?.result as string;
+      loadFromJson(text);
+    };
+    reader.readAsText(file);
+    e.target.value = '';
+  };
+
+  return (
+    <div className={clsx('min-h-screen bg-gray-50 dark:bg-gray-950 transition-colors', darkMode && 'dark')}>
+      {/* Top Nav */}
+      <header className="sticky top-0 z-50 bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-800 shadow-sm">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 py-3 flex items-center gap-4">
+          <div className="flex items-center gap-2 flex-shrink-0">
+            <div className="w-8 h-8 rounded-lg bg-brand-600 flex items-center justify-center">
+              <Building2 size={16} className="text-white" />
+            </div>
+            <span className="font-bold text-gray-900 dark:text-white hidden sm:block">CRE Deal Analyzer</span>
+          </div>
+
+          <div className="flex-1 overflow-hidden">
+            <WizardNav current={step} completed={completedSteps} onNavigate={handleNavigate} />
+          </div>
+
+          <div className="flex items-center gap-2 flex-shrink-0">
+            <label className="btn-secondary cursor-pointer text-xs px-2 py-1.5">
+              <Upload size={12} />
+              <span className="hidden sm:inline">Load JSON</span>
+              <input type="file" accept=".json" className="sr-only" onChange={handleFileLoad} />
+            </label>
+            <button onClick={resetDeal} className="btn-secondary px-2 py-1.5 text-xs" title="New Deal">
+              <RotateCcw size={12} />
+            </button>
+            <button onClick={toggleDarkMode} className="btn-secondary px-2 py-1.5">
+              {darkMode ? <Sun size={14} /> : <Moon size={14} />}
+            </button>
+          </div>
+        </div>
+      </header>
+
+      {/* Deal name subtitle */}
+      <div className="bg-brand-600 dark:bg-brand-800 px-4 sm:px-6 py-2">
+        <div className="max-w-7xl mx-auto flex items-center justify-between">
+          <span className="text-sm text-brand-100 font-medium truncate">{deal.name || deal.property_info.name}</span>
+          <span className="text-xs text-brand-200">{deal.property_info.units} units · ${(deal.property_info.purchase_price / 1_000_000).toFixed(1)}M</span>
+        </div>
+      </div>
+
+      {/* Main Content */}
+      <main className="max-w-7xl mx-auto px-4 sm:px-6">
+        {step === 'upload' && <UploadPage />}
+        {step === 'review' && <ReviewDataPage />}
+        {step === 'assumptions' && <AssumptionsPage />}
+        {step === 'financing' && <FinancingPage />}
+        {step === 'waterfall' && <WaterfallConfigPage />}
+        {step === 'results' && <ResultsPage />}
+      </main>
+
+      {/* Footer */}
+      <footer className="mt-16 border-t border-gray-200 dark:border-gray-800 px-4 py-6 text-center text-xs text-gray-400">
+        CRE Deal Analyzer · Powered by Claude · For professional use only · Not financial advice
+      </footer>
+    </div>
+  );
+}

--- a/cre-analyzer/frontend/src/api/client.ts
+++ b/cre-analyzer/frontend/src/api/client.ts
@@ -1,0 +1,53 @@
+import axios from 'axios';
+import type { DealState, AnalysisResults, SensitivityResults } from '../types/deal';
+
+const api = axios.create({ baseURL: '/api' });
+
+export async function parseDocument(
+  file: File,
+  docType: 'om' | 't12' | 'rent_roll'
+) {
+  const form = new FormData();
+  form.append('file', file);
+  form.append('doc_type', docType);
+  const { data } = await api.post('/documents/parse', form);
+  return data;
+}
+
+export async function getDemoData() {
+  const { data } = await api.get('/documents/demo');
+  return data;
+}
+
+export async function runAnalysis(deal: DealState): Promise<AnalysisResults> {
+  const { data } = await api.post('/analysis/run', { deal });
+  return data;
+}
+
+export async function runSensitivity(deal: DealState): Promise<SensitivityResults> {
+  const { data } = await api.post('/analysis/sensitivity', { deal });
+  return data;
+}
+
+export async function solveDeal(
+  deal: DealState,
+  targetLpIrr: number,
+  solveFor: 'purchase_price' | 'exit_cap_rate'
+) {
+  const { data } = await api.post('/analysis/solve', {
+    deal,
+    target_lp_irr: targetLpIrr,
+    solve_for: solveFor,
+  });
+  return data;
+}
+
+export async function saveDeal(deal: DealState) {
+  const { data } = await api.post('/deals/', deal);
+  return data;
+}
+
+export async function loadDeal(dealId: string): Promise<DealState> {
+  const { data } = await api.get(`/deals/${dealId}`);
+  return data;
+}

--- a/cre-analyzer/frontend/src/components/charts/CashFlowChart.tsx
+++ b/cre-analyzer/frontend/src/components/charts/CashFlowChart.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import {
+  ComposedChart,
+  Bar,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from 'recharts';
+import type { AnnualRow } from '../../types/deal';
+
+interface Props {
+  rows: AnnualRow[];
+}
+
+const fmt = (v: number) =>
+  Math.abs(v) >= 1_000_000
+    ? `$${(v / 1_000_000).toFixed(1)}M`
+    : `$${(v / 1_000).toFixed(0)}K`;
+
+export function CashFlowChart({ rows }: Props) {
+  const data = rows.map((r) => ({
+    year: `Yr ${r.year}`,
+    NOI: r.noi,
+    'Debt Service': -r.debt_service,
+    'Levered CF': r.levered_cf,
+    EGI: r.egi,
+    OpEx: -r.total_expenses,
+  }));
+
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <ComposedChart data={data} margin={{ top: 8, right: 16, left: 16, bottom: 4 }}>
+        <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+        <XAxis dataKey="year" tick={{ fontSize: 11 }} />
+        <YAxis tickFormatter={fmt} tick={{ fontSize: 11 }} width={60} />
+        <Tooltip
+          formatter={(v: number) => fmt(v)}
+          contentStyle={{ fontSize: 12 }}
+        />
+        <Legend wrapperStyle={{ fontSize: 12 }} />
+        <Bar dataKey="NOI" fill="#3b82f6" radius={[3, 3, 0, 0]} />
+        <Bar dataKey="Debt Service" fill="#f87171" radius={[3, 3, 0, 0]} />
+        <Line
+          type="monotone"
+          dataKey="Levered CF"
+          stroke="#10b981"
+          strokeWidth={2}
+          dot={{ r: 4 }}
+        />
+      </ComposedChart>
+    </ResponsiveContainer>
+  );
+}
+
+export function NOIGrowthChart({ rows }: Props) {
+  const data = rows.map((r) => ({
+    year: `Yr ${r.year}`,
+    GPR: r.gross_potential_rent,
+    EGI: r.egi,
+    NOI: r.noi,
+  }));
+
+  return (
+    <ResponsiveContainer width="100%" height={250}>
+      <ComposedChart data={data} margin={{ top: 8, right: 16, left: 16, bottom: 4 }}>
+        <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+        <XAxis dataKey="year" tick={{ fontSize: 11 }} />
+        <YAxis tickFormatter={fmt} tick={{ fontSize: 11 }} width={60} />
+        <Tooltip formatter={(v: number) => fmt(v)} contentStyle={{ fontSize: 12 }} />
+        <Legend wrapperStyle={{ fontSize: 12 }} />
+        <Line type="monotone" dataKey="GPR" stroke="#6366f1" strokeWidth={2} dot={{ r: 3 }} />
+        <Line type="monotone" dataKey="EGI" stroke="#3b82f6" strokeWidth={2} dot={{ r: 3 }} />
+        <Line type="monotone" dataKey="NOI" stroke="#10b981" strokeWidth={2.5} dot={{ r: 4 }} />
+      </ComposedChart>
+    </ResponsiveContainer>
+  );
+}

--- a/cre-analyzer/frontend/src/components/charts/SensitivityHeatmap.tsx
+++ b/cre-analyzer/frontend/src/components/charts/SensitivityHeatmap.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import clsx from 'clsx';
+import type { SensitivityTable } from '../../types/deal';
+
+interface Props {
+  table: SensitivityTable;
+  title: string;
+  rowLabel: string;
+  colLabel: string;
+  formatRow?: (v: number) => string;
+  formatCol?: (v: number) => string;
+  formatCell?: (v: number) => string;
+  thresholds?: { green: number; yellow: number }; // above green=green, above yellow=yellow, else red
+}
+
+function cellColor(val: number | null, thresholds: { green: number; yellow: number }): string {
+  if (val == null) return 'bg-gray-100 dark:bg-gray-700 text-gray-400';
+  if (val >= thresholds.green) return 'bg-emerald-100 dark:bg-emerald-900/40 text-emerald-800 dark:text-emerald-300 font-semibold';
+  if (val >= thresholds.yellow) return 'bg-amber-100 dark:bg-amber-900/40 text-amber-800 dark:text-amber-300';
+  return 'bg-red-100 dark:bg-red-900/40 text-red-800 dark:text-red-300';
+}
+
+const fmtDefault = (v: number) => v.toFixed(2);
+
+export function SensitivityHeatmap({
+  table,
+  title,
+  rowLabel,
+  colLabel,
+  formatRow = fmtDefault,
+  formatCol = fmtDefault,
+  formatCell = fmtDefault,
+  thresholds = { green: 14, yellow: 10 },
+}: Props) {
+  return (
+    <div className="overflow-x-auto">
+      <div className="mb-2">
+        <h4 className="text-sm font-semibold text-gray-800 dark:text-gray-200">{title}</h4>
+        <p className="text-xs text-gray-500">
+          Row: {rowLabel} &nbsp;|&nbsp; Col: {colLabel}
+        </p>
+      </div>
+      <table className="text-xs border-collapse w-full">
+        <thead>
+          <tr>
+            <th className="px-2 py-1.5 text-left text-gray-500 dark:text-gray-400 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 font-medium">
+              {rowLabel} ↓ / {colLabel} →
+            </th>
+            {table.col_values.map((cv) => (
+              <th
+                key={cv}
+                className="px-2 py-1.5 text-center text-gray-600 dark:text-gray-300 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 font-medium whitespace-nowrap"
+              >
+                {formatCol(cv)}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {table.row_values.map((rv, ri) => (
+            <tr key={rv}>
+              <td className="px-2 py-1.5 text-left text-gray-600 dark:text-gray-300 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 font-medium whitespace-nowrap">
+                {formatRow(rv)}
+              </td>
+              {table.col_values.map((_, ci) => {
+                const val = table.table[ri]?.[ci] ?? null;
+                return (
+                  <td
+                    key={ci}
+                    className={clsx(
+                      'px-2 py-1.5 text-center border border-gray-200 dark:border-gray-700 tabular-nums',
+                      cellColor(val, thresholds)
+                    )}
+                  >
+                    {val != null ? formatCell(val) : '—'}
+                  </td>
+                );
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <div className="flex items-center gap-4 mt-2">
+        {[
+          { cls: 'bg-emerald-100 dark:bg-emerald-900/40', label: `≥ ${thresholds.green}%` },
+          { cls: 'bg-amber-100 dark:bg-amber-900/40', label: `${thresholds.yellow}–${thresholds.green}%` },
+          { cls: 'bg-red-100 dark:bg-red-900/40', label: `< ${thresholds.yellow}%` },
+        ].map((leg) => (
+          <div key={leg.label} className="flex items-center gap-1.5">
+            <div className={clsx('w-3 h-3 rounded-sm', leg.cls)} />
+            <span className="text-xs text-gray-500">{leg.label}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/cre-analyzer/frontend/src/components/charts/WaterfallChart.tsx
+++ b/cre-analyzer/frontend/src/components/charts/WaterfallChart.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+  Cell,
+} from 'recharts';
+import type { WaterfallYear } from '../../types/deal';
+
+interface Props {
+  years: WaterfallYear[];
+}
+
+const fmt = (v: number) =>
+  Math.abs(v) >= 1_000_000
+    ? `$${(v / 1_000_000).toFixed(2)}M`
+    : `$${(v / 1_000).toFixed(0)}K`;
+
+export function WaterfallDistributionChart({ years }: Props) {
+  const data = years.map((y) => ({
+    name: y.is_exit ? `Yr ${y.year}\n(Exit)` : `Yr ${y.year}`,
+    'RoC (LP)': y.tier_roc_lp,
+    'Pref Return': y.tier_preferred_return,
+    'GP Catch-up': y.tier_gp_catchup,
+    'LP Promote': y.tier_lp_promote,
+    'GP Promote': y.tier_gp_promote,
+    'RoC (GP)': y.tier_roc_gp,
+  }));
+
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <BarChart data={data} margin={{ top: 8, right: 16, left: 16, bottom: 4 }}>
+        <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+        <XAxis dataKey="name" tick={{ fontSize: 10 }} />
+        <YAxis tickFormatter={fmt} tick={{ fontSize: 11 }} width={70} />
+        <Tooltip formatter={(v: number) => fmt(v)} contentStyle={{ fontSize: 12 }} />
+        <Legend wrapperStyle={{ fontSize: 11 }} />
+        <Bar dataKey="RoC (LP)" stackId="a" fill="#93c5fd" />
+        <Bar dataKey="RoC (GP)" stackId="a" fill="#c4b5fd" />
+        <Bar dataKey="Pref Return" stackId="a" fill="#6ee7b7" />
+        <Bar dataKey="GP Catch-up" stackId="a" fill="#fcd34d" />
+        <Bar dataKey="LP Promote" stackId="a" fill="#3b82f6" radius={[0, 0, 0, 0]} />
+        <Bar dataKey="GP Promote" stackId="a" fill="#8b5cf6" radius={[3, 3, 0, 0]} />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}
+
+export function LPGPSplitChart({ years }: Props) {
+  const data = years.map((y) => ({
+    name: y.is_exit ? `Exit` : `Yr ${y.year}`,
+    LP: y.lp_distribution,
+    GP: y.gp_distribution,
+  }));
+
+  return (
+    <ResponsiveContainer width="100%" height={250}>
+      <BarChart data={data} margin={{ top: 8, right: 16, left: 16, bottom: 4 }}>
+        <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+        <XAxis dataKey="name" tick={{ fontSize: 11 }} />
+        <YAxis tickFormatter={fmt} tick={{ fontSize: 11 }} width={70} />
+        <Tooltip formatter={(v: number) => fmt(v)} contentStyle={{ fontSize: 12 }} />
+        <Legend wrapperStyle={{ fontSize: 12 }} />
+        <Bar dataKey="LP" fill="#3b82f6" radius={[3, 3, 0, 0]} />
+        <Bar dataKey="GP" fill="#8b5cf6" radius={[3, 3, 0, 0]} />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/cre-analyzer/frontend/src/components/tables/CashFlowTable.tsx
+++ b/cre-analyzer/frontend/src/components/tables/CashFlowTable.tsx
@@ -1,0 +1,156 @@
+import React, { useState } from 'react';
+import clsx from 'clsx';
+import type { AnnualRow, ExitSummary } from '../../types/deal';
+import { fmtCurrency, fmtPct, fmtNum } from '../../utils/calculations';
+
+interface Props {
+  rows: AnnualRow[];
+  exit: ExitSummary;
+}
+
+type Section = 'income' | 'expenses' | 'summary';
+
+interface RowDef {
+  key: keyof AnnualRow | string;
+  label: string;
+  bold?: boolean;
+  indent?: boolean;
+  negative?: boolean;
+  pct?: boolean;
+  separator?: boolean;
+}
+
+const INCOME_ROWS: RowDef[] = [
+  { key: 'gross_potential_rent', label: 'Gross Potential Rent', bold: false },
+  { key: 'vacancy_loss', label: 'Less: Vacancy Loss', indent: true, negative: true },
+  { key: 'credit_loss', label: 'Less: Credit Loss', indent: true, negative: true },
+  { key: 'other_income', label: 'Plus: Other Income', indent: true },
+  { key: 'egi', label: 'Effective Gross Income', bold: true, separator: true },
+];
+
+const EXPENSE_ROWS: RowDef[] = [
+  { key: 'property_taxes', label: 'Property Taxes', indent: true, negative: true },
+  { key: 'insurance', label: 'Insurance', indent: true, negative: true },
+  { key: 'management_fee', label: 'Management Fee', indent: true, negative: true },
+  { key: 'maintenance', label: 'Maintenance & Repairs', indent: true, negative: true },
+  { key: 'utilities', label: 'Utilities', indent: true, negative: true },
+  { key: 'payroll', label: 'Payroll', indent: true, negative: true },
+  { key: 'general_admin', label: 'General & Admin', indent: true, negative: true },
+  { key: 'marketing', label: 'Marketing', indent: true, negative: true },
+  { key: 'capex_reserves', label: 'CapEx Reserves', indent: true, negative: true },
+  { key: 'total_expenses', label: 'Total Operating Expenses', bold: true, negative: true },
+];
+
+const SUMMARY_ROWS: RowDef[] = [
+  { key: 'noi', label: 'Net Operating Income', bold: true, separator: true },
+  { key: 'debt_service', label: 'Less: Debt Service', indent: true, negative: true },
+  { key: 'levered_cf', label: 'Levered Cash Flow', bold: true },
+  { key: 'dscr', label: 'DSCR', pct: false },
+];
+
+export function CashFlowTable({ rows, exit }: Props) {
+  const [collapsed, setCollapsed] = useState<Set<Section>>(new Set());
+
+  const toggle = (s: Section) =>
+    setCollapsed((prev) => {
+      const next = new Set(prev);
+      next.has(s) ? next.delete(s) : next.add(s);
+      return next;
+    });
+
+  const renderRow = (def: RowDef) => (
+    <tr
+      key={def.key}
+      className={clsx(
+        'hover:bg-gray-50 dark:hover:bg-gray-700/30',
+        def.separator && 'border-t-2 border-gray-300 dark:border-gray-600'
+      )}
+    >
+      <td className={clsx('px-3 py-1.5 text-sm text-left', def.indent && 'pl-6', def.bold && 'font-semibold')}>
+        {def.label}
+      </td>
+      {rows.map((r) => {
+        const raw = r[def.key as keyof AnnualRow] as number | null;
+        const display =
+          def.pct === false && def.key === 'dscr'
+            ? fmtNum(raw)
+            : fmtCurrency(raw);
+        return (
+          <td
+            key={r.year}
+            className={clsx(
+              'table-cell',
+              def.bold && 'font-semibold',
+              def.negative && typeof raw === 'number' && raw > 0 && 'text-red-500'
+            )}
+          >
+            {def.negative && typeof raw === 'number' && raw > 0 ? `(${fmtCurrency(raw)})` : display}
+          </td>
+        );
+      })}
+    </tr>
+  );
+
+  const headerCls = 'bg-gray-100 dark:bg-gray-700 text-left px-3 py-1.5 text-xs font-semibold text-gray-600 dark:text-gray-300 uppercase tracking-wide cursor-pointer hover:bg-gray-200 dark:hover:bg-gray-600 select-none';
+
+  return (
+    <div className="overflow-x-auto text-sm">
+      <table className="w-full border-collapse">
+        <thead>
+          <tr>
+            <th className="table-header text-left px-3 py-2 text-gray-600 dark:text-gray-300">Line Item</th>
+            {rows.map((r) => (
+              <th key={r.year} className="table-header">Year {r.year}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {/* Income */}
+          <tr>
+            <td
+              colSpan={rows.length + 1}
+              className={headerCls}
+              onClick={() => toggle('income')}
+            >
+              {collapsed.has('income') ? '▶' : '▼'} Income
+            </td>
+          </tr>
+          {!collapsed.has('income') && INCOME_ROWS.map(renderRow)}
+
+          {/* Expenses */}
+          <tr>
+            <td
+              colSpan={rows.length + 1}
+              className={headerCls}
+              onClick={() => toggle('expenses')}
+            >
+              {collapsed.has('expenses') ? '▶' : '▼'} Operating Expenses
+            </td>
+          </tr>
+          {!collapsed.has('expenses') && EXPENSE_ROWS.map(renderRow)}
+
+          {/* Summary */}
+          <tr>
+            <td
+              colSpan={rows.length + 1}
+              className={headerCls}
+              onClick={() => toggle('summary')}
+            >
+              {collapsed.has('summary') ? '▶' : '▼'} Cash Flow Summary
+            </td>
+          </tr>
+          {!collapsed.has('summary') && SUMMARY_ROWS.map(renderRow)}
+
+          {/* Exit row */}
+          <tr className="border-t-2 border-gray-300 dark:border-gray-600 bg-brand-50 dark:bg-brand-900/20">
+            <td className="px-3 py-2 text-sm font-bold text-brand-800 dark:text-brand-300">Exit / Reversion</td>
+            <td colSpan={rows.length - 1} />
+            <td className="table-cell font-bold text-brand-700 dark:text-brand-300">
+              {fmtCurrency(exit.net_sale_proceeds)}
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/cre-analyzer/frontend/src/components/tables/RentRollTable.tsx
+++ b/cre-analyzer/frontend/src/components/tables/RentRollTable.tsx
@@ -1,0 +1,104 @@
+import React, { useState } from 'react';
+import clsx from 'clsx';
+import type { RentRollUnit } from '../../types/deal';
+import { fmtCurrency } from '../../utils/calculations';
+
+interface Props {
+  units: RentRollUnit[];
+  onEdit?: (idx: number, field: keyof RentRollUnit, value: string | number) => void;
+}
+
+const statusColors: Record<string, string> = {
+  Occupied: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-400',
+  Vacant: 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-400',
+  MTM: 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-400',
+};
+
+export function RentRollTable({ units, onEdit }: Props) {
+  const [page, setPage] = useState(0);
+  const PER_PAGE = 20;
+  const pages = Math.ceil(units.length / PER_PAGE);
+  const visible = units.slice(page * PER_PAGE, (page + 1) * PER_PAGE);
+
+  const summary = {
+    total: units.length,
+    occupied: units.filter((u) => u.status === 'Occupied').length,
+    vacant: units.filter((u) => u.status === 'Vacant').length,
+    mtm: units.filter((u) => u.status === 'MTM').length,
+    avgMarket: units.length ? units.reduce((s, u) => s + u.market_rent, 0) / units.length : 0,
+    avgCurrent: units.length ? units.reduce((s, u) => s + u.current_rent, 0) / units.length : 0,
+  };
+
+  return (
+    <div>
+      {/* Summary bar */}
+      <div className="flex flex-wrap gap-4 mb-3 text-xs">
+        {[
+          { label: 'Total', value: summary.total },
+          { label: 'Occupied', value: summary.occupied, cls: 'text-emerald-600' },
+          { label: 'Vacant', value: summary.vacant, cls: 'text-red-500' },
+          { label: 'MTM', value: summary.mtm, cls: 'text-amber-500' },
+          { label: 'Occ %', value: `${summary.total ? ((summary.occupied / summary.total) * 100).toFixed(1) : 0}%` },
+          { label: 'Avg Market', value: fmtCurrency(summary.avgMarket) },
+          { label: 'Avg Current', value: fmtCurrency(summary.avgCurrent) },
+        ].map((s) => (
+          <div key={s.label} className="flex gap-1">
+            <span className="text-gray-500">{s.label}:</span>
+            <span className={clsx('font-semibold', s.cls)}>{s.value}</span>
+          </div>
+        ))}
+      </div>
+
+      <div className="overflow-x-auto">
+        <table className="w-full border-collapse text-xs">
+          <thead>
+            <tr>
+              {['Unit', 'Type', 'SqFt', 'Market Rent', 'Current Rent', 'Lease End', 'Status'].map((h) => (
+                <th key={h} className="table-header">{h}</th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {visible.map((u, i) => (
+              <tr key={i} className={i % 2 === 0 ? 'table-row-alt' : ''}>
+                <td className="table-cell text-left font-mono">{u.unit_number}</td>
+                <td className="table-cell text-left">{u.unit_type}</td>
+                <td className="table-cell">{u.sqft.toLocaleString()}</td>
+                <td className="table-cell">{fmtCurrency(u.market_rent)}</td>
+                <td className={clsx('table-cell', u.current_rent < u.market_rent ? 'text-amber-600 dark:text-amber-400' : '')}>
+                  {fmtCurrency(u.current_rent)}
+                </td>
+                <td className="table-cell">{u.lease_end || '—'}</td>
+                <td className="table-cell text-center">
+                  <span className={clsx('px-1.5 py-0.5 rounded-full text-xs font-medium', statusColors[u.status])}>
+                    {u.status}
+                  </span>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {pages > 1 && (
+        <div className="flex items-center justify-center gap-2 mt-3">
+          <button
+            className="btn-secondary px-2 py-1 text-xs"
+            disabled={page === 0}
+            onClick={() => setPage((p) => p - 1)}
+          >
+            ←
+          </button>
+          <span className="text-xs text-gray-500">Page {page + 1} of {pages}</span>
+          <button
+            className="btn-secondary px-2 py-1 text-xs"
+            disabled={page === pages - 1}
+            onClick={() => setPage((p) => p + 1)}
+          >
+            →
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/cre-analyzer/frontend/src/components/tables/WaterfallTable.tsx
+++ b/cre-analyzer/frontend/src/components/tables/WaterfallTable.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import clsx from 'clsx';
+import type { WaterfallYear } from '../../types/deal';
+import { fmtCurrency } from '../../utils/calculations';
+
+interface Props {
+  years: WaterfallYear[];
+}
+
+export function WaterfallTable({ years }: Props) {
+  const totals = years.reduce(
+    (acc, y) => ({
+      distributable: acc.distributable + y.distributable,
+      lp: acc.lp + y.lp_distribution,
+      gp: acc.gp + y.gp_distribution,
+      roc_lp: acc.roc_lp + y.tier_roc_lp,
+      roc_gp: acc.roc_gp + y.tier_roc_gp,
+      pref: acc.pref + y.tier_preferred_return,
+      catchup: acc.catchup + y.tier_gp_catchup,
+      lp_prom: acc.lp_prom + y.tier_lp_promote,
+      gp_prom: acc.gp_prom + y.tier_gp_promote,
+    }),
+    { distributable: 0, lp: 0, gp: 0, roc_lp: 0, roc_gp: 0, pref: 0, catchup: 0, lp_prom: 0, gp_prom: 0 }
+  );
+
+  const cols = [
+    { key: 'distributable', label: 'Distributable' },
+    { key: 'lp_distribution', label: 'LP Total' },
+    { key: 'gp_distribution', label: 'GP Total' },
+    { key: 'tier_roc_lp', label: 'RoC (LP)' },
+    { key: 'tier_roc_gp', label: 'RoC (GP)' },
+    { key: 'tier_preferred_return', label: 'Pref Return' },
+    { key: 'tier_gp_catchup', label: 'GP Catch-up' },
+    { key: 'tier_lp_promote', label: 'LP Promote' },
+    { key: 'tier_gp_promote', label: 'GP Promote' },
+  ] as const;
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full border-collapse text-xs">
+        <thead>
+          <tr>
+            <th className="table-header text-left">Period</th>
+            {cols.map((c) => (
+              <th key={c.key} className="table-header">{c.label}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {years.map((y, i) => (
+            <tr
+              key={y.year}
+              className={clsx(
+                i % 2 === 0 ? 'table-row-alt' : '',
+                y.is_exit && 'bg-brand-50 dark:bg-brand-900/20 font-semibold'
+              )}
+            >
+              <td className="px-3 py-1.5 text-left font-medium">
+                {y.is_exit ? `Year ${y.year} (Exit)` : `Year ${y.year}`}
+              </td>
+              {cols.map((c) => (
+                <td key={c.key} className="table-cell">
+                  {fmtCurrency(y[c.key as keyof WaterfallYear] as number)}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+        <tfoot>
+          <tr className="border-t-2 border-gray-300 dark:border-gray-600 font-bold bg-gray-100 dark:bg-gray-700">
+            <td className="px-3 py-2 text-left">Total</td>
+            <td className="table-cell">{fmtCurrency(totals.distributable)}</td>
+            <td className="table-cell text-brand-600 dark:text-brand-400">{fmtCurrency(totals.lp)}</td>
+            <td className="table-cell text-purple-600 dark:text-purple-400">{fmtCurrency(totals.gp)}</td>
+            <td className="table-cell">{fmtCurrency(totals.roc_lp)}</td>
+            <td className="table-cell">{fmtCurrency(totals.roc_gp)}</td>
+            <td className="table-cell">{fmtCurrency(totals.pref)}</td>
+            <td className="table-cell">{fmtCurrency(totals.catchup)}</td>
+            <td className="table-cell">{fmtCurrency(totals.lp_prom)}</td>
+            <td className="table-cell">{fmtCurrency(totals.gp_prom)}</td>
+          </tr>
+        </tfoot>
+      </table>
+    </div>
+  );
+}

--- a/cre-analyzer/frontend/src/components/ui/Button.tsx
+++ b/cre-analyzer/frontend/src/components/ui/Button.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import clsx from 'clsx';
+import { Loader2 } from 'lucide-react';
+
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'primary' | 'secondary' | 'danger' | 'ghost';
+  size?: 'sm' | 'md' | 'lg';
+  loading?: boolean;
+  icon?: React.ReactNode;
+}
+
+export function Button({
+  variant = 'primary',
+  size = 'md',
+  loading,
+  icon,
+  children,
+  className,
+  disabled,
+  ...props
+}: ButtonProps) {
+  const variants = {
+    primary: 'btn-primary',
+    secondary: 'btn-secondary',
+    danger: 'inline-flex items-center gap-2 rounded-lg bg-red-600 hover:bg-red-700 text-white px-4 py-2 text-sm font-medium transition disabled:opacity-50',
+    ghost: 'inline-flex items-center gap-2 rounded-lg text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 px-3 py-2 text-sm font-medium transition',
+  };
+  const sizes = {
+    sm: 'px-3 py-1.5 text-xs',
+    md: 'px-4 py-2 text-sm',
+    lg: 'px-5 py-2.5 text-base',
+  };
+
+  return (
+    <button
+      className={clsx(variants[variant], size !== 'md' && sizes[size], className)}
+      disabled={disabled || loading}
+      {...props}
+    >
+      {loading ? <Loader2 size={14} className="animate-spin" /> : icon}
+      {children}
+    </button>
+  );
+}

--- a/cre-analyzer/frontend/src/components/ui/Card.tsx
+++ b/cre-analyzer/frontend/src/components/ui/Card.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import clsx from 'clsx';
+
+interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
+  title?: string;
+  subtitle?: string;
+  action?: React.ReactNode;
+  padding?: boolean;
+}
+
+export function Card({ title, subtitle, action, padding = true, className, children, ...props }: CardProps) {
+  return (
+    <div className={clsx('card', className)} {...props}>
+      {(title || action) && (
+        <div className="flex items-center justify-between px-5 pt-4 pb-2">
+          <div>
+            {title && <h3 className="text-sm font-semibold text-gray-800 dark:text-gray-200">{title}</h3>}
+            {subtitle && <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">{subtitle}</p>}
+          </div>
+          {action && <div className="flex-shrink-0">{action}</div>}
+        </div>
+      )}
+      <div className={padding ? 'p-5 pt-2' : ''}>{children}</div>
+    </div>
+  );
+}
+
+interface MetricCardProps {
+  label: string;
+  value: string | number;
+  sub?: string;
+  highlight?: 'green' | 'yellow' | 'red' | 'blue' | 'default';
+}
+
+export function MetricCard({ label, value, sub, highlight = 'default' }: MetricCardProps) {
+  const colors: Record<string, string> = {
+    green: 'text-emerald-600 dark:text-emerald-400',
+    yellow: 'text-amber-500 dark:text-amber-400',
+    red: 'text-red-500 dark:text-red-400',
+    blue: 'text-brand-600 dark:text-brand-400',
+    default: 'text-gray-900 dark:text-white',
+  };
+  return (
+    <div className="metric-card">
+      <span className="label">{label}</span>
+      <span className={clsx('text-2xl font-bold', colors[highlight])}>{value}</span>
+      {sub && <span className="text-xs text-gray-500 dark:text-gray-400">{sub}</span>}
+    </div>
+  );
+}

--- a/cre-analyzer/frontend/src/components/ui/Input.tsx
+++ b/cre-analyzer/frontend/src/components/ui/Input.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import clsx from 'clsx';
+
+interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  label?: string;
+  suffix?: string;
+  prefix?: string;
+  hint?: string;
+  error?: string;
+}
+
+export function Input({ label, suffix, prefix, hint, error, className, ...props }: InputProps) {
+  return (
+    <div className="flex flex-col gap-1">
+      {label && (
+        <label className="text-xs font-medium text-gray-600 dark:text-gray-400">{label}</label>
+      )}
+      <div className="relative flex items-center">
+        {prefix && (
+          <span className="absolute left-3 text-sm text-gray-400 pointer-events-none">{prefix}</span>
+        )}
+        <input
+          className={clsx(
+            'input-field',
+            prefix && 'pl-7',
+            suffix && 'pr-10',
+            error && 'border-red-400 focus:ring-red-400',
+            className
+          )}
+          {...props}
+        />
+        {suffix && (
+          <span className="absolute right-3 text-sm text-gray-400 pointer-events-none">{suffix}</span>
+        )}
+      </div>
+      {hint && !error && <span className="text-xs text-gray-400">{hint}</span>}
+      {error && <span className="text-xs text-red-500">{error}</span>}
+    </div>
+  );
+}
+
+interface SelectProps extends React.SelectHTMLAttributes<HTMLSelectElement> {
+  label?: string;
+  options: { value: string | number; label: string }[];
+}
+
+export function Select({ label, options, className, ...props }: SelectProps) {
+  return (
+    <div className="flex flex-col gap-1">
+      {label && <label className="text-xs font-medium text-gray-600 dark:text-gray-400">{label}</label>}
+      <select className={clsx('input-field', className)} {...props}>
+        {options.map((o) => (
+          <option key={o.value} value={o.value}>{o.label}</option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+interface ToggleProps {
+  label: string;
+  checked: boolean;
+  onChange: (v: boolean) => void;
+  hint?: string;
+}
+
+export function Toggle({ label, checked, onChange, hint }: ToggleProps) {
+  return (
+    <label className="flex items-center gap-3 cursor-pointer">
+      <div className="relative">
+        <input
+          type="checkbox"
+          className="sr-only"
+          checked={checked}
+          onChange={(e) => onChange(e.target.checked)}
+        />
+        <div className={clsx(
+          'w-10 h-6 rounded-full transition',
+          checked ? 'bg-brand-600' : 'bg-gray-300 dark:bg-gray-600'
+        )} />
+        <div className={clsx(
+          'absolute top-1 left-1 w-4 h-4 rounded-full bg-white shadow transition-transform',
+          checked && 'translate-x-4'
+        )} />
+      </div>
+      <div>
+        <span className="text-sm font-medium text-gray-700 dark:text-gray-300">{label}</span>
+        {hint && <p className="text-xs text-gray-500">{hint}</p>}
+      </div>
+    </label>
+  );
+}

--- a/cre-analyzer/frontend/src/components/ui/NumericInput.tsx
+++ b/cre-analyzer/frontend/src/components/ui/NumericInput.tsx
@@ -1,0 +1,103 @@
+import React, { useState, useEffect } from 'react';
+import clsx from 'clsx';
+
+interface NumericInputProps {
+  label?: string;
+  value: number;
+  onChange: (value: number) => void;
+  prefix?: string;
+  suffix?: string;
+  hint?: string;
+  decimals?: number;
+  className?: string;
+  disabled?: boolean;
+}
+
+function formatWithCommas(n: number, decimals = 0): string {
+  if (!isFinite(n)) return '';
+  return n.toLocaleString('en-US', {
+    minimumFractionDigits: decimals,
+    maximumFractionDigits: decimals,
+  });
+}
+
+function parseFormatted(s: string): number {
+  const cleaned = s.replace(/,/g, '').trim();
+  const n = parseFloat(cleaned);
+  return isNaN(n) ? 0 : n;
+}
+
+/**
+ * A text input that displays numbers with thousands commas when not focused,
+ * and allows free-form numeric entry when focused.
+ */
+export function NumericInput({
+  label,
+  value,
+  onChange,
+  prefix,
+  suffix,
+  hint,
+  decimals = 0,
+  className,
+  disabled,
+}: NumericInputProps) {
+  const [focused, setFocused] = useState(false);
+  const [raw, setRaw] = useState('');
+
+  // When focus is gained, populate raw with the plain number string
+  const handleFocus = () => {
+    setRaw(value === 0 ? '' : String(value));
+    setFocused(true);
+  };
+
+  const handleBlur = () => {
+    setFocused(false);
+    const parsed = parseFormatted(raw);
+    onChange(parsed);
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    // Allow digits, commas, dots, minus
+    const v = e.target.value.replace(/[^0-9.,\-]/g, '');
+    setRaw(v);
+  };
+
+  const displayValue = focused ? raw : formatWithCommas(value, decimals);
+
+  return (
+    <div className="flex flex-col gap-1">
+      {label && (
+        <label className="text-xs font-medium text-gray-600 dark:text-gray-400">{label}</label>
+      )}
+      <div className="relative flex items-center">
+        {prefix && (
+          <span className="absolute left-3 text-sm text-gray-400 pointer-events-none select-none">
+            {prefix}
+          </span>
+        )}
+        <input
+          type="text"
+          inputMode="numeric"
+          className={clsx(
+            'input-field tabular-nums',
+            prefix && 'pl-7',
+            suffix && 'pr-10',
+            className
+          )}
+          value={displayValue}
+          onFocus={handleFocus}
+          onBlur={handleBlur}
+          onChange={handleChange}
+          disabled={disabled}
+        />
+        {suffix && (
+          <span className="absolute right-3 text-sm text-gray-400 pointer-events-none select-none">
+            {suffix}
+          </span>
+        )}
+      </div>
+      {hint && <span className="text-xs text-gray-400">{hint}</span>}
+    </div>
+  );
+}

--- a/cre-analyzer/frontend/src/components/wizard/WizardNav.tsx
+++ b/cre-analyzer/frontend/src/components/wizard/WizardNav.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import clsx from 'clsx';
+import { Check } from 'lucide-react';
+import type { WizardStep } from '../../types/deal';
+
+const STEPS: { id: WizardStep; label: string; short: string }[] = [
+  { id: 'upload', label: 'Upload Docs', short: 'Upload' },
+  { id: 'review', label: 'Review Data', short: 'Review' },
+  { id: 'assumptions', label: 'Assumptions', short: 'Assume' },
+  { id: 'financing', label: 'Financing', short: 'Finance' },
+  { id: 'waterfall', label: 'Waterfall', short: 'Waterfall' },
+  { id: 'results', label: 'Results', short: 'Results' },
+];
+
+interface Props {
+  current: WizardStep;
+  completed: Set<WizardStep>;
+  onNavigate: (step: WizardStep) => void;
+}
+
+export function WizardNav({ current, completed, onNavigate }: Props) {
+  return (
+    <nav className="flex items-center gap-0 overflow-x-auto">
+      {STEPS.map((step, i) => {
+        const isCompleted = completed.has(step.id);
+        const isCurrent = step.id === current;
+        const isAccessible = isCompleted || isCurrent;
+
+        return (
+          <React.Fragment key={step.id}>
+            {i > 0 && (
+              <div className={clsx(
+                'h-0.5 flex-1 min-w-4',
+                isCompleted ? 'bg-brand-500' : 'bg-gray-200 dark:bg-gray-700'
+              )} />
+            )}
+            <button
+              onClick={() => isAccessible && onNavigate(step.id)}
+              disabled={!isAccessible}
+              className={clsx(
+                'flex flex-col items-center gap-1 flex-shrink-0',
+                isAccessible ? 'cursor-pointer' : 'cursor-not-allowed opacity-40'
+              )}
+            >
+              <div className={clsx(
+                'w-8 h-8 rounded-full flex items-center justify-center text-xs font-semibold transition',
+                isCurrent && 'bg-brand-600 text-white ring-2 ring-brand-300',
+                isCompleted && !isCurrent && 'bg-brand-600 text-white',
+                !isCurrent && !isCompleted && 'bg-gray-200 dark:bg-gray-700 text-gray-500'
+              )}>
+                {isCompleted && !isCurrent ? <Check size={14} /> : i + 1}
+              </div>
+              <span className={clsx(
+                'text-xs font-medium hidden sm:block',
+                isCurrent ? 'text-brand-600 dark:text-brand-400' : 'text-gray-500'
+              )}>
+                {step.short}
+              </span>
+            </button>
+          </React.Fragment>
+        );
+      })}
+    </nav>
+  );
+}

--- a/cre-analyzer/frontend/src/index.css
+++ b/cre-analyzer/frontend/src/index.css
@@ -1,0 +1,50 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  body {
+    @apply bg-gray-50 text-gray-900 antialiased;
+  }
+  .dark body {
+    @apply bg-gray-950 text-gray-100;
+  }
+}
+
+@layer components {
+  .card {
+    @apply bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm;
+  }
+  .input-field {
+    @apply block w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 px-3 py-2 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent transition;
+  }
+  .btn-primary {
+    @apply inline-flex items-center gap-2 rounded-lg bg-brand-600 hover:bg-brand-700 text-white px-4 py-2 text-sm font-medium transition disabled:opacity-50 disabled:cursor-not-allowed;
+  }
+  .btn-secondary {
+    @apply inline-flex items-center gap-2 rounded-lg bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-300 px-4 py-2 text-sm font-medium transition;
+  }
+  .metric-card {
+    @apply card p-4 flex flex-col gap-1;
+  }
+  .label {
+    @apply text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide;
+  }
+  .value-lg {
+    @apply text-2xl font-bold text-gray-900 dark:text-white;
+  }
+  .table-header {
+    @apply text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide px-3 py-2 text-right;
+  }
+  .table-cell {
+    @apply px-3 py-2 text-sm text-right tabular-nums;
+  }
+  .table-row-alt {
+    @apply bg-gray-50 dark:bg-gray-700/30;
+  }
+}
+
+/* Scrollbar styling */
+::-webkit-scrollbar { width: 6px; height: 6px; }
+::-webkit-scrollbar-track { @apply bg-gray-100 dark:bg-gray-800; }
+::-webkit-scrollbar-thumb { @apply bg-gray-300 dark:bg-gray-600 rounded-full; }

--- a/cre-analyzer/frontend/src/main.tsx
+++ b/cre-analyzer/frontend/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/cre-analyzer/frontend/src/pages/Assumptions.tsx
+++ b/cre-analyzer/frontend/src/pages/Assumptions.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { ArrowRight } from 'lucide-react';
+import { Card } from '../components/ui/Card';
+import { Input, Toggle } from '../components/ui/Input';
+import { Button } from '../components/ui/Button';
+import { useDealStore } from '../store/dealStore';
+import type { Assumptions, ValueAddAssumptions } from '../types/deal';
+
+export function AssumptionsPage() {
+  const { deal, updateDeal, setStep } = useDealStore();
+  const a = deal.assumptions;
+  const va = a.value_add;
+
+  const upA = <K extends keyof Assumptions>(k: K, v: Assumptions[K]) =>
+    updateDeal({ assumptions: { ...a, [k]: v } });
+
+  const upVA = <K extends keyof ValueAddAssumptions>(k: K, v: ValueAddAssumptions[K]) =>
+    updateDeal({ assumptions: { ...a, value_add: { ...va, [k]: v } } });
+
+  return (
+    <div className="space-y-6 py-6">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+        <div>
+          <h2 className="text-xl font-bold text-gray-900 dark:text-white">Underwriting Assumptions</h2>
+          <p className="text-sm text-gray-500 mt-1">Set growth rates, vacancy, and value-add parameters.</p>
+        </div>
+        <Button onClick={() => setStep('financing')} icon={<ArrowRight size={14} />}>Continue to Financing</Button>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <Card title="Revenue Assumptions" padding>
+          <div className="space-y-4">
+            <Input label="Rent Growth Rate (%/yr)" type="number" suffix="%" value={a.rent_growth_rate}
+              onChange={(e) => upA('rent_growth_rate', +e.target.value)} hint="Annual market rent growth" />
+            <Input label="Vacancy Rate (%)" type="number" suffix="%" value={a.vacancy_rate}
+              onChange={(e) => upA('vacancy_rate', +e.target.value)} hint="Physical vacancy assumption" />
+            <Input label="Credit Loss (%)" type="number" suffix="%" value={a.credit_loss_rate}
+              onChange={(e) => upA('credit_loss_rate', +e.target.value)} hint="Bad debt / collection loss" />
+            <Input label="Other Income Growth (%/yr)" type="number" suffix="%" value={a.other_income_growth}
+              onChange={(e) => upA('other_income_growth', +e.target.value)} />
+          </div>
+        </Card>
+
+        <Card title="Expense Assumptions" padding>
+          <div className="space-y-4">
+            <Input label="Expense Growth Rate (%/yr)" type="number" suffix="%" value={a.expense_growth_rate}
+              onChange={(e) => upA('expense_growth_rate', +e.target.value)} />
+            <Input label="Management Fee (% of EGI)" type="number" suffix="%" value={a.management_fee_pct}
+              onChange={(e) => upA('management_fee_pct', +e.target.value)} hint="Replaces T12 management fee" />
+            <Input label="CapEx Reserves ($/unit/yr)" type="number" prefix="$" value={a.capex_reserves_per_unit}
+              onChange={(e) => upA('capex_reserves_per_unit', +e.target.value)} />
+          </div>
+        </Card>
+      </div>
+
+      <Card title="Value-Add Underwriting" padding>
+        <div className="space-y-4">
+          <Toggle
+            label="Enable Value-Add Scenario"
+            checked={va.enabled}
+            onChange={(v) => upVA('enabled', v)}
+            hint="Model unit renovation program with rent premiums"
+          />
+          {va.enabled && (
+            <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 mt-2 pt-4 border-t border-gray-100 dark:border-gray-700">
+              <Input label="Units to Renovate" type="number" value={va.units_to_renovate}
+                onChange={(e) => upVA('units_to_renovate', +e.target.value)}
+                hint={`of ${deal.property_info.units} total`} />
+              <Input label="Reno Cost / Unit" type="number" prefix="$" value={va.renovation_cost_per_unit}
+                onChange={(e) => upVA('renovation_cost_per_unit', +e.target.value)} />
+              <Input label="Rent Premium / Unit / Mo" type="number" prefix="$" value={va.rent_premium_per_unit}
+                onChange={(e) => upVA('rent_premium_per_unit', +e.target.value)} />
+              <Input label="Absorption Period (yrs)" type="number" value={va.absorption_years}
+                onChange={(e) => upVA('absorption_years', +e.target.value)} />
+            </div>
+          )}
+        </div>
+      </Card>
+
+      <Card title="Exit Assumptions" padding>
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          <Input label="Hold Period (years)" type="number" value={deal.exit_assumptions.hold_period_years}
+            onChange={(e) => updateDeal({ exit_assumptions: { ...deal.exit_assumptions, hold_period_years: +e.target.value } })} />
+          <Input label="Exit Cap Rate (%)" type="number" suffix="%" value={deal.exit_assumptions.exit_cap_rate}
+            onChange={(e) => updateDeal({ exit_assumptions: { ...deal.exit_assumptions, exit_cap_rate: +e.target.value } })} />
+          <Input label="Selling Costs (%)" type="number" suffix="%" value={deal.exit_assumptions.selling_costs_pct}
+            onChange={(e) => updateDeal({ exit_assumptions: { ...deal.exit_assumptions, selling_costs_pct: +e.target.value } })} />
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/cre-analyzer/frontend/src/pages/Assumptions.tsx
+++ b/cre-analyzer/frontend/src/pages/Assumptions.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { ArrowRight } from 'lucide-react';
 import { Card } from '../components/ui/Card';
 import { Input, Toggle } from '../components/ui/Input';
+import { NumericInput } from '../components/ui/NumericInput';
 import { Button } from '../components/ui/Button';
 import { useDealStore } from '../store/dealStore';
 import type { Assumptions, ValueAddAssumptions } from '../types/deal';
@@ -47,8 +48,8 @@ export function AssumptionsPage() {
               onChange={(e) => upA('expense_growth_rate', +e.target.value)} />
             <Input label="Management Fee (% of EGI)" type="number" suffix="%" value={a.management_fee_pct}
               onChange={(e) => upA('management_fee_pct', +e.target.value)} hint="Replaces T12 management fee" />
-            <Input label="CapEx Reserves ($/unit/yr)" type="number" prefix="$" value={a.capex_reserves_per_unit}
-              onChange={(e) => upA('capex_reserves_per_unit', +e.target.value)} />
+            <NumericInput label="CapEx Reserves ($/unit/yr)" prefix="$" value={a.capex_reserves_per_unit}
+              onChange={(v) => upA('capex_reserves_per_unit', v)} />
           </div>
         </Card>
       </div>
@@ -66,10 +67,10 @@ export function AssumptionsPage() {
               <Input label="Units to Renovate" type="number" value={va.units_to_renovate}
                 onChange={(e) => upVA('units_to_renovate', +e.target.value)}
                 hint={`of ${deal.property_info.units} total`} />
-              <Input label="Reno Cost / Unit" type="number" prefix="$" value={va.renovation_cost_per_unit}
-                onChange={(e) => upVA('renovation_cost_per_unit', +e.target.value)} />
-              <Input label="Rent Premium / Unit / Mo" type="number" prefix="$" value={va.rent_premium_per_unit}
-                onChange={(e) => upVA('rent_premium_per_unit', +e.target.value)} />
+              <NumericInput label="Reno Cost / Unit" prefix="$" value={va.renovation_cost_per_unit}
+                onChange={(v) => upVA('renovation_cost_per_unit', v)} />
+              <NumericInput label="Rent Premium / Unit / Mo" prefix="$" value={va.rent_premium_per_unit}
+                onChange={(v) => upVA('rent_premium_per_unit', v)} />
               <Input label="Absorption Period (yrs)" type="number" value={va.absorption_years}
                 onChange={(e) => upVA('absorption_years', +e.target.value)} />
             </div>

--- a/cre-analyzer/frontend/src/pages/Financing.tsx
+++ b/cre-analyzer/frontend/src/pages/Financing.tsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import { ArrowRight } from 'lucide-react';
+import { Card } from '../components/ui/Card';
+import { Input, Select, Toggle } from '../components/ui/Input';
+import { Button } from '../components/ui/Button';
+import { useDealStore } from '../store/dealStore';
+import { fmtCurrency } from '../utils/calculations';
+import type { FinancingAssumptions } from '../types/deal';
+
+export function FinancingPage() {
+  const { deal, updateDeal, setStep } = useDealStore();
+  const f = deal.financing;
+  const pp = deal.property_info.purchase_price;
+
+  const upF = <K extends keyof FinancingAssumptions>(k: K, v: FinancingAssumptions[K]) =>
+    updateDeal({ financing: { ...f, [k]: v } });
+
+  const loanAmt = pp * f.ltv_pct / 100;
+  const equity = pp - loanAmt;
+  const ioPayment = loanAmt * f.interest_rate / 100;
+  const r = f.interest_rate / 100 / 12;
+  const n = f.amortization_years * 12;
+  const monthlyAm = r > 0 ? loanAmt * (r * Math.pow(1 + r, n)) / (Math.pow(1 + r, n) - 1) : loanAmt / (f.amortization_years * 12);
+  const amPayment = monthlyAm * 12;
+
+  return (
+    <div className="space-y-6 py-6">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+        <div>
+          <h2 className="text-xl font-bold text-gray-900 dark:text-white">Financing Structure</h2>
+          <p className="text-sm text-gray-500 mt-1">Configure loan terms and debt service schedule.</p>
+        </div>
+        <Button onClick={() => setStep('waterfall')} icon={<ArrowRight size={14} />}>Continue to Waterfall</Button>
+      </div>
+
+      {/* Quick summary */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        {[
+          { label: 'Purchase Price', value: fmtCurrency(pp) },
+          { label: 'Loan Amount', value: fmtCurrency(loanAmt) },
+          { label: 'Equity Required', value: fmtCurrency(equity) },
+          { label: 'I/O Debt Service / yr', value: fmtCurrency(ioPayment) },
+        ].map((m) => (
+          <div key={m.label} className="card p-3">
+            <div className="label">{m.label}</div>
+            <div className="text-lg font-bold text-gray-900 dark:text-white mt-0.5">{m.value}</div>
+          </div>
+        ))}
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <Card title="Loan Terms" padding>
+          <div className="space-y-4">
+            <Select label="Loan Type" value={f.loan_type}
+              options={[{ value: 'Agency', label: 'Agency (Fannie/Freddie)' }, { value: 'Bridge', label: 'Bridge' }, { value: 'CMBS', label: 'CMBS' }]}
+              onChange={(e) => upF('loan_type', e.target.value)} />
+            <Input label="LTV (%)" type="number" suffix="%" value={f.ltv_pct}
+              onChange={(e) => upF('ltv_pct', +e.target.value)}
+              hint={`Loan: ${fmtCurrency(loanAmt)} | Equity: ${fmtCurrency(equity)}`} />
+            <Input label="Interest Rate (%)" type="number" suffix="%" value={f.interest_rate}
+              onChange={(e) => upF('interest_rate', +e.target.value)} />
+            <Input label="I/O Period (years)" type="number" value={f.io_period_years}
+              onChange={(e) => upF('io_period_years', +e.target.value)}
+              hint={`I/O payment: ${fmtCurrency(ioPayment)}/yr`} />
+            <Input label="Amortization (years)" type="number" value={f.amortization_years}
+              onChange={(e) => upF('amortization_years', +e.target.value)}
+              hint={`Am payment: ${fmtCurrency(amPayment)}/yr`} />
+            <Input label="Loan Term (years)" type="number" value={f.loan_term_years}
+              onChange={(e) => upF('loan_term_years', +e.target.value)} />
+          </div>
+        </Card>
+
+        <Card title="Refi / Cash-Out Scenario" padding>
+          <div className="space-y-4">
+            <Toggle label="Enable Refi Scenario" checked={f.enable_refi} onChange={(v) => upF('enable_refi', v)}
+              hint="Model an optional cash-out refinance at stabilization" />
+            {f.enable_refi && (
+              <div className="space-y-4 pt-3 border-t border-gray-100 dark:border-gray-700">
+                <Input label="Refi Year" type="number" value={f.refi_year}
+                  onChange={(e) => upF('refi_year', +e.target.value)} />
+                <Input label="Refi LTV (%)" type="number" suffix="%" value={f.refi_ltv_pct}
+                  onChange={(e) => upF('refi_ltv_pct', +e.target.value)} />
+                <Input label="Refi Rate (%)" type="number" suffix="%" value={f.refi_rate}
+                  onChange={(e) => upF('refi_rate', +e.target.value)} />
+              </div>
+            )}
+          </div>
+        </Card>
+      </div>
+
+      {/* Debt service table preview */}
+      <Card title="Debt Service Preview" padding={false}>
+        <div className="overflow-x-auto p-4">
+          <table className="w-full text-xs border-collapse">
+            <thead>
+              <tr>
+                {['Year', 'Type', 'Annual Payment', 'Interest', 'Principal'].map((h) => (
+                  <th key={h} className="table-header">{h}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {Array.from({ length: Math.min(deal.exit_assumptions.hold_period_years, 10) }, (_, i) => {
+                const yr = i + 1;
+                const isIO = yr <= f.io_period_years;
+                const pmt = isIO ? ioPayment : amPayment;
+                const interest = loanAmt * f.interest_rate / 100;
+                const principal = isIO ? 0 : pmt - interest;
+                return (
+                  <tr key={yr} className={i % 2 === 0 ? 'table-row-alt' : ''}>
+                    <td className="table-cell text-left pl-3">Year {yr}</td>
+                    <td className="table-cell text-left">
+                      <span className={`px-1.5 py-0.5 rounded text-xs ${isIO ? 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400' : 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400'}`}>
+                        {isIO ? 'I/O' : 'Am'}
+                      </span>
+                    </td>
+                    <td className="table-cell font-medium">{fmtCurrency(pmt)}</td>
+                    <td className="table-cell text-red-500">{fmtCurrency(interest)}</td>
+                    <td className="table-cell">{fmtCurrency(principal > 0 ? principal : 0)}</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/cre-analyzer/frontend/src/pages/Financing.tsx
+++ b/cre-analyzer/frontend/src/pages/Financing.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { ArrowRight } from 'lucide-react';
 import { Card } from '../components/ui/Card';
 import { Input, Select, Toggle } from '../components/ui/Input';
+import { NumericInput } from '../components/ui/NumericInput';
 import { Button } from '../components/ui/Button';
 import { useDealStore } from '../store/dealStore';
 import { fmtCurrency } from '../utils/calculations';

--- a/cre-analyzer/frontend/src/pages/Results.tsx
+++ b/cre-analyzer/frontend/src/pages/Results.tsx
@@ -1,0 +1,369 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Download, FileSpreadsheet, BarChart3, RefreshCw,
+  TrendingUp, DollarSign, Building, Target, AlertCircle,
+} from 'lucide-react';
+import { Card, MetricCard } from '../components/ui/Card';
+import { Button } from '../components/ui/Button';
+import { CashFlowChart, NOIGrowthChart } from '../components/charts/CashFlowChart';
+import { WaterfallDistributionChart, LPGPSplitChart } from '../components/charts/WaterfallChart';
+import { SensitivityHeatmap } from '../components/charts/SensitivityHeatmap';
+import { CashFlowTable } from '../components/tables/CashFlowTable';
+import { WaterfallTable } from '../components/tables/WaterfallTable';
+import { RentRollTable } from '../components/tables/RentRollTable';
+import { useDealStore } from '../store/dealStore';
+import { runAnalysis, runSensitivity, solveDeal } from '../api/client';
+import { exportExcel, exportDealJson } from '../utils/export';
+import { fmtCurrency, fmtPct, fmtMultiple, fmtNum } from '../utils/calculations';
+import type { SensitivityResults } from '../types/deal';
+
+type ResultTab = 'overview' | 'proforma' | 'waterfall' | 'sensitivity' | 'rentroll';
+
+export function ResultsPage() {
+  const { deal, setResults, setSensitivity, isLoading, isSensLoading, setLoading, setSensLoading, setError, error, sensitivity } = useDealStore();
+  const [tab, setTab] = useState<ResultTab>('overview');
+  const [solveResult, setSolveResult] = useState<{ value: number; label: string } | null>(null);
+  const [targetIrr, setTargetIrr] = useState(14);
+  const [solveFor, setSolveFor] = useState<'purchase_price' | 'exit_cap_rate'>('purchase_price');
+
+  const results = deal.results;
+
+  useEffect(() => {
+    if (!results) handleRunAnalysis();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleRunAnalysis = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await runAnalysis(deal);
+      setResults(res);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Analysis failed. Is the backend running?');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleRunSensitivity = async () => {
+    setSensLoading(true);
+    try {
+      const res = await runSensitivity(deal);
+      setSensitivity(res as SensitivityResults);
+      setTab('sensitivity');
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Sensitivity failed');
+    } finally {
+      setSensLoading(false);
+    }
+  };
+
+  const handleSolve = async () => {
+    try {
+      const res = await solveDeal(deal, targetIrr, solveFor);
+      setSolveResult({
+        value: res.value,
+        label: solveFor === 'purchase_price'
+          ? `Max Purchase Price for ${targetIrr}% LP IRR: ${fmtCurrency(res.value)}`
+          : `Min Exit Cap Rate for ${targetIrr}% LP IRR: ${res.value.toFixed(2)}%`,
+      });
+    } catch { /* ignore */ }
+  };
+
+  const tabs: { id: ResultTab; label: string; icon: React.ReactNode }[] = [
+    { id: 'overview', label: 'Overview', icon: <BarChart3 size={14} /> },
+    { id: 'proforma', label: '10-Year Pro Forma', icon: <TrendingUp size={14} /> },
+    { id: 'waterfall', label: 'LP/GP Waterfall', icon: <DollarSign size={14} /> },
+    { id: 'sensitivity', label: 'Sensitivity', icon: <Target size={14} /> },
+    { id: 'rentroll', label: 'Rent Roll', icon: <Building size={14} /> },
+  ];
+
+  return (
+    <div className="space-y-6 py-6">
+      {/* Header */}
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+        <div>
+          <h2 className="text-xl font-bold text-gray-900 dark:text-white">{deal.property_info.name}</h2>
+          <p className="text-sm text-gray-500">{deal.property_info.address} · {deal.property_info.units} units · {fmtCurrency(deal.property_info.purchase_price, true)}</p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Button variant="secondary" onClick={handleRunAnalysis} loading={isLoading} icon={<RefreshCw size={14} />}>
+            Recalculate
+          </Button>
+          <Button variant="secondary" onClick={handleRunSensitivity} loading={isSensLoading} icon={<Target size={14} />}>
+            Run Sensitivity
+          </Button>
+          {results && (
+            <>
+              <Button variant="secondary" onClick={() => exportExcel(deal, results)} icon={<FileSpreadsheet size={14} />}>
+                Export Excel
+              </Button>
+              <Button variant="secondary" onClick={() => exportDealJson(deal)} icon={<Download size={14} />}>
+                Save JSON
+              </Button>
+            </>
+          )}
+        </div>
+      </div>
+
+      {error && (
+        <div className="flex items-start gap-3 rounded-lg bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 px-4 py-3 text-sm text-red-700 dark:text-red-400">
+          <AlertCircle size={16} className="flex-shrink-0 mt-0.5" />
+          <div>
+            <strong>Error:</strong> {error}
+            <p className="text-xs mt-1 opacity-80">Make sure the backend is running on port 8000 and ANTHROPIC_API_KEY is set.</p>
+          </div>
+        </div>
+      )}
+
+      {isLoading && (
+        <div className="text-center py-16 text-gray-400">
+          <RefreshCw size={32} className="animate-spin mx-auto mb-3" />
+          <p>Running analysis...</p>
+        </div>
+      )}
+
+      {results && !isLoading && (
+        <>
+          {/* Key Metrics Cards */}
+          <div className="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-8 gap-3">
+            <MetricCard label="LP IRR" value={fmtPct(results.lp_irr)} highlight={results.lp_irr != null && results.lp_irr >= 14 ? 'green' : results.lp_irr != null && results.lp_irr >= 10 ? 'yellow' : 'red'} />
+            <MetricCard label="Levered IRR" value={fmtPct(results.levered_irr)} highlight="blue" />
+            <MetricCard label="Unlev IRR" value={fmtPct(results.metrics.unlevered_irr)} />
+            <MetricCard label="LP EM" value={fmtMultiple(results.waterfall.lp_em)} highlight="green" />
+            <MetricCard label="Levered EM" value={fmtMultiple(results.levered_em)} />
+            <MetricCard label="CoC (Yr 1)" value={fmtPct(results.levered_coc)} />
+            <MetricCard label="Going-in Cap" value={fmtPct(results.metrics.going_in_cap_rate)} />
+            <MetricCard label="DSCR (Yr 1)" value={fmtNum(results.metrics.dscr_year1)} highlight={results.metrics.dscr_year1 != null && results.metrics.dscr_year1 >= 1.25 ? 'green' : 'yellow'} />
+          </div>
+
+          {/* Tabs */}
+          <div className="flex gap-1 border-b border-gray-200 dark:border-gray-700 overflow-x-auto">
+            {tabs.map((t) => (
+              <button key={t.id} onClick={() => setTab(t.id)}
+                className={`flex items-center gap-1.5 px-4 py-2.5 text-sm font-medium border-b-2 -mb-px transition whitespace-nowrap ${
+                  tab === t.id ? 'border-brand-500 text-brand-600 dark:text-brand-400' : 'border-transparent text-gray-500 hover:text-gray-700'
+                }`}
+              >
+                {t.icon} {t.label}
+              </button>
+            ))}
+          </div>
+
+          {/* Overview Tab */}
+          {tab === 'overview' && (
+            <div className="space-y-6">
+              <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+                <Card title="10-Year Cash Flow" padding>
+                  <CashFlowChart rows={results.proforma.annual_rows} />
+                </Card>
+                <Card title="NOI Growth" padding>
+                  <NOIGrowthChart rows={results.proforma.annual_rows} />
+                </Card>
+              </div>
+
+              <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+                <Card title="Deal Summary" padding>
+                  <dl className="space-y-2 text-sm">
+                    {[
+                      ['Purchase Price', fmtCurrency(results.metrics.purchase_price)],
+                      ['Loan Amount', fmtCurrency(results.metrics.loan_amount)],
+                      ['Equity Required', fmtCurrency(results.metrics.equity_required)],
+                      ['Year 1 NOI', fmtCurrency(results.metrics.year1_noi)],
+                      ['Year 1 EGI', fmtCurrency(results.metrics.year1_egi)],
+                      ['NOI Margin', fmtPct(results.metrics.noi_margin)],
+                      ['Going-in Cap', fmtPct(results.metrics.going_in_cap_rate)],
+                      ['Stabilized Cap', fmtPct(results.metrics.stabilized_cap_rate)],
+                      ['NPV @ 10%', fmtCurrency(results.metrics.npv_10pct)],
+                    ].map(([k, v]) => (
+                      <div key={k} className="flex justify-between py-1 border-b border-gray-100 dark:border-gray-700">
+                        <dt className="text-gray-500">{k}</dt>
+                        <dd className="font-medium">{v}</dd>
+                      </div>
+                    ))}
+                  </dl>
+                </Card>
+
+                <Card title="Exit / Disposition" padding>
+                  <dl className="space-y-2 text-sm">
+                    {[
+                      ['Exit Cap Rate', fmtPct(results.proforma.exit.exit_cap_rate)],
+                      ['Exit Year NOI', fmtCurrency(results.proforma.exit.exit_year_noi)],
+                      ['Gross Sale Price', fmtCurrency(results.proforma.exit.gross_sale_price)],
+                      ['Selling Costs', `(${fmtCurrency(results.proforma.exit.selling_costs)})`],
+                      ['Net Sale Price', fmtCurrency(results.proforma.exit.net_sale_price)],
+                      ['Loan Payoff', `(${fmtCurrency(results.proforma.exit.loan_payoff)})`],
+                      ['Net Proceeds to Equity', fmtCurrency(results.proforma.exit.net_sale_proceeds)],
+                    ].map(([k, v]) => (
+                      <div key={k} className="flex justify-between py-1 border-b border-gray-100 dark:border-gray-700">
+                        <dt className="text-gray-500">{k}</dt>
+                        <dd className="font-medium">{v}</dd>
+                      </div>
+                    ))}
+                  </dl>
+                </Card>
+
+                <Card title="Waterfall Summary" padding>
+                  <dl className="space-y-2 text-sm">
+                    {[
+                      ['LP Invested', fmtCurrency(results.waterfall.lp_invested)],
+                      ['LP Total Distributions', fmtCurrency(results.waterfall.lp_total_distributions)],
+                      ['LP IRR', fmtPct(results.waterfall.lp_irr)],
+                      ['LP Equity Multiple', fmtMultiple(results.waterfall.lp_em)],
+                      ['GP Invested', fmtCurrency(results.waterfall.gp_invested)],
+                      ['GP Total Distributions', fmtCurrency(results.waterfall.gp_total_distributions)],
+                      ['GP IRR', fmtPct(results.waterfall.gp_irr)],
+                      ['GP Equity Multiple', fmtMultiple(results.waterfall.gp_em)],
+                      ['GP Promote Earned', fmtCurrency(results.waterfall.gp_promote_earned)],
+                    ].map(([k, v]) => (
+                      <div key={k} className="flex justify-between py-1 border-b border-gray-100 dark:border-gray-700">
+                        <dt className="text-gray-500">{k}</dt>
+                        <dd className="font-medium">{v}</dd>
+                      </div>
+                    ))}
+                  </dl>
+                </Card>
+              </div>
+
+              {/* Solve Mode */}
+              <Card title="Solve Mode" subtitle="Back-solve for target LP IRR" padding>
+                <div className="flex flex-wrap gap-3 items-end">
+                  <div className="flex flex-col gap-1">
+                    <label className="text-xs font-medium text-gray-600 dark:text-gray-400">Target LP IRR (%)</label>
+                    <input type="number" className="input-field w-28" value={targetIrr} onChange={(e) => setTargetIrr(+e.target.value)} />
+                  </div>
+                  <div className="flex flex-col gap-1">
+                    <label className="text-xs font-medium text-gray-600 dark:text-gray-400">Solve For</label>
+                    <select className="input-field" value={solveFor} onChange={(e) => setSolveFor(e.target.value as 'purchase_price' | 'exit_cap_rate')}>
+                      <option value="purchase_price">Max Purchase Price</option>
+                      <option value="exit_cap_rate">Min Exit Cap Rate</option>
+                    </select>
+                  </div>
+                  <Button onClick={handleSolve} icon={<Target size={14} />}>Solve</Button>
+                  {solveResult && (
+                    <div className="px-4 py-2 rounded-lg bg-emerald-50 dark:bg-emerald-900/20 border border-emerald-200 dark:border-emerald-800 text-sm text-emerald-700 dark:text-emerald-400 font-medium">
+                      {solveResult.label}
+                    </div>
+                  )}
+                </div>
+              </Card>
+            </div>
+          )}
+
+          {/* Pro Forma Tab */}
+          {tab === 'proforma' && (
+            <div className="space-y-6">
+              <Card title="10-Year Cash Flow Model" subtitle="Click section headers to collapse" padding={false}>
+                <CashFlowTable rows={results.proforma.annual_rows} exit={results.proforma.exit} />
+              </Card>
+              <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+                <Card title="NOI & Cash Flow by Year" padding>
+                  <CashFlowChart rows={results.proforma.annual_rows} />
+                </Card>
+                <Card title="Revenue Growth" padding>
+                  <NOIGrowthChart rows={results.proforma.annual_rows} />
+                </Card>
+              </div>
+            </div>
+          )}
+
+          {/* Waterfall Tab */}
+          {tab === 'waterfall' && (
+            <div className="space-y-6">
+              <Card title="Waterfall Distribution Table" subtitle="Year-by-year cash flow through each tier" padding={false}>
+                <div className="p-4">
+                  <WaterfallTable years={results.waterfall.yearly} />
+                </div>
+              </Card>
+              <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+                <Card title="Distributions by Tier" padding>
+                  <WaterfallDistributionChart years={results.waterfall.yearly} />
+                </Card>
+                <Card title="LP vs GP Distributions" padding>
+                  <LPGPSplitChart years={results.waterfall.yearly} />
+                </Card>
+              </div>
+            </div>
+          )}
+
+          {/* Sensitivity Tab */}
+          {tab === 'sensitivity' && (
+            <div className="space-y-6">
+              {!sensitivity ? (
+                <div className="text-center py-16">
+                  <p className="text-gray-400 mb-4">Click "Run Sensitivity" to generate heatmap tables.</p>
+                  <Button onClick={handleRunSensitivity} loading={isSensLoading} icon={<Target size={14} />}>
+                    Run Sensitivity Analysis
+                  </Button>
+                </div>
+              ) : (
+                <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
+                  <Card title="LP IRR vs. Purchase Price × Exit Cap Rate" padding>
+                    <SensitivityHeatmap
+                      table={sensitivity.lp_irr_vs_price_x_exit_cap}
+                      title=""
+                      rowLabel="Purchase Price"
+                      colLabel="Exit Cap Rate"
+                      formatRow={(v) => `$${(v / 1_000_000).toFixed(1)}M`}
+                      formatCol={(v) => `${v.toFixed(2)}%`}
+                      formatCell={(v) => `${v.toFixed(1)}%`}
+                      thresholds={{ green: 14, yellow: 10 }}
+                    />
+                  </Card>
+                  <Card title="LP IRR vs. Rent Growth × Vacancy" padding>
+                    <SensitivityHeatmap
+                      table={sensitivity.lp_irr_vs_rent_x_vacancy}
+                      title=""
+                      rowLabel="Rent Growth"
+                      colLabel="Vacancy"
+                      formatRow={(v) => `${v.toFixed(1)}%`}
+                      formatCol={(v) => `${v.toFixed(0)}%`}
+                      formatCell={(v) => `${v.toFixed(1)}%`}
+                      thresholds={{ green: 14, yellow: 10 }}
+                    />
+                  </Card>
+                  <Card title="Cash-on-Cash vs. LTV × Interest Rate" padding>
+                    <SensitivityHeatmap
+                      table={sensitivity.coc_vs_ltv_x_rate}
+                      title=""
+                      rowLabel="LTV"
+                      colLabel="Interest Rate"
+                      formatRow={(v) => `${v.toFixed(0)}%`}
+                      formatCol={(v) => `${v.toFixed(1)}%`}
+                      formatCell={(v) => `${v.toFixed(1)}%`}
+                      thresholds={{ green: 7, yellow: 4 }}
+                    />
+                  </Card>
+                  <Card title="Equity Multiple vs. Hold Period × Exit Cap" padding>
+                    <SensitivityHeatmap
+                      table={sensitivity.em_vs_hold_x_exit_cap}
+                      title=""
+                      rowLabel="Hold Period"
+                      colLabel="Exit Cap Rate"
+                      formatRow={(v) => `${v}yr`}
+                      formatCol={(v) => `${v.toFixed(2)}%`}
+                      formatCell={(v) => `${v.toFixed(2)}x`}
+                      thresholds={{ green: 1.8, yellow: 1.4 }}
+                    />
+                  </Card>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Rent Roll Tab */}
+          {tab === 'rentroll' && (
+            <Card title="Rent Roll" subtitle={`${deal.rent_roll.length} units`} padding>
+              {deal.rent_roll.length > 0 ? (
+                <RentRollTable units={deal.rent_roll} />
+              ) : (
+                <div className="text-center py-8 text-gray-400 text-sm">No rent roll data. Upload a rent roll document in the Upload step.</div>
+              )}
+            </Card>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/cre-analyzer/frontend/src/pages/ReviewData.tsx
+++ b/cre-analyzer/frontend/src/pages/ReviewData.tsx
@@ -1,0 +1,174 @@
+import React, { useState } from 'react';
+import { Card } from '../components/ui/Card';
+import { Input } from '../components/ui/Input';
+import { Button } from '../components/ui/Button';
+import { RentRollTable } from '../components/tables/RentRollTable';
+import { useDealStore } from '../store/dealStore';
+import { fmtCurrency } from '../utils/calculations';
+import type { T12Data, PropertyInfo, RentRollUnit } from '../types/deal';
+import { ArrowRight, Building2, DollarSign, Users } from 'lucide-react';
+
+type Tab = 'property' | 't12' | 'rentroll';
+
+export function ReviewDataPage() {
+  const { deal, updateDeal, setStep } = useDealStore();
+  const [tab, setTab] = useState<Tab>('property');
+
+  const updateProp = <K extends keyof PropertyInfo>(k: K, v: PropertyInfo[K]) =>
+    updateDeal({ property_info: { ...deal.property_info, [k]: v } });
+
+  const updateT12 = <K extends keyof T12Data>(k: K, v: T12Data[K]) =>
+    updateDeal({ t12_data: { ...deal.t12_data, [k]: v } });
+
+  const updateUnit = (idx: number, field: keyof RentRollUnit, value: string | number) => {
+    const rr = [...deal.rent_roll];
+    rr[idx] = { ...rr[idx], [field]: value };
+    updateDeal({ rent_roll: rr });
+  };
+
+  const egi =
+    deal.t12_data.gross_potential_rent -
+    deal.t12_data.vacancy_loss -
+    deal.t12_data.concessions -
+    deal.t12_data.bad_debt +
+    deal.t12_data.other_income;
+
+  const totalExp =
+    deal.t12_data.property_taxes +
+    deal.t12_data.insurance +
+    deal.t12_data.management_fee +
+    deal.t12_data.maintenance_repairs +
+    deal.t12_data.utilities +
+    deal.t12_data.payroll +
+    deal.t12_data.general_admin +
+    deal.t12_data.marketing +
+    deal.t12_data.capex_reserves +
+    deal.t12_data.other_expenses;
+
+  const noi = egi - totalExp;
+  const goingIn = deal.property_info.purchase_price > 0 ? (noi / deal.property_info.purchase_price) * 100 : 0;
+
+  const tabs: { id: Tab; label: string; icon: React.ReactNode }[] = [
+    { id: 'property', label: 'Property Info', icon: <Building2 size={14} /> },
+    { id: 't12', label: 'T12 Financials', icon: <DollarSign size={14} /> },
+    { id: 'rentroll', label: `Rent Roll (${deal.rent_roll.length})`, icon: <Users size={14} /> },
+  ];
+
+  return (
+    <div className="space-y-6 py-6">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+        <div>
+          <h2 className="text-xl font-bold text-gray-900 dark:text-white">Review Extracted Data</h2>
+          <p className="text-sm text-gray-500 mt-1">Edit any values extracted from your documents. Live NOI: <strong className="text-gray-800 dark:text-gray-200">{fmtCurrency(noi)}</strong> ({goingIn.toFixed(2)}% cap)</p>
+        </div>
+        <Button onClick={() => setStep('assumptions')} icon={<ArrowRight size={14} />}>
+          Continue to Assumptions
+        </Button>
+      </div>
+
+      {/* Tabs */}
+      <div className="flex gap-1 border-b border-gray-200 dark:border-gray-700">
+        {tabs.map((t) => (
+          <button
+            key={t.id}
+            onClick={() => setTab(t.id)}
+            className={`flex items-center gap-1.5 px-4 py-2.5 text-sm font-medium border-b-2 -mb-px transition ${
+              tab === t.id
+                ? 'border-brand-500 text-brand-600 dark:text-brand-400'
+                : 'border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'
+            }`}
+          >
+            {t.icon} {t.label}
+          </button>
+        ))}
+      </div>
+
+      {tab === 'property' && (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          <Input label="Property Name" value={deal.property_info.name} onChange={(e) => updateProp('name', e.target.value)} />
+          <Input label="Address" value={deal.property_info.address} onChange={(e) => updateProp('address', e.target.value)} />
+          <Input label="Market" value={deal.property_info.market} onChange={(e) => updateProp('market', e.target.value)} />
+          <Input label="Asset Type" value={deal.property_info.asset_type} onChange={(e) => updateProp('asset_type', e.target.value)} />
+          <Input label="Total Units" type="number" value={deal.property_info.units} onChange={(e) => updateProp('units', +e.target.value)} />
+          <Input label="Total SqFt" type="number" value={deal.property_info.sqft} onChange={(e) => updateProp('sqft', +e.target.value)} />
+          <Input label="Year Built" type="number" value={deal.property_info.year_built} onChange={(e) => updateProp('year_built', +e.target.value)} />
+          <Input label="Purchase Price" type="number" prefix="$" value={deal.property_info.purchase_price} onChange={(e) => updateProp('purchase_price', +e.target.value)} />
+          <Input label="Asking Price" type="number" prefix="$" value={deal.property_info.asking_price} onChange={(e) => updateProp('asking_price', +e.target.value)} />
+        </div>
+      )}
+
+      {tab === 't12' && (
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          <Card title="Income" padding>
+            <div className="space-y-3">
+              {(
+                [
+                  ['gross_potential_rent', 'Gross Potential Rent'],
+                  ['vacancy_loss', 'Vacancy Loss'],
+                  ['concessions', 'Concessions'],
+                  ['bad_debt', 'Bad Debt'],
+                  ['other_income', 'Other Income'],
+                ] as [keyof T12Data, string][]
+              ).map(([k, label]) => (
+                <Input key={k} label={label} type="number" prefix="$" value={deal.t12_data[k] as number}
+                  onChange={(e) => updateT12(k, +e.target.value)} />
+              ))}
+              <div className="pt-2 border-t border-gray-200 dark:border-gray-600">
+                <div className="flex justify-between text-sm">
+                  <span className="font-semibold text-gray-700 dark:text-gray-300">EGI</span>
+                  <span className="font-bold">{fmtCurrency(egi)}</span>
+                </div>
+              </div>
+            </div>
+          </Card>
+
+          <Card title="Expenses" padding>
+            <div className="space-y-3">
+              {(
+                [
+                  ['property_taxes', 'Property Taxes'],
+                  ['insurance', 'Insurance'],
+                  ['management_fee', 'Management Fee'],
+                  ['maintenance_repairs', 'Maintenance & Repairs'],
+                  ['utilities', 'Utilities'],
+                  ['payroll', 'Payroll'],
+                  ['general_admin', 'General & Admin'],
+                  ['marketing', 'Marketing'],
+                  ['capex_reserves', 'CapEx Reserves'],
+                  ['other_expenses', 'Other Expenses'],
+                ] as [keyof T12Data, string][]
+              ).map(([k, label]) => (
+                <Input key={k} label={label} type="number" prefix="$" value={deal.t12_data[k] as number}
+                  onChange={(e) => updateT12(k, +e.target.value)} />
+              ))}
+              <div className="pt-2 border-t border-gray-200 dark:border-gray-600 space-y-1">
+                <div className="flex justify-between text-sm">
+                  <span className="text-gray-500">Total OpEx</span>
+                  <span className="font-medium text-red-500">({fmtCurrency(totalExp)})</span>
+                </div>
+                <div className="flex justify-between text-sm">
+                  <span className="font-semibold text-gray-700 dark:text-gray-300">NOI</span>
+                  <span className={`font-bold ${noi > 0 ? 'text-emerald-600' : 'text-red-500'}`}>{fmtCurrency(noi)}</span>
+                </div>
+              </div>
+            </div>
+          </Card>
+        </div>
+      )}
+
+      {tab === 'rentroll' && (
+        <Card title="Rent Roll" subtitle="Unit-by-unit lease data" padding={false}>
+          {deal.rent_roll.length > 0 ? (
+            <div className="p-4">
+              <RentRollTable units={deal.rent_roll} onEdit={updateUnit} />
+            </div>
+          ) : (
+            <div className="p-8 text-center text-gray-400 text-sm">
+              No rent roll data extracted. Upload a rent roll document or add units manually.
+            </div>
+          )}
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/cre-analyzer/frontend/src/pages/ReviewData.tsx
+++ b/cre-analyzer/frontend/src/pages/ReviewData.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Card } from '../components/ui/Card';
 import { Input } from '../components/ui/Input';
+import { NumericInput } from '../components/ui/NumericInput';
 import { Button } from '../components/ui/Button';
 import { RentRollTable } from '../components/tables/RentRollTable';
 import { useDealStore } from '../store/dealStore';
@@ -89,11 +90,11 @@ export function ReviewDataPage() {
           <Input label="Address" value={deal.property_info.address} onChange={(e) => updateProp('address', e.target.value)} />
           <Input label="Market" value={deal.property_info.market} onChange={(e) => updateProp('market', e.target.value)} />
           <Input label="Asset Type" value={deal.property_info.asset_type} onChange={(e) => updateProp('asset_type', e.target.value)} />
-          <Input label="Total Units" type="number" value={deal.property_info.units} onChange={(e) => updateProp('units', +e.target.value)} />
-          <Input label="Total SqFt" type="number" value={deal.property_info.sqft} onChange={(e) => updateProp('sqft', +e.target.value)} />
+          <NumericInput label="Total Units" value={deal.property_info.units} onChange={(v) => updateProp('units', v)} />
+          <NumericInput label="Total SqFt" value={deal.property_info.sqft} onChange={(v) => updateProp('sqft', v)} />
           <Input label="Year Built" type="number" value={deal.property_info.year_built} onChange={(e) => updateProp('year_built', +e.target.value)} />
-          <Input label="Purchase Price" type="number" prefix="$" value={deal.property_info.purchase_price} onChange={(e) => updateProp('purchase_price', +e.target.value)} />
-          <Input label="Asking Price" type="number" prefix="$" value={deal.property_info.asking_price} onChange={(e) => updateProp('asking_price', +e.target.value)} />
+          <NumericInput label="Purchase Price" prefix="$" value={deal.property_info.purchase_price} onChange={(v) => updateProp('purchase_price', v)} />
+          <NumericInput label="Asking Price" prefix="$" value={deal.property_info.asking_price} onChange={(v) => updateProp('asking_price', v)} />
         </div>
       )}
 
@@ -110,8 +111,8 @@ export function ReviewDataPage() {
                   ['other_income', 'Other Income'],
                 ] as [keyof T12Data, string][]
               ).map(([k, label]) => (
-                <Input key={k} label={label} type="number" prefix="$" value={deal.t12_data[k] as number}
-                  onChange={(e) => updateT12(k, +e.target.value)} />
+                <NumericInput key={k} label={label} prefix="$" value={deal.t12_data[k] as number}
+                  onChange={(v) => updateT12(k, v)} />
               ))}
               <div className="pt-2 border-t border-gray-200 dark:border-gray-600">
                 <div className="flex justify-between text-sm">
@@ -138,8 +139,8 @@ export function ReviewDataPage() {
                   ['other_expenses', 'Other Expenses'],
                 ] as [keyof T12Data, string][]
               ).map(([k, label]) => (
-                <Input key={k} label={label} type="number" prefix="$" value={deal.t12_data[k] as number}
-                  onChange={(e) => updateT12(k, +e.target.value)} />
+                <NumericInput key={k} label={label} prefix="$" value={deal.t12_data[k] as number}
+                  onChange={(v) => updateT12(k, v)} />
               ))}
               <div className="pt-2 border-t border-gray-200 dark:border-gray-600 space-y-1">
                 <div className="flex justify-between text-sm">

--- a/cre-analyzer/frontend/src/pages/Upload.tsx
+++ b/cre-analyzer/frontend/src/pages/Upload.tsx
@@ -46,8 +46,11 @@ export function UploadPage() {
       setFiles((prev) => prev.map((f) => f.docType === entry.docType ? { ...f, status: 'done', result: res.data } : f));
       return res.data;
     } catch (e: unknown) {
-      const msg = e instanceof Error ? e.message : 'Parse error';
+      // Extract the server's error detail from axios response if available
+      const axiosMsg = (e as { response?: { data?: { detail?: string } } })?.response?.data?.detail;
+      const msg = axiosMsg || (e instanceof Error ? e.message : 'Parse error');
       setFiles((prev) => prev.map((f) => f.docType === entry.docType ? { ...f, status: 'error', error: msg } : f));
+      setGlobalError(`Parse failed: ${msg}`);
       throw e;
     }
   };
@@ -57,22 +60,48 @@ export function UploadPage() {
     setParseAll(true);
     setGlobalError(null);
     const merged: Record<string, unknown> = {};
+    let anySuccess = false;
     for (const f of files) {
       try {
         const data = await parseFile(f);
         Object.assign(merged, data);
-      } catch { /* handled in parseFile */ }
+        anySuccess = true;
+      } catch { /* error already shown in parseFile */ }
     }
-    applyExtraction(merged);
-    setParseAll(false);
-    setStep('review');
+    if (anySuccess) {
+      applyExtraction(merged);
+      setParseAll(false);
+      setStep('review');
+    } else {
+      setParseAll(false);
+    }
   };
 
   const applyExtraction = (data: Record<string, unknown>) => {
     const updates: Partial<typeof deal> = { raw_extraction: data };
-    if (data.property_info) updates.property_info = { ...deal.property_info, ...(data.property_info as object) };
-    if (data.t12_data) updates.t12_data = { ...deal.t12_data, ...(data.t12_data as object) };
-    if (Array.isArray(data.rent_roll)) updates.rent_roll = data.rent_roll as typeof deal.rent_roll;
+
+    // Property info — handle both direct and nested shapes
+    const pi = data.property_info as Record<string, unknown> | undefined;
+    if (pi) updates.property_info = { ...deal.property_info, ...pi };
+
+    // T12 — Claude may return t12_data directly or inline financials
+    const t12 = data.t12_data as Record<string, unknown> | undefined;
+    if (t12) updates.t12_data = { ...deal.t12_data, ...t12 };
+
+    // Rent roll
+    if (Array.isArray(data.rent_roll)) {
+      updates.rent_roll = data.rent_roll as typeof deal.rent_roll;
+    }
+
+    // OM may return unit_mix — convert to rough GPR estimate
+    const unitMix = data.unit_mix as Array<{ count?: number; market_rent?: number }> | undefined;
+    if (unitMix && !t12) {
+      const annualGPR = unitMix.reduce((sum, u) => sum + (u.count ?? 0) * (u.market_rent ?? 0) * 12, 0);
+      if (annualGPR > 0) {
+        updates.t12_data = { ...deal.t12_data, gross_potential_rent: annualGPR };
+      }
+    }
+
     updateDeal(updates);
   };
 

--- a/cre-analyzer/frontend/src/pages/Upload.tsx
+++ b/cre-analyzer/frontend/src/pages/Upload.tsx
@@ -1,0 +1,180 @@
+import React, { useCallback, useState } from 'react';
+import { useDropzone } from 'react-dropzone';
+import { Upload as UploadIcon, FileText, Loader2, Sparkles, AlertCircle } from 'lucide-react';
+import clsx from 'clsx';
+import { Card } from '../components/ui/Card';
+import { Button } from '../components/ui/Button';
+import { useDealStore } from '../store/dealStore';
+import { parseDocument, getDemoData } from '../api/client';
+import type { WizardStep } from '../types/deal';
+
+type DocType = 'om' | 't12' | 'rent_roll';
+
+interface DocSlot {
+  type: DocType;
+  label: string;
+  desc: string;
+  extensions: string[];
+}
+
+const SLOTS: DocSlot[] = [
+  { type: 'om', label: 'Offering Memorandum', desc: 'PDF with property details, pricing, sponsor projections', extensions: ['.pdf'] },
+  { type: 't12', label: 'T12 Financials', desc: 'PDF or Excel with trailing 12-month income & expenses', extensions: ['.pdf', '.xlsx', '.xls'] },
+  { type: 'rent_roll', label: 'Rent Roll', desc: 'PDF or Excel with unit-by-unit lease data', extensions: ['.pdf', '.xlsx', '.xls'] },
+];
+
+interface UploadedFile { file: File; docType: DocType; status: 'pending' | 'parsing' | 'done' | 'error'; result?: Record<string, unknown>; error?: string }
+
+export function UploadPage() {
+  const { deal, updateDeal, setStep } = useDealStore();
+  const [files, setFiles] = useState<UploadedFile[]>([]);
+  const [demoLoading, setDemoLoading] = useState(false);
+  const [parseAll, setParseAll] = useState(false);
+  const [globalError, setGlobalError] = useState<string | null>(null);
+
+  const addFile = (file: File, docType: DocType) => {
+    setFiles((prev) => {
+      const filtered = prev.filter((f) => f.docType !== docType);
+      return [...filtered, { file, docType, status: 'pending' }];
+    });
+  };
+
+  const parseFile = async (entry: UploadedFile): Promise<Record<string, unknown>> => {
+    setFiles((prev) => prev.map((f) => f.docType === entry.docType ? { ...f, status: 'parsing' } : f));
+    try {
+      const res = await parseDocument(entry.file, entry.docType);
+      setFiles((prev) => prev.map((f) => f.docType === entry.docType ? { ...f, status: 'done', result: res.data } : f));
+      return res.data;
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : 'Parse error';
+      setFiles((prev) => prev.map((f) => f.docType === entry.docType ? { ...f, status: 'error', error: msg } : f));
+      throw e;
+    }
+  };
+
+  const handleParseAll = async () => {
+    if (files.length === 0) { setGlobalError('Upload at least one document first.'); return; }
+    setParseAll(true);
+    setGlobalError(null);
+    const merged: Record<string, unknown> = {};
+    for (const f of files) {
+      try {
+        const data = await parseFile(f);
+        Object.assign(merged, data);
+      } catch { /* handled in parseFile */ }
+    }
+    applyExtraction(merged);
+    setParseAll(false);
+    setStep('review');
+  };
+
+  const applyExtraction = (data: Record<string, unknown>) => {
+    const updates: Partial<typeof deal> = { raw_extraction: data };
+    if (data.property_info) updates.property_info = { ...deal.property_info, ...(data.property_info as object) };
+    if (data.t12_data) updates.t12_data = { ...deal.t12_data, ...(data.t12_data as object) };
+    if (Array.isArray(data.rent_roll)) updates.rent_roll = data.rent_roll as typeof deal.rent_roll;
+    updateDeal(updates);
+  };
+
+  const handleDemo = async () => {
+    setDemoLoading(true);
+    setGlobalError(null);
+    try {
+      const data = await getDemoData();
+      applyExtraction(data);
+      setStep('review');
+    } catch (e: unknown) {
+      setGlobalError(e instanceof Error ? e.message : 'Failed to load demo');
+    } finally {
+      setDemoLoading(false);
+    }
+  };
+
+  const skipToReview = () => setStep('review');
+
+  return (
+    <div className="max-w-2xl mx-auto space-y-6 py-6">
+      <div>
+        <h2 className="text-xl font-bold text-gray-900 dark:text-white">Upload Documents</h2>
+        <p className="text-sm text-gray-500 mt-1">Upload one or more deal documents. Claude will extract and normalize the data automatically.</p>
+      </div>
+
+      {globalError && (
+        <div className="flex items-center gap-2 rounded-lg bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 px-4 py-3 text-sm text-red-700 dark:text-red-400">
+          <AlertCircle size={16} /> {globalError}
+        </div>
+      )}
+
+      <div className="space-y-3">
+        {SLOTS.map((slot) => (
+          <DocDropzone
+            key={slot.type}
+            slot={slot}
+            file={files.find((f) => f.docType === slot.type)}
+            onDrop={(f) => addFile(f, slot.type)}
+          />
+        ))}
+      </div>
+
+      <div className="flex flex-col sm:flex-row gap-3">
+        <Button onClick={handleParseAll} loading={parseAll} icon={<UploadIcon size={14} />} disabled={files.length === 0}>
+          Parse Documents with Claude
+        </Button>
+        <Button variant="secondary" onClick={handleDemo} loading={demoLoading} icon={<Sparkles size={14} />}>
+          Load Demo Deal
+        </Button>
+        <Button variant="ghost" onClick={skipToReview}>
+          Skip → Use Defaults
+        </Button>
+      </div>
+
+      <p className="text-xs text-gray-400">
+        Supported: PDF, XLSX, XLS. Documents are sent to Claude for extraction. Ensure you have your ANTHROPIC_API_KEY set.
+      </p>
+    </div>
+  );
+}
+
+function DocDropzone({ slot, file, onDrop }: { slot: DocSlot; file?: UploadedFile; onDrop: (f: File) => void }) {
+  const { getRootProps, getInputProps, isDragActive } = useDropzone({
+    onDrop: (accepted) => accepted[0] && onDrop(accepted[0]),
+    accept: slot.extensions.reduce((acc, ext) => {
+      if (ext === '.pdf') acc['application/pdf'] = ['.pdf'];
+      if (ext === '.xlsx') acc['application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'] = ['.xlsx'];
+      if (ext === '.xls') acc['application/vnd.ms-excel'] = ['.xls'];
+      return acc;
+    }, {} as Record<string, string[]>),
+    maxFiles: 1,
+  });
+
+  const statusIcon = () => {
+    if (!file) return null;
+    if (file.status === 'parsing') return <Loader2 size={14} className="animate-spin text-brand-500" />;
+    if (file.status === 'done') return <span className="text-emerald-500 text-xs font-medium">✓ Parsed</span>;
+    if (file.status === 'error') return <span className="text-red-500 text-xs">{file.error}</span>;
+    return <span className="text-xs text-gray-500">{file.file.name}</span>;
+  };
+
+  return (
+    <div
+      {...getRootProps()}
+      className={clsx(
+        'card p-4 flex items-center gap-4 cursor-pointer transition',
+        isDragActive && 'ring-2 ring-brand-400 bg-brand-50 dark:bg-brand-900/20',
+        file?.status === 'done' && 'ring-1 ring-emerald-400'
+      )}
+    >
+      <input {...getInputProps()} />
+      <div className="w-10 h-10 rounded-lg bg-brand-100 dark:bg-brand-900/30 flex items-center justify-center flex-shrink-0">
+        <FileText size={18} className="text-brand-600 dark:text-brand-400" />
+      </div>
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-semibold text-gray-800 dark:text-gray-200">{slot.label}</p>
+        <p className="text-xs text-gray-500 truncate">{file ? statusIcon() : slot.desc}</p>
+      </div>
+      <div className="text-xs text-gray-400 flex-shrink-0">
+        {isDragActive ? 'Drop here' : slot.extensions.join(', ')}
+      </div>
+    </div>
+  );
+}

--- a/cre-analyzer/frontend/src/pages/WaterfallConfig.tsx
+++ b/cre-analyzer/frontend/src/pages/WaterfallConfig.tsx
@@ -4,6 +4,7 @@ import { Card } from '../components/ui/Card';
 import { Input, Toggle } from '../components/ui/Input';
 import { Button } from '../components/ui/Button';
 import { useDealStore } from '../store/dealStore';
+import { fmtCurrency } from '../utils/calculations';
 import type { WaterfallConfig, WaterfallTier } from '../types/deal';
 
 export function WaterfallConfigPage() {
@@ -51,11 +52,11 @@ export function WaterfallConfigPage() {
           <div className="space-y-4">
             <div className="grid grid-cols-2 gap-4">
               <Input label="LP Equity (%)" type="number" suffix="%" value={wf.lp_equity_pct}
-                onChange={(e) => { const v = +e.target.value; upWF('lp_equity_pct', v); upWF('gp_equity_pct', 100 - v); }}
-                hint={`LP invests ~$${(lpEquity / 1_000_000).toFixed(1)}M`} />
+                onChange={(e) => { const v = Math.max(0, Math.min(100, +e.target.value)); updateDeal({ waterfall_config: { ...wf, lp_equity_pct: v, gp_equity_pct: 100 - v } }); }}
+                hint={`LP invests ${fmtCurrency(lpEquity, true)}`} />
               <Input label="GP Equity (%)" type="number" suffix="%" value={wf.gp_equity_pct}
-                onChange={(e) => { const v = +e.target.value; upWF('gp_equity_pct', v); upWF('lp_equity_pct', 100 - v); }}
-                hint={`GP invests ~$${(gpEquity / 1_000_000).toFixed(1)}M`} />
+                onChange={(e) => { const v = Math.max(0, Math.min(100, +e.target.value)); updateDeal({ waterfall_config: { ...wf, gp_equity_pct: v, lp_equity_pct: 100 - v } }); }}
+                hint={`GP invests ${fmtCurrency(gpEquity, true)}`} />
             </div>
             <div className="w-full h-4 rounded-full bg-gray-100 dark:bg-gray-700 overflow-hidden flex">
               <div className="h-full bg-brand-500 transition-all" style={{ width: `${wf.lp_equity_pct}%` }} />
@@ -110,9 +111,9 @@ export function WaterfallConfigPage() {
                 onChange={(e) => updateTier(i, 'irr_max', +e.target.value)}
                 hint={tier.irr_max >= 999 ? '(uncapped)' : undefined} />
               <Input label="LP Split (%)" type="number" suffix="%" value={tier.lp_split}
-                onChange={(e) => { updateTier(i, 'lp_split', +e.target.value); updateTier(i, 'gp_split', 100 - +e.target.value); }} />
+                onChange={(e) => { const v = Math.max(0, Math.min(100, +e.target.value)); updateDeal({ waterfall_config: { ...wf, tiers: wf.tiers.map((t, idx) => idx === i ? { ...t, lp_split: v, gp_split: 100 - v } : t) } }); }} />
               <Input label="GP Split (%)" type="number" suffix="%" value={tier.gp_split}
-                onChange={(e) => { updateTier(i, 'gp_split', +e.target.value); updateTier(i, 'lp_split', 100 - +e.target.value); }} />
+                onChange={(e) => { const v = Math.max(0, Math.min(100, +e.target.value)); updateDeal({ waterfall_config: { ...wf, tiers: wf.tiers.map((t, idx) => idx === i ? { ...t, gp_split: v, lp_split: 100 - v } : t) } }); }} />
               <Button variant="ghost" size="sm" icon={<Trash2 size={14} />} onClick={() => removeTier(i)}
                 disabled={wf.tiers.length <= 1} className="text-red-500 hover:text-red-600" />
             </div>

--- a/cre-analyzer/frontend/src/pages/WaterfallConfig.tsx
+++ b/cre-analyzer/frontend/src/pages/WaterfallConfig.tsx
@@ -1,0 +1,138 @@
+import React from 'react';
+import { ArrowRight, Plus, Trash2 } from 'lucide-react';
+import { Card } from '../components/ui/Card';
+import { Input, Toggle } from '../components/ui/Input';
+import { Button } from '../components/ui/Button';
+import { useDealStore } from '../store/dealStore';
+import type { WaterfallConfig, WaterfallTier } from '../types/deal';
+
+export function WaterfallConfigPage() {
+  const { deal, updateDeal, setStep } = useDealStore();
+  const wf = deal.waterfall_config;
+
+  const upWF = <K extends keyof WaterfallConfig>(k: K, v: WaterfallConfig[K]) =>
+    updateDeal({ waterfall_config: { ...wf, [k]: v } });
+
+  const updateTier = (i: number, field: keyof WaterfallTier, value: number) => {
+    const tiers = wf.tiers.map((t, idx) => idx === i ? { ...t, [field]: value } : t);
+    upWF('tiers', tiers);
+  };
+
+  const addTier = () => {
+    const last = wf.tiers[wf.tiers.length - 1];
+    upWF('tiers', [
+      ...wf.tiers.slice(0, -1),
+      { ...last, irr_max: last.irr_min + 4, lp_split: 70, gp_split: 30 },
+      { irr_min: last.irr_min + 4, irr_max: 999, lp_split: 60, gp_split: 40 },
+    ]);
+  };
+
+  const removeTier = (i: number) => {
+    if (wf.tiers.length <= 1) return;
+    upWF('tiers', wf.tiers.filter((_, idx) => idx !== i));
+  };
+
+  const equity = deal.property_info.purchase_price * (1 - deal.financing.ltv_pct / 100);
+  const lpEquity = equity * wf.lp_equity_pct / 100;
+  const gpEquity = equity * wf.gp_equity_pct / 100;
+
+  return (
+    <div className="space-y-6 py-6">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+        <div>
+          <h2 className="text-xl font-bold text-gray-900 dark:text-white">LP/GP Waterfall Structure</h2>
+          <p className="text-sm text-gray-500 mt-1">Configure equity split, preferred return, catch-up, and promote tiers.</p>
+        </div>
+        <Button onClick={() => setStep('results')} icon={<ArrowRight size={14} />}>Run Analysis</Button>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <Card title="Equity Split" padding>
+          <div className="space-y-4">
+            <div className="grid grid-cols-2 gap-4">
+              <Input label="LP Equity (%)" type="number" suffix="%" value={wf.lp_equity_pct}
+                onChange={(e) => { const v = +e.target.value; upWF('lp_equity_pct', v); upWF('gp_equity_pct', 100 - v); }}
+                hint={`LP invests ~$${(lpEquity / 1_000_000).toFixed(1)}M`} />
+              <Input label="GP Equity (%)" type="number" suffix="%" value={wf.gp_equity_pct}
+                onChange={(e) => { const v = +e.target.value; upWF('gp_equity_pct', v); upWF('lp_equity_pct', 100 - v); }}
+                hint={`GP invests ~$${(gpEquity / 1_000_000).toFixed(1)}M`} />
+            </div>
+            <div className="w-full h-4 rounded-full bg-gray-100 dark:bg-gray-700 overflow-hidden flex">
+              <div className="h-full bg-brand-500 transition-all" style={{ width: `${wf.lp_equity_pct}%` }} />
+              <div className="h-full bg-purple-500 transition-all" style={{ width: `${wf.gp_equity_pct}%` }} />
+            </div>
+            <div className="flex gap-4 text-xs text-gray-500">
+              <div className="flex items-center gap-1.5"><div className="w-2.5 h-2.5 rounded-sm bg-brand-500" />LP {wf.lp_equity_pct}%</div>
+              <div className="flex items-center gap-1.5"><div className="w-2.5 h-2.5 rounded-sm bg-purple-500" />GP {wf.gp_equity_pct}%</div>
+            </div>
+          </div>
+        </Card>
+
+        <Card title="Preferred Return & Catch-up" padding>
+          <div className="space-y-4">
+            <Input label="Preferred Return (%/yr)" type="number" suffix="%" value={wf.preferred_return}
+              onChange={(e) => upWF('preferred_return', +e.target.value)}
+              hint="Annual preferred return to LP on invested capital" />
+            <Toggle label="Compounding Pref" checked={wf.pref_compounding} onChange={(v) => upWF('pref_compounding', v)}
+              hint="Unchecked = simple (non-compounding)" />
+            <Toggle label="GP Catch-up" checked={wf.gp_catchup} onChange={(v) => upWF('gp_catchup', v)}
+              hint="GP receives catch-up distribution after LP pref" />
+            {wf.gp_catchup && (
+              <div className="grid grid-cols-2 gap-3 pt-2 border-t border-gray-100 dark:border-gray-700">
+                <Input label="Catch-up Rate (% to GP)" type="number" suffix="%" value={wf.gp_catchup_rate}
+                  onChange={(e) => upWF('gp_catchup_rate', +e.target.value)}
+                  hint="% of distributions to GP during catch-up" />
+                <Input label="GP Promote Target (%)" type="number" suffix="%" value={wf.gp_target_promote_pct}
+                  onChange={(e) => upWF('gp_target_promote_pct', +e.target.value)}
+                  hint="GP's target % of total profits" />
+              </div>
+            )}
+          </div>
+        </Card>
+      </div>
+
+      <Card
+        title="Promote Tiers"
+        subtitle="IRR-based profit splits after preferred return & catch-up"
+        action={
+          <Button variant="secondary" size="sm" icon={<Plus size={12} />} onClick={addTier}>
+            Add Tier
+          </Button>
+        }
+        padding
+      >
+        <div className="space-y-3 mt-2">
+          {wf.tiers.map((tier, i) => (
+            <div key={i} className="grid grid-cols-5 gap-3 items-end p-3 rounded-lg bg-gray-50 dark:bg-gray-700/30">
+              <Input label="LP IRR Floor (%)" type="number" suffix="%" value={tier.irr_min}
+                onChange={(e) => updateTier(i, 'irr_min', +e.target.value)} />
+              <Input label="LP IRR Ceiling (%)" type="number" suffix="%" value={tier.irr_max >= 999 ? 999 : tier.irr_max}
+                onChange={(e) => updateTier(i, 'irr_max', +e.target.value)}
+                hint={tier.irr_max >= 999 ? '(uncapped)' : undefined} />
+              <Input label="LP Split (%)" type="number" suffix="%" value={tier.lp_split}
+                onChange={(e) => { updateTier(i, 'lp_split', +e.target.value); updateTier(i, 'gp_split', 100 - +e.target.value); }} />
+              <Input label="GP Split (%)" type="number" suffix="%" value={tier.gp_split}
+                onChange={(e) => { updateTier(i, 'gp_split', +e.target.value); updateTier(i, 'lp_split', 100 - +e.target.value); }} />
+              <Button variant="ghost" size="sm" icon={<Trash2 size={14} />} onClick={() => removeTier(i)}
+                disabled={wf.tiers.length <= 1} className="text-red-500 hover:text-red-600" />
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-4 p-3 rounded-lg bg-brand-50 dark:bg-brand-900/20 border border-brand-100 dark:border-brand-800">
+          <p className="text-xs text-brand-700 dark:text-brand-300 font-medium mb-1">Waterfall Order:</p>
+          <ol className="text-xs text-brand-600 dark:text-brand-400 space-y-0.5 list-decimal list-inside">
+            <li>Return of capital (pro-rata {wf.lp_equity_pct}/{wf.gp_equity_pct})</li>
+            <li>LP preferred return ({wf.preferred_return}% {wf.pref_compounding ? 'compounding' : 'simple'}, cumulative)</li>
+            {wf.gp_catchup && <li>GP catch-up ({wf.gp_target_promote_pct}% of total profits)</li>}
+            {wf.tiers.map((t, i) => (
+              <li key={i}>
+                IRR {t.irr_min}–{t.irr_max >= 999 ? '∞' : t.irr_max}%: {t.lp_split}/{t.gp_split} LP/GP
+              </li>
+            ))}
+          </ol>
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/cre-analyzer/frontend/src/pages/__tests__/WaterfallConfig.test.tsx
+++ b/cre-analyzer/frontend/src/pages/__tests__/WaterfallConfig.test.tsx
@@ -1,0 +1,307 @@
+/**
+ * WaterfallConfig UI Tests
+ *
+ * Primary goal: verify that the stale-closure bug (two sequential updateDeal
+ * calls each spreading the same stale `wf` snapshot) is fixed. Every linked
+ * input pair must issue exactly ONE updateDeal call containing BOTH fields.
+ */
+
+import React from 'react'
+import { render, screen, fireEvent, within } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { WaterfallConfigPage } from '../WaterfallConfig'
+import { useDealStore } from '../../store/dealStore'
+
+// ---------------------------------------------------------------------------
+// Mock the Zustand store so we control state and capture updateDeal calls
+// ---------------------------------------------------------------------------
+
+vi.mock('../../store/dealStore')
+
+/**
+ * The Input component renders <label> + <input> inside a flex-col container
+ * without htmlFor/id association.  Find the input by locating the label text
+ * and querying the nearest sibling input.
+ */
+function getInputByLabel(labelText: string): HTMLInputElement {
+  const labels = screen.getAllByText(labelText)
+  for (const label of labels) {
+    const input = label.parentElement?.querySelector('input')
+    if (input) return input as HTMLInputElement
+  }
+  throw new Error(`No input found for label: "${labelText}"`)
+}
+
+function getAllInputsByLabel(labelText: string): HTMLInputElement[] {
+  return screen
+    .getAllByText(labelText)
+    .map((label) => label.parentElement?.querySelector('input'))
+    .filter((el): el is HTMLInputElement => el !== null && el !== undefined)
+}
+
+const DEFAULT_WF = {
+  lp_equity_pct: 90,
+  gp_equity_pct: 10,
+  preferred_return: 8.0,
+  pref_compounding: false,
+  gp_catchup: true,
+  gp_catchup_rate: 50,
+  gp_target_promote_pct: 20,
+  tiers: [
+    { irr_min: 0, irr_max: 14, lp_split: 80, gp_split: 20 },
+    { irr_min: 14, irr_max: 18, lp_split: 70, gp_split: 30 },
+    { irr_min: 18, irr_max: 999, lp_split: 60, gp_split: 40 },
+  ],
+}
+
+const DEFAULT_DEAL = {
+  waterfall_config: DEFAULT_WF,
+  property_info: { purchase_price: 15_000_000 },
+  financing: { ltv_pct: 65 },
+}
+
+function setupMock(wf = DEFAULT_WF) {
+  const mockUpdateDeal = vi.fn()
+  const mockSetStep = vi.fn()
+  vi.mocked(useDealStore).mockReturnValue({
+    deal: { ...DEFAULT_DEAL, waterfall_config: wf },
+    updateDeal: mockUpdateDeal,
+    setStep: mockSetStep,
+  } as ReturnType<typeof useDealStore>)
+  return { mockUpdateDeal, mockSetStep }
+}
+
+// ---------------------------------------------------------------------------
+// LP / GP Equity split
+// ---------------------------------------------------------------------------
+
+describe('LP/GP Equity — linked pair atomicity (bug fix)', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('changing LP equity issues exactly ONE updateDeal call', () => {
+    const { mockUpdateDeal } = setupMock()
+    render(<WaterfallConfigPage />)
+    fireEvent.change(getInputByLabel('LP Equity (%)'), { target: { value: '80' } })
+    expect(mockUpdateDeal).toHaveBeenCalledTimes(1)
+  })
+
+  it('changing GP equity issues exactly ONE updateDeal call', () => {
+    const { mockUpdateDeal } = setupMock()
+    render(<WaterfallConfigPage />)
+    fireEvent.change(getInputByLabel('GP Equity (%)'), { target: { value: '15' } })
+    expect(mockUpdateDeal).toHaveBeenCalledTimes(1)
+  })
+
+  it('LP=80 → both lp_equity_pct=80 and gp_equity_pct=20 in the same call', () => {
+    const { mockUpdateDeal } = setupMock()
+    render(<WaterfallConfigPage />)
+    fireEvent.change(getInputByLabel('LP Equity (%)'), { target: { value: '80' } })
+    const wf = mockUpdateDeal.mock.calls[0][0].waterfall_config
+    expect(wf.lp_equity_pct).toBe(80)
+    expect(wf.gp_equity_pct).toBe(20)
+  })
+
+  it('GP=15 → both gp_equity_pct=15 and lp_equity_pct=85 in the same call', () => {
+    const { mockUpdateDeal } = setupMock()
+    render(<WaterfallConfigPage />)
+    fireEvent.change(getInputByLabel('GP Equity (%)'), { target: { value: '15' } })
+    const wf = mockUpdateDeal.mock.calls[0][0].waterfall_config
+    expect(wf.gp_equity_pct).toBe(15)
+    expect(wf.lp_equity_pct).toBe(85)
+  })
+
+  it('LP + GP always sum to 100', () => {
+    const { mockUpdateDeal } = setupMock()
+    render(<WaterfallConfigPage />)
+    for (const val of [0, 25, 50, 75, 100]) {
+      mockUpdateDeal.mockClear()
+      fireEvent.change(getInputByLabel('LP Equity (%)'), { target: { value: String(val) } })
+      const wf = mockUpdateDeal.mock.calls[0][0].waterfall_config
+      expect(wf.lp_equity_pct + wf.gp_equity_pct).toBe(100)
+    }
+  })
+
+  it('clamps LP > 100 to 100 (GP becomes 0)', () => {
+    const { mockUpdateDeal } = setupMock()
+    render(<WaterfallConfigPage />)
+    fireEvent.change(getInputByLabel('LP Equity (%)'), { target: { value: '150' } })
+    const wf = mockUpdateDeal.mock.calls[0][0].waterfall_config
+    expect(wf.lp_equity_pct).toBe(100)
+    expect(wf.gp_equity_pct).toBe(0)
+  })
+
+  it('clamps LP < 0 to 0 (GP becomes 100)', () => {
+    const { mockUpdateDeal } = setupMock()
+    render(<WaterfallConfigPage />)
+    fireEvent.change(getInputByLabel('LP Equity (%)'), { target: { value: '-10' } })
+    const wf = mockUpdateDeal.mock.calls[0][0].waterfall_config
+    expect(wf.lp_equity_pct).toBe(0)
+    expect(wf.gp_equity_pct).toBe(100)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Promote Tier Splits
+// ---------------------------------------------------------------------------
+
+describe('Promote tier LP/GP split — linked pair atomicity (bug fix)', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('changing tier-0 LP split issues exactly ONE updateDeal call', () => {
+    const { mockUpdateDeal } = setupMock()
+    render(<WaterfallConfigPage />)
+    const lpSplits = getAllInputsByLabel('LP Split (%)')
+    fireEvent.change(lpSplits[0], { target: { value: '75' } })
+    expect(mockUpdateDeal).toHaveBeenCalledTimes(1)
+  })
+
+  it('tier-0 LP=75 → lp_split=75 and gp_split=25 in same call', () => {
+    const { mockUpdateDeal } = setupMock()
+    render(<WaterfallConfigPage />)
+    fireEvent.change(getAllInputsByLabel('LP Split (%)')[0], { target: { value: '75' } })
+    const tiers = mockUpdateDeal.mock.calls[0][0].waterfall_config.tiers
+    expect(tiers[0].lp_split).toBe(75)
+    expect(tiers[0].gp_split).toBe(25)
+  })
+
+  it('tier-0 GP=35 → gp_split=35 and lp_split=65 in same call', () => {
+    const { mockUpdateDeal } = setupMock()
+    render(<WaterfallConfigPage />)
+    fireEvent.change(getAllInputsByLabel('GP Split (%)')[0], { target: { value: '35' } })
+    const tiers = mockUpdateDeal.mock.calls[0][0].waterfall_config.tiers
+    expect(tiers[0].gp_split).toBe(35)
+    expect(tiers[0].lp_split).toBe(65)
+  })
+
+  it('updating tier-1 does not mutate tier-0 or tier-2', () => {
+    const { mockUpdateDeal } = setupMock()
+    render(<WaterfallConfigPage />)
+    fireEvent.change(getAllInputsByLabel('LP Split (%)')[1], { target: { value: '65' } })
+    const tiers = mockUpdateDeal.mock.calls[0][0].waterfall_config.tiers
+    expect(tiers[0].lp_split).toBe(80)   // unchanged
+    expect(tiers[1].lp_split).toBe(65)   // changed
+    expect(tiers[1].gp_split).toBe(35)   // counterpart updated
+    expect(tiers[2].lp_split).toBe(60)   // unchanged
+  })
+
+  it('updating tier-2 (uncapped) only changes tier-2', () => {
+    const { mockUpdateDeal } = setupMock()
+    render(<WaterfallConfigPage />)
+    fireEvent.change(getAllInputsByLabel('LP Split (%)')[2], { target: { value: '55' } })
+    const tiers = mockUpdateDeal.mock.calls[0][0].waterfall_config.tiers
+    expect(tiers[2].lp_split).toBe(55)
+    expect(tiers[2].gp_split).toBe(45)
+    expect(tiers[0].lp_split).toBe(80)   // unchanged
+  })
+
+  it('tier split LP + GP always sum to 100', () => {
+    const { mockUpdateDeal } = setupMock()
+    render(<WaterfallConfigPage />)
+    for (const val of [0, 30, 50, 70, 100]) {
+      mockUpdateDeal.mockClear()
+      fireEvent.change(getAllInputsByLabel('LP Split (%)')[0], { target: { value: String(val) } })
+      const t = mockUpdateDeal.mock.calls[0][0].waterfall_config.tiers[0]
+      expect(t.lp_split + t.gp_split).toBe(100)
+    }
+  })
+
+  it('clamps tier GP split > 100 to 100 (LP becomes 0)', () => {
+    const { mockUpdateDeal } = setupMock()
+    render(<WaterfallConfigPage />)
+    fireEvent.change(getAllInputsByLabel('GP Split (%)')[0], { target: { value: '120' } })
+    const tiers = mockUpdateDeal.mock.calls[0][0].waterfall_config.tiers
+    expect(tiers[0].gp_split).toBe(100)
+    expect(tiers[0].lp_split).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Single-field waterfall controls (should still work as before)
+// ---------------------------------------------------------------------------
+
+describe('Single-field controls', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('preferred return input fires updateDeal with new value', () => {
+    const { mockUpdateDeal } = setupMock()
+    render(<WaterfallConfigPage />)
+    fireEvent.change(getInputByLabel('Preferred Return (%/yr)'), { target: { value: '10' } })
+    expect(mockUpdateDeal).toHaveBeenCalledTimes(1)
+    expect(mockUpdateDeal.mock.calls[0][0].waterfall_config.preferred_return).toBe(10)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Waterfall order summary display
+// ---------------------------------------------------------------------------
+
+describe('Waterfall order summary', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('displays the correct preferred return rate in the summary', () => {
+    setupMock()
+    render(<WaterfallConfigPage />)
+    // The ordered list contains "LP preferred return (8% simple, cumulative)"
+    const listItems = document.querySelectorAll('ol li')
+    const prefItem = Array.from(listItems).find((li) => li.textContent?.includes('preferred return'))
+    expect(prefItem).toBeTruthy()
+    expect(prefItem!.textContent).toMatch(/8%/)
+  })
+
+  it('displays all three IRR tier ranges', () => {
+    setupMock()
+    render(<WaterfallConfigPage />)
+    expect(screen.getByText(/IRR 0–14%/)).toBeInTheDocument()
+    expect(screen.getByText(/IRR 14–18%/)).toBeInTheDocument()
+    expect(screen.getByText(/IRR 18–∞%/)).toBeInTheDocument()
+  })
+
+  it('shows the LP/GP equity bar with correct widths', () => {
+    setupMock()
+    render(<WaterfallConfigPage />)
+    const bars = document.querySelectorAll('[style*="width"]')
+    const lpBar = Array.from(bars).find((el) => (el as HTMLElement).style.width === '90%')
+    const gpBar = Array.from(bars).find((el) => (el as HTMLElement).style.width === '10%')
+    expect(lpBar).toBeTruthy()
+    expect(gpBar).toBeTruthy()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Add / Remove tier
+// ---------------------------------------------------------------------------
+
+describe('Add and remove tiers', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('Add Tier calls updateDeal with one more tier', () => {
+    const { mockUpdateDeal } = setupMock()
+    render(<WaterfallConfigPage />)
+    fireEvent.click(screen.getByRole('button', { name: /Add Tier/i }))
+    expect(mockUpdateDeal).toHaveBeenCalledTimes(1)
+    const newTiers = mockUpdateDeal.mock.calls[0][0].waterfall_config.tiers
+    expect(newTiers).toHaveLength(DEFAULT_WF.tiers.length + 1)
+  })
+
+  it('Remove Tier on tier-1 calls updateDeal with one fewer tier', () => {
+    const { mockUpdateDeal } = setupMock()
+    render(<WaterfallConfigPage />)
+    // There are 3 tiers; trash buttons are not disabled (count > 1)
+    const trashButtons = screen.getAllByRole('button').filter(
+      (btn) => btn.querySelector('svg') && !btn.textContent?.trim()
+    )
+    fireEvent.click(trashButtons[1])  // remove second tier
+    const newTiers = mockUpdateDeal.mock.calls[0][0].waterfall_config.tiers
+    expect(newTiers).toHaveLength(DEFAULT_WF.tiers.length - 1)
+  })
+
+  it('Remove Tier is disabled when only one tier remains', () => {
+    const singleTierWF = { ...DEFAULT_WF, tiers: [DEFAULT_WF.tiers[0]] }
+    setupMock(singleTierWF)
+    render(<WaterfallConfigPage />)
+    const trashBtn = screen.getAllByRole('button').find(
+      (btn) => btn.querySelector('svg') && !btn.textContent?.trim()
+    )
+    expect(trashBtn).toBeDisabled()
+  })
+})

--- a/cre-analyzer/frontend/src/store/dealStore.ts
+++ b/cre-analyzer/frontend/src/store/dealStore.ts
@@ -1,0 +1,155 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import type {
+  DealState,
+  WizardStep,
+  AnalysisResults,
+  SensitivityResults,
+} from '../types/deal';
+
+const DEFAULT_DEAL: DealState = {
+  deal_id: crypto.randomUUID(),
+  name: 'New Deal',
+  property_info: {
+    name: 'Sunset Ridge Apartments',
+    address: '4500 Sunset Ridge Dr, Austin, TX 78741',
+    asset_type: 'Multifamily',
+    units: 100,
+    sqft: 85000,
+    year_built: 1998,
+    purchase_price: 15_000_000,
+    asking_price: 15_500_000,
+    market: 'Austin, TX',
+    submarket: 'South Austin',
+    sponsor_projected_noi: 825_000,
+  },
+  t12_data: {
+    gross_potential_rent: 1_260_000,
+    vacancy_loss: 63_000,
+    concessions: 12_600,
+    bad_debt: 6_300,
+    other_income: 60_000,
+    effective_gross_income: 1_238_100,
+    property_taxes: 138_000,
+    insurance: 42_000,
+    management_fee: 49_524,
+    maintenance_repairs: 65_000,
+    utilities: 38_000,
+    payroll: 78_000,
+    general_admin: 28_000,
+    marketing: 15_000,
+    capex_reserves: 25_000,
+    other_expenses: 7_576,
+    total_expenses: 486_100,
+    noi: 752_000,
+  },
+  rent_roll: [],
+  assumptions: {
+    rent_growth_rate: 3.0,
+    vacancy_rate: 5.0,
+    credit_loss_rate: 0.5,
+    other_income_growth: 3.0,
+    expense_growth_rate: 3.0,
+    management_fee_pct: 4.0,
+    capex_reserves_per_unit: 250,
+    value_add: {
+      enabled: false,
+      units_to_renovate: 50,
+      renovation_cost_per_unit: 15_000,
+      rent_premium_per_unit: 150,
+      absorption_years: 2,
+    },
+  },
+  financing: {
+    ltv_pct: 65.0,
+    interest_rate: 6.5,
+    io_period_years: 2,
+    amortization_years: 30,
+    loan_term_years: 5,
+    loan_type: 'Agency',
+    enable_refi: false,
+    refi_year: 3,
+    refi_ltv_pct: 70.0,
+    refi_rate: 6.0,
+  },
+  exit_assumptions: {
+    hold_period_years: 5,
+    exit_cap_rate: 5.25,
+    selling_costs_pct: 2.0,
+  },
+  waterfall_config: {
+    lp_equity_pct: 90,
+    gp_equity_pct: 10,
+    preferred_return: 8.0,
+    pref_compounding: false,
+    gp_catchup: true,
+    gp_catchup_rate: 50,
+    gp_target_promote_pct: 20,
+    tiers: [
+      { irr_min: 0, irr_max: 14, lp_split: 80, gp_split: 20 },
+      { irr_min: 14, irr_max: 18, lp_split: 70, gp_split: 30 },
+      { irr_min: 18, irr_max: 999, lp_split: 60, gp_split: 40 },
+    ],
+  },
+  results: null,
+  raw_extraction: null,
+};
+
+interface StoreState {
+  deal: DealState;
+  step: WizardStep;
+  isLoading: boolean;
+  isSensLoading: boolean;
+  error: string | null;
+  sensitivity: SensitivityResults | null;
+  darkMode: boolean;
+
+  setDeal: (deal: DealState) => void;
+  updateDeal: (partial: Partial<DealState>) => void;
+  setStep: (step: WizardStep) => void;
+  setResults: (results: AnalysisResults) => void;
+  setSensitivity: (s: SensitivityResults) => void;
+  setLoading: (v: boolean) => void;
+  setSensLoading: (v: boolean) => void;
+  setError: (e: string | null) => void;
+  resetDeal: () => void;
+  toggleDarkMode: () => void;
+  loadFromJson: (json: string) => void;
+  exportJson: () => string;
+}
+
+export const useDealStore = create<StoreState>()(
+  persist(
+    (set, get) => ({
+      deal: DEFAULT_DEAL,
+      step: 'upload',
+      isLoading: false,
+      isSensLoading: false,
+      error: null,
+      sensitivity: null,
+      darkMode: false,
+
+      setDeal: (deal) => set({ deal }),
+      updateDeal: (partial) => set((s) => ({ deal: { ...s.deal, ...partial } })),
+      setStep: (step) => set({ step }),
+      setResults: (results) =>
+        set((s) => ({ deal: { ...s.deal, results } })),
+      setSensitivity: (sensitivity) => set({ sensitivity }),
+      setLoading: (isLoading) => set({ isLoading }),
+      setSensLoading: (isSensLoading) => set({ isSensLoading }),
+      setError: (error) => set({ error }),
+      resetDeal: () => set({ deal: { ...DEFAULT_DEAL, deal_id: crypto.randomUUID() }, step: 'upload', sensitivity: null }),
+      toggleDarkMode: () => set((s) => ({ darkMode: !s.darkMode })),
+      loadFromJson: (json) => {
+        try {
+          const deal = JSON.parse(json) as DealState;
+          set({ deal, step: 'results' });
+        } catch {
+          set({ error: 'Invalid deal file' });
+        }
+      },
+      exportJson: () => JSON.stringify(get().deal, null, 2),
+    }),
+    { name: 'cre-deal-store', partialize: (s) => ({ deal: s.deal, darkMode: s.darkMode }) }
+  )
+);

--- a/cre-analyzer/frontend/src/test/setup.ts
+++ b/cre-analyzer/frontend/src/test/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom'

--- a/cre-analyzer/frontend/src/types/deal.ts
+++ b/cre-analyzer/frontend/src/types/deal.ts
@@ -1,0 +1,239 @@
+export interface PropertyInfo {
+  name: string;
+  address: string;
+  asset_type: string;
+  units: number;
+  sqft: number;
+  year_built: number;
+  purchase_price: number;
+  asking_price: number;
+  market: string;
+  submarket: string;
+  sponsor_projected_noi: number;
+}
+
+export interface T12Data {
+  gross_potential_rent: number;
+  vacancy_loss: number;
+  concessions: number;
+  bad_debt: number;
+  other_income: number;
+  effective_gross_income: number;
+  property_taxes: number;
+  insurance: number;
+  management_fee: number;
+  maintenance_repairs: number;
+  utilities: number;
+  payroll: number;
+  general_admin: number;
+  marketing: number;
+  capex_reserves: number;
+  other_expenses: number;
+  total_expenses: number;
+  noi: number;
+}
+
+export interface RentRollUnit {
+  unit_number: string;
+  unit_type: string;
+  sqft: number;
+  market_rent: number;
+  current_rent: number;
+  lease_start: string | null;
+  lease_end: string | null;
+  status: 'Occupied' | 'Vacant' | 'MTM';
+}
+
+export interface ValueAddAssumptions {
+  enabled: boolean;
+  units_to_renovate: number;
+  renovation_cost_per_unit: number;
+  rent_premium_per_unit: number;
+  absorption_years: number;
+}
+
+export interface Assumptions {
+  rent_growth_rate: number;
+  vacancy_rate: number;
+  credit_loss_rate: number;
+  other_income_growth: number;
+  expense_growth_rate: number;
+  management_fee_pct: number;
+  capex_reserves_per_unit: number;
+  value_add: ValueAddAssumptions;
+}
+
+export interface FinancingAssumptions {
+  ltv_pct: number;
+  interest_rate: number;
+  io_period_years: number;
+  amortization_years: number;
+  loan_term_years: number;
+  loan_type: string;
+  enable_refi: boolean;
+  refi_year: number;
+  refi_ltv_pct: number;
+  refi_rate: number;
+}
+
+export interface ExitAssumptions {
+  hold_period_years: number;
+  exit_cap_rate: number;
+  selling_costs_pct: number;
+}
+
+export interface WaterfallTier {
+  irr_min: number;
+  irr_max: number;
+  lp_split: number;
+  gp_split: number;
+}
+
+export interface WaterfallConfig {
+  lp_equity_pct: number;
+  gp_equity_pct: number;
+  preferred_return: number;
+  pref_compounding: boolean;
+  gp_catchup: boolean;
+  gp_catchup_rate: number;
+  gp_target_promote_pct: number;
+  tiers: WaterfallTier[];
+}
+
+export interface DealState {
+  deal_id: string;
+  name: string;
+  property_info: PropertyInfo;
+  t12_data: T12Data;
+  rent_roll: RentRollUnit[];
+  assumptions: Assumptions;
+  financing: FinancingAssumptions;
+  exit_assumptions: ExitAssumptions;
+  waterfall_config: WaterfallConfig;
+  results?: AnalysisResults | null;
+  raw_extraction?: Record<string, unknown> | null;
+}
+
+// Analysis result types
+export interface AnnualRow {
+  year: number;
+  gross_potential_rent: number;
+  vacancy_loss: number;
+  credit_loss: number;
+  other_income: number;
+  egi: number;
+  property_taxes: number;
+  insurance: number;
+  management_fee: number;
+  maintenance: number;
+  utilities: number;
+  payroll: number;
+  general_admin: number;
+  marketing: number;
+  capex_reserves: number;
+  other_expenses: number;
+  total_expenses: number;
+  noi: number;
+  debt_service: number;
+  levered_cf: number;
+  dscr: number | null;
+}
+
+export interface Metrics {
+  purchase_price: number;
+  loan_amount: number;
+  equity_required: number;
+  closing_costs: number;
+  going_in_cap_rate: number;
+  stabilized_cap_rate: number;
+  year1_noi: number;
+  year1_egi: number;
+  noi_margin: number | null;
+  dscr_year1: number | null;
+  levered_coc: number | null;
+  unlevered_coc: number;
+  levered_irr: number | null;
+  unlevered_irr: number | null;
+  levered_em: number | null;
+  unlevered_em: number | null;
+  npv_10pct: number;
+}
+
+export interface ExitSummary {
+  exit_year_noi: number;
+  exit_cap_rate: number;
+  gross_sale_price: number;
+  selling_costs: number;
+  net_sale_price: number;
+  loan_payoff: number;
+  net_sale_proceeds: number;
+}
+
+export interface WaterfallYear {
+  year: number;
+  is_exit: boolean;
+  distributable: number;
+  lp_distribution: number;
+  gp_distribution: number;
+  tier_roc_lp: number;
+  tier_roc_gp: number;
+  tier_preferred_return: number;
+  tier_gp_catchup: number;
+  tier_lp_promote: number;
+  tier_gp_promote: number;
+}
+
+export interface WaterfallResults {
+  yearly: WaterfallYear[];
+  lp_total_distributions: number;
+  gp_total_distributions: number;
+  lp_irr: number | null;
+  gp_irr: number | null;
+  lp_em: number | null;
+  gp_em: number | null;
+  gp_promote_earned: number;
+  lp_invested: number;
+  gp_invested: number;
+  pref_paid: number;
+}
+
+export interface SensitivityTable {
+  row_param: string;
+  col_param: string;
+  row_values: number[];
+  col_values: number[];
+  output_metric: string;
+  table: (number | null)[][];
+}
+
+export interface AnalysisResults {
+  proforma: {
+    annual_rows: AnnualRow[];
+    metrics: Metrics;
+    exit: ExitSummary;
+    cash_flows: { levered: number[]; unlevered: number[] };
+    loan_amount: number;
+    total_equity: number;
+  };
+  waterfall: WaterfallResults;
+  metrics: Metrics;
+  lp_irr: number | null;
+  levered_irr: number | null;
+  levered_em: number | null;
+  levered_coc: number | null;
+}
+
+export interface SensitivityResults {
+  lp_irr_vs_price_x_exit_cap: SensitivityTable;
+  lp_irr_vs_rent_x_vacancy: SensitivityTable;
+  coc_vs_ltv_x_rate: SensitivityTable;
+  em_vs_hold_x_exit_cap: SensitivityTable;
+}
+
+export type WizardStep =
+  | 'upload'
+  | 'review'
+  | 'assumptions'
+  | 'financing'
+  | 'waterfall'
+  | 'results';

--- a/cre-analyzer/frontend/src/utils/calculations.ts
+++ b/cre-analyzer/frontend/src/utils/calculations.ts
@@ -1,0 +1,98 @@
+/**
+ * Client-side calculation utilities for instant feedback.
+ * The authoritative calculations run on the backend.
+ */
+
+export function fmtCurrency(n: number | null | undefined, compact = false): string {
+  if (n == null) return '—';
+  if (compact) {
+    if (Math.abs(n) >= 1_000_000) return `$${(n / 1_000_000).toFixed(2)}M`;
+    if (Math.abs(n) >= 1_000) return `$${(n / 1_000).toFixed(0)}K`;
+  }
+  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 }).format(n);
+}
+
+export function fmtPct(n: number | null | undefined, decimals = 2): string {
+  if (n == null) return '—';
+  return `${n.toFixed(decimals)}%`;
+}
+
+export function fmtNum(n: number | null | undefined, decimals = 2): string {
+  if (n == null) return '—';
+  return n.toFixed(decimals);
+}
+
+export function fmtMultiple(n: number | null | undefined): string {
+  if (n == null) return '—';
+  return `${n.toFixed(2)}x`;
+}
+
+export function computeEGI(t12: {
+  gross_potential_rent: number;
+  vacancy_loss: number;
+  concessions: number;
+  bad_debt: number;
+  other_income: number;
+}): number {
+  return (
+    t12.gross_potential_rent -
+    t12.vacancy_loss -
+    t12.concessions -
+    t12.bad_debt +
+    t12.other_income
+  );
+}
+
+export function computeT12Expenses(t12: {
+  property_taxes: number;
+  insurance: number;
+  management_fee: number;
+  maintenance_repairs: number;
+  utilities: number;
+  payroll: number;
+  general_admin: number;
+  marketing: number;
+  capex_reserves: number;
+  other_expenses: number;
+}): number {
+  return (
+    t12.property_taxes +
+    t12.insurance +
+    t12.management_fee +
+    t12.maintenance_repairs +
+    t12.utilities +
+    t12.payroll +
+    t12.general_admin +
+    t12.marketing +
+    t12.capex_reserves +
+    t12.other_expenses
+  );
+}
+
+export function computeNOI(egi: number, expenses: number): number {
+  return egi - expenses;
+}
+
+export function computeGoingInCap(noi: number, purchasePrice: number): number {
+  return purchasePrice > 0 ? (noi / purchasePrice) * 100 : 0;
+}
+
+export function rentRollSummary(units: { market_rent: number; current_rent: number; status: string }[]) {
+  const total = units.length;
+  const occupied = units.filter((u) => u.status === 'Occupied').length;
+  const vacant = units.filter((u) => u.status === 'Vacant').length;
+  const mtm = units.filter((u) => u.status === 'MTM').length;
+  const avgMarket = total ? units.reduce((s, u) => s + u.market_rent, 0) / total : 0;
+  const avgCurrent = total ? units.reduce((s, u) => s + u.current_rent, 0) / total : 0;
+  return {
+    total,
+    occupied,
+    vacant,
+    mtm,
+    occupancy_pct: total ? (occupied / total) * 100 : 0,
+    avg_market_rent: avgMarket,
+    avg_current_rent: avgCurrent,
+    total_market_gpr: units.reduce((s, u) => s + u.market_rent * 12, 0),
+    total_current_gpr: units.reduce((s, u) => s + u.current_rent * 12, 0),
+  };
+}

--- a/cre-analyzer/frontend/src/utils/export.ts
+++ b/cre-analyzer/frontend/src/utils/export.ts
@@ -1,0 +1,102 @@
+import * as XLSX from 'xlsx';
+import type { DealState, AnalysisResults } from '../types/deal';
+import { fmtCurrency, fmtPct, fmtMultiple } from './calculations';
+
+export function exportExcel(deal: DealState, results: AnalysisResults) {
+  const wb = XLSX.utils.book_new();
+
+  // --- Summary sheet ---
+  const m = results.metrics;
+  const wf = results.waterfall;
+  const summaryData = [
+    ['CRE Deal Analyzer — Deal Summary'],
+    [],
+    ['Property', deal.property_info.name],
+    ['Address', deal.property_info.address],
+    ['Units', deal.property_info.units],
+    ['Purchase Price', m.purchase_price],
+    ['Loan Amount', m.loan_amount],
+    ['Equity Required', m.equity_required],
+    [],
+    ['--- Return Metrics ---'],
+    ['Going-in Cap Rate', fmtPct(m.going_in_cap_rate)],
+    ['Stabilized Cap Rate', fmtPct(m.stabilized_cap_rate)],
+    ['Year 1 NOI', fmtCurrency(m.year1_noi)],
+    ['DSCR (Year 1)', fmtNum(m.dscr_year1)],
+    ['Levered CoC', fmtPct(m.levered_coc)],
+    ['Levered IRR', fmtPct(m.levered_irr)],
+    ['Unlevered IRR', fmtPct(m.unlevered_irr)],
+    ['Levered EM', fmtMultiple(m.levered_em)],
+    ['Unlevered EM', fmtMultiple(m.unlevered_em)],
+    [],
+    ['--- Waterfall ---'],
+    ['LP IRR', fmtPct(wf.lp_irr)],
+    ['GP IRR', fmtPct(wf.gp_irr)],
+    ['LP EM', fmtMultiple(wf.lp_em)],
+    ['GP EM', fmtMultiple(wf.gp_em)],
+    ['LP Total Distributions', fmtCurrency(wf.lp_total_distributions)],
+    ['GP Total Distributions', fmtCurrency(wf.gp_total_distributions)],
+    ['GP Promote Earned', fmtCurrency(wf.gp_promote_earned)],
+  ];
+  const ws1 = XLSX.utils.aoa_to_sheet(summaryData);
+  XLSX.utils.book_append_sheet(wb, ws1, 'Summary');
+
+  // --- Pro Forma sheet ---
+  const pf = results.proforma;
+  const pfHeaders = [
+    'Year', 'GPR', 'Vacancy', 'Credit Loss', 'Other Income', 'EGI',
+    'Taxes', 'Insurance', 'Mgmt Fee', 'Maintenance', 'Utilities',
+    'Payroll', 'G&A', 'Marketing', 'CapEx', 'Total Exp', 'NOI',
+    'Debt Service', 'Levered CF', 'DSCR',
+  ];
+  const pfRows = pf.annual_rows.map((r) => [
+    r.year, r.gross_potential_rent, r.vacancy_loss, r.credit_loss, r.other_income, r.egi,
+    r.property_taxes, r.insurance, r.management_fee, r.maintenance, r.utilities,
+    r.payroll, r.general_admin, r.marketing, r.capex_reserves, r.total_expenses, r.noi,
+    r.debt_service, r.levered_cf, r.dscr,
+  ]);
+  const ws2 = XLSX.utils.aoa_to_sheet([pfHeaders, ...pfRows]);
+  XLSX.utils.book_append_sheet(wb, ws2, 'Pro Forma');
+
+  // --- Waterfall sheet ---
+  const wfHeaders = [
+    'Year', 'Distributable', 'LP Dist', 'GP Dist',
+    'RoC LP', 'RoC GP', 'Pref Return', 'GP Catch-up', 'LP Promote', 'GP Promote',
+  ];
+  const wfRows = wf.yearly.map((r) => [
+    r.is_exit ? `Year ${r.year} (Exit)` : `Year ${r.year}`,
+    r.distributable, r.lp_distribution, r.gp_distribution,
+    r.tier_roc_lp, r.tier_roc_gp, r.tier_preferred_return,
+    r.tier_gp_catchup, r.tier_lp_promote, r.tier_gp_promote,
+  ]);
+  const ws3 = XLSX.utils.aoa_to_sheet([wfHeaders, ...wfRows]);
+  XLSX.utils.book_append_sheet(wb, ws3, 'Waterfall');
+
+  // --- Rent Roll sheet ---
+  if (deal.rent_roll.length > 0) {
+    const rrHeaders = ['Unit', 'Type', 'SqFt', 'Market Rent', 'Current Rent', 'Lease Start', 'Lease End', 'Status'];
+    const rrRows = deal.rent_roll.map((u) => [
+      u.unit_number, u.unit_type, u.sqft, u.market_rent, u.current_rent,
+      u.lease_start, u.lease_end, u.status,
+    ]);
+    const ws4 = XLSX.utils.aoa_to_sheet([rrHeaders, ...rrRows]);
+    XLSX.utils.book_append_sheet(wb, ws4, 'Rent Roll');
+  }
+
+  XLSX.writeFile(wb, `${deal.name || 'cre-deal'}.xlsx`);
+}
+
+function fmtNum(n: number | null | undefined, d = 2): string {
+  if (n == null) return '—';
+  return n.toFixed(d);
+}
+
+export function exportDealJson(deal: DealState) {
+  const blob = new Blob([JSON.stringify(deal, null, 2)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `${deal.name || 'deal'}.json`;
+  a.click();
+  URL.revokeObjectURL(url);
+}

--- a/cre-analyzer/frontend/tailwind.config.js
+++ b/cre-analyzer/frontend/tailwind.config.js
@@ -1,0 +1,20 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
+  darkMode: 'class',
+  theme: {
+    extend: {
+      colors: {
+        brand: {
+          50: '#eff6ff',
+          100: '#dbeafe',
+          500: '#3b82f6',
+          600: '#2563eb',
+          700: '#1d4ed8',
+          900: '#1e3a8a',
+        },
+      },
+    },
+  },
+  plugins: [],
+}

--- a/cre-analyzer/frontend/tsconfig.json
+++ b/cre-analyzer/frontend/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}

--- a/cre-analyzer/frontend/vite.config.ts
+++ b/cre-analyzer/frontend/vite.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8000',
+        changeOrigin: true,
+      },
+    },
+  },
+})

--- a/cre-analyzer/frontend/vitest.config.ts
+++ b/cre-analyzer/frontend/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./src/test/setup.ts'],
+    globals: true,
+  },
+})

--- a/cre-analyzer/start.sh
+++ b/cre-analyzer/start.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -e
+
+# CRE Analyzer startup script
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Check for ANTHROPIC_API_KEY
+if [ -z "$ANTHROPIC_API_KEY" ]; then
+  if [ -f "$SCRIPT_DIR/backend/.env" ]; then
+    export $(cat "$SCRIPT_DIR/backend/.env" | xargs)
+  else
+    echo "⚠️  Warning: ANTHROPIC_API_KEY not set. Document parsing will fail."
+    echo "   Copy backend/.env.example to backend/.env and add your key."
+  fi
+fi
+
+# Add node to PATH if via homebrew
+export PATH="/opt/homebrew/bin:$PATH"
+
+echo "🏗️  Starting CRE Deal Analyzer..."
+
+# Start backend
+echo "  → Starting FastAPI backend on :8000"
+cd "$SCRIPT_DIR/backend"
+if [ ! -d ".venv" ]; then
+  python3 -m venv .venv
+  .venv/bin/pip install -q -r requirements.txt
+fi
+.venv/bin/python main.py &
+BACKEND_PID=$!
+
+# Start frontend
+echo "  → Starting Vite frontend on :5173"
+cd "$SCRIPT_DIR/frontend"
+if [ ! -d "node_modules" ]; then
+  npm install
+fi
+npm run dev &
+FRONTEND_PID=$!
+
+echo ""
+echo "✅ CRE Deal Analyzer running!"
+echo "   Frontend: http://localhost:5173"
+echo "   Backend:  http://localhost:8000"
+echo "   API Docs: http://localhost:8000/docs"
+echo ""
+echo "Press Ctrl+C to stop both servers."
+
+# Wait and cleanup
+trap "kill $BACKEND_PID $FRONTEND_PID 2>/dev/null; echo 'Stopped.'" SIGINT SIGTERM
+wait


### PR DESCRIPTION
## Summary

Adds a comprehensive Commercial Real Estate Deal Analyzer web application under `cre-analyzer/`. This is a self-contained full-stack tool that does not modify any existing Auto-GPT code.

> Supersedes #13134 (closed and could not be reopened). Includes an additional fix commit (`f956dbd2c`) correcting solve-mode IRR and WaterfallConfig inputs, plus a 67-test suite (backend financial accuracy + frontend WaterfallConfig).

### What is included

**Backend (FastAPI + Python)**
- Document ingestion pipeline using Claude API (`claude-sonnet-4-20250514`) to extract data from Offering Memorandums, T12 financials, and rent rolls (PDF + Excel via openpyxl)
- Underwriting engine: 10-year pro forma builder, Newton-Raphson IRR solver, NPV, DSCR, cash-on-cash, equity multiple, going-in/stabilized cap rates
- LP/GP waterfall engine with configurable preferred return, GP catch-up, and IRR-based promote tiers (binary-search solver for tier boundaries at exit)
- Sensitivity analysis: 4 heatmap tables (LP IRR vs price×exit cap, IRR vs rent growth×vacancy, CoC vs LTV×rate, EM vs hold×exit cap)
- Back-solve mode: find max purchase price or min exit cap rate for a target LP IRR
- REST API: `/documents/parse`, `/analysis/run`, `/analysis/sensitivity`, `/analysis/solve`, `/deals` CRUD

**Frontend (React + TypeScript + Tailwind)**
- 6-step wizard: Upload → Review Data → Assumptions → Financing → Waterfall → Results
- Real-time recalculation on all input changes
- Recharts visualizations: cash flow, NOI growth, waterfall distribution, LP/GP split charts
- Color-coded sensitivity heatmaps (green/yellow/red thresholds)
- Collapsible 10-year pro forma table with inline editing
- Paginated rent roll table with occupancy summary
- Excel export (SheetJS) and JSON deal save/load
- Dark mode, Zustand state persisted to localStorage
- Demo mode pre-populated with 100-unit $15M multifamily deal

### Fixes since the original PR
- Corrected solve-mode (back-solve) LP IRR: solvers now use the shared `waterfall_from_proforma` helper as a single source of truth, fixing an inflated max-purchase-price result that contradicted the deal's actual LP IRR
- Fixed WaterfallConfig stale-closure bug where linked LP/GP equity and tier-split inputs showed corrupted values; linked pairs now update atomically with clamping
- Added 67 tests (backend financial accuracy + frontend WaterfallConfig atomicity)

## Test plan

- [ ] Run `./cre-analyzer/start.sh` and open http://localhost:5173
- [ ] Click "Load Demo Deal" and verify wizard auto-populates
- [ ] Walk through all 6 wizard steps
- [ ] On Results page, click "Recalculate" and verify metrics render (going-in cap ~5.25%, LP IRR ~6-7%)
- [ ] Click "Run Sensitivity" and verify 4 heatmap tables appear
- [ ] Test Export Excel — verify workbook downloads with Summary, Pro Forma, Waterfall, and Rent Roll sheets
- [ ] Upload a real OM/T12/rent roll PDF with `ANTHROPIC_API_KEY` set and verify extraction
- [ ] Run backend tests: `cd cre-analyzer/backend && pytest`
- [ ] Run frontend tests: `cd cre-analyzer/frontend && pnpm test`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)