### PR TITLE
fix(frontend/copilot): pair tool calls to outputs by position

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/copilot/helpers/__tests__/convertChatSessionToUiMessages.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/helpers/__tests__/convertChatSessionToUiMessages.test.ts
@@ -278,6 +278,272 @@ describe("convertChatSessionMessagesToUiMessages", () => {
     const mergedId = result.messages[1].id;
     expect(result.stats.get(mergedId)?.createdAt).toBe(later);
   });
+
+  // ----------------------------------------------------------------- //
+  //  Tool-call → tool-result pairing (#13306)                          //
+  // ----------------------------------------------------------------- //
+  //
+  // The LLM provider does NOT guarantee globally-unique tool_call_ids
+  // across multiple turns of the same session — only within one
+  // completions response.  When a duplicate id reappears in a later
+  // turn, naive id-keyed pairing collapses both occurrences onto the
+  // last tool message and the earlier assistant tool call ends up
+  // displaying the WRONG output (issue #13306: "tool call descriptions
+  // and result pairings are getting mixed up").  Pairing must be
+  // position-aware: each assistant tool_call slot is filled by the
+  // NEAREST FOLLOWING tool message with the matching id, and once
+  // filled it cannot be re-bound to a later tool message of the same
+  // id.
+
+  it("pairs duplicate tool_call_ids by position so each assistant tool call gets its own output", () => {
+    // Two distinct turns (user message between them) where the LLM
+    // happens to reuse "call_dup" for an unrelated web_search call in
+    // the second turn.  Pre-fix, both assistant messages received the
+    // SAME (last-wins) output because the helper keyed on tool_call_id
+    // alone.  Post-fix, each assistant call binds to its own slot.
+    const result = convertChatSessionMessagesToUiMessages(
+      SESSION_ID,
+      [
+        { role: "user", content: "search foo", sequence: 0 },
+        {
+          role: "assistant",
+          content: null,
+          sequence: 1,
+          tool_calls: [
+            {
+              id: "call_dup",
+              type: "function",
+              function: {
+                name: "web_search",
+                arguments: JSON.stringify({ query: "foo" }),
+              },
+            },
+          ],
+        },
+        {
+          role: "tool",
+          tool_call_id: "call_dup",
+          content: JSON.stringify({ results: [{ title: "foo result" }] }),
+          sequence: 2,
+        },
+        { role: "user", content: "now search bar", sequence: 3 },
+        {
+          role: "assistant",
+          content: null,
+          sequence: 4,
+          tool_calls: [
+            {
+              id: "call_dup",
+              type: "function",
+              function: {
+                name: "web_search",
+                arguments: JSON.stringify({ query: "bar" }),
+              },
+            },
+          ],
+        },
+        {
+          role: "tool",
+          tool_call_id: "call_dup",
+          content: JSON.stringify({ results: [{ title: "bar result" }] }),
+          sequence: 5,
+        },
+      ],
+      { isComplete: true },
+    );
+
+    // user, assistant(foo), user, assistant(bar)
+    expect(result.messages).toHaveLength(4);
+
+    const firstToolPart = result.messages[1].parts.find((p) =>
+      p.type.startsWith("tool-"),
+    );
+    const secondToolPart = result.messages[3].parts.find((p) =>
+      p.type.startsWith("tool-"),
+    );
+    expect(firstToolPart).toBeDefined();
+    expect(secondToolPart).toBeDefined();
+    expect(firstToolPart).toMatchObject({
+      type: "tool-web_search",
+      input: { query: "foo" },
+      output: { results: [{ title: "foo result" }] },
+    });
+    expect(secondToolPart).toMatchObject({
+      type: "tool-web_search",
+      input: { query: "bar" },
+      output: { results: [{ title: "bar result" }] },
+    });
+  });
+
+  it("preserves pairing when multiple tool_calls in the same assistant message share an id with later calls", () => {
+    const result = convertChatSessionMessagesToUiMessages(
+      SESSION_ID,
+      [
+        { role: "user", content: "do two things", sequence: 0 },
+        {
+          role: "assistant",
+          content: null,
+          sequence: 1,
+          tool_calls: [
+            {
+              id: "call_a",
+              type: "function",
+              function: {
+                name: "web_search",
+                arguments: JSON.stringify({ query: "alpha" }),
+              },
+            },
+            {
+              id: "call_b",
+              type: "function",
+              function: {
+                name: "web_search",
+                arguments: JSON.stringify({ query: "beta" }),
+              },
+            },
+          ],
+        },
+        {
+          role: "tool",
+          tool_call_id: "call_a",
+          content: JSON.stringify({ results: [{ title: "alpha result" }] }),
+          sequence: 2,
+        },
+        {
+          role: "tool",
+          tool_call_id: "call_b",
+          content: JSON.stringify({ results: [{ title: "beta result" }] }),
+          sequence: 3,
+        },
+        { role: "user", content: "do alpha again", sequence: 4 },
+        {
+          role: "assistant",
+          content: null,
+          sequence: 5,
+          tool_calls: [
+            {
+              id: "call_a",
+              type: "function",
+              function: {
+                name: "web_search",
+                arguments: JSON.stringify({ query: "alpha-again" }),
+              },
+            },
+          ],
+        },
+        {
+          role: "tool",
+          tool_call_id: "call_a",
+          content: JSON.stringify({
+            results: [{ title: "alpha-again result" }],
+          }),
+          sequence: 6,
+        },
+      ],
+      { isComplete: true },
+    );
+
+    // user, assistant(2 calls), user, assistant(1 call)
+    expect(result.messages).toHaveLength(4);
+    const firstAssistantParts = result.messages[1].parts.filter((p) =>
+      p.type.startsWith("tool-"),
+    );
+    const secondAssistantParts = result.messages[3].parts.filter((p) =>
+      p.type.startsWith("tool-"),
+    );
+
+    expect(firstAssistantParts).toHaveLength(2);
+    expect(firstAssistantParts[0]).toMatchObject({
+      input: { query: "alpha" },
+      output: { results: [{ title: "alpha result" }] },
+    });
+    expect(firstAssistantParts[1]).toMatchObject({
+      input: { query: "beta" },
+      output: { results: [{ title: "beta result" }] },
+    });
+
+    expect(secondAssistantParts).toHaveLength(1);
+    expect(secondAssistantParts[0]).toMatchObject({
+      input: { query: "alpha-again" },
+      output: { results: [{ title: "alpha-again result" }] },
+    });
+  });
+
+  it("uses extraToolOutputs only for the FIRST unfilled slot when an id reappears later in the same page", () => {
+    // Cross-page handoff: tool message for an assistant call landed on
+    // an adjacent page and is passed in via extraToolOutputs keyed by
+    // tool_call_id.  If the same id is reused later in the current
+    // page, the cross-page output must attach to the FIRST assistant
+    // call (oldest slot) and the in-page tool message attaches to the
+    // later one.  Without slot-based pairing, the cross-page seed
+    // would clobber the in-page output (or vice versa) and one of the
+    // assistant cards would render with the wrong results.
+    const cross = new Map<string, unknown>([
+      ["call_dup", JSON.stringify({ results: [{ title: "from-other-page" }] })],
+    ]);
+
+    const result = convertChatSessionMessagesToUiMessages(
+      SESSION_ID,
+      [
+        { role: "user", content: "first", sequence: 10 },
+        {
+          role: "assistant",
+          content: null,
+          sequence: 11,
+          tool_calls: [
+            {
+              id: "call_dup",
+              type: "function",
+              function: {
+                name: "web_search",
+                arguments: JSON.stringify({ query: "first-call" }),
+              },
+            },
+          ],
+        },
+        { role: "user", content: "second", sequence: 12 },
+        {
+          role: "assistant",
+          content: null,
+          sequence: 13,
+          tool_calls: [
+            {
+              id: "call_dup",
+              type: "function",
+              function: {
+                name: "web_search",
+                arguments: JSON.stringify({ query: "second-call" }),
+              },
+            },
+          ],
+        },
+        {
+          role: "tool",
+          tool_call_id: "call_dup",
+          content: JSON.stringify({ results: [{ title: "in-page result" }] }),
+          sequence: 14,
+        },
+      ],
+      { isComplete: true, extraToolOutputs: cross },
+    );
+
+    // user, assistant(first-call), user, assistant(second-call)
+    expect(result.messages).toHaveLength(4);
+    const firstToolPart = result.messages[1].parts.find((p) =>
+      p.type.startsWith("tool-"),
+    );
+    const secondToolPart = result.messages[3].parts.find((p) =>
+      p.type.startsWith("tool-"),
+    );
+    expect(firstToolPart).toMatchObject({
+      input: { query: "first-call" },
+      output: { results: [{ title: "from-other-page" }] },
+    });
+    expect(secondToolPart).toMatchObject({
+      input: { query: "second-call" },
+      output: { results: [{ title: "in-page result" }] },
+    });
+  });
 });
 
 // --------------------------------------------------------------------------- //

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/helpers/__tests__/convertChatSessionToUiMessages.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/helpers/__tests__/convertChatSessionToUiMessages.test.ts
@@ -544,6 +544,153 @@ describe("convertChatSessionMessagesToUiMessages", () => {
       output: { results: [{ title: "in-page result" }] },
     });
   });
