### PR TITLE
fix(backend/copilot-bot): don't reply to @everyone or @here

### DIFF
--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter.py
@@ -278,7 +278,10 @@ class DiscordAdapter(PlatformAdapter):
     def _is_mentioned(self, message: discord.Message) -> bool:
         if message.guild is None:
             return True  # DMs always count
-        return bool(self._client.user and self._client.user.mentioned_in(message))
+        bot_user = self._client.user
+        if bot_user is None:
+            return False
+        return any(user.id == bot_user.id for user in message.mentions)
 
     @staticmethod
     def _channel_type(message: discord.Message) -> ChannelType:

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter_test.py
@@ -146,21 +146,19 @@ class TestShouldIgnoreMessage:
     def test_ignores_unmentioned_bot_message(self):
         # A bot that doesn't @mention us is skipped — otherwise two bots
         # sharing a thread (our own dev + prod included) loop forever.
-        adapter, client = _bare_adapter(bot_id=1000)
+        adapter, _ = _bare_adapter(bot_id=1000)
         msg = _message("hi", [])
         msg.author = MagicMock(id=2000, bot=True)
         msg.guild = MagicMock()
-        client.user.mentioned_in.return_value = False
 
         assert adapter._should_ignore_message(msg) is True
 
     def test_allows_mentioned_bot_message(self):
         # Another bot can still reach us by explicitly @mentioning us.
-        adapter, client = _bare_adapter(bot_id=1000)
-        msg = _message("hi", [])
+        adapter, _ = _bare_adapter(bot_id=1000)
+        msg = _message("hi", [_mention(1000, "AutoPilot")])
         msg.author = MagicMock(id=2000, bot=True)
         msg.guild = MagicMock()
-        client.user.mentioned_in.return_value = True
 
         assert adapter._should_ignore_message(msg) is False
 
@@ -180,24 +178,41 @@ class TestIsMentioned:
         assert adapter._is_mentioned(msg) is True
 
     def test_guild_requires_explicit_mention(self):
-        adapter, client = _bare_adapter(bot_id=1000)
-        msg = MagicMock()
+        adapter, _ = _bare_adapter(bot_id=1000)
+        msg = _message("hi", [_mention(2000, "someone-else")])
         msg.guild = MagicMock()
-        client.user.mentioned_in.return_value = False
         assert adapter._is_mentioned(msg) is False
 
     def test_guild_with_mention_passes(self):
-        adapter, client = _bare_adapter(bot_id=1000)
-        msg = MagicMock()
+        adapter, _ = _bare_adapter(bot_id=1000)
+        msg = _message("hi", [_mention(1000, "AutoPilot")])
         msg.guild = MagicMock()
-        client.user.mentioned_in.return_value = True
         assert adapter._is_mentioned(msg) is True
 
     def test_no_bot_user_treats_guild_mention_as_false(self):
         adapter, _ = _bare_adapter(bot_id=None)
-        msg = MagicMock()
+        msg = _message("hi", [_mention(1000, "AutoPilot")])
         msg.guild = MagicMock()
         assert adapter._is_mentioned(msg) is False
+
+    def test_everyone_ping_alone_is_not_a_mention(self):
+        # `discord.User.mentioned_in` short-circuits to True on @everyone /
+        # @here, which used to make the bot reply to every server-wide ping.
+        # We now check `message.mentions` so only explicit @bot counts.
+        adapter, _ = _bare_adapter(bot_id=1000)
+        msg = _message("hey @everyone heads up", [])
+        msg.guild = MagicMock()
+        msg.mention_everyone = True
+        assert adapter._is_mentioned(msg) is False
+
+    def test_everyone_ping_with_explicit_bot_mention_still_counts(self):
+        # If they ping the bot AND @everyone, the bot is still in
+        # `message.mentions` and we should reply normally.
+        adapter, _ = _bare_adapter(bot_id=1000)
+        msg = _message("@everyone and @AutoPilot", [_mention(1000, "AutoPilot")])
+        msg.guild = MagicMock()
+        msg.mention_everyone = True
+        assert adapter._is_mentioned(msg) is True
 
 
 # ── _resolve_channel ───────────────────────────────────────────────────


### PR DESCRIPTION
## Why

The bot replies to every `@everyone` and `@here` ping. In channels where the bot is a member, server-wide pings get a reply each time, which is noisy in busy guilds and quietly burns tokens.

Root cause: our guild-side mention check uses `discord.User.mentioned_in(message)`, which short-circuits to `True` whenever `message.mention_everyone` is set. The bot is part of "everyone," so every `@everyone` / `@here` qualifies.

## What

`_is_mentioned` now checks membership in `message.mentions` directly. Only explicit `@bot` pings count. If a user pings both `@everyone` and `@bot` in the same message, the bot still replies (the bot is in `message.mentions`).

## How

- One-line behaviour change in `adapters/discord/adapter.py::_is_mentioned`.
- Migrated the existing `TestIsMentioned` / `TestShouldIgnoreMessage` mocks from `client.user.mentioned_in.return_value = ...` to populating `msg.mentions`.
- Added two regression tests:
  - `@everyone` alone → not a mention
  - `@everyone` + explicit `@bot` → still a mention
