### PR TITLE
feat(blocks): add variable inputs to Execute Code block

### DIFF
--- a/autogpt_platform/backend/backend/blocks/code_executor.py
+++ b/autogpt_platform/backend/backend/blocks/code_executor.py
@@ -230,7 +230,7 @@ class ExecuteCodeBlock(Block, BaseE2BExecutorMixin):
             description=(
                 "Variables defined here can be used directly in your Python or "
                 "JavaScript code. Values wired in from other blocks keep their "
-                "type; values typed directly here come in as strings, so parse "
+                "type; default values set on this node come in as strings, so parse "
                 "them in your code if you need a number or other type."
             ),
             default_factory=dict,

--- a/autogpt_platform/backend/backend/blocks/code_executor.py
+++ b/autogpt_platform/backend/backend/blocks/code_executor.py
@@ -1,4 +1,3 @@
-from enum import Enum
 from typing import TYPE_CHECKING, Any, Literal, Optional
 
 from e2b_code_interpreter import AsyncSandbox
@@ -12,6 +11,10 @@ from backend.blocks._base import (
     BlockOutput,
     BlockSchemaInput,
     BlockSchemaOutput,
+)
+from backend.blocks.code_executor_helpers import (
+    ProgrammingLanguage,
+    build_variable_injection,
 )
 from backend.data.model import (
     APIKeyCredentials,
@@ -41,14 +44,6 @@ TEST_CREDENTIALS_INPUT = {
     "type": TEST_CREDENTIALS.type,
     "title": TEST_CREDENTIALS.type,
 }
-
-
-class ProgrammingLanguage(Enum):
-    PYTHON = "python"
-    JAVASCRIPT = "js"
-    BASH = "bash"
-    R = "r"
-    JAVA = "java"
 
 
 class MainCodeExecutionResult(BaseModel):
@@ -107,6 +102,7 @@ class BaseE2BExecutorMixin:
         dispose_sandbox: bool = False,
         execution_context: Optional["ExecutionContext"] = None,
         extract_files: bool = False,
+        envs: Optional[dict[str, str]] = None,
     ):
         """
         Unified code execution method that handles all three use cases:
@@ -145,6 +141,7 @@ class BaseE2BExecutorMixin:
             execution = await sandbox.run_code(  # type: ignore[attr-defined]
                 code,
                 language=language.value,
+                envs=envs,
                 on_error=lambda e: sandbox.kill(),  # Kill the sandbox on error
             )
 
@@ -228,6 +225,18 @@ class ExecuteCodeBlock(Block, BaseE2BExecutorMixin):
             advanced=False,
         )
 
+        variables: dict[str, Any] = SchemaField(
+            title="Variables (Python/JS only)",
+            description=(
+                "Variables defined here can be used directly in your Python or "
+                "JavaScript code. Values are parsed as JSON when possible "
+                "(e.g. 42 becomes a number, true a boolean); anything else is "
+                'treated as text. Wrap in quotes to force a string (e.g. "42").'
+            ),
+            default_factory=dict,
+            advanced=False,
+        )
+
         code: str = SchemaField(
             description="Code to execute in the sandbox",
             placeholder="print('Hello, World!')",
@@ -308,7 +317,7 @@ class ExecuteCodeBlock(Block, BaseE2BExecutorMixin):
                 ("files", []),
             ],
             test_mock={
-                "execute_code": lambda api_key, code, language, template_id, setup_commands, timeout, dispose_sandbox, execution_context, extract_files: (  # noqa
+                "execute_code": lambda api_key, code, language, template_id, setup_commands, timeout, dispose_sandbox, execution_context, extract_files, envs: (  # noqa
                     [],  # results
                     "Hello World",  # text_output
                     "Hello World\n",  # stdout_logs
@@ -328,9 +337,17 @@ class ExecuteCodeBlock(Block, BaseE2BExecutorMixin):
         **kwargs,
     ) -> BlockOutput:
         try:
+            # Expose user-provided variables by passing them as a JSON env var and
+            # prepending a constant snippet that deserializes them into the runtime.
+            # Keeping the data in the env var (not the code string) avoids injection.
+            envs, prefix = build_variable_injection(
+                input_data.variables, input_data.language
+            )
+            code = prefix + input_data.code
+
             results, text_output, stdout, stderr, _, files = await self.execute_code(
                 api_key=credentials.api_key.get_secret_value(),
-                code=input_data.code,
+                code=code,
                 language=input_data.language,
                 template_id=input_data.template_id,
                 setup_commands=input_data.setup_commands,
@@ -338,6 +355,7 @@ class ExecuteCodeBlock(Block, BaseE2BExecutorMixin):
                 dispose_sandbox=input_data.dispose_sandbox,
                 execution_context=execution_context,
                 extract_files=True,
+                envs=envs,
             )
 
             # Determine result object shape & filter out empty formats

--- a/autogpt_platform/backend/backend/blocks/code_executor.py
+++ b/autogpt_platform/backend/backend/blocks/code_executor.py
@@ -229,9 +229,9 @@ class ExecuteCodeBlock(Block, BaseE2BExecutorMixin):
             title="Variables (Python/JS only)",
             description=(
                 "Variables defined here can be used directly in your Python or "
-                "JavaScript code. Values are parsed as JSON when possible "
-                "(e.g. 42 becomes a number, true a boolean); anything else is "
-                'treated as text. Wrap in quotes to force a string (e.g. "42").'
+                "JavaScript code. Values wired in from other blocks keep their "
+                "type; values typed directly here come in as strings, so parse "
+                "them in your code if you need a number or other type."
             ),
             default_factory=dict,
             advanced=False,

--- a/autogpt_platform/backend/backend/blocks/code_executor.py
+++ b/autogpt_platform/backend/backend/blocks/code_executor.py
@@ -38,6 +38,20 @@ TEST_CREDENTIALS = APIKeyCredentials(
     title="Mock E2B API key",
     expires_at=None,
 )
+
+
+def _mock_execute_code(
+    *args: Any, **kwargs: Any
+) -> tuple[list, str, str, str, str, list]:
+    """Stub for `execute_code` used by the blocks' test_mock.
+
+    Returns the (results, text, stdout, stderr, sandbox_id, files) tuple,
+    echoing back any provided `sandbox_id` so the step block's test sees it.
+    """
+    sandbox_id = kwargs.get("sandbox_id") or "sandbox_id"
+    return [], "Hello World", "Hello World\n", "", sandbox_id, []
+
+
 TEST_CREDENTIALS_INPUT = {
     "provider": TEST_CREDENTIALS.provider,
     "id": TEST_CREDENTIALS.id,
@@ -141,7 +155,7 @@ class BaseE2BExecutorMixin:
             execution = await sandbox.run_code(  # type: ignore[attr-defined]
                 code,
                 language=language.value,
-                envs=envs,
+                envs=envs or {},
                 on_error=lambda e: sandbox.kill(),  # Kill the sandbox on error
             )
 
@@ -316,16 +330,7 @@ class ExecuteCodeBlock(Block, BaseE2BExecutorMixin):
                 ("stdout_logs", "Hello World\n"),
                 ("files", []),
             ],
-            test_mock={
-                "execute_code": lambda api_key, code, language, template_id, setup_commands, timeout, dispose_sandbox, execution_context, extract_files, envs: (  # noqa
-                    [],  # results
-                    "Hello World",  # text_output
-                    "Hello World\n",  # stdout_logs
-                    "",  # stderr_logs
-                    "sandbox_id",  # sandbox_id
-                    [],  # files
-                ),
-            },
+            test_mock={"execute_code": _mock_execute_code},
         )
 
     async def run(
@@ -461,16 +466,7 @@ class InstantiateCodeSandboxBlock(Block, BaseE2BExecutorMixin):
                 ("response", "Hello World"),
                 ("stdout_logs", "Hello World\n"),
             ],
-            test_mock={
-                "execute_code": lambda api_key, code, language, template_id, setup_commands, timeout: (  # noqa
-                    [],  # results
-                    "Hello World",  # text_output
-                    "Hello World\n",  # stdout_logs
-                    "",  # stderr_logs
-                    "sandbox_id",  # sandbox_id
-                    [],  # files
-                ),
-            },
+            test_mock={"execute_code": _mock_execute_code},
         )
 
     async def run(
@@ -569,16 +565,7 @@ class ExecuteCodeStepBlock(Block, BaseE2BExecutorMixin):
                 ("response", "Hello World"),
                 ("stdout_logs", "Hello World\n"),
             ],
-            test_mock={
-                "execute_code": lambda api_key, code, language, sandbox_id, dispose_sandbox: (  # noqa
-                    [],  # results
-                    "Hello World",  # text_output
-                    "Hello World\n",  # stdout_logs
-                    "",  # stderr_logs
-                    sandbox_id,  # sandbox_id
-                    [],  # files
-                ),
-            },
+            test_mock={"execute_code": _mock_execute_code},
         )
 
     async def run(

--- a/autogpt_platform/backend/backend/blocks/code_executor_helpers.py
+++ b/autogpt_platform/backend/backend/blocks/code_executor_helpers.py
@@ -67,8 +67,23 @@ def build_variable_injection(
         )
 
     coerced = {key: _coerce_value(value) for key, value in variables.items()}
-    envs = {VARIABLES_ENV_KEY: json.dumps(coerced)}
+    try:
+        serialized = json.dumps(coerced)
+    except TypeError as e:
+        bad_keys = [k for k, v in coerced.items() if not _is_json_serializable(v)]
+        raise ValueError(
+            f"Variable value is not serializable for key(s): {', '.join(bad_keys)}"
+        ) from e
+    envs = {VARIABLES_ENV_KEY: serialized}
     return envs, prefix
+
+
+def _is_json_serializable(value: Any) -> bool:
+    try:
+        json.dumps(value)
+        return True
+    except TypeError:
+        return False
 
 
 def _coerce_value(value: Any) -> Any:

--- a/autogpt_platform/backend/backend/blocks/code_executor_helpers.py
+++ b/autogpt_platform/backend/backend/blocks/code_executor_helpers.py
@@ -8,6 +8,7 @@ principle as parameterized SQL queries.
 """
 
 import json
