### PR TITLE
fix(backend/copilot-bot): include forwarded message content in Discord messages

### DIFF
--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter.py
@@ -265,7 +265,7 @@ class DiscordAdapter(PlatformAdapter):
                 message_id=str(message.id),
                 user_id=str(message.author.id),
                 username=message.author.display_name,
-                text=self._strip_mentions(message),
+                text=self._message_text(message),
                 bot_mentioned=bot_mentioned,
                 thread_history=thread_history,
                 mentionable_users=self._collect_mentionable_users(message),
@@ -313,6 +313,43 @@ class DiscordAdapter(PlatformAdapter):
         if isinstance(message.channel, discord.Thread):
             return "thread"
         return "channel"
+
+    def _message_text(self, message: discord.Message) -> str:
+        """The full message body the LLM should see.
+
+        A Discord *forward* carries the forwarded message in
+        ``message.message_snapshots`` — separate from ``content``, which only
+        holds the comment the user typed alongside the forward. Reading
+        ``content`` alone (as ``_strip_mentions`` does) drops the forwarded
+        message entirely, so the LLM acts on just the comment and can badly
+        misread the request. Stitch the forwarded content back in here.
+        """
+        own = self._strip_mentions(message)
+        forwarded = self._forwarded_text(message)
+        if not forwarded:
+            return own
+        if own:
+            return f"{own}\n\n[Forwarded message]\n{forwarded}"
+        return f"[Forwarded message]\n{forwarded}"
+
+    @staticmethod
+    def _forwarded_text(message: discord.Message) -> str:
+        """Flatten any forwarded message snapshots into labelled text."""
+        # ``message_snapshots`` is a real runtime attribute (in ``Message``'s
+        # slots) but isn't in discord.py 2.6's type stubs yet; read it through
+        # getattr so the type checker is happy and older builds without message
+        # forwarding degrade to "no snapshots".
+        snapshots = getattr(message, "message_snapshots", [])
+        parts: list[str] = []
+        for snapshot in snapshots:
+            content = (snapshot.content or "").strip()
+            if content:
+                parts.append(content)
+            # Surface forwarded attachments by name so the LLM knows files came
+            # with the forward, even though we can't inline their bytes here.
+            for attachment in snapshot.attachments:
+                parts.append(f"[Attached file: {attachment.filename}]")
+        return "\n\n".join(parts).strip()
 
     def _strip_mentions(self, message: discord.Message) -> str:
         """Strip the bot's own mention; replace other users' raw mention

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter_test.py
@@ -110,6 +110,50 @@ class TestStripMentions:
         assert adapter._strip_mentions(msg) == expected
 
 
+# ── _message_text (forwarded messages) ─────────────────────────────────
+
+
+def _snapshot(content: str = "", filenames: tuple[str, ...] = ()) -> MagicMock:
+    snapshot = MagicMock()
+    snapshot.content = content
+    snapshot.attachments = [MagicMock(filename=name) for name in filenames]
+    return snapshot
+
+
+class TestMessageText:
+    def test_plain_message_without_forward(self):
+        adapter, _ = _bare_adapter(bot_id=1000)
+        msg = _message("hello", [])
+        msg.message_snapshots = []
+        assert adapter._message_text(msg) == "hello"
+
+    def test_forward_with_comment_includes_both(self):
+        # The dangerous case Toran hit: a forward + comment used to arrive as
+        # just the comment, losing the forwarded message entirely.
+        adapter, _ = _bare_adapter(bot_id=1000)
+        msg = _message("can you make a ticket for this?", [])
+        msg.message_snapshots = [_snapshot("The original forwarded request")]
+        result = adapter._message_text(msg)
+        assert "can you make a ticket for this?" in result
+        assert "[Forwarded message]" in result
+        assert "The original forwarded request" in result
+
+    def test_forward_without_comment_uses_forwarded_content(self):
+        adapter, _ = _bare_adapter(bot_id=1000)
+        msg = _message("", [])
+        msg.message_snapshots = [_snapshot("Just the forwarded text")]
+        result = adapter._message_text(msg)
+        assert result.startswith("[Forwarded message]")
+        assert "Just the forwarded text" in result
+
+    def test_forward_notes_attachment_filenames(self):
+        adapter, _ = _bare_adapter(bot_id=1000)
+        msg = _message("look at this", [])
+        msg.message_snapshots = [_snapshot("", filenames=("report.pdf",))]
+        result = adapter._message_text(msg)
+        assert "[Attached file: report.pdf]" in result
+
+
 # ── _channel_type ──────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
### Why

A user forwarded a Discord message to AutoPilot in DMs with a short comment. The bot only received the **comment**, not the forwarded message — so it acted on a request with the real content missing and did the wrong thing (created a Linear ticket from prior-session memory instead of the forwarded request). This is a safety issue: the bot can confidently act on a misread request.

Root cause: a Discord *forward* carries the forwarded message in `message.message_snapshots`, which is **separate** from `message.content` (which holds only the comment typed alongside the forward). The adapter built `ctx.text` from `content` alone, dropping the forwarded message entirely.

### What

- `ctx.text` is now built from the user's comment **plus** the forwarded snapshot content, labelled `[Forwarded message]`.
- Forwarded attachments are surfaced by filename (`[Attached file: …]`) so the LLM knows files came with the forward.
- A forward with **no** comment is no longer treated as an empty message.

### How

- New `DiscordAdapter._message_text()` composes comment + `_forwarded_text()`; `on_message` uses it instead of `_strip_mentions()` directly.
- `message_snapshots` is a real runtime attribute but isn't in discord.py 2.6's type stubs, so it's read via `getattr(..., [])` — which also degrades gracefully on builds without message forwarding.
- Added unit tests: comment+forward keeps both, forward-only uses the forwarded content, attachments are named, plain messages are unchanged.

### Checklist
- [x] Tests added for new behaviour
- [x] `black` / `ruff` / `pyright` clean
- [x] No new out-of-scope changes
