### PR TITLE
feat(frontend): add navigate & action sections to global search

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/components/GlobalSearchModal/GlobalSearchModal.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/components/GlobalSearchModal/GlobalSearchModal.tsx
@@ -1,5 +1,11 @@
 import type { SearchResultItem } from "@/app/api/__generated__/models/searchResultItem";
+import { useToast } from "@/components/molecules/Toast/use-toast";
 import { SearchCommandModal } from "@/components/organisms/SearchCommandModal/SearchCommandModal";
+import { useSupabase } from "@/lib/supabase/hooks/useSupabase";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import { ACTIONS_BUCKET_KEY, COPY_USER_ID_ACTION } from "./actions";
+import { NAV_BUCKET_KEY, getNavigationHref } from "./navigation";
 import { useGlobalSearch } from "./useGlobalSearch";
 
 interface Props {
@@ -9,10 +15,51 @@ interface Props {
 }
 
 export function GlobalSearchModal({ isOpen, onClose, onSelectItem }: Props) {
+  const router = useRouter();
+  const { toast } = useToast();
+  const { user } = useSupabase();
   const { query, setQuery, buckets, itemsById, isFetching, isError } =
     useGlobalSearch(isOpen);
+  // Id of the row whose select is in-flight. The modal stays open with a
+  // trailing spinner on that row while the work runs — a navigation
+  // routing to a (possibly slow) page, or an action awaiting a side
+  // effect like a clipboard write.
+  const [busyItemId, setBusyItemId] = useState<string | null>(null);
 
-  function handleSelect(id: string) {
+  useEffect(() => {
+    if (!isOpen) setBusyItemId(null);
+  }, [isOpen]);
+
+  async function runAction(id: string) {
+    if (id === COPY_USER_ID_ACTION) {
+      if (!user?.id) {
+        toast({ title: "You're not signed in", variant: "destructive" });
+        return;
+      }
+      try {
+        await navigator.clipboard.writeText(user.id);
+        toast({ title: "User ID copied to clipboard" });
+      } catch {
+        toast({ title: "Couldn't copy User ID", variant: "destructive" });
+      }
+    }
+  }
+
+  function handleSelect(id: string, bucketKey: string) {
+    if (busyItemId) return;
+    if (bucketKey === NAV_BUCKET_KEY) {
+      const href = getNavigationHref(id);
+      if (!href) return;
+      // No close: the destination page mounting unmounts this tree.
+      setBusyItemId(id);
+      router.push(href);
+      return;
+    }
+    if (bucketKey === ACTIONS_BUCKET_KEY) {
+      setBusyItemId(id);
+      void runAction(id).finally(onClose);
+      return;
+    }
     const apiItem = itemsById.get(id);
     if (!apiItem) return;
     onSelectItem(apiItem);
@@ -32,7 +79,8 @@ export function GlobalSearchModal({ isOpen, onClose, onSelectItem }: Props) {
       inputAriaLabel="Global search"
       idleEmptyLabel="No recent items"
       searchingEmptyLabel="No results found"
-      onSelectItem={(item) => handleSelect(item.id)}
+      loadingItemId={busyItemId ?? undefined}
+      onSelectItem={(item, bucketKey) => handleSelect(item.id, bucketKey)}
     />
   );
 }

--- a/autogpt_platform/frontend/src/app/(platform)/components/GlobalSearchModal/GlobalSearchModal.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/components/GlobalSearchModal/GlobalSearchModal.tsx
@@ -2,7 +2,7 @@ import type { SearchResultItem } from "@/app/api/__generated__/models/searchResu
 import { useToast } from "@/components/molecules/Toast/use-toast";
 import { SearchCommandModal } from "@/components/organisms/SearchCommandModal/SearchCommandModal";
 import { useSupabase } from "@/lib/supabase/hooks/useSupabase";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { ACTIONS_BUCKET_KEY, COPY_USER_ID_ACTION } from "./actions";
 import { NAV_BUCKET_KEY, getNavigationHref } from "./navigation";
@@ -16,6 +16,7 @@ interface Props {
 
 export function GlobalSearchModal({ isOpen, onClose, onSelectItem }: Props) {
   const router = useRouter();
+  const pathname = usePathname();
   const { toast } = useToast();
   const { user } = useSupabase();
   const { query, setQuery, buckets, itemsById, isFetching, isError } =
@@ -29,6 +30,15 @@ export function GlobalSearchModal({ isOpen, onClose, onSelectItem }: Props) {
   useEffect(() => {
     if (!isOpen) setBusyItemId(null);
   }, [isOpen]);
+
+  // A navigation row keeps the spinner up until the route actually
+  // changes (router.push resolves async). Clearing on the resolved
+  // pathname is the real end of the action — don't rely on the tree
+  // unmounting, so the row never stays stuck if this modal ever lives
+  // in a layout that persists across pages.
+  useEffect(() => {
+    setBusyItemId(null);
+  }, [pathname]);
 
   async function runAction(id: string) {
     if (id === COPY_USER_ID_ACTION) {

--- a/autogpt_platform/frontend/src/app/(platform)/components/GlobalSearchModal/__tests__/GlobalSearchModal.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/components/GlobalSearchModal/__tests__/GlobalSearchModal.test.tsx
@@ -247,8 +247,7 @@ describe("GlobalSearchModal", () => {
 
     // Non-exact match keeps navigation after the search results.
     expect(
-      builder.compareDocumentPosition(alpha) &
-        Node.DOCUMENT_POSITION_PRECEDING,
+      builder.compareDocumentPosition(alpha) & Node.DOCUMENT_POSITION_PRECEDING,
     ).toBeTruthy();
   });
 
@@ -266,8 +265,7 @@ describe("GlobalSearchModal", () => {
 
     // Exact match: Builder is rendered before the first search result.
     expect(
-      builder.compareDocumentPosition(alpha) &
-        Node.DOCUMENT_POSITION_FOLLOWING,
+      builder.compareDocumentPosition(alpha) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
   });
 

--- a/autogpt_platform/frontend/src/app/(platform)/components/GlobalSearchModal/__tests__/GlobalSearchModal.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/components/GlobalSearchModal/__tests__/GlobalSearchModal.test.tsx
@@ -116,7 +116,7 @@ describe("GlobalSearchModal", () => {
     expect(screen.queryByText("Chats")).toBeNull();
   });
 
-  it("shows the empty state when the API returns no items", async () => {
+  it("shows navigation destinations when the API returns no recent items", async () => {
     server.use(
       getGetSearchGlobalSearchMockHandler200({
         agents: [],
@@ -126,7 +126,11 @@ describe("GlobalSearchModal", () => {
     );
     renderModal();
 
-    expect(await screen.findByText("No recent items")).toBeDefined();
+    // Navigation is always available, so the idle empty-state never
+    // shows; the "Go to" destinations stand in for an empty list.
+    expect(await screen.findByText("Go to")).toBeDefined();
+    expect(screen.getByRole("option", { name: /builder/i })).toBeDefined();
+    expect(screen.queryByText("No recent items")).toBeNull();
   });
 
   it("shows a query-specific empty state when searching with no results", async () => {
@@ -225,6 +229,93 @@ describe("GlobalSearchModal", () => {
     });
     await user.click(clearButton);
     expect(input.value).toBe("");
+  });
+
+  it("shows navigation matches below search results while typing", async () => {
+    const user = userEvent.setup();
+    server.use(getGetSearchGlobalSearchMockHandler200(fixedResponse()));
+    renderModal();
+
+    await screen.findByText("Alpha agent");
+    const input = screen.getByRole("textbox", { name: /global search/i });
+    await user.type(input, "build");
+
+    // "Go to" section surfaces the Builder destination.
+    expect(await screen.findByText("Go to")).toBeDefined();
+    const builder = screen.getByRole("option", { name: /builder/i });
+    const alpha = screen.getByRole("option", { name: /alpha agent/i });
+
+    // Non-exact match keeps navigation after the search results.
+    expect(
+      builder.compareDocumentPosition(alpha) &
+        Node.DOCUMENT_POSITION_PRECEDING,
+    ).toBeTruthy();
+  });
+
+  it("hoists navigation above search results on an exact name match", async () => {
+    const user = userEvent.setup();
+    server.use(getGetSearchGlobalSearchMockHandler200(fixedResponse()));
+    renderModal();
+
+    await screen.findByText("Alpha agent");
+    const input = screen.getByRole("textbox", { name: /global search/i });
+    await user.type(input, "Builder");
+
+    const builder = await screen.findByRole("option", { name: /builder/i });
+    const alpha = screen.getByRole("option", { name: /alpha agent/i });
+
+    // Exact match: Builder is rendered before the first search result.
+    expect(
+      builder.compareDocumentPosition(alpha) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it("shows a spinner and stays open while a navigation item is routing", async () => {
+    const user = userEvent.setup();
+    server.use(getGetSearchGlobalSearchMockHandler200(fixedResponse()));
+    const onClose = vi.fn();
+    const onSelectItem = vi.fn();
+    renderModal({ onClose, onSelectItem });
+
+    const input = await screen.findByRole("textbox", {
+      name: /global search/i,
+    });
+    await user.type(input, "Builder");
+
+    const builder = await screen.findByRole("option", { name: /builder/i });
+    await user.click(builder);
+
+    // Navigation routes internally via the router, not through the
+    // ``onSelectItem`` API-item contract. The modal stays open with a
+    // trailing spinner until the destination page mounts.
+    expect(onSelectItem).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+    expect(await screen.findByLabelText("Opening")).toBeDefined();
+  });
+
+  it("exposes the Copy user ID action and closes when chosen", async () => {
+    const user = userEvent.setup();
+    server.use(getGetSearchGlobalSearchMockHandler200(fixedResponse()));
+    const onClose = vi.fn();
+    const onSelectItem = vi.fn();
+    renderModal({ onClose, onSelectItem });
+
+    const input = await screen.findByRole("textbox", {
+      name: /global search/i,
+    });
+    await user.type(input, "copy");
+
+    expect(await screen.findByText("Actions")).toBeDefined();
+    const action = await screen.findByRole("option", {
+      name: /copy user id/i,
+    });
+    await user.click(action);
+
+    // Actions run a side effect locally, never the API-item contract,
+    // then close once the work settles.
+    expect(onSelectItem).not.toHaveBeenCalled();
+    await vi.waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
   });
 
   it("highlights the matching query substring inside the title", async () => {

--- a/autogpt_platform/frontend/src/app/(platform)/components/GlobalSearchModal/__tests__/GlobalSearchModal.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/components/GlobalSearchModal/__tests__/GlobalSearchModal.test.tsx
@@ -4,10 +4,16 @@ import {
 } from "@/app/api/__generated__/endpoints/search/search.msw";
 import type { GlobalSearchResponse } from "@/app/api/__generated__/models/globalSearchResponse";
 import { server } from "@/mocks/mock-server";
-import { fireEvent, render, screen } from "@/tests/integrations/test-utils";
+import {
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@/tests/integrations/test-utils";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { GlobalSearchModal } from "../GlobalSearchModal";
+import { NAV_BUCKET_LABEL } from "../navigation";
 
 function fixedResponse(
   overrides: Partial<GlobalSearchResponse> = {},
@@ -127,8 +133,13 @@ describe("GlobalSearchModal", () => {
     renderModal();
 
     // Navigation is always available, so the idle empty-state never
-    // shows; the "Go to" destinations stand in for an empty list.
-    expect(await screen.findByText("Go to")).toBeDefined();
+    // shows; the navigation destinations stand in for an empty list.
+    // Scope to the result list so the "Navigate" footer hint (the
+    // ``↑↓ Navigate`` shortcut) doesn't collide with the section label.
+    const results = await screen.findByRole("listbox", {
+      name: "Search results",
+    });
+    expect(within(results).getByText(NAV_BUCKET_LABEL)).toBeDefined();
     expect(screen.getByRole("option", { name: /builder/i })).toBeDefined();
     expect(screen.queryByText("No recent items")).toBeNull();
   });
@@ -240,9 +251,15 @@ describe("GlobalSearchModal", () => {
     const input = screen.getByRole("textbox", { name: /global search/i });
     await user.type(input, "build");
 
-    // "Go to" section surfaces the Builder destination.
-    expect(await screen.findByText("Go to")).toBeDefined();
-    const builder = screen.getByRole("option", { name: /builder/i });
+    // Navigation section surfaces the Builder destination. Scope to the
+    // result list so the "Navigate" footer hint doesn't collide.
+    const navResults = await screen.findByRole("listbox", {
+      name: "Search results",
+    });
+    expect(within(navResults).getByText(NAV_BUCKET_LABEL)).toBeDefined();
+    // The matched substring ("Build") renders in its own span, so the
+    // option's accessible name is "Build er" — allow the split.
+    const builder = screen.getByRole("option", { name: /build\s*er/i });
     const alpha = screen.getByRole("option", { name: /alpha agent/i });
 
     // Non-exact match keeps navigation after the search results.

--- a/autogpt_platform/frontend/src/app/(platform)/components/GlobalSearchModal/actions.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/components/GlobalSearchModal/actions.tsx
@@ -1,0 +1,73 @@
+import type { SearchCommandBucket } from "@/components/organisms/SearchCommandModal/helpers";
+import { CopyIcon } from "@phosphor-icons/react";
+import type { ComponentType } from "react";
+
+export const ACTIONS_BUCKET_KEY = "actions";
+export const ACTIONS_BUCKET_LABEL = "Actions";
+
+export const COPY_USER_ID_ACTION = "action:copy-user-id";
+
+interface ActionTarget {
+  id: string;
+  title: string;
+  // Extra terms that match this action beyond its title.
+  keywords: string[];
+  icon: ComponentType<{ className?: string }>;
+}
+
+// Namespaced ids so they never collide with API result / navigation ids
+// in the shared keyboard-nav flattening.
+const ACTION_TARGETS: ActionTarget[] = [
+  {
+    id: COPY_USER_ID_ACTION,
+    title: "Copy user ID",
+    keywords: ["copy", "user", "id", "uid", "account"],
+    icon: CopyIcon,
+  },
+];
+
+function matchesQuery(target: ActionTarget, query: string): boolean {
+  if (target.title.toLocaleLowerCase().includes(query)) return true;
+  return target.keywords.some((keyword) =>
+    keyword.toLocaleLowerCase().includes(query),
+  );
+}
+
+function isExactTitleMatch(target: ActionTarget, query: string): boolean {
+  return target.title.toLocaleLowerCase() === query;
+}
+
+/**
+ * Build the static "Actions" bucket filtered by ``query``. Actions run a
+ * side effect (e.g. copy to clipboard) rather than navigate. An empty
+ * query lists every action so they stay available on the idle list.
+ * ``isExactMatch`` lets the caller hoist actions above the search
+ * results when the user typed an action name verbatim.
+ */
+export function buildActionsBucket(query: string): {
+  bucket: SearchCommandBucket | null;
+  isExactMatch: boolean;
+} {
+  const normalized = query.trim().toLocaleLowerCase();
+
+  const matches = normalized
+    ? ACTION_TARGETS.filter((target) => matchesQuery(target, normalized))
+    : ACTION_TARGETS;
+  if (matches.length === 0) return { bucket: null, isExactMatch: false };
+
+  const isExactMatch = normalized
+    ? matches.some((target) => isExactTitleMatch(target, normalized))
+    : false;
+
+  const bucket: SearchCommandBucket = {
+    key: ACTIONS_BUCKET_KEY,
+    label: ACTIONS_BUCKET_LABEL,
+    items: matches.map((target) => ({
+      id: target.id,
+      title: target.title,
+      icon: target.icon,
+    })),
+  };
+
+  return { bucket, isExactMatch };
+}

--- a/autogpt_platform/frontend/src/app/(platform)/components/GlobalSearchModal/navigation.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/components/GlobalSearchModal/navigation.tsx
@@ -1,0 +1,144 @@
+import type { SearchCommandBucket } from "@/components/organisms/SearchCommandModal/helpers";
+import {
+  ChatCircleIcon,
+  CreditCardIcon,
+  GearIcon,
+  HammerIcon,
+  StackIcon,
+  StorefrontIcon,
+  UserIcon,
+} from "@phosphor-icons/react";
+import type { ComponentType } from "react";
+
+export const NAV_BUCKET_KEY = "navigation";
+export const NAV_BUCKET_LABEL = "Navigate";
+
+// Idle (empty query) only previews a few destinations; typing reveals
+// the full filtered set.
+const IDLE_NAV_LIMIT = 4;
+
+interface NavTarget {
+  id: string;
+  title: string;
+  href: string;
+  // Extra terms that should match this target beyond its title (e.g.
+  // "agents" routing to the library page).
+  keywords: string[];
+  icon: ComponentType<{ className?: string }>;
+}
+
+// Namespaced ids so they never collide with API result ids in the
+// shared ``itemsById`` map / keyboard-nav flattening.
+const NAV_TARGETS: NavTarget[] = [
+  {
+    id: "nav:builder",
+    title: "Builder",
+    href: "/build",
+    keywords: ["build", "editor", "graph", "workflow", "create"],
+    icon: HammerIcon,
+  },
+  {
+    id: "nav:library",
+    title: "Library",
+    href: "/library",
+    keywords: ["agents", "my agents"],
+    icon: StackIcon,
+  },
+  {
+    id: "nav:marketplace",
+    title: "Marketplace",
+    href: "/marketplace",
+    keywords: ["store", "explore", "templates"],
+    icon: StorefrontIcon,
+  },
+  {
+    id: "nav:chat",
+    title: "Chat",
+    href: "/copilot",
+    keywords: ["copilot", "home", "assistant"],
+    icon: ChatCircleIcon,
+  },
+  {
+    id: "nav:settings",
+    title: "Settings",
+    href: "/settings",
+    keywords: ["preferences", "account"],
+    icon: GearIcon,
+  },
+  {
+    id: "nav:billing",
+    title: "Billing",
+    href: "/settings/billing",
+    keywords: ["credits", "payment", "wallet", "subscription"],
+    icon: CreditCardIcon,
+  },
+  {
+    id: "nav:profile",
+    title: "Profile",
+    href: "/settings/profile",
+    keywords: ["account", "me"],
+    icon: UserIcon,
+  },
+];
+
+const HREF_BY_ID = new Map(
+  NAV_TARGETS.map((target) => [target.id, target.href]),
+);
+
+export function getNavigationHref(id: string): string | undefined {
+  return HREF_BY_ID.get(id);
+}
+
+function isExactTitleMatch(target: NavTarget, query: string): boolean {
+  return target.title.toLocaleLowerCase() === query;
+}
+
+function matchesQuery(target: NavTarget, query: string): boolean {
+  if (target.title.toLocaleLowerCase().includes(query)) return true;
+  return target.keywords.some((keyword) =>
+    keyword.toLocaleLowerCase().includes(query),
+  );
+}
+
+/**
+ * Build the static "Go to" bucket filtered by ``query``. The
+ * destination matching ``currentPath`` is dropped — there's no point
+ * navigating to the page you're already on. An empty query previews a
+ * few destinations alongside the idle recent-items list; typing reveals
+ * the full filtered set. ``isExactMatch`` lets the caller hoist
+ * navigation above the search results when the user typed a destination
+ * name verbatim (e.g. "Builder").
+ */
+export function buildNavigationBucket(
+  query: string,
+  currentPath: string | null,
+): {
+  bucket: SearchCommandBucket | null;
+  isExactMatch: boolean;
+} {
+  const normalized = query.trim().toLocaleLowerCase();
+
+  const available = NAV_TARGETS.filter(
+    (target) => target.href !== currentPath,
+  );
+  const matches = normalized
+    ? available.filter((target) => matchesQuery(target, normalized))
+    : available.slice(0, IDLE_NAV_LIMIT);
+  if (matches.length === 0) return { bucket: null, isExactMatch: false };
+
+  const isExactMatch = normalized
+    ? matches.some((target) => isExactTitleMatch(target, normalized))
+    : false;
+
+  const bucket: SearchCommandBucket = {
+    key: NAV_BUCKET_KEY,
+    label: NAV_BUCKET_LABEL,
+    items: matches.map((target) => ({
+      id: target.id,
+      title: target.title,
+      icon: target.icon,
+    })),
+  };
+
+  return { bucket, isExactMatch };
+}

--- a/autogpt_platform/frontend/src/app/(platform)/components/GlobalSearchModal/navigation.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/components/GlobalSearchModal/navigation.tsx
@@ -93,6 +93,20 @@ function isExactTitleMatch(target: NavTarget, query: string): boolean {
   return target.title.toLocaleLowerCase() === query;
 }
 
+// True when ``currentPath`` is the target itself or any page nested under
+// it (e.g. ``/settings/billing`` is "on" ``/settings``). The trailing
+// slash keeps unrelated routes that merely share a prefix (``/settings-x``)
+// from matching.
+function isCurrentDestination(
+  target: NavTarget,
+  currentPath: string | null,
+): boolean {
+  if (!currentPath) return false;
+  return (
+    currentPath === target.href || currentPath.startsWith(`${target.href}/`)
+  );
+}
+
 function matchesQuery(target: NavTarget, query: string): boolean {
   if (target.title.toLocaleLowerCase().includes(query)) return true;
   return target.keywords.some((keyword) =>
@@ -118,7 +132,9 @@ export function buildNavigationBucket(
 } {
   const normalized = query.trim().toLocaleLowerCase();
 
-  const available = NAV_TARGETS.filter((target) => target.href !== currentPath);
+  const available = NAV_TARGETS.filter(
+    (target) => !isCurrentDestination(target, currentPath),
+  );
   const matches = normalized
     ? available.filter((target) => matchesQuery(target, normalized))
     : available.slice(0, IDLE_NAV_LIMIT);

--- a/autogpt_platform/frontend/src/app/(platform)/components/GlobalSearchModal/navigation.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/components/GlobalSearchModal/navigation.tsx
@@ -115,7 +115,7 @@ function matchesQuery(target: NavTarget, query: string): boolean {
 }
 
 /**
- * Build the static "Go to" bucket filtered by ``query``. The
+ * Build the static "Navigate" bucket filtered by ``query``. The
  * destination matching ``currentPath`` is dropped — there's no point
  * navigating to the page you're already on. An empty query previews a
  * few destinations alongside the idle recent-items list; typing reveals

--- a/autogpt_platform/frontend/src/app/(platform)/components/GlobalSearchModal/navigation.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/components/GlobalSearchModal/navigation.tsx
@@ -118,9 +118,7 @@ export function buildNavigationBucket(
 } {
   const normalized = query.trim().toLocaleLowerCase();
 
-  const available = NAV_TARGETS.filter(
-    (target) => target.href !== currentPath,
-  );
+  const available = NAV_TARGETS.filter((target) => target.href !== currentPath);
   const matches = normalized
     ? available.filter((target) => matchesQuery(target, normalized))
     : available.slice(0, IDLE_NAV_LIMIT);

--- a/autogpt_platform/frontend/src/app/(platform)/components/GlobalSearchModal/useGlobalSearch.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/components/GlobalSearchModal/useGlobalSearch.ts
@@ -1,12 +1,16 @@
+import { usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
 import { useGetSearchGlobalSearch } from "@/app/api/__generated__/endpoints/search/search";
 import type { GlobalSearchResponse } from "@/app/api/__generated__/models/globalSearchResponse";
+import { buildActionsBucket } from "./actions";
 import { buildBucketsFromResponse } from "./helpers";
+import { buildNavigationBucket } from "./navigation";
 
 const DEBOUNCE_MS = 200;
 const PER_TYPE_LIMIT = 4;
 
 export function useGlobalSearch(isOpen: boolean) {
+  const pathname = usePathname();
   const [query, setQuery] = useState("");
   const [debouncedQuery, setDebouncedQuery] = useState("");
 
@@ -43,7 +47,26 @@ export function useGlobalSearch(isOpen: boolean) {
   const response =
     data?.status === 200 ? (data.data as GlobalSearchResponse) : undefined;
 
-  const { buckets, itemsById } = buildBucketsFromResponse(response);
+  const { buckets: searchBuckets, itemsById } =
+    buildBucketsFromResponse(response);
+
+  // Client-side command buckets (navigation + actions) filtered against
+  // the live query (no debounce — local match is instant). On an exact
+  // name match ("Builder", "Copy user ID") the bucket is hoisted above
+  // the search results; otherwise it trails them so search stays the
+  // primary intent. Priority order on exact match: navigation, actions.
+  const commandBuckets = [
+    buildNavigationBucket(query, pathname),
+    buildActionsBucket(query),
+  ];
+  const topBuckets = commandBuckets.flatMap((entry) =>
+    entry.bucket && entry.isExactMatch ? [entry.bucket] : [],
+  );
+  const bottomBuckets = commandBuckets.flatMap((entry) =>
+    entry.bucket && !entry.isExactMatch ? [entry.bucket] : [],
+  );
+
+  const buckets = [...topBuckets, ...searchBuckets, ...bottomBuckets];
 
   return {
     query,

--- a/autogpt_platform/frontend/src/components/organisms/SearchCommandModal/SearchCommandModal.tsx
+++ b/autogpt_platform/frontend/src/components/organisms/SearchCommandModal/SearchCommandModal.tsx
@@ -34,6 +34,8 @@ interface Props {
   isError?: boolean;
   placeholder?: string;
   inputAriaLabel?: string;
+  /** Id of the row whose action is in-flight (renders a spinner). */
+  loadingItemId?: string;
 }
 
 export function SearchCommandModal({
@@ -50,6 +52,7 @@ export function SearchCommandModal({
   isError = false,
   placeholder = "Search…",
   inputAriaLabel = "Search",
+  loadingItemId,
 }: Props) {
   const inputRef = useRef<HTMLInputElement>(null);
   const reactId = useId();
@@ -114,14 +117,11 @@ export function SearchCommandModal({
       <RXDialog.Portal>
         <RXDialog.Overlay className="fixed inset-0 z-[80] bg-black/20 backdrop-blur-sm" />
         <RXDialog.Content
-          aria-labelledby={`${idPrefix}-title`}
           onOpenAutoFocus={handleOpenAutoFocus}
           className="fixed left-1/2 top-[18vh] z-[80] w-[calc(100%-2rem)] max-w-xl -translate-x-1/2 overflow-hidden rounded-3xl bg-white shadow-2xl ring-1 ring-zinc-200 focus:outline-none"
           onKeyDown={handleKeyDown}
         >
-          <RXDialog.Title id={`${idPrefix}-title`} className="sr-only">
-            Search
-          </RXDialog.Title>
+          <RXDialog.Title className="sr-only">Search</RXDialog.Title>
           <div className="flex items-center gap-3 bg-zinc-50 p-3">
             <MagnifyingGlassIcon className="h-5 w-5 shrink-0 text-zinc-800" />
             <Input
@@ -181,6 +181,7 @@ export function SearchCommandModal({
                   highlightedRef={highlightedRef}
                   onHighlight={setHighlightedIndex}
                   onSelect={onSelectItem}
+                  loadingItemId={loadingItemId}
                 />
               ) : showLoading ? (
                 // Skeleton over text: the input-side spinner already

--- a/autogpt_platform/frontend/src/components/organisms/SearchCommandModal/SearchCommandResultItem.tsx
+++ b/autogpt_platform/frontend/src/components/organisms/SearchCommandModal/SearchCommandResultItem.tsx
@@ -1,3 +1,4 @@
+import { LoadingSpinner } from "@/components/atoms/LoadingSpinner/LoadingSpinner";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import type { MutableRefObject } from "react";
@@ -9,6 +10,8 @@ interface Props {
   idPrefix: string;
   query: string;
   isHighlighted: boolean;
+  /** Shows a trailing spinner while the row's action is in-flight. */
+  isLoading?: boolean;
   highlightedRef?: MutableRefObject<HTMLButtonElement | null>;
   onHighlight: () => void;
   onSelect: () => void;
@@ -28,6 +31,7 @@ export function SearchCommandResultItem({
   idPrefix,
   query,
   isHighlighted,
+  isLoading = false,
   highlightedRef,
   onHighlight,
   onSelect,
@@ -92,15 +96,23 @@ export function SearchCommandResultItem({
             </div>
           ) : null}
         </div>
-        <span
-          aria-hidden="true"
-          className={cn(
-            "inline-flex h-5 min-w-5 shrink-0 items-center justify-center rounded-md border border-zinc-200 bg-white px-1 font-sans text-[11px] text-zinc-600 shadow-[inset_0_-1px_0_rgba(15,15,20,0.04),0_1px_1px_rgba(15,15,20,0.04)] transition-opacity duration-150",
-            isHighlighted ? "opacity-100" : "opacity-0",
-          )}
-        >
-          ↵
-        </span>
+        {isLoading ? (
+          <LoadingSpinner
+            size="small"
+            aria-label="Opening"
+            className="shrink-0 text-zinc-500"
+          />
+        ) : (
+          <span
+            aria-hidden="true"
+            className={cn(
+              "inline-flex h-5 min-w-5 shrink-0 items-center justify-center rounded-md border border-zinc-200 bg-white px-1 font-sans text-[11px] text-zinc-600 shadow-[inset_0_-1px_0_rgba(15,15,20,0.04),0_1px_1px_rgba(15,15,20,0.04)] transition-opacity duration-150",
+              isHighlighted ? "opacity-100" : "opacity-0",
+            )}
+          >
+            ↵
+          </span>
+        )}
       </div>
     </Button>
   );

--- a/autogpt_platform/frontend/src/components/organisms/SearchCommandModal/SearchCommandResults.tsx
+++ b/autogpt_platform/frontend/src/components/organisms/SearchCommandModal/SearchCommandResults.tsx
@@ -15,6 +15,8 @@ interface Props {
   highlightedRef: MutableRefObject<HTMLButtonElement | null>;
   onHighlight: (index: number) => void;
   onSelect: (item: SearchCommandItem, bucketKey: string) => void;
+  /** Id of the row whose action is in-flight (renders a spinner). */
+  loadingItemId?: string;
 }
 
 export function SearchCommandResults({
@@ -25,6 +27,7 @@ export function SearchCommandResults({
   highlightedRef,
   onHighlight,
   onSelect,
+  loadingItemId,
 }: Props) {
   const flat = flattenBuckets(buckets);
   // Group the flat list back by bucket so the absolute ``index`` survives
@@ -56,6 +59,7 @@ export function SearchCommandResults({
                   idPrefix={idPrefix}
                   query={query}
                   isHighlighted={entry.index === highlightedIndex}
+                  isLoading={entry.item.id === loadingItemId}
                   highlightedRef={
                     entry.index === highlightedIndex
                       ? highlightedRef


### PR DESCRIPTION
### Why

The global search palette (⌘K) only surfaced backend search results (agents, files, chats). Users had no fast way to jump between core areas of the app or run common utilities from the same surface — they had to leave search and hunt through the nav. This adds keyboard-first navigation and actions to the palette they already open.

### What

Two new **client-side** command sections in `GlobalSearchModal`:

- **Navigate** — Builder, Library, Marketplace, Chat, Settings, Billing, Profile.
  - Filtered by title/keyword while typing.
  - Exact name match (e.g. typing `Builder`) hoists the section **above** search results; otherwise it trails them so search stays primary.
  - The destination matching the **current page** is hidden (no "go to the page you're already on").
  - Idle (empty query) previews up to 4 destinations alongside recent items.
- **Actions** — local side effects. Ships with **Copy user ID** (writes the Supabase user id to clipboard with toast feedback).

UX details:
- Selecting a Navigate/Action row shows a **trailing spinner** on that row and keeps the modal open while the work is in-flight (routing to a slow page, or awaiting the clipboard write), then settles/closes.
- Fixes a Radix `DialogTitle` accessibility warning surfaced in the search modal.

Frontend-only. Backend search endpoint untouched.


https://github.com/user-attachments/assets/299e21bb-c7bc-4831-8882-4617832c9b75



### How

- `navigation.tsx` / `actions.tsx` — static target lists + `buildNavigationBucket` / `buildActionsBucket(query)` returning a bucket + `isExactMatch` flag, namespaced ids (`nav:*`, `action:*`) to avoid collisions in the shared keyboard-nav flattening.
- `useGlobalSearch.ts` — composes command buckets generically: any bucket with an exact match is hoisted above search results (priority: navigation → actions); the rest trail. Current pathname (via `usePathname`) drops the active destination.
- `GlobalSearchModal.tsx` — routes Navigate rows via `useRouter`, runs Action rows via a local `runAction` (clipboard + `useToast`), tracks an in-flight `busyItemId` to drive the per-row spinner.
- `SearchCommandModal` organism — generic `loadingItemId` prop threads a per-row spinner down to `SearchCommandResultItem` (replaces the `↵` hint while busy). `DialogTitle` now lets Radix auto-wire its id.

### Test plan

- [x] Integration tests added in `GlobalSearchModal/__tests__`: Navigate below results on partial match, hoisted on exact match, spinner-on-route, Copy user ID action surfaces + runs locally, nav shown when API returns no recent items.
- [ ] `pnpm test:unit` green
- [ ] Manual: ⌘K → type `builder`/`library`/`copy`, verify ordering, current-page hidden, spinner on select.

### Checklist

- [x] Client-first; generated API hooks where applicable
- [x] Uses `src/components` design-system primitives + Phosphor icons
- [x] Logic split into `helpers`/hook files; render kept thin
- [x] Navigation uses the Next.js router
- [x] Integration tests added/updated