+import keyword
 from enum import Enum
 from typing import Any
 
@@ -22,6 +23,11 @@ class ProgrammingLanguage(Enum):
 
 # Env var name used to carry the serialized variables into the sandbox.
 VARIABLES_ENV_KEY = "AGPT_VARIABLES"
+
+# Cap the serialized payload to stay well under typical OS environment limits
+# (which range from ~128 KB to a couple MB). Keeps failures clear instead of
+# surfacing as cryptic sandbox startup errors.
+MAX_VARIABLES_PAYLOAD_BYTES = 64 * 1024
 
 
 class UnsupportedLanguageError(ValueError):
@@ -66,20 +72,55 @@ def build_variable_injection(
             "Supported languages: python, js."
         )
 
+    _validate_keys(variables)
+
     try:
         serialized = json.dumps(variables)
-    except TypeError as e:
+    except (TypeError, ValueError) as e:
         bad_keys = [k for k, v in variables.items() if not _is_json_serializable(v)]
         raise ValueError(
             f"Variable value is not serializable for key(s): {', '.join(bad_keys)}"
         ) from e
+
+    if len(serialized.encode("utf-8")) > MAX_VARIABLES_PAYLOAD_BYTES:
+        raise ValueError(
+            "Variables payload is too large "
+            f"(max {MAX_VARIABLES_PAYLOAD_BYTES // 1024} KB). "
+            "Pass large data through a file or upstream block instead."
+        )
+
     envs = {VARIABLES_ENV_KEY: serialized}
     return envs, prefix