+
+  it("marks an unresolved tool call with an empty output when the session is complete", () => {
+    // Session finished (no active stream) but the DB has no tool row for
+    // this call — e.g. the tool errored server-side before persisting a
+    // result.  The slot stays unfilled, so the card must render as
+    // output-available with an empty output to stop a stale spinner
+    // rather than hang in the input-available state forever.
+    const result = convertChatSessionMessagesToUiMessages(
+      SESSION_ID,
+      [
+        { role: "user", content: "search foo", sequence: 0 },
+        {
+          role: "assistant",
+          content: null,
+          sequence: 1,
+          tool_calls: [
+            {
+              id: "call_orphan",
+              type: "function",
+              function: {
+                name: "web_search",
+                arguments: JSON.stringify({ query: "foo" }),
+              },
+            },
+          ],
+        },
+      ],
+      { isComplete: true },
+    );
+
+    expect(result.messages).toHaveLength(2);
+    const toolPart = result.messages[1].parts.find((p) =>
+      p.type.startsWith("tool-"),
+    );
+    expect(toolPart).toMatchObject({
+      type: "tool-web_search",
+      state: "output-available",
+      input: { query: "foo" },
+      output: "",
+    });
+  });
+
+  it("leaves an unresolved tool call as input-available while the session is still streaming", () => {
+    // isComplete is false: the tool call is genuinely still in flight, so
+    // the card keeps the input-available (spinner) state and carries no
+    // output yet.
+    const result = convertChatSessionMessagesToUiMessages(
+      SESSION_ID,
+      [
+        { role: "user", content: "search foo", sequence: 0 },
+        {
+          role: "assistant",
+          content: null,
+          sequence: 1,
+          tool_calls: [
+            {
+              id: "call_pending",
+              type: "function",
+              function: {
+                name: "web_search",
+                arguments: JSON.stringify({ query: "foo" }),
+              },
+            },
+          ],
+        },
+      ],
+      { isComplete: false },
+    );
+
+    expect(result.messages).toHaveLength(2);
+    const toolPart = result.messages[1].parts.find((p) =>
+      p.type.startsWith("tool-"),
+    );
+    expect(toolPart).toMatchObject({
+      type: "tool-web_search",
+      state: "input-available",
+      input: { query: "foo" },
+    });
+    expect(toolPart).not.toHaveProperty("output");
+  });
+
+  it("skips malformed tool_calls entries and still pairs the valid call, ignoring an orphan tool row", () => {
+    // Providers occasionally emit junk in the tool_calls array (a null
+    // entry, or an entry with a blank id).  Those must not consume a slot
+    // or crash pairing — only the well-formed call renders.  A trailing
+    // tool row whose id matches no assistant call (call_ghost), and a
+    // second tool row for an already-filled id (call_ok), are both
+    // dropped without disturbing the valid pairing.
+    const result = convertChatSessionMessagesToUiMessages(
+      SESSION_ID,
+      [
+        { role: "user", content: "do it", sequence: 0 },
+        {
+          role: "assistant",
+          content: null,
+          sequence: 1,
+          tool_calls: [
+            null,
+            {
+              id: "   ",
+              type: "function",
+              function: { name: "web_search", arguments: "{}" },
+            },
+            {
+              id: "call_ok",
+              type: "function",
+              function: {
+                name: "web_search",
+                arguments: JSON.stringify({ query: "real" }),
+              },
+            },
+          ],
+        },
+        {
+          role: "tool",
+          tool_call_id: "call_ok",
+          content: JSON.stringify({ results: [{ title: "real result" }] }),
+          sequence: 2,
+        },
+        {
+          role: "tool",
+          tool_call_id: "call_ok",
+          content: JSON.stringify({ results: [{ title: "second (dropped)" }] }),
+          sequence: 3,
+        },
+        {
+          role: "tool",
+          tool_call_id: "call_ghost",
+          content: JSON.stringify({ results: [{ title: "orphan (dropped)" }] }),
+          sequence: 4,
+        },
+      ],
+      { isComplete: true },
+    );
+
+    expect(result.messages).toHaveLength(2);
+    const toolParts = result.messages[1].parts.filter((p) =>
+      p.type.startsWith("tool-"),
+    );
+    // Only the well-formed call renders; malformed entries are skipped.
+    expect(toolParts).toHaveLength(1);
+    expect(toolParts[0]).toMatchObject({
+      type: "tool-web_search",
+      input: { query: "real" },
+      output: { results: [{ title: "real result" }] },
+    });
+  });
 });
 
 // --------------------------------------------------------------------------- //

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/helpers/convertChatSessionToUiMessages.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/helpers/convertChatSessionToUiMessages.ts
@@ -289,13 +289,83 @@ export function convertChatSessionMessagesToUiMessages(
   const latestUserMessageIndex = messages.findLastIndex(
     (m) => m.role === "user",
   );
-  const toolOutputsByCallId = new Map<string, unknown>();
 
-  // Seed with extra tool outputs from adjacent pages first;
-  // outputs from this page will override if present in both.
+  // Position-aware tool-call → tool-output pairing (#13306).
+  //
+  // LLM providers do NOT guarantee globally-unique ``tool_call_id``s
+  // across separate completions calls, only within a single response.
+  // A naive ``Map<id, output>`` collapses every reappearance of an id
+  // onto the latest tool message, so the earlier assistant card
+  // displays the wrong output ("description and result pairings are
+  // mixed up" — issue #13306).
+  //
+  // Walk messages in DB order and, per occurrence of each
+  // ``tool_call_id``, allocate a slot.  Tool messages fill the OLDEST
+  // unfilled slot for their id.  Cross-page seeds from
+  // ``extraToolOutputs`` fill the first slot in the same FIFO manner —
+  // they represent tool outputs that landed on an adjacent page for
+  // the earliest assistant call(s) on this page.  An assistant card
+  // renders the output bound to its specific slot, not whatever
+  // happens to be the last value under that id.
+  type ToolSlotKey = string;
+  const slotsById = new Map<string, ToolSlotKey[]>();
+  const slotOutputs = new Map<ToolSlotKey, unknown>();
+  let slotCounter = 0;
+
+  function allocateSlot(toolCallId: string): ToolSlotKey {
+    const slotKey = `${toolCallId}#${slotCounter++}`;
+    const existing = slotsById.get(toolCallId);
+    if (existing) {
+      existing.push(slotKey);
+    } else {
+      slotsById.set(toolCallId, [slotKey]);
+    }
+    return slotKey;
+  }
+
+  function fillNextSlot(toolCallId: string, output: unknown): boolean {
+    const queue = slotsById.get(toolCallId);
+    if (!queue || queue.length === 0) return false;
+    for (let i = 0; i < queue.length; i++) {
+      const slotKey = queue[i];
+      if (!slotOutputs.has(slotKey)) {
+        slotOutputs.set(slotKey, output);
+        return true;
+      }
+    }
+    return false;
+  }
+
+  // Allocate slots for every assistant tool_call in DB order, then bind
+  // outputs in two passes: cross-page seeds first (oldest pending slot
+  // wins), in-page tool messages second (next pending slot for that id).
+  // This preserves the "in-page wins over cross-page" semantics from
+  // before for the common no-duplicate case while keeping each
+  // duplicate id occurrence in its own bucket.
+  const assistantToolCallSlots = new Map<number, ToolSlotKey[]>();
+  messages.forEach((msg, idx) => {
+    if (msg.role !== "assistant") return;
+    if (!Array.isArray(msg.tool_calls)) return;
+    const slots: ToolSlotKey[] = [];
+    for (const rawToolCall of msg.tool_calls) {
+      if (!rawToolCall || typeof rawToolCall !== "object") {
+        slots.push("");
+        continue;
+      }
+      const toolCall = rawToolCall as { id?: unknown };
+      const toolCallId = String(toolCall.id ?? "").trim();
+      if (!toolCallId) {
+        slots.push("");
+        continue;
+      }
+      slots.push(allocateSlot(toolCallId));
+    }
+    assistantToolCallSlots.set(idx, slots);
+  });
+
   if (options?.extraToolOutputs) {
     for (const [id, output] of options.extraToolOutputs) {
-      toolOutputsByCallId.set(id, output);
+      fillNextSlot(id, output);
     }
   }
 
@@ -304,7 +374,7 @@ export function convertChatSessionMessagesToUiMessages(
     const toolCallId = msg.tool_call_id?.trim();
     if (!toolCallId) continue;
     if (msg.content == null) continue;
-    toolOutputsByCallId.set(toolCallId, msg.content);
+    fillNextSlot(toolCallId, msg.content);
   }
 
   const uiMessages: UIMessage<unknown, UIDataTypes, UITools>[] = [];
@@ -385,8 +455,9 @@ export function convertChatSessionMessagesToUiMessages(
     }
 
     if (uiRole === "assistant" && Array.isArray(msg.tool_calls)) {
-      for (const rawToolCall of msg.tool_calls) {
-        if (!rawToolCall || typeof rawToolCall !== "object") continue;
+      const slotKeys = assistantToolCallSlots.get(idx) ?? [];
+      msg.tool_calls.forEach((rawToolCall, callIdx) => {
+        if (!rawToolCall || typeof rawToolCall !== "object") return;
         const toolCall = rawToolCall as {
           id?: unknown;
           function?: { name?: unknown; arguments?: unknown };
@@ -394,10 +465,11 @@ export function convertChatSessionMessagesToUiMessages(
 
         const toolCallId = String(toolCall.id ?? "").trim();
         const toolName = String(toolCall.function?.name ?? "").trim();
-        if (!toolCallId || !toolName) continue;
+        if (!toolCallId || !toolName) return;
 
         const input = toToolInput(toolCall.function?.arguments);
-        const output = toolOutputsByCallId.get(toolCallId);
+        const slotKey = slotKeys[callIdx];
+        const output = slotKey ? slotOutputs.get(slotKey) : undefined;
 
         if (output !== undefined) {
           parts.push({
@@ -425,7 +497,7 @@ export function convertChatSessionMessagesToUiMessages(
             input,
           });
         }
-      }
+      });
     }
 
     // User messages must always be rendered, even with empty content, so the


### PR DESCRIPTION
### Why / What / How

**Why:** Issue #13306 reports that, in the AutoPilot UI, the
descriptions of tool calls and their corresponding results are paired
with the wrong tool — a tool call's description is shown alongside
another call's result. The screenshot in the issue shows two adjacent
search-result cards whose descriptions match the OTHER card's results.

The root cause is in
`autogpt_platform/frontend/src/app/(platform)/copilot/helpers/convertChatSessionToUiMessages.ts`.
That helper flattens every `role: "tool"` message in the session into
a single `Map<tool_call_id, output>`:

```ts
for (const msg of messages) {
  if (msg.role !== "tool") continue;
  if (!msg.tool_call_id) continue;
  if (msg.content == null) continue;
  toolOutputsByCallId.set(msg.tool_call_id, msg.content);
}
```

Then for each assistant `tool_call`, it pairs by `tool_call_id`:

```ts
const output = toolOutputsByCallId.get(toolCallId);
```

LLM providers do **not** guarantee globally-unique `tool_call_id`s
across turns of the same session — only within a single
`completions.create` response. When a duplicate id reappears in a
later turn the flat map keeps only the LAST output and every earlier
assistant tool call with the same id silently picks up the WRONG
output. The user sees a `tool-web_search` accordion whose
"description" (built from the assistant's own input arguments)
belongs to the call that was made — but whose results body belongs to
a later, unrelated call.

The same bug also explains the cross-page symptom: the helper accepts
an `extraToolOutputs` map and an in-page override pass, both keyed by
`tool_call_id` — a duplicate id across pages collapses to a single
surviving output.

**What:** Make tool-call → tool-output pairing position-aware so a
duplicate `tool_call_id` cannot leak across turns. Each assistant
tool_call occurrence gets its own slot; tool messages and
cross-page seeds fill the OLDEST unfilled slot for that id in FIFO
order.

**How:**

- Walk messages in DB order. For each assistant `tool_calls` entry,
  allocate one slot per occurrence in `slotsById` (a
  `Map<tool_call_id, slotKey[]>`).
- After slot allocation, bind outputs in two passes:
  1. Cross-page seeds from `extraToolOutputs` fill the oldest pending
     slot for each id (FIFO). These represent tool outputs that
     landed on an adjacent page for the earliest assistant call(s) on
     this page.
  2. In-page `role: "tool"` messages fill the next pending slot for
     each id (also FIFO).
- Each assistant card renders the output bound to its specific slot,
  not whatever happens to be the last value under that id.

The "in-page wins over cross-page" semantics are preserved for the
common no-duplicate case — when both contribute one entry under the
same id, the cross-page seed fills slot 0 and in-page fills slot 1
(or, if there's only one assistant call, the cross-page seed fills it
and the in-page tool message has no slot to attach to). The pre-fix
code's "in-page overrides cross-page when both target the SAME id"
case was load-bearing only when an id collision existed — exactly the
bug case — and the post-fix behavior gives both occurrences distinct
outputs instead of dropping one.

### Changes 🏗️

- `autogpt_platform/frontend/src/app/(platform)/copilot/helpers/convertChatSessionToUiMessages.ts`:
  Replace the flat `toolOutputsByCallId` map with position-aware slot
  allocation and FIFO output binding. ~80 lines added (slot
  allocation + binding) / ~10 lines removed (old single-pass loop).
- `autogpt_platform/frontend/src/app/(platform)/copilot/helpers/__tests__/convertChatSessionToUiMessages.test.ts`:
  Add three regression tests covering duplicate-id pairing within a
  page, mixed ids across multiple turns, and cross-page seed +
  duplicate-id interaction.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `pnpm vitest run src/app/(platform)/copilot/helpers/__tests__/convertChatSessionToUiMessages.test.ts` — 29/29 pass (26 existing + 3 new)
  - [x] New tests fail against the pre-fix code (verified by stashing the source change locally) and pass after the fix
  - [x] `pnpm format` clean (prettier --check passes on changed files)
  - [x] `pnpm lint` clean (next lint reports no warnings or errors on changed files)
  - [x] `pnpm types` clean (`tsc --noEmit -p tsconfig.json` exits 0)
  - [ ] Manual: open a chat that triggered the bug; confirm each tool card's description matches the snippet/results body inside the accordion below it (deferred — requires running the full platform stack)
