### PR TITLE
ci(frontend): make Playwright auth seeding resilient to CI contention

### DIFF
--- a/autogpt_platform/frontend/src/playwright/utils/auth.ts
+++ b/autogpt_platform/frontend/src/playwright/utils/auth.ts
@@ -228,7 +228,46 @@ export async function getInvalidSeededAuthStateKeys(
   );
 }
 
+// Seed logins are retried because the /login form is gated behind client
+// hydration + a getCurrentUser() round-trip; on constrained CI runners a single
+// attempt occasionally exceeds the form timeout. Without a retry one slow login
+// fails the whole suite, since global setup is not covered by Playwright's
+// `retries`.
+const AUTH_SETUP_MAX_ATTEMPTS = 3;
+
+// Cap how many seed logins run at once. Logging in every account in parallel
+// overwhelms the frontend + auth service on a 2-vCPU runner, which is what
+// pushed the form render past its timeout to begin with.
+const AUTH_SETUP_CONCURRENCY = 2;
+
 async function createAuthStateForUser(
+  baseURL: string,
+  accountKey: (typeof AUTH_STATE_KEYS)[number],
+): Promise<void> {
+  const { email } = SEEDED_TEST_ACCOUNTS[accountKey];
+
+  for (let attempt = 1; attempt <= AUTH_SETUP_MAX_ATTEMPTS; attempt += 1) {
+    try {
+      await attemptCreateAuthState(baseURL, accountKey);
+      return;
+    } catch (error) {
+      if (attempt === AUTH_SETUP_MAX_ATTEMPTS) {
+        throw new Error(
+          `Failed to create auth state for ${email} after ${AUTH_SETUP_MAX_ATTEMPTS} attempts: ${String(
+            error,
+          )}. If these seeded QA accounts are missing, seed them with backend/test/e2e_test_data.py before running Playwright.`,
+        );
+      }
+      console.warn(
+        `⚠️ Auth state seeding for ${email} failed on attempt ${attempt}/${AUTH_SETUP_MAX_ATTEMPTS}, retrying: ${String(
+          error,
+        )}`,
+      );
+    }
+  }
+}
+
+async function attemptCreateAuthState(
   baseURL: string,
   accountKey: (typeof AUTH_STATE_KEYS)[number],
 ): Promise<void> {
@@ -261,13 +300,6 @@ async function createAuthStateForUser(
     fs.mkdirSync(path.dirname(statePath), { recursive: true });
     await context.storageState({ path: statePath });
     await context.close();
-  } catch (error) {
-    const { email } = SEEDED_TEST_ACCOUNTS[accountKey];
-    throw new Error(
-      `Failed to create auth state for ${email}: ${String(
-        error,
-      )}. If these seeded QA accounts are missing, seed them with backend/test/e2e_test_data.py before running Playwright.`,
-    );
   } finally {
     await browser.close();
   }
@@ -276,9 +308,44 @@ async function createAuthStateForUser(
 export async function ensureSeededAuthStates(baseURL: string): Promise<void> {
   const invalidKeys = await getInvalidSeededAuthStateKeys(baseURL);
 
-  await Promise.all(
-    invalidKeys.map((accountKey) =>
-      createAuthStateForUser(baseURL, accountKey),
-    ),
+  const results = await mapWithConcurrency(
+    invalidKeys,
+    AUTH_SETUP_CONCURRENCY,
+    (accountKey) => createAuthStateForUser(baseURL, accountKey),
   );
+
+  const firstFailure = results.find(
+    (result): result is PromiseRejectedResult => result.status === "rejected",
+  );
+  if (firstFailure) {
+    throw firstFailure.reason;
+  }
+}
+
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  limit: number,
+  task: (item: T) => Promise<R>,
+): Promise<PromiseSettledResult<R>[]> {
+  const results: PromiseSettledResult<R>[] = new Array(items.length);
+  let cursor = 0;
+
+  async function worker(): Promise<void> {
+    while (cursor < items.length) {
+      const index = cursor;
+      cursor += 1;
+      try {
+        results[index] = {
+          status: "fulfilled",
+          value: await task(items[index]),
+        };
+      } catch (reason) {
+        results[index] = { status: "rejected", reason };
+      }
+    }
+  }
+
+  const workerCount = Math.max(1, Math.min(limit, items.length));
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+  return results;
 }


### PR DESCRIPTION
### Why / What / How

**Why:** The `end-to-end tests` job has been failing/flaky across many unrelated PRs since ~2026-06-05. The failure is in Playwright **global setup**, not in any test — the report shows `Tests: 0`. Global setup seeds auth state by logging into 6 seeded QA accounts in parallel; one login intermittently times out waiting for the `/login` form to render (`waiting for locator('form')`, 30s default). Because global setup is **not** covered by Playwright's `retries` and uses a fail-fast `Promise.all`, a single slow login aborts the entire suite. Bisection showed no code change introduced this — the trigger was a CI runner capacity shift on 2026-06-05 — but the setup was already fragile: 6 concurrent cold logins on a 2-vCPU runner, where the form only renders after client hydration + a `getCurrentUser()` round-trip.

**What:** Make the seeded auth-state setup resilient to transient CI contention, without masking genuinely slow logins.

**How:**
- **Cap concurrency 6 → 2** via a small `mapWithConcurrency` worker pool, removing the contention that pushed the form render past its timeout in the first place.
- **Retry each login up to 3×**, each attempt with a fresh browser/context (no stuck-state carryover). Each attempt keeps the **original 30s** `waitForSelector("form")` — a login that consistently takes ≥30s still exhausts its retries and fails, by design. The retry only rescues transient one-off blips.

### Changes 🏗️

- `autogpt_platform/frontend/src/playwright/utils/auth.ts`:
  - Split the single-attempt seeding body into `attemptCreateAuthState`; `createAuthStateForUser` now wraps it in a 3-attempt retry loop and only throws (with the original "seed with e2e_test_data.py" hint) after all attempts fail.
  - `ensureSeededAuthStates` now runs logins through a `mapWithConcurrency` pool (limit 2) instead of `Promise.all`, and rethrows the first failure.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  <!-- This is test-only infra; the full Playwright suite requires the docker stack and is exercised by this PR's own CI. -->
  - [x] `end-to-end tests` CI job passes on this PR
  - [x] Re-run the `end-to-end tests` job several times to confirm global setup no longer flakes (the bug reproduces intermittently, so a single green run is not sufficient)