### PR TITLE
fix(backend/copilot-bot): exit threads on /leave or kick

### DIFF
--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter.py
@@ -12,6 +12,7 @@ from typing import Optional
 import discord
 from discord import app_commands
 
+from backend.copilot.bot import threads
 from backend.copilot.bot.bot_backend import BotBackend
 
 from ..base import (
@@ -214,6 +215,22 @@ class DiscordAdapter(PlatformAdapter):
         async def on_guild_update(before: discord.Guild, after: discord.Guild) -> None:
             if before.name != after.name:
                 await self._refresh_server_name(after)
+
+        @self._client.event
+        async def on_thread_member_remove(member: discord.ThreadMember) -> None:
+            # Fires when anyone is removed from a thread (kicked or self-leave).
+            # If the kicked member is us, drop the auto-reply subscription so
+            # we don't keep replying if someone re-adds us by @mention later.
+            bot_user = self._client.user
+            if bot_user is None or member.id != bot_user.id:
+                return
+            try:
+                await threads.unsubscribe("discord", str(member.thread_id))
+            except Exception:
+                logger.exception(
+                    "Failed to unsubscribe thread %s after bot kick",
+                    member.thread_id,
+                )
 
         @self._client.event
         async def on_message(message: discord.Message) -> None:

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter.py
@@ -217,19 +217,18 @@ class DiscordAdapter(PlatformAdapter):
                 await self._refresh_server_name(after)
 
         @self._client.event
-        async def on_thread_member_remove(member: discord.ThreadMember) -> None:
-            # Fires when anyone is removed from a thread (kicked or self-leave).
-            # If the kicked member is us, drop the auto-reply subscription so
-            # we don't keep replying if someone re-adds us by @mention later.
-            bot_user = self._client.user
-            if bot_user is None or member.id != bot_user.id:
-                return
+        async def on_thread_remove(thread: discord.Thread) -> None:
+            # Fires when a thread is removed from the client's cache — the
+            # typical path is the bot being kicked or the thread being made
+            # private without us in it. Drop the auto-reply subscription so a
+            # subsequent re-add by @mention starts in the @-only mode again.
+            # Unlike on_thread_member_remove, this event only requires the
+            # default Intents.guilds and not the privileged members intent.
             try:
-                await threads.unsubscribe("discord", str(member.thread_id))
+                await threads.unsubscribe("discord", str(thread.id))
             except Exception:
                 logger.exception(
-                    "Failed to unsubscribe thread %s after bot kick",
-                    member.thread_id,
+                    f"Failed to unsubscribe thread {thread.id} after removal"
                 )
 
         @self._client.event

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter_test.py
@@ -516,14 +516,13 @@ class TestRefreshServerNames:
         await adapter._refresh_server_name(_guild(1, "Server One"))
 
 
-# ── on_thread_member_remove ─────────────────────────────────────────────
+# ── on_thread_remove ────────────────────────────────────────────────────
 
 
-def _thread_member(member_id: int, thread_id: int) -> MagicMock:
-    member = MagicMock(spec=discord.ThreadMember)
-    member.id = member_id
-    member.thread_id = thread_id
-    return member
+def _thread(thread_id: int) -> MagicMock:
+    thread = MagicMock(spec=discord.Thread)
+    thread.id = thread_id
+    return thread
 
 
 def _register_events_with_mocked_decorator(adapter: DiscordAdapter) -> dict:
@@ -540,9 +539,13 @@ def _register_events_with_mocked_decorator(adapter: DiscordAdapter) -> dict:
     return handlers
 
 
-class TestOnThreadMemberRemove:
+class TestOnThreadRemove:
     @pytest.mark.asyncio
-    async def test_bot_kicked_unsubscribes_thread(self):
+    async def test_removal_unsubscribes_thread(self):
+        # We use on_thread_remove instead of on_thread_member_remove so we
+        # don't need the privileged `members` intent. The trade-off is that
+        # this only tells us the bot lost access — which is exactly when we
+        # want to drop the subscription, so the trade-off is free.
         adapter, _ = _bare_adapter(bot_id=1000)
         handlers = _register_events_with_mocked_decorator(adapter)
 
@@ -550,22 +553,9 @@ class TestOnThreadMemberRemove:
             "backend.copilot.bot.threads.unsubscribe",
             new=AsyncMock(),
         ) as mock_unsub:
