### PR TITLE
feat: Add LinkedIn OAuth integration and network blocks

### DIFF
--- a/autogpt_platform/backend/backend/blocks/linkedin/__init__.py
+++ b/autogpt_platform/backend/backend/blocks/linkedin/__init__.py
@@ -1,0 +1,3 @@
+from .network import GetLinkedInNetworkSizeBlock, GetLinkedInProfileBlock
+
+__all__ = ["GetLinkedInNetworkSizeBlock", "GetLinkedInProfileBlock"]

--- a/autogpt_platform/backend/backend/blocks/linkedin/_auth.py
+++ b/autogpt_platform/backend/backend/blocks/linkedin/_auth.py
@@ -1,0 +1,49 @@
+from typing import Literal
+
+from pydantic import SecretStr
+
+from backend.data.model import (
+    CredentialsField,
+    CredentialsMetaInput,
+    OAuth2Credentials,
+    ProviderName,
+)
+from backend.integrations.oauth.linkedin import LinkedInOAuthHandler
+from backend.util.settings import Secrets
+
+secrets = Secrets()
+LINKEDIN_OAUTH_IS_CONFIGURED = bool(
+    secrets.linkedin_client_id and secrets.linkedin_client_secret
+)
+
+LinkedInCredentials = OAuth2Credentials
+LinkedInCredentialsInput = CredentialsMetaInput[
+    Literal[ProviderName.LINKEDIN], Literal["oauth2"]
+]
+
+
+def LinkedInCredentialsField(scopes: list[str]) -> LinkedInCredentialsInput:
+    return CredentialsField(
+        required_scopes=set(LinkedInOAuthHandler.DEFAULT_SCOPES + scopes),
+        description="Connect your LinkedIn account via OAuth2.",
+    )
+
+
+TEST_CREDENTIALS = OAuth2Credentials(
+    id="01234567-89ab-cdef-0123-456789abcdef",
+    provider="linkedin",
+    access_token=SecretStr("mock-linkedin-access-token"),
+    refresh_token=SecretStr("mock-linkedin-refresh-token"),
+    access_token_expires_at=9999999999,
+    scopes=["openid", "profile", "email", "r_1st_connections_size"],
+    title="Mock LinkedIn OAuth2 Credentials",
+    username="mock-linkedin-user@example.com",
+    refresh_token_expires_at=None,
+)
+
+TEST_CREDENTIALS_INPUT = {
+    "provider": TEST_CREDENTIALS.provider,
+    "id": TEST_CREDENTIALS.id,
+    "type": TEST_CREDENTIALS.type,
+    "title": TEST_CREDENTIALS.title,
+}

