### PR TITLE
feat(backend/copilot-bot): attach workspace artifacts to bot replies

### DIFF
--- a/autogpt_platform/backend/backend/copilot/bot/adapters/base.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/base.py
@@ -29,6 +29,21 @@ class MessageHistoryEntry:
 
 
 @dataclass
+class FileAttachment:
+    """A workspace artifact ready to attach to a platform message.
+
+    ``content`` carries the file bytes — the handler only ever produces
+    these after the backend has already checked them against the adapter's
+    ``max_attachment_bytes``, so adapters can attach directly without
+    re-validating size.
+    """
+
+    filename: str
+    mime_type: str
+    content: bytes
+
+
+@dataclass
 class MessageContext:
     """Everything the core handler needs to know about an incoming message."""
 
@@ -146,5 +161,20 @@ class PlatformAdapter(ABC):
         Should be slightly under max_message_length to leave headroom for
         any trailing content that the splitter might pull into the current
         chunk.
+        """
+        ...
+
+    @property
+    @abstractmethod
+    def max_attachment_bytes(self) -> int:
+        """Hard platform cap on a single uploaded file's size in bytes."""
+        ...
+
+    @abstractmethod
+    async def send_file(self, channel_id: str, text: str, file: FileAttachment) -> None:
+        """Send a single file as an attachment, with optional accompanying text.
+
+        Callers must ensure ``len(file.content) <= max_attachment_bytes`` —
+        the handler enforces that upstream via the workspace fetch path.
         """
         ...

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/base.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/base.py
@@ -9,6 +9,8 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Awaitable, Callable, Literal, Optional
 
+from pydantic import BaseModel
+
 # Callback signature: (ctx, adapter) -> awaitable None
 MessageCallback = Callable[["MessageContext", "PlatformAdapter"], Awaitable[None]]
 
@@ -28,8 +30,7 @@ class MessageHistoryEntry:
     text: str
 
 
-@dataclass
-class FileAttachment:
+class FileAttachment(BaseModel):
     """A workspace artifact ready to attach to a platform message.
 
     ``content`` carries the file bytes — the handler only ever produces

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter.py
@@ -5,6 +5,7 @@ thread creation, typing, button rendering. All platform-agnostic logic lives
 in the core handler. Slash commands live in commands.py.
 """
 
+import io
 import logging
 import re
 from typing import Optional
@@ -16,6 +17,7 @@ from backend.copilot.bot.bot_backend import BotBackend
 
 from ..base import (
     ChannelType,
+    FileAttachment,
     MessageCallback,
     MessageContext,
     MessageHistoryEntry,
@@ -57,6 +59,10 @@ class DiscordAdapter(PlatformAdapter):
     @property
     def chunk_flush_at(self) -> int:
         return config.CHUNK_FLUSH_AT
+
+    @property
+    def max_attachment_bytes(self) -> int:
+        return config.MAX_ATTACHMENT_BYTES
 
     def on_message(self, callback: MessageCallback) -> None:
         self._on_message_callback = callback
@@ -112,6 +118,20 @@ class DiscordAdapter(PlatformAdapter):
             )
         )
         await channel.send(text, view=view, tts=False)
+
+    async def send_file(self, channel_id: str, text: str, file: FileAttachment) -> None:
+        channel = await self._resolve_channel(channel_id)
+        if channel is None or not isinstance(channel, discord.abc.Messageable):
+            return
+        # spoiler=False — AutoPilot output is untrusted but spoilering every
+        # generated file would be noisy; the workspace fetcher already
+        # validated user ownership before we got bytes.
+        attachment = discord.File(
+            io.BytesIO(file.content),
+            filename=file.filename or "file",
+            spoiler=False,
+        )
+        await channel.send(text or None, file=attachment, tts=False)
 
     async def send_reply(
         self,

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter_test.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock
 import discord
 import pytest
 
+from backend.copilot.bot.adapters.base import FileAttachment
 from backend.copilot.bot.adapters.discord.adapter import (
     THREAD_HISTORY_LIMIT,
     DiscordAdapter,
@@ -294,8 +295,6 @@ class TestSendMethods:
 
     @pytest.mark.asyncio
     async def test_send_file_attaches_bytes_with_display_name(self):
-        from backend.copilot.bot.adapters.base import FileAttachment
-
         adapter, client = _bare_adapter()
         channel = MagicMock(spec=discord.TextChannel)
         channel.send = AsyncMock()
@@ -321,8 +320,6 @@ class TestSendMethods:
     async def test_send_file_drops_empty_caption_to_none(self):
         # discord.py rejects empty-string content alongside a file; we
         # collapse `text=""` to None so the upload still succeeds.
-        from backend.copilot.bot.adapters.base import FileAttachment
-
         adapter, client = _bare_adapter()
         channel = MagicMock(spec=discord.TextChannel)
         channel.send = AsyncMock()

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter_test.py
@@ -293,6 +293,53 @@ class TestSendMethods:
         )
 
     @pytest.mark.asyncio
+    async def test_send_file_attaches_bytes_with_display_name(self):
+        from backend.copilot.bot.adapters.base import FileAttachment
+
+        adapter, client = _bare_adapter()
+        channel = MagicMock(spec=discord.TextChannel)
+        channel.send = AsyncMock()
+        client.get_channel.return_value = channel
+
+        await adapter.send_file(
+            "123",
+            "here's your result",
+            FileAttachment(
+                filename="chart.png", mime_type="image/png", content=b"\x89PNG"
+            ),
+        )
+
+        channel.send.assert_awaited_once()
+        args, kwargs = channel.send.await_args
+        assert args == ("here's your result",)
+        attached = kwargs["file"]
+        assert isinstance(attached, discord.File)
+        assert attached.filename == "chart.png"
+        assert kwargs["tts"] is False
+
+    @pytest.mark.asyncio
+    async def test_send_file_drops_empty_caption_to_none(self):
+        # discord.py rejects empty-string content alongside a file; we
+        # collapse `text=""` to None so the upload still succeeds.
+        from backend.copilot.bot.adapters.base import FileAttachment
+
+        adapter, client = _bare_adapter()
+        channel = MagicMock(spec=discord.TextChannel)
+        channel.send = AsyncMock()
+        client.get_channel.return_value = channel
+
+        await adapter.send_file(
+            "123",
+            "",
+            FileAttachment(
+                filename="x.bin", mime_type="application/octet-stream", content=b"x"
+            ),
+        )
+
+        args, _ = channel.send.await_args
+        assert args == (None,)
+
+    @pytest.mark.asyncio
     async def test_send_reply_falls_back_to_send_when_message_missing(self):
         adapter, client = _bare_adapter()
         channel = MagicMock(spec=discord.TextChannel)

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/config.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/config.py
@@ -25,6 +25,12 @@ MAX_MESSAGE_LENGTH = 2000
 # 2000 cap so the boundary-splitter has room to reach a natural break point.
 CHUNK_FLUSH_AT = 1900
 
+# Discord's hard per-attachment cap for non-Nitro bot uploads. Bots can't have
+# Nitro and Discord shrank this from 50 MB to 25 MB years ago, so it's
+# hardcoded rather than configurable. Over-cap artifacts fall back to a
+# link-to-chat button.
+MAX_ATTACHMENT_BYTES = 25 * 1024 * 1024
+
 # Sensible default Discord permissions for the "Add to server" invite URL —
 # covers send messages, embed links, attach files, read history, add
 # reactions, use external emoji, slash commands, public threads, and sending

--- a/autogpt_platform/backend/backend/copilot/bot/bot_backend.py
+++ b/autogpt_platform/backend/backend/copilot/bot/bot_backend.py
@@ -28,6 +28,7 @@ from backend.platform_linking.models import (
     CreateLinkTokenRequest,
     CreateUserLinkTokenRequest,
     Platform,
+    WorkspaceArtifact,
 )
 from backend.util.clients import get_platform_linking_manager_client
 from backend.util.exceptions import (
@@ -188,6 +189,17 @@ class BotBackend:
             )
             for s in resp.sessions
         ]