-            await handlers["on_thread_member_remove"](_thread_member(1000, 555))
+            await handlers["on_thread_remove"](_thread(555))
 
         mock_unsub.assert_awaited_once_with("discord", "555")
-
-    @pytest.mark.asyncio
-    async def test_other_member_kicked_is_ignored(self):
-        adapter, _ = _bare_adapter(bot_id=1000)
-        handlers = _register_events_with_mocked_decorator(adapter)
-
-        with patch(
-            "backend.copilot.bot.threads.unsubscribe",
-            new=AsyncMock(),
-        ) as mock_unsub:
-            await handlers["on_thread_member_remove"](_thread_member(2000, 555))
-
-        mock_unsub.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_swallows_redis_failures(self):
@@ -576,5 +566,5 @@ class TestOnThreadMemberRemove:
             "backend.copilot.bot.threads.unsubscribe",
             new=AsyncMock(side_effect=RuntimeError("redis down")),
         ):
-            # Must not raise — kick handling is never critical-path.
-            await handlers["on_thread_member_remove"](_thread_member(1000, 555))
+            # Must not raise — cleanup is never critical-path.
+            await handlers["on_thread_remove"](_thread(555))

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter_test.py
@@ -1,7 +1,7 @@
 """Tests for DiscordAdapter helpers that don't need a live gateway."""
 
 from typing import cast
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import discord
 import pytest
@@ -514,3 +514,67 @@ class TestRefreshServerNames:
         api.refresh_server_name.side_effect = RuntimeError("rpc down")
         # Must not raise — refreshing names is never critical-path.
         await adapter._refresh_server_name(_guild(1, "Server One"))
+
+
+# ── on_thread_member_remove ─────────────────────────────────────────────
+
+
+def _thread_member(member_id: int, thread_id: int) -> MagicMock:
+    member = MagicMock(spec=discord.ThreadMember)
+    member.id = member_id
+    member.thread_id = thread_id
+    return member
+
+
+def _register_events_with_mocked_decorator(adapter: DiscordAdapter) -> dict:
+    """Capture the @client.event handlers without actually attaching to
+    discord.py. Returns a name→coroutine map for direct invocation."""
+    handlers: dict = {}
+
+    def _event(coro):
+        handlers[coro.__name__] = coro
+        return coro
+
+    adapter._client.event = _event  # type: ignore[assignment]
+    adapter._register_events()
+    return handlers
+
+
+class TestOnThreadMemberRemove:
+    @pytest.mark.asyncio
+    async def test_bot_kicked_unsubscribes_thread(self):
+        adapter, _ = _bare_adapter(bot_id=1000)
+        handlers = _register_events_with_mocked_decorator(adapter)
+
+        with patch(
+            "backend.copilot.bot.threads.unsubscribe",
+            new=AsyncMock(),
+        ) as mock_unsub:
+            await handlers["on_thread_member_remove"](_thread_member(1000, 555))
+
+        mock_unsub.assert_awaited_once_with("discord", "555")
+
+    @pytest.mark.asyncio
+    async def test_other_member_kicked_is_ignored(self):
+        adapter, _ = _bare_adapter(bot_id=1000)
+        handlers = _register_events_with_mocked_decorator(adapter)
+
+        with patch(
+            "backend.copilot.bot.threads.unsubscribe",
+            new=AsyncMock(),
+        ) as mock_unsub:
+            await handlers["on_thread_member_remove"](_thread_member(2000, 555))
+
+        mock_unsub.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_swallows_redis_failures(self):
+        adapter, _ = _bare_adapter(bot_id=1000)
+        handlers = _register_events_with_mocked_decorator(adapter)
+
+        with patch(
+            "backend.copilot.bot.threads.unsubscribe",
+            new=AsyncMock(side_effect=RuntimeError("redis down")),
+        ):
+            # Must not raise — kick handling is never critical-path.
+            await handlers["on_thread_member_remove"](_thread_member(1000, 555))

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/commands.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/commands.py
@@ -11,7 +11,7 @@ from datetime import datetime
 import discord
 from discord import app_commands
 