--- a/autogpt_platform/backend/backend/blocks/linkedin/network.py
+++ b/autogpt_platform/backend/backend/blocks/linkedin/network.py
@@ -1,0 +1,163 @@
+"""
+LinkedIn network blocks using LinkedIn OAuth2.
+
+Note: LinkedIn's public API does not expose a user's full connections list to
+third-party apps; that endpoint (r_1st_connections) requires LinkedIn Partner
+status. These blocks expose what IS available to regular OAuth apps:
+  - Authenticated user profile (OpenID Connect)
+  - First-degree connection count (r_1st_connections_size scope)
+"""
+
+import logging
+from typing import Optional
+
+from backend.blocks._base import (
+    Block,
+    BlockCategory,
+    BlockOutput,
+    BlockSchemaInput,
+    BlockSchemaOutput,
+)
+from backend.data.model import OAuth2Credentials, SchemaField
+from backend.util.request import Requests
+
+from ._auth import (
+    TEST_CREDENTIALS,
+    TEST_CREDENTIALS_INPUT,
+    LinkedInCredentials,
+    LinkedInCredentialsField,
+)
+
+logger = logging.getLogger(__name__)
+
+LINKEDIN_API_BASE = "https://api.linkedin.com/v2"
+
+
+async def _linkedin_get(path: str, access_token: str, params: dict | None = None):
+    headers = {
+        "Authorization": f"Bearer {access_token}",
+        "X-Restli-Protocol-Version": "2.0.0",
+    }
+    return await Requests().get(
+        f"{LINKEDIN_API_BASE}{path}", headers=headers, params=params or {}
+    )
+
+
+class GetLinkedInProfileBlock(Block):
+    """Fetch the authenticated user's LinkedIn profile via OpenID Connect."""
+
+    class Input(BlockSchemaInput):
+        credentials: LinkedInCredentials = LinkedInCredentialsField(
+            scopes=["openid", "profile", "email"]
+        )
+
+    class Output(BlockSchemaOutput):
+        sub: str = SchemaField(description="LinkedIn member ID")
+        name: str = SchemaField(description="Full name")
+        given_name: Optional[str] = SchemaField(description="First name", default=None)
+        family_name: Optional[str] = SchemaField(description="Last name", default=None)
+        email: Optional[str] = SchemaField(description="Email address", default=None)
+        picture: Optional[str] = SchemaField(
+            description="Profile picture URL", default=None
+        )
+        error: str = SchemaField(description="Error message if request failed")
+
+    def __init__(self):
+        super().__init__(
+            id="a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+            description="Fetch your LinkedIn profile (name, email, picture) using OAuth2",
+            categories={BlockCategory.SOCIAL},
+            input_schema=GetLinkedInProfileBlock.Input,
+            output_schema=GetLinkedInProfileBlock.Output,
+            test_input={"credentials": TEST_CREDENTIALS_INPUT},
+            test_output=[
+                ("sub", "abc123"),
+                ("name", "Jane Doe"),
+                ("email", "jane@example.com"),
+            ],
+            test_credentials=TEST_CREDENTIALS,
+            test_mock={
+                "_fetch_profile": lambda *a, **kw: {
+                    "sub": "abc123",
+                    "name": "Jane Doe",
+                    "email": "jane@example.com",
+                }
+            },
+        )
+
+    @staticmethod
+    async def _fetch_profile(credentials: OAuth2Credentials) -> dict:
+        response = await _linkedin_get(
+            "/userinfo", credentials.access_token.get_secret_value()
+        )
+        response.raise_for_status()
+        return response.json()
+
+    async def run(
+        self, input_data: Input, *, credentials: OAuth2Credentials, **kwargs
+    ) -> BlockOutput:
+        try:
+            data = await self._fetch_profile(credentials)
+            yield "sub", data.get("sub", "")
+            yield "name", data.get("name", "")
+            yield "given_name", data.get("given_name")
+            yield "family_name", data.get("family_name")
+            yield "email", data.get("email")
+            yield "picture", data.get("picture")
+        except Exception as e:
+            logger.error(f"Error fetching LinkedIn profile: {e}")
+            yield "error", str(e)
+
+
+class GetLinkedInNetworkSizeBlock(Block):
+    """
+    Return the number of first-degree LinkedIn connections for the authenticated user.
+
+    Uses the r_1st_connections_size scope — available to all LinkedIn apps.
+    The full connections list (names, profiles) requires LinkedIn Partner API
+    access (r_1st_connections scope) which is not available to regular apps.
+    """
+
+    class Input(BlockSchemaInput):
+        credentials: LinkedInCredentials = LinkedInCredentialsField(
+            scopes=["r_1st_connections_size"]
+        )
+
+    class Output(BlockSchemaOutput):
+        connection_count: int = SchemaField(
+            description="Number of first-degree connections"
+        )
+        error: str = SchemaField(description="Error message if request failed")
+
+    def __init__(self):
+        super().__init__(
+            id="b2c3d4e5-f6a7-8901-bcde-f12345678901",
+            description="Get your LinkedIn first-degree connection count (requires r_1st_connections_size scope)",
+            categories={BlockCategory.SOCIAL},
+            input_schema=GetLinkedInNetworkSizeBlock.Input,
+            output_schema=GetLinkedInNetworkSizeBlock.Output,
+            test_input={"credentials": TEST_CREDENTIALS_INPUT},
+            test_output=[("connection_count", 342)],
+            test_credentials=TEST_CREDENTIALS,
+            test_mock={"_fetch_connection_count": lambda *a, **kw: 342},
+        )
+
+    @staticmethod
+    async def _fetch_connection_count(credentials: OAuth2Credentials) -> int:
+        response = await _linkedin_get(
+            "/connections",
+            credentials.access_token.get_secret_value(),
+            params={"q": "viewer", "count": "0"},
+        )
+        response.raise_for_status()
+        return response.json().get("paging", {}).get("total", 0)
+
+    async def run(
+        self, input_data: Input, *, credentials: OAuth2Credentials, **kwargs
+    ) -> BlockOutput:
+        try:
+            count = await self._fetch_connection_count(credentials)
+            yield "connection_count", count
+        except Exception as e:
+            logger.error(f"Error fetching LinkedIn connection count: {e}")
+            yield "error", str(e)

