### PR TITLE
fix(backend/copilot-bot): skip messages in locked Discord threads

### DIFF
--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter.py
@@ -238,6 +238,13 @@ class DiscordAdapter(PlatformAdapter):
             if self._on_message_callback is None:
                 return
 
+            # A locked thread rejects bot sends — processing the message would
+            # just burn a turn and error on every reply. Skip until it's
+            # unlocked. (`locked` is set on archive-locked threads too.)
+            channel = message.channel
+            if isinstance(channel, discord.Thread) and channel.locked:
+                return
+
             channel_type = self._channel_type(message)
             bot_mentioned = self._is_mentioned(message)
 

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter_test.py
@@ -583,3 +583,48 @@ class TestOnThreadRemove:
         ):
             # Must not raise — cleanup is never critical-path.
             await handlers["on_thread_remove"](_thread(555))
+
+
+# ── on_message: locked threads ──────────────────────────────────────────
+
+
+class TestLockedThread:
+    @pytest.mark.asyncio
+    async def test_locked_thread_message_is_skipped(self):
+        # A locked thread rejects bot sends, so processing the message would
+        # just burn a turn and error on every reply. Bail before the handler.
+        adapter, _ = _bare_adapter(bot_id=1000)
+        callback = AsyncMock()
+        adapter.on_message(callback)
+        handlers = _register_events_with_mocked_decorator(adapter)
+
+        thread = _thread(555)
+        thread.locked = True
+        msg = MagicMock()
+        msg.author = MagicMock(id=2000, bot=False)
+        msg.channel = thread
+
+        await handlers["on_message"](msg)
+
+        callback.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_unlocked_thread_message_is_processed(self):
+        adapter, _ = _bare_adapter(bot_id=1000)
+        callback = AsyncMock()
+        adapter.on_message(callback)
+        handlers = _register_events_with_mocked_decorator(adapter)
+
+        thread = _thread(555)
+        thread.locked = False
+        msg = MagicMock()
+        msg.id = 999
+        msg.author = MagicMock(id=2000, bot=False, display_name="Bently")
+        msg.guild = MagicMock(id=111)
+        msg.channel = thread
+        msg.content = "hi"
+        msg.mentions = []
+
+        await handlers["on_message"](msg)
+
+        callback.assert_awaited_once()


### PR DESCRIPTION
## Why

When a Discord thread is **locked**, only moderators can post in it — the bot's sends are rejected. But the bot was still receiving and fully processing every message in a locked thread: it burned an AutoPilot turn per message and errored on every reply attempt, silently. Locking a thread is the natural way a user expects to make the bot stop, and it didn't work.

## What

`on_message` now bails out early when the incoming message's channel is a **locked thread**, before constructing a `MessageContext` or invoking the handler. The bot stays completely quiet in that thread until it's unlocked; an unlocked thread behaves exactly as before.

## How

- One guard in `adapters/discord/adapter.py::on_message`: `isinstance(channel, discord.Thread) and channel.locked → return`. Locked-thread is a Discord-specific concept, so the check lives in the Discord adapter rather than the platform-agnostic handler (locality rule). `Thread.locked` is also set on archive-locked threads, so those are covered too.
- Tests (`adapter_test.py::TestLockedThread`): a locked-thread message is skipped (callback not invoked); an unlocked-thread message is still processed (callback invoked). Uses the existing `_register_events_with_mocked_decorator` helper to capture and invoke the real `on_message` closure.