+
+
+def _validate_keys(variables: dict[str, Any]) -> None:
+    """Reject keys that can't be used as a variable name in the sandbox.
+
+    Each key becomes a global variable, so it must be a valid identifier that
+    isn't a language keyword. Dunder names are rejected because they can shadow
+    builtins/internals, and `_agpt_`-prefixed names would collide with the
+    deserialization snippet's own imports.
+    """
+    invalid = [
+        key
+        for key in variables
+        if not key.isidentifier()
+        or keyword.iskeyword(key)
+        or key.startswith("__")
+        or key.startswith("_agpt_")
+    ]
+    if invalid:
+        raise ValueError(
+            "Invalid variable name(s): "
+            f"{', '.join(repr(k) for k in invalid)}. "
+            "Names must be valid identifiers, not language keywords, and not "
+            "start with '__' or '_agpt_'."
+        )
 
 
 def _is_json_serializable(value: Any) -> bool:
     try:
         json.dumps(value)
         return True
-    except TypeError:
+    except (TypeError, ValueError):
         return False

--- a/autogpt_platform/backend/backend/blocks/code_executor_helpers.py
+++ b/autogpt_platform/backend/backend/blocks/code_executor_helpers.py
@@ -1,0 +1,86 @@
+"""Helpers for injecting user-provided variables into sandboxed code.
+
+Strategy: serialize the variables to JSON and pass them through an environment
+variable (the data channel), then prepend a small *constant* snippet that
+deserializes that env var into named variables inside the sandbox. No user data
+ever enters the code string, so there is no code-injection surface -- the same
+principle as parameterized SQL queries.
+"""
+
+import json
+from enum import Enum
+from typing import Any
+
+
+class ProgrammingLanguage(Enum):
+    PYTHON = "python"
+    JAVASCRIPT = "js"
+    BASH = "bash"
+    R = "r"
+    JAVA = "java"
+
+
+# Env var name used to carry the serialized variables into the sandbox.
+VARIABLES_ENV_KEY = "AGPT_VARIABLES"
+
+
+class UnsupportedLanguageError(ValueError):
+    """Raised when variable injection is requested for an unsupported language."""
+
+
+# Constant prefixes. They reference only the env var (data), never user values.
+_PYTHON_PREFIX = (
+    "import json as _agpt_json, os as _agpt_os\n"
+    f'globals().update(_agpt_json.loads(_agpt_os.environ["{VARIABLES_ENV_KEY}"]))\n'
+)
+_JAVASCRIPT_PREFIX = (
+    f"Object.assign(globalThis, JSON.parse(process.env.{VARIABLES_ENV_KEY}));\n"
+)
+
+_PREFIX_BY_LANGUAGE = {
+    ProgrammingLanguage.PYTHON: _PYTHON_PREFIX,
+    ProgrammingLanguage.JAVASCRIPT: _JAVASCRIPT_PREFIX,
+}
+
+
+def build_variable_injection(
+    variables: dict[str, Any],
+    language: ProgrammingLanguage,
+) -> tuple[dict[str, str], str]:
+    """Build the env vars and code prefix needed to expose `variables`.
+
+    Returns a tuple of:
+      - envs: env-var dict to pass to the sandbox (empty if no variables)
+      - prefix: code to prepend so the variables exist as named variables
+                (empty string if no variables)
+
+    Raises UnsupportedLanguageError if `language` has no injection strategy.
+    """
+    if not variables:
+        return {}, ""
+
+    prefix = _PREFIX_BY_LANGUAGE.get(language)
+    if prefix is None:
+        raise UnsupportedLanguageError(
+            f"Variable injection is not supported for {language.value}. "
+            "Supported languages: python, js."
+        )
+
+    coerced = {key: _coerce_value(value) for key, value in variables.items()}
+    envs = {VARIABLES_ENV_KEY: json.dumps(coerced)}
+    return envs, prefix
+
+
+def _coerce_value(value: Any) -> Any:
+    """Parse a string value as JSON so types survive (42 -> int, true -> bool).
+
+    The builder's dynamic-dict widget stores every value as a string. Trying
+    json.loads recovers the intended type; values that aren't valid JSON (e.g.
+    `hello`) are kept as plain strings. Non-string values are passed through.
+    """
+    if not isinstance(value, str):
+        return value
+    try:
+        return json.loads(value)
+    except (json.JSONDecodeError, ValueError):
+        return value

