### PR TITLE
refactor(backend): aggregate Stripe reconciliation alerting into one Discord system alert

### DIFF
--- a/autogpt_platform/backend/backend/api/features/v1_stripe_webhook_test.py
+++ b/autogpt_platform/backend/backend/api/features/v1_stripe_webhook_test.py
@@ -555,15 +555,16 @@ async def test_reconcile_stripe_tier_no_active_sub_downgrades_payer(
 
     assert await reconcile_stripe_tier_for_user("user_abc") is True
     mock_set.assert_awaited_once_with("user_abc", SubscriptionTier.NO_TIER)
-    # A silently-missed cancellation webhook must alert ops, not be corrected quietly.
-    mock_alert.assert_awaited_once()
-    assert "DOWNGRADED" in mock_alert.await_args.args[0]
+    # The lazy path does NOT ping ops per-user; the sweep's aggregate Discord
+    # alert reports corrections. The change is still recorded (log + PostHog).
+    mock_alert.assert_not_awaited()
 
 
-async def test_reconcile_stripe_tier_lazy_upgrade_alerts(
+async def test_reconcile_stripe_tier_lazy_upgrade_no_per_user_alert(
     mocker: pytest_mock.MockFixture,
 ) -> None:
-    """A lazy reconcile that finds an active sub the DB missed also alerts ops."""
+    """A lazy reconcile that finds an active sub the DB missed converts the tier
+    but does NOT ping ops per-user (the sweep aggregates alerts)."""
     user = MagicMock(
         stripe_customer_id="cus_abc",
         subscription_tier=SubscriptionTier.NO_TIER,
@@ -588,8 +589,7 @@ async def test_reconcile_stripe_tier_lazy_upgrade_alerts(
     )
 
     assert await reconcile_stripe_tier_for_user("user_abc") is True
-    mock_alert.assert_awaited_once()
-    assert "upgrade" in mock_alert.await_args.args[0]
+    mock_alert.assert_not_awaited()
 
 
 async def test_reconcile_stripe_tier_enterprise_user_skipped(

--- a/autogpt_platform/backend/backend/data/credit.py
+++ b/autogpt_platform/backend/backend/data/credit.py
@@ -2424,17 +2424,14 @@ async def reconcile_stripe_tier_for_user(user_id: str) -> bool:
         ).subscription_tier or SubscriptionTier.NO_TIER
         if new_tier == current_tier:
             return False
-        direction = log_tier_reconciliation_discrepancy(
+        # Recorded (info + PostHog) only; ops alerting is aggregated by the
+        # sweep's Discord system alert, not pinged per-user here.
+        log_tier_reconciliation_discrepancy(
             user_id=user_id,
             stripe_customer_id=user.stripe_customer_id,
             previous_tier=current_tier,
             new_tier=new_tier,
             via="lazy-reconcile",
-        )
-        await alert_tier_reconciliation_discrepancy(
-            f"⚠️ Payments integrity: on-access reconcile {direction} user "
-            f"`{user_id}` {current_tier.value} → {new_tier.value} — Stripe "
-            f"disagreed with our DB, a subscription webhook was likely missed."
         )
         return True
     # No active/trialing sub — downgrade a reconcilable row to NO_TIER.
@@ -2447,12 +2444,6 @@ async def reconcile_stripe_tier_for_user(user_id: str) -> bool:
         previous_tier=current_tier,
         new_tier=SubscriptionTier.NO_TIER,
         via="lazy-reconcile",
-    )
-    await alert_tier_reconciliation_discrepancy(
-        f"🚨 Payments integrity: on-access reconcile DOWNGRADED user `{user_id}` "
-        f"{current_tier.value} → NO_TIER — no active Stripe subscription, but our "
-        f"DB had them on a paid tier. A cancellation webhook was likely missed; "
-        f"investigate the webhook pipeline."
     )
     return True
 
@@ -2799,18 +2790,16 @@ def log_tier_reconciliation_discrepancy(
     new_tier: SubscriptionTier,
     via: str,
 ) -> str:
-    """Record a Stripe<->DB tier discrepancy that reconciliation had to correct.
+    """Record a Stripe<->DB tier discrepancy that reconciliation corrected.
 
-    A correction means a Stripe webhook was missed or dropped — a payments-
-    integrity signal to investigate, NOT a routine fix. Emits an ERROR log
-    (captured by Sentry via the logging integration) plus a PostHog event so the
-    rate of discrepancies is trended. Returns the direction ("downgrade"/"upgrade").
+    Emits an INFO log + a PostHog event so the rate of discrepancies is trended.
+    Ops alerting is handled in aggregate by the sweep's Discord system alert
+    (:func:`_alert_sweep_discrepancies`) — one ping with the affected user-id
+    list + counts, rather than a per-user Sentry event. Returns the direction.
     """
     direction = "upgrade" if is_tier_upgrade(previous_tier, new_tier) else "downgrade"
-    logger.error(
-        "Stripe tier reconciliation %s for user %s (%s -> %s, via %s): a Stripe "
-        "webhook was likely missed. Investigate the webhook pipeline — payments-"
-        "integrity signal, not a routine correction.",
+    logger.info(
+        "Stripe tier reconciliation %s for user %s (%s -> %s, via %s)",
         direction,
         user_id[:8],
         previous_tier.value,

--- a/autogpt_platform/backend/backend/data/stripe_reconciliation.py
+++ b/autogpt_platform/backend/backend/data/stripe_reconciliation.py
@@ -103,35 +103,34 @@ async def reconcile_all_stripe_tiers() -> ReconciliationSummary:
 
 
 async def _alert_sweep_discrepancies(summary: ReconciliationSummary) -> None:
-    """Loudly surface that the sweep had to correct tiers.
+    """Post ONE Discord system alert summarizing the sweep's corrections.
 
     A non-empty sweep means Stripe webhooks were dropped or missed — a payments-
-    integrity incident, not a routine correction. Steady state must be ZERO, so
-    any correction pages the ops channel and logs at ERROR (→ Sentry).
+    integrity signal, not a routine correction. One aggregate ops ping (with the
+    affected user-id list + counts) replaces per-user Sentry noise. Steady state
+    must be ZERO.
     """
+    n = len(summary.discrepancies)
     lines = "\n".join(
-        f"- {d.direction}: {d.previous_tier.value} → {d.new_tier.value} "
-        f"user={d.user_id} customer={d.stripe_customer_id}"
+        f"- {d.direction} {d.previous_tier.value}→{d.new_tier.value} `{d.user_id}`"
         for d in summary.discrepancies[:_ALERT_DETAIL_CAP]
     )
-    overflow = len(summary.discrepancies) - _ALERT_DETAIL_CAP
+    overflow = n - _ALERT_DETAIL_CAP
     if overflow > 0:
         lines += f"\n…and {overflow} more"
-    logger.error(
-        "Stripe tier reconciliation sweep corrected %d discrepancy(ies) "
-        "(%d downgrade, %d upgrade) — Stripe webhooks are likely dropping events; "
-        "steady state must be ZERO.",
-        len(summary.discrepancies),
-        summary.downgrades,
+    logger.warning(
+        "Stripe tier reconciliation sweep reconciled %d account(s) "
+        "(%d upgraded, %d downgraded); webhooks likely dropping events — "
+        "steady state should be ZERO.",
+        n,
         summary.upgrades,
+        summary.downgrades,
     )
     await alert_tier_reconciliation_discrepancy(
-        f"🚨 **Stripe tier reconciliation sweep corrected "
-        f"{len(summary.discrepancies)} discrepancy(ies)** "
-        f"({summary.downgrades} downgrade, {summary.upgrades} upgrade).\n"
-        f"Each means a Stripe webhook was likely missed — **investigate the "
-        f"webhook pipeline**; this is a payments-integrity signal, not a routine "
-        f"correction. Steady state must be ZERO.\n{lines}"
+        f"🔁 **Stripe tier reconciliation reconciled {n} account(s)** "
+        f"({summary.upgrades} upgraded, {summary.downgrades} downgraded).\n"
+        f"Each means a Stripe webhook was likely missed — investigate the webhook "
+        f"pipeline; steady state should be ZERO.\nUser IDs:\n{lines}"
     )
 
 

--- a/autogpt_platform/backend/backend/data/stripe_reconciliation_test.py
+++ b/autogpt_platform/backend/backend/data/stripe_reconciliation_test.py
@@ -118,8 +118,11 @@ async def test_sweep_upgrades_downgrades_and_skips_unchanged(
     assert len(summary.discrepancies) == 2
     mock_alert.assert_awaited_once()
     alert_msg = mock_alert.await_args.args[0]
-    assert "2 discrepancy" in alert_msg
-    assert "1 downgrade" in alert_msg and "1 upgrade" in alert_msg
+    assert "reconciled 2 account" in alert_msg
+    assert "1 upgraded" in alert_msg and "1 downgraded" in alert_msg
+    # The single system alert lists the affected user IDs.
+    assert "User IDs:" in alert_msg
+    assert "u_up" in alert_msg and "u_down" in alert_msg
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Background

Follow-up to the merged Stripe tier reconciliation work (#13284).

- Why: the reconciliation alerting emitted a **per-user ERROR log → one Sentry event per reconciled account**, plus a per-user Discord ping on the lazy path. In practice a sweep that corrects N accounts produced N separate Sentry alerts (observed: a single-person alert for one reconciled tester), which is noise, not signal. Ops wants one aggregate notification.

### Changes 🏗️

What
- Replace the per-user Sentry alerts with **one Discord system alert per sweep** (`DiscordChannel.PLATFORM`) that states **"reconciled N account(s) (X upgraded, Y downgraded)"** and lists the affected **user IDs**.
- Per-discrepancy logging drops from `ERROR` (one Sentry event each) to `INFO` + the existing PostHog metric, so the discrepancy rate is still trended without per-user paging.
- The lazy on-access reconcile no longer pings ops per-user; corrections are reported in aggregate by the sweep.
- Steady-state sweeps stay completely silent (no discrepancies → no alert).

How
- `log_tier_reconciliation_discrepancy`: `logger.error` → `logger.info` (keeps the PostHog event).
- `reconcile_stripe_tier_for_user`: removed the two per-user `alert_tier_reconciliation_discrepancy` calls (keeps the info/metric record).
- `_alert_sweep_discrepancies`: single Discord alert with the user-id list + "reconciled N accounts" summary; its own log demoted `ERROR` → `WARNING` (Discord is the alert surface, not Sentry).

### Checklist 📋

- [x] Changes listed in the PR description
- [x] Test plan made and executed:
  - [x] Sweep alert asserts the aggregate message ("reconciled N account", "X upgraded/downgraded", "User IDs:" + ids)
  - [x] Lazy reconcile asserts it does NOT ping ops per-user; steady-state asserts no alert
  - [x] Affected suites green (329 passed); `black` + `ruff` clean
