### PR TITLE
fix(platform): show NO_TIER in admin rate-limit display + aggregate reconciliation alerting into one Discord alert

### DIFF
--- a/autogpt_platform/backend/backend/api/features/admin/rate_limit_admin_routes.py
+++ b/autogpt_platform/backend/backend/api/features/admin/rate_limit_admin_routes.py
@@ -11,6 +11,7 @@ from backend.copilot.config import ChatConfig
 from backend.copilot.rate_limit import (
     SubscriptionTier,
     get_global_rate_limits,
+    get_tier_multipliers,
     get_usage_status,
     get_user_tier,
     reset_user_usage,
@@ -37,6 +38,9 @@ class UserRateLimitResponse(BaseModel):
     daily_cost_used_microdollars: int
     weekly_cost_used_microdollars: int
     tier: SubscriptionTier
+    # Full per-tier multiplier map incl. admin-managed tiers like ENTERPRISE,
+    # unlike the price-filtered /credits/subscription map.
+    tier_multipliers: dict[str, float] = {}
 
 
 class UserTierResponse(BaseModel):
@@ -106,6 +110,7 @@ async def get_user_rate_limit(
         config.weekly_cost_limit_microdollars,
     )
     usage = await get_usage_status(resolved_id, daily_limit, weekly_limit, tier=tier)
+    multipliers = await get_tier_multipliers()
 
     return UserRateLimitResponse(
         user_id=resolved_id,
@@ -115,6 +120,7 @@ async def get_user_rate_limit(
         daily_cost_used_microdollars=usage.daily.used,
         weekly_cost_used_microdollars=usage.weekly.used,
         tier=tier,
+        tier_multipliers=multipliers,
     )
 
 
@@ -148,6 +154,7 @@ async def reset_user_rate_limit(
         config.weekly_cost_limit_microdollars,
     )
     usage = await get_usage_status(user_id, daily_limit, weekly_limit, tier=tier)
+    multipliers = await get_tier_multipliers()
 
     try:
         resolved_email = await get_user_email_by_id(user_id)
@@ -163,6 +170,7 @@ async def reset_user_rate_limit(
         daily_cost_used_microdollars=usage.daily.used,
         weekly_cost_used_microdollars=usage.weekly.used,
         tier=tier,
+        tier_multipliers=multipliers,
     )
 
 

--- a/autogpt_platform/backend/backend/api/features/admin/rate_limit_admin_routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/admin/rate_limit_admin_routes_test.py
@@ -22,6 +22,14 @@ _MOCK_MODULE = "backend.api.features.admin.rate_limit_admin_routes"
 
 _TARGET_EMAIL = "target@example.com"
 
+_MOCK_TIER_MULTIPLIERS = {
+    "NO_TIER": 0.0,
+    "BASIC": 1.0,
+    "PRO": 5.0,
+    "BUSINESS": 20.0,
+    "ENTERPRISE": 60.0,
+}
+
 
 @pytest.fixture(autouse=True)
 def setup_app_admin_auth(mock_jwt_admin):
@@ -69,6 +77,11 @@ def _patch_rate_limit_deps(
         new_callable=AsyncMock,
         return_value=_TARGET_EMAIL,
     )
+    mocker.patch(
+        f"{_MOCK_MODULE}.get_tier_multipliers",
+        new_callable=AsyncMock,
+        return_value=dict(_MOCK_TIER_MULTIPLIERS),
+    )
 
 
 def test_get_rate_limit(
@@ -90,6 +103,8 @@ def test_get_rate_limit(
     assert data["daily_cost_used_microdollars"] == 500_000
     assert data["weekly_cost_used_microdollars"] == 3_000_000
     assert data["tier"] == "BASIC"
+    # Full per-tier map incl. admin-managed tiers (ENTERPRISE) is passed through.
+    assert data["tier_multipliers"] == _MOCK_TIER_MULTIPLIERS
 
     configured_snapshot.assert_match(
         json.dumps(data, indent=2, sort_keys=True) + "\n",
@@ -164,6 +179,7 @@ def test_reset_user_usage_daily_only(
     # Weekly is untouched
     assert data["weekly_cost_used_microdollars"] == 3_000_000
     assert data["tier"] == "BASIC"
+    assert data["tier_multipliers"] == _MOCK_TIER_MULTIPLIERS
 
     mock_reset.assert_awaited_once_with(target_user_id, reset_weekly=False)
 
@@ -242,6 +258,11 @@ def test_get_rate_limit_email_lookup_failure(
         f"{_MOCK_MODULE}.get_user_email_by_id",
         new_callable=AsyncMock,
         side_effect=Exception("DB connection lost"),
+    )
+    mocker.patch(
+        f"{_MOCK_MODULE}.get_tier_multipliers",
+        new_callable=AsyncMock,
+        return_value=dict(_MOCK_TIER_MULTIPLIERS),
     )
 
     response = client.get("/admin/rate_limit", params={"user_id": target_user_id})

--- a/autogpt_platform/backend/backend/api/features/v1_stripe_webhook_test.py
+++ b/autogpt_platform/backend/backend/api/features/v1_stripe_webhook_test.py
@@ -555,15 +555,16 @@ async def test_reconcile_stripe_tier_no_active_sub_downgrades_payer(
 
     assert await reconcile_stripe_tier_for_user("user_abc") is True
     mock_set.assert_awaited_once_with("user_abc", SubscriptionTier.NO_TIER)
-    # A silently-missed cancellation webhook must alert ops, not be corrected quietly.
-    mock_alert.assert_awaited_once()
-    assert "DOWNGRADED" in mock_alert.await_args.args[0]
+    # The lazy path does NOT ping ops per-user; the sweep's aggregate Discord
+    # alert reports corrections. The change is still recorded (log + PostHog).
+    mock_alert.assert_not_awaited()
 
 
-async def test_reconcile_stripe_tier_lazy_upgrade_alerts(
+async def test_reconcile_stripe_tier_lazy_upgrade_no_per_user_alert(
     mocker: pytest_mock.MockFixture,
 ) -> None:
-    """A lazy reconcile that finds an active sub the DB missed also alerts ops."""
+    """A lazy reconcile that finds an active sub the DB missed converts the tier
+    but does NOT ping ops per-user (the sweep aggregates alerts)."""
     user = MagicMock(
         stripe_customer_id="cus_abc",
         subscription_tier=SubscriptionTier.NO_TIER,
@@ -588,8 +589,7 @@ async def test_reconcile_stripe_tier_lazy_upgrade_alerts(
     )
 
     assert await reconcile_stripe_tier_for_user("user_abc") is True
-    mock_alert.assert_awaited_once()
-    assert "upgrade" in mock_alert.await_args.args[0]
+    mock_alert.assert_not_awaited()
 
 
 async def test_reconcile_stripe_tier_enterprise_user_skipped(

--- a/autogpt_platform/backend/backend/data/credit.py
+++ b/autogpt_platform/backend/backend/data/credit.py
@@ -2424,17 +2424,14 @@ async def reconcile_stripe_tier_for_user(user_id: str) -> bool:
         ).subscription_tier or SubscriptionTier.NO_TIER
         if new_tier == current_tier:
             return False
-        direction = log_tier_reconciliation_discrepancy(
+        # Recorded (info + PostHog) only; ops alerting is aggregated by the
+        # sweep's Discord system alert, not pinged per-user here.
+        log_tier_reconciliation_discrepancy(
             user_id=user_id,
             stripe_customer_id=user.stripe_customer_id,
             previous_tier=current_tier,
             new_tier=new_tier,
             via="lazy-reconcile",
-        )
-        await alert_tier_reconciliation_discrepancy(
-            f"⚠️ Payments integrity: on-access reconcile {direction} user "
-            f"`{user_id}` {current_tier.value} → {new_tier.value} — Stripe "
-            f"disagreed with our DB, a subscription webhook was likely missed."
         )
         return True
     # No active/trialing sub — downgrade a reconcilable row to NO_TIER.
@@ -2447,12 +2444,6 @@ async def reconcile_stripe_tier_for_user(user_id: str) -> bool:
         previous_tier=current_tier,
         new_tier=SubscriptionTier.NO_TIER,
         via="lazy-reconcile",
-    )
-    await alert_tier_reconciliation_discrepancy(
-        f"🚨 Payments integrity: on-access reconcile DOWNGRADED user `{user_id}` "
-        f"{current_tier.value} → NO_TIER — no active Stripe subscription, but our "
-        f"DB had them on a paid tier. A cancellation webhook was likely missed; "
-        f"investigate the webhook pipeline."
     )
     return True
 
@@ -2799,18 +2790,16 @@ def log_tier_reconciliation_discrepancy(
     new_tier: SubscriptionTier,
     via: str,
 ) -> str:
-    """Record a Stripe<->DB tier discrepancy that reconciliation had to correct.
+    """Record a Stripe<->DB tier discrepancy that reconciliation corrected.
 
-    A correction means a Stripe webhook was missed or dropped — a payments-
-    integrity signal to investigate, NOT a routine fix. Emits an ERROR log
-    (captured by Sentry via the logging integration) plus a PostHog event so the
-    rate of discrepancies is trended. Returns the direction ("downgrade"/"upgrade").
+    Emits an INFO log + a PostHog event so the rate of discrepancies is trended.
+    Ops alerting is handled in aggregate by the sweep's Discord system alert
+    (:func:`_alert_sweep_discrepancies`) — one ping with the affected user-id
+    list + counts, rather than a per-user Sentry event. Returns the direction.
     """
     direction = "upgrade" if is_tier_upgrade(previous_tier, new_tier) else "downgrade"
-    logger.error(
-        "Stripe tier reconciliation %s for user %s (%s -> %s, via %s): a Stripe "
-        "webhook was likely missed. Investigate the webhook pipeline — payments-"
-        "integrity signal, not a routine correction.",
+    logger.info(
+        "Stripe tier reconciliation %s for user %s (%s -> %s, via %s)",
         direction,
         user_id[:8],
         previous_tier.value,

--- a/autogpt_platform/backend/backend/data/credit.py
+++ b/autogpt_platform/backend/backend/data/credit.py
@@ -2822,12 +2822,20 @@ def log_tier_reconciliation_discrepancy(
 
 async def alert_tier_reconciliation_discrepancy(message: str) -> None:
     """Best-effort ops alert to the platform Discord channel. Never raises so a
-    Discord outage can't break reconciliation."""
+    Discord outage can't break reconciliation — but a delivery failure is logged
+    at ERROR (→ Sentry) so a broken bot token surfaces loudly instead of leaving
+    ops blind. Discord is the primary alert surface; this is the fallback."""
     try:
         await discord_send_alert(message, DiscordChannel.PLATFORM)
     except Exception:
-        logger.warning(
-            "failed to send tier-reconciliation Discord alert", exc_info=True
+        # Discord delivery failed (bad token / channel / gateway timeout) — log
+        # the FULL alert content at ERROR so Sentry carries the same payload the
+        # Discord message would have, and ops isn't left blind.
+        logger.error(
+            "Discord reconciliation alert delivery FAILED — ops NOT notified via "
+            "Discord; full alert content follows:\n%s",
+            message,
+            exc_info=True,
         )
 
 

--- a/autogpt_platform/backend/backend/data/stripe_reconciliation.py
+++ b/autogpt_platform/backend/backend/data/stripe_reconciliation.py
@@ -103,35 +103,34 @@ async def reconcile_all_stripe_tiers() -> ReconciliationSummary:
 
 
 async def _alert_sweep_discrepancies(summary: ReconciliationSummary) -> None:
-    """Loudly surface that the sweep had to correct tiers.
+    """Post ONE Discord system alert summarizing the sweep's corrections.
 
     A non-empty sweep means Stripe webhooks were dropped or missed — a payments-
-    integrity incident, not a routine correction. Steady state must be ZERO, so
-    any correction pages the ops channel and logs at ERROR (→ Sentry).
+    integrity signal, not a routine correction. One aggregate ops ping (with the
+    affected user-id list + counts) replaces per-user Sentry noise. Steady state
+    must be ZERO.
     """
+    n = len(summary.discrepancies)
     lines = "\n".join(
-        f"- {d.direction}: {d.previous_tier.value} → {d.new_tier.value} "
-        f"user={d.user_id} customer={d.stripe_customer_id}"
+        f"- {d.direction} {d.previous_tier.value}→{d.new_tier.value} `{d.user_id}`"
         for d in summary.discrepancies[:_ALERT_DETAIL_CAP]
     )
-    overflow = len(summary.discrepancies) - _ALERT_DETAIL_CAP
+    overflow = n - _ALERT_DETAIL_CAP
     if overflow > 0:
         lines += f"\n…and {overflow} more"
-    logger.error(
-        "Stripe tier reconciliation sweep corrected %d discrepancy(ies) "
-        "(%d downgrade, %d upgrade) — Stripe webhooks are likely dropping events; "
-        "steady state must be ZERO.",
-        len(summary.discrepancies),
-        summary.downgrades,
+    logger.warning(
+        "Stripe tier reconciliation sweep reconciled %d account(s) "
+        "(%d upgraded, %d downgraded); webhooks likely dropping events — "
+        "steady state should be ZERO.",
+        n,
         summary.upgrades,
+        summary.downgrades,
     )
     await alert_tier_reconciliation_discrepancy(
-        f"🚨 **Stripe tier reconciliation sweep corrected "
-        f"{len(summary.discrepancies)} discrepancy(ies)** "
-        f"({summary.downgrades} downgrade, {summary.upgrades} upgrade).\n"
-        f"Each means a Stripe webhook was likely missed — **investigate the "
-        f"webhook pipeline**; this is a payments-integrity signal, not a routine "
-        f"correction. Steady state must be ZERO.\n{lines}"
+        f"🔁 **Stripe tier reconciliation reconciled {n} account(s)** "
+        f"({summary.upgrades} upgraded, {summary.downgrades} downgraded).\n"
+        f"Each means a Stripe webhook was likely missed — investigate the webhook "
+        f"pipeline; steady state should be ZERO.\nUser IDs:\n{lines}"
     )
 
 

--- a/autogpt_platform/backend/backend/data/stripe_reconciliation.py
+++ b/autogpt_platform/backend/backend/data/stripe_reconciliation.py
@@ -29,11 +29,6 @@ from backend.data.credit import (
 
 logger = logging.getLogger(__name__)
 
-# Discord caps a message at 2000 chars; leave headroom for the chunk marker so
-# the FULL affected-user list is delivered (split across messages if needed)
-# rather than truncated.
-_DISCORD_MAX_CHARS = 1800
-
 # Bound the Stripe pagination so a runaway/unexpected dataset can't loop forever.
 # At 100 subs/page this caps a single sweep at 500k subscriptions; if it's ever
 # hit the sweep logs and stops rather than silently truncating without notice.
@@ -108,10 +103,11 @@ async def _alert_sweep_discrepancies(summary: ReconciliationSummary) -> None:
 
     A non-empty sweep means Stripe webhooks were dropped or missed — a payments-
     integrity signal, not a routine correction. ONE aggregate ops notification:
-    a count header up front (how many reconciled, up vs down), then the FULL
-    affected-user list at the end — each line ``user_id  from_tier → to_tier
-    (direction)`` — chunked to respect Discord's message-size limit. Discord is
-    the alert surface; this path logs at WARNING and never raises to Sentry.
+    a count header (how many reconciled, up vs down) followed by the FULL
+    affected-user list — each line ``user_id  from_tier → to_tier (direction)``.
+    Sent as a single message; ``SendDiscordMessageBlock`` splits anything over
+    Discord's 2000-char limit on its own. Discord is the alert surface; this path
+    logs at WARNING and never raises to Sentry.
     """
     n = len(summary.discrepancies)
     logger.warning(
@@ -122,41 +118,16 @@ async def _alert_sweep_discrepancies(summary: ReconciliationSummary) -> None:
         summary.upgrades,
         summary.downgrades,
     )
-    header = (
+    user_lines = "\n".join(
+        f"- `{d.user_id}`  {d.previous_tier.value} → {d.new_tier.value} ({d.direction})"
+        for d in summary.discrepancies
+    )
+    await alert_tier_reconciliation_discrepancy(
         f"🔁 **Stripe tier reconciliation: reconciled {n} account(s)** — "
         f"{summary.upgrades} upgraded, {summary.downgrades} downgraded.\n"
         f"Each means a Stripe webhook was likely missed — investigate the webhook "
-        f"pipeline; steady state should be ZERO.\nAffected users:"
+        f"pipeline; steady state should be ZERO.\nAffected users:\n{user_lines}"
     )
-    user_lines = [
-        f"- `{d.user_id}`  {d.previous_tier.value} → {d.new_tier.value} ({d.direction})"
-        for d in summary.discrepancies
-    ]
-    for message in _chunk_alert(header, user_lines):
-        await alert_tier_reconciliation_discrepancy(message)
-
-
-def _chunk_alert(header: str, lines: list[str]) -> list[str]:
-    """Pack ``header`` + the full ``lines`` list into Discord-sized messages.
-
-    The header leads the first message; lines are appended until the next would
-    exceed :data:`_DISCORD_MAX_CHARS`, then a new message starts. The full list
-    is always delivered (no truncation); multi-message runs are tagged
-    ``(part i/N)``.
-    """
-    chunks: list[str] = []
-    current = header
-    for line in lines:
-        if len(current) + 1 + len(line) > _DISCORD_MAX_CHARS:
-            chunks.append(current)
-            current = line
-        else:
-            current = f"{current}\n{line}"
-    chunks.append(current)
-    if len(chunks) == 1:
-        return chunks
-    total = len(chunks)
-    return [f"{c}\n_(part {i}/{total})_" for i, c in enumerate(chunks, 1)]
 
 
 async def _reconcile_one(

--- a/autogpt_platform/backend/backend/data/stripe_reconciliation.py
+++ b/autogpt_platform/backend/backend/data/stripe_reconciliation.py
@@ -29,9 +29,10 @@ from backend.data.credit import (
 
 logger = logging.getLogger(__name__)
 
-# Cap how many per-user lines are inlined into the Discord ops alert so a mass
-# incident doesn't post a wall of text; the full set is in the logs/PostHog.
-_ALERT_DETAIL_CAP = 25
+# Discord caps a message at 2000 chars; leave headroom for the chunk marker so
+# the FULL affected-user list is delivered (split across messages if needed)
+# rather than truncated.
+_DISCORD_MAX_CHARS = 1800
 
 # Bound the Stripe pagination so a runaway/unexpected dataset can't loop forever.
 # At 100 subs/page this caps a single sweep at 500k subscriptions; if it's ever
@@ -103,21 +104,16 @@ async def reconcile_all_stripe_tiers() -> ReconciliationSummary:
 
 
 async def _alert_sweep_discrepancies(summary: ReconciliationSummary) -> None:
-    """Post ONE Discord system alert summarizing the sweep's corrections.
+    """Post a Discord (PLATFORM) system alert summarizing the sweep's corrections.
 
     A non-empty sweep means Stripe webhooks were dropped or missed — a payments-
-    integrity signal, not a routine correction. One aggregate ops ping (with the
-    affected user-id list + counts) replaces per-user Sentry noise. Steady state
-    must be ZERO.
+    integrity signal, not a routine correction. ONE aggregate ops notification:
+    a count header up front (how many reconciled, up vs down), then the FULL
+    affected-user list at the end — each line ``user_id  from_tier → to_tier
+    (direction)`` — chunked to respect Discord's message-size limit. Discord is
+    the alert surface; this path logs at WARNING and never raises to Sentry.
     """
     n = len(summary.discrepancies)
-    lines = "\n".join(
-        f"- {d.direction} {d.previous_tier.value}→{d.new_tier.value} `{d.user_id}`"
-        for d in summary.discrepancies[:_ALERT_DETAIL_CAP]
-    )
-    overflow = n - _ALERT_DETAIL_CAP
-    if overflow > 0:
-        lines += f"\n…and {overflow} more"
     logger.warning(
         "Stripe tier reconciliation sweep reconciled %d account(s) "
         "(%d upgraded, %d downgraded); webhooks likely dropping events — "
@@ -126,12 +122,41 @@ async def _alert_sweep_discrepancies(summary: ReconciliationSummary) -> None:
         summary.upgrades,
         summary.downgrades,
     )
-    await alert_tier_reconciliation_discrepancy(
-        f"🔁 **Stripe tier reconciliation reconciled {n} account(s)** "
-        f"({summary.upgrades} upgraded, {summary.downgrades} downgraded).\n"
+    header = (
+        f"🔁 **Stripe tier reconciliation: reconciled {n} account(s)** — "
+        f"{summary.upgrades} upgraded, {summary.downgrades} downgraded.\n"
         f"Each means a Stripe webhook was likely missed — investigate the webhook "
-        f"pipeline; steady state should be ZERO.\nUser IDs:\n{lines}"
+        f"pipeline; steady state should be ZERO.\nAffected users:"
     )
+    user_lines = [
+        f"- `{d.user_id}`  {d.previous_tier.value} → {d.new_tier.value} ({d.direction})"
+        for d in summary.discrepancies
+    ]
+    for message in _chunk_alert(header, user_lines):
+        await alert_tier_reconciliation_discrepancy(message)
+
+
+def _chunk_alert(header: str, lines: list[str]) -> list[str]:
+    """Pack ``header`` + the full ``lines`` list into Discord-sized messages.
+
+    The header leads the first message; lines are appended until the next would
+    exceed :data:`_DISCORD_MAX_CHARS`, then a new message starts. The full list
+    is always delivered (no truncation); multi-message runs are tagged
+    ``(part i/N)``.
+    """
+    chunks: list[str] = []
+    current = header
+    for line in lines:
+        if len(current) + 1 + len(line) > _DISCORD_MAX_CHARS:
+            chunks.append(current)
+            current = line
+        else:
+            current = f"{current}\n{line}"
+    chunks.append(current)
+    if len(chunks) == 1:
+        return chunks
+    total = len(chunks)
+    return [f"{c}\n_(part {i}/{total})_" for i, c in enumerate(chunks, 1)]
 
 
 async def _reconcile_one(

--- a/autogpt_platform/backend/backend/data/stripe_reconciliation_test.py
+++ b/autogpt_platform/backend/backend/data/stripe_reconciliation_test.py
@@ -8,34 +8,11 @@ import stripe
 from prisma.enums import SubscriptionTier
 
 from backend.data.stripe_reconciliation import (
-    _DISCORD_MAX_CHARS,
     ReconciliationSummary,
-    _chunk_alert,
     _collect_status_page,
     _record_subscription,
     reconcile_all_stripe_tiers,
 )
-
-
-def test_chunk_alert_delivers_full_list_without_truncation() -> None:
-    """A large reconcile must deliver EVERY affected user across as many Discord
-    messages as needed — never truncate — staying within the message-size cap."""
-    lines = [f"- `user_{i:04d}`  PRO → NO_TIER (downgrade)" for i in range(300)]
-    chunks = _chunk_alert("HEADER", lines)
-    assert len(chunks) > 1  # 300 lines exceed a single Discord message
-    joined = "\n".join(chunks)
-    for i in range(300):
-        assert f"user_{i:04d}" in joined  # no user dropped
-    # +40 char allowance for the appended "(part i/N)" marker
-    assert all(len(c) <= _DISCORD_MAX_CHARS + 40 for c in chunks)
-    assert "(part 1/" in chunks[0]
-    assert chunks[0].startswith("HEADER")
-
-
-def test_chunk_alert_single_message_has_no_part_marker() -> None:
-    chunks = _chunk_alert("HEADER", ["- `u1` PRO → NO_TIER (downgrade)"])
-    assert len(chunks) == 1
-    assert "part" not in chunks[0]
 
 
 class _SubDict(dict):

--- a/autogpt_platform/backend/backend/data/stripe_reconciliation_test.py
+++ b/autogpt_platform/backend/backend/data/stripe_reconciliation_test.py
@@ -8,11 +8,34 @@ import stripe
 from prisma.enums import SubscriptionTier
 
 from backend.data.stripe_reconciliation import (
+    _DISCORD_MAX_CHARS,
     ReconciliationSummary,
+    _chunk_alert,
     _collect_status_page,
     _record_subscription,
     reconcile_all_stripe_tiers,
 )
+
+
+def test_chunk_alert_delivers_full_list_without_truncation() -> None:
+    """A large reconcile must deliver EVERY affected user across as many Discord
+    messages as needed — never truncate — staying within the message-size cap."""
+    lines = [f"- `user_{i:04d}`  PRO → NO_TIER (downgrade)" for i in range(300)]
+    chunks = _chunk_alert("HEADER", lines)
+    assert len(chunks) > 1  # 300 lines exceed a single Discord message
+    joined = "\n".join(chunks)
+    for i in range(300):
+        assert f"user_{i:04d}" in joined  # no user dropped
+    # +40 char allowance for the appended "(part i/N)" marker
+    assert all(len(c) <= _DISCORD_MAX_CHARS + 40 for c in chunks)
+    assert "(part 1/" in chunks[0]
+    assert chunks[0].startswith("HEADER")
+
+
+def test_chunk_alert_single_message_has_no_part_marker() -> None:
+    chunks = _chunk_alert("HEADER", ["- `u1` PRO → NO_TIER (downgrade)"])
+    assert len(chunks) == 1
+    assert "part" not in chunks[0]
 
 
 class _SubDict(dict):
@@ -118,11 +141,14 @@ async def test_sweep_upgrades_downgrades_and_skips_unchanged(
     assert len(summary.discrepancies) == 2
     mock_alert.assert_awaited_once()
     alert_msg = mock_alert.await_args.args[0]
+    # Count header up front.
     assert "reconciled 2 account" in alert_msg
     assert "1 upgraded" in alert_msg and "1 downgraded" in alert_msg
-    # The single system alert lists the affected user IDs.
-    assert "User IDs:" in alert_msg
+    # Full affected-user list at the end, each with its tier change.
+    assert "Affected users:" in alert_msg
     assert "u_up" in alert_msg and "u_down" in alert_msg
+    assert "NO_TIER → PRO (upgrade)" in alert_msg
+    assert "PRO → NO_TIER (downgrade)" in alert_msg
 
 
 @pytest.mark.asyncio

--- a/autogpt_platform/backend/backend/data/stripe_reconciliation_test.py
+++ b/autogpt_platform/backend/backend/data/stripe_reconciliation_test.py
@@ -118,8 +118,11 @@ async def test_sweep_upgrades_downgrades_and_skips_unchanged(
     assert len(summary.discrepancies) == 2
     mock_alert.assert_awaited_once()
     alert_msg = mock_alert.await_args.args[0]
-    assert "2 discrepancy" in alert_msg
-    assert "1 downgrade" in alert_msg and "1 upgrade" in alert_msg
+    assert "reconciled 2 account" in alert_msg
+    assert "1 upgraded" in alert_msg and "1 downgraded" in alert_msg
+    # The single system alert lists the affected user IDs.
+    assert "User IDs:" in alert_msg
+    assert "u_up" in alert_msg and "u_down" in alert_msg
 
 
 @pytest.mark.asyncio

--- a/autogpt_platform/backend/snapshots/get_rate_limit
+++ b/autogpt_platform/backend/snapshots/get_rate_limit
@@ -2,6 +2,13 @@
   "daily_cost_limit_microdollars": 2500000,
   "daily_cost_used_microdollars": 500000,
   "tier": "BASIC",
+  "tier_multipliers": {
+    "BASIC": 1.0,
+    "BUSINESS": 20.0,
+    "ENTERPRISE": 60.0,
+    "NO_TIER": 0.0,
+    "PRO": 5.0
+  },
   "user_email": "target@example.com",
   "user_id": "5e53486c-cf57-477e-ba2a-cb02dc828e1c",
   "weekly_cost_limit_microdollars": 12500000,

--- a/autogpt_platform/backend/snapshots/reset_user_usage_daily_and_weekly
+++ b/autogpt_platform/backend/snapshots/reset_user_usage_daily_and_weekly
@@ -2,6 +2,13 @@
   "daily_cost_limit_microdollars": 2500000,
   "daily_cost_used_microdollars": 0,
   "tier": "BASIC",
+  "tier_multipliers": {
+    "BASIC": 1.0,
+    "BUSINESS": 20.0,
+    "ENTERPRISE": 60.0,
+    "NO_TIER": 0.0,
+    "PRO": 5.0
+  },
   "user_email": "target@example.com",
   "user_id": "5e53486c-cf57-477e-ba2a-cb02dc828e1c",
   "weekly_cost_limit_microdollars": 12500000,

--- a/autogpt_platform/backend/snapshots/reset_user_usage_daily_only
+++ b/autogpt_platform/backend/snapshots/reset_user_usage_daily_only
@@ -2,6 +2,13 @@
   "daily_cost_limit_microdollars": 2500000,
   "daily_cost_used_microdollars": 0,
   "tier": "BASIC",
+  "tier_multipliers": {
+    "BASIC": 1.0,
+    "BUSINESS": 20.0,
+    "ENTERPRISE": 60.0,
+    "NO_TIER": 0.0,
+    "PRO": 5.0
+  },
   "user_email": "target@example.com",
   "user_id": "5e53486c-cf57-477e-ba2a-cb02dc828e1c",
   "weekly_cost_limit_microdollars": 12500000,

--- a/autogpt_platform/frontend/src/app/(platform)/admin/rate-limits/components/RateLimitDisplay.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/rate-limits/components/RateLimitDisplay.tsx
@@ -16,15 +16,6 @@ const TIERS = [
 ] as const;
 type Tier = (typeof TIERS)[number];
 
-const TIER_MULTIPLIERS: Record<Tier, string> = {
-  NO_TIER: "no access (paywalled)",
-  BASIC: "1x base limits",
-  PRO: "5x base limits",
-  MAX: "20x base limits",
-  BUSINESS: "60x base limits",
-  ENTERPRISE: "60x base limits",
-};
-
 const TIER_COLORS: Record<Tier, string> = {
   NO_TIER: "bg-red-100 text-red-700",
   BASIC: "bg-gray-100 text-gray-700",
@@ -34,10 +25,29 @@ const TIER_COLORS: Record<Tier, string> = {
   ENTERPRISE: "bg-amber-100 text-amber-700",
 };
 
+// Derives the per-tier label from the live, LaunchDarkly-driven multiplier map.
+// NO_TIER is paywalled (0 / absent), and tiers missing from the map (not
+// priceable) fall back to a generic label rather than a fabricated number.
+function tierLabel(
+  tier: Tier,
+  tierMultipliers?: Record<string, number>,
+): string {
+  if (tier === "NO_TIER") return "no access (paywalled)";
+
+  const multiplier = tierMultipliers?.[tier];
+  if (multiplier === undefined || multiplier <= 0) return "tier limits";
+
+  // Round to at most 2 decimals (5 → "5", 42.664 → "42.66").
+  const rounded = Math.round(multiplier * 100) / 100;
+  return `${rounded}× base limits`;
+}
+
 interface Props {
   data: UserRateLimitResponse;
   onReset: (resetWeekly: boolean) => Promise<void>;
   onTierChange?: (newTier: string) => Promise<void>;
+  /** Live LaunchDarkly-driven tier → multiplier map from the subscription status endpoint. */
+  tierMultipliers?: Record<string, number>;
   /** Override the outer container classes (default: bordered card). */
   className?: string;
 }
@@ -46,6 +56,7 @@ export function RateLimitDisplay({
   data,
   onReset,
   onTierChange,
+  tierMultipliers,
   className,
 }: Props) {
   const [isResetting, setIsResetting] = useState(false);
@@ -85,7 +96,7 @@ export function RateLimitDisplay({
       await onTierChange(newTier);
       toast({
         title: "Tier updated",
-        description: `Changed to ${newTier} (${TIER_MULTIPLIERS[newTier as Tier]}).`,
+        description: `Changed to ${newTier} (${tierLabel(newTier as Tier, tierMultipliers)}).`,
       });
     } catch {
       toast({
@@ -134,7 +145,7 @@ export function RateLimitDisplay({
         >
           {TIERS.map((tier) => (
             <option key={tier} value={tier}>
-              {tier} — {TIER_MULTIPLIERS[tier]}
+              {tier} — {tierLabel(tier, tierMultipliers)}
             </option>
           ))}
         </select>

--- a/autogpt_platform/frontend/src/app/(platform)/admin/rate-limits/components/RateLimitDisplay.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/rate-limits/components/RateLimitDisplay.tsx
@@ -26,8 +26,8 @@ const TIER_COLORS: Record<Tier, string> = {
 };
 
 // Derives the per-tier label from the live, LaunchDarkly-driven multiplier map.
-// NO_TIER is paywalled (0 / absent), and tiers missing from the map (not
-// priceable) fall back to a generic label rather than a fabricated number.
+// NO_TIER is paywalled (0 / absent), and tiers missing from the map fall back
+// to a generic label rather than a fabricated number.
 function tierLabel(
   tier: Tier,
   tierMultipliers?: Record<string, number>,
@@ -46,7 +46,7 @@ interface Props {
   data: UserRateLimitResponse;
   onReset: (resetWeekly: boolean) => Promise<void>;
   onTierChange?: (newTier: string) => Promise<void>;
-  /** Live LaunchDarkly-driven tier → multiplier map from the subscription status endpoint. */
+  /** Full per-tier multiplier map (incl. admin-managed tiers) from the admin rate-limit endpoint. */
   tierMultipliers?: Record<string, number>;
   /** Override the outer container classes (default: bordered card). */
   className?: string;

--- a/autogpt_platform/frontend/src/app/(platform)/admin/rate-limits/components/RateLimitDisplay.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/rate-limits/components/RateLimitDisplay.tsx
@@ -6,10 +6,18 @@ import type { UserRateLimitResponse } from "@/app/api/__generated__/models/userR
 import { useToast } from "@/components/molecules/Toast/use-toast";
 import { UsageBar } from "../../components/UsageBar";
 
-const TIERS = ["BASIC", "PRO", "MAX", "BUSINESS", "ENTERPRISE"] as const;
+const TIERS = [
+  "NO_TIER",
+  "BASIC",
+  "PRO",
+  "MAX",
+  "BUSINESS",
+  "ENTERPRISE",
+] as const;
 type Tier = (typeof TIERS)[number];
 
 const TIER_MULTIPLIERS: Record<Tier, string> = {
+  NO_TIER: "no access (paywalled)",
   BASIC: "1x base limits",
   PRO: "5x base limits",
   MAX: "20x base limits",
@@ -18,6 +26,7 @@ const TIER_MULTIPLIERS: Record<Tier, string> = {
 };
 
 const TIER_COLORS: Record<Tier, string> = {
+  NO_TIER: "bg-red-100 text-red-700",
   BASIC: "bg-gray-100 text-gray-700",
   PRO: "bg-blue-100 text-blue-700",
   MAX: "bg-indigo-100 text-indigo-700",
@@ -46,7 +55,7 @@ export function RateLimitDisplay({
 
   const currentTier = TIERS.includes(data.tier as Tier)
     ? (data.tier as Tier)
-    : "BASIC";
+    : "NO_TIER";
 
   async function handleReset() {
     const msg = resetWeekly

--- a/autogpt_platform/frontend/src/app/(platform)/admin/rate-limits/components/RateLimitManager.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/rate-limits/components/RateLimitManager.tsx
@@ -11,6 +11,7 @@ export function RateLimitManager() {
     searchResults,
     selectedUser,
     rateLimitData,
+    tierMultipliers,
     handleSearch,
     handleSelectUser,
     handleReset,
@@ -79,6 +80,7 @@ export function RateLimitManager() {
           data={rateLimitData}
           onReset={handleReset}
           onTierChange={handleTierChange}
+          tierMultipliers={tierMultipliers}
         />
       )}
     </div>

--- a/autogpt_platform/frontend/src/app/(platform)/admin/rate-limits/components/__tests__/RateLimitDisplay.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/rate-limits/components/__tests__/RateLimitDisplay.test.tsx
@@ -341,6 +341,28 @@ describe("RateLimitDisplay", () => {
     expect(select.textContent).not.toContain("ENTERPRISE — 60");
   });
 
+  it("shows the multiplier for ENTERPRISE when present in the full map", () => {
+    render(
+      <RateLimitDisplay
+        data={makeData()}
+        onReset={vi.fn()}
+        tierMultipliers={{
+          NO_TIER: 0,
+          BASIC: 1,
+          PRO: 5,
+          BUSINESS: 20,
+          ENTERPRISE: 60,
+        }}
+      />,
+    );
+    const select = screen.getByLabelText("Subscription tier");
+    expect(select.textContent).toContain("ENTERPRISE — 60× base limits");
+    expect(select.textContent).toContain("BUSINESS — 20× base limits");
+    expect(select.textContent).not.toContain("ENTERPRISE — tier limits");
+    // NO_TIER's 0 short-circuits to the paywalled label, not "0× base limits".
+    expect(select.textContent).toContain("NO_TIER — no access (paywalled)");
+  });
+
   it("falls back to generic labels when no multipliers map is provided", () => {
     render(<RateLimitDisplay data={makeData()} onReset={vi.fn()} />);
     const select = screen.getByLabelText("Subscription tier");

--- a/autogpt_platform/frontend/src/app/(platform)/admin/rate-limits/components/__tests__/RateLimitDisplay.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/rate-limits/components/__tests__/RateLimitDisplay.test.tsx
@@ -71,22 +71,42 @@ describe("RateLimitDisplay", () => {
     expect(badge.className).toContain("bg-blue-100");
   });
 
-  it("defaults unknown tier to BASIC", () => {
+  it("defaults unknown tier to NO_TIER", () => {
     render(
       <RateLimitDisplay
         data={makeData({ tier: "UNKNOWN" as UserRateLimitResponse["tier"] })}
         onReset={vi.fn()}
       />,
     );
-    const badge = screen.getByText("BASIC");
+    const badge = screen.getByText("NO_TIER");
     expect(badge).toBeDefined();
+    expect(screen.queryByText("BASIC")).toBeNull();
+  });
+
+  it("displays NO_TIER as a first-class tier instead of masking as BASIC", () => {
+    render(
+      <RateLimitDisplay
+        data={makeData({ tier: "NO_TIER" })}
+        onReset={vi.fn()}
+      />,
+    );
+    const badge = screen.getByText("NO_TIER");
+    expect(badge).toBeDefined();
+    expect(badge.className).toContain("bg-red-100");
+    expect(screen.queryByText("BASIC")).toBeNull();
+    expect(screen.getByText(/no access \(paywalled\)/)).toBeDefined();
+
+    const select = screen.getByLabelText(
+      "Subscription tier",
+    ) as HTMLSelectElement;
+    expect(select.value).toBe("NO_TIER");
   });
 
   it("renders tier dropdown with all tiers", () => {
     render(<RateLimitDisplay data={makeData()} onReset={vi.fn()} />);
     const select = screen.getByLabelText("Subscription tier");
     expect(select).toBeDefined();
-    expect(select.querySelectorAll("option").length).toBe(5);
+    expect(select.querySelectorAll("option").length).toBe(6);
   });
 
   it("disables tier dropdown when onTierChange is not provided", () => {

--- a/autogpt_platform/frontend/src/app/(platform)/admin/rate-limits/components/__tests__/RateLimitDisplay.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/rate-limits/components/__tests__/RateLimitDisplay.test.tsx
@@ -288,6 +288,66 @@ describe("RateLimitDisplay", () => {
     });
   });
 
+  it("shows live multiplier label for PRO from the tierMultipliers map", () => {
+    render(
+      <RateLimitDisplay
+        data={makeData({ tier: "PRO" })}
+        onReset={vi.fn()}
+        tierMultipliers={{ BASIC: 1, PRO: 5, MAX: 42.66 }}
+      />,
+    );
+    const select = screen.getByLabelText("Subscription tier");
+    expect(select.textContent).toContain("PRO — 5× base limits");
+  });
+
+  it("renders a non-default fractional multiplier (MAX 42.66) from the map", () => {
+    render(
+      <RateLimitDisplay
+        data={makeData()}
+        onReset={vi.fn()}
+        tierMultipliers={{ BASIC: 1, PRO: 5, MAX: 42.66 }}
+      />,
+    );
+    const select = screen.getByLabelText("Subscription tier");
+    expect(select.textContent).toContain("MAX — 42.66× base limits");
+    // The old hardcoded "20x" value must not appear.
+    expect(select.textContent).not.toContain("20x");
+  });
+
+  it("keeps NO_TIER paywalled label even with a multipliers map present", () => {
+    render(
+      <RateLimitDisplay
+        data={makeData({ tier: "NO_TIER" })}
+        onReset={vi.fn()}
+        tierMultipliers={{ BASIC: 1, PRO: 5, MAX: 42.66 }}
+      />,
+    );
+    expect(screen.getByText(/no access \(paywalled\)/)).toBeDefined();
+    const select = screen.getByLabelText("Subscription tier");
+    expect(select.textContent).not.toContain("NO_TIER — 0");
+  });
+
+  it("does not fabricate a number for a tier missing from the map", () => {
+    render(
+      <RateLimitDisplay
+        data={makeData()}
+        onReset={vi.fn()}
+        tierMultipliers={{ BASIC: 1, PRO: 5, MAX: 42.66 }}
+      />,
+    );
+    const select = screen.getByLabelText("Subscription tier");
+    // ENTERPRISE has no entry -> generic label, never a hardcoded multiplier.
+    expect(select.textContent).toContain("ENTERPRISE — tier limits");
+    expect(select.textContent).not.toContain("ENTERPRISE — 60");
+  });
+
+  it("falls back to generic labels when no multipliers map is provided", () => {
+    render(<RateLimitDisplay data={makeData()} onReset={vi.fn()} />);
+    const select = screen.getByLabelText("Subscription tier");
+    expect(select.textContent).toContain("PRO — tier limits");
+    expect(select.textContent).not.toContain("5x");
+  });
+
   it("applies custom className when provided", () => {
     const { container } = render(
       <RateLimitDisplay

--- a/autogpt_platform/frontend/src/app/(platform)/admin/rate-limits/components/useRateLimitManager.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/rate-limits/components/useRateLimitManager.ts
@@ -10,7 +10,6 @@ import {
   postV2ResetUserRateLimitUsage,
   postV2SetUserRateLimitTier,
 } from "@/app/api/__generated__/endpoints/admin/admin";
-import { useGetSubscriptionStatus } from "@/app/api/__generated__/endpoints/credits/credits";
 
 export interface UserOption {
   user_id: string;
@@ -36,12 +35,7 @@ export function useRateLimitManager() {
   const [rateLimitData, setRateLimitData] =
     useState<UserRateLimitResponse | null>(null);
 
-  const { data: tierMultipliers } = useGetSubscriptionStatus({
-    query: {
-      select: (res) =>
-        res.status === 200 ? res.data.tier_multipliers : undefined,
-    },
-  });
+  const tierMultipliers = rateLimitData?.tier_multipliers;
 
   async function handleDirectLookup(trimmed: string) {
     setIsSearching(true);

--- a/autogpt_platform/frontend/src/app/(platform)/admin/rate-limits/components/useRateLimitManager.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/rate-limits/components/useRateLimitManager.ts
@@ -10,6 +10,7 @@ import {
   postV2ResetUserRateLimitUsage,
   postV2SetUserRateLimitTier,
 } from "@/app/api/__generated__/endpoints/admin/admin";
+import { useGetSubscriptionStatus } from "@/app/api/__generated__/endpoints/credits/credits";
 
 export interface UserOption {
   user_id: string;
@@ -34,6 +35,13 @@ export function useRateLimitManager() {
   const [selectedUser, setSelectedUser] = useState<UserOption | null>(null);
   const [rateLimitData, setRateLimitData] =
     useState<UserRateLimitResponse | null>(null);
+
+  const { data: tierMultipliers } = useGetSubscriptionStatus({
+    query: {
+      select: (res) =>
+        res.status === 200 ? res.data.tier_multipliers : undefined,
+    },
+  });
 
   async function handleDirectLookup(trimmed: string) {
     setIsSearching(true);
@@ -206,6 +214,7 @@ export function useRateLimitManager() {
     searchResults,
     selectedUser,
     rateLimitData,
+    tierMultipliers,
     handleSearch,
     handleSelectUser,
     handleReset,

--- a/autogpt_platform/frontend/src/app/api/openapi.json
+++ b/autogpt_platform/frontend/src/app/api/openapi.json
@@ -20161,7 +20161,13 @@
             "type": "integer",
             "title": "Weekly Cost Used Microdollars"
           },
-          "tier": { "$ref": "#/components/schemas/SubscriptionTier" }
+          "tier": { "$ref": "#/components/schemas/SubscriptionTier" },
+          "tier_multipliers": {
+            "additionalProperties": { "type": "number" },
+            "type": "object",
+            "title": "Tier Multipliers",
+            "default": {}
+          }
         },
         "type": "object",
         "required": [


### PR DESCRIPTION
### Why / What / How

**Why:** The admin "User Rate Limits" page rendered `NO_TIER` users as **BASIC**. `NO_TIER` was not part of the component's known tier list, so the unknown-tier fallback masked it as `BASIC`. During the payments launch this is actively misleading — a paywalled / no-access user appears to have BASIC access. Concretely, a `NO_TIER` tester showed up in the admin UI as `BASIC`, hiding the fact that they had no access.

**What:** Handle `NO_TIER` as a first-class tier in `RateLimitDisplay` (badge, dropdown option, label, color) and make it the safe fallback for unknown/missing tiers instead of `BASIC`.

**How:**
- Added `NO_TIER` as the first entry of the `TIERS` tuple.
- Added `NO_TIER: "no access (paywalled)"` to `TIER_MULTIPLIERS` and `NO_TIER: "bg-red-100 text-red-700"` to `TIER_COLORS`.
- Changed the unknown-tier fallback from `"BASIC"` to `"NO_TIER"` — an unknown/missing tier is effectively no-tier, not BASIC.

`NO_TIER` is a valid `SubscriptionTier` enum value in the OpenAPI spec, and `SetUserTierRequest.tier` accepts it, so the dropdown can now also SET `NO_TIER` to revoke access (the backend `set_user_rate_limit_tier` / `set_user_tier` already accepts it). No other spot in the `admin/rate-limits` feature hardcodes the tier list or assumes BASIC as default — `useRateLimitManager.ts` passes the tier through as a string.

### Changes 🏗️

- `RateLimitDisplay.tsx`: add `NO_TIER` to `TIERS`, `TIER_MULTIPLIERS`, `TIER_COLORS`; fall back to `NO_TIER` (not `BASIC`) for unknown tiers.
- `RateLimitDisplay.test.tsx`: assert `NO_TIER` renders as its own badge + "no access (paywalled)" label + selected dropdown value (not BASIC); update unknown-tier fallback test to expect `NO_TIER`; bump dropdown option count to 6.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `pnpm format`, `pnpm lint`, `pnpm types` pass
  - [x] `pnpm test:unit RateLimitDisplay` — 21 tests pass (including new NO_TIER cases)
  - [x] `pnpm test:unit RateLimitManager` — 19 tests pass (no regression)
