### PR TITLE
feat(backend/copilot-bot): only auto-reply in bot-created threads

### DIFF
--- a/autogpt_platform/backend/backend/copilot/bot/handler.py
+++ b/autogpt_platform/backend/backend/copilot/bot/handler.py
@@ -64,13 +64,20 @@ class MessageHandler:
                 )
             return
 
-        should_subscribe_thread = False
+        # In a thread we only auto-reply when we own it (= we created it in
+        # response to an @mention in a channel). For any other existing
+        # thread we'd been added to, require an explicit @mention each turn
+        # so we don't hijack ongoing team conversations.
+        include_thread_history = False
         if ctx.channel_type == "thread":
             is_subscribed = await threads.is_subscribed(ctx.platform, ctx.channel_id)
             if not is_subscribed:
                 if not ctx.bot_mentioned:
                     return
-                should_subscribe_thread = True
+                # First time we're @-ed into this thread — pull the recent
+                # thread history into the prompt so AutoPilot has context,
+                # but DON'T subscribe. Future messages here need another @.
+                include_thread_history = True
 
         if not await self._ensure_linked(ctx, adapter):
             return
@@ -79,10 +86,7 @@ class MessageHandler:
         if not target_id:
             return  # Thread not subscribed, ignore silently
 
-        if should_subscribe_thread:
-            await threads.subscribe(ctx.platform, ctx.channel_id)
-
-        message_text = self._message_text(ctx) if should_subscribe_thread else ctx.text
+        message_text = self._message_text(ctx) if include_thread_history else ctx.text
         await self._enqueue_and_process(ctx, adapter, target_id, message_text)
 
     # -- Target resolution --

--- a/autogpt_platform/backend/backend/copilot/bot/handler_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/handler_test.py
@@ -235,7 +235,11 @@ class TestResolveTarget:
 
 class TestThreadAdoption:
     @pytest.mark.asyncio
-    async def test_mentioned_unsubscribed_thread_is_subscribed(self):
+    async def test_mentioned_unsubscribed_thread_replies_without_subscribing(self):
+        # Bot was @-ed into an existing thread it didn't create. Reply this
+        # turn so the user gets an answer, but DON'T subscribe — future
+        # messages here need another @ to wake it back up. This keeps the
+        # bot from hijacking ongoing team conversations.
         handler = MessageHandler(_api())
         adapter = _adapter()
         enqueue = AsyncMock()
@@ -259,8 +263,36 @@ class TestThreadAdoption:
                 adapter,
             )
 
-        subscribe.assert_awaited_once_with("discord", "thread-existing")
+        subscribe.assert_not_awaited()
         enqueue.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_unmentioned_unsubscribed_thread_message_is_ignored(self):
+        handler = MessageHandler(_api())
+        adapter = _adapter()
+        enqueue = AsyncMock()
+
+        with (
+            patch.object(handler, "_enqueue_and_process", new=enqueue),
+            patch(
+                "backend.copilot.bot.handler.threads.is_subscribed",
+                new=AsyncMock(return_value=False),
+            ),
+            patch(
+                "backend.copilot.bot.handler.threads.subscribe", new=AsyncMock()
+            ) as subscribe,
+        ):
+            await handler.handle(
+                _ctx(
+                    channel_type="thread",
+                    channel_id="thread-existing",
+                    bot_mentioned=False,
+                ),
+                adapter,
+            )
+
+        subscribe.assert_not_awaited()
+        enqueue.assert_not_awaited()
 
     def test_thread_history_is_included_in_message_text(self):
         handler = MessageHandler(_api())

--- a/autogpt_platform/backend/backend/copilot/bot/handler_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/handler_test.py
@@ -239,7 +239,8 @@ class TestThreadAdoption:
         # Bot was @-ed into an existing thread it didn't create. Reply this
         # turn so the user gets an answer, but DON'T subscribe — future
         # messages here need another @ to wake it back up. This keeps the
-        # bot from hijacking ongoing team conversations.
+        # bot from hijacking ongoing team conversations. The reply should
+        # carry the thread history so AutoPilot has context.
         handler = MessageHandler(_api())
         adapter = _adapter()
         enqueue = AsyncMock()
@@ -259,12 +260,21 @@ class TestThreadAdoption:
                     channel_type="thread",
                     channel_id="thread-existing",
                     bot_mentioned=True,
+                    thread_history=(
+                        MessageHistoryEntry("Alice", "u-1", "I think option A"),
+                    ),
                 ),
                 adapter,
             )
 
         subscribe.assert_not_awaited()
         enqueue.assert_awaited_once()
+        # The enqueued message_text (4th positional arg) must carry the
+        # history-enriched prompt — otherwise include_thread_history is
+        # silently bypassed and the LLM gets the bare message.
+        message_text = enqueue.await_args.args[3]
+        assert "Recent thread context" in message_text
+        assert "I think option A" in message_text
 
     @pytest.mark.asyncio
     async def test_unmentioned_unsubscribed_thread_message_is_ignored(self):


### PR DESCRIPTION
## Why

Toran summoned the bot into an existing team thread with an `@AutoPilot`. After that one mention the bot subscribed the thread and started replying to every message in it — including team chatter that wasn't directed at it. The only way out today is to lock the thread or kick the bot (and even that doesn't clean up the subscription — see #13268).

The bot should be eager when it owns the room (a thread it created in response to a fresh channel @), and reserved when it's a guest (someone added it to an existing thread).

## What

- **Threads the bot creates** (channel @-mention → `_resolve_target` spins up a fresh thread): subscribed on creation. Auto-replies to all subsequent messages until kicked or `/leave`. Unchanged.
- **Threads the bot is added to via @-mention**: replies to that one @ with the recent thread history included as context, but does **not** subscribe. Future messages in the thread need another @ to wake it back up.
- **Threads the bot is in with no @-mention and no subscription**: silent. Unchanged.

## How

One semantic shift in `handler.py::handle`: the path that used to set `should_subscribe_thread = True` now sets `include_thread_history = True` only. The `threads.subscribe()` call is removed from this branch — `subscribe` is now invoked exclusively from `_resolve_target` when the bot creates a thread.

Thread history still gets prefixed to the prompt on first @-encounter (so the bot has context), so the user experience for "summon the bot into an existing conversation" stays good — it just doesn't take the room over after.

Tests:
- Renamed `test_mentioned_unsubscribed_thread_is_subscribed` → `test_mentioned_unsubscribed_thread_replies_without_subscribing`, asserts `subscribe` is **not** awaited.
- Added `test_unmentioned_unsubscribed_thread_message_is_ignored` to lock in the silent path.
- All other thread/`subscribe` tests are unchanged — channel→thread creation still subscribes the new thread, which is the only remaining path that writes the subscription key.
