### PR TITLE
refactor(frontend/copilot): restore pre-ContextPanel visual styling

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/copilot/CopilotPage.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/CopilotPage.tsx
@@ -99,11 +99,11 @@ function MainArea({
     <div className="relative mr-5 mt-2.5 flex h-full w-full flex-row pb-1 lg:mr-[0.3rem]">
       <div className="relative flex min-w-0 flex-1 overflow-hidden bg-[#fafafa] p-2">
         <FileDropZone
-          className="relative flex min-w-0 flex-1 flex-col overflow-hidden rounded-2xl border border-[#8080801a] bg-white px-0 shadow-sm"
+          className="relative flex min-w-0 flex-1 flex-col overflow-hidden rounded-2xl border border-[#80808033] bg-white px-0 shadow-sm"
           onFilesDropped={setDroppedFiles}
         >
           {isMobile && <MobileHeader />}
-          <LowCreditBanner className="m-4" />
+          <LowCreditBanner />
           <NotificationBanner />
           <CopilotChatHost
             key={`chat-host-${sessionId ?? "new"}`}

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/CopilotPage.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/CopilotPage.tsx
@@ -3,6 +3,7 @@
 import { LowCreditBanner } from "@/components/layout/TopUpPrompt/LowCreditBanner/LowCreditBanner";
 import { SidebarProvider } from "@/components/ui/sidebar";
 import { useSupabase } from "@/lib/supabase/hooks/useSupabase";
+import { cn } from "@/lib/utils";
 import { Flag, useGetFlag } from "@/services/feature-flags/use-get-flag";
 import dynamic from "next/dynamic";
 import { parseAsString, useQueryState } from "nuqs";
@@ -68,7 +69,7 @@ export function CopilotPage() {
         droppedFiles={droppedFiles}
         setDroppedFiles={setDroppedFiles}
       />
-      {isMobile && isContextPanelEnabled && (
+      {isMobile && isContextPanelEnabled && sessionId && (
         <ContextPanel sessionId={sessionId} mobile />
       )}
       {isArtifactsEnabled && !isContextPanelEnabled && (
@@ -95,11 +96,21 @@ function MainArea({
   droppedFiles,
   setDroppedFiles,
 }: MainAreaProps) {
+  const hasSession = !!sessionId;
   return (
     <div className="relative mr-5 mt-2.5 flex h-full w-full flex-row pb-1 lg:mr-[0.3rem]">
-      <div className="relative flex min-w-0 flex-1 overflow-hidden bg-[#fafafa] p-2">
+      <div
+        className={cn(
+          "relative flex min-w-0 flex-1 overflow-hidden",
+          hasSession && "bg-[#fafafa] p-2",
+        )}
+      >
         <FileDropZone
-          className="relative flex min-w-0 flex-1 flex-col overflow-hidden rounded-2xl border border-[#80808033] bg-white px-0 shadow-sm"
+          className={cn(
+            "relative flex min-w-0 flex-1 flex-col overflow-hidden px-0",
+            hasSession &&
+              "rounded-2xl border border-[#80808033] bg-white shadow-sm",
+          )}
           onFilesDropped={setDroppedFiles}
         >
           {isMobile && <MobileHeader />}
@@ -120,7 +131,7 @@ function MainArea({
           )}
         </FileDropZone>
       </div>
-      {!isMobile && isContextPanelEnabled && (
+      {!isMobile && isContextPanelEnabled && sessionId && (
         <ContextPanel sessionId={sessionId} />
       )}
       {!isMobile && isContextPanelEnabled && sessionId && (

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatContainer/ChatContainer.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatContainer/ChatContainer.tsx
@@ -150,7 +150,12 @@ export const ChatContainer = ({
   return (
     <CopilotChatActionsProvider onSend={onSend}>
       <LayoutGroup id="copilot-2-chat-layout">
-        <div className="flex h-full min-h-0 flex-col bg-white">
+        <div
+          className={cn(
+            "flex h-full min-h-0 flex-col",
+            sessionId && "bg-white",
+          )}
+        >
           {sessionId ? (
             <>
               <div className="flex min-h-0 flex-1 flex-col px-2 pt-[15px] lg:px-0">

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatContainer/ChatContainer.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatContainer/ChatContainer.tsx
@@ -188,13 +188,8 @@ export const ChatContainer = ({
                 initial={{ opacity: 0 }}
                 animate={{ opacity: 1 }}
                 transition={{ duration: 0.3 }}
-                className="relative bg-[#6b91d012] [&_[data-slot=input-group-control]::placeholder]:!text-slate-500"
+                className="relative bg-zinc-50"
               >
-                <div
-                  aria-hidden="true"
-                  className="pointer-events-none absolute -top-[12px] left-0 right-0 z-10 h-[5px] bg-white"
-                  style={{ boxShadow: "rgb(255, 255, 255) 0px -8px 12px 13px" }}
-                />
                 <div
                   className={cn(
                     "relative mx-auto w-full px-3 pb-2 pt-0",

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/components/BlockCaret.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/components/BlockCaret.tsx
@@ -157,7 +157,7 @@ export function BlockCaret({ textareaId }: Props) {
       className="pointer-events-none absolute z-10 bg-blue-500"
       style={{
         left: pos.left,
-        top: 12,
+        top: pos.top,
         height: pos.height,
         width: CARET_WIDTH,
         opacity: visible ? 1 : 0,

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatMessagesContainer/ChatMessagesContainer.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatMessagesContainer/ChatMessagesContainer.tsx
@@ -480,10 +480,10 @@ export function ChatMessagesContainer({
       }
     >
       <ConversationContent
-        className="flex min-h-full flex-1 flex-col gap-6 px-6 pb-8 pt-0"
+        className="flex min-h-full flex-1 flex-col gap-6 px-6 py-0"
         style={
           bottomContentPadding
-            ? { paddingBottom: bottomContentPadding + 32 }
+            ? { paddingBottom: bottomContentPadding + 24 }
             : undefined
         }
       >

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/EmptySession/EmptySession.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/EmptySession/EmptySession.tsx
@@ -71,7 +71,7 @@ export function EmptySession({
   }, []);
 
   return (
-    <div className="flex h-full flex-1 items-center justify-center overflow-y-auto bg-white px-0 py-5 md:px-6 md:py-10">
+    <div className="flex h-full flex-1 items-center justify-center overflow-y-auto px-0 py-5 md:px-6 md:py-10">
       <motion.div
         className="w-full max-w-[52rem] text-center"
         initial={{ opacity: 0 }}

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/EmptySession/EmptySession.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/EmptySession/EmptySession.tsx
@@ -4,7 +4,6 @@ import { ChatInput } from "@/app/(platform)/copilot/components/ChatInput/ChatInp
 import { useGetV2GetSuggestedPrompts } from "@/app/api/__generated__/endpoints/chat/chat";
 import { Skeleton } from "@/components/atoms/Skeleton/Skeleton";
 import { Text } from "@/components/atoms/Text/Text";
-import { AuroraBackground } from "@/components/ui/aurora-background";
 import { useSupabase } from "@/lib/supabase/hooks/useSupabase";
 import { motion } from "framer-motion";
 import { useEffect, useState } from "react";
@@ -72,26 +71,20 @@ export function EmptySession({
   }, []);
 
   return (
-    <AuroraBackground
-      showRadialGradient={false}
-      className="h-full flex-1 overflow-y-auto bg-white px-0 py-5 md:px-6 md:py-10 [&>[aria-hidden]>div]:!opacity-10"
-    >
+    <div className="flex h-full flex-1 items-center justify-center overflow-y-auto bg-white px-0 py-5 md:px-6 md:py-10">
       <motion.div
-        className="relative z-10 w-full max-w-[52rem] text-center"
+        className="w-full max-w-[52rem] text-center"
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         transition={{ duration: 0.3 }}
       >
         <div className="mx-auto max-w-[52rem]">
-          <Text
-            variant="h3"
-            className="mb-1 !text-[1.375rem] !font-medium !text-neutral-800"
-          >
-            Hey, {greetingName}
+          <Text variant="h3" className="mb-1 !text-[1.375rem] text-zinc-700">
+            Hey, <span className="text-violet-600">{greetingName}</span>
             <EditNameDialog currentName={greetingName} />
           </Text>
-          <Text variant="h3" className="mb-8 !font-medium !text-neutral-800">
-            Tell me about your work, I&apos;ll find what to automate.
+          <Text variant="h3" className="mb-8 !font-normal">
+            Tell me about your work — I&apos;ll find what to automate.
           </Text>
 
           {isAgentBriefingEnabled && (
@@ -102,7 +95,7 @@ export function EmptySession({
             <motion.div
               layoutId={inputLayoutId}
               transition={{ type: "spring", bounce: 0.2, duration: 0.65 }}
-              className="w-full px-2 [&_[data-slot=input-group-control]::placeholder]:!text-slate-500 [&_[data-slot=input-group]]:!border-[#bfdbfe6b] [&_[data-slot=input-group]]:!bg-[#f5f7fc]"
+              className="w-full px-2"
             >
               <ChatInput
                 inputId="chat-input-empty"
@@ -132,6 +125,6 @@ export function EmptySession({
           />
         )}
       </motion.div>
-    </AuroraBackground>
+    </div>
   );
 }

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/EmptySession/components/EditNameDialog/EditNameDialog.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/EmptySession/components/EditNameDialog/EditNameDialog.tsx
@@ -72,7 +72,7 @@ export function EditNameDialog({ currentName }: Props) {
       <Dialog.Trigger>
         <button
           type="button"
-          className="ml-1 inline-flex items-center text-indigo-500 transition-colors hover:text-indigo-700"
+          className="ml-1 inline-flex items-center text-violet-500 transition-colors hover:text-violet-700"
         >
           <PencilSimpleIcon size={16} />
         </button>


### PR DESCRIPTION
### Why / What / How

**Why:** PR #13228 (`feature/autopilot-workspace-files`) layered a number of visual chrome + typography tweaks on top of the new ContextPanel work. We want to ship the panel without the styling changes so the Copilot/Autopilot pages keep their pre-feature look while the workspace sidebar lands.

**What:** Strictly reverts the visual / typography deltas introduced on top of the ContextPanel work. All sidebar functionality (Progress tab, Files tab with count, auto-open, TaskListNotice pill, backend `TodoWrite` closing-out rules, Autopilot rename, mount-level Artifact/Context exclusion) is preserved.

**How:** Six files touched, ~15 insertions / 27 deletions. Each change is a narrow restore of the styling that existed before the WIP visual pass.

### Changes 🏗️

**Reverted (visual chrome + typography):**

- `EmptySession.tsx`
  - `AuroraBackground` → plain `<div className="flex h-full flex-1 items-center justify-center …">`.
  - Greeting `Text`: `mb-1 !text-[1.375rem] text-zinc-700` with `<span className="text-violet-600">{greetingName}</span>`.
  - Subtitle `Text`: `mb-8 !font-normal`, copy back to `Tell me about your work — I'll find what to automate.` (em dash, not comma).
  - Input wrapper: `w-full px-2` (no `#f5f7fc` bg, no `#bfdbfe6b` border, no placeholder override).
- `EditNameDialog.tsx`: pencil icon back to `text-violet-500 / hover:text-violet-700`.
- `CopilotPage.tsx`: `FileDropZone` border back to `#80808033`; `<LowCreditBanner />` (no `m-4`).
- `ChatContainer.tsx`: input dock `bg-zinc-50`; removed the fade strip + `0px -8px 12px 13px` box-shadow.
- `BlockCaret.tsx`: `top: pos.top` (multi-line tracking) instead of `top: 12`.
- `ChatMessagesContainer.tsx`: `ConversationContent` back to `px-6 py-0` with `bottomContentPadding + 24`.

**Kept on purpose (functionality / accepted product decisions):**

- All ContextPanel work: shell, Progress tab implementation, Files (n) label, TaskListNotice pill, `useAutoOpenForProgress`, store changes, mount-level `ArtifactPanel` / `ContextPanel` mutual exclusion.
- Backend `prompting.py` `SHARED_TOOL_NOTES` block requiring `TodoWrite` to close out with no `in_progress` items.
- Otto → Autopilot user-facing copy.
- Button color/variant tweaks (`ModeToggleButton`, `ModelToggleButton`, `DryRunToggleButton`, `SuggestionThemes` secondary + `!bg-white`).
- `ContextPanelToggle` hidden on the empty homepage (`sessionId` guard).

> **Base branch:** targets `feature/autopilot-workspace-files` because the styling diff only makes sense relative to that branch's tip. Retarget to `dev` once #13228 merges (or merge them in order).

### Checklist 📋

#### For code changes:

- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [x] `pnpm format`, `pnpm lint`, `pnpm types` clean
  - [ ] Manual: empty `/copilot` no longer shows the Aurora gradient, greeting reads `Hey, <violet name>`, subtitle reads `Tell me about your work — I'll find what to automate.` with `!font-normal`
  - [ ] Manual: chat input on the homepage has no border tint / no `#f5f7fc` bg
  - [ ] Manual: in a session, the input dock has `bg-zinc-50` and the white fade strip above the input is gone
  - [ ] Manual: ContextPanel still mounts, Progress + Files (n) tabs still work, TaskListNotice pill still appears while tasks stream, panel still auto-opens on first file
  - [ ] Manual: pencil icon next to greeting is violet, BlockCaret stays glued to the textarea caret across line wraps

#### For configuration changes:

- [ ] `.env.default` is updated or already compatible with my changes
- [ ] `docker-compose.yml` is updated or already compatible with my changes
- [ ] I have included a list of my configuration changes in the PR description (under **Changes**)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
