### PR TITLE
fix(frontend): route paywall logout through shared /logout page

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/PaywallGate/PaywallGate.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/PaywallGate/PaywallGate.tsx
@@ -5,6 +5,7 @@ import { usePathname } from "next/navigation";
 import { useGetSubscriptionStatus } from "@/app/api/__generated__/endpoints/credits/credits";
 import { Flag, useGetFlag } from "@/services/feature-flags/use-get-flag";
 import { environment } from "@/services/environment";
+import { useSupabase } from "@/lib/supabase/hooks/useSupabase";
 import { PaywallModal } from "./PaywallModal";
 
 // Routes that bypass the paywall regardless of subscription state — primarily
@@ -25,6 +26,7 @@ const PAYWALL_EXEMPT_PREFIXES = [
 
 export function PaywallGate({ children }: { children: ReactNode }) {
   const pathname = usePathname();
+  const { isLoggedIn } = useSupabase();
   const isPaymentEnabled = useGetFlag(Flag.ENABLE_PLATFORM_PAYMENT);
   const { data: subscription, isLoading } = useGetSubscriptionStatus({
     query: {
@@ -44,6 +46,10 @@ export function PaywallGate({ children }: { children: ReactNode }) {
   // change land on NO_TIER (the explicit "no active subscription" state).
   const shouldGate =
     !!isPaymentEnabled &&
+    // Never gate a logged-out user — they're on their way to /login (e.g. via
+    // the modal's own Log out button), and the modal must not linger or block
+    // that exit.
+    isLoggedIn &&
     !isLoading &&
     !isExempt &&
     // Never gate local dev — running the stack locally shouldn't require a

--- a/autogpt_platform/frontend/src/app/(platform)/PaywallGate/__tests__/PaywallGate.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/PaywallGate/__tests__/PaywallGate.test.tsx
@@ -8,6 +8,12 @@ vi.mock("next/navigation", () => ({
   useRouter: () => ({ replace: vi.fn() }),
 }));
 
+// Mock the auth hook — toggle logged-in vs logged-out per test.
+let mockIsLoggedIn = true;
+vi.mock("@/lib/supabase/hooks/useSupabase", () => ({
+  useSupabase: () => ({ isLoggedIn: mockIsLoggedIn }),
+}));
+
 // Mock the LD flag hook — toggle paid-cohort vs beta-cohort per test.
 let mockIsPaymentEnabled: boolean | undefined = false;
 vi.mock("@/services/feature-flags/use-get-flag", () => ({
@@ -45,6 +51,7 @@ import { PaywallGate } from "../PaywallGate";
 describe("PaywallGate", () => {
   beforeEach(() => {
     mockPathname = "/build";
+    mockIsLoggedIn = true;
     mockIsPaymentEnabled = false;
     mockSubscriptionResult = { data: null, isLoading: false };
     mockIsLocal = false;
@@ -72,6 +79,19 @@ describe("PaywallGate", () => {
     );
     expect(screen.getByText("protected")).toBeDefined();
     expect(screen.getByTestId("paywall-modal")).toBeDefined();
+  });
+
+  it("does not render modal once the user is logged out, even when paid cohort + tier is NO_TIER", () => {
+    mockIsPaymentEnabled = true;
+    mockIsLoggedIn = false;
+    mockSubscriptionResult = { data: { tier: "NO_TIER" }, isLoading: false };
+    render(
+      <PaywallGate>
+        <div>protected</div>
+      </PaywallGate>,
+    );
+    expect(screen.getByText("protected")).toBeDefined();
+    expect(screen.queryByTestId("paywall-modal")).toBeNull();
   });
 
   it("does not render modal in local dev even when paid cohort + tier is NO_TIER", () => {

--- a/autogpt_platform/frontend/src/app/(platform)/PaywallGate/__tests__/PaywallModal.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/PaywallGate/__tests__/PaywallModal.test.tsx
@@ -39,9 +39,19 @@ vi.mock("@/components/molecules/Dialog/Dialog", () => ({
   Dialog: MockDialog,
 }));
 
-const mockLogOut = vi.fn();
-vi.mock("@/lib/supabase/hooks/useSupabase", () => ({
-  useSupabase: () => ({ logOut: mockLogOut }),
+const mockReplace = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: mockReplace,
+    prefetch: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    refresh: vi.fn(),
+  }),
+  usePathname: () => "/build",
+  useSearchParams: () => new URLSearchParams(),
+  useParams: () => ({}),
 }));
 
 import { PaywallModal } from "../PaywallModal";
@@ -137,7 +147,7 @@ describe("PaywallModal — dynamic plan rendering", () => {
 });
 
 describe("PaywallModal — logout", () => {
-  it("logs out when the Log out button is clicked", () => {
+  it("routes to the shared /logout page when the Log out button is clicked", () => {
     setupMocks({
       subscription: { tier: "NO_TIER", tier_costs: { PRO: 5000 } },
     });
@@ -146,7 +156,7 @@ describe("PaywallModal — logout", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /log out/i }));
 
-    expect(mockLogOut).toHaveBeenCalled();
+    expect(mockReplace).toHaveBeenCalledWith("/logout");
   });
 });
 

--- a/autogpt_platform/frontend/src/app/(platform)/PaywallGate/usePaywallModal.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/PaywallGate/usePaywallModal.ts
@@ -1,12 +1,12 @@
 "use client";
 
 import { useState } from "react";
+import { useRouter } from "next/navigation";
 import {
   useGetSubscriptionStatus,
   useUpdateSubscriptionTier,
 } from "@/app/api/__generated__/endpoints/credits/credits";
 import type { SubscriptionTierRequestTier } from "@/app/api/__generated__/models/subscriptionTierRequestTier";
-import { useSupabase } from "@/lib/supabase/hooks/useSupabase";
 import { toast } from "@/components/molecules/Toast/use-toast";
 import { COUNTRIES } from "@/components/molecules/PlanCard/countries";
 import {
@@ -55,7 +55,7 @@ export function usePaywallModal() {
     query: { select: (res) => (res.status === 200 ? res.data : null) },
   });
   const { mutateAsync: updateTier, isPending } = useUpdateSubscriptionTier();
-  const { logOut } = useSupabase();
+  const router = useRouter();
   const [selectedCycle, setSelectedCycle] = useState<"monthly" | "yearly">(
     "yearly",
   );
@@ -140,8 +140,12 @@ export function usePaywallModal() {
     setPendingTier(null);
   }
 
+  // Route through the shared /logout page (same path the Navbar uses) rather
+  // than calling logOut() inline: it runs the full sign-out, then redirects to
+  // /login. Navigating away also unmounts this modal — without the redirect the
+  // user would be left logged-out but stranded behind the paywall.
   function handleLogout() {
-    void logOut();
+    router.replace("/logout");
   }
 
   const pendingTierLabel = pendingTier


### PR DESCRIPTION
### Why / What / How

**Why:** The non-dismissable paywall modal (`PaywallGate` → `PaywallModal`, shown to `NO_TIER` users) had a broken "Log out" button. It called `useSupabase().logOut()` inline, which signs the user out on the server/client **but never navigates**. The user was left logged-out while still sitting on a protected `(platform)` route, behind the modal — effectively stuck. The Navbar's "Log out" does this correctly: `router.replace("/logout")`, which runs the full sign-out flow and then redirects to `/login`.

**What:** Make the paywall logout use the **same mechanism as the Navbar**, and make sure the modal can never linger once the session is gone.

**How:**
- `usePaywallModal.handleLogout` now does `router.replace("/logout")` — the exact path the Navbar's `AccountLogoutOption` uses. The shared `(no-navbar)/logout` page runs `logOut()` and redirects to `/login`. Because `/logout` lives outside the `(platform)` layout, navigating there also unmounts `PaywallGate`, so the modal disappears immediately.
- `PaywallGate` now also guards on `isLoggedIn` (via `useSupabase`). Defense-in-depth: even if a stale/cross-tab subscription result reports `NO_TIER`, the modal will not render for a logged-out user.

### Changes 🏗️

- `usePaywallModal.ts`: replace inline `logOut()` with `router.replace("/logout")`; drop the now-unused `useSupabase` import, add `useRouter`.
- `PaywallGate.tsx`: add `isLoggedIn` to the `shouldGate` condition so the modal never shows for logged-out users.
- `__tests__/PaywallModal.test.tsx`: logout test now asserts `router.replace("/logout")`.
- `__tests__/PaywallGate.test.tsx`: add a case asserting the modal does not render once logged out (paid cohort + `NO_TIER`).

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Unit: `pnpm vitest run` on both PaywallGate test files — 24/24 pass
  - [x] `pnpm types` and `pnpm lint` clean (no new issues in changed files)
  - [ ] Manual: as a `NO_TIER` user with the paywall modal up, click **Log out** → lands on `/logout` spinner → redirected to `/login`; modal does not reappear

🤖 Generated with [Claude Code](https://claude.com/claude-code)
