### PR TITLE
fix(backend/copilot-bot): keep copilot session alive as long as the thread auto-replies

### DIFF
--- a/autogpt_platform/backend/backend/copilot/bot/config.py
+++ b/autogpt_platform/backend/backend/copilot/bot/config.py
@@ -1,4 +1,12 @@
 """Platform-agnostic bot config."""
 
-# Cache TTL for AutoPilot session IDs (per channel/thread)
-SESSION_TTL = 86400  # 24 hours
+# Cache TTL for AutoPilot session IDs (per channel/thread).
+#
+# Must be >= the thread auto-reply subscription TTL (``threads.
+# THREAD_SUBSCRIPTION_TTL``, 7 days). If it's shorter, the bot keeps
+# auto-replying in a thread after the session cache has expired and silently
+# starts a *fresh* copilot session that has lost the whole conversation — it
+# then acts on stale cross-session memory instead of the actual thread, which is
+# dangerous. Each turn refreshes this TTL, so an active conversation never loses
+# context within the subscription window.
+SESSION_TTL = 7 * 86400  # 7 days — matches the thread subscription window

--- a/autogpt_platform/backend/backend/copilot/bot/sessions_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/sessions_test.py
@@ -4,7 +4,16 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from backend.copilot.bot import sessions
+from backend.copilot.bot import sessions, threads
+from backend.copilot.bot.config import SESSION_TTL
+
+
+def test_session_ttl_outlives_thread_subscription():
+    # If the session cache expires before the thread stops auto-replying, a
+    # follow-up message silently starts a fresh copilot session and loses the
+    # whole conversation. The session must live at least as long as the bot
+    # keeps replying in the thread.
+    assert SESSION_TTL >= threads.THREAD_SUBSCRIPTION_TTL
 
 
 def test_session_cache_key_format():


### PR DESCRIPTION
### Why

A user had an ongoing thread with AutoPilot: last message June 5, follow-up June 8. The bot replied — but in a **brand-new copilot session**, having lost the entire prior conversation. It then nearly acted on stale cross-session memory instead of the actual thread (AutoPilot itself reported "what I treated as context was memories from prior sessions, not today's thread"). That's a safety problem: the bot confidently acts with the wrong context.

Root cause: two mismatched Redis TTLs.
- `config.SESSION_TTL` (thread → copilot session-id cache) = **24h**
- `threads.THREAD_SUBSCRIPTION_TTL` (how long the bot keeps auto-replying in a thread) = **7 days**

So for ~6 of the 7 days a thread stays "live", the session cache has already expired. A follow-up in that window finds no cached session and starts a fresh one — context lost — while the bot still auto-replies because the subscription is alive.

### What

- Raise `SESSION_TTL` from 24h to **7 days**, matching the thread subscription window.
- Add a guard test pinning the invariant `SESSION_TTL >= THREAD_SUBSCRIPTION_TTL`.

### How

The session cache is re-set on every turn, so an active conversation already keeps extending its TTL — the only failure mode was a gap longer than 24h but shorter than the 7-day subscription. Coupling the two windows means: as long as the bot will still auto-reply in a thread, it resumes the same session; once both expire together, a fresh start (with a new @mention) is the consistent, expected behaviour. The session never *outlives* usefulness because it can only persist while the user keeps the thread active.

### Checklist
- [x] Regression-guard test added
- [x] `black` / `ruff` / `pyright` clean
- [x] One-line config change, no out-of-scope edits