+
+    async def fetch_workspace_artifact(
+        self, session_id: str, file_id: str, max_bytes: int
+    ) -> WorkspaceArtifact | None:
+        """Resolve a ``workspace://`` URI from the chat stream to bytes,
+        scoped to the session's owning user. Returns ``None`` when the file
+        is too large, missing, or doesn't belong to the session — in which
+        case the caller drops a link-to-chat fallback button."""
+        return await self._client.fetch_workspace_artifact(
+            session_id=session_id, file_id=file_id, max_bytes=max_bytes
+        )
 
     async def stream_chat(
         self,

--- a/autogpt_platform/backend/backend/copilot/bot/handler.py
+++ b/autogpt_platform/backend/backend/copilot/bot/handler.py
@@ -7,12 +7,15 @@ persistent typing indicator.
 
 import asyncio
 import logging
-import re
 from dataclasses import dataclass, field
 from typing import Any
 from urllib.parse import quote
 
 from backend.data.redis_client import get_redis_async
+from backend.data.sharing.workspace_refs import (
+    WorkspaceArtifactLink,
+    extract_artifact_links,
+)
 from backend.util.exceptions import (
     DuplicateChatMessageError,
     LinkAlreadyExistsError,
@@ -32,20 +35,6 @@ THREAD_NAME_MAX_LENGTH = 100
 THREAD_NAME_PREFIX = "AutoPilot: "
 TITLE_RENAME_ATTEMPTS = 5
 TITLE_RENAME_INTERVAL_SECONDS = 1.0
-
-# Matches the workspace artifact markdown the LLM emits: `[name](workspace://uuid#mime)`.
-# Both the display name and the trailing `#mime` fragment are optional from
-# our side — we only rely on the file ID (group 2) for the actual fetch.
-_WORKSPACE_ARTIFACT_RE = re.compile(
-    r"\[([^\]]+)\]\(workspace://([A-Za-z0-9_-]+)(?:#([^)]*))?\)"
-)
-
-
-@dataclass(frozen=True)
-class _ParsedArtifact:
-    display_name: str
-    file_id: str
-    mime_hint: str | None
 
 
 @dataclass
@@ -183,7 +172,7 @@ class MessageHandler:
         when small enough, otherwise we drop a link button pointing at the
         chat on the platform so the user can grab it from there.
         """
-        stripped, artifacts = _extract_artifacts(text)
+        stripped, artifacts = extract_artifact_links(text)
         sent_any = False
         if stripped:
             await adapter.send_message(
@@ -201,7 +190,7 @@ class MessageHandler:
         self,
         adapter: PlatformAdapter,
         target_id: str,
-        artifact: _ParsedArtifact,
+        artifact: WorkspaceArtifactLink,
         session_id: str | None,
     ) -> bool:
         """Attach the file inline when possible; otherwise drop a link to
@@ -214,51 +203,78 @@ class MessageHandler:
                 "Workspace artifact %s referenced before session id known",
                 artifact.file_id,
             )
-            await adapter.send_message(
-                target_id,
-                f"_(produced `{artifact.display_name}` — open the chat to download)_",
-            )
+            await self._send_artifact_note(adapter, target_id, artifact)
             return True
-        max_bytes = adapter.max_attachment_bytes
-        fetched = None
+        if await self._attach_artifact(adapter, target_id, artifact, session_id):
+            return True
+        await self._send_artifact_fallback(adapter, target_id, artifact, session_id)
+        return True
+
+    async def _attach_artifact(
+        self,
+        adapter: PlatformAdapter,
+        target_id: str,
+        artifact: WorkspaceArtifactLink,
+        session_id: str,
+    ) -> bool:
+        """Fetch and inline-attach the file. Returns False when it's missing,
+        unowned, too large, or the fetch errored."""
         try:
             fetched = await self._api.fetch_workspace_artifact(
                 session_id=session_id,
                 file_id=artifact.file_id,
-                max_bytes=max_bytes,
+                max_bytes=adapter.max_attachment_bytes,
             )
         except Exception:
             logger.exception("Failed to fetch workspace artifact %s", artifact.file_id)
-        if fetched is not None:
-            await adapter.send_file(
-                target_id,
-                text="",
-                file=FileAttachment(
-                    filename=artifact.display_name or fetched.filename,
-                    mime_type=fetched.mime_type,
-                    content=fetched.content,
-                ),
-            )
-            return True
-        # Too large, not found, or fetch errored → link the user to the chat.
+            return False
+        if fetched is None:
+            return False
+        await adapter.send_file(
+            target_id,
+            text="",
+            file=FileAttachment(
+                filename=artifact.display_name or fetched.filename,
+                mime_type=fetched.mime_type,
+                content=fetched.content,
+            ),
+        )
+        return True
+
+    async def _send_artifact_fallback(
+        self,
+        adapter: PlatformAdapter,
+        target_id: str,
+        artifact: WorkspaceArtifactLink,
+        session_id: str,
+    ) -> None:
+        """Link the user to the chat when the file can't be attached here —
+        covers missing, unavailable, errored and too-large cases alike."""
         session_url = _copilot_session_url(session_id)
         if session_url is None:
             logger.warning(
                 "No base URL configured; can't render fallback link for %s",
                 artifact.file_id,
             )
-            await adapter.send_message(
-                target_id,
-                f"_(produced `{artifact.display_name}` — open the chat to download)_",
-            )
-            return True
+            await self._send_artifact_note(adapter, target_id, artifact)
+            return
         await adapter.send_link(
             target_id,
-            f"`{artifact.display_name}` is too large to attach here.",
+            f"Open AutoGPT to download `{artifact.display_name}`.",
             link_label="Open in AutoGPT",
             link_url=session_url,
         )
-        return True
+
+    async def _send_artifact_note(
+        self,
+        adapter: PlatformAdapter,
+        target_id: str,
+        artifact: WorkspaceArtifactLink,
+    ) -> None:
+        await adapter.send_message(
+            target_id,
+            f"_(produced `{artifact.display_name}` — open the chat to download)_",
+        )
 
     async def _stream_batch(
         self,
@@ -296,15 +312,19 @@ class MessageHandler:
             setup_output: dict[str, Any],
             _tool_name: str | None,
         ) -> None:
-            nonlocal buffer, sent_any_content, setup_prompt_sent
+            nonlocal active_session_id, buffer, sent_any_content, setup_prompt_sent
             if setup_prompt_sent:
                 return
             setup_prompt_sent = True
+            # This callback carries the authoritative session id — adopt it so
+            # buffered workspace artifacts resolve instead of falling back to
+            # the "no session" plain-text note.
+            active_session_id = session_id
             # Drain any pending text first so the link button doesn't render
             # ahead of the message it belongs to.
             if buffer.strip():
                 if await self._send_text_and_artifacts(
-                    adapter, target_id, buffer, ctx, active_session_id
+                    adapter, target_id, buffer, ctx, session_id
                 ):
                     sent_any_content = True
                 buffer = ""
@@ -501,34 +521,6 @@ class MessageHandler:
                 ctx.channel_id,
                 "Something went wrong setting up the link. Try again later.",
             )