--- a/autogpt_platform/backend/backend/integrations/oauth/__init__.py
+++ b/autogpt_platform/backend/backend/integrations/oauth/__init__.py
@@ -9,6 +9,7 @@ from .github import GitHubOAuthHandler
 from .google import GoogleOAuthHandler
 from .notion import NotionOAuthHandler
 from .reddit import RedditOAuthHandler
+from .linkedin import LinkedInOAuthHandler
 from .twitter import TwitterOAuthHandler
 
 if TYPE_CHECKING:
@@ -23,6 +24,7 @@ _ORIGINAL_HANDLERS = [
     NotionOAuthHandler,
     RedditOAuthHandler,
     TwitterOAuthHandler,
+    LinkedInOAuthHandler,
     TodoistOAuthHandler,
 ]
 

--- a/autogpt_platform/backend/backend/integrations/oauth/linkedin.py
+++ b/autogpt_platform/backend/backend/integrations/oauth/linkedin.py
@@ -1,0 +1,104 @@
+import time
+import urllib.parse
+from typing import ClassVar, Optional
+
+from backend.data.model import OAuth2Credentials, ProviderName
+from backend.integrations.oauth.base import BaseOAuthHandler
+from backend.util.request import Requests
+
+
+class LinkedInOAuthHandler(BaseOAuthHandler):
+    PROVIDER_NAME = ProviderName.LINKEDIN
+    DEFAULT_SCOPES: ClassVar[list[str]] = [
+        "openid",
+        "profile",
+        "email",
+        "w_member_social",
+        "r_basicprofile",
+        "r_1st_connections_size",
+    ]
+
+    AUTHORIZE_URL = "https://www.linkedin.com/oauth/v2/authorization"
+    TOKEN_URL = "https://www.linkedin.com/oauth/v2/accessToken"
+    USERINFO_URL = "https://api.linkedin.com/v2/userinfo"
+
+    def __init__(self, client_id: str, client_secret: str, redirect_uri: str):
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.redirect_uri = redirect_uri
+
+    def get_login_url(
+        self, scopes: list[str], state: str, code_challenge: Optional[str]
+    ) -> str:
+        params = {
+            "response_type": "code",
+            "client_id": self.client_id,
+            "redirect_uri": self.redirect_uri,
+            "scope": " ".join(self.DEFAULT_SCOPES),
+            "state": state,
+        }
+        return f"{self.AUTHORIZE_URL}?{urllib.parse.urlencode(params)}"
+
+    async def exchange_code_for_tokens(
+        self, code: str, scopes: list[str], code_verifier: Optional[str]
+    ) -> OAuth2Credentials:
+        data = {
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": self.redirect_uri,
+            "client_id": self.client_id,
+            "client_secret": self.client_secret,
+        }
+        headers = {"Content-Type": "application/x-www-form-urlencoded"}
+        response = await Requests().post(self.TOKEN_URL, headers=headers, data=data)
+        tokens = response.json()
+        username = await self._get_username(tokens["access_token"])
+        return OAuth2Credentials(
+            provider=self.PROVIDER_NAME,
+            title=None,
+            username=username,
+            access_token=tokens["access_token"],
+            refresh_token=tokens.get("refresh_token"),
+            access_token_expires_at=int(time.time()) + tokens.get("expires_in", 3600),
+            refresh_token_expires_at=None,
+            scopes=scopes,
+        )
+
+    async def _get_username(self, access_token: str) -> str:
+        headers = {"Authorization": f"Bearer {access_token}"}
+        response = await Requests().get(self.USERINFO_URL, headers=headers)
+        data = response.json()
+        return data.get("email") or data.get("sub", "linkedin-user")
+
+    async def _refresh_tokens(
+        self, credentials: OAuth2Credentials
+    ) -> OAuth2Credentials:
+        if not credentials.refresh_token:
+            raise ValueError("No refresh token available")
+        data = {
+            "grant_type": "refresh_token",
+            "refresh_token": credentials.refresh_token.get_secret_value(),
+            "client_id": self.client_id,
+            "client_secret": self.client_secret,
+        }
+        headers = {"Content-Type": "application/x-www-form-urlencoded"}
+        response = await Requests().post(self.TOKEN_URL, headers=headers, data=data)
+        if not response.ok:
+            raise ValueError(f"Token refresh failed: {response.status_code}")
+        tokens = response.json()
+        username = await self._get_username(tokens["access_token"])
+        return OAuth2Credentials(
+            id=credentials.id,
+            provider=self.PROVIDER_NAME,
+            title=None,
+            username=username,
+            access_token=tokens["access_token"],
+            refresh_token=tokens.get("refresh_token", credentials.refresh_token),
+            access_token_expires_at=int(time.time()) + tokens.get("expires_in", 3600),
+            refresh_token_expires_at=None,
+            scopes=credentials.scopes,
+        )
+
+    async def revoke_tokens(self, credentials: OAuth2Credentials) -> bool:
+        # LinkedIn does not provide a token revocation endpoint
+        return True