-from backend.copilot.bot import sessions
+from backend.copilot.bot import sessions, threads
 from backend.copilot.bot.bot_backend import BotBackend, ChatSummary
 from backend.util.exceptions import LinkAlreadyExistsError
 from backend.util.settings import Settings
@@ -54,6 +54,13 @@ def register(tree: app_commands.CommandTree, api: BotBackend) -> None:
     )
     async def resume_command(interaction: discord.Interaction) -> None:
         await _handle_resume(interaction, api)
+
+    @tree.command(
+        name="leave",
+        description="Stop AutoPilot from auto-replying in this thread",
+    )
+    async def leave_command(interaction: discord.Interaction) -> None:
+        await _handle_leave(interaction)
 
 
 async def _handle_setup(interaction: discord.Interaction, api: BotBackend) -> None:
@@ -183,6 +190,31 @@ async def _handle_new(interaction: discord.Interaction) -> None:
 
     await interaction.response.send_message(
         "Started a fresh conversation — send a message to begin.",
+        ephemeral=True,
+    )
+
+
+async def _handle_leave(interaction: discord.Interaction) -> None:
+    if not isinstance(interaction.channel, discord.Thread):
+        await interaction.response.send_message(
+            "Use `/leave` inside a thread. I only auto-reply in threads I'm "
+            "subscribed to.",
+            ephemeral=True,
+        )
+        return
+
+    try:
+        await threads.unsubscribe("discord", str(interaction.channel.id))
+    except Exception:
+        logger.exception("Failed to unsubscribe thread for /leave")
+        await interaction.response.send_message(
+            "Couldn't step out of this thread right now. Please try again in a moment.",
+            ephemeral=True,
+        )
+        return
+
+    await interaction.response.send_message(
+        "Going quiet in this thread. @mention me to bring me back.",
         ephemeral=True,
     )
 

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/commands_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/commands_test.py
@@ -15,6 +15,7 @@ from backend.util.exceptions import LinkAlreadyExistsError
 from ...bot_backend import ChatSummary, LinkTokenResult
 from .commands import (
     _handle_help,
+    _handle_leave,
     _handle_new,
     _handle_resume,
     _handle_setup,
@@ -247,6 +248,69 @@ class TestHandleNew:
             new=AsyncMock(side_effect=RuntimeError("redis down")),
         ):
             await _handle_new(interaction)
+
+        interaction.response.send_message.assert_awaited_once()
+        sent = interaction.response.send_message.await_args
+        assert sent.kwargs["ephemeral"] is True
+        assert "try again" in sent.args[0].lower()
+
+
+class TestHandleLeave:
+    @pytest.mark.asyncio
+    async def test_thread_unsubscribes(self):
+        interaction = _interaction()
+        interaction.channel = MagicMock(spec=discord.Thread)
+        interaction.channel.id = 777
+        with patch(
+            "backend.copilot.bot.threads.unsubscribe",
+            new=AsyncMock(),
+        ) as mock_unsub:
+            await _handle_leave(interaction)
+
+        mock_unsub.assert_awaited_once_with("discord", "777")
+        interaction.response.send_message.assert_awaited_once()
+        sent = interaction.response.send_message.await_args
+        assert sent.kwargs["ephemeral"] is True
+        assert "quiet" in sent.args[0].lower()
+
+    @pytest.mark.asyncio
+    async def test_plain_channel_is_rejected(self):
+        # Channels aren't subscribed in the first place — /leave only makes
+        # sense in a thread we'd otherwise auto-reply in.
+        interaction = _interaction()
+        interaction.channel = MagicMock()
+        with patch(
+            "backend.copilot.bot.threads.unsubscribe",
+            new=AsyncMock(),
+        ) as mock_unsub:
+            await _handle_leave(interaction)
+
+        mock_unsub.assert_not_awaited()
+        interaction.response.send_message.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_dm_is_rejected(self):
+        interaction = _interaction(guild=False)
+        interaction.channel = MagicMock()
+        with patch(
+            "backend.copilot.bot.threads.unsubscribe",
+            new=AsyncMock(),
+        ) as mock_unsub:
+            await _handle_leave(interaction)
+
+        mock_unsub.assert_not_awaited()
+        interaction.response.send_message.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_redis_failure_sends_fallback_message(self):
+        interaction = _interaction()
+        interaction.channel = MagicMock(spec=discord.Thread)
+        interaction.channel.id = 777
+        with patch(
+            "backend.copilot.bot.threads.unsubscribe",
+            new=AsyncMock(side_effect=RuntimeError("redis down")),
+        ):
+            await _handle_leave(interaction)
 
         interaction.response.send_message.assert_awaited_once()
         sent = interaction.response.send_message.await_args