-
-
-def _extract_artifacts(text: str) -> tuple[str, list[_ParsedArtifact]]:
-    """Strip workspace artifact markdown links out of ``text`` and return
-    them separately.
-
-    Raw ``workspace://`` URIs are useless to a chat-platform user, so the
-    handler peels them out of the streamed text and either inline-attaches
-    the file or replaces them with a link-to-chat button instead.
-    """
-    artifacts: list[_ParsedArtifact] = []
-
-    def _capture(match: re.Match[str]) -> str:
-        artifacts.append(
-            _ParsedArtifact(
-                display_name=match.group(1).strip(),
-                file_id=match.group(2),
-                mime_hint=match.group(3) or None,
-            )
-        )
-        return ""
-
-    stripped = _WORKSPACE_ARTIFACT_RE.sub(_capture, text)
-    # Clean up the gaps the removed URIs left behind so the surrounding
-    # prose still reads naturally.
-    stripped = re.sub(r"[ \t]+\n", "\n", stripped)
-    stripped = re.sub(r"\n{3,}", "\n\n", stripped)
-    return stripped.strip(), artifacts
 
 
 async def _keep_typing(adapter: PlatformAdapter, target_id: str) -> None:

--- a/autogpt_platform/backend/backend/copilot/bot/handler.py
+++ b/autogpt_platform/backend/backend/copilot/bot/handler.py
@@ -7,6 +7,7 @@ persistent typing indicator.
 
 import asyncio
 import logging
+import re
 from dataclasses import dataclass, field
 from typing import Any
 from urllib.parse import quote