--- a/autogpt_platform/backend/backend/blocks/code_executor_helpers.py
+++ b/autogpt_platform/backend/backend/blocks/code_executor_helpers.py
@@ -66,11 +66,10 @@ def build_variable_injection(
             "Supported languages: python, js."
         )
 
-    coerced = {key: _coerce_value(value) for key, value in variables.items()}
     try:
-        serialized = json.dumps(coerced)
+        serialized = json.dumps(variables)
     except TypeError as e:
-        bad_keys = [k for k, v in coerced.items() if not _is_json_serializable(v)]
+        bad_keys = [k for k, v in variables.items() if not _is_json_serializable(v)]
         raise ValueError(
             f"Variable value is not serializable for key(s): {', '.join(bad_keys)}"
         ) from e
@@ -84,18 +83,3 @@ def _is_json_serializable(value: Any) -> bool:
         return True
     except TypeError:
         return False
-
-
-def _coerce_value(value: Any) -> Any:
-    """Parse a string value as JSON so types survive (42 -> int, true -> bool).
-
-    The builder's dynamic-dict widget stores every value as a string. Trying
-    json.loads recovers the intended type; values that aren't valid JSON (e.g.
-    `hello`) are kept as plain strings. Non-string values are passed through.
-    """
-    if not isinstance(value, str):
-        return value
-    try:
-        return json.loads(value)
-    except (json.JSONDecodeError, ValueError):
-        return value

--- a/autogpt_platform/backend/backend/blocks/code_executor_test.py
+++ b/autogpt_platform/backend/backend/blocks/code_executor_test.py
@@ -76,30 +76,6 @@ class TestBuildVariableInjection:
         assert "process.env" in prefix
         assert "Blake" not in prefix
 
-    def test_string_values_are_coerced_to_json_types(self):
-        """The builder stores values as strings; valid JSON recovers the type."""
-        variables = {
-            "num": "42",
-            "flt": "3.14",
-            "flag": "true",
-            "lst": "[1, 2, 3]",
-            "obj": '{"a": 1}',
-            "text": "hello",  # not valid JSON -> stays a string
-            "empty": "",  # not valid JSON -> stays empty string
-            "quoted": '"42"',  # explicitly a string
-        }
-        envs, _ = build_variable_injection(variables, ProgrammingLanguage.PYTHON)
-        decoded = json.loads(envs[VARIABLES_ENV_KEY])
-
-        assert decoded["num"] == 42 and isinstance(decoded["num"], int)
-        assert decoded["flt"] == 3.14
-        assert decoded["flag"] is True
-        assert decoded["lst"] == [1, 2, 3]
-        assert decoded["obj"] == {"a": 1}
-        assert decoded["text"] == "hello"
-        assert decoded["empty"] == ""
-        assert decoded["quoted"] == "42" and isinstance(decoded["quoted"], str)
-
     def test_malicious_value_cannot_break_out_of_code_channel(self):
         """A value that looks like code stays inert: it's only ever JSON data."""
         variables = {"evil": "'); import os; os.system('rm -rf /'); ('"}

--- a/autogpt_platform/backend/backend/blocks/code_executor_test.py
+++ b/autogpt_platform/backend/backend/blocks/code_executor_test.py
@@ -120,6 +120,12 @@ class TestBuildVariableInjection:
         with pytest.raises(UnsupportedLanguageError):
             build_variable_injection({"x": 1}, language)
 
+    def test_non_serializable_value_raises_clear_error_with_key(self):
+        with pytest.raises(ValueError, match="bad"):
+            build_variable_injection(
+                {"ok": 1, "bad": {1, 2, 3}}, ProgrammingLanguage.PYTHON
+            )
+
 
 class TestExecuteCodeBlockRun:
     """run() should inject variables: prefix the code and pass the env var."""

--- a/autogpt_platform/backend/backend/blocks/code_executor_test.py
+++ b/autogpt_platform/backend/backend/blocks/code_executor_test.py
@@ -9,16 +9,18 @@ injection -- analogous to parameterized SQL queries.
 
 import json
 import uuid
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from backend.blocks.code_executor import (
     TEST_CREDENTIALS,
+    TEST_CREDENTIALS_INPUT,
     ExecuteCodeBlock,
     ProgrammingLanguage,
 )
 from backend.blocks.code_executor_helpers import (
+    MAX_VARIABLES_PAYLOAD_BYTES,
     VARIABLES_ENV_KEY,
     UnsupportedLanguageError,
     build_variable_injection,
@@ -38,8 +40,25 @@ def _execution_context() -> ExecutionContext:
     )
 
 
-async def _collect(agen):
-    return [item async for item in agen]
+def _make_input(**overrides) -> ExecuteCodeBlock.Input:
+    data: dict = {
+        "credentials": TEST_CREDENTIALS_INPUT,
+        "code": "print('hi')",
+        "language": ProgrammingLanguage.PYTHON.value,
+    }
+    data.update(overrides)
+    return ExecuteCodeBlock.Input.model_validate(data)
+
+
+async def _run(block: ExecuteCodeBlock, input_data: ExecuteCodeBlock.Input):
+    return [
+        item
+        async for item in block.run(
+            input_data,
+            credentials=TEST_CREDENTIALS,
+            execution_context=_execution_context(),
+        )
+    ]
 
 
 class TestBuildVariableInjection:
