### PR TITLE
fix(backend): enforce paywall on create chat session

### DIFF
--- a/autogpt_platform/backend/backend/api/features/chat/routes.py
+++ b/autogpt_platform/backend/backend/api/features/chat/routes.py
@@ -427,6 +427,7 @@ async def list_sessions(
 
 @router.post(
     "/sessions",
+    dependencies=[Depends(enforce_payment_paywall)],
 )
 async def create_session(
     user_id: Annotated[str, Security(auth.get_user_id)],


### PR DESCRIPTION
### Why / What / How

Why: Currently the paywall is not enforced at the create chat session endpoint on the backend. This allows users to create new sessions without being subject to paywall restrictions, even if they are not on a paid plan.

What: Enforce the paywall check when a new chat session is created on the backend.

How: Update the create chat session endpoint to check for the required plan before allowing session creation.

### Changes 🏗️

- Update the create chat session endpoint to include a paywall check.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [x] Check ci passes