@@ -20,7 +21,7 @@ from backend.util.exceptions import (
 from backend.util.settings import Settings
 
 from . import sessions, threads
-from .adapters.base import MessageContext, PlatformAdapter
+from .adapters.base import FileAttachment, MessageContext, PlatformAdapter
 from .bot_backend import BotBackend
 from .config import SESSION_TTL
 from .text import format_batch, split_at_boundary
@@ -31,6 +32,20 @@ THREAD_NAME_MAX_LENGTH = 100
 THREAD_NAME_PREFIX = "AutoPilot: "
 TITLE_RENAME_ATTEMPTS = 5
 TITLE_RENAME_INTERVAL_SECONDS = 1.0
+
+# Matches the workspace artifact markdown the LLM emits: `[name](workspace://uuid#mime)`.
+# Both the display name and the trailing `#mime` fragment are optional from
+# our side — we only rely on the file ID (group 2) for the actual fetch.
+_WORKSPACE_ARTIFACT_RE = re.compile(
+    r"\[([^\]]+)\]\(workspace://([A-Za-z0-9_-]+)(?:#([^)]*))?\)"
+)
+
+
+@dataclass(frozen=True)
+class _ParsedArtifact:
+    display_name: str
+    file_id: str
+    mime_hint: str | None
 
 
 @dataclass
@@ -153,6 +168,98 @@ class MessageHandler:
             if not state.pending:
                 self._targets.pop(target_id, None)
 
+    async def _send_text_and_artifacts(
+        self,
+        adapter: PlatformAdapter,
+        target_id: str,
+        text: str,
+        ctx: MessageContext,
+        session_id: str | None,
+    ) -> bool:
+        """Send a finished chunk of text, then any workspace artifacts it
+        referenced. Returns True if anything was sent to the channel.
+
+        Each artifact gets its own platform message — files attach inline
+        when small enough, otherwise we drop a link button pointing at the
+        chat on the platform so the user can grab it from there.
+        """
+        stripped, artifacts = _extract_artifacts(text)
+        sent_any = False
+        if stripped:
+            await adapter.send_message(
+                target_id, stripped, mentionable_users=ctx.mentionable_users
+            )
+            sent_any = True
+        for artifact in artifacts:
+            sent = await self._deliver_artifact(
+                adapter, target_id, artifact, session_id
+            )
+            sent_any = sent_any or sent
+        return sent_any
+
+    async def _deliver_artifact(
+        self,
+        adapter: PlatformAdapter,
+        target_id: str,
+        artifact: _ParsedArtifact,
+        session_id: str | None,
+    ) -> bool:
+        """Attach the file inline when possible; otherwise drop a link to
+        the chat on the platform. Returns whether anything was sent."""
+        if session_id is None:
+            # Can't fetch or build a link button without a session id. Surface
+            # the artifact name as plain text so the user knows something was
+            # produced, even if they can't grab it from here.
+            logger.warning(
+                "Workspace artifact %s referenced before session id known",
+                artifact.file_id,
+            )
+            await adapter.send_message(
+                target_id,
+                f"_(produced `{artifact.display_name}` — open the chat to download)_",
+            )
+            return True
+        max_bytes = adapter.max_attachment_bytes
+        fetched = None
+        try:
+            fetched = await self._api.fetch_workspace_artifact(
+                session_id=session_id,
+                file_id=artifact.file_id,
+                max_bytes=max_bytes,
+            )
+        except Exception:
+            logger.exception("Failed to fetch workspace artifact %s", artifact.file_id)
+        if fetched is not None:
+            await adapter.send_file(
+                target_id,
+                text="",
+                file=FileAttachment(
+                    filename=artifact.display_name or fetched.filename,
+                    mime_type=fetched.mime_type,
+                    content=fetched.content,
+                ),
+            )
+            return True
+        # Too large, not found, or fetch errored → link the user to the chat.
+        session_url = _copilot_session_url(session_id)
+        if session_url is None:
+            logger.warning(
+                "No base URL configured; can't render fallback link for %s",
+                artifact.file_id,
+            )
+            await adapter.send_message(
+                target_id,
+                f"_(produced `{artifact.display_name}` — open the chat to download)_",
+            )
+            return True
+        await adapter.send_link(
+            target_id,
+            f"`{artifact.display_name}` is too large to attach here.",
+            link_label="Open in AutoGPT",
+            link_url=session_url,
+        )
+        return True
+
     async def _stream_batch(
         self,
         batch: list[tuple[str, str, str]],
@@ -196,9 +303,10 @@ class MessageHandler:
             # Drain any pending text first so the link button doesn't render
             # ahead of the message it belongs to.
             if buffer.strip():
-                await adapter.send_message(
-                    target_id, buffer, mentionable_users=ctx.mentionable_users
-                )
+                if await self._send_text_and_artifacts(
+                    adapter, target_id, buffer, ctx, active_session_id
+                ):
+                    sent_any_content = True
                 buffer = ""
             sent_any_content = True
             session_url = _copilot_session_url(session_id)
@@ -235,13 +343,10 @@ class MessageHandler:
                 buffer += chunk
                 if len(buffer) >= flush_at:
                     post, buffer = split_at_boundary(buffer, flush_at)
-                    if post:
-                        await adapter.send_message(
-                            target_id,
-                            post,
-                            mentionable_users=ctx.mentionable_users,
-                        )
-                        if post.strip():
+                    if post and post.strip():
+                        if await self._send_text_and_artifacts(
+                            adapter, target_id, post, ctx, active_session_id
+                        ):
                             sent_any_content = True
         except DuplicateChatMessageError:
             # Another in-flight turn is already processing this exact message —
@@ -272,10 +377,10 @@ class MessageHandler:
             await adapter.stop_typing(target_id)
 
         if buffer.strip():
-            await adapter.send_message(
-                target_id, buffer, mentionable_users=ctx.mentionable_users
-            )
-            sent_any_content = True
+            if await self._send_text_and_artifacts(
+                adapter, target_id, buffer, ctx, active_session_id
+            ):
+                sent_any_content = True
 
         if not sent_any_content:
             await adapter.send_message(
@@ -396,6 +501,34 @@ class MessageHandler:
                 ctx.channel_id,
                 "Something went wrong setting up the link. Try again later.",
             )
+
+
+def _extract_artifacts(text: str) -> tuple[str, list[_ParsedArtifact]]:
+    """Strip workspace artifact markdown links out of ``text`` and return
+    them separately.
+
+    Raw ``workspace://`` URIs are useless to a chat-platform user, so the
+    handler peels them out of the streamed text and either inline-attaches
+    the file or replaces them with a link-to-chat button instead.
+    """
+    artifacts: list[_ParsedArtifact] = []
+
+    def _capture(match: re.Match[str]) -> str:
+        artifacts.append(
+            _ParsedArtifact(
+                display_name=match.group(1).strip(),
+                file_id=match.group(2),
+                mime_hint=match.group(3) or None,
+            )
+        )
+        return ""
+
+    stripped = _WORKSPACE_ARTIFACT_RE.sub(_capture, text)
+    # Clean up the gaps the removed URIs left behind so the surrounding
+    # prose still reads naturally.
+    stripped = re.sub(r"[ \t]+\n", "\n", stripped)
+    stripped = re.sub(r"\n{3,}", "\n\n", stripped)
+    return stripped.strip(), artifacts
 
 
 async def _keep_typing(adapter: PlatformAdapter, target_id: str) -> None:

--- a/autogpt_platform/backend/backend/copilot/bot/handler_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/handler_test.py
@@ -11,13 +11,7 @@ from backend.util.exceptions import DuplicateChatMessageError, NotFoundError
 
 from .adapters.base import ChannelType, MessageContext, MessageHistoryEntry
 from .bot_backend import LinkTokenResult, ResolveResult
-from .handler import (
-    MessageHandler,
-    TargetState,
-    _extract_artifacts,
-    build_thread_name,
-    clamp_thread_name,
-)
+from .handler import MessageHandler, TargetState, build_thread_name, clamp_thread_name
 
 
 def _ctx(
@@ -677,47 +671,6 @@ class TestThreadNames:
 # ── Workspace artifact extraction & delivery ────────────────────────────
 
 
-class TestExtractArtifacts:
-    def test_no_artifacts_returns_text_unchanged(self):
-        text, artifacts = _extract_artifacts("hello world")
-        assert text == "hello world"
-        assert artifacts == []
-
-    def test_strips_artifact_markdown(self):
-        text, artifacts = _extract_artifacts(
-            "Here's your result: [chart.png](workspace://abc-123#image/png)"
-        )
-        assert text == "Here's your result:"
-        assert len(artifacts) == 1
-        assert artifacts[0].file_id == "abc-123"
-        assert artifacts[0].display_name == "chart.png"
-        assert artifacts[0].mime_hint == "image/png"
-
-    def test_handles_artifact_with_no_mime_fragment(self):
-        text, artifacts = _extract_artifacts("[doc.pdf](workspace://xyz)")
-        assert text == ""
-        assert artifacts[0].file_id == "xyz"
-        assert artifacts[0].mime_hint is None
-
-    def test_handles_multiple_artifacts(self):
-        text, artifacts = _extract_artifacts(
-            "First [a.png](workspace://1#image/png) "
-            "then [b.csv](workspace://2#text/csv)"
-        )
-        assert "workspace://" not in text
-        assert [a.file_id for a in artifacts] == ["1", "2"]
-
-    def test_collapses_blank_lines_left_behind(self):
-        # The URI lives alone on its line — once stripped we shouldn't leave
-        # a triple-newline scar in the surrounding prose.
-        text, _ = _extract_artifacts(
-            "Above paragraph.\n\n[file.png](workspace://abc)\n\nBelow paragraph."
-        )
-        assert "\n\n\n" not in text
-        assert "Above paragraph." in text
-        assert "Below paragraph." in text
-
-
 class TestDeliverArtifact:
     @pytest.mark.asyncio
     async def test_small_file_attaches_inline(self):
@@ -740,6 +693,12 @@ class TestDeliverArtifact:
 
         adapter.send_message.assert_awaited_once()
         adapter.send_file.assert_awaited_once()
+        # The adapter's size cap must be forwarded so the backend enforces it.
+        handler._api.fetch_workspace_artifact.assert_awaited_once_with(
+            session_id="sess-1",
+            file_id="abc",
+            max_bytes=adapter.max_attachment_bytes,
+        )
         sent_file = adapter.send_file.await_args.kwargs["file"]
         # The bot uses the LLM's display name as the filename, not the
         # backend's storage name — that's what the user expects to see.
@@ -767,6 +726,11 @@ class TestDeliverArtifact:
 
         adapter.send_file.assert_not_awaited()
         adapter.send_link.assert_awaited_once()
+        handler._api.fetch_workspace_artifact.assert_awaited_once_with(
+            session_id="sess-42",
+            file_id="big",
+            max_bytes=adapter.max_attachment_bytes,
+        )
         # send_link(target_id, text, link_label=..., link_url=...) — text is
         # positional arg[1], the URL is a kwarg.
         assert "big.zip" in adapter.send_link.await_args.args[1]
@@ -793,6 +757,11 @@ class TestDeliverArtifact:
 
         adapter.send_file.assert_not_awaited()
         adapter.send_link.assert_awaited_once()
+        handler._api.fetch_workspace_artifact.assert_awaited_once_with(
+            session_id="sess-1",
+            file_id="x",
+            max_bytes=adapter.max_attachment_bytes,
+        )
 
     @pytest.mark.asyncio
     async def test_no_session_id_drops_inline_note(self):

--- a/autogpt_platform/backend/backend/copilot/bot/handler_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/handler_test.py
@@ -6,11 +6,18 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from backend.platform_linking.models import WorkspaceArtifact
 from backend.util.exceptions import DuplicateChatMessageError, NotFoundError
 
 from .adapters.base import ChannelType, MessageContext, MessageHistoryEntry
 from .bot_backend import LinkTokenResult, ResolveResult
-from .handler import MessageHandler, TargetState, build_thread_name, clamp_thread_name
+from .handler import (
+    MessageHandler,
+    TargetState,
+    _extract_artifacts,
+    build_thread_name,
+    clamp_thread_name,
+)
 
 
 def _ctx(
@@ -42,9 +49,11 @@ def _ctx(
 def _adapter() -> MagicMock:
     adapter = MagicMock()
     adapter.chunk_flush_at = 1900
+    adapter.max_attachment_bytes = 25 * 1024 * 1024
     adapter.send_message = AsyncMock()
     adapter.send_reply = AsyncMock()
     adapter.send_link = AsyncMock()
+    adapter.send_file = AsyncMock()
     adapter.start_typing = AsyncMock()
     adapter.stop_typing = AsyncMock()
     adapter.create_thread = AsyncMock(return_value="thread-new")
@@ -63,6 +72,7 @@ def _api(*, server_linked: bool = True, user_linked: bool = True) -> MagicMock:
             expires_at="2099-01-01T00:00:00Z",
         )
     )
+    api.fetch_workspace_artifact = AsyncMock(return_value=None)
 
     async def _empty_stream(*args, **kwargs):
         if False:
@@ -662,3 +672,140 @@ class TestThreadNames:
 
     def test_clamp_thread_name_falls_back_when_blank(self):
         assert clamp_thread_name("   ") == "AutoPilot Chat"
+
+
+# ── Workspace artifact extraction & delivery ────────────────────────────
+
+
+class TestExtractArtifacts:
+    def test_no_artifacts_returns_text_unchanged(self):
+        text, artifacts = _extract_artifacts("hello world")
+        assert text == "hello world"
+        assert artifacts == []
+
+    def test_strips_artifact_markdown(self):
+        text, artifacts = _extract_artifacts(
+            "Here's your result: [chart.png](workspace://abc-123#image/png)"
+        )
+        assert text == "Here's your result:"
+        assert len(artifacts) == 1
+        assert artifacts[0].file_id == "abc-123"
+        assert artifacts[0].display_name == "chart.png"
+        assert artifacts[0].mime_hint == "image/png"
+
+    def test_handles_artifact_with_no_mime_fragment(self):
+        text, artifacts = _extract_artifacts("[doc.pdf](workspace://xyz)")
+        assert text == ""
+        assert artifacts[0].file_id == "xyz"
+        assert artifacts[0].mime_hint is None
+
+    def test_handles_multiple_artifacts(self):
+        text, artifacts = _extract_artifacts(
+            "First [a.png](workspace://1#image/png) "
+            "then [b.csv](workspace://2#text/csv)"
+        )
+        assert "workspace://" not in text
+        assert [a.file_id for a in artifacts] == ["1", "2"]
+
+    def test_collapses_blank_lines_left_behind(self):
+        # The URI lives alone on its line — once stripped we shouldn't leave
+        # a triple-newline scar in the surrounding prose.
+        text, _ = _extract_artifacts(
+            "Above paragraph.\n\n[file.png](workspace://abc)\n\nBelow paragraph."
+        )
+        assert "\n\n\n" not in text
+        assert "Above paragraph." in text
+        assert "Below paragraph." in text
+
+
+class TestDeliverArtifact:
+    @pytest.mark.asyncio
+    async def test_small_file_attaches_inline(self):
+        handler = MessageHandler(_api())
+        adapter = _adapter()
+        handler._api.fetch_workspace_artifact = AsyncMock(
+            return_value=WorkspaceArtifact(
+                file_id="abc",
+                filename="server.name",
+                mime_type="image/png",
+                size_bytes=10,
+                content=b"\x89PNG\r\n",
+            )
+        )
+        text = "Here is your result: [chart.png](workspace://abc#image/png)"
+
+        await handler._send_text_and_artifacts(
+            adapter, "target-1", text, _ctx(), "sess-1"
+        )
+
+        adapter.send_message.assert_awaited_once()
+        adapter.send_file.assert_awaited_once()
+        sent_file = adapter.send_file.await_args.kwargs["file"]
+        # The bot uses the LLM's display name as the filename, not the
+        # backend's storage name — that's what the user expects to see.
+        assert sent_file.filename == "chart.png"
+        assert sent_file.content == b"\x89PNG\r\n"
+        adapter.send_link.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_too_large_falls_back_to_link_button(self):
+        handler = MessageHandler(_api())
+        adapter = _adapter()
+        handler._api.fetch_workspace_artifact = AsyncMock(return_value=None)
+        fake_settings = MagicMock()
+        fake_settings.config.frontend_base_url = "https://app.example.com"
+        fake_settings.config.platform_base_url = ""
+
+        with patch("backend.copilot.bot.handler.Settings", return_value=fake_settings):
+            await handler._send_text_and_artifacts(
+                adapter,
+                "target-1",
+                "[big.zip](workspace://big)",
+                _ctx(),
+                "sess-42",
+            )
+
+        adapter.send_file.assert_not_awaited()
+        adapter.send_link.assert_awaited_once()
+        # send_link(target_id, text, link_label=..., link_url=...) — text is
+        # positional arg[1], the URL is a kwarg.
+        assert "big.zip" in adapter.send_link.await_args.args[1]
+        assert "sess-42" in adapter.send_link.await_args.kwargs["link_url"]
+
+    @pytest.mark.asyncio
+    async def test_fetch_failure_falls_back_to_link_button(self):
+        # The backend call could raise (network blip, RPC timeout) — that
+        # must not crash the stream; we still surface the artifact via a
+        # link so the user has a way to grab it.
+        handler = MessageHandler(_api())
+        adapter = _adapter()
+        handler._api.fetch_workspace_artifact = AsyncMock(
+            side_effect=RuntimeError("rpc down")
+        )
+        fake_settings = MagicMock()
+        fake_settings.config.frontend_base_url = "https://app.example.com"
+        fake_settings.config.platform_base_url = ""
+
+        with patch("backend.copilot.bot.handler.Settings", return_value=fake_settings):
+            await handler._send_text_and_artifacts(
+                adapter, "target-1", "[x.png](workspace://x)", _ctx(), "sess-1"
+            )
+
+        adapter.send_file.assert_not_awaited()
+        adapter.send_link.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_no_session_id_drops_inline_note(self):
+        # If artifacts somehow arrive before we have a session id, we can't
+        # fetch or build a fallback URL — just tell the user.
+        handler = MessageHandler(_api())
+        adapter = _adapter()
+
+        await handler._send_text_and_artifacts(
+            adapter, "target-1", "[x.png](workspace://x)", _ctx(), None
+        )
+
+        handler._api.fetch_workspace_artifact.assert_not_awaited()
+        adapter.send_file.assert_not_awaited()
+        adapter.send_message.assert_awaited_once()
+        assert "x.png" in adapter.send_message.await_args.args[1]

--- a/autogpt_platform/backend/backend/copilot/bot/text.py
+++ b/autogpt_platform/backend/backend/copilot/bot/text.py
@@ -2,6 +2,8 @@
 
 import re
 
+from backend.data.sharing.workspace_refs import cut_lands_inside_artifact_link
+
 # Matches a triple-backtick fence with an optional language tag. Used to tell
 # whether a cut falls inside an open Markdown code block.
 _CODE_FENCE = re.compile(r"```(\w*)")
@@ -48,21 +50,33 @@ def split_at_boundary(text: str, flush_at: int) -> tuple[str, str]:
     for sep in ("\n\n", "\n"):
         idx = search_region.rfind(sep)
         if idx != -1:
-            cut = search_start + idx
+            cut = _guarded_cut(text, search_start + idx)
             return _balance_code_fences(text[:cut].rstrip(), text[cut:].lstrip("\n"))
 
     for sep in (". ", "! ", "? "):
         idx = search_region.rfind(sep)
         if idx != -1:
-            cut = search_start + idx + len(sep)
+            cut = _guarded_cut(text, search_start + idx + len(sep))
             return _balance_code_fences(text[:cut], text[cut:])
 
     idx = search_region.rfind(" ")
     if idx != -1:
-        cut = search_start + idx
+        cut = _guarded_cut(text, search_start + idx)
         return _balance_code_fences(text[:cut], text[cut:].lstrip())
 
-    return _balance_code_fences(text[:flush_at], text[flush_at:])
+    cut = _guarded_cut(text, flush_at)
+    return _balance_code_fences(text[:cut], text[cut:])
+
+
+def _guarded_cut(text: str, cut: int) -> int:
+    """Keep a workspace artifact markdown link from being split across chunks.
+
+    ``split_at_boundary`` picks a cut purely from prose boundaries, so it can
+    land inside ``[name](workspace://...)`` — which would stop the downstream
+    artifact extractor matching it. Pull the cut back to the link's start so the
+    whole link travels intact into the remainder.
+    """
+    return cut_lands_inside_artifact_link(text, cut)
 
 
 def _balance_code_fences(before: str, after: str) -> tuple[str, str]:

--- a/autogpt_platform/backend/backend/copilot/bot/text_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/text_test.py
@@ -1,5 +1,7 @@
 """Tests for message batching + boundary splitting."""
 
+from backend.data.sharing.workspace_refs import extract_artifact_links
+
 from .text import _balance_code_fences, format_batch, split_at_boundary
 
 
@@ -63,6 +65,16 @@ class TestSplitAtBoundary:
         before, after = split_at_boundary(text, 100)
         assert len(before) == 100
         assert after == "a" * 400
+
+    def test_does_not_split_inside_workspace_artifact_link(self):
+        # A sentence boundary inside the display name would otherwise bisect
+        # the `[name](workspace://id)` link and break artifact extraction.
+        text = "x [report. final.txt](workspace://abc-123) y"
+        before, after = split_at_boundary(text, 12)
+        assert "workspace://" not in before
+        assert "[report. final.txt](workspace://abc-123)" in after
+        _, artifacts = extract_artifact_links(after)
+        assert [a.file_id for a in artifacts] == ["abc-123"]
 
 
 class TestBalanceCodeFences:

--- a/autogpt_platform/backend/backend/copilot/bot/text_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/text_test.py
@@ -76,6 +76,16 @@ class TestSplitAtBoundary:
         _, artifacts = extract_artifact_links(after)
         assert [a.file_id for a in artifacts] == ["abc-123"]
 
+    def test_leading_long_artifact_link_does_not_stall(self):
+        # A long link at the very start spanning the boundary must not return
+        # an empty chunk (which would stall the stream) — emit the whole link.
+        link = "[" + "report " * 30 + "final.txt](workspace://abc-123)"
+        text = link + " and then more trailing text"
+        before, after = split_at_boundary(text, 30)
+        assert before != ""  # forward progress — never empty
+        assert link in before  # whole link emitted intact
+        assert "workspace://" not in after
+
 
 class TestBalanceCodeFences:
     def test_balanced_code_unchanged(self):

--- a/autogpt_platform/backend/backend/data/db_manager.py
+++ b/autogpt_platform/backend/backend/data/db_manager.py
@@ -389,6 +389,7 @@ class DatabaseManager(AppService):
     cleanup_expired_platform_link_tokens = _(
         platform_linking_db.cleanup_expired_platform_link_tokens
     )
+    fetch_workspace_artifact = _(platform_linking_db.fetch_workspace_artifact)
 
     # ============ CoPilot Chat Sessions ============ #
     # NOTE: no eager-load `get_chat_session` here — callers go through
@@ -632,6 +633,7 @@ class DatabaseManagerAsyncClient(AppServiceClient):
     delete_server_link = d.delete_server_link
     delete_user_link = d.delete_user_link
     cleanup_expired_platform_link_tokens = d.cleanup_expired_platform_link_tokens
+    fetch_workspace_artifact = d.fetch_workspace_artifact
 
     # ============ CoPilot Chat Sessions ============ #
     get_chat_session_metadata = d.get_chat_session_metadata

--- a/autogpt_platform/backend/backend/data/sharing/workspace_refs.py
+++ b/autogpt_platform/backend/backend/data/sharing/workspace_refs.py
@@ -99,15 +99,19 @@ def extract_artifact_links(text: str) -> tuple[str, list[WorkspaceArtifactLink]]
 
 
 def cut_lands_inside_artifact_link(text: str, cut: int) -> int:
-    """Pull *cut* back to the start of any artifact link it would bisect.
+    """Move *cut* off any artifact link it would bisect, keeping the link whole.
 
     Splitting a streamed buffer mid-``[name](workspace://...)`` would leave the
-    fragment unrecognisable to :func:`extract_artifact_links`, so the link must
-    move intact to the remainder. Returns the (possibly earlier) cut index.
+    fragment unrecognisable to :func:`extract_artifact_links`, so the link is
+    kept intact. Normally we pull the cut back to the link's start so the link
+    travels into the remainder — but if the link sits at the very start of the
+    buffer, that yields an empty chunk and stalls the stream (the buffer never
+    advances). In that case we cut at the link's end instead, emitting the whole
+    link as one chunk. Either way the returned cut makes forward progress.
     """
     for match in _WORKSPACE_ARTIFACT_LINK_RE.finditer(text):
         if match.start() < cut < match.end():
-            return match.start()
+            return match.start() if match.start() > 0 else match.end()
     return cut
 
 

--- a/autogpt_platform/backend/backend/data/sharing/workspace_refs.py
+++ b/autogpt_platform/backend/backend/data/sharing/workspace_refs.py
@@ -24,6 +24,8 @@ All three forms are handled by a single recursive walker.
 import re
 from typing import Any
 
+from pydantic import BaseModel
+
 # Match ``workspace://<id>`` anywhere in a string.  Assistant messages
 # embed these URIs inside markdown (``![chart](workspace://uuid#mime)``)
 # so a whole-string ``startswith`` check used to miss them — the file
@@ -46,6 +48,67 @@ _FILE_ID_RE = re.compile(
     r'(?:file_id=|"file_id"\s*:\s*")'
     r"([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\b"
 )
+
+# Full markdown artifact reference the assistant emits — either a file link
+# ``[report.csv](workspace://<id>#text/csv)`` or an image embed
+# ``![chart](workspace://<id>#image/png)`` (the prompt instructs both forms,
+# see ``backend/copilot/prompting.py``). The leading ``!`` is consumed so image
+# embeds don't leave a dangling marker once the link is stripped. Builds on the
+# same ``workspace://<id>`` grammar as ``_WORKSPACE_URI_RE`` above, but also
+# captures the human label and optional ``#mime`` hint — chat-bot delivery needs
+# both to attach the file with a sensible filename.
+_WORKSPACE_ARTIFACT_LINK_RE = re.compile(
+    r"!?\[([^\]]+)\]\(workspace://([a-z0-9-]+)(?:#([^)]*))?\)"
+)
+
+
+class WorkspaceArtifactLink(BaseModel):
+    """A ``[name](workspace://id#mime)`` reference parsed out of assistant text."""
+
+    display_name: str
+    file_id: str
+    mime_hint: str | None = None
+
+
+def extract_artifact_links(text: str) -> tuple[str, list[WorkspaceArtifactLink]]:
+    """Pull ``[name](workspace://id#mime)`` markdown links out of *text*.
+
+    Returns the text with those links removed (surrounding whitespace tidied)
+    plus the parsed artifacts in document order. Raw ``workspace://`` URIs are
+    useless to a chat-platform user, so callers strip them here and deliver the
+    referenced file (or a link to it) separately.
+    """
+    artifacts: list[WorkspaceArtifactLink] = []
+
+    def _capture(match: re.Match[str]) -> str:
+        artifacts.append(
+            WorkspaceArtifactLink(
+                display_name=match.group(1).strip(),
+                file_id=match.group(2),
+                mime_hint=match.group(3) or None,
+            )
+        )
+        return ""
+
+    stripped = _WORKSPACE_ARTIFACT_LINK_RE.sub(_capture, text)
+    # Clean up the gaps the removed links leave behind so surrounding prose
+    # still reads naturally.
+    stripped = re.sub(r"[ \t]+\n", "\n", stripped)
+    stripped = re.sub(r"\n{3,}", "\n\n", stripped)
+    return stripped.strip(), artifacts
+
+
+def cut_lands_inside_artifact_link(text: str, cut: int) -> int:
+    """Pull *cut* back to the start of any artifact link it would bisect.
+
+    Splitting a streamed buffer mid-``[name](workspace://...)`` would leave the
+    fragment unrecognisable to :func:`extract_artifact_links`, so the link must
+    move intact to the remainder. Returns the (possibly earlier) cut index.
+    """
+    for match in _WORKSPACE_ARTIFACT_LINK_RE.finditer(text):
+        if match.start() < cut < match.end():
+            return match.start()
+    return cut
 
 
 def extract_workspace_file_ids(value: Any) -> set[str]:

--- a/autogpt_platform/backend/backend/data/sharing/workspace_refs_test.py
+++ b/autogpt_platform/backend/backend/data/sharing/workspace_refs_test.py
@@ -10,7 +10,11 @@ new patterns and the cross-pattern de-dup behaviour.
 
 from __future__ import annotations
 
-from backend.data.sharing.workspace_refs import extract_workspace_file_ids
+from backend.data.sharing.workspace_refs import (
+    cut_lands_inside_artifact_link,
+    extract_artifact_links,
+    extract_workspace_file_ids,
+)
 
 UUID_A = "11111111-2222-3333-4444-555555555555"
 UUID_B = "66666666-7777-8888-9999-aaaaaaaaaaaa"
@@ -97,3 +101,78 @@ class TestMixedInput:
             "ref": [f"workspace://{UUID_A}"],
         }
         assert extract_workspace_file_ids(outputs) == {UUID_A}
+
+
+class TestExtractArtifactLinks:
+    """``[name](workspace://id#mime)`` markdown parsing used by chat-bot
+    delivery to peel artifacts out of assistant text."""
+
+    def test_no_artifacts_returns_text_unchanged(self):
+        text, artifacts = extract_artifact_links("hello world")
+        assert text == "hello world"
+        assert artifacts == []
+
+    def test_strips_artifact_markdown(self):
+        text, artifacts = extract_artifact_links(
+            "Here's your result: [chart.png](workspace://abc-123#image/png)"
+        )
+        assert text == "Here's your result:"
+        assert len(artifacts) == 1
+        assert artifacts[0].file_id == "abc-123"
+        assert artifacts[0].display_name == "chart.png"
+        assert artifacts[0].mime_hint == "image/png"
+
+    def test_handles_artifact_with_no_mime_fragment(self):
+        text, artifacts = extract_artifact_links("[doc.pdf](workspace://xyz)")
+        assert text == ""
+        assert artifacts[0].file_id == "xyz"
+        assert artifacts[0].mime_hint is None
+
+    def test_strips_image_embed_without_leaving_bang(self):
+        # The prompt tells the LLM to emit images as `![name](workspace://...)`;
+        # the leading `!` must be consumed so no marker is left behind.
+        text, artifacts = extract_artifact_links(
+            "Result: ![chart](workspace://abc-123#image/png)"
+        )
+        assert text == "Result:"
+        assert "!" not in text
+        assert artifacts[0].file_id == "abc-123"
+        assert artifacts[0].display_name == "chart"
+        assert artifacts[0].mime_hint == "image/png"
+
+    def test_handles_multiple_artifacts(self):
+        text, artifacts = extract_artifact_links(
+            "First [a.png](workspace://1#image/png) "
+            "then [b.csv](workspace://2#text/csv)"
+        )
+        assert "workspace://" not in text
+        assert [a.file_id for a in artifacts] == ["1", "2"]
+
+    def test_collapses_blank_lines_left_behind(self):
+        text, _ = extract_artifact_links(
+            "Above paragraph.\n\n[file.png](workspace://abc)\n\nBelow paragraph."
+        )
+        assert "\n\n\n" not in text
+        assert "Above paragraph." in text
+        assert "Below paragraph." in text
+
+
+class TestCutLandsInsideArtifactLink:
+    def test_cut_inside_link_pulls_back_to_start(self):
+        text = "see [chart.png](workspace://abc-123#image/png) now"
+        start = text.index("[chart.png]")
+        mid = text.index("workspace://")  # a cut landing inside the link
+        assert cut_lands_inside_artifact_link(text, mid) == start
+
+    def test_cut_outside_link_is_unchanged(self):
+        text = "see [chart.png](workspace://abc) now"
+        end = len(text) - 1
+        assert cut_lands_inside_artifact_link(text, end) == end
+
+    def test_cut_at_link_boundaries_is_unchanged(self):
+        text = "x [a.png](workspace://a) y"
+        start = text.index("[a.png]")
+        after = text.index(") y") + 1
+        # Boundaries are exclusive — exactly at start/end keeps the link whole.
+        assert cut_lands_inside_artifact_link(text, start) == start
+        assert cut_lands_inside_artifact_link(text, after) == after

--- a/autogpt_platform/backend/backend/data/sharing/workspace_refs_test.py
+++ b/autogpt_platform/backend/backend/data/sharing/workspace_refs_test.py
@@ -176,3 +176,12 @@ class TestCutLandsInsideArtifactLink:
         # Boundaries are exclusive — exactly at start/end keeps the link whole.
         assert cut_lands_inside_artifact_link(text, start) == start
         assert cut_lands_inside_artifact_link(text, after) == after
+
+    def test_cut_inside_leading_link_returns_end_not_zero(self):
+        # A link at index 0 can't pull the cut back to its start — that yields
+        # an empty chunk and stalls the stream. Cut at the link's end instead so
+        # the whole link is emitted and the buffer advances.
+        link = "[report.txt](workspace://abc-123#text/plain)"
+        text = link + " trailing text"
+        cut = link.index("workspace://")  # inside the leading link
+        assert cut_lands_inside_artifact_link(text, cut) == len(link)

--- a/autogpt_platform/backend/backend/platform_linking/db.py
+++ b/autogpt_platform/backend/backend/platform_linking/db.py
@@ -13,7 +13,9 @@ from datetime import datetime, timedelta, timezone
 from prisma.errors import UniqueViolationError
 from prisma.models import PlatformLink, PlatformLinkToken, PlatformUserLink
 
+from backend.copilot.db import get_chat_session_metadata
 from backend.data.db import transaction
+from backend.data.workspace import get_workspace, get_workspace_file
 from backend.util.exceptions import (
     LinkAlreadyExistsError,
     LinkFlowMismatchError,
@@ -22,6 +24,7 @@ from backend.util.exceptions import (
     NotFoundError,
 )
 from backend.util.settings import Settings
+from backend.util.workspace import WorkspaceManager
 
 from .models import (
     ConfirmLinkResponse,
@@ -36,6 +39,7 @@ from .models import (
     PlatformLinkInfo,
     PlatformUserLinkInfo,
     ResolveResponse,
+    WorkspaceArtifact,
 )
 
 logger = logging.getLogger(__name__)
@@ -476,6 +480,72 @@ async def delete_user_link(link_id: str, user_id: str) -> DeleteLinkResponse:
 
 # Keep recently-expired rows for debugging.
 LINK_TOKEN_RETENTION_HOURS = 24
+
+
+async def fetch_workspace_artifact(
+    session_id: str, file_id: str, max_bytes: int
+) -> WorkspaceArtifact | None:
+    """Resolve a workspace file ID to bytes, scoped to a chat session's owner.
+
+    Returns ``None`` when the file doesn't exist, doesn't belong to the
+    session's owning user, or is larger than ``max_bytes``. The bot uses
+    ``None`` as the trigger to fall back to a link-to-chat button.
+
+    The session→user→workspace→file chain is load-bearing: the LLM emits
+    arbitrary ``workspace://`` URIs in the chat stream, so we must never
+    serve a file just because the bot claimed an ID — only files owned by
+    the same user the session belongs to are returned.
+    """
+    session = await get_chat_session_metadata(session_id)
+    if session is None:
+        logger.debug("fetch_workspace_artifact: session %s not found", session_id)
+        return None
+    workspace = await get_workspace(session.user_id)
+    if workspace is None:
+        logger.debug(
+            "fetch_workspace_artifact: no workspace for session %s", session_id
+        )
+        return None
+    file = await get_workspace_file(file_id, workspace.id)
+    if file is None:
+        # File isn't owned by the session's user — expected when the LLM emits
+        # a stale or hallucinated workspace URI, so debug rather than warn.
+        logger.debug(
+            "fetch_workspace_artifact: file %s not in workspace for session %s",
+            file_id,
+            session_id,
+        )
+        return None
+    if file.size_bytes > max_bytes:
+        logger.debug(
+            "fetch_workspace_artifact: file %s is %d bytes, over %d cap",
+            file_id,
+            file.size_bytes,
+            max_bytes,
+        )
+        return None
+
+    manager = WorkspaceManager(
+        user_id=session.user_id, workspace_id=workspace.id, session_id=session_id
+    )
+    try:
+        content = await manager.read_file_by_id(file_id)
+    except FileNotFoundError:
+        # DB row exists but the storage blob is gone — genuinely unexpected,
+        # so keep this one at warning level.
+        logger.warning(
+            "fetch_workspace_artifact: file %s db row present but storage "
+            "blob missing",
+            file_id,
+        )
+        return None
+    return WorkspaceArtifact(
+        file_id=file_id,
+        filename=file.name,
+        mime_type=file.mime_type or "application/octet-stream",
+        size_bytes=file.size_bytes,
+        content=content,
+    )
 
 
 async def cleanup_expired_platform_link_tokens() -> int:

--- a/autogpt_platform/backend/backend/platform_linking/manager.py
+++ b/autogpt_platform/backend/backend/platform_linking/manager.py
@@ -17,6 +17,7 @@ from .models import (
     ListUserChatsResponse,
     Platform,
     ResolveResponse,
+    WorkspaceArtifact,
 )
 
 logger = logging.getLogger(__name__)
@@ -81,6 +82,14 @@ class PlatformLinkingManager(AppService):
     ) -> ListUserChatsResponse:
         return await list_user_chats(platform, platform_user_id, limit, offset)
 
+    @expose
+    async def fetch_workspace_artifact(
+        self, session_id: str, file_id: str, max_bytes: int
+    ) -> WorkspaceArtifact | None:
+        return await platform_linking_db().fetch_workspace_artifact(
+            session_id, file_id, max_bytes
+        )
+
 
 class PlatformLinkingManagerClient(AppServiceClient):
     @classmethod
@@ -103,3 +112,6 @@ class PlatformLinkingManagerClient(AppServiceClient):
         PlatformLinkingManager.refresh_server_link_name
     )
     list_user_chats = endpoint_to_async(PlatformLinkingManager.list_user_chats)
+    fetch_workspace_artifact = endpoint_to_async(
+        PlatformLinkingManager.fetch_workspace_artifact
+    )

--- a/autogpt_platform/backend/backend/platform_linking/models.py
+++ b/autogpt_platform/backend/backend/platform_linking/models.py
@@ -208,3 +208,19 @@ class ChatSessionSummary(BaseModel):
 class ListUserChatsResponse(BaseModel):
     sessions: list[ChatSessionSummary]
     total: int
+
+
+class WorkspaceArtifact(BaseModel):
+    """A user-owned workspace file resolved to bytes for bot attachment.
+
+    Returned by ``fetch_workspace_artifact`` when the file exists, belongs to
+    the session's owning user, and fits under the requested ``max_bytes``.
+    The bot uses ``content`` to attach the file inline; over-the-limit or
+    missing files come back as ``None`` and trigger the link-to-chat fallback.
+    """
+
+    file_id: str
+    filename: str
+    mime_type: str
+    size_bytes: int
+    content: bytes

--- a/autogpt_platform/docker-compose.platform.yml
+++ b/autogpt_platform/docker-compose.platform.yml
@@ -341,12 +341,6 @@ services:
       <<: *backend-env
     ports:
       - "8005:8005"
-    volumes:
-      # database_manager serves workspace file reads (e.g. the bot's
-      # fetch_workspace_artifact RPC and embedding backfill), so it needs the
-      # same local-storage volume as the writer/reader services. No-op in
-      # prod where workspace storage is GCS.
-      - workspace-data:/app/autogpt_platform/backend/workspaces
     networks:
       - app-network
     logging:

--- a/autogpt_platform/docker-compose.platform.yml
+++ b/autogpt_platform/docker-compose.platform.yml
@@ -341,6 +341,12 @@ services:
       <<: *backend-env
     ports:
       - "8005:8005"
+    volumes:
+      # database_manager serves workspace file reads (e.g. the bot's
+      # fetch_workspace_artifact RPC and embedding backfill), so it needs the
+      # same local-storage volume as the writer/reader services. No-op in
+      # prod where workspace storage is GCS.
+      - workspace-data:/app/autogpt_platform/backend/workspaces
     networks:
       - app-network
     logging:


### PR DESCRIPTION
## Why

When AutoPilot produces a file in a chat (e.g. "research X and write it up to a file and send it to me"), the Discord bot was dumping the raw `workspace://<uuid>` URI into the channel — a useless, unclickable string. The user had no way to get the file without opening the web app.

## What

The bot now **downloads the file and attaches it inline** to the chat. If the file is over the platform's hard upload cap (25 MB on Discord — bots can't have Nitro), it falls back to an **"Open in AutoGPT" button** linking to the session, mirroring the existing OAuth-link-button pattern.

This works on every surface the bot replies on (DMs, threads, channels) and is platform-agnostic — Telegram/Slack adapters get it for free once they implement `send_file`.

## How

- **`platform_linking`** — new `fetch_workspace_artifact(session_id, file_id, max_bytes)` RPC on `PlatformLinkingManager`. It:
  - resolves `session → user → workspace → file`, enforcing that the file belongs to the **session's owning user**. This check is load-bearing: the LLM emits arbitrary `workspace://` URIs into untrusted chat text, so we never serve a file just because the bot claimed an ID.
  - bails out early (returns `None`) if the file is over `max_bytes`, missing, or not owned — `None` triggers the link-to-chat fallback.
  - reads bytes through the existing `WorkspaceManager` storage abstraction — GCS in prod, filesystem locally. No bespoke file handling, same path the web download uses.
- **adapters** — new `FileAttachment` dataclass + `send_file()` + `max_attachment_bytes` on the platform-agnostic `PlatformAdapter`. Discord implements `send_file` with an in-memory `discord.File(io.BytesIO(...))`.
- **handler** — peels `[name](workspace://uuid#mime)` artifact links out of the streamed text (same regex shape the frontend already uses), attaches inline when they fit, else drops the fallback button.
- **docker-compose** — mounts the shared `workspace-data` volume on `database_manager` so it can read local-storage blobs. **No-op in prod** (workspace storage is GCS there); without it the feature silently fails for every dev running local filesystem storage, because `database_manager` is where the file read executes.

### Data flow / lifecycle

Bytes stream `workspace storage → DatabaseManager → bot → Discord`, held **only in memory** the whole way. Nothing is written to the bot's disk — no temp files, no persistence. The 25 MB cap bounds memory use.

### Reviewer notes (honest tradeoffs)

- **DatabaseManager reads blob storage.** The file read runs in the DB-manager process (that's where `platform_linking_db()` resolves to). It already reads workspace files for embeddings, so it's not a new responsibility, but it's why the compose volume mount is needed. Reasonable, but flagging it openly.
- **Whole file in memory, briefly in two processes** (DB manager + bot) plus RPC serialization. Fine at 25 MB; called out so it's not a surprise.
- **Artifact detection is regex over streamed text**, not a structured stream event. Matches the frontend's own approach. A mid-stream chunk split could theoretically miss an artifact; a follow-up to emit structured artifact events would remove that fragility.

## Testing

- `handler_test.py`: artifact extraction (regex correctness, blank-line cleanup), inline-attach happy path, too-large → button, fetch-failure → button, missing-session → inline note.
- `adapter_test.py`: `send_file` attaches bytes with the display name; empty-caption collapses to `None`.
- Manually verified end-to-end on Discord: small file attaches inline; debug-lowered cap confirms the >cap fallback button.
- `pyright` clean on all changed files; black/isort/ruff applied.