--- a/autogpt_platform/backend/backend/integrations/providers.py
+++ b/autogpt_platform/backend/backend/integrations/providers.py
@@ -29,6 +29,7 @@ class ProviderName(str, Enum):
     ENRICHLAYER = "enrichlayer"
     IDEOGRAM = "ideogram"
     JINA = "jina"
+    LINKEDIN = "linkedin"
     LLAMA_API = "llama_api"
     MCP = "mcp"
     MEDIUM = "medium"

--- a/autogpt_platform/backend/backend/util/settings.py
+++ b/autogpt_platform/backend/backend/util/settings.py
@@ -606,6 +606,10 @@ class Secrets(UpdateTrackingModel["Secrets"], BaseSettings):
     twitter_client_secret: str = Field(
         default="", description="Twitter/X OAuth client secret"
     )
+    linkedin_client_id: str = Field(default="", description="LinkedIn OAuth client ID")
+    linkedin_client_secret: str = Field(
+        default="", description="LinkedIn OAuth client secret"
+    )
     discord_client_id: str = Field(default="", description="Discord OAuth client ID")
     discord_client_secret: str = Field(
         default="", description="Discord OAuth client secret"


### PR DESCRIPTION
## Summary

Adds first-class LinkedIn OAuth2 support to the AutoGPT platform, plus two new blocks for retrieving LinkedIn network data.

## Changes

### New: `integrations/oauth/linkedin.py`
- Full OAuth 2.0 authorization code flow (no PKCE — LinkedIn doesn't support it)
- Token refresh and silent revocation
- Uses `/v2/userinfo` (OpenID Connect) to resolve the username on connect

### New: `blocks/linkedin/`
| Block | Scope(s) | Description |
|-------|----------|-------------|
| `GetLinkedInProfileBlock` | `openid profile email` | Authenticated user's name, email, profile picture |
| `GetLinkedInNetworkSizeBlock` | `r_1st_connections_size` | First-degree connection count |

### Supporting changes
- `ProviderName.LINKEDIN` added to the enum
- `linkedin_client_id` / `linkedin_client_secret` added to `Secrets`
- `LinkedInOAuthHandler` registered in `integrations/oauth/__init__.py`

## LinkedIn API Limitation

LinkedIn's full connections list (`r_1st_connections` scope) is **not available to regular third-party apps** — it requires LinkedIn Partner status (deprecated since 2015). `GetLinkedInNetworkSizeBlock` returns the total connection count via `GET /v2/connections?q=viewer&count=0`, which **is** available to all approved apps.

If LinkedIn partner access becomes available in the future, a `GetLinkedInConnectionsBlock` can be added on top of this OAuth foundation.

## Setup

Add to your environment / secrets:
```
LINKEDIN_CLIENT_ID=...
LINKEDIN_CLIENT_SECRET=...
```

Create a LinkedIn app at https://developer.linkedin.com with the following scopes: `openid`, `profile`, `email`, `w_member_social`, `r_basicprofile`, `r_1st_connections_size`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces OAuth token handling and external API calls for member profile data; behavior follows existing provider patterns but misconfiguration or scope issues could break connect flows.
> 
> **Overview**
> Adds **LinkedIn OAuth2** end-to-end so users can connect a LinkedIn account and run new **social** blocks against the LinkedIn API.
> 
> A new `LinkedInOAuthHandler` implements authorize, code exchange, refresh, and a no-op revoke (LinkedIn has no revocation endpoint). Login uses a fixed default scope set; usernames come from OpenID **`/v2/userinfo`**. **`ProviderName.LINKEDIN`**, **`linkedin_client_id` / `linkedin_client_secret`** in secrets, and handler registration wire the provider into the existing OAuth registry.
> 
> New blocks (with shared credential helpers and tests): **`GetLinkedInProfileBlock`** returns the signed-in member’s profile fields from userinfo; **`GetLinkedInNetworkSizeBlock`** returns first-degree connection **count** via `GET /v2/connections?q=viewer&count=0` (not the full connections list, which needs LinkedIn Partner access).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d82eeee47c58d5b10c22d067c608eeb5da0dd0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->