### PR TITLE
fix(backend/copilot-bot): read full thread history when adopted, not just last 20

### DIFF
--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter.py
@@ -25,7 +25,15 @@ from ..base import (
 from . import commands, config, intro
 
 logger = logging.getLogger(__name__)
-THREAD_HISTORY_LIMIT = 20
+
+# When the bot is @-ed into an existing thread it pulls the prior messages in as
+# context. Read the whole thread (up to this hard cap, ~10 Discord API pages)
+# rather than just the last handful — skipping older messages makes the bot act
+# on a partial conversation. THREAD_HISTORY_CHAR_BUDGET then keeps the assembled
+# context within the copilot request size limit, preferring the most recent
+# messages when a thread is very long.
+THREAD_HISTORY_LIMIT = 1000
+THREAD_HISTORY_CHAR_BUDGET = 24000
 
 
 class DiscordAdapter(PlatformAdapter):
@@ -345,12 +353,16 @@ class DiscordAdapter(PlatformAdapter):
             return ()
 
         entries: list[MessageHistoryEntry] = []
+        used_chars = 0
         bot_user_id = self._client.user.id if self._client.user else None
         try:
+            # Newest-first so that when a long thread exceeds the size budget we
+            # keep the most recent (most relevant) messages instead of the
+            # oldest; we reverse back to chronological order before returning.
             async for prior in message.channel.history(
                 limit=THREAD_HISTORY_LIMIT,
                 before=message,
-                oldest_first=True,
+                oldest_first=False,
             ):
                 # Skip our own outputs — copilot has its own transcript for
                 # that side. Other bots' messages are kept as context.
@@ -359,6 +371,11 @@ class DiscordAdapter(PlatformAdapter):
                 text = self._strip_mentions(prior)
                 if not text:
                     continue
+                # Stop once we'd blow the request size budget, but always keep
+                # at least the most recent message.
+                if entries and used_chars + len(text) > THREAD_HISTORY_CHAR_BUDGET:
+                    break
+                used_chars += len(text)
                 entries.append(
                     MessageHistoryEntry(
                         username=prior.author.display_name,
@@ -370,6 +387,7 @@ class DiscordAdapter(PlatformAdapter):
             logger.warning("Could not fetch Discord thread history", exc_info=True)
             return ()
 
+        entries.reverse()  # chronological order for the prompt
         return tuple(entries)
 
 

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter.py
@@ -375,13 +375,14 @@ class DiscordAdapter(PlatformAdapter):
                 remaining = THREAD_HISTORY_CHAR_BUDGET - used_chars
                 if remaining <= 0:
                     break
-                if len(text) > remaining:
-                    # Doesn't fit. Stop if we already have context; otherwise
-                    # this lone (most recent) message is itself over budget —
-                    # keep a truncated head so we never send an oversized
-                    # payload to the copilot API.
-                    if entries:
-                        break
+                oversized = len(text) > remaining
+                if oversized and entries:
+                    # No room for another whole message — stop and keep what we
+                    # have (the more recent messages).
+                    break
+                if oversized:
+                    # Lone most-recent message is itself over budget: keep a
+                    # truncated head of it.
                     text = _truncate_to_budget(text, remaining)
                 used_chars += len(text)
                 entries.append(
@@ -391,6 +392,11 @@ class DiscordAdapter(PlatformAdapter):
                         text=text,
                     )
                 )
+                if oversized:
+                    # We just truncated the newest message to the budget; older
+                    # messages are both less relevant and would otherwise sneak
+                    # into the whitespace `rstrip` freed up. Stop here.
+                    break
         except (discord.Forbidden, discord.HTTPException):
             logger.warning("Could not fetch Discord thread history", exc_info=True)
             return ()

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter.py
@@ -34,6 +34,7 @@ logger = logging.getLogger(__name__)
 # messages when a thread is very long.
 THREAD_HISTORY_LIMIT = 1000
 THREAD_HISTORY_CHAR_BUDGET = 24000
+_HISTORY_TRUNCATION_MARKER = "\n… [message truncated]"
 
 
 class DiscordAdapter(PlatformAdapter):
@@ -371,10 +372,17 @@ class DiscordAdapter(PlatformAdapter):
                 text = self._strip_mentions(prior)
                 if not text:
                     continue
-                # Stop once we'd blow the request size budget, but always keep
-                # at least the most recent message.
-                if entries and used_chars + len(text) > THREAD_HISTORY_CHAR_BUDGET:
+                remaining = THREAD_HISTORY_CHAR_BUDGET - used_chars
+                if remaining <= 0:
                     break
+                if len(text) > remaining:
+                    # Doesn't fit. Stop if we already have context; otherwise
+                    # this lone (most recent) message is itself over budget —
+                    # keep a truncated head so we never send an oversized
+                    # payload to the copilot API.
+                    if entries:
+                        break
+                    text = _truncate_to_budget(text, remaining)
                 used_chars += len(text)
                 entries.append(
                     MessageHistoryEntry(
@@ -389,6 +397,19 @@ class DiscordAdapter(PlatformAdapter):
 
         entries.reverse()  # chronological order for the prompt
         return tuple(entries)
+
+
+def _truncate_to_budget(text: str, limit: int) -> str:
+    """Trim ``text`` to at most ``limit`` characters, leaving a visible marker.
+
+    Used only when a single thread message is itself larger than the history
+    budget — keep a head of it (with context that it was cut) rather than emit
+    an oversized payload or drop the message entirely.
+    """
+    if len(text) <= limit:
+        return text
+    keep = max(0, limit - len(_HISTORY_TRUNCATION_MARKER))
+    return text[:keep].rstrip() + _HISTORY_TRUNCATION_MARKER
 
 
 def _resolve_mentions(

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter_test.py
@@ -7,6 +7,7 @@ import discord
 import pytest
 
 from backend.copilot.bot.adapters.discord.adapter import (
+    THREAD_HISTORY_CHAR_BUDGET,
     THREAD_HISTORY_LIMIT,
     DiscordAdapter,
     _resolve_mentions,
@@ -415,6 +416,26 @@ class TestThreadHistory:
             "User5",
             "User6",
         ]
+
+    @pytest.mark.asyncio
+    async def test_truncates_a_single_oversized_message(self):
+        # If the latest message alone exceeds the budget, keep a truncated head
+        # rather than drop all context or emit an oversized payload.
+        adapter, _ = _bare_adapter(bot_id=1000)
+        huge = "y" * (THREAD_HISTORY_CHAR_BUDGET + 6000)
+        msg = _message(huge, [])
+        msg.author = MagicMock(bot=False, id=2000, display_name="Alice")
+
+        channel = MagicMock(spec=discord.Thread)
+        channel.history.return_value = _AsyncHistory([msg])
+        message = _message("help", [])
+        message.channel = channel
+
+        history = await adapter._thread_history(message)
+
+        assert len(history) == 1
+        assert len(history[0].text) <= THREAD_HISTORY_CHAR_BUDGET
+        assert history[0].text.endswith("[message truncated]")
 
 
 class TestProperties:

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter_test.py
@@ -355,7 +355,9 @@ class TestRenameThread:
 
 class TestThreadHistory:
     @pytest.mark.asyncio
-    async def test_fetches_user_thread_history_oldest_first(self):
+    async def test_fetches_user_thread_history_chronological(self):
+        # Discord returns history newest-first; the adapter reverses it back to
+        # chronological order, dropping its own outputs.
         adapter, _ = _bare_adapter(bot_id=1000)
         bot = _mention(1000, "AutoPilot")
 
@@ -367,7 +369,8 @@ class TestThreadHistory:
         bot_msg.author = MagicMock(bot=True, id=1000, display_name="AutoPilot")
 
         channel = MagicMock(spec=discord.Thread)
-        channel.history.return_value = _AsyncHistory([prior_1, bot_msg, prior_2])
+        # newest-first as the Discord API delivers it: Bob, (bot), Alice
+        channel.history.return_value = _AsyncHistory([prior_2, bot_msg, prior_1])
         message = _message("<@1000> help", [bot])
         message.channel = channel
 
@@ -376,13 +379,41 @@ class TestThreadHistory:
         channel.history.assert_called_once_with(
             limit=THREAD_HISTORY_LIMIT,
             before=message,
-            oldest_first=True,
+            oldest_first=False,
         )
         assert [entry.username for entry in history] == ["Alice", "Bob"]
         assert [entry.user_id for entry in history] == ["2000", "3000"]
         assert [entry.text for entry in history] == [
             "first idea",
             "can ignore old bot ping",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_drops_oldest_messages_past_the_size_budget(self):
+        # A very long thread can't all fit in one copilot request. Keep the most
+        # recent messages (newest-first scan, budget cut) and drop the oldest.
+        adapter, _ = _bare_adapter(bot_id=1000)
+
+        big = "x" * 5000  # 4 fit in the 24000-char budget, the 5th overflows
+        newest_first = []
+        for i in range(6, 0, -1):  # User6 (newest) .. User1 (oldest)
+            msg = _message(big, [])
+            msg.author = MagicMock(bot=False, id=i, display_name=f"User{i}")
+            newest_first.append(msg)
+
+        channel = MagicMock(spec=discord.Thread)
+        channel.history.return_value = _AsyncHistory(newest_first)
+        message = _message("help", [])
+        message.channel = channel
+
+        history = await adapter._thread_history(message)
+
+        # Most-recent 4 kept, returned chronologically; oldest two dropped.
+        assert [entry.username for entry in history] == [
+            "User3",
+            "User4",
+            "User5",
+            "User6",
         ]
 
 

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter_test.py
@@ -437,6 +437,26 @@ class TestThreadHistory:
         assert len(history[0].text) <= THREAD_HISTORY_CHAR_BUDGET
         assert history[0].text.endswith("[message truncated]")
 
+    @pytest.mark.asyncio
+    async def test_truncated_newest_message_stops_older_messages(self):
+        # Once the newest message is truncated to the budget, older messages
+        # must not be appended into the whitespace the truncation freed up.
+        adapter, _ = _bare_adapter(bot_id=1000)
+        huge = "y" * (THREAD_HISTORY_CHAR_BUDGET + 6000)
+        newest = _message(huge, [])
+        newest.author = MagicMock(bot=False, id=2000, display_name="Newest")
+        older = _message("older context", [])
+        older.author = MagicMock(bot=False, id=3000, display_name="Older")
+
+        channel = MagicMock(spec=discord.Thread)
+        channel.history.return_value = _AsyncHistory([newest, older])  # newest-first
+        message = _message("help", [])
+        message.channel = channel
+
+        history = await adapter._thread_history(message)
+
+        assert [entry.username for entry in history] == ["Newest"]
+
 
 class TestProperties:
     def test_platform_name_is_discord(self):


### PR DESCRIPTION
### Why

When the bot is @-mentioned into an **existing** thread, it pulls the prior messages in as context for that turn. It only read the **last 20** messages (`THREAD_HISTORY_LIMIT = 20`) and silently dropped everything older — so on any thread longer than ~20 messages it acted on a partial conversation and "skipped loads of messages." That leads to wrong/again-dangerous actions because the model is missing context it appears to have.

### What

- Read the **whole thread** when adopting it, up to a 1000-message hard cap (~10 Discord API pages) instead of 20.
- Bound the assembled context with `THREAD_HISTORY_CHAR_BUDGET` (24k chars) so it stays under the copilot request size limit.
- Scan newest-first and reverse to chronological, so a very long thread keeps the **most recent** (most relevant) messages rather than truncating arbitrarily.

### How

`_thread_history` now accumulates messages newest-first until the char budget is hit (always keeping at least the latest message), then reverses to chronological order for the prompt. Bot's own outputs are still skipped (copilot has that side already). Added a test that a thread exceeding the budget keeps the most recent messages and drops the oldest; updated the ordering test for the newest-first fetch.

### Checklist
- [x] Tests added/updated (chronological order + budget drop-oldest)
- [x] `black` / `ruff` / `pyright` clean
- [x] Single focused change
