### PR TITLE
feat(backend): add bot usage analytics (events + presence)

### DIFF
--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter.py
@@ -211,6 +211,13 @@ class DiscordAdapter(PlatformAdapter):
             # rows that pre-date name capture. Cheap: in-memory cache only,
             # no Discord API calls.
             await self._refresh_known_server_names()
+            # Reconcile presence analytics: record every server we're currently
+            # in and mark any we've left while disconnected. Drives the admin
+            # server-count / sharding-prediction charts.
+            self._api.sync_guilds(
+                "discord",
+                [(str(guild.id), guild.name) for guild in self._client.guilds],
+            )
             # Sync slash commands once per process — on_ready fires on every
             # gateway reconnect, but the command tree only needs uploading once.
             if self._commands_synced:
@@ -225,6 +232,7 @@ class DiscordAdapter(PlatformAdapter):
         @self._client.event
         async def on_guild_join(guild: discord.Guild) -> None:
             await self._refresh_server_name(guild)
+            self._api.track_guild_joined("discord", str(guild.id), guild.name)
             channel = intro.pick_intro_channel(guild)
             if channel is None:
                 logger.info(
@@ -244,6 +252,12 @@ class DiscordAdapter(PlatformAdapter):
         async def on_guild_update(before: discord.Guild, after: discord.Guild) -> None:
             if before.name != after.name:
                 await self._refresh_server_name(after)
+
+        @self._client.event
+        async def on_guild_remove(guild: discord.Guild) -> None:
+            # Bot was kicked or the server was deleted — mark presence as left
+            # so the live server count and sharding prediction stay accurate.
+            self._api.track_guild_left("discord", str(guild.id))
 
         @self._client.event
         async def on_thread_remove(thread: discord.Thread) -> None:

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/commands.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/commands.py
@@ -22,16 +22,26 @@ logger = logging.getLogger(__name__)
 def register(tree: app_commands.CommandTree, api: BotBackend) -> None:
     """Register all slash commands on the given CommandTree."""
 
+    def _track(interaction: discord.Interaction, command_name: str) -> None:
+        api.track_event(
+            platform="discord",
+            event_type="command_used",
+            server_id=str(interaction.guild.id) if interaction.guild else None,
+            command_name=command_name,
+        )
+
     @tree.command(
         name="setup",
         description="Link this server to an AutoGPT account for AutoPilot",
     )
     @app_commands.default_permissions(manage_guild=True)
     async def setup_command(interaction: discord.Interaction) -> None:
+        _track(interaction, "setup")
         await _handle_setup(interaction, api)
 
     @tree.command(name="help", description="Show AutoPilot bot usage info")
     async def help_command(interaction: discord.Interaction) -> None:
+        _track(interaction, "help")
         await _handle_help(interaction)
 
     @tree.command(
@@ -39,6 +49,7 @@ def register(tree: app_commands.CommandTree, api: BotBackend) -> None:
         description="Manage linked servers from your AutoGPT settings",
     )
     async def unlink_command(interaction: discord.Interaction) -> None:
+        _track(interaction, "unlink")
         await _handle_unlink(interaction)
 
     @tree.command(
@@ -46,6 +57,7 @@ def register(tree: app_commands.CommandTree, api: BotBackend) -> None:
         description="Start a fresh AutoPilot conversation in this DM or thread",
     )
     async def new_command(interaction: discord.Interaction) -> None:
+        _track(interaction, "new")
         await _handle_new(interaction)
 
     @tree.command(
@@ -53,6 +65,7 @@ def register(tree: app_commands.CommandTree, api: BotBackend) -> None:
         description="Resume one of your past AutoPilot conversations (DMs only)",
     )
     async def resume_command(interaction: discord.Interaction) -> None:
+        _track(interaction, "resume")
         await _handle_resume(interaction, api)
 
     @tree.command(
@@ -60,6 +73,7 @@ def register(tree: app_commands.CommandTree, api: BotBackend) -> None:
         description="Stop AutoPilot from auto-replying in this thread",
     )
     async def leave_command(interaction: discord.Interaction) -> None:
+        _track(interaction, "leave")
         await _handle_leave(interaction)
 
 

--- a/autogpt_platform/backend/backend/copilot/bot/bot_backend.py
+++ b/autogpt_platform/backend/backend/copilot/bot/bot_backend.py
@@ -25,6 +25,8 @@ from backend.copilot.response_model import (
 )
 from backend.platform_linking.models import (
     BotChatRequest,
+    BotEventInput,
+    BotGuildInput,
     CreateLinkTokenRequest,
     CreateUserLinkTokenRequest,
     Platform,
@@ -84,11 +86,91 @@ class BotBackend:
 
     def __init__(self):
         self._client = get_platform_linking_manager_client()
+        self._analytics_tasks: set[asyncio.Task] = set()
 
     async def close(self) -> None:
         # The client's lifecycle is owned by the thread-cached factory; nothing
         # to close here. Kept for API compatibility with older bot code.
         pass
+
+    # ── Analytics (fire-and-forget) ──────────────────────────────────────
+    # Usage telemetry must never block or break a user's reply, so every
+    # write is scheduled as a background task that swallows its own errors.
+    # No message content is ever sent — only counts, enums and metrics.
+
+    def _fire_and_forget(self, coro: Awaitable[None]) -> None:
+        task = asyncio.ensure_future(coro)
+        self._analytics_tasks.add(task)
+        task.add_done_callback(self._on_analytics_done)
+
+    def _on_analytics_done(self, task: asyncio.Task) -> None:
+        self._analytics_tasks.discard(task)
+        exc = task.exception()
+        if exc is not None:
+            logger.warning("Bot analytics write failed: %s", exc)
+
+    def track_event(
+        self,
+        *,
+        platform: str,
+        event_type: str,
+        server_id: str | None = None,
+        channel_type: str | None = None,
+        command_name: str | None = None,
+        error_kind: str | None = None,
+        char_count: int | None = None,
+        duration_ms: int | None = None,
+    ) -> None:
+        self._fire_and_forget(
+            self._client.record_bot_event(
+                event=BotEventInput(
+                    platform=Platform(platform.upper()),
+                    event_type=event_type,
+                    server_id=server_id,
+                    channel_type=channel_type,
+                    command_name=command_name,
+                    error_kind=error_kind,
+                    char_count=char_count,
+                    duration_ms=duration_ms,
+                )
+            )
+        )
+
+    def track_guild_joined(
+        self, platform: str, server_id: str, name: str | None = None
+    ) -> None:
+        self._fire_and_forget(
+            self._client.record_guild_joined(
+                guild=BotGuildInput(
+                    platform=Platform(platform.upper()),
+                    server_id=server_id,
+                    name=name,
+                )
+            )
+        )
+
+    def track_guild_left(self, platform: str, server_id: str) -> None:
+        self._fire_and_forget(
+            self._client.mark_guild_left(
+                platform=Platform(platform.upper()),
+                server_id=server_id,
+            )
+        )
+
+    def sync_guilds(self, platform: str, guilds: list[tuple[str, str | None]]) -> None:
+        self._fire_and_forget(
+            self._client.sync_guild_presence(
+                platform=Platform(platform.upper()),
+                guilds=[
+                    BotGuildInput(
+                        platform=Platform(platform.upper()),
+                        server_id=server_id,
+                        name=name,
+                    )
+                    for server_id, name in guilds
+                ],
+            )
+        )
 
     async def resolve_server(
         self, platform: str, platform_server_id: str

--- a/autogpt_platform/backend/backend/copilot/bot/bot_backend.py
+++ b/autogpt_platform/backend/backend/copilot/bot/bot_backend.py
@@ -46,8 +46,22 @@ STREAM_CHUNK_TIMEOUT_SECONDS = 120
 
 logger = logging.getLogger(__name__)
 
+
+class BotStreamError(Exception):
+    """A copilot stream couldn't produce a successful reply.
+
+    Carries a bounded ``error_kind`` so the handler can attribute analytics
+    accurately instead of guessing from the inline text.
+    """
+
+    def __init__(self, error_kind: str, message: str):
+        super().__init__(message)
+        self.error_kind = error_kind
+
+
 __all__ = [
     "BotBackend",
+    "BotStreamError",
     "ChatSummary",
     "DuplicateChatMessageError",
     "LinkAlreadyExistsError",
@@ -319,8 +333,10 @@ class BotBackend:
             last_message_id=handle.subscribe_from,
         )
         if queue is None:
-            yield "\n[Error: failed to subscribe to response stream]"
-            return
+            raise BotStreamError(
+                "subscribe_failed",
+                "failed to subscribe to response stream",
+            )
 
         setup_notified = False
 
@@ -336,8 +352,10 @@ class BotBackend:
                         STREAM_CHUNK_TIMEOUT_SECONDS,
                         handle.session_id,
                     )
-                    yield "\n[Error: response timed out]"
-                    return
+                    raise BotStreamError(
+                        "stream_timeout",
+                        "response timed out",
+                    )
                 if isinstance(chunk, StreamTextDelta):
                     if chunk.delta:
                         yield chunk.delta
@@ -354,8 +372,10 @@ class BotBackend:
                     return
                 elif isinstance(chunk, StreamError):
                     logger.error("Stream error from backend: %s", chunk.errorText)
-                    yield f"\n[Error: {chunk.errorText}]"
-                    return
+                    raise BotStreamError(
+                        "backend_stream_error",
+                        chunk.errorText,
+                    )
                 # Other StreamX types (StreamStart, StreamTextStart, tool events,
                 # etc.) are emitted by the executor for the frontend UI and
                 # aren't useful for the plain-text bot transcript.

--- a/autogpt_platform/backend/backend/copilot/bot/bot_backend.py
+++ b/autogpt_platform/backend/backend/copilot/bot/bot_backend.py
@@ -105,6 +105,8 @@ class BotBackend:
 
     def _on_analytics_done(self, task: asyncio.Task) -> None:
         self._analytics_tasks.discard(task)
+        if task.cancelled():
+            return
         exc = task.exception()
         if exc is not None:
             logger.warning("Bot analytics write failed: %s", exc)
@@ -158,12 +160,13 @@ class BotBackend:
         )
 
     def sync_guilds(self, platform: str, guilds: list[tuple[str, str | None]]) -> None:
+        platform_enum = Platform(platform.upper())
         self._fire_and_forget(
             self._client.sync_guild_presence(
-                platform=Platform(platform.upper()),
+                platform=platform_enum,
                 guilds=[
                     BotGuildInput(
-                        platform=Platform(platform.upper()),
+                        platform=platform_enum,
                         server_id=server_id,
                         name=name,
                     )

--- a/autogpt_platform/backend/backend/copilot/bot/bot_backend.py
+++ b/autogpt_platform/backend/backend/copilot/bot/bot_backend.py
@@ -125,6 +125,11 @@ class BotBackend:
         if exc is not None:
             logger.warning("Bot analytics write failed: %s", exc)
 
+    # NOTE: each track method defers Platform() and Pydantic construction into
+    # the background coroutine — that way a bad platform string or validation
+    # error fails the analytics task (which is swallowed) instead of leaking
+    # back into the caller's reply path.
+
     def track_event(
         self,
         *,
@@ -137,8 +142,8 @@ class BotBackend:
         char_count: int | None = None,
         duration_ms: int | None = None,
     ) -> None:
-        self._fire_and_forget(
-            self._client.record_bot_event(
+        async def _send() -> None:
+            await self._client.record_bot_event(
                 event=BotEventInput(
                     platform=Platform(platform.upper()),
                     event_type=event_type,
@@ -150,33 +155,36 @@ class BotBackend:
                     duration_ms=duration_ms,
                 )
             )
-        )
+
+        self._fire_and_forget(_send())
 
     def track_guild_joined(
         self, platform: str, server_id: str, name: str | None = None
     ) -> None:
-        self._fire_and_forget(
-            self._client.record_guild_joined(
+        async def _send() -> None:
+            await self._client.record_guild_joined(
                 guild=BotGuildInput(
                     platform=Platform(platform.upper()),
                     server_id=server_id,
                     name=name,
                 )
             )
-        )
+
+        self._fire_and_forget(_send())
 
     def track_guild_left(self, platform: str, server_id: str) -> None:
-        self._fire_and_forget(
-            self._client.mark_guild_left(
+        async def _send() -> None:
+            await self._client.mark_guild_left(
                 platform=Platform(platform.upper()),
                 server_id=server_id,
             )
-        )
+
+        self._fire_and_forget(_send())
 
     def sync_guilds(self, platform: str, guilds: list[tuple[str, str | None]]) -> None:
-        platform_enum = Platform(platform.upper())
-        self._fire_and_forget(
-            self._client.sync_guild_presence(
+        async def _send() -> None:
+            platform_enum = Platform(platform.upper())
+            await self._client.sync_guild_presence(
                 platform=platform_enum,
                 guilds=[
                     BotGuildInput(
@@ -187,7 +195,8 @@ class BotBackend:
                     for server_id, name in guilds
                 ],
             )
-        )
+
+        self._fire_and_forget(_send())
 
     async def resolve_server(
         self, platform: str, platform_server_id: str

--- a/autogpt_platform/backend/backend/copilot/bot/bot_backend_analytics_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/bot_backend_analytics_test.py
@@ -84,6 +84,19 @@ async def test_analytics_failure_is_swallowed():
 
 
 @pytest.mark.asyncio
+async def test_bad_platform_string_is_swallowed():
+    # Platform(...) raises ValueError on an unknown string. That must fail the
+    # background task — never the synchronous caller in the reply path.
+    backend, client = _backend()
+    backend.track_event(platform="myspace", event_type="message_received")
+    await _drain(backend)
+    assert backend._analytics_tasks == set()
+    # The bad platform must short-circuit before the RPC; the client must not
+    # have been called.
+    client.record_bot_event.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_cancelled_analytics_task_is_silent():
     # Cancelled tasks during shutdown must not raise CancelledError from the
     # done-callback (which would print as an unhandled exception by asyncio).

--- a/autogpt_platform/backend/backend/copilot/bot/bot_backend_analytics_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/bot_backend_analytics_test.py
@@ -1,0 +1,83 @@
+"""Tests for BotBackend fire-and-forget analytics methods."""
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from backend.copilot.bot.bot_backend import BotBackend
+from backend.platform_linking.models import BotEventInput, BotGuildInput, Platform
+
+
+def _backend() -> tuple[BotBackend, AsyncMock]:
+    backend = BotBackend.__new__(BotBackend)
+    client = AsyncMock()
+    backend._client = client
+    backend._analytics_tasks = set()
+    return backend, client
+
+
+async def _drain(backend: BotBackend) -> None:
+    if backend._analytics_tasks:
+        await asyncio.gather(*backend._analytics_tasks, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_track_event_records_bot_event():
+    backend, client = _backend()
+    backend.track_event(
+        platform="discord",
+        event_type="message_received",
+        server_id="42",
+        channel_type="thread",
+        char_count=12,
+    )
+    await _drain(backend)
+
+    client.record_bot_event.assert_awaited_once()
+    event = client.record_bot_event.await_args.kwargs["event"]
+    assert isinstance(event, BotEventInput)
+    assert event.platform == Platform.DISCORD
+    assert event.event_type == "message_received"
+    assert event.server_id == "42"
+    assert event.channel_type == "thread"
+    assert event.char_count == 12
+
+
+@pytest.mark.asyncio
+async def test_track_guild_joined_and_left():
+    backend, client = _backend()
+    backend.track_guild_joined("discord", "7", "Cool Server")
+    backend.track_guild_left("discord", "7")
+    await _drain(backend)
+
+    guild = client.record_guild_joined.await_args.kwargs["guild"]
+    assert isinstance(guild, BotGuildInput)
+    assert guild.server_id == "7"
+    assert guild.name == "Cool Server"
+    client.mark_guild_left.assert_awaited_once_with(
+        platform=Platform.DISCORD, server_id="7"
+    )
+
+
+@pytest.mark.asyncio
+async def test_sync_guilds_maps_all_servers():
+    backend, client = _backend()
+    backend.sync_guilds("discord", [("1", "A"), ("2", None)])
+    await _drain(backend)
+
+    kwargs = client.sync_guild_presence.await_args.kwargs
+    assert kwargs["platform"] == Platform.DISCORD
+    guilds = kwargs["guilds"]
+    assert [g.server_id for g in guilds] == ["1", "2"]
+    assert guilds[1].name is None
+
+
+@pytest.mark.asyncio
+async def test_analytics_failure_is_swallowed():
+    backend, client = _backend()
+    client.record_bot_event.side_effect = RuntimeError("rpc down")
+    backend.track_event(platform="discord", event_type="message_received")
+    # A failing write must never propagate into the caller's reply path.
+    await _drain(backend)
+    assert backend._analytics_tasks == set()

--- a/autogpt_platform/backend/backend/copilot/bot/bot_backend_analytics_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/bot_backend_analytics_test.py
@@ -81,3 +81,21 @@ async def test_analytics_failure_is_swallowed():
     # A failing write must never propagate into the caller's reply path.
     await _drain(backend)
     assert backend._analytics_tasks == set()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_analytics_task_is_silent():
+    # Cancelled tasks during shutdown must not raise CancelledError from the
+    # done-callback (which would print as an unhandled exception by asyncio).
+    backend, client = _backend()
+
+    async def hang() -> None:
+        await asyncio.sleep(3600)
+
+    client.record_bot_event.side_effect = lambda **_: hang()
+    backend.track_event(platform="discord", event_type="message_received")
+    task = next(iter(backend._analytics_tasks))
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert backend._analytics_tasks == set()

--- a/autogpt_platform/backend/backend/copilot/bot/bot_backend_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/bot_backend_test.py
@@ -24,7 +24,7 @@ from backend.util.exceptions import (
     NotFoundError,
 )
 
-from .bot_backend import BotBackend
+from .bot_backend import BotBackend, BotStreamError
 
 
 @pytest.fixture
@@ -180,14 +180,15 @@ class TestStreamChat:
                 "backend.copilot.bot.bot_backend.stream_registry.unsubscribe_from_session",
                 new=AsyncMock(),
             ),
+            pytest.raises(BotStreamError) as excinfo,
         ):
-            chunks: list[str] = []
-            async for chunk in api.stream_chat(
+            async for _ in api.stream_chat(
                 platform="discord", platform_user_id="u1", message="hi"
             ):
-                chunks.append(chunk)
+                pass
 
-        assert any("executor crashed" in c for c in chunks)
+        assert excinfo.value.error_kind == "backend_stream_error"
+        assert "executor crashed" in str(excinfo.value)
 
     @pytest.mark.asyncio
     async def test_notifies_setup_requirements_tool_output(self, api: BotBackend):
@@ -266,7 +267,7 @@ class TestStreamChat:
                 pass
 
     @pytest.mark.asyncio
-    async def test_subscribe_returns_none_yields_error(self, api: BotBackend):
+    async def test_subscribe_returns_none_raises(self, api: BotBackend):
         handle = ChatTurnHandle(session_id="sess", turn_id="turn", user_id="u1")
         api._client.start_chat_turn = AsyncMock(return_value=handle)
 
@@ -279,11 +280,11 @@ class TestStreamChat:
                 "backend.copilot.bot.bot_backend.stream_registry.unsubscribe_from_session",
                 new=AsyncMock(),
             ),
+            pytest.raises(BotStreamError) as excinfo,
         ):
-            chunks: list[str] = []
-            async for chunk in api.stream_chat(
+            async for _ in api.stream_chat(
                 platform="discord", platform_user_id="u1", message="hi"
             ):
-                chunks.append(chunk)
+                pass
 
-        assert any("failed to subscribe" in c.lower() for c in chunks)
+        assert excinfo.value.error_kind == "subscribe_failed"

--- a/autogpt_platform/backend/backend/copilot/bot/handler.py
+++ b/autogpt_platform/backend/backend/copilot/bot/handler.py
@@ -7,6 +7,7 @@ persistent typing indicator.
 
 import asyncio
 import logging
+import time
 from dataclasses import dataclass, field
 from typing import Any
 from urllib.parse import quote
@@ -89,6 +90,14 @@ class MessageHandler:
         target_id = await self._resolve_target(ctx, adapter)
         if not target_id:
             return  # Thread not subscribed, ignore silently
+
+        self._api.track_event(
+            platform=ctx.platform,
+            event_type="message_received",
+            server_id=ctx.server_id,
+            channel_type=ctx.channel_type,
+            char_count=len(ctx.text),
+        )
 
         message_text = self._message_text(ctx) if include_thread_history else ctx.text
         await self._enqueue_and_process(ctx, adapter, target_id, message_text)
@@ -353,6 +362,8 @@ class MessageHandler:
                 link_url=session_url,
             )
 
+        started_at = time.monotonic()
+        reply_chars = 0
         typing_task = asyncio.create_task(_keep_typing(adapter, target_id))
         try:
             async for chunk in self._api.stream_chat(
@@ -365,6 +376,7 @@ class MessageHandler:
                 on_setup_required=_on_setup_required,
             ):
                 buffer += chunk
+                reply_chars += len(chunk)
                 if len(buffer) >= flush_at:
                     post, buffer = split_at_boundary(buffer, flush_at)
                     if post and post.strip():
@@ -379,6 +391,7 @@ class MessageHandler:
             return
         except NotFoundError:
             logger.exception("Chat turn rejected")
+            self._track_stream_error(ctx, "chat_turn_rejected")
             await adapter.send_message(
                 target_id, "AutoPilot ran into an error. Try again later."
             )
@@ -387,6 +400,7 @@ class MessageHandler:
             logger.exception(
                 "Unexpected error during streaming for target %s", target_id
             )
+            self._track_stream_error(ctx, "stream_exception")
             await adapter.send_message(
                 target_id,
                 "Something went wrong. Try again in a moment.",
@@ -411,6 +425,15 @@ class MessageHandler:
                 target_id,
                 "AutoPilot didn't produce a response. Try rephrasing your question.",
             )
+
+        self._api.track_event(
+            platform=ctx.platform,
+            event_type="reply_sent",
+            server_id=ctx.server_id,
+            channel_type=ctx.channel_type,
+            char_count=reply_chars,
+            duration_ms=int((time.monotonic() - started_at) * 1000),
+        )
 
         if (
             ctx.channel_type == "channel"
@@ -449,6 +472,15 @@ class MessageHandler:
                 return
             if attempt < TITLE_RENAME_ATTEMPTS - 1:
                 await asyncio.sleep(TITLE_RENAME_INTERVAL_SECONDS)
+
+    def _track_stream_error(self, ctx: MessageContext, error_kind: str) -> None:
+        self._api.track_event(
+            platform=ctx.platform,
+            event_type="stream_error",
+            server_id=ctx.server_id,
+            channel_type=ctx.channel_type,
+            error_kind=error_kind,
+        )
 
     # -- Linking --
 

--- a/autogpt_platform/backend/backend/copilot/bot/handler.py
+++ b/autogpt_platform/backend/backend/copilot/bot/handler.py
@@ -26,7 +26,7 @@ from backend.util.settings import Settings
 
 from . import sessions, threads
 from .adapters.base import FileAttachment, MessageContext, PlatformAdapter
-from .bot_backend import BotBackend
+from .bot_backend import BotBackend, BotStreamError
 from .config import SESSION_TTL
 from .text import format_batch, split_at_boundary
 
@@ -388,6 +388,22 @@ class MessageHandler:
             # Another in-flight turn is already processing this exact message —
             # stay quiet so the user doesn't get a double response.
             logger.info("Duplicate message dropped for target %s", target_id)
+            return
+        except BotStreamError as exc:
+            # Stream couldn't complete (timeout, subscribe fail, backend stream
+            # error). Track the specific kind, surface a generic message, and
+            # do NOT fire reply_sent below.
+            logger.warning(
+                "Stream failed for target %s: %s (%s)",
+                target_id,
+                exc,
+                exc.error_kind,
+            )
+            self._track_stream_error(ctx, exc.error_kind)
+            await adapter.send_message(
+                target_id,
+                "AutoPilot ran into an error. Try again in a moment.",
+            )
             return
         except NotFoundError:
             logger.exception("Chat turn rejected")

--- a/autogpt_platform/backend/backend/copilot/bot/handler.py
+++ b/autogpt_platform/backend/backend/copilot/bot/handler.py
@@ -441,6 +441,8 @@ class MessageHandler:
                 target_id,
                 "AutoPilot didn't produce a response. Try rephrasing your question.",
             )
+            self._track_stream_error(ctx, "empty_reply")
+            return
 
         self._api.track_event(
             platform=ctx.platform,

--- a/autogpt_platform/backend/backend/data/bot_analytics.py
+++ b/autogpt_platform/backend/backend/data/bot_analytics.py
@@ -1,0 +1,87 @@
+"""Bot usage analytics writes (privacy-preserving).
+
+Records discrete bot usage events and per-server presence for the admin
+analytics page. NEVER stores message content — only counts, bounded enums,
+timestamps and numeric metrics.
+
+Directly accessed by the ``DatabaseManager`` pod (which holds the Prisma
+connection). Other services (notably the out-of-process bot) reach these
+through ``backend.data.db_accessors.bot_analytics_db`` so calls are
+transparently routed via ``DatabaseManagerAsyncClient``.
+"""
+
+import logging
+from datetime import datetime, timezone
+
+from prisma.models import BotEvent, BotGuild
+
+from backend.platform_linking.models import BotEventInput, BotGuildInput, Platform
+
+logger = logging.getLogger(__name__)
+
+
+async def record_bot_event(event: BotEventInput) -> None:
+    await BotEvent.prisma().create(
+        data={
+            "platform": event.platform.value,
+            "eventType": event.event_type,
+            "serverId": event.server_id,
+            "channelType": event.channel_type,
+            "commandName": event.command_name,
+            "errorKind": event.error_kind,
+            "charCount": event.char_count,
+            "durationMs": event.duration_ms,
+        }
+    )
+
+
+async def record_guild_joined(guild: BotGuildInput) -> None:
+    await BotGuild.prisma().upsert(
+        where={
+            "platform_serverId": {
+                "platform": guild.platform.value,
+                "serverId": guild.server_id,
+            }
+        },
+        data={
+            "create": {
+                "platform": guild.platform.value,
+                "serverId": guild.server_id,
+                "name": guild.name,
+            },
+            "update": {
+                "name": guild.name,
+                "leftAt": None,
+                "lastSeenAt": datetime.now(timezone.utc),
+            },
+        },
+    )
+
+
+async def mark_guild_left(platform: Platform, server_id: str) -> None:
+    await BotGuild.prisma().update_many(
+        where={
+            "platform": platform.value,
+            "serverId": server_id,
+            "leftAt": None,
+        },
+        data={"leftAt": datetime.now(timezone.utc)},
+    )
+
+
+async def sync_guild_presence(platform: Platform, guilds: list[BotGuildInput]) -> None:
+    """Full presence reconcile (on connect): upsert every server the bot is in
+    now and mark any previously-joined server it is no longer in as left."""
+    for guild in guilds:
+        await record_guild_joined(guild)
+
+    present = {guild.server_id for guild in guilds}
+    joined = await BotGuild.prisma().find_many(
+        where={"platform": platform.value, "leftAt": None}
+    )
+    stale_ids = [row.id for row in joined if row.serverId not in present]
+    if stale_ids:
+        await BotGuild.prisma().update_many(
+            where={"id": {"in": stale_ids}},
+            data={"leftAt": datetime.now(timezone.utc)},
+        )

--- a/autogpt_platform/backend/backend/data/bot_analytics_test.py
+++ b/autogpt_platform/backend/backend/data/bot_analytics_test.py
@@ -1,0 +1,100 @@
+"""Tests for bot_analytics writer functions (prisma mocked)."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from backend.data import bot_analytics
+from backend.platform_linking.models import BotEventInput, BotGuildInput, Platform
+
+
+@pytest.mark.asyncio
+async def test_record_bot_event_creates_row():
+    prisma_mock = MagicMock()
+    prisma_mock.create = AsyncMock()
+    with patch.object(bot_analytics.BotEvent, "prisma", return_value=prisma_mock):
+        await bot_analytics.record_bot_event(
+            BotEventInput(
+                platform=Platform.DISCORD,
+                event_type="reply_sent",
+                server_id="9",
+                char_count=100,
+                duration_ms=2500,
+            )
+        )
+
+    data = prisma_mock.create.await_args.kwargs["data"]
+    assert data["platform"] == "DISCORD"
+    assert data["eventType"] == "reply_sent"
+    assert data["serverId"] == "9"
+    assert data["charCount"] == 100
+    assert data["durationMs"] == 2500
+
+
+@pytest.mark.asyncio
+async def test_record_guild_joined_upserts():
+    prisma_mock = MagicMock()
+    prisma_mock.upsert = AsyncMock()
+    with patch.object(bot_analytics.BotGuild, "prisma", return_value=prisma_mock):
+        await bot_analytics.record_guild_joined(
+            BotGuildInput(platform=Platform.DISCORD, server_id="5", name="Srv")
+        )
+
+    kwargs = prisma_mock.upsert.await_args.kwargs
+    assert kwargs["where"]["platform_serverId"] == {
+        "platform": "DISCORD",
+        "serverId": "5",
+    }
+    assert kwargs["data"]["create"]["serverId"] == "5"
+    assert kwargs["data"]["update"]["leftAt"] is None
+
+
+@pytest.mark.asyncio
+async def test_mark_guild_left_updates_active_rows():
+    prisma_mock = MagicMock()
+    prisma_mock.update_many = AsyncMock()
+    with patch.object(bot_analytics.BotGuild, "prisma", return_value=prisma_mock):
+        await bot_analytics.mark_guild_left(Platform.DISCORD, "5")
+
+    where = prisma_mock.update_many.await_args.kwargs["where"]
+    assert where == {"platform": "DISCORD", "serverId": "5", "leftAt": None}
+
+
+@pytest.mark.asyncio
+async def test_sync_guild_presence_marks_absent_as_left():
+    prisma_mock = MagicMock()
+    prisma_mock.upsert = AsyncMock()
+    prisma_mock.update_many = AsyncMock()
+    # Two rows currently joined; only "1" is still present.
+    joined = [
+        MagicMock(id="row1", serverId="1"),
+        MagicMock(id="row2", serverId="2"),
+    ]
+    prisma_mock.find_many = AsyncMock(return_value=joined)
+
+    with patch.object(bot_analytics.BotGuild, "prisma", return_value=prisma_mock):
+        await bot_analytics.sync_guild_presence(
+            Platform.DISCORD,
+            [BotGuildInput(platform=Platform.DISCORD, server_id="1", name="A")],
+        )
+
+    prisma_mock.upsert.assert_awaited_once()
+    prisma_mock.update_many.assert_awaited_once()
+    where = prisma_mock.update_many.await_args.kwargs["where"]
+    assert where == {"id": {"in": ["row2"]}}
+
+
+@pytest.mark.asyncio
+async def test_sync_guild_presence_noop_when_nothing_stale():
+    prisma_mock = MagicMock()
+    prisma_mock.upsert = AsyncMock()
+    prisma_mock.update_many = AsyncMock()
+    prisma_mock.find_many = AsyncMock(return_value=[MagicMock(id="row1", serverId="1")])
+
+    with patch.object(bot_analytics.BotGuild, "prisma", return_value=prisma_mock):
+        await bot_analytics.sync_guild_presence(
+            Platform.DISCORD,
+            [BotGuildInput(platform=Platform.DISCORD, server_id="1", name="A")],
+        )
+
+    prisma_mock.update_many.assert_not_awaited()

--- a/autogpt_platform/backend/backend/data/db_accessors.py
+++ b/autogpt_platform/backend/backend/data/db_accessors.py
@@ -168,3 +168,16 @@ def platform_linking_db():
         platform_linking_db = get_database_manager_async_client()
 
     return platform_linking_db
+
+
+def bot_analytics_db():
+    if db.is_connected():
+        from backend.data import bot_analytics as _bot_analytics_db
+
+        bot_analytics_db = _bot_analytics_db
+    else:
+        from backend.util.clients import get_database_manager_async_client
+
+        bot_analytics_db = get_database_manager_async_client()
+
+    return bot_analytics_db

--- a/autogpt_platform/backend/backend/data/db_manager.py
+++ b/autogpt_platform/backend/backend/data/db_manager.py
@@ -35,6 +35,7 @@ from backend.api.features.store.db import (
 from backend.api.features.store.embeddings import backfill_missing_embeddings
 from backend.copilot import db as chat_db
 from backend.copilot.sharing.db import link_new_execution_to_chat_share
+from backend.data import bot_analytics as bot_analytics_db
 from backend.data import db
 from backend.data.analytics import (
     get_accuracy_trends_and_alerts,
@@ -395,6 +396,12 @@ class DatabaseManager(AppService):
     )
     fetch_workspace_artifact = _(platform_linking_db.fetch_workspace_artifact)
 
+    # ============ Bot Analytics ============ #
+    record_bot_event = _(bot_analytics_db.record_bot_event)
+    record_guild_joined = _(bot_analytics_db.record_guild_joined)
+    mark_guild_left = _(bot_analytics_db.mark_guild_left)
+    sync_guild_presence = _(bot_analytics_db.sync_guild_presence)
+
     # ============ CoPilot Chat Sessions ============ #
     # NOTE: no eager-load `get_chat_session` here — callers go through
     # `get_chat_messages_paginated` (with `limit=MAX_LOADED_CHAT_MESSAGES`) so
@@ -641,6 +648,12 @@ class DatabaseManagerAsyncClient(AppServiceClient):
     delete_user_link = d.delete_user_link
     cleanup_expired_platform_link_tokens = d.cleanup_expired_platform_link_tokens
     fetch_workspace_artifact = d.fetch_workspace_artifact
+
+    # ============ Bot Analytics ============ #
+    record_bot_event = d.record_bot_event
+    record_guild_joined = d.record_guild_joined
+    mark_guild_left = d.mark_guild_left
+    sync_guild_presence = d.sync_guild_presence
 
     # ============ CoPilot Chat Sessions ============ #
     get_chat_session_metadata = d.get_chat_session_metadata

--- a/autogpt_platform/backend/backend/data/db_manager_test.py
+++ b/autogpt_platform/backend/backend/data/db_manager_test.py
@@ -1,6 +1,17 @@
-from .db_manager import DatabaseManagerAsyncClient
+from .db_manager import DatabaseManager, DatabaseManagerAsyncClient
 
 
 def test_async_client_exposes_chat_methods() -> None:
     assert hasattr(DatabaseManagerAsyncClient, "delete_chat_session")
     assert hasattr(DatabaseManagerAsyncClient, "set_turn_duration")
+
+
+def test_bot_analytics_methods_registered() -> None:
+    for method in (
+        "record_bot_event",
+        "record_guild_joined",
+        "mark_guild_left",
+        "sync_guild_presence",
+    ):
+        assert hasattr(DatabaseManager, method)
+        assert hasattr(DatabaseManagerAsyncClient, method)

--- a/autogpt_platform/backend/backend/platform_linking/manager.py
+++ b/autogpt_platform/backend/backend/platform_linking/manager.py
@@ -2,13 +2,15 @@
 
 import logging
 
-from backend.data.db_accessors import platform_linking_db
+from backend.data.db_accessors import bot_analytics_db, platform_linking_db
 from backend.util.service import AppService, AppServiceClient, endpoint_to_async, expose
 from backend.util.settings import Settings
 
 from .chat import list_user_chats, start_chat_turn
 from .models import (
     BotChatRequest,
+    BotEventInput,
+    BotGuildInput,
     ChatTurnHandle,
     CreateLinkTokenRequest,
     CreateUserLinkTokenRequest,
@@ -90,6 +92,24 @@ class PlatformLinkingManager(AppService):
             session_id, file_id, max_bytes
         )
 
+    @expose
+    async def record_bot_event(self, event: BotEventInput) -> None:
+        await bot_analytics_db().record_bot_event(event)
+
+    @expose
+    async def record_guild_joined(self, guild: BotGuildInput) -> None:
+        await bot_analytics_db().record_guild_joined(guild)
+
+    @expose
+    async def mark_guild_left(self, platform: Platform, server_id: str) -> None:
+        await bot_analytics_db().mark_guild_left(platform, server_id)
+
+    @expose
+    async def sync_guild_presence(
+        self, platform: Platform, guilds: list[BotGuildInput]
+    ) -> None:
+        await bot_analytics_db().sync_guild_presence(platform, guilds)
+
 
 class PlatformLinkingManagerClient(AppServiceClient):
     @classmethod
@@ -115,3 +135,7 @@ class PlatformLinkingManagerClient(AppServiceClient):
     fetch_workspace_artifact = endpoint_to_async(
         PlatformLinkingManager.fetch_workspace_artifact
     )
+    record_bot_event = endpoint_to_async(PlatformLinkingManager.record_bot_event)
+    record_guild_joined = endpoint_to_async(PlatformLinkingManager.record_guild_joined)
+    mark_guild_left = endpoint_to_async(PlatformLinkingManager.mark_guild_left)
+    sync_guild_presence = endpoint_to_async(PlatformLinkingManager.sync_guild_presence)

--- a/autogpt_platform/backend/backend/platform_linking/models.py
+++ b/autogpt_platform/backend/backend/platform_linking/models.py
@@ -224,3 +224,24 @@ class WorkspaceArtifact(BaseModel):
     mime_type: str
     size_bytes: int
     content: bytes
+
+
+class BotEventInput(BaseModel):
+    """A single bot usage event. Never carries message content."""
+
+    platform: Platform
+    event_type: str
+    server_id: str | None = None
+    channel_type: str | None = None
+    command_name: str | None = None
+    error_kind: str | None = None
+    char_count: int | None = None
+    duration_ms: int | None = None
+
+
+class BotGuildInput(BaseModel):
+    """Presence of the bot in a single server."""
+
+    platform: Platform
+    server_id: str
+    name: str | None = None

--- a/autogpt_platform/backend/migrations/20260608120000_add_bot_analytics_tables/migration.sql
+++ b/autogpt_platform/backend/migrations/20260608120000_add_bot_analytics_tables/migration.sql
@@ -1,0 +1,51 @@
+-- CreateTable
+-- BotEvent is an append-only stream of discrete bot usage events. It NEVER
+-- stores message content — only counts, timestamps, bounded enums and numeric
+-- metrics. Powers message-volume, command-usage, error-rate and per-server
+-- activity charts on the admin analytics page.
+CREATE TABLE "BotEvent" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "platform" "PlatformType" NOT NULL,
+    "eventType" TEXT NOT NULL,
+    "serverId" TEXT,
+    "channelType" TEXT,
+    "commandName" TEXT,
+    "errorKind" TEXT,
+    "charCount" INTEGER,
+    "durationMs" INTEGER,
+
+    CONSTRAINT "BotEvent_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+-- BotGuild is the presence table: which servers the bot is physically in right
+-- now (a superset of PlatformLink, since the bot can be in servers that never
+-- ran /setup). leftAt IS NULL means currently joined; the joinedAt histogram
+-- drives growth charts and sharding-threshold prediction.
+CREATE TABLE "BotGuild" (
+    "id" TEXT NOT NULL,
+    "platform" "PlatformType" NOT NULL,
+    "serverId" TEXT NOT NULL,
+    "name" TEXT,
+    "joinedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "leftAt" TIMESTAMP(3),
+    "lastSeenAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "BotGuild_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "BotEvent_platform_eventType_createdAt_idx" ON "BotEvent"("platform", "eventType", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "BotEvent_platform_serverId_createdAt_idx" ON "BotEvent"("platform", "serverId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "BotEvent_createdAt_idx" ON "BotEvent"("createdAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "BotGuild_platform_serverId_key" ON "BotGuild"("platform", "serverId");
+
+-- CreateIndex
+CREATE INDEX "BotGuild_platform_leftAt_idx" ON "BotGuild"("platform", "leftAt");

--- a/autogpt_platform/backend/schema.prisma
+++ b/autogpt_platform/backend/schema.prisma
@@ -1589,3 +1589,47 @@ model PlatformLinkToken {
   @@index([platform, platformUserId])
   @@index([expiresAt])
 }
+
+// ── Bot usage analytics ────────────────────────────────────────────────
+// Privacy: these tables NEVER store message content. Only counts,
+// timestamps, bounded enums (event type, channel type, error kind) and
+// numeric metrics (reply length, latency). Tagged with PlatformType so the
+// same analytics work for every chat-bot platform.
+
+// Append-only stream of discrete bot usage events. Powers message-volume,
+// command-usage, error-rate and per-server activity charts.
+model BotEvent {
+  id          String       @id @default(uuid())
+  createdAt   DateTime     @default(now())
+  platform    PlatformType
+  // Bounded event kind, e.g. "message_received", "reply_sent",
+  // "command_used", "link_created", "link_removed", "stream_error".
+  eventType   String
+  serverId    String? // Platform server/guild ID; null for DMs
+  channelType String? // "dm" | "channel" | "thread"
+  commandName String? // For command_used events (e.g. "/new", "/resume")
+  errorKind   String? // Bounded failure category for stream_error events
+  charCount   Int? // Reply length in characters — a metric, NOT content
+  durationMs  Int? // Receive→reply latency in milliseconds
+
+  @@index([platform, eventType, createdAt])
+  @@index([platform, serverId, createdAt])
+  @@index([createdAt])
+}
+
+// Presence table: which servers the bot is physically in right now (a
+// superset of PlatformLink, since the bot can be in servers that haven't run
+// /setup). `leftAt IS NULL` is the live membership; the joinedAt histogram
+// drives growth charts and sharding-threshold prediction.
+model BotGuild {
+  id         String       @id @default(uuid())
+  platform   PlatformType
+  serverId   String // Platform server/guild ID
+  name       String? // Server display name (best-effort, may go stale)
+  joinedAt   DateTime     @default(now())
+  leftAt     DateTime? // Set when the bot is removed; null = currently joined
+  lastSeenAt DateTime     @default(now()) // Last reconcile that confirmed presence
+
+  @@unique([platform, serverId])
+  @@index([platform, leftAt])
+}


### PR DESCRIPTION
### Why / What / How

**Why** — we have zero visibility into how the AutoPilot Discord bot is actually being used. We don't know how many servers it's in (so can't predict when we'll need to shard the gateway), how often it's invoked, how often it errors, or which commands matter. Adding analytics also has to clear a hard privacy bar: the bot reads user DMs and channel messages, so the data layer must make it **impossible** to log message content or user identity.

**What** — adds two append-only tables (`BotEvent`, `BotGuild`), a writes module, four RPC endpoints on `PlatformLinkingManager`, a fire-and-forget facade on `BotBackend`, and instrumentation at every bot entry point (message received / reply sent / command used / stream error / guild joined-left).

**How** —
- **Privacy by schema.** `BotEvent` columns are: bounded enums (`eventType`, `channelType`, `errorKind`), a `commandName` slug, a `serverId`, plus two ints (`charCount`, `durationMs`). There is no `content`, no `userId`, no `username`. `BotGuild` stores `(platform, serverId, name, joinedAt, leftAt, lastSeenAt)`. The privacy guarantee is enforced by the columns not existing, not by code discipline.
- **Fire-and-forget writes.** `BotBackend.track_event/track_guild_*` schedule writes as background tasks with errors swallowed and logged at WARNING. A failing analytics write can never block or break a user's reply.
- **Presence reconciliation.** On `on_ready` the bot calls `sync_guilds()` which upserts every server it's currently in and marks any previously-joined server it isn't in any more as left — recovers state after the bot was down. `on_guild_join`/`on_guild_remove` keep the live count tracked in real time.
- **Routing.** Writes go through `bot_analytics_db()` in `db_accessors.py` — same pattern as `platform_linking_db`. In-process for the DatabaseManager pod, RPC via `DatabaseManagerAsyncClient` elsewhere.

This PR is **writes only**. The admin read API and dashboard ship in the stacked PR on top of this one.

### Changes 🏗️

- **Schema** (`schema.prisma` + migration `20260608120000_add_bot_analytics_tables`):
  - `BotEvent` — append-only event stream, indexed `(platform, eventType, createdAt)`, `(platform, serverId, createdAt)`, `(createdAt)`
  - `BotGuild` — presence row, unique on `(platform, serverId)`, indexed `(platform, leftAt)`
- **Writes**: `backend/data/bot_analytics.py` — `record_bot_event`, `record_guild_joined`, `mark_guild_left`, `sync_guild_presence`
- **Accessor**: `backend/data/db_accessors.py::bot_analytics_db()`
- **RPC**: 4 new `@expose` methods on `PlatformLinkingManager` + mirrored stubs on `PlatformLinkingManagerClient`
- **DB manager**: registers the same 4 methods on `DatabaseManager` and `DatabaseManagerAsyncClient`
- **Facade**: `BotBackend` — `track_event`, `track_guild_joined`, `track_guild_left`, `sync_guilds` (all fire-and-forget; errors logged not raised)
- **Instrumentation**:
  - `handler.py` — `message_received` (with `char_count`), `reply_sent` (with `char_count` + `duration_ms`), `stream_error` (with bounded `error_kind`)
  - `adapters/discord/commands.py` — `command_used` for every slash command
  - `adapters/discord/adapter.py` — `sync_guilds` on `on_ready`, `track_guild_joined` on `on_guild_join`, `track_guild_left` on `on_guild_remove`
- **Models**: `BotEventInput`, `BotGuildInput` in `platform_linking/models.py`

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Verified the bot runs and analytics calls don't block replies (a failing write logs a WARNING and the reply still goes out)
  - [x] Verified `on_ready` reconciles presence — joining/leaving a server while the bot was offline is reflected on next connect
  - [x] Verified slash commands record `command_used` rows with the correct command name
  - [x] Verified the schema literally cannot store message content or user identity (no such columns)
  - [x] `black`, `isort`, `ruff`, `pyright` all clean on changed files
  - [x] `bot_backend_analytics_test.py` (incl. "failure is swallowed" case) and `db_manager_test.py` pass

#### For configuration changes:
- [x] `.env.default` is updated or already compatible with my changes (no env changes)
- [x] `docker-compose.yml` is updated or already compatible with my changes (no service changes)
- [x] I have included a list of my configuration changes in the PR description (under **Changes**) — none required

### Privacy

The schema **cannot** store message content or user identity. The closest thing to a user-identifying field is `BotGuild.name` (server display name, best-effort). The closest thing to a message-content field is `BotEvent.charCount` (an integer). This is intentional and the whole reason the schema looks the way it does.

### Stacked

Read API + admin dashboard ship on top of this in the follow-up PR.
