### PR TITLE
fix(frontend): move onboarding paywall before profile steps

### DIFF
--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/__tests__/page.test.tsx
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/__tests__/page.test.tsx
@@ -118,13 +118,22 @@ describe("OnboardingPage — flag-gated SubscriptionStep", () => {
     expect(screen.queryByTestId("step-subscription")).toBeNull();
   });
 
-  it("renders SubscriptionStep at step 4 when payments are enabled", async () => {
+  it("renders SubscriptionStep first (step 1) when payments are enabled", async () => {
     mockFlagValue = true;
-    window.sessionStorage.setItem(STEP_STORAGE_KEY, "4");
-    currentSearchParams = new URLSearchParams("step=4");
+    currentSearchParams = new URLSearchParams("step=1");
     render(<OnboardingPage />);
     expect(await screen.findByTestId("step-subscription")).toBeDefined();
+    expect(screen.queryByTestId("step-welcome")).toBeNull();
     expect(screen.queryByTestId("step-preparing")).toBeNull();
+  });
+
+  it("renders Welcome at step 2 (after the paywall) when payments are enabled", async () => {
+    mockFlagValue = true;
+    window.sessionStorage.setItem(STEP_STORAGE_KEY, "2");
+    currentSearchParams = new URLSearchParams("step=2");
+    render(<OnboardingPage />);
+    expect(await screen.findByTestId("step-welcome")).toBeDefined();
+    expect(screen.queryByTestId("step-subscription")).toBeNull();
   });
 
   it("treats step 5 as Preparing when payments are enabled", async () => {
@@ -138,55 +147,56 @@ describe("OnboardingPage — flag-gated SubscriptionStep", () => {
 
   it("clamps ?step=5 to the user's highest reached step (no fast-forward)", async () => {
     mockFlagValue = true;
-    window.sessionStorage.setItem(STEP_STORAGE_KEY, "2");
+    window.sessionStorage.setItem(STEP_STORAGE_KEY, "3");
     currentSearchParams = new URLSearchParams("step=5");
     render(<OnboardingPage />);
-    // Highest reached is 2 (RoleStep), so manually editing the URL to step=5
-    // should land the user back on step 2, not let them skip ahead.
+    // Highest reached is 3 (RoleStep), so manually editing the URL to step=5
+    // should land the user back on step 3, not let them skip ahead.
     expect(await screen.findByTestId("step-role")).toBeDefined();
     expect(screen.queryByTestId("step-preparing")).toBeNull();
   });
 
   it("resumes from the highest reached step when ?step= is omitted", async () => {
     mockFlagValue = true;
-    window.sessionStorage.setItem(STEP_STORAGE_KEY, "3");
+    window.sessionStorage.setItem(STEP_STORAGE_KEY, "4");
     // No step param — user navigated to /onboarding directly.
     render(<OnboardingPage />);
     expect(await screen.findByTestId("step-painpoints")).toBeDefined();
-    expect(screen.queryByTestId("step-welcome")).toBeNull();
-  });
-
-  it("rejects decimal step values and falls back to step 1", async () => {
-    mockFlagValue = true;
-    currentSearchParams = new URLSearchParams("step=2.5");
-    render(<OnboardingPage />);
-    expect(await screen.findByTestId("step-welcome")).toBeDefined();
-    expect(screen.queryByTestId("step-role")).toBeNull();
-  });
-
-  it("rejects non-numeric step values and falls back to step 1", async () => {
-    mockFlagValue = true;
-    currentSearchParams = new URLSearchParams("step=foo");
-    render(<OnboardingPage />);
-    expect(await screen.findByTestId("step-welcome")).toBeDefined();
-  });
-
-  it("lets ?step=5&subscription=success bypass the highestStep ceiling", async () => {
-    // Simulates returning from a successful Stripe checkout. The highest
-    // reached step before the redirect was 4 (SubscriptionStep). Without the
-    // success-bypass, ceiling=min(4,5)=4 would clamp the user back to step 4.
-    mockFlagValue = true;
-    window.sessionStorage.setItem(STEP_STORAGE_KEY, "4");
-    currentSearchParams = new URLSearchParams("step=5&subscription=success");
-    render(<OnboardingPage />);
-    expect(await screen.findByTestId("step-preparing")).toBeDefined();
     expect(screen.queryByTestId("step-subscription")).toBeNull();
   });
 
-  it("returns to SubscriptionStep on ?step=4&subscription=cancelled", async () => {
+  it("rejects decimal step values and falls back to step 1 (the paywall)", async () => {
     mockFlagValue = true;
-    window.sessionStorage.setItem(STEP_STORAGE_KEY, "4");
-    currentSearchParams = new URLSearchParams("step=4&subscription=cancelled");
+    currentSearchParams = new URLSearchParams("step=2.5");
+    render(<OnboardingPage />);
+    expect(await screen.findByTestId("step-subscription")).toBeDefined();
+    expect(screen.queryByTestId("step-welcome")).toBeNull();
+  });
+
+  it("rejects non-numeric step values and falls back to step 1 (the paywall)", async () => {
+    mockFlagValue = true;
+    currentSearchParams = new URLSearchParams("step=foo");
+    render(<OnboardingPage />);
+    expect(await screen.findByTestId("step-subscription")).toBeDefined();
+  });
+
+  it("lets ?step=2&subscription=success land on Welcome past the paywall", async () => {
+    // Simulates returning from a successful Stripe checkout. The highest
+    // reached step before the redirect was 1 (the paywall). Without the
+    // success-bypass, ceiling=min(1,2)=1 would clamp the user back onto the
+    // paywall they just paid through.
+    mockFlagValue = true;
+    window.sessionStorage.setItem(STEP_STORAGE_KEY, "1");
+    currentSearchParams = new URLSearchParams("step=2&subscription=success");
+    render(<OnboardingPage />);
+    expect(await screen.findByTestId("step-welcome")).toBeDefined();
+    expect(screen.queryByTestId("step-subscription")).toBeNull();
+  });
+
+  it("returns to SubscriptionStep on ?step=1&subscription=cancelled", async () => {
+    mockFlagValue = true;
+    window.sessionStorage.setItem(STEP_STORAGE_KEY, "1");
+    currentSearchParams = new URLSearchParams("step=1&subscription=cancelled");
     render(<OnboardingPage />);
     expect(await screen.findByTestId("step-subscription")).toBeDefined();
     expect(useOnboardingWizardStore.getState().selectedPlan).toBeNull();
@@ -222,8 +232,7 @@ describe("OnboardingPage — flag-gated SubscriptionStep", () => {
   it("still shows SubscriptionStep for NO_TIER users with payments enabled", async () => {
     mockFlagValue = true;
     mockSubscriptionTier = "NO_TIER";
-    window.sessionStorage.setItem(STEP_STORAGE_KEY, "4");
-    currentSearchParams = new URLSearchParams("step=4");
+    currentSearchParams = new URLSearchParams("step=1");
     render(<OnboardingPage />);
     expect(await screen.findByTestId("step-subscription")).toBeDefined();
     expect(screen.queryByTestId("step-preparing")).toBeNull();
@@ -264,7 +273,7 @@ describe("OnboardingPage — flag-gated SubscriptionStep", () => {
     });
     currentSearchParams = new URLSearchParams("step=4");
     render(<OnboardingPage />);
-    expect(await screen.findByTestId("step-subscription")).toBeDefined();
+    expect(await screen.findByTestId("step-painpoints")).toBeDefined();
     const state = useOnboardingWizardStore.getState();
     expect(state.name).toBe("Alice");
     expect(state.role).toBe("Engineering");

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/page.tsx
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/page.tsx
@@ -9,7 +9,7 @@ import { PreparingStep } from "./steps/PreparingStep";
 import { RoleStep } from "./steps/RoleStep";
 import { SubscriptionStep } from "./steps/SubscriptionStep/SubscriptionStep";
 import { WelcomeStep } from "./steps/WelcomeStep";
-import { useOnboardingWizardStore } from "./store";
+import { PAYWALL_FIRST_STEPS, useOnboardingWizardStore } from "./store";
 import { useOnboardingPage } from "./useOnboardingPage";
 
 export default function OnboardingPage() {
@@ -18,6 +18,7 @@ export default function OnboardingPage() {
     isLoading,
     handlePreparingComplete,
     isPaymentEnabled,
+    steps,
     preparingStep,
     totalSteps,
   } = useOnboardingPage();
@@ -28,7 +29,10 @@ export default function OnboardingPage() {
   // ProgressBar + StepIndicator track only the user-interactive steps.
   // PreparingStep is a transition view that hides both indicators.
   const showDots = currentStep <= totalSteps;
-  const showBack = currentStep > 1 && currentStep <= totalSteps;
+  // Back is hidden on Welcome (the first profile step): going back from there
+  // when payments are on would return the user to the paywall they already
+  // paid through and let them re-trigger checkout.
+  const showBack = currentStep > steps.welcome && currentStep <= totalSteps;
   const showProgressBar = currentStep <= totalSteps;
   const showLogout = currentStep <= totalSteps;
 
@@ -50,10 +54,13 @@ export default function OnboardingPage() {
       )}
 
       <div className="flex flex-1 items-center pb-8 pt-16">
-        {currentStep === 1 && <WelcomeStep />}
-        {currentStep === 2 && <RoleStep />}
-        {currentStep === 3 && <PainPointsStep />}
-        {isPaymentEnabled && currentStep === 4 && <SubscriptionStep />}
+        {isPaymentEnabled &&
+          currentStep === PAYWALL_FIRST_STEPS.subscription && (
+            <SubscriptionStep />
+          )}
+        {currentStep === steps.welcome && <WelcomeStep />}
+        {currentStep === steps.role && <RoleStep />}
+        {currentStep === steps.painPoints && <PainPointsStep />}
         {currentStep === preparingStep && (
           <PreparingStep onComplete={handlePreparingComplete} />
         )}

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/useSubscriptionStep.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/useSubscriptionStep.ts
@@ -1,11 +1,9 @@
 import { useUpdateSubscriptionTier } from "@/app/api/__generated__/endpoints/credits/credits";
-import { postV1SubmitOnboardingProfile } from "@/app/api/__generated__/endpoints/onboarding/onboarding";
 import type { SubscriptionTierRequestTier } from "@/app/api/__generated__/models/subscriptionTierRequestTier";
 import { toast } from "@/components/molecules/Toast/use-toast";
 import { environment } from "@/services/environment";
 import { useState } from "react";
-import { normalizeOnboardingProfile } from "../../helpers";
-import { useOnboardingWizardStore } from "../../store";
+import { PAYWALL_FIRST_STEPS, useOnboardingWizardStore } from "../../store";
 import { COUNTRIES } from "@/components/molecules/PlanCard/countries";
 import {
   PLAN_KEYS,
@@ -74,29 +72,17 @@ export function useSubscriptionStep() {
     setSelectedPlan(planKey);
     const tier = PLAN_TO_TIER[planKey];
 
-    const { name, role, painPoints } = normalizeOnboardingProfile(
-      useOnboardingWizardStore.getState(),
-    );
-
     try {
-      // POST the profile pre-redirect as defence in depth: zustand persist
-      // (sessionStorage) keeps the store across the Stripe round-trip, but
-      // submitting now also covers the case where the user closes the tab
-      // mid-checkout — the backend still has their name / role / pain
-      // points. Abort on failure rather than starting a Checkout session
-      // we'd have to reconcile with a missing profile after success.
-      await postV1SubmitOnboardingProfile({
-        user_name: name,
-        user_role: role,
-        pain_points: painPoints,
-      });
-
+      // The paywall is the first step, so there's no profile to submit yet —
+      // name / role / pain points are collected after payment. On a successful
+      // checkout Stripe returns the user to Welcome to begin onboarding; on
+      // cancel, back to this paywall.
       const baseUrl = `${window.location.origin}/onboarding`;
       const result = await updateTier({
         data: {
           tier,
-          success_url: `${baseUrl}?step=5&subscription=success`,
-          cancel_url: `${baseUrl}?step=4&subscription=cancelled`,
+          success_url: `${baseUrl}?step=${PAYWALL_FIRST_STEPS.welcome}&subscription=success`,
+          cancel_url: `${baseUrl}?step=${PAYWALL_FIRST_STEPS.subscription}&subscription=cancelled`,
           billing_cycle: isYearly ? "yearly" : "monthly",
         },
       });

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/__tests__/SubscriptionStep.test.tsx
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/__tests__/SubscriptionStep.test.tsx
@@ -39,7 +39,8 @@ afterEach(cleanup);
 beforeEach(() => {
   postHog.variant = undefined;
   useOnboardingWizardStore.getState().reset();
-  useOnboardingWizardStore.getState().goToStep(4);
+  // The paywall is the first step.
+  useOnboardingWizardStore.getState().goToStep(1);
   // Default tests to cloud mode so they exercise the Stripe Checkout path.
   // The local-bypass test below opts back into LOCAL.
   vi.spyOn(environment, "isLocal").mockReturnValue(false);
@@ -143,26 +144,17 @@ describe("SubscriptionStep", () => {
     expect(screen.getByLabelText("Charged today: $320.00")).toBeDefined();
   });
 
-  test("selecting Pro persists selectedPlan, submits the profile, and redirects to Stripe Checkout", async () => {
-    useOnboardingWizardStore.getState().setName("Ada Lovelace");
-    useOnboardingWizardStore.getState().setRole("Engineer");
-    useOnboardingWizardStore.getState().togglePainPoint("Repetitive work");
-
+  test("selecting Pro persists selectedPlan and redirects to Stripe Checkout (Welcome on success, paywall on cancel)", async () => {
     let capturedTierBody: {
       tier?: string;
       success_url?: string;
       cancel_url?: string;
     } | null = null;
-    let capturedProfileBody: {
-      user_name?: string;
-      user_role?: string;
-      pain_points?: string[];
-    } | null = null;
+    let profileCalled = false;
 
     server.use(
-      http.post("*/api/onboarding/profile", async ({ request }) => {
-        capturedProfileBody =
-          (await request.json()) as typeof capturedProfileBody;
+      http.post("*/api/onboarding/profile", () => {
+        profileCalled = true;
         return HttpResponse.json({}, { status: 200 });
       }),
       http.post("*/api/credits/subscription", async ({ request }) => {
@@ -182,16 +174,17 @@ describe("SubscriptionStep", () => {
 
     expect(useOnboardingWizardStore.getState().selectedPlan).toBe("PRO");
     expect(capturedTierBody!.tier).toBe("PRO");
+    // Success returns to Welcome (step 2) to begin onboarding; cancel returns
+    // to the paywall (step 1).
     expect(capturedTierBody!.success_url).toContain(
-      "/onboarding?step=5&subscription=success",
+      "/onboarding?step=2&subscription=success",
     );
     expect(capturedTierBody!.cancel_url).toContain(
-      "/onboarding?step=4&subscription=cancelled",
+      "/onboarding?step=1&subscription=cancelled",
     );
-    expect(capturedProfileBody).not.toBeNull();
-    expect(capturedProfileBody!.user_name).toBe("Ada Lovelace");
-    expect(capturedProfileBody!.user_role).toBe("Engineer");
-    expect(capturedProfileBody!.pain_points).toEqual(["Repetitive work"]);
+    // Paywall-first: no profile data exists yet, so nothing is POSTed here —
+    // the Preparing step submits the profile at the end of onboarding.
+    expect(profileCalled).toBe(false);
   });
 
   test("default yearly + selecting Pro forwards billing_cycle=yearly", async () => {
@@ -278,7 +271,7 @@ describe("SubscriptionStep", () => {
       );
       const state = useOnboardingWizardStore.getState();
       expect(state.selectedPlan).toBeNull();
-      expect(state.currentStep).toBe(4);
+      expect(state.currentStep).toBe(1);
     } finally {
       openSpy.mockRestore();
     }
@@ -306,11 +299,12 @@ describe("SubscriptionStep", () => {
     await waitFor(() => {
       expect(useOnboardingWizardStore.getState().selectedPlan).toBe("PRO");
     });
-    // Local short-circuit: no Stripe Checkout, no pre-redirect profile POST
-    // (the Preparing step handles submission via useOnboardingPage).
+    // Local short-circuit: no Stripe Checkout, no profile POST (the Preparing
+    // step handles submission via useOnboardingPage). Advances from the
+    // paywall (step 1) to Welcome (step 2).
     expect(stripeCalled).toBe(false);
     expect(profileCalledSync).toBe(false);
-    expect(useOnboardingWizardStore.getState().currentStep).toBe(5);
+    expect(useOnboardingWizardStore.getState().currentStep).toBe(2);
   });
 
   test("clicking a plan keeps the request in flight: clicked card spins, others lock", async () => {

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/store.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/store.ts
@@ -4,6 +4,25 @@ import { createJSONStorage, persist } from "zustand/middleware";
 export const MAX_PAIN_POINT_SELECTIONS = 3;
 export type Step = 1 | 2 | 3 | 4 | 5;
 
+// Wizard step layouts. With payments enabled the paywall is the FIRST step so
+// the user pays before personalising; the profile-collection steps shift down
+// by one. Centralised here so page rendering, the page hook's URL clamping and
+// the SubscriptionStep's Stripe success/cancel return URLs can't drift apart.
+export const PAYWALL_FIRST_STEPS = {
+  subscription: 1,
+  welcome: 2,
+  role: 3,
+  painPoints: 4,
+  preparing: 5,
+} as const;
+
+export const NO_PAYWALL_STEPS = {
+  welcome: 1,
+  role: 2,
+  painPoints: 3,
+  preparing: 4,
+} as const;
+
 interface OnboardingWizardState {
   currentStep: Step;
   name: string;

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/useOnboardingPage.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/useOnboardingPage.ts
@@ -13,7 +13,12 @@ import { useLDClient } from "launchdarkly-react-client-sdk";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { normalizeOnboardingProfile } from "./helpers";
-import { Step, useOnboardingWizardStore } from "./store";
+import {
+  NO_PAYWALL_STEPS,
+  PAYWALL_FIRST_STEPS,
+  Step,
+  useOnboardingWizardStore,
+} from "./store";
 
 const LD_INIT_TIMEOUT_SECONDS = 5;
 
@@ -102,7 +107,8 @@ export function useOnboardingPage() {
 
   const isPaymentEnabled =
     (paymentEnabledSnapshot.current ?? false) && !userHasActivePlan;
-  const preparingStep: Step = isPaymentEnabled ? 5 : 4;
+  const steps = isPaymentEnabled ? PAYWALL_FIRST_STEPS : NO_PAYWALL_STEPS;
+  const preparingStep: Step = steps.preparing;
   const totalSteps = isPaymentEnabled ? 4 : 3;
 
   // Wait for auth too — without !isUserLoading, LD can resolve while
@@ -126,19 +132,21 @@ export function useOnboardingPage() {
     if (!isReady || hasInitialized.current) return;
     hasInitialized.current = true;
     const urlStep = parseStepParam(searchParams.get("step"), preparingStep);
-    // A successful Stripe checkout return is a trusted intent to advance to
-    // Preparing — without this, the highestStep ceiling (capped at 4 before
-    // redirect) clamps the user back to step 4 and onboarding deadlocks.
+    // The paywall is the first step, so a successful Stripe checkout return is
+    // a trusted intent to advance past it onto Welcome and start the actual
+    // onboarding — without this, the highestStep ceiling (capped at the
+    // subscription step before redirect) would clamp the user back onto the
+    // paywall they just paid through.
     const isSubscriptionSuccess =
       searchParams.get("subscription") === "success";
     const ceiling = isSubscriptionSuccess
-      ? preparingStep
+      ? steps.welcome
       : (Math.min(readHighestStep(), preparingStep) as Step);
     const target = (
       urlStep === null ? ceiling : Math.min(urlStep, ceiling)
     ) as Step;
     goToStep(target);
-  }, [isReady, searchParams, goToStep, preparingStep]);
+  }, [isReady, searchParams, goToStep, preparingStep, steps]);
 
   // Sync store → URL when step changes; record the new ceiling.
   useEffect(() => {
@@ -188,15 +196,11 @@ export function useOnboardingPage() {
       useOnboardingWizardStore.getState(),
     );
 
-    // Profile is submitted before the Stripe Checkout redirect (defence in
-    // depth: persist keeps the store across the round-trip, but submitting
-    // pre-redirect ensures the backend has the data even if the user
-    // closes the tab during checkout). Skip the resubmit on return to
-    // avoid overwriting saved data with empties — belt-and-suspenders:
-    // also skip when `name` is empty so that even if the success query
-    // param gets stripped (manual edit, share link, upstream proxy
-    // normalising URLs), we don't blank the saved profile.
-    if (searchParams.get("subscription") === "success" || !name.trim()) return;
+    // The paywall now runs first (before any profile data is collected), so
+    // the profile is only ever submitted here, once, on reaching Preparing.
+    // Guard against an empty name so a stray Preparing visit can't blank a
+    // previously-saved profile.
+    if (!name.trim()) return;
 
     postV1SubmitOnboardingProfile({
       user_name: name,
@@ -205,7 +209,7 @@ export function useOnboardingPage() {
     }).catch(() => {
       // Best effort — profile data is non-critical for accessing copilot
     });
-  }, [currentStep, preparingStep, searchParams]);
+  }, [currentStep, preparingStep]);
 
   async function handlePreparingComplete() {
     for (let attempt = 0; attempt < 3; attempt++) {
@@ -229,6 +233,7 @@ export function useOnboardingPage() {
     isLoading: isOnboardingStateLoading || !isReady,
     handlePreparingComplete,
     isPaymentEnabled,
+    steps,
     preparingStep,
     totalSteps,
   };


### PR DESCRIPTION
## Why

We want users to pay **before** doing the actual onboarding (name, role, pain points), rather than at the end. Today the `SubscriptionStep` paywall is the 4th step, after profile collection — so people invest in personalising before ever hitting the plan picker. Moving the paywall first puts the commitment up front.

## What

Reorder the onboarding wizard so the paywall comes first **when payments are enabled**:

| Step | Before | After |
| ---- | ------ | ----- |
| 1 | Welcome (name) | **Subscription (paywall)** |
| 2 | Role | Welcome (name) |
| 3 | Pain points | Role |
| 4 | Subscription | Pain points |
| 5 | Preparing | Preparing |

The payments-**disabled** flow is unchanged (`Welcome → Role → Pain points → Preparing`), and users already on a paid tier still skip the paywall entirely.

Because checkout redirects to Stripe, the return URLs were updated so that **on successful payment the user lands on `WelcomeStep`** to begin onboarding, and **on cancel they return to the paywall**.

## How

- **`store.ts`** — centralise the step layout in two exported constants (`PAYWALL_FIRST_STEPS` / `NO_PAYWALL_STEPS`) so the page renderer, the page hook's URL clamping, and the SubscriptionStep's Stripe return URLs can't drift apart.
- **`page.tsx`** — render `SubscriptionStep` at step 1, shift Welcome/Role/PainPoints via the layout, and hide the **Back** button on Welcome when payments are on (otherwise a paid user could navigate back into the paywall and re-trigger checkout).
- **`useOnboardingPage.ts`** — derive all step numbers from the layout; a `subscription=success` return now bypasses the highest-step ceiling onto **Welcome** (not Preparing). The profile is now submitted only once, at the Preparing step.
- **`useSubscriptionStep.ts`** — drop the pre-redirect profile POST (there is no profile data yet at paywall-first); point `success_url` at Welcome and `cancel_url` at the paywall.
- Tests in `__tests__/page.test.tsx` and `steps/__tests__/SubscriptionStep.test.tsx` updated to the new step numbers and return URLs.

### Checklist

- [x] `pnpm format`, `pnpm lint`, `pnpm types` pass locally
- [x] Integration tests updated for the new ordering
- [x] No new `BackendAPI` usages; design-system + generated hooks only

> Note: the local test runner (`pnpm test:unit`) was not executed in this environment; CI / pre-commit will validate.
