### PR TITLE
feat(frontend): move Builder link into the account menu

### DIFF
--- a/autogpt_platform/frontend/src/components/layout/Navbar/Navbar.tsx
+++ b/autogpt_platform/frontend/src/components/layout/Navbar/Navbar.tsx
@@ -23,7 +23,6 @@ import { getAccountMenuItems, loggedInLinks, loggedOutLinks } from "./helpers";
 
 const MOBILE_NAV_ICONS: Readonly<Record<string, IconType>> = {
   "/marketplace": IconType.Marketplace,
-  "/build": IconType.Builder,
   "/copilot": IconType.Chat,
   "/library": IconType.Library,
   "/artifacts": IconType.UploadCloud,

--- a/autogpt_platform/frontend/src/components/layout/Navbar/__tests__/helpers.test.tsx
+++ b/autogpt_platform/frontend/src/components/layout/Navbar/__tests__/helpers.test.tsx
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "vitest";
+import { getAccountMenuItems, loggedInLinks } from "../helpers";
+
+describe("loggedInLinks", () => {
+  test("no longer exposes the Builder as a top-level navbar link", () => {
+    expect(loggedInLinks.some((link) => link.href === "/build")).toBe(false);
+  });
+});
+
+describe("getAccountMenuItems", () => {
+  test("places the Builder entry directly after Profile", () => {
+    const items = getAccountMenuItems().flatMap((group) => group.items);
+    const labels = items.map((item) => item.text);
+    const profileIndex = labels.indexOf("Profile");
+
+    expect(profileIndex).toBeGreaterThanOrEqual(0);
+    expect(labels[profileIndex + 1]).toBe("Builder");
+  });
+
+  test("Builder entry links to the build page", () => {
+    const builder = getAccountMenuItems()
+      .flatMap((group) => group.items)
+      .find((item) => item.text === "Builder");
+
+    expect(builder?.href).toBe("/build");
+  });
+});

--- a/autogpt_platform/frontend/src/components/layout/Navbar/__tests__/helpers.test.tsx
+++ b/autogpt_platform/frontend/src/components/layout/Navbar/__tests__/helpers.test.tsx
@@ -1,5 +1,12 @@
+import { IconType } from "@/components/__legacy__/ui/icons";
+import { CubeIcon } from "@phosphor-icons/react";
+import { isValidElement } from "react";
 import { describe, expect, test } from "vitest";
-import { getAccountMenuItems, loggedInLinks } from "../helpers";
+import {
+  getAccountMenuItems,
+  getAccountMenuOptionIcon,
+  loggedInLinks,
+} from "../helpers";
 
 describe("loggedInLinks", () => {
   test("does not expose Builder as a top-level navbar link", () => {
@@ -34,5 +41,13 @@ describe("getAccountMenuItems", () => {
     expect(profileIndex).toBeGreaterThanOrEqual(0);
     expect(labels[profileIndex + 1]).toBe("Builder");
     expect(labels).toContain("Admin");
+  });
+});
+
+describe("getAccountMenuOptionIcon", () => {
+  test("maps the Builder icon to the Phosphor CubeIcon for mobile", () => {
+    const result = getAccountMenuOptionIcon(IconType.Builder);
+    expect(isValidElement(result)).toBe(true);
+    expect((result as React.ReactElement).type).toBe(CubeIcon);
   });
 });

--- a/autogpt_platform/frontend/src/components/layout/Navbar/__tests__/helpers.test.tsx
+++ b/autogpt_platform/frontend/src/components/layout/Navbar/__tests__/helpers.test.tsx
@@ -2,7 +2,7 @@ import { describe, expect, test } from "vitest";
 import { getAccountMenuItems, loggedInLinks } from "../helpers";
 
 describe("loggedInLinks", () => {
-  test("no longer exposes the Builder as a top-level navbar link", () => {
+  test("does not expose Builder as a top-level navbar link", () => {
     expect(loggedInLinks.some((link) => link.href === "/build")).toBe(false);
   });
 });
@@ -23,5 +23,16 @@ describe("getAccountMenuItems", () => {
       .find((item) => item.text === "Builder");
 
     expect(builder?.href).toBe("/build");
+  });
+
+  test("keeps Builder after Profile for admin users", () => {
+    const labels = getAccountMenuItems("admin")
+      .flatMap((group) => group.items)
+      .map((item) => item.text);
+    const profileIndex = labels.indexOf("Profile");
+
+    expect(profileIndex).toBeGreaterThanOrEqual(0);
+    expect(labels[profileIndex + 1]).toBe("Builder");
+    expect(labels).toContain("Admin");
   });
 });

--- a/autogpt_platform/frontend/src/components/layout/Navbar/components/AccountMenu/AccountMenu.stories.tsx
+++ b/autogpt_platform/frontend/src/components/layout/Navbar/components/AccountMenu/AccountMenu.stories.tsx
@@ -22,6 +22,11 @@ const userGroups = [
         href: "/settings/profile",
       },
       {
+        icon: IconType.Builder,
+        text: "Builder",
+        href: "/build",
+      },
+      {
         icon: IconType.Settings,
         text: "Settings",
         href: "/settings/account",

--- a/autogpt_platform/frontend/src/components/layout/Navbar/components/AccountMenu/__tests__/AccountMenu.test.tsx
+++ b/autogpt_platform/frontend/src/components/layout/Navbar/components/AccountMenu/__tests__/AccountMenu.test.tsx
@@ -36,6 +36,11 @@ const baseGroups: MenuItemGroup[] = [
         href: "/settings/profile",
       },
       {
+        icon: IconType.Builder,
+        text: "Builder",
+        href: "/build",
+      },
+      {
         icon: IconType.Settings,
         text: "Settings",
         href: "/settings/account",
@@ -114,10 +119,25 @@ describe("AccountMenu", () => {
     );
 
     expect(screen.getByText("Profile")).toBeDefined();
+    expect(screen.getByText("Builder")).toBeDefined();
     expect(screen.getByText("Settings")).toBeDefined();
     expect(screen.getByText("Help & Docs")).toBeDefined();
     expect(screen.getByText("Publish an agent")).toBeDefined();
     expect(screen.getByText("Log out")).toBeDefined();
+  });
+
+  test("renders the Builder item linking to the build page", () => {
+    render(
+      <AccountMenu
+        userName="Ada"
+        userEmail="ada@example.com"
+        menuItemGroups={baseGroups}
+      />,
+    );
+
+    expect(screen.getByText("Builder").closest("a")?.getAttribute("href")).toBe(
+      "/build",
+    );
   });
 
   test("renders external link with target=_blank", () => {

--- a/autogpt_platform/frontend/src/components/layout/Navbar/components/AccountMenu/__tests__/helpers.test.tsx
+++ b/autogpt_platform/frontend/src/components/layout/Navbar/components/AccountMenu/__tests__/helpers.test.tsx
@@ -5,6 +5,7 @@ import { getAccountMenuPhosphorIcon } from "../helpers";
 describe("getAccountMenuPhosphorIcon", () => {
   test.each([
     IconType.Edit,
+    IconType.Builder,
     IconType.LayoutDashboard,
     IconType.UploadCloud,
     IconType.Sliders,

--- a/autogpt_platform/frontend/src/components/layout/Navbar/components/AccountMenu/__tests__/helpers.test.tsx
+++ b/autogpt_platform/frontend/src/components/layout/Navbar/components/AccountMenu/__tests__/helpers.test.tsx
@@ -1,4 +1,5 @@
 import { IconType } from "@/components/__legacy__/ui/icons";
+import { CubeIcon } from "@phosphor-icons/react";
 import { describe, expect, test } from "vitest";
 import { getAccountMenuPhosphorIcon } from "../helpers";
 
@@ -16,6 +17,11 @@ describe("getAccountMenuPhosphorIcon", () => {
   ])("returns a Phosphor icon element for %s", (icon) => {
     const result = getAccountMenuPhosphorIcon(icon);
     expect(result).not.toBeNull();
+  });
+
+  test("maps the Builder icon to CubeIcon", () => {
+    const result = getAccountMenuPhosphorIcon(IconType.Builder);
+    expect(result?.type).toBe(CubeIcon);
   });
 
   test("returns null for unmapped icon types", () => {

--- a/autogpt_platform/frontend/src/components/layout/Navbar/components/AccountMenu/helpers.tsx
+++ b/autogpt_platform/frontend/src/components/layout/Navbar/components/AccountMenu/helpers.tsx
@@ -2,6 +2,7 @@ import { IconType } from "@/components/__legacy__/ui/icons";
 import {
   ChartLineUpIcon,
   CreditCardIcon,
+  CubeIcon,
   GearIcon,
   QuestionIcon,
   SignOutIcon,
@@ -16,6 +17,8 @@ export function getAccountMenuPhosphorIcon(icon: IconType) {
   switch (icon) {
     case IconType.Edit:
       return <UserIcon className={className} weight={weight} />;
+    case IconType.Builder:
+      return <CubeIcon className={className} weight={weight} />;
     case IconType.LayoutDashboard:
       return <ChartLineUpIcon className={className} weight={weight} />;
     case IconType.UploadCloud:

--- a/autogpt_platform/frontend/src/components/layout/Navbar/helpers.tsx
+++ b/autogpt_platform/frontend/src/components/layout/Navbar/helpers.tsx
@@ -27,10 +27,6 @@ export const loggedInLinks: Link[] = [
     name: "Marketplace",
     href: "/marketplace",
   },
-  {
-    name: "Build",
-    href: "/build",
-  },
 ];
 
 export const loggedOutLinks: Link[] = [
@@ -101,6 +97,11 @@ export function getAccountMenuItems(userRole?: string): MenuItemGroup[] {
           icon: IconType.Edit,
           text: "Profile",
           href: "/settings/profile",
+        },
+        {
+          icon: IconType.Builder,
+          text: "Builder",
+          href: "/build",
         },
         {
           icon: IconType.Settings,

--- a/autogpt_platform/frontend/src/components/layout/Navbar/helpers.tsx
+++ b/autogpt_platform/frontend/src/components/layout/Navbar/helpers.tsx
@@ -1,5 +1,4 @@
 import {
-  IconBuilder,
   IconEdit,
   IconLibrary,
   IconLogOut,
@@ -13,6 +12,7 @@ import {
 import {
   ChatsIcon,
   CreditCardIcon,
+  CubeIcon,
   QuestionIcon,
   StorefrontIcon,
 } from "@phosphor-icons/react";
@@ -46,48 +46,6 @@ export type MenuItemGroup = {
     onClick?: () => void;
   }[];
 };
-
-export const accountMenuItems: MenuItemGroup[] = [
-  {
-    items: [
-      {
-        icon: IconType.Edit,
-        text: "Account",
-        href: "/settings/account",
-      },
-    ],
-  },
-  {
-    items: [
-      {
-        icon: IconType.LayoutDashboard,
-        text: "Creator Dashboard",
-        href: "/settings/creator-dashboard",
-      },
-      {
-        icon: IconType.UploadCloud,
-        text: "Publish an agent",
-      },
-    ],
-  },
-  {
-    items: [
-      {
-        icon: IconType.Settings,
-        text: "Settings",
-        href: "/settings",
-      },
-    ],
-  },
-  {
-    items: [
-      {
-        icon: IconType.LogOut,
-        text: "Log out",
-      },
-    ],
-  },
-];
 
 export function getAccountMenuItems(userRole?: string): MenuItemGroup[] {
   const baseMenuItems: MenuItemGroup[] = [
@@ -170,7 +128,7 @@ export function getAccountMenuOptionIcon(icon: IconType) {
     case IconType.Library:
       return <IconLibrary className={iconClass} />;
     case IconType.Builder:
-      return <IconBuilder className={iconClass} />;
+      return <CubeIcon className={iconClass} />;
     case IconType.Sliders:
       return <IconSliders className={iconClass} />;
     case IconType.Chat:


### PR DESCRIPTION
### Why / What / How

**Why:** The top navbar was getting crowded, and the Builder is an account-scoped entry point rather than a primary, browse-style destination like Home / Agents / Marketplace. Moving it into the account menu declutters the main nav while keeping the Builder one click away.

**What:** Moves the "Builder" link out of the top navbar links and into the account menu, placed immediately after "Profile".

**How:** The navbar links and the account-menu item groups are both defined in `Navbar/helpers.tsx`. I removed the `Build` entry from `loggedInLinks` (top nav) and added a `Builder` item (`/build`, `IconType.Builder`) right after `Profile` in `getAccountMenuItems`. Because both the desktop `AccountMenu` and the `MobileNavBar` render the same account-menu groups, the change applies to both. The desktop menu maps `IconType` to Phosphor icons via `AccountMenu/helpers.tsx`, which had no `Builder` case, so I added one (`CubeIcon`); the mobile nav already mapped `IconType.Builder`. The Storybook story and the icon-mapping test were updated to stay representative.

### Changes 🏗️

- Removed the "Build" link from the top navbar (`loggedInLinks`).
- Added a "Builder" item (`/build`) after "Profile" in the account menu (`getAccountMenuItems`) — appears in both the desktop AccountMenu and the mobile nav.
- Added an `IconType.Builder` → `CubeIcon` mapping in `AccountMenu/helpers.tsx` so the desktop menu renders an icon.
- Updated the `AccountMenu` Storybook story and the `getAccountMenuPhosphorIcon` test to include the Builder entry.

### Checklist 📋

#### For code changes:
- [ ] I have clearly listed my changes in the PR description
- [ ] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [ ] Logged in, opened the account menu, and confirmed "Builder" appears directly after "Profile" and navigates to `/build`
  - [ ] Confirmed "Build" no longer appears in the top navbar links
  - [ ] Verified the Builder entry and icon render in the mobile nav menu