@@ -102,28 +121,30 @@ class TestBuildVariableInjection:
                 {"ok": 1, "bad": {1, 2, 3}}, ProgrammingLanguage.PYTHON
             )
 
+    @pytest.mark.parametrize(
+        "bad_key",
+        ["my var", "2x", "for", "__builtins__", "_agpt_json"],
+    )
+    def test_invalid_variable_names_raise(self, bad_key):
+        with pytest.raises(ValueError, match="Invalid variable name"):
+            build_variable_injection({bad_key: 1}, ProgrammingLanguage.PYTHON)
+
+    def test_oversized_payload_raises(self):
+        big = {"data": "x" * (MAX_VARIABLES_PAYLOAD_BYTES + 1)}
+        with pytest.raises(ValueError, match="too large"):
+            build_variable_injection(big, ProgrammingLanguage.PYTHON)
+
 
 class TestExecuteCodeBlockRun:
     """run() should inject variables: prefix the code and pass the env var."""
 
-    async def test_run_prefixes_code_and_passes_envs(self):
+    async def test_run_prefixes_python_code_and_passes_envs(self):
         block = ExecuteCodeBlock()
         mock = AsyncMock(return_value=([], "", "", "", "sandbox_id", []))
-        block.execute_code = mock  # type: ignore[method-assign]
-
-        input_data = ExecuteCodeBlock.Input(
-            credentials=TEST_CREDENTIALS.model_dump(),  # type: ignore[arg-type]
-            code="print(name)",
-            language=ProgrammingLanguage.PYTHON,
-            variables={"name": "blake"},
-        )
-        await _collect(
-            block.run(
-                input_data,
-                credentials=TEST_CREDENTIALS,
-                execution_context=_execution_context(),
+        with patch.object(block, "execute_code", mock):
+            await _run(
+                block, _make_input(code="print(name)", variables={"name": "blake"})
             )
-        )
 
         kwargs = mock.call_args.kwargs
         # The user's code is prefixed with the deserialize snippet.
@@ -132,23 +153,29 @@ class TestExecuteCodeBlockRun:
         # Variables travel via the env var, JSON-encoded.
         assert kwargs["envs"] == {VARIABLES_ENV_KEY: json.dumps({"name": "blake"})}
 
+    async def test_run_prefixes_javascript_code_and_passes_envs(self):
+        block = ExecuteCodeBlock()
+        mock = AsyncMock(return_value=([], "", "", "", "sandbox_id", []))
+        with patch.object(block, "execute_code", mock):
+            await _run(
+                block,
+                _make_input(
+                    code="console.log(name)",
+                    language=ProgrammingLanguage.JAVASCRIPT.value,
+                    variables={"name": "blake"},
+                ),
+            )
+
+        kwargs = mock.call_args.kwargs
+        assert kwargs["code"].endswith("console.log(name)")
+        assert "Object.assign(globalThis" in kwargs["code"]
+        assert kwargs["envs"] == {VARIABLES_ENV_KEY: json.dumps({"name": "blake"})}
+
     async def test_run_without_variables_sends_no_envs_and_unmodified_code(self):
         block = ExecuteCodeBlock()
         mock = AsyncMock(return_value=([], "", "", "", "sandbox_id", []))
-        block.execute_code = mock  # type: ignore[method-assign]
-
-        input_data = ExecuteCodeBlock.Input(
-            credentials=TEST_CREDENTIALS.model_dump(),  # type: ignore[arg-type]
-            code="print('hi')",
-            language=ProgrammingLanguage.PYTHON,
-        )
-        await _collect(
-            block.run(
-                input_data,
-                credentials=TEST_CREDENTIALS,
-                execution_context=_execution_context(),
-            )
-        )
+        with patch.object(block, "execute_code", mock):
+            await _run(block, _make_input(code="print('hi')"))
 
         kwargs = mock.call_args.kwargs
         assert kwargs["code"] == "print('hi')"
@@ -156,31 +183,20 @@ class TestExecuteCodeBlockRun:
 
     async def test_run_yields_all_outputs_when_present(self):
         block = ExecuteCodeBlock()
-        block.execute_code = AsyncMock(  # type: ignore[method-assign]
+        mock = AsyncMock(
             return_value=([], "42", "stdout text", "stderr text", "sandbox_id", [])
         )
-        # process_execution_results parses E2B-specific result objects; mock it so
+        # process_execution_results parses E2B-specific result objects; patch it so
         # this test only exercises run()'s own output-forwarding branches.
-        block.process_execution_results = lambda results: (  # type: ignore[method-assign]
-            {"text": "42"},
-            [],
-        )
-
-        input_data = ExecuteCodeBlock.Input(
-            credentials=TEST_CREDENTIALS.model_dump(),  # type: ignore[arg-type]
-            code="print(name)",
-            language=ProgrammingLanguage.PYTHON,
-            variables={"name": "blake"},
-        )
-        outputs = dict(
-            await _collect(
-                block.run(
-                    input_data,
-                    credentials=TEST_CREDENTIALS,
-                    execution_context=_execution_context(),
+        with patch.object(block, "execute_code", mock), patch.object(
+            block, "process_execution_results", return_value=({"text": "42"}, [])
+        ):
+            outputs = dict(
+                await _run(
+                    block,
+                    _make_input(code="print(name)", variables={"name": "blake"}),
                 )
             )
-        )
 
         assert outputs["main_result"] == {"text": "42"}
         assert outputs["response"] == "42"
@@ -190,21 +206,16 @@ class TestExecuteCodeBlockRun:
 
     async def test_run_unsupported_language_with_variables_yields_error(self):
         block = ExecuteCodeBlock()
-        block.execute_code = AsyncMock()  # type: ignore[method-assign]
-
-        input_data = ExecuteCodeBlock.Input(
-            credentials=TEST_CREDENTIALS.model_dump(),  # type: ignore[arg-type]
-            code="echo hi",
-            language=ProgrammingLanguage.BASH,
-            variables={"name": "blake"},
-        )
-        outputs = await _collect(
-            block.run(
-                input_data,
-                credentials=TEST_CREDENTIALS,
-                execution_context=_execution_context(),
+        mock = AsyncMock()
+        with patch.object(block, "execute_code", mock):
+            outputs = await _run(
+                block,
+                _make_input(
+                    code="echo hi",
+                    language=ProgrammingLanguage.BASH.value,
+                    variables={"name": "blake"},
+                ),
             )
-        )
 
         assert any(name == "error" for name, _ in outputs)
-        block.execute_code.assert_not_called()
+        mock.assert_not_called()

--- a/autogpt_platform/backend/backend/blocks/code_executor_test.py
+++ b/autogpt_platform/backend/backend/blocks/code_executor_test.py
@@ -1,0 +1,228 @@
+"""Tests for the Execute Code block's variable-injection helper.
+
+The helper serializes user-provided variables to JSON, passes them via an
+environment variable, and prepends a constant snippet that deserializes them
+into named variables inside the sandbox. Keeping user data in the env var (the
+data channel) rather than the code string (the code channel) avoids code
+injection -- analogous to parameterized SQL queries.
+"""
+
+import json
+import uuid
+from unittest.mock import AsyncMock
+
+import pytest
+
+from backend.blocks.code_executor import (
+    TEST_CREDENTIALS,
+    ExecuteCodeBlock,
+    ProgrammingLanguage,
+)
+from backend.blocks.code_executor_helpers import (
+    VARIABLES_ENV_KEY,
+    UnsupportedLanguageError,
+    build_variable_injection,
+)
+from backend.executor.utils import ExecutionContext
+
+
+def _execution_context() -> ExecutionContext:
+    ids = {k: str(uuid.uuid4()) for k in ("user", "graph", "exec", "node", "nexec")}
+    return ExecutionContext(
+        user_id=ids["user"],
+        graph_id=ids["graph"],
+        graph_exec_id=ids["exec"],
+        graph_version=1,
+        node_id=ids["node"],
+        node_exec_id=ids["nexec"],
+    )
+
+
+async def _collect(agen):
+    return [item async for item in agen]
+
+
+class TestBuildVariableInjection:
+    def test_empty_variables_returns_noop(self):
+        """No variables -> no env var, no prepended code (don't touch anything)."""
+        envs, prefix = build_variable_injection({}, ProgrammingLanguage.PYTHON)
+        assert envs == {}
+        assert prefix == ""
+
+    def test_python_serializes_to_env_and_unpacks_to_globals(self):
+        variables = {"x": 42, "name": "Blake", "items": [1, 2, 3]}
+        envs, prefix = build_variable_injection(variables, ProgrammingLanguage.PYTHON)
+
+        # Data travels in the env var, JSON-encoded.
+        assert envs == {VARIABLES_ENV_KEY: json.dumps(variables)}
+
+        # Prefix is constant code that reads the env var as data and unpacks it.
+        assert "json.loads" in prefix
+        assert "globals().update" in prefix
+        assert VARIABLES_ENV_KEY in prefix
+        # Crucially: no user data is embedded in the code string.
+        assert "Blake" not in prefix
+        assert "42" not in prefix
+
+    def test_javascript_serializes_to_env_and_unpacks_to_globalthis(self):
+        variables = {"x": 42, "name": "Blake"}
+        envs, prefix = build_variable_injection(
+            variables, ProgrammingLanguage.JAVASCRIPT
+        )
+
+        assert envs == {VARIABLES_ENV_KEY: json.dumps(variables)}
+        assert "JSON.parse" in prefix
+        assert "Object.assign(globalThis" in prefix
+        assert "process.env" in prefix
+        assert "Blake" not in prefix
+
+    def test_string_values_are_coerced_to_json_types(self):
+        """The builder stores values as strings; valid JSON recovers the type."""
+        variables = {
+            "num": "42",
+            "flt": "3.14",
+            "flag": "true",
+            "lst": "[1, 2, 3]",
+            "obj": '{"a": 1}',
+            "text": "hello",  # not valid JSON -> stays a string
+            "empty": "",  # not valid JSON -> stays empty string
+            "quoted": '"42"',  # explicitly a string
+        }
+        envs, _ = build_variable_injection(variables, ProgrammingLanguage.PYTHON)
+        decoded = json.loads(envs[VARIABLES_ENV_KEY])
+
+        assert decoded["num"] == 42 and isinstance(decoded["num"], int)
+        assert decoded["flt"] == 3.14
+        assert decoded["flag"] is True
+        assert decoded["lst"] == [1, 2, 3]
+        assert decoded["obj"] == {"a": 1}
+        assert decoded["text"] == "hello"
+        assert decoded["empty"] == ""
+        assert decoded["quoted"] == "42" and isinstance(decoded["quoted"], str)
+
+    def test_malicious_value_cannot_break_out_of_code_channel(self):
+        """A value that looks like code stays inert: it's only ever JSON data."""
+        variables = {"evil": "'); import os; os.system('rm -rf /'); ('"}
+        envs, prefix = build_variable_injection(variables, ProgrammingLanguage.PYTHON)
+        # The dangerous string lives only in the env payload, never in the code.
+        assert "os.system" not in prefix
+        assert envs[VARIABLES_ENV_KEY] == json.dumps(variables)
+
+    @pytest.mark.parametrize(
+        "language",
+        [
+            ProgrammingLanguage.BASH,
+            ProgrammingLanguage.R,
+            ProgrammingLanguage.JAVA,
+        ],
+    )
+    def test_unsupported_languages_raise(self, language):
+        with pytest.raises(UnsupportedLanguageError):
+            build_variable_injection({"x": 1}, language)
+
+
+class TestExecuteCodeBlockRun:
+    """run() should inject variables: prefix the code and pass the env var."""
+
+    async def test_run_prefixes_code_and_passes_envs(self):
+        block = ExecuteCodeBlock()
+        mock = AsyncMock(return_value=([], "", "", "", "sandbox_id", []))
+        block.execute_code = mock  # type: ignore[method-assign]
+
+        input_data = ExecuteCodeBlock.Input(
+            credentials=TEST_CREDENTIALS.model_dump(),  # type: ignore[arg-type]
+            code="print(name)",
+            language=ProgrammingLanguage.PYTHON,
+            variables={"name": "blake"},
+        )
+        await _collect(
+            block.run(
+                input_data,
+                credentials=TEST_CREDENTIALS,
+                execution_context=_execution_context(),
+            )
+        )
+
+        kwargs = mock.call_args.kwargs
+        # The user's code is prefixed with the deserialize snippet.
+        assert kwargs["code"].endswith("print(name)")
+        assert "globals().update" in kwargs["code"]
+        # Variables travel via the env var, JSON-encoded.
+        assert kwargs["envs"] == {VARIABLES_ENV_KEY: json.dumps({"name": "blake"})}
+
+    async def test_run_without_variables_sends_no_envs_and_unmodified_code(self):
+        block = ExecuteCodeBlock()
+        mock = AsyncMock(return_value=([], "", "", "", "sandbox_id", []))
+        block.execute_code = mock  # type: ignore[method-assign]
+
+        input_data = ExecuteCodeBlock.Input(
+            credentials=TEST_CREDENTIALS.model_dump(),  # type: ignore[arg-type]
+            code="print('hi')",
+            language=ProgrammingLanguage.PYTHON,
+        )
+        await _collect(
+            block.run(
+                input_data,
+                credentials=TEST_CREDENTIALS,
+                execution_context=_execution_context(),
+            )
+        )
+
+        kwargs = mock.call_args.kwargs
+        assert kwargs["code"] == "print('hi')"
+        assert kwargs["envs"] == {}
+
+    async def test_run_yields_all_outputs_when_present(self):
+        block = ExecuteCodeBlock()
+        block.execute_code = AsyncMock(  # type: ignore[method-assign]
+            return_value=([], "42", "stdout text", "stderr text", "sandbox_id", [])
+        )
+        # process_execution_results parses E2B-specific result objects; mock it so
+        # this test only exercises run()'s own output-forwarding branches.
+        block.process_execution_results = lambda results: (  # type: ignore[method-assign]
+            {"text": "42"},
+            [],
+        )
+
+        input_data = ExecuteCodeBlock.Input(
+            credentials=TEST_CREDENTIALS.model_dump(),  # type: ignore[arg-type]
+            code="print(name)",
+            language=ProgrammingLanguage.PYTHON,
+            variables={"name": "blake"},
+        )
+        outputs = dict(
+            await _collect(
+                block.run(
+                    input_data,
+                    credentials=TEST_CREDENTIALS,
+                    execution_context=_execution_context(),
+                )
+            )
+        )
+
+        assert outputs["main_result"] == {"text": "42"}
+        assert outputs["response"] == "42"
+        assert outputs["stdout_logs"] == "stdout text"
+        assert outputs["stderr_logs"] == "stderr text"
+        assert outputs["files"] == []
+
+    async def test_run_unsupported_language_with_variables_yields_error(self):
+        block = ExecuteCodeBlock()
+        block.execute_code = AsyncMock()  # type: ignore[method-assign]
+
+        input_data = ExecuteCodeBlock.Input(
+            credentials=TEST_CREDENTIALS.model_dump(),  # type: ignore[arg-type]
+            code="echo hi",
+            language=ProgrammingLanguage.BASH,
+            variables={"name": "blake"},
+        )
+        outputs = await _collect(
+            block.run(
+                input_data,
+                credentials=TEST_CREDENTIALS,
+                execution_context=_execution_context(),
+            )
+        )
+
+        assert any(name == "error" for name, _ in outputs)
+        block.execute_code.assert_not_called()

--- a/docs/integrations/block-integrations/misc.md
+++ b/docs/integrations/block-integrations/misc.md
@@ -247,7 +247,7 @@ The sandbox includes pip and npm pre-installed. Set timeout to limit execution t
 | Input | Description | Type | Required |
 |-------|-------------|------|----------|
 | setup_commands | Shell commands to set up the sandbox before running the code. You can use `curl` or `git` to install your desired Debian based package manager. `pip` and `npm` are pre-installed.  These commands are executed with `sh`, in the foreground. | List[str] | No |
-| variables | Variables defined here can be used directly in your Python or JavaScript code. Values wired in from other blocks keep their type; values typed directly here come in as strings, so parse them in your code if you need a number or other type. | Dict[str, Any] | No |
+| variables | Variables defined here can be used directly in your Python or JavaScript code. Values wired in from other blocks keep their type; default values set on this node come in as strings, so parse them in your code if you need a number or other type. | Dict[str, Any] | No |
 | code | Code to execute in the sandbox | str | No |
 | language | Programming language to execute | "python" \| "js" \| "bash" \| "r" \| "java" | No |
 | timeout | Execution timeout in seconds | int | No |

--- a/docs/integrations/block-integrations/misc.md
+++ b/docs/integrations/block-integrations/misc.md
@@ -247,7 +247,7 @@ The sandbox includes pip and npm pre-installed. Set timeout to limit execution t
 | Input | Description | Type | Required |
 |-------|-------------|------|----------|
 | setup_commands | Shell commands to set up the sandbox before running the code. You can use `curl` or `git` to install your desired Debian based package manager. `pip` and `npm` are pre-installed.  These commands are executed with `sh`, in the foreground. | List[str] | No |
-| variables | Variables defined here can be used directly in your Python or JavaScript code. Values are parsed as JSON when possible (e.g. 42 becomes a number, true a boolean); anything else is treated as text. Wrap in quotes to force a string (e.g. "42"). | Dict[str, Any] | No |
+| variables | Variables defined here can be used directly in your Python or JavaScript code. Values wired in from other blocks keep their type; values typed directly here come in as strings, so parse them in your code if you need a number or other type. | Dict[str, Any] | No |
 | code | Code to execute in the sandbox | str | No |
 | language | Programming language to execute | "python" \| "js" \| "bash" \| "r" \| "java" | No |
 | timeout | Execution timeout in seconds | int | No |

--- a/docs/integrations/block-integrations/misc.md
+++ b/docs/integrations/block-integrations/misc.md
@@ -247,6 +247,7 @@ The sandbox includes pip and npm pre-installed. Set timeout to limit execution t
 | Input | Description | Type | Required |
 |-------|-------------|------|----------|
 | setup_commands | Shell commands to set up the sandbox before running the code. You can use `curl` or `git` to install your desired Debian based package manager. `pip` and `npm` are pre-installed.  These commands are executed with `sh`, in the foreground. | List[str] | No |
+| variables | Variables defined here can be used directly in your Python or JavaScript code. Values are parsed as JSON when possible (e.g. 42 becomes a number, true a boolean); anything else is treated as text. Wrap in quotes to force a string (e.g. "42"). | Dict[str, Any] | No |
 | code | Code to execute in the sandbox | str | No |
 | language | Programming language to execute | "python" \| "js" \| "bash" \| "r" \| "java" | No |
 | timeout | Execution timeout in seconds | int | No |


### PR DESCRIPTION
### Why / What / How

Closes #13286

Right now there's no way to get data into an Execute Code block directly. If you want to use some upstream data in your code, you have to route it through other blocks first, usually something like convert to string, then fill text template, then feed that into the code field. It's clunky, and it pushes AutoPilot into using AI blocks in a use case where LLMs are genuinely wasteful. 

This PR adds a variables field to the block. The values get passed to the sandbox as a JSON env var, and a small fixed snippet prepended to the code reads them back out into named variables (globals().update(...) in Python, Object.assign(globalThis, ...) in JS). The snippet is constant, so user data only ever rides in the env var, never in the code string. Values wired in from other blocks keep their type, and default values set on the node come in as strings, so you parse them in your code if you need a number or other type.

### Changes 🏗️

- code_executor.py: added the variables field to ExecuteCodeBlock.Input (above code).  run() now builds the env var and prefix from the helper and prepends the snippet to the code. Added an envs arg to execute_code that gets passed through to sandbox.run_code. Only ExecuteCodeBlock uses this; the other two code blocks are untouched.

- code_executor_helpers.py (new): build_variable_injection() does the serialization, the per-language prefix, and the unsupported-language check. Also moved ProgrammingLanguage here because the helper needs it and the block needs the helper, which was a circular import. It's re-exported from code_executor.py so nothing else breaks.

- code_executor_test.py (new): covers the helper (both language prefixes, a malicious value staying inert, unsupported languages raising) and run() (prefixing the code, passing envs, doing nothing when there are no variables, erroring on an unsupported language with variables set).

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Add an Execute Code block set to `Python`, set a variable `name` = `World`, run `print(f"Hello {name}")`, confirm it outputs `Hello World`
  - [x] Wire an upstream block's numeric output into a variable `x`, run `print(x + 1)`, confirm the number flows through with its type intact
  - [x] Switch to JavaScript, variable `name` = `World`, run ``console.log(`Hello ${name}`)``, confirm `Hello World`
  - [x] Set the block to Bash with a variable set, confirm it errors out due to Bash being an unsupported language for variables.
  - [x] confirm code in other languages still runs when no variables are defined on the block.



#### For configuration changes:
No configuration changes

<img width="1437" height="1560" alt="image" src="https://github.com/user-attachments/assets/f96fa5d8-e74d-4368-b464-0324bee1c498" />