--- a/autogpt_platform/backend/backend/copilot/bot/threads.py
+++ b/autogpt_platform/backend/backend/copilot/bot/threads.py
@@ -23,3 +23,10 @@ async def is_subscribed(platform: str, thread_id: str) -> bool:
 async def subscribe(platform: str, thread_id: str) -> None:
     redis = await get_redis_async()
     await redis.set(_key(platform, thread_id), "1", ex=THREAD_SUBSCRIPTION_TTL)
+
+
+async def unsubscribe(platform: str, thread_id: str) -> None:
+    """Drop the auto-reply subscription for a thread — used when the user
+    runs `/leave` or when the bot is kicked from the thread."""
+    redis = await get_redis_async()
+    await redis.delete(_key(platform, thread_id))

--- a/autogpt_platform/backend/backend/copilot/bot/threads_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/threads_test.py
@@ -12,6 +12,7 @@ def redis_mock():
     mock = AsyncMock()
     mock.get = AsyncMock()
     mock.set = AsyncMock()
+    mock.delete = AsyncMock()
     with patch("backend.copilot.bot.threads.get_redis_async", return_value=mock):
         yield mock
 
@@ -53,3 +54,20 @@ class TestIsSubscribed:
         read_key = redis_mock.get.await_args.args[0]
         write_key = redis_mock.set.await_args.args[0]
         assert read_key == write_key
+
+
+class TestUnsubscribe:
+    @pytest.mark.asyncio
+    async def test_deletes_the_key(self, redis_mock):
+        await threads.unsubscribe("discord", "thread-1")
+        redis_mock.delete.assert_awaited_once_with(
+            "copilot-bot:thread:discord:thread-1"
+        )
+
+    @pytest.mark.asyncio
+    async def test_uses_same_key_as_subscribe(self, redis_mock):
+        await threads.unsubscribe("discord", "thread-1")
+        await threads.subscribe("discord", "thread-1")
+        del_key = redis_mock.delete.await_args.args[0]
+        write_key = redis_mock.set.await_args.args[0]
+        assert del_key == write_key


### PR DESCRIPTION
## Why

Two ways the bot ends up in a thread it shouldn't be in, with no way out today:

1. Someone adds the bot to an old/unrelated thread by @-mentioning it. The bot subscribes and replies to every message in that thread for 7 days. There's no way for the user to make it stop short of an admin locking the thread.
2. An admin kicks the bot from a thread. The Redis subscription stays, so if anyone re-adds the bot later (or it gets re-added by another @-mention), it keeps auto-replying as if nothing happened.

## What

- **New `/leave` slash command** — thread-only, ephemeral reply, clears the Redis subscription. The bot stops auto-replying. An @-mention brings it back into the thread normally.
- **`on_thread_member_remove` listener** — when discord.py tells us the bot itself was removed from a thread, we drop the subscription the same way `/leave` does.

Both paths land on a new `threads.unsubscribe()` helper so the same Redis key is used everywhere.

## How

- `bot/threads.py` — add `unsubscribe(platform, thread_id)` using `redis.delete` on the same key `subscribe` writes.
- `adapters/discord/commands.py` — register `/leave`; `_handle_leave` rejects DMs and plain channels, calls `unsubscribe`, swallows Redis failures with an ephemeral fallback.
- `adapters/discord/adapter.py` — register `on_thread_member_remove`; if `member.id == bot.user.id`, call `unsubscribe`. Failures are logged, not re-raised.
- Tests for all three: `threads_test.py`, `commands_test.py::TestHandleLeave`, `adapter_test.py::TestOnThreadMemberRemove` (including ignoring other members and swallowing Redis failures).
