### PR TITLE
feat(frontend): move chat source icon beside timestamp and desaturate it

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatOriginIcon/ChatOriginIcon.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatOriginIcon/ChatOriginIcon.tsx
@@ -16,16 +16,16 @@ export function ChatOriginIcon({ sourcePlatform }: Props) {
 
   return (
     <span
-      className="inline-flex size-4 shrink-0 items-center justify-center"
+      className="inline-flex size-3.5 shrink-0 items-center justify-center"
       title={`From ${logo.name}`}
     >
       <Image
         src={logo.src}
         alt={logo.name}
-        width={16}
-        height={16}
+        width={14}
+        height={14}
         loading="lazy"
-        className="size-4 object-contain"
+        className="size-3.5 object-contain opacity-80 grayscale"
         onError={() => setBrokenSrc(logo.src)}
       />
     </span>

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatSessionBlock/ChatSessionBlock.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatSessionBlock/ChatSessionBlock.tsx
@@ -64,7 +64,6 @@ export function ChatSessionBlock({
     <div
       className={cn("flex min-w-0 max-w-full items-center gap-2", className)}
     >
-      <ChatOriginIcon sourcePlatform={sourcePlatform} />
       <div className="min-w-0 flex-1">
         <div className="flex min-w-0 items-center">
           <Text
@@ -77,9 +76,12 @@ export function ChatSessionBlock({
             {titleContent || displayTitle}
           </Text>
         </div>
-        <Text variant="small" className="text-neutral-400">
-          {formatDate(updatedAt)}
-        </Text>
+        <div className="flex items-center gap-1.5">
+          <Text variant="small" className="text-neutral-400">
+            {formatDate(updatedAt)}
+          </Text>
+          <ChatOriginIcon sourcePlatform={sourcePlatform} />
+        </div>
       </div>
       {chatStatus === "running" ? (
         <span


### PR DESCRIPTION
### Why / What / How

**Why:** In the Copilot chat sidebar, each session shows where the chat originated (Discord, Slack, Telegram, etc.). The origin logo was placed to the left of the chat title in full brand color, which pulled attention away from the title and clashed with the otherwise neutral, monochrome list styling.

**What:** Move the source/origin icon from the left of the title to the right of the timestamp (below the title), and render it in black & white instead of full color.

**How:**
- `ChatSessionBlock.tsx` — `<ChatOriginIcon>` no longer renders before the title. It now sits inline next to the date in a `flex items-center gap-1.5` row below the title.
- `ChatOriginIcon.tsx` — the brand PNG is desaturated with `grayscale` and dimmed with `opacity-80` so it reads as a muted glyph next to the `neutral-400` timestamp. Icon shrunk from `size-4` → `size-3.5` to pair visually with the small date text.

Kept the existing `<Image>`-based approach (rather than swapping to Phosphor brand icons) because Phosphor has no Linear logo — Linear is a valid `source_platform` — and the sidebar test asserts the logo via `alt` text. Grayscale covers all 7 platforms (Discord, Slack, Telegram, Teams, WhatsApp, GitHub, Linear) uniformly.

### Changes 🏗️

- Relocate chat origin icon to the right of the session timestamp (below the title).
- Render the origin icon in grayscale at 80% opacity, sized `3.5`.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [ ] Open the Copilot chat sidebar and confirm sessions from an external platform show the origin icon to the right of the timestamp, below the title
  - [ ] Confirm the icon renders in black & white (not full color)
  - [ ] Confirm a native Copilot chat (no source platform) shows no origin icon
  - [ ] Verify the same in the mobile drawer
