### PR TITLE
feat(platform): bot analytics admin page + read API

### DIFF
--- a/autogpt_platform/backend/backend/api/features/admin/bot_analytics_routes.py
+++ b/autogpt_platform/backend/backend/api/features/admin/bot_analytics_routes.py
@@ -1,0 +1,107 @@
+"""Admin read API for bot usage analytics.
+
+All endpoints are admin-gated (router-level ``requires_admin_user``) and
+read-only. They surface aggregate counts, server presence and performance
+metrics for every live bot — never message content or user identity (the
+underlying schema stores neither).
+"""
+
+import logging
+
+from autogpt_libs.auth import requires_admin_user
+from fastapi import APIRouter, Query, Security
+
+from backend.data.bot_analytics_reads import (
+    BotAnalyticsSummary,
+    BotCommandUsage,
+    BotGuildInfo,
+    BotServerActivity,
+    BotServerCountPoint,
+    BotTimeseriesPoint,
+    get_bot_analytics_summary,
+    get_bot_command_usage,
+    get_bot_message_timeseries,
+    get_bot_server_timeseries,
+    get_bot_top_servers,
+    list_bot_guilds,
+)
+from backend.platform_linking.models import Platform
+
+logger = logging.getLogger(__name__)
+
+
+router = APIRouter(
+    prefix="/bot-analytics",
+    tags=["bot-analytics", "admin"],
+    dependencies=[Security(requires_admin_user)],
+)
+
+
+def _platform_value(platform: Platform | None) -> str | None:
+    return platform.value if platform else None
+
+
+@router.get("/summary", response_model=BotAnalyticsSummary, summary="Bot Usage Summary")
+async def bot_summary(
+    platform: Platform | None = Query(None),
+    days: int = Query(30, ge=1, le=365),
+) -> BotAnalyticsSummary:
+    return await get_bot_analytics_summary(_platform_value(platform), days)
+
+
+@router.get(
+    "/timeseries",
+    response_model=list[BotTimeseriesPoint],
+    summary="Bot Message Timeseries",
+)
+async def bot_timeseries(
+    platform: Platform | None = Query(None),
+    days: int = Query(30, ge=1, le=365),
+) -> list[BotTimeseriesPoint]:
+    return await get_bot_message_timeseries(_platform_value(platform), days)
+
+
+@router.get(
+    "/server-timeseries",
+    response_model=list[BotServerCountPoint],
+    summary="Bot Server-Count Timeseries (sharding curve)",
+)
+async def bot_server_timeseries(
+    platform: Platform | None = Query(None),
+    days: int = Query(30, ge=1, le=365),
+) -> list[BotServerCountPoint]:
+    return await get_bot_server_timeseries(_platform_value(platform), days)
+
+
+@router.get(
+    "/top-servers",
+    response_model=list[BotServerActivity],
+    summary="Top Servers by Activity",
+)
+async def bot_top_servers(
+    platform: Platform | None = Query(None),
+    days: int = Query(30, ge=1, le=365),
+    limit: int = Query(20, ge=1, le=100),
+) -> list[BotServerActivity]:
+    return await get_bot_top_servers(_platform_value(platform), days, limit)
+
+
+@router.get(
+    "/command-usage",
+    response_model=list[BotCommandUsage],
+    summary="Command Usage Breakdown",
+)
+async def bot_command_usage(
+    platform: Platform | None = Query(None),
+    days: int = Query(30, ge=1, le=365),
+) -> list[BotCommandUsage]:
+    return await get_bot_command_usage(_platform_value(platform), days)
+
+
+@router.get("/guilds", response_model=list[BotGuildInfo], summary="Bot Server Roster")
+async def bot_guilds(
+    platform: Platform | None = Query(None),
+    include_left: bool = Query(False),
+    limit: int = Query(500, ge=1, le=2000),
+) -> list[BotGuildInfo]:
+    return await list_bot_guilds(_platform_value(platform), include_left, limit)

--- a/autogpt_platform/backend/backend/api/features/admin/bot_analytics_routes.py
+++ b/autogpt_platform/backend/backend/api/features/admin/bot_analytics_routes.py
@@ -32,7 +32,7 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(
     prefix="/bot-analytics",
-    tags=["bot-analytics", "admin"],
+    tags=["bot-analytics"],
     dependencies=[Security(requires_admin_user)],
 )
 

--- a/autogpt_platform/backend/backend/api/features/admin/bot_analytics_routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/admin/bot_analytics_routes_test.py
@@ -28,82 +28,77 @@ def setup_app_auth(mock_jwt_admin):
 
 
 def test_summary_returns_metrics(mocker):
-    mocker.patch.object(
-        bot_analytics_routes,
-        "get_bot_analytics_summary",
-        AsyncMock(
-            return_value=BotAnalyticsSummary(
-                platform="DISCORD",
-                window_days=30,
-                live_servers=5,
-                messages_received=100,
-                replies_sent=90,
-                commands_used=10,
-                stream_errors=2,
-                avg_reply_ms=1200.0,
-                error_rate=0.02,
-            )
-        ),
+    mock_summary = AsyncMock(
+        return_value=BotAnalyticsSummary(
+            platform="DISCORD",
+            window_days=30,
+            live_servers=5,
+            messages_received=100,
+            replies_sent=90,
+            commands_used=10,
+            stream_errors=2,
+            avg_reply_ms=1200.0,
+            error_rate=0.02,
+        )
     )
+    mocker.patch.object(bot_analytics_routes, "get_bot_analytics_summary", mock_summary)
     resp = client.get("/api/admin/bot-analytics/summary?platform=DISCORD&days=30")
     assert resp.status_code == 200
     data = resp.json()
     assert data["live_servers"] == 5
     assert data["messages_received"] == 100
     assert data["error_rate"] == 0.02
+    mock_summary.assert_awaited_once_with("DISCORD", 30)
 
 
 def test_timeseries_returns_list(mocker):
+    mock_timeseries = AsyncMock(
+        return_value=[
+            BotTimeseriesPoint(
+                date=datetime(2026, 6, 1, tzinfo=timezone.utc),
+                messages=10,
+                replies=9,
+                errors=1,
+            )
+        ]
+    )
     mocker.patch.object(
-        bot_analytics_routes,
-        "get_bot_message_timeseries",
-        AsyncMock(
-            return_value=[
-                BotTimeseriesPoint(
-                    date=datetime(2026, 6, 1, tzinfo=timezone.utc),
-                    messages=10,
-                    replies=9,
-                    errors=1,
-                )
-            ]
-        ),
+        bot_analytics_routes, "get_bot_message_timeseries", mock_timeseries
     )
     resp = client.get("/api/admin/bot-analytics/timeseries?days=7")
     assert resp.status_code == 200
     body = resp.json()
     assert len(body) == 1
     assert body[0]["messages"] == 10
+    mock_timeseries.assert_awaited_once_with(None, 7)
 
 
 def test_command_usage_and_guilds(mocker):
-    mocker.patch.object(
-        bot_analytics_routes,
-        "get_bot_command_usage",
-        AsyncMock(return_value=[BotCommandUsage(command="setup", uses=3)]),
+    mock_commands = AsyncMock(return_value=[BotCommandUsage(command="setup", uses=3)])
+    mock_guilds = AsyncMock(
+        return_value=[
+            BotGuildInfo(
+                platform="DISCORD",
+                server_id="9",
+                name="Srv",
+                joined_at=datetime(2026, 5, 1, tzinfo=timezone.utc),
+                left_at=None,
+                active=True,
+            )
+        ]
     )
-    mocker.patch.object(
-        bot_analytics_routes,
-        "list_bot_guilds",
-        AsyncMock(
-            return_value=[
-                BotGuildInfo(
-                    platform="DISCORD",
-                    server_id="9",
-                    name="Srv",
-                    joined_at=datetime(2026, 5, 1, tzinfo=timezone.utc),
-                    left_at=None,
-                    active=True,
-                )
-            ]
-        ),
-    )
+    mocker.patch.object(bot_analytics_routes, "get_bot_command_usage", mock_commands)
+    mocker.patch.object(bot_analytics_routes, "list_bot_guilds", mock_guilds)
+
     cmd = client.get("/api/admin/bot-analytics/command-usage")
     assert cmd.status_code == 200
     assert cmd.json()[0]["command"] == "setup"
+    mock_commands.assert_awaited_once_with(None, 30)
 
     guilds = client.get("/api/admin/bot-analytics/guilds")
     assert guilds.status_code == 200
     assert guilds.json()[0]["active"] is True
+    mock_guilds.assert_awaited_once_with(None, False, 500)
 
 
 def test_days_out_of_range_rejected():

--- a/autogpt_platform/backend/backend/api/features/admin/bot_analytics_routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/admin/bot_analytics_routes_test.py
@@ -1,0 +1,116 @@
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock
+
+import fastapi
+import fastapi.testclient
+import pytest
+
+from backend.api.features.admin import bot_analytics_routes
+from backend.data.bot_analytics_reads import (
+    BotAnalyticsSummary,
+    BotCommandUsage,
+    BotGuildInfo,
+    BotTimeseriesPoint,
+)
+
+app = fastapi.FastAPI()
+app.include_router(bot_analytics_routes.router, prefix="/api/admin")
+client = fastapi.testclient.TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def setup_app_auth(mock_jwt_admin):
+    from autogpt_libs.auth.jwt_utils import get_jwt_payload
+
+    app.dependency_overrides[get_jwt_payload] = mock_jwt_admin["get_jwt_payload"]
+    yield
+    app.dependency_overrides.clear()
+
+
+def test_summary_returns_metrics(mocker):
+    mocker.patch.object(
+        bot_analytics_routes,
+        "get_bot_analytics_summary",
+        AsyncMock(
+            return_value=BotAnalyticsSummary(
+                platform="DISCORD",
+                window_days=30,
+                live_servers=5,
+                messages_received=100,
+                replies_sent=90,
+                commands_used=10,
+                stream_errors=2,
+                avg_reply_ms=1200.0,
+                error_rate=0.02,
+            )
+        ),
+    )
+    resp = client.get("/api/admin/bot-analytics/summary?platform=DISCORD&days=30")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["live_servers"] == 5
+    assert data["messages_received"] == 100
+    assert data["error_rate"] == 0.02
+
+
+def test_timeseries_returns_list(mocker):
+    mocker.patch.object(
+        bot_analytics_routes,
+        "get_bot_message_timeseries",
+        AsyncMock(
+            return_value=[
+                BotTimeseriesPoint(
+                    date=datetime(2026, 6, 1, tzinfo=timezone.utc),
+                    messages=10,
+                    replies=9,
+                    errors=1,
+                )
+            ]
+        ),
+    )
+    resp = client.get("/api/admin/bot-analytics/timeseries?days=7")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body) == 1
+    assert body[0]["messages"] == 10
+
+
+def test_command_usage_and_guilds(mocker):
+    mocker.patch.object(
+        bot_analytics_routes,
+        "get_bot_command_usage",
+        AsyncMock(return_value=[BotCommandUsage(command="setup", uses=3)]),
+    )
+    mocker.patch.object(
+        bot_analytics_routes,
+        "list_bot_guilds",
+        AsyncMock(
+            return_value=[
+                BotGuildInfo(
+                    platform="DISCORD",
+                    server_id="9",
+                    name="Srv",
+                    joined_at=datetime(2026, 5, 1, tzinfo=timezone.utc),
+                    left_at=None,
+                    active=True,
+                )
+            ]
+        ),
+    )
+    cmd = client.get("/api/admin/bot-analytics/command-usage")
+    assert cmd.status_code == 200
+    assert cmd.json()[0]["command"] == "setup"
+
+    guilds = client.get("/api/admin/bot-analytics/guilds")
+    assert guilds.status_code == 200
+    assert guilds.json()[0]["active"] is True
+
+
+def test_days_out_of_range_rejected():
+    resp = client.get("/api/admin/bot-analytics/summary?days=9999")
+    assert resp.status_code == 422
+
+
+def test_invalid_platform_rejected():
+    resp = client.get("/api/admin/bot-analytics/summary?platform=MYSPACE")
+    assert resp.status_code == 422

--- a/autogpt_platform/backend/backend/api/rest_api.py
+++ b/autogpt_platform/backend/backend/api/rest_api.py
@@ -17,6 +17,7 @@ from fastapi.routing import APIRoute
 from prisma.errors import PrismaError
 
 import backend.api.features.admin.block_cost_admin_routes
+import backend.api.features.admin.bot_analytics_routes
 import backend.api.features.admin.credit_admin_routes
 import backend.api.features.admin.diagnostics_admin_routes
 import backend.api.features.admin.execution_analytics_routes
@@ -364,6 +365,11 @@ app.include_router(
 )
 app.include_router(
     backend.api.features.admin.platform_cost_routes.router,
+    tags=["v2", "admin"],
+    prefix="/api/admin",
+)
+app.include_router(
+    backend.api.features.admin.bot_analytics_routes.router,
     tags=["v2", "admin"],
     prefix="/api/admin",
 )

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter.py
@@ -211,6 +211,13 @@ class DiscordAdapter(PlatformAdapter):
             # rows that pre-date name capture. Cheap: in-memory cache only,
             # no Discord API calls.
             await self._refresh_known_server_names()
+            # Reconcile presence analytics: record every server we're currently
+            # in and mark any we've left while disconnected. Drives the admin
+            # server-count / sharding-prediction charts.
+            self._api.sync_guilds(
+                "discord",
+                [(str(guild.id), guild.name) for guild in self._client.guilds],
+            )
             # Sync slash commands once per process — on_ready fires on every
             # gateway reconnect, but the command tree only needs uploading once.
             if self._commands_synced:
@@ -225,6 +232,7 @@ class DiscordAdapter(PlatformAdapter):
         @self._client.event
         async def on_guild_join(guild: discord.Guild) -> None:
             await self._refresh_server_name(guild)
+            self._api.track_guild_joined("discord", str(guild.id), guild.name)
             channel = intro.pick_intro_channel(guild)
             if channel is None:
                 logger.info(
@@ -244,6 +252,12 @@ class DiscordAdapter(PlatformAdapter):
         async def on_guild_update(before: discord.Guild, after: discord.Guild) -> None:
             if before.name != after.name:
                 await self._refresh_server_name(after)
+
+        @self._client.event
+        async def on_guild_remove(guild: discord.Guild) -> None:
+            # Bot was kicked or the server was deleted — mark presence as left
+            # so the live server count and sharding prediction stay accurate.
+            self._api.track_guild_left("discord", str(guild.id))
 
         @self._client.event
         async def on_thread_remove(thread: discord.Thread) -> None:

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/commands.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/commands.py
@@ -22,16 +22,26 @@ logger = logging.getLogger(__name__)
 def register(tree: app_commands.CommandTree, api: BotBackend) -> None:
     """Register all slash commands on the given CommandTree."""
 
+    def _track(interaction: discord.Interaction, command_name: str) -> None:
+        api.track_event(
+            platform="discord",
+            event_type="command_used",
+            server_id=str(interaction.guild.id) if interaction.guild else None,
+            command_name=command_name,
+        )
+
     @tree.command(
         name="setup",
         description="Link this server to an AutoGPT account for AutoPilot",
     )
     @app_commands.default_permissions(manage_guild=True)
     async def setup_command(interaction: discord.Interaction) -> None:
+        _track(interaction, "setup")
         await _handle_setup(interaction, api)
 
     @tree.command(name="help", description="Show AutoPilot bot usage info")
     async def help_command(interaction: discord.Interaction) -> None:
+        _track(interaction, "help")
         await _handle_help(interaction)
 
     @tree.command(
@@ -39,6 +49,7 @@ def register(tree: app_commands.CommandTree, api: BotBackend) -> None:
         description="Manage linked servers from your AutoGPT settings",
     )
     async def unlink_command(interaction: discord.Interaction) -> None:
+        _track(interaction, "unlink")
         await _handle_unlink(interaction)
 
     @tree.command(
@@ -46,6 +57,7 @@ def register(tree: app_commands.CommandTree, api: BotBackend) -> None:
         description="Start a fresh AutoPilot conversation in this DM or thread",
     )
     async def new_command(interaction: discord.Interaction) -> None:
+        _track(interaction, "new")
         await _handle_new(interaction)
 
     @tree.command(
@@ -53,6 +65,7 @@ def register(tree: app_commands.CommandTree, api: BotBackend) -> None:
         description="Resume one of your past AutoPilot conversations (DMs only)",
     )
     async def resume_command(interaction: discord.Interaction) -> None:
+        _track(interaction, "resume")
         await _handle_resume(interaction, api)
 
     @tree.command(
@@ -60,6 +73,7 @@ def register(tree: app_commands.CommandTree, api: BotBackend) -> None:
         description="Stop AutoPilot from auto-replying in this thread",
     )
     async def leave_command(interaction: discord.Interaction) -> None:
+        _track(interaction, "leave")
         await _handle_leave(interaction)
 
 

--- a/autogpt_platform/backend/backend/copilot/bot/bot_backend.py
+++ b/autogpt_platform/backend/backend/copilot/bot/bot_backend.py
@@ -25,6 +25,8 @@ from backend.copilot.response_model import (
 )
 from backend.platform_linking.models import (
     BotChatRequest,
+    BotEventInput,
+    BotGuildInput,
     CreateLinkTokenRequest,
     CreateUserLinkTokenRequest,
     Platform,
@@ -84,11 +86,91 @@ class BotBackend:
 
     def __init__(self):
         self._client = get_platform_linking_manager_client()
+        self._analytics_tasks: set[asyncio.Task] = set()
 
     async def close(self) -> None:
         # The client's lifecycle is owned by the thread-cached factory; nothing
         # to close here. Kept for API compatibility with older bot code.
         pass
+
+    # ── Analytics (fire-and-forget) ──────────────────────────────────────
+    # Usage telemetry must never block or break a user's reply, so every
+    # write is scheduled as a background task that swallows its own errors.
+    # No message content is ever sent — only counts, enums and metrics.
+
+    def _fire_and_forget(self, coro: Awaitable[None]) -> None:
+        task = asyncio.ensure_future(coro)
+        self._analytics_tasks.add(task)
+        task.add_done_callback(self._on_analytics_done)
+
+    def _on_analytics_done(self, task: asyncio.Task) -> None:
+        self._analytics_tasks.discard(task)
+        exc = task.exception()
+        if exc is not None:
+            logger.warning("Bot analytics write failed: %s", exc)
+
+    def track_event(
+        self,
+        *,
+        platform: str,
+        event_type: str,
+        server_id: str | None = None,
+        channel_type: str | None = None,
+        command_name: str | None = None,
+        error_kind: str | None = None,
+        char_count: int | None = None,
+        duration_ms: int | None = None,
+    ) -> None:
+        self._fire_and_forget(
+            self._client.record_bot_event(
+                event=BotEventInput(
+                    platform=Platform(platform.upper()),
+                    event_type=event_type,
+                    server_id=server_id,
+                    channel_type=channel_type,
+                    command_name=command_name,
+                    error_kind=error_kind,
+                    char_count=char_count,
+                    duration_ms=duration_ms,
+                )
+            )
+        )
+
+    def track_guild_joined(
+        self, platform: str, server_id: str, name: str | None = None
+    ) -> None:
+        self._fire_and_forget(
+            self._client.record_guild_joined(
+                guild=BotGuildInput(
+                    platform=Platform(platform.upper()),
+                    server_id=server_id,
+                    name=name,
+                )
+            )
+        )
+
+    def track_guild_left(self, platform: str, server_id: str) -> None:
+        self._fire_and_forget(
+            self._client.mark_guild_left(
+                platform=Platform(platform.upper()),
+                server_id=server_id,
+            )
+        )
+
+    def sync_guilds(self, platform: str, guilds: list[tuple[str, str | None]]) -> None:
+        self._fire_and_forget(
+            self._client.sync_guild_presence(
+                platform=Platform(platform.upper()),
+                guilds=[
+                    BotGuildInput(
+                        platform=Platform(platform.upper()),
+                        server_id=server_id,
+                        name=name,
+                    )
+                    for server_id, name in guilds
+                ],
+            )
+        )
 
     async def resolve_server(
         self, platform: str, platform_server_id: str

--- a/autogpt_platform/backend/backend/copilot/bot/bot_backend.py
+++ b/autogpt_platform/backend/backend/copilot/bot/bot_backend.py
@@ -46,8 +46,22 @@ STREAM_CHUNK_TIMEOUT_SECONDS = 120
 
 logger = logging.getLogger(__name__)
 
+
+class BotStreamError(Exception):
+    """A copilot stream couldn't produce a successful reply.
+
+    Carries a bounded ``error_kind`` so the handler can attribute analytics
+    accurately instead of guessing from the inline text.
+    """
+
+    def __init__(self, error_kind: str, message: str):
+        super().__init__(message)
+        self.error_kind = error_kind
+
+
 __all__ = [
     "BotBackend",
+    "BotStreamError",
     "ChatSummary",
     "DuplicateChatMessageError",
     "LinkAlreadyExistsError",
@@ -319,8 +333,10 @@ class BotBackend:
             last_message_id=handle.subscribe_from,
         )
         if queue is None:
-            yield "\n[Error: failed to subscribe to response stream]"
-            return
+            raise BotStreamError(
+                "subscribe_failed",
+                "failed to subscribe to response stream",
+            )
 
         setup_notified = False
 
@@ -336,8 +352,10 @@ class BotBackend:
                         STREAM_CHUNK_TIMEOUT_SECONDS,
                         handle.session_id,
                     )
-                    yield "\n[Error: response timed out]"
-                    return
+                    raise BotStreamError(
+                        "stream_timeout",
+                        "response timed out",
+                    )
                 if isinstance(chunk, StreamTextDelta):
                     if chunk.delta:
                         yield chunk.delta
@@ -354,8 +372,10 @@ class BotBackend:
                     return
                 elif isinstance(chunk, StreamError):
                     logger.error("Stream error from backend: %s", chunk.errorText)
-                    yield f"\n[Error: {chunk.errorText}]"
-                    return
+                    raise BotStreamError(
+                        "backend_stream_error",
+                        chunk.errorText,
+                    )
                 # Other StreamX types (StreamStart, StreamTextStart, tool events,
                 # etc.) are emitted by the executor for the frontend UI and
                 # aren't useful for the plain-text bot transcript.

--- a/autogpt_platform/backend/backend/copilot/bot/bot_backend.py
+++ b/autogpt_platform/backend/backend/copilot/bot/bot_backend.py
@@ -105,6 +105,8 @@ class BotBackend:
 
     def _on_analytics_done(self, task: asyncio.Task) -> None:
         self._analytics_tasks.discard(task)
+        if task.cancelled():
+            return
         exc = task.exception()
         if exc is not None:
             logger.warning("Bot analytics write failed: %s", exc)
@@ -158,12 +160,13 @@ class BotBackend:
         )
 
     def sync_guilds(self, platform: str, guilds: list[tuple[str, str | None]]) -> None:
+        platform_enum = Platform(platform.upper())
         self._fire_and_forget(
             self._client.sync_guild_presence(
-                platform=Platform(platform.upper()),
+                platform=platform_enum,
                 guilds=[
                     BotGuildInput(
-                        platform=Platform(platform.upper()),
+                        platform=platform_enum,
                         server_id=server_id,
                         name=name,
                     )

--- a/autogpt_platform/backend/backend/copilot/bot/bot_backend.py
+++ b/autogpt_platform/backend/backend/copilot/bot/bot_backend.py
@@ -125,6 +125,11 @@ class BotBackend:
         if exc is not None:
             logger.warning("Bot analytics write failed: %s", exc)
 
+    # NOTE: each track method defers Platform() and Pydantic construction into
+    # the background coroutine — that way a bad platform string or validation
+    # error fails the analytics task (which is swallowed) instead of leaking
+    # back into the caller's reply path.
+
     def track_event(
         self,
         *,
@@ -137,8 +142,8 @@ class BotBackend:
         char_count: int | None = None,
         duration_ms: int | None = None,
     ) -> None:
-        self._fire_and_forget(
-            self._client.record_bot_event(
+        async def _send() -> None:
+            await self._client.record_bot_event(
                 event=BotEventInput(
                     platform=Platform(platform.upper()),
                     event_type=event_type,
@@ -150,33 +155,36 @@ class BotBackend:
                     duration_ms=duration_ms,
                 )
             )
-        )
+
+        self._fire_and_forget(_send())
 
     def track_guild_joined(
         self, platform: str, server_id: str, name: str | None = None
     ) -> None:
-        self._fire_and_forget(
-            self._client.record_guild_joined(
+        async def _send() -> None:
+            await self._client.record_guild_joined(
                 guild=BotGuildInput(
                     platform=Platform(platform.upper()),
                     server_id=server_id,
                     name=name,
                 )
             )
-        )
+
+        self._fire_and_forget(_send())
 
     def track_guild_left(self, platform: str, server_id: str) -> None:
-        self._fire_and_forget(
-            self._client.mark_guild_left(
+        async def _send() -> None:
+            await self._client.mark_guild_left(
                 platform=Platform(platform.upper()),
                 server_id=server_id,
             )
-        )
+
+        self._fire_and_forget(_send())
 
     def sync_guilds(self, platform: str, guilds: list[tuple[str, str | None]]) -> None:
-        platform_enum = Platform(platform.upper())
-        self._fire_and_forget(
-            self._client.sync_guild_presence(
+        async def _send() -> None:
+            platform_enum = Platform(platform.upper())
+            await self._client.sync_guild_presence(
                 platform=platform_enum,
                 guilds=[
                     BotGuildInput(
@@ -187,7 +195,8 @@ class BotBackend:
                     for server_id, name in guilds
                 ],
             )
-        )
+
+        self._fire_and_forget(_send())
 
     async def resolve_server(
         self, platform: str, platform_server_id: str

--- a/autogpt_platform/backend/backend/copilot/bot/bot_backend_analytics_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/bot_backend_analytics_test.py
@@ -84,6 +84,19 @@ async def test_analytics_failure_is_swallowed():
 
 
 @pytest.mark.asyncio
+async def test_bad_platform_string_is_swallowed():
+    # Platform(...) raises ValueError on an unknown string. That must fail the
+    # background task — never the synchronous caller in the reply path.
+    backend, client = _backend()
+    backend.track_event(platform="myspace", event_type="message_received")
+    await _drain(backend)
+    assert backend._analytics_tasks == set()
+    # The bad platform must short-circuit before the RPC; the client must not
+    # have been called.
+    client.record_bot_event.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_cancelled_analytics_task_is_silent():
     # Cancelled tasks during shutdown must not raise CancelledError from the
     # done-callback (which would print as an unhandled exception by asyncio).

--- a/autogpt_platform/backend/backend/copilot/bot/bot_backend_analytics_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/bot_backend_analytics_test.py
@@ -1,0 +1,83 @@
+"""Tests for BotBackend fire-and-forget analytics methods."""
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from backend.copilot.bot.bot_backend import BotBackend
+from backend.platform_linking.models import BotEventInput, BotGuildInput, Platform
+
+
+def _backend() -> tuple[BotBackend, AsyncMock]:
+    backend = BotBackend.__new__(BotBackend)
+    client = AsyncMock()
+    backend._client = client
+    backend._analytics_tasks = set()
+    return backend, client
+
+
+async def _drain(backend: BotBackend) -> None:
+    if backend._analytics_tasks:
+        await asyncio.gather(*backend._analytics_tasks, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_track_event_records_bot_event():
+    backend, client = _backend()
+    backend.track_event(
+        platform="discord",
+        event_type="message_received",
+        server_id="42",
+        channel_type="thread",
+        char_count=12,
+    )
+    await _drain(backend)
+
+    client.record_bot_event.assert_awaited_once()
+    event = client.record_bot_event.await_args.kwargs["event"]
+    assert isinstance(event, BotEventInput)
+    assert event.platform == Platform.DISCORD
+    assert event.event_type == "message_received"
+    assert event.server_id == "42"
+    assert event.channel_type == "thread"
+    assert event.char_count == 12
+
+
+@pytest.mark.asyncio
+async def test_track_guild_joined_and_left():
+    backend, client = _backend()
+    backend.track_guild_joined("discord", "7", "Cool Server")
+    backend.track_guild_left("discord", "7")
+    await _drain(backend)
+
+    guild = client.record_guild_joined.await_args.kwargs["guild"]
+    assert isinstance(guild, BotGuildInput)
+    assert guild.server_id == "7"
+    assert guild.name == "Cool Server"
+    client.mark_guild_left.assert_awaited_once_with(
+        platform=Platform.DISCORD, server_id="7"
+    )
+
+
+@pytest.mark.asyncio
+async def test_sync_guilds_maps_all_servers():
+    backend, client = _backend()
+    backend.sync_guilds("discord", [("1", "A"), ("2", None)])
+    await _drain(backend)
+
+    kwargs = client.sync_guild_presence.await_args.kwargs
+    assert kwargs["platform"] == Platform.DISCORD
+    guilds = kwargs["guilds"]
+    assert [g.server_id for g in guilds] == ["1", "2"]
+    assert guilds[1].name is None
+
+
+@pytest.mark.asyncio
+async def test_analytics_failure_is_swallowed():
+    backend, client = _backend()
+    client.record_bot_event.side_effect = RuntimeError("rpc down")
+    backend.track_event(platform="discord", event_type="message_received")
+    # A failing write must never propagate into the caller's reply path.
+    await _drain(backend)
+    assert backend._analytics_tasks == set()

--- a/autogpt_platform/backend/backend/copilot/bot/bot_backend_analytics_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/bot_backend_analytics_test.py
@@ -81,3 +81,21 @@ async def test_analytics_failure_is_swallowed():
     # A failing write must never propagate into the caller's reply path.
     await _drain(backend)
     assert backend._analytics_tasks == set()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_analytics_task_is_silent():
+    # Cancelled tasks during shutdown must not raise CancelledError from the
+    # done-callback (which would print as an unhandled exception by asyncio).
+    backend, client = _backend()
+
+    async def hang() -> None:
+        await asyncio.sleep(3600)
+
+    client.record_bot_event.side_effect = lambda **_: hang()
+    backend.track_event(platform="discord", event_type="message_received")
+    task = next(iter(backend._analytics_tasks))
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert backend._analytics_tasks == set()

--- a/autogpt_platform/backend/backend/copilot/bot/bot_backend_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/bot_backend_test.py
@@ -24,7 +24,7 @@ from backend.util.exceptions import (
     NotFoundError,
 )
 
-from .bot_backend import BotBackend
+from .bot_backend import BotBackend, BotStreamError
 
 
 @pytest.fixture
@@ -180,14 +180,15 @@ class TestStreamChat:
                 "backend.copilot.bot.bot_backend.stream_registry.unsubscribe_from_session",
                 new=AsyncMock(),
             ),
+            pytest.raises(BotStreamError) as excinfo,
         ):
-            chunks: list[str] = []
-            async for chunk in api.stream_chat(
+            async for _ in api.stream_chat(
                 platform="discord", platform_user_id="u1", message="hi"
             ):
-                chunks.append(chunk)
+                pass
 
-        assert any("executor crashed" in c for c in chunks)
+        assert excinfo.value.error_kind == "backend_stream_error"
+        assert "executor crashed" in str(excinfo.value)
 
     @pytest.mark.asyncio
     async def test_notifies_setup_requirements_tool_output(self, api: BotBackend):
@@ -266,7 +267,7 @@ class TestStreamChat:
                 pass
 
     @pytest.mark.asyncio
-    async def test_subscribe_returns_none_yields_error(self, api: BotBackend):
+    async def test_subscribe_returns_none_raises(self, api: BotBackend):
         handle = ChatTurnHandle(session_id="sess", turn_id="turn", user_id="u1")
         api._client.start_chat_turn = AsyncMock(return_value=handle)
 
@@ -279,11 +280,11 @@ class TestStreamChat:
                 "backend.copilot.bot.bot_backend.stream_registry.unsubscribe_from_session",
                 new=AsyncMock(),
             ),
+            pytest.raises(BotStreamError) as excinfo,
         ):
-            chunks: list[str] = []
-            async for chunk in api.stream_chat(
+            async for _ in api.stream_chat(
                 platform="discord", platform_user_id="u1", message="hi"
             ):
-                chunks.append(chunk)
+                pass
 
-        assert any("failed to subscribe" in c.lower() for c in chunks)
+        assert excinfo.value.error_kind == "subscribe_failed"

--- a/autogpt_platform/backend/backend/copilot/bot/handler.py
+++ b/autogpt_platform/backend/backend/copilot/bot/handler.py
@@ -7,6 +7,7 @@ persistent typing indicator.
 
 import asyncio
 import logging
+import time
 from dataclasses import dataclass, field
 from typing import Any
 from urllib.parse import quote
@@ -89,6 +90,14 @@ class MessageHandler:
         target_id = await self._resolve_target(ctx, adapter)
         if not target_id:
             return  # Thread not subscribed, ignore silently
+
+        self._api.track_event(
+            platform=ctx.platform,
+            event_type="message_received",
+            server_id=ctx.server_id,
+            channel_type=ctx.channel_type,
+            char_count=len(ctx.text),
+        )
 
         message_text = self._message_text(ctx) if include_thread_history else ctx.text
         await self._enqueue_and_process(ctx, adapter, target_id, message_text)
@@ -353,6 +362,8 @@ class MessageHandler:
                 link_url=session_url,
             )
 
+        started_at = time.monotonic()
+        reply_chars = 0
         typing_task = asyncio.create_task(_keep_typing(adapter, target_id))
         try:
             async for chunk in self._api.stream_chat(
@@ -365,6 +376,7 @@ class MessageHandler:
                 on_setup_required=_on_setup_required,
             ):
                 buffer += chunk
+                reply_chars += len(chunk)
                 if len(buffer) >= flush_at:
                     post, buffer = split_at_boundary(buffer, flush_at)
                     if post and post.strip():
@@ -379,6 +391,7 @@ class MessageHandler:
             return
         except NotFoundError:
             logger.exception("Chat turn rejected")
+            self._track_stream_error(ctx, "chat_turn_rejected")
             await adapter.send_message(
                 target_id, "AutoPilot ran into an error. Try again later."
             )
@@ -387,6 +400,7 @@ class MessageHandler:
             logger.exception(
                 "Unexpected error during streaming for target %s", target_id
             )
+            self._track_stream_error(ctx, "stream_exception")
             await adapter.send_message(
                 target_id,
                 "Something went wrong. Try again in a moment.",
@@ -411,6 +425,15 @@ class MessageHandler:
                 target_id,
                 "AutoPilot didn't produce a response. Try rephrasing your question.",
             )
+
+        self._api.track_event(
+            platform=ctx.platform,
+            event_type="reply_sent",
+            server_id=ctx.server_id,
+            channel_type=ctx.channel_type,
+            char_count=reply_chars,
+            duration_ms=int((time.monotonic() - started_at) * 1000),
+        )
 
         if (
             ctx.channel_type == "channel"
@@ -449,6 +472,15 @@ class MessageHandler:
                 return
             if attempt < TITLE_RENAME_ATTEMPTS - 1:
                 await asyncio.sleep(TITLE_RENAME_INTERVAL_SECONDS)
+
+    def _track_stream_error(self, ctx: MessageContext, error_kind: str) -> None:
+        self._api.track_event(
+            platform=ctx.platform,
+            event_type="stream_error",
+            server_id=ctx.server_id,
+            channel_type=ctx.channel_type,
+            error_kind=error_kind,
+        )
 
     # -- Linking --
 

--- a/autogpt_platform/backend/backend/copilot/bot/handler.py
+++ b/autogpt_platform/backend/backend/copilot/bot/handler.py
@@ -26,7 +26,7 @@ from backend.util.settings import Settings
 
 from . import sessions, threads
 from .adapters.base import FileAttachment, MessageContext, PlatformAdapter
-from .bot_backend import BotBackend
+from .bot_backend import BotBackend, BotStreamError
 from .config import SESSION_TTL
 from .text import format_batch, split_at_boundary
 
@@ -388,6 +388,22 @@ class MessageHandler:
             # Another in-flight turn is already processing this exact message —
             # stay quiet so the user doesn't get a double response.
             logger.info("Duplicate message dropped for target %s", target_id)
+            return
+        except BotStreamError as exc:
+            # Stream couldn't complete (timeout, subscribe fail, backend stream
+            # error). Track the specific kind, surface a generic message, and
+            # do NOT fire reply_sent below.
+            logger.warning(
+                "Stream failed for target %s: %s (%s)",
+                target_id,
+                exc,
+                exc.error_kind,
+            )
+            self._track_stream_error(ctx, exc.error_kind)
+            await adapter.send_message(
+                target_id,
+                "AutoPilot ran into an error. Try again in a moment.",
+            )
             return
         except NotFoundError:
             logger.exception("Chat turn rejected")

--- a/autogpt_platform/backend/backend/copilot/bot/handler.py
+++ b/autogpt_platform/backend/backend/copilot/bot/handler.py
@@ -441,6 +441,8 @@ class MessageHandler:
                 target_id,
                 "AutoPilot didn't produce a response. Try rephrasing your question.",
             )
+            self._track_stream_error(ctx, "empty_reply")
+            return
 
         self._api.track_event(
             platform=ctx.platform,

--- a/autogpt_platform/backend/backend/data/bot_analytics.py
+++ b/autogpt_platform/backend/backend/data/bot_analytics.py
@@ -1,0 +1,87 @@
+"""Bot usage analytics writes (privacy-preserving).
+
+Records discrete bot usage events and per-server presence for the admin
+analytics page. NEVER stores message content — only counts, bounded enums,
+timestamps and numeric metrics.
+
+Directly accessed by the ``DatabaseManager`` pod (which holds the Prisma
+connection). Other services (notably the out-of-process bot) reach these
+through ``backend.data.db_accessors.bot_analytics_db`` so calls are
+transparently routed via ``DatabaseManagerAsyncClient``.
+"""
+
+import logging
+from datetime import datetime, timezone
+
+from prisma.models import BotEvent, BotGuild
+
+from backend.platform_linking.models import BotEventInput, BotGuildInput, Platform
+
+logger = logging.getLogger(__name__)
+
+
+async def record_bot_event(event: BotEventInput) -> None:
+    await BotEvent.prisma().create(
+        data={
+            "platform": event.platform.value,
+            "eventType": event.event_type,
+            "serverId": event.server_id,
+            "channelType": event.channel_type,
+            "commandName": event.command_name,
+            "errorKind": event.error_kind,
+            "charCount": event.char_count,
+            "durationMs": event.duration_ms,
+        }
+    )
+
+
+async def record_guild_joined(guild: BotGuildInput) -> None:
+    await BotGuild.prisma().upsert(
+        where={
+            "platform_serverId": {
+                "platform": guild.platform.value,
+                "serverId": guild.server_id,
+            }
+        },
+        data={
+            "create": {
+                "platform": guild.platform.value,
+                "serverId": guild.server_id,
+                "name": guild.name,
+            },
+            "update": {
+                "name": guild.name,
+                "leftAt": None,
+                "lastSeenAt": datetime.now(timezone.utc),
+            },
+        },
+    )
+
+
+async def mark_guild_left(platform: Platform, server_id: str) -> None:
+    await BotGuild.prisma().update_many(
+        where={
+            "platform": platform.value,
+            "serverId": server_id,
+            "leftAt": None,
+        },
+        data={"leftAt": datetime.now(timezone.utc)},
+    )
+
+
+async def sync_guild_presence(platform: Platform, guilds: list[BotGuildInput]) -> None:
+    """Full presence reconcile (on connect): upsert every server the bot is in
+    now and mark any previously-joined server it is no longer in as left."""
+    for guild in guilds:
+        await record_guild_joined(guild)
+
+    present = {guild.server_id for guild in guilds}
+    joined = await BotGuild.prisma().find_many(
+        where={"platform": platform.value, "leftAt": None}
+    )
+    stale_ids = [row.id for row in joined if row.serverId not in present]
+    if stale_ids:
+        await BotGuild.prisma().update_many(
+            where={"id": {"in": stale_ids}},
+            data={"leftAt": datetime.now(timezone.utc)},
+        )

--- a/autogpt_platform/backend/backend/data/bot_analytics_reads.py
+++ b/autogpt_platform/backend/backend/data/bot_analytics_reads.py
@@ -170,6 +170,11 @@ async def get_bot_server_timeseries(
     params: list = [days]
     joined_filter = _platform_filter(platform, params, alias="g.")
     left_filter = joined_filter  # same param ($2) reused in both subqueries
+    # The BotGuild.joinedAt / leftAt columns are `timestamp` (no tz) storing
+    # naive UTC values (Prisma's default for DateTime). `now() AT TIME ZONE 'utc'`
+    # also produces a naive UTC `timestamp`, so date_trunc here uses neither the
+    # session TZ nor any implicit cast — comparisons stay naive-to-naive and the
+    # daily buckets line up with UTC days regardless of session TZ.
     rows = await query_raw_with_schema(
         f"""
         SELECT

--- a/autogpt_platform/backend/backend/data/bot_analytics_reads.py
+++ b/autogpt_platform/backend/backend/data/bot_analytics_reads.py
@@ -134,10 +134,13 @@ async def get_bot_message_timeseries(
 ) -> list[BotTimeseriesPoint]:
     params: list = [_since(days)]
     platform_filter = _platform_filter(platform, params)
+    # date_trunc on a timestamptz uses the session's time zone by default —
+    # convert to UTC explicitly via AT TIME ZONE so days are bucketed by UTC
+    # regardless of the connection's TZ (mirrors platform_cost's pattern).
     rows = await query_raw_with_schema(
         f"""
         SELECT
-            date_trunc('day', "createdAt") AS day,
+            date_trunc('day', "createdAt" AT TIME ZONE 'UTC') AT TIME ZONE 'UTC' AS day,
             count(*) FILTER (WHERE "eventType" = 'message_received') AS messages,
             count(*) FILTER (WHERE "eventType" = 'reply_sent') AS replies,
             count(*) FILTER (WHERE "eventType" = 'stream_error') AS errors

--- a/autogpt_platform/backend/backend/data/bot_analytics_reads.py
+++ b/autogpt_platform/backend/backend/data/bot_analytics_reads.py
@@ -11,7 +11,7 @@ rows. There is no message content or user identity anywhere in the schema.
 import logging
 from datetime import datetime, timedelta, timezone
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from backend.data.db import query_raw_with_schema
 
@@ -21,7 +21,13 @@ logger = logging.getLogger(__name__)
 class BotAnalyticsSummary(BaseModel):
     platform: str | None
     window_days: int
-    live_servers: int
+    live_servers: int = Field(
+        description=(
+            "Current count of servers the bot is in right now. "
+            "Point-in-time gauge — intentionally ignores window_days. "
+            "Use the server-count timeseries endpoint for the windowed growth curve."
+        ),
+    )
     messages_received: int
     replies_sent: int
     commands_used: int

--- a/autogpt_platform/backend/backend/data/bot_analytics_reads.py
+++ b/autogpt_platform/backend/backend/data/bot_analytics_reads.py
@@ -96,7 +96,7 @@ async def get_bot_analytics_summary(
             count(*) FILTER (WHERE "eventType" = 'stream_error') AS errors,
             avg("durationMs") FILTER (WHERE "eventType" = 'reply_sent') AS avg_reply_ms
         FROM {{schema_prefix}}"BotEvent"
-        WHERE "createdAt" >= $1::timestamp {event_filter}
+        WHERE "createdAt" >= $1::timestamptz {event_filter}
         """,
         *event_params,
     )
@@ -142,7 +142,7 @@ async def get_bot_message_timeseries(
             count(*) FILTER (WHERE "eventType" = 'reply_sent') AS replies,
             count(*) FILTER (WHERE "eventType" = 'stream_error') AS errors
         FROM {{schema_prefix}}"BotEvent"
-        WHERE "createdAt" >= $1::timestamp {platform_filter}
+        WHERE "createdAt" >= $1::timestamptz {platform_filter}
         GROUP BY day
         ORDER BY day
         """,
@@ -212,7 +212,7 @@ async def get_bot_top_servers(
         FROM {{schema_prefix}}"BotEvent" e
         LEFT JOIN {{schema_prefix}}"BotGuild" g
             ON g."serverId" = e."serverId" AND g."platform" = e."platform"
-        WHERE e."createdAt" >= $1::timestamp AND e."serverId" IS NOT NULL {platform_filter}
+        WHERE e."createdAt" >= $1::timestamptz AND e."serverId" IS NOT NULL {platform_filter}
         GROUP BY e."serverId", g."name"
         ORDER BY messages DESC
         LIMIT ${len(params)}::int
@@ -241,7 +241,7 @@ async def get_bot_command_usage(
         FROM {{schema_prefix}}"BotEvent"
         WHERE "eventType" = 'command_used'
             AND "commandName" IS NOT NULL
-            AND "createdAt" >= $1::timestamp {platform_filter}
+            AND "createdAt" >= $1::timestamptz {platform_filter}
         GROUP BY "commandName"
         ORDER BY uses DESC
         """,

--- a/autogpt_platform/backend/backend/data/bot_analytics_reads.py
+++ b/autogpt_platform/backend/backend/data/bot_analytics_reads.py
@@ -1,0 +1,276 @@
+"""Bot analytics read/aggregate queries for the admin dashboard.
+
+Read-only counterpart to ``bot_analytics`` (writes). Runs in-process against
+Prisma via ``query_raw_with_schema`` — the same direct-call pattern as
+``platform_cost`` — so the admin REST routes call these without RPC.
+
+Privacy: these queries only ever aggregate counts, durations and server-level
+rows. There is no message content or user identity anywhere in the schema.
+"""
+
+import logging
+from datetime import datetime, timedelta, timezone
+
+from pydantic import BaseModel
+
+from backend.data.db import query_raw_with_schema
+
+logger = logging.getLogger(__name__)
+
+
+class BotAnalyticsSummary(BaseModel):
+    platform: str | None
+    window_days: int
+    live_servers: int
+    messages_received: int
+    replies_sent: int
+    commands_used: int
+    stream_errors: int
+    avg_reply_ms: float | None
+    error_rate: float
+
+
+class BotTimeseriesPoint(BaseModel):
+    date: datetime
+    messages: int
+    replies: int
+    errors: int
+
+
+class BotServerCountPoint(BaseModel):
+    date: datetime
+    server_count: int
+
+
+class BotServerActivity(BaseModel):
+    server_id: str
+    name: str | None
+    messages: int
+    commands: int
+
+
+class BotCommandUsage(BaseModel):
+    command: str
+    uses: int
+
+
+class BotGuildInfo(BaseModel):
+    platform: str
+    server_id: str
+    name: str | None
+    joined_at: datetime
+    left_at: datetime | None
+    active: bool
+
+
+def _since(days: int) -> datetime:
+    return datetime.now(timezone.utc) - timedelta(days=days)
+
+
+def _platform_filter(platform: str | None, params: list, *, alias: str = "") -> str:
+    """Append a platform value to ``params`` and return a SQL fragment."""
+    if not platform:
+        return ""
+    params.append(platform)
+    col = f'{alias}"platform"' if alias else '"platform"'
+    return f"AND {col}::text = ${len(params)}"
+
+
+async def get_bot_analytics_summary(
+    platform: str | None = None, days: int = 30
+) -> BotAnalyticsSummary:
+    event_params: list = [_since(days)]
+    event_filter = _platform_filter(platform, event_params)
+    event_rows = await query_raw_with_schema(
+        f"""
+        SELECT
+            count(*) FILTER (WHERE "eventType" = 'message_received') AS messages,
+            count(*) FILTER (WHERE "eventType" = 'reply_sent') AS replies,
+            count(*) FILTER (WHERE "eventType" = 'command_used') AS commands,
+            count(*) FILTER (WHERE "eventType" = 'stream_error') AS errors,
+            avg("durationMs") FILTER (WHERE "eventType" = 'reply_sent') AS avg_reply_ms
+        FROM {{schema_prefix}}"BotEvent"
+        WHERE "createdAt" >= $1::timestamp {event_filter}
+        """,
+        *event_params,
+    )
+    row = event_rows[0] if event_rows else {}
+
+    guild_params: list = []
+    guild_filter = _platform_filter(platform, guild_params)
+    guild_rows = await query_raw_with_schema(
+        f"""
+        SELECT count(*) AS live
+        FROM {{schema_prefix}}"BotGuild"
+        WHERE "leftAt" IS NULL {guild_filter}
+        """,
+        *guild_params,
+    )
+
+    messages = int(row.get("messages") or 0)
+    errors = int(row.get("errors") or 0)
+    avg_reply_ms = row.get("avg_reply_ms")
+    return BotAnalyticsSummary(
+        platform=platform,
+        window_days=days,
+        live_servers=int(guild_rows[0]["live"]) if guild_rows else 0,
+        messages_received=messages,
+        replies_sent=int(row.get("replies") or 0),
+        commands_used=int(row.get("commands") or 0),
+        stream_errors=errors,
+        avg_reply_ms=float(avg_reply_ms) if avg_reply_ms is not None else None,
+        error_rate=(errors / messages) if messages else 0.0,
+    )
+
+
+async def get_bot_message_timeseries(
+    platform: str | None = None, days: int = 30
+) -> list[BotTimeseriesPoint]:
+    params: list = [_since(days)]
+    platform_filter = _platform_filter(platform, params)
+    rows = await query_raw_with_schema(
+        f"""
+        SELECT
+            date_trunc('day', "createdAt") AS day,
+            count(*) FILTER (WHERE "eventType" = 'message_received') AS messages,
+            count(*) FILTER (WHERE "eventType" = 'reply_sent') AS replies,
+            count(*) FILTER (WHERE "eventType" = 'stream_error') AS errors
+        FROM {{schema_prefix}}"BotEvent"
+        WHERE "createdAt" >= $1::timestamp {platform_filter}
+        GROUP BY day
+        ORDER BY day
+        """,
+        *params,
+    )
+    return [
+        BotTimeseriesPoint(
+            date=row["day"],
+            messages=int(row["messages"]),
+            replies=int(row["replies"]),
+            errors=int(row["errors"]),
+        )
+        for row in rows
+    ]
+
+
+async def get_bot_server_timeseries(
+    platform: str | None = None, days: int = 30
+) -> list[BotServerCountPoint]:
+    """Cumulative live-server count at the end of each day — the curve to watch
+    against the sharding threshold."""
+    params: list = [days]
+    joined_filter = _platform_filter(platform, params, alias="g.")
+    left_filter = joined_filter  # same param ($2) reused in both subqueries
+    rows = await query_raw_with_schema(
+        f"""
+        SELECT
+            d.day,
+            (
+                SELECT count(*) FROM {{schema_prefix}}"BotGuild" g
+                WHERE g."joinedAt" < d.day + interval '1 day' {joined_filter}
+            ) - (
+                SELECT count(*) FROM {{schema_prefix}}"BotGuild" g
+                WHERE g."leftAt" IS NOT NULL
+                    AND g."leftAt" < d.day + interval '1 day' {left_filter}
+            ) AS server_count
+        FROM generate_series(
+            date_trunc('day', now() AT TIME ZONE 'utc') - ($1::int - 1) * interval '1 day',
+            date_trunc('day', now() AT TIME ZONE 'utc'),
+            interval '1 day'
+        ) AS d(day)
+        ORDER BY d.day
+        """,
+        *params,
+    )
+    return [
+        BotServerCountPoint(
+            date=row["day"], server_count=max(0, int(row["server_count"]))
+        )
+        for row in rows
+    ]
+
+
+async def get_bot_top_servers(
+    platform: str | None = None, days: int = 30, limit: int = 20
+) -> list[BotServerActivity]:
+    params: list = [_since(days)]
+    platform_filter = _platform_filter(platform, params, alias="e.")
+    params.append(limit)
+    rows = await query_raw_with_schema(
+        f"""
+        SELECT
+            e."serverId" AS server_id,
+            g."name" AS name,
+            count(*) FILTER (WHERE e."eventType" = 'message_received') AS messages,
+            count(*) FILTER (WHERE e."eventType" = 'command_used') AS commands
+        FROM {{schema_prefix}}"BotEvent" e
+        LEFT JOIN {{schema_prefix}}"BotGuild" g
+            ON g."serverId" = e."serverId" AND g."platform" = e."platform"
+        WHERE e."createdAt" >= $1::timestamp AND e."serverId" IS NOT NULL {platform_filter}
+        GROUP BY e."serverId", g."name"
+        ORDER BY messages DESC
+        LIMIT ${len(params)}::int
+        """,
+        *params,
+    )
+    return [
+        BotServerActivity(
+            server_id=row["server_id"],
+            name=row["name"],
+            messages=int(row["messages"]),
+            commands=int(row["commands"]),
+        )
+        for row in rows
+    ]
+
+
+async def get_bot_command_usage(
+    platform: str | None = None, days: int = 30
+) -> list[BotCommandUsage]:
+    params: list = [_since(days)]
+    platform_filter = _platform_filter(platform, params)
+    rows = await query_raw_with_schema(
+        f"""
+        SELECT "commandName" AS command, count(*) AS uses
+        FROM {{schema_prefix}}"BotEvent"
+        WHERE "eventType" = 'command_used'
+            AND "commandName" IS NOT NULL
+            AND "createdAt" >= $1::timestamp {platform_filter}
+        GROUP BY "commandName"
+        ORDER BY uses DESC
+        """,
+        *params,
+    )
+    return [
+        BotCommandUsage(command=row["command"], uses=int(row["uses"])) for row in rows
+    ]
+
+
+async def list_bot_guilds(
+    platform: str | None = None, include_left: bool = False, limit: int = 500
+) -> list[BotGuildInfo]:
+    params: list = []
+    platform_filter = _platform_filter(platform, params)
+    active_filter = "" if include_left else 'AND "leftAt" IS NULL'
+    params.append(limit)
+    rows = await query_raw_with_schema(
+        f"""
+        SELECT "platform", "serverId" AS server_id, "name", "joinedAt", "leftAt"
+        FROM {{schema_prefix}}"BotGuild"
+        WHERE 1 = 1 {platform_filter} {active_filter}
+        ORDER BY ("leftAt" IS NULL) DESC, "joinedAt" DESC
+        LIMIT ${len(params)}::int
+        """,
+        *params,
+    )
+    return [
+        BotGuildInfo(
+            platform=row["platform"],
+            server_id=row["server_id"],
+            name=row["name"],
+            joined_at=row["joinedAt"],
+            left_at=row["leftAt"],
+            active=row["leftAt"] is None,
+        )
+        for row in rows
+    ]

--- a/autogpt_platform/backend/backend/data/bot_analytics_test.py
+++ b/autogpt_platform/backend/backend/data/bot_analytics_test.py
@@ -1,0 +1,100 @@
+"""Tests for bot_analytics writer functions (prisma mocked)."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from backend.data import bot_analytics
+from backend.platform_linking.models import BotEventInput, BotGuildInput, Platform
+
+
+@pytest.mark.asyncio
+async def test_record_bot_event_creates_row():
+    prisma_mock = MagicMock()
+    prisma_mock.create = AsyncMock()
+    with patch.object(bot_analytics.BotEvent, "prisma", return_value=prisma_mock):
+        await bot_analytics.record_bot_event(
+            BotEventInput(
+                platform=Platform.DISCORD,
+                event_type="reply_sent",
+                server_id="9",
+                char_count=100,
+                duration_ms=2500,
+            )
+        )
+
+    data = prisma_mock.create.await_args.kwargs["data"]
+    assert data["platform"] == "DISCORD"
+    assert data["eventType"] == "reply_sent"
+    assert data["serverId"] == "9"
+    assert data["charCount"] == 100
+    assert data["durationMs"] == 2500
+
+
+@pytest.mark.asyncio
+async def test_record_guild_joined_upserts():
+    prisma_mock = MagicMock()
+    prisma_mock.upsert = AsyncMock()
+    with patch.object(bot_analytics.BotGuild, "prisma", return_value=prisma_mock):
+        await bot_analytics.record_guild_joined(
+            BotGuildInput(platform=Platform.DISCORD, server_id="5", name="Srv")
+        )
+
+    kwargs = prisma_mock.upsert.await_args.kwargs
+    assert kwargs["where"]["platform_serverId"] == {
+        "platform": "DISCORD",
+        "serverId": "5",
+    }
+    assert kwargs["data"]["create"]["serverId"] == "5"
+    assert kwargs["data"]["update"]["leftAt"] is None
+
+
+@pytest.mark.asyncio
+async def test_mark_guild_left_updates_active_rows():
+    prisma_mock = MagicMock()
+    prisma_mock.update_many = AsyncMock()
+    with patch.object(bot_analytics.BotGuild, "prisma", return_value=prisma_mock):
+        await bot_analytics.mark_guild_left(Platform.DISCORD, "5")
+
+    where = prisma_mock.update_many.await_args.kwargs["where"]
+    assert where == {"platform": "DISCORD", "serverId": "5", "leftAt": None}
+
+
+@pytest.mark.asyncio
+async def test_sync_guild_presence_marks_absent_as_left():
+    prisma_mock = MagicMock()
+    prisma_mock.upsert = AsyncMock()
+    prisma_mock.update_many = AsyncMock()
+    # Two rows currently joined; only "1" is still present.
+    joined = [
+        MagicMock(id="row1", serverId="1"),
+        MagicMock(id="row2", serverId="2"),
+    ]
+    prisma_mock.find_many = AsyncMock(return_value=joined)
+
+    with patch.object(bot_analytics.BotGuild, "prisma", return_value=prisma_mock):
+        await bot_analytics.sync_guild_presence(
+            Platform.DISCORD,
+            [BotGuildInput(platform=Platform.DISCORD, server_id="1", name="A")],
+        )
+
+    prisma_mock.upsert.assert_awaited_once()
+    prisma_mock.update_many.assert_awaited_once()
+    where = prisma_mock.update_many.await_args.kwargs["where"]
+    assert where == {"id": {"in": ["row2"]}}
+
+
+@pytest.mark.asyncio
+async def test_sync_guild_presence_noop_when_nothing_stale():
+    prisma_mock = MagicMock()
+    prisma_mock.upsert = AsyncMock()
+    prisma_mock.update_many = AsyncMock()
+    prisma_mock.find_many = AsyncMock(return_value=[MagicMock(id="row1", serverId="1")])
+
+    with patch.object(bot_analytics.BotGuild, "prisma", return_value=prisma_mock):
+        await bot_analytics.sync_guild_presence(
+            Platform.DISCORD,
+            [BotGuildInput(platform=Platform.DISCORD, server_id="1", name="A")],
+        )
+
+    prisma_mock.update_many.assert_not_awaited()

--- a/autogpt_platform/backend/backend/data/db_accessors.py
+++ b/autogpt_platform/backend/backend/data/db_accessors.py
@@ -168,3 +168,16 @@ def platform_linking_db():
         platform_linking_db = get_database_manager_async_client()
 
     return platform_linking_db
+
+
+def bot_analytics_db():
+    if db.is_connected():
+        from backend.data import bot_analytics as _bot_analytics_db
+
+        bot_analytics_db = _bot_analytics_db
+    else:
+        from backend.util.clients import get_database_manager_async_client
+
+        bot_analytics_db = get_database_manager_async_client()
+
+    return bot_analytics_db

--- a/autogpt_platform/backend/backend/data/db_manager.py
+++ b/autogpt_platform/backend/backend/data/db_manager.py
@@ -35,6 +35,7 @@ from backend.api.features.store.db import (
 from backend.api.features.store.embeddings import backfill_missing_embeddings
 from backend.copilot import db as chat_db
 from backend.copilot.sharing.db import link_new_execution_to_chat_share
+from backend.data import bot_analytics as bot_analytics_db
 from backend.data import db
 from backend.data.analytics import (
     get_accuracy_trends_and_alerts,
@@ -395,6 +396,12 @@ class DatabaseManager(AppService):
     )
     fetch_workspace_artifact = _(platform_linking_db.fetch_workspace_artifact)
 
+    # ============ Bot Analytics ============ #
+    record_bot_event = _(bot_analytics_db.record_bot_event)
+    record_guild_joined = _(bot_analytics_db.record_guild_joined)
+    mark_guild_left = _(bot_analytics_db.mark_guild_left)
+    sync_guild_presence = _(bot_analytics_db.sync_guild_presence)
+
     # ============ CoPilot Chat Sessions ============ #
     # NOTE: no eager-load `get_chat_session` here — callers go through
     # `get_chat_messages_paginated` (with `limit=MAX_LOADED_CHAT_MESSAGES`) so
@@ -641,6 +648,12 @@ class DatabaseManagerAsyncClient(AppServiceClient):
     delete_user_link = d.delete_user_link
     cleanup_expired_platform_link_tokens = d.cleanup_expired_platform_link_tokens
     fetch_workspace_artifact = d.fetch_workspace_artifact
+
+    # ============ Bot Analytics ============ #
+    record_bot_event = d.record_bot_event
+    record_guild_joined = d.record_guild_joined
+    mark_guild_left = d.mark_guild_left
+    sync_guild_presence = d.sync_guild_presence
 
     # ============ CoPilot Chat Sessions ============ #
     get_chat_session_metadata = d.get_chat_session_metadata

--- a/autogpt_platform/backend/backend/data/db_manager_test.py
+++ b/autogpt_platform/backend/backend/data/db_manager_test.py
@@ -1,6 +1,17 @@
-from .db_manager import DatabaseManagerAsyncClient
+from .db_manager import DatabaseManager, DatabaseManagerAsyncClient
 
 
 def test_async_client_exposes_chat_methods() -> None:
     assert hasattr(DatabaseManagerAsyncClient, "delete_chat_session")
     assert hasattr(DatabaseManagerAsyncClient, "set_turn_duration")
+
+
+def test_bot_analytics_methods_registered() -> None:
+    for method in (
+        "record_bot_event",
+        "record_guild_joined",
+        "mark_guild_left",
+        "sync_guild_presence",
+    ):
+        assert hasattr(DatabaseManager, method)
+        assert hasattr(DatabaseManagerAsyncClient, method)

--- a/autogpt_platform/backend/backend/platform_linking/manager.py
+++ b/autogpt_platform/backend/backend/platform_linking/manager.py
@@ -2,13 +2,15 @@
 
 import logging
 
-from backend.data.db_accessors import platform_linking_db
+from backend.data.db_accessors import bot_analytics_db, platform_linking_db
 from backend.util.service import AppService, AppServiceClient, endpoint_to_async, expose
 from backend.util.settings import Settings
 
 from .chat import list_user_chats, start_chat_turn
 from .models import (
     BotChatRequest,
+    BotEventInput,
+    BotGuildInput,
     ChatTurnHandle,
     CreateLinkTokenRequest,
     CreateUserLinkTokenRequest,
@@ -90,6 +92,24 @@ class PlatformLinkingManager(AppService):
             session_id, file_id, max_bytes
         )
 
+    @expose
+    async def record_bot_event(self, event: BotEventInput) -> None:
+        await bot_analytics_db().record_bot_event(event)
+
+    @expose
+    async def record_guild_joined(self, guild: BotGuildInput) -> None:
+        await bot_analytics_db().record_guild_joined(guild)
+
+    @expose
+    async def mark_guild_left(self, platform: Platform, server_id: str) -> None:
+        await bot_analytics_db().mark_guild_left(platform, server_id)
+
+    @expose
+    async def sync_guild_presence(
+        self, platform: Platform, guilds: list[BotGuildInput]
+    ) -> None:
+        await bot_analytics_db().sync_guild_presence(platform, guilds)
+
 
 class PlatformLinkingManagerClient(AppServiceClient):
     @classmethod
@@ -115,3 +135,7 @@ class PlatformLinkingManagerClient(AppServiceClient):
     fetch_workspace_artifact = endpoint_to_async(
         PlatformLinkingManager.fetch_workspace_artifact
     )
+    record_bot_event = endpoint_to_async(PlatformLinkingManager.record_bot_event)
+    record_guild_joined = endpoint_to_async(PlatformLinkingManager.record_guild_joined)
+    mark_guild_left = endpoint_to_async(PlatformLinkingManager.mark_guild_left)
+    sync_guild_presence = endpoint_to_async(PlatformLinkingManager.sync_guild_presence)

--- a/autogpt_platform/backend/backend/platform_linking/models.py
+++ b/autogpt_platform/backend/backend/platform_linking/models.py
@@ -224,3 +224,24 @@ class WorkspaceArtifact(BaseModel):
     mime_type: str
     size_bytes: int
     content: bytes
+
+
+class BotEventInput(BaseModel):
+    """A single bot usage event. Never carries message content."""
+
+    platform: Platform
+    event_type: str
+    server_id: str | None = None
+    channel_type: str | None = None
+    command_name: str | None = None
+    error_kind: str | None = None
+    char_count: int | None = None
+    duration_ms: int | None = None
+
+
+class BotGuildInput(BaseModel):
+    """Presence of the bot in a single server."""
+
+    platform: Platform
+    server_id: str
+    name: str | None = None

--- a/autogpt_platform/backend/migrations/20260608120000_add_bot_analytics_tables/migration.sql
+++ b/autogpt_platform/backend/migrations/20260608120000_add_bot_analytics_tables/migration.sql
@@ -1,0 +1,51 @@
+-- CreateTable
+-- BotEvent is an append-only stream of discrete bot usage events. It NEVER
+-- stores message content — only counts, timestamps, bounded enums and numeric
+-- metrics. Powers message-volume, command-usage, error-rate and per-server
+-- activity charts on the admin analytics page.
+CREATE TABLE "BotEvent" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "platform" "PlatformType" NOT NULL,
+    "eventType" TEXT NOT NULL,
+    "serverId" TEXT,
+    "channelType" TEXT,
+    "commandName" TEXT,
+    "errorKind" TEXT,
+    "charCount" INTEGER,
+    "durationMs" INTEGER,
+
+    CONSTRAINT "BotEvent_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+-- BotGuild is the presence table: which servers the bot is physically in right
+-- now (a superset of PlatformLink, since the bot can be in servers that never
+-- ran /setup). leftAt IS NULL means currently joined; the joinedAt histogram
+-- drives growth charts and sharding-threshold prediction.
+CREATE TABLE "BotGuild" (
+    "id" TEXT NOT NULL,
+    "platform" "PlatformType" NOT NULL,
+    "serverId" TEXT NOT NULL,
+    "name" TEXT,
+    "joinedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "leftAt" TIMESTAMP(3),
+    "lastSeenAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "BotGuild_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "BotEvent_platform_eventType_createdAt_idx" ON "BotEvent"("platform", "eventType", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "BotEvent_platform_serverId_createdAt_idx" ON "BotEvent"("platform", "serverId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "BotEvent_createdAt_idx" ON "BotEvent"("createdAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "BotGuild_platform_serverId_key" ON "BotGuild"("platform", "serverId");
+
+-- CreateIndex
+CREATE INDEX "BotGuild_platform_leftAt_idx" ON "BotGuild"("platform", "leftAt");

--- a/autogpt_platform/backend/schema.prisma
+++ b/autogpt_platform/backend/schema.prisma
@@ -1589,3 +1589,47 @@ model PlatformLinkToken {
   @@index([platform, platformUserId])
   @@index([expiresAt])
 }
+
+// ── Bot usage analytics ────────────────────────────────────────────────
+// Privacy: these tables NEVER store message content. Only counts,
+// timestamps, bounded enums (event type, channel type, error kind) and
+// numeric metrics (reply length, latency). Tagged with PlatformType so the
+// same analytics work for every chat-bot platform.
+
+// Append-only stream of discrete bot usage events. Powers message-volume,
+// command-usage, error-rate and per-server activity charts.
+model BotEvent {
+  id          String       @id @default(uuid())
+  createdAt   DateTime     @default(now())
+  platform    PlatformType
+  // Bounded event kind, e.g. "message_received", "reply_sent",
+  // "command_used", "link_created", "link_removed", "stream_error".
+  eventType   String
+  serverId    String? // Platform server/guild ID; null for DMs
+  channelType String? // "dm" | "channel" | "thread"
+  commandName String? // For command_used events (e.g. "/new", "/resume")
+  errorKind   String? // Bounded failure category for stream_error events
+  charCount   Int? // Reply length in characters — a metric, NOT content
+  durationMs  Int? // Receive→reply latency in milliseconds
+
+  @@index([platform, eventType, createdAt])
+  @@index([platform, serverId, createdAt])
+  @@index([createdAt])
+}
+
+// Presence table: which servers the bot is physically in right now (a
+// superset of PlatformLink, since the bot can be in servers that haven't run
+// /setup). `leftAt IS NULL` is the live membership; the joinedAt histogram
+// drives growth charts and sharding-threshold prediction.
+model BotGuild {
+  id         String       @id @default(uuid())
+  platform   PlatformType
+  serverId   String // Platform server/guild ID
+  name       String? // Server display name (best-effort, may go stale)
+  joinedAt   DateTime     @default(now())
+  leftAt     DateTime? // Set when the bot is removed; null = currently joined
+  lastSeenAt DateTime     @default(now()) // Last reconcile that confirmed presence
+
+  @@unique([platform, serverId])
+  @@index([platform, leftAt])
+}

--- a/autogpt_platform/frontend/src/app/(platform)/admin/bots/__tests__/main.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/bots/__tests__/main.test.tsx
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getGetV2BotMessageTimeseriesMockHandler200,
+  getGetV2BotServerCountTimeseriesShardingCurveMockHandler200,
+  getGetV2BotServerRosterMockHandler200,
+  getGetV2BotUsageSummaryMockHandler200,
+  getGetV2CommandUsageBreakdownMockHandler200,
+  getGetV2TopServersByActivityMockHandler200,
+} from "@/app/api/__generated__/endpoints/admin/admin.msw";
+import { server } from "@/mocks/mock-server";
+import { render, screen } from "@/tests/integrations/test-utils";
+
+import { BotsContent } from "../components/BotsContent";
+
+function mockAllEndpoints() {
+  server.use(
+    getGetV2BotUsageSummaryMockHandler200({
+      platform: "DISCORD",
+      window_days: 30,
+      live_servers: 42,
+      messages_received: 1000,
+      replies_sent: 950,
+      commands_used: 30,
+      stream_errors: 5,
+      avg_reply_ms: 1500,
+      error_rate: 0.005,
+    }),
+    getGetV2BotMessageTimeseriesMockHandler200([
+      {
+        date: new Date("2026-06-01T00:00:00Z"),
+        messages: 10,
+        replies: 9,
+        errors: 1,
+      },
+    ]),
+    getGetV2BotServerCountTimeseriesShardingCurveMockHandler200([
+      { date: new Date("2026-06-01T00:00:00Z"), server_count: 42 },
+    ]),
+    getGetV2TopServersByActivityMockHandler200([
+      { server_id: "1", name: "Cool Guild", messages: 500, commands: 10 },
+    ]),
+    getGetV2CommandUsageBreakdownMockHandler200([
+      { command: "setup", uses: 12 },
+    ]),
+    getGetV2BotServerRosterMockHandler200([
+      {
+        platform: "DISCORD",
+        server_id: "1",
+        name: "Cool Guild",
+        joined_at: new Date("2026-05-01T00:00:00Z"),
+        left_at: null,
+        active: true,
+      },
+    ]),
+  );
+}
+
+describe("BotsContent", () => {
+  it("renders the live server count and headline metrics", async () => {
+    mockAllEndpoints();
+    render(<BotsContent />);
+
+    expect(await screen.findByText("Live servers")).toBeDefined();
+    expect(await screen.findByText("42")).toBeDefined();
+    expect(await screen.findByText("0.5%")).toBeDefined();
+  });
+
+  it("renders server activity, command usage and roster rows", async () => {
+    mockAllEndpoints();
+    render(<BotsContent />);
+
+    expect(await screen.findAllByText("Cool Guild")).toHaveLength(2);
+    expect(await screen.findByText("/setup")).toBeDefined();
+    expect(await screen.findByText("Active")).toBeDefined();
+  });
+});

--- a/autogpt_platform/frontend/src/app/(platform)/admin/bots/components/BotsContent.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/bots/components/BotsContent.tsx
@@ -12,7 +12,7 @@ import { SummaryCard } from "./SummaryCard";
 import { useBotsContent } from "./useBotsContent";
 import {
   DAYS_OPTIONS,
-  formatDateTime,
+  formatDate,
   formatDuration,
   formatNumber,
   formatPercent,
@@ -135,7 +135,7 @@ export function BotsContent() {
                 rows={state.roster.map((guild) => [
                   guild.name || guild.server_id,
                   guild.active ? "Active" : "Left",
-                  formatDateTime(guild.joined_at),
+                  formatDate(guild.joined_at),
                 ])}
               />
             </Card>

--- a/autogpt_platform/frontend/src/app/(platform)/admin/bots/components/BotsContent.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/bots/components/BotsContent.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { Card } from "@/components/atoms/Card/Card";
+import { ErrorCard } from "@/components/molecules/ErrorCard/ErrorCard";
+import { Select } from "@/components/atoms/Select/Select";
+import { Skeleton } from "@/components/atoms/Skeleton/Skeleton";
+
+import { MessageVolumeChart } from "./MessageVolumeChart";
+import { ServerGrowthChart } from "./ServerGrowthChart";
+import { SimpleTable } from "./SimpleTable";
+import { SummaryCard } from "./SummaryCard";
+import { useBotsContent } from "./useBotsContent";
+import {
+  DAYS_OPTIONS,
+  formatDateTime,
+  formatDuration,
+  formatNumber,
+  formatPercent,
+  PLATFORM_OPTIONS,
+} from "./helpers";
+
+export function BotsContent() {
+  const state = useBotsContent();
+  const { summary } = state;
+
+  const tiles = [
+    { label: "Live servers", value: formatNumber(summary?.live_servers) },
+    {
+      label: "Messages received",
+      value: formatNumber(summary?.messages_received),
+    },
+    { label: "Replies sent", value: formatNumber(summary?.replies_sent) },
+    { label: "Commands used", value: formatNumber(summary?.commands_used) },
+    {
+      label: "Error rate",
+      value: formatPercent(summary?.error_rate),
+      subtitle: `${formatNumber(summary?.stream_errors)} stream errors`,
+    },
+    {
+      label: "Avg reply time",
+      value: formatDuration(summary?.avg_reply_ms),
+    },
+  ];
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-wrap gap-3">
+        <Select
+          id="platform-filter"
+          label="Platform"
+          hideLabel
+          value={state.platform}
+          onValueChange={state.setPlatform}
+          options={PLATFORM_OPTIONS}
+          size="small"
+        />
+        <Select
+          id="days-filter"
+          label="Range"
+          hideLabel
+          value={String(state.days)}
+          onValueChange={(value) => state.setDays(Number(value))}
+          options={DAYS_OPTIONS}
+          size="small"
+        />
+      </div>
+
+      {state.isError ? (
+        <ErrorCard
+          httpError={{
+            message:
+              state.error instanceof Error
+                ? state.error.message
+                : "Failed to load bot analytics",
+          }}
+          context="bot analytics"
+          hint="Make sure the backend is running the latest build and try again."
+        />
+      ) : state.isLoading ? (
+        <div className="grid grid-cols-2 gap-4 md:grid-cols-3">
+          {Array.from({ length: 6 }).map((_, index) => (
+            <Skeleton key={index} className="h-24 rounded-lg" />
+          ))}
+        </div>
+      ) : (
+        <>
+          <div className="grid grid-cols-2 gap-4 md:grid-cols-3">
+            {tiles.map((tile) => (
+              <SummaryCard key={tile.label} {...tile} />
+            ))}
+          </div>
+
+          <Card>
+            <h2 className="mb-4 text-xl font-semibold">
+              Server growth & sharding outlook
+            </h2>
+            <ServerGrowthChart data={state.servers} />
+          </Card>
+
+          <Card>
+            <h2 className="mb-4 text-xl font-semibold">Message volume</h2>
+            <MessageVolumeChart data={state.messages} />
+          </Card>
+
+          <Card>
+            <h2 className="mb-4 text-xl font-semibold">
+              Top servers by activity
+            </h2>
+            <SimpleTable
+              columns={["Server", "Messages", "Commands"]}
+              rows={state.topServers.map((server) => [
+                server.name || server.server_id,
+                formatNumber(server.messages),
+                formatNumber(server.commands),
+              ])}
+            />
+          </Card>
+
+          <div className="grid gap-6 lg:grid-cols-2">
+            <Card>
+              <h2 className="mb-4 text-xl font-semibold">Command usage</h2>
+              <SimpleTable
+                columns={["Command", "Uses"]}
+                rows={state.commands.map((command) => [
+                  `/${command.command}`,
+                  formatNumber(command.uses),
+                ])}
+              />
+            </Card>
+
+            <Card>
+              <h2 className="mb-4 text-xl font-semibold">Server roster</h2>
+              <SimpleTable
+                columns={["Server", "Status", "Joined"]}
+                rows={state.roster.map((guild) => [
+                  guild.name || guild.server_id,
+                  guild.active ? "Active" : "Left",
+                  formatDateTime(guild.joined_at),
+                ])}
+              />
+            </Card>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/admin/bots/components/MessageVolumeChart.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/bots/components/MessageVolumeChart.tsx
@@ -1,0 +1,63 @@
+import {
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+import type { BotTimeseriesPoint } from "@/app/api/__generated__/models/botTimeseriesPoint";
+
+import { formatDay } from "./helpers";
+
+interface Props {
+  data: BotTimeseriesPoint[];
+}
+
+export function MessageVolumeChart({ data }: Props) {
+  const chartData = data.map((point) => ({
+    date: formatDay(point.date),
+    Messages: point.messages,
+    Replies: point.replies,
+    Errors: point.errors,
+  }));
+
+  return (
+    <ResponsiveContainer width="100%" height={320}>
+      <LineChart
+        data={chartData}
+        margin={{ top: 8, right: 24, left: 0, bottom: 0 }}
+      >
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="date" fontSize={12} />
+        <YAxis allowDecimals={false} fontSize={12} />
+        <Tooltip />
+        <Legend />
+        <Line
+          type="monotone"
+          dataKey="Messages"
+          stroke="#6366f1"
+          strokeWidth={2}
+          dot={false}
+        />
+        <Line
+          type="monotone"
+          dataKey="Replies"
+          stroke="#10b981"
+          strokeWidth={2}
+          dot={false}
+        />
+        <Line
+          type="monotone"
+          dataKey="Errors"
+          stroke="#ef4444"
+          strokeWidth={2}
+          dot={false}
+        />
+      </LineChart>
+    </ResponsiveContainer>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/admin/bots/components/ServerGrowthChart.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/bots/components/ServerGrowthChart.tsx
@@ -1,0 +1,78 @@
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  ReferenceLine,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+import type { BotServerCountPoint } from "@/app/api/__generated__/models/botServerCountPoint";
+
+import { formatDay, formatNumber, SHARDING_THRESHOLD } from "./helpers";
+
+interface Props {
+  data: BotServerCountPoint[];
+}
+
+export function ServerGrowthChart({ data }: Props) {
+  const chartData = data.map((point) => ({
+    date: formatDay(point.date),
+    Servers: point.server_count,
+  }));
+  const peak = data.reduce(
+    (max, point) => Math.max(max, point.server_count),
+    0,
+  );
+  // Only fold the (far-off) sharding threshold into the Y-axis once we're
+  // actually approaching it — otherwise a handful of servers would render as a
+  // flat line pinned to the bottom of a 0–2500 axis.
+  const nearThreshold = peak > SHARDING_THRESHOLD * 0.4;
+
+  return (
+    <div>
+      <ResponsiveContainer width="100%" height={320}>
+        <AreaChart
+          data={chartData}
+          margin={{ top: 8, right: 24, left: 0, bottom: 0 }}
+        >
+          <defs>
+            <linearGradient id="serverFill" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="5%" stopColor="#6366f1" stopOpacity={0.3} />
+              <stop offset="95%" stopColor="#6366f1" stopOpacity={0} />
+            </linearGradient>
+          </defs>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="date" fontSize={12} />
+          <YAxis
+            allowDecimals={false}
+            fontSize={12}
+            domain={nearThreshold ? [0, SHARDING_THRESHOLD] : undefined}
+          />
+          <Tooltip />
+          {nearThreshold && (
+            <ReferenceLine
+              y={SHARDING_THRESHOLD}
+              stroke="#ef4444"
+              strokeDasharray="4 4"
+              label="Sharding threshold"
+            />
+          )}
+          <Area
+            type="monotone"
+            dataKey="Servers"
+            stroke="#6366f1"
+            strokeWidth={2}
+            fill="url(#serverFill)"
+          />
+        </AreaChart>
+      </ResponsiveContainer>
+      <p className="mt-2 text-xs text-muted-foreground">
+        Sharding threshold: {formatNumber(SHARDING_THRESHOLD)} servers · current
+        peak in range: {formatNumber(peak)}
+      </p>
+    </div>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/admin/bots/components/SimpleTable.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/bots/components/SimpleTable.tsx
@@ -24,8 +24,8 @@ export function SimpleTable({
       <table className="w-full text-sm">
         <thead>
           <tr className="border-b text-left text-muted-foreground">
-            {columns.map((column) => (
-              <th key={column} className="px-3 py-2 font-medium">
+            {columns.map((column, columnIndex) => (
+              <th key={columnIndex} className="px-3 py-2 font-medium">
                 {column}
               </th>
             ))}

--- a/autogpt_platform/frontend/src/app/(platform)/admin/bots/components/SimpleTable.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/bots/components/SimpleTable.tsx
@@ -1,0 +1,48 @@
+import type { ReactNode } from "react";
+
+interface Props {
+  columns: string[];
+  rows: ReactNode[][];
+  emptyLabel?: string;
+}
+
+export function SimpleTable({
+  columns,
+  rows,
+  emptyLabel = "No data yet",
+}: Props) {
+  if (rows.length === 0) {
+    return (
+      <p className="py-6 text-center text-sm text-muted-foreground">
+        {emptyLabel}
+      </p>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b text-left text-muted-foreground">
+            {columns.map((column) => (
+              <th key={column} className="px-3 py-2 font-medium">
+                {column}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, rowIndex) => (
+            <tr key={rowIndex} className="border-b last:border-0">
+              {row.map((cell, cellIndex) => (
+                <td key={cellIndex} className="px-3 py-2">
+                  {cell}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/admin/bots/components/SummaryCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/bots/components/SummaryCard.tsx
@@ -1,0 +1,17 @@
+interface Props {
+  label: string;
+  value: string;
+  subtitle?: string;
+}
+
+export function SummaryCard({ label, value, subtitle }: Props) {
+  return (
+    <div className="rounded-lg border p-4">
+      <div className="text-sm text-muted-foreground">{label}</div>
+      <div className="text-2xl font-bold">{value}</div>
+      {subtitle && (
+        <div className="mt-1 text-xs text-muted-foreground">{subtitle}</div>
+      )}
+    </div>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/admin/bots/components/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/bots/components/helpers.ts
@@ -34,9 +34,7 @@ export function formatDay(value: string | Date): string {
   });
 }
 
-export function formatDateTime(
-  value: string | Date | null | undefined,
-): string {
+export function formatDate(value: string | Date | null | undefined): string {
   if (!value) return "—";
   return new Date(value).toLocaleDateString(undefined, {
     year: "numeric",

--- a/autogpt_platform/frontend/src/app/(platform)/admin/bots/components/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/bots/components/helpers.ts
@@ -1,0 +1,46 @@
+export const SHARDING_THRESHOLD = 2500;
+
+export const DAYS_OPTIONS = [
+  { value: "7", label: "Last 7 days" },
+  { value: "30", label: "Last 30 days" },
+  { value: "90", label: "Last 90 days" },
+];
+
+export const PLATFORM_OPTIONS = [
+  { value: "all", label: "All platforms" },
+  { value: "DISCORD", label: "Discord" },
+];
+
+export function formatNumber(value: number | null | undefined): string {
+  if (value == null) return "—";
+  return value.toLocaleString();
+}
+
+export function formatDuration(ms: number | null | undefined): string {
+  if (ms == null) return "—";
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+export function formatPercent(rate: number | null | undefined): string {
+  if (rate == null) return "—";
+  return `${(rate * 100).toFixed(1)}%`;
+}
+
+export function formatDay(value: string | Date): string {
+  return new Date(value).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  });
+}
+
+export function formatDateTime(
+  value: string | Date | null | undefined,
+): string {
+  if (!value) return "—";
+  return new Date(value).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}

--- a/autogpt_platform/frontend/src/app/(platform)/admin/bots/components/useBotsContent.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/bots/components/useBotsContent.ts
@@ -56,8 +56,26 @@ export function useBotsContent() {
     topServers: topServers.data ?? [],
     commands: commands.data ?? [],
     roster: roster.data ?? [],
-    isLoading: summary.isLoading || messages.isLoading || servers.isLoading,
-    isError: summary.isError || messages.isError,
-    error: summary.error || messages.error,
+    isLoading:
+      summary.isLoading ||
+      messages.isLoading ||
+      servers.isLoading ||
+      topServers.isLoading ||
+      commands.isLoading ||
+      roster.isLoading,
+    isError:
+      summary.isError ||
+      messages.isError ||
+      servers.isError ||
+      topServers.isError ||
+      commands.isError ||
+      roster.isError,
+    error:
+      summary.error ||
+      messages.error ||
+      servers.error ||
+      topServers.error ||
+      commands.error ||
+      roster.error,
   };
 }

--- a/autogpt_platform/frontend/src/app/(platform)/admin/bots/components/useBotsContent.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/bots/components/useBotsContent.ts
@@ -1,0 +1,63 @@
+"use client";
+
+import { useState } from "react";
+
+import {
+  useGetV2BotMessageTimeseries,
+  useGetV2BotServerCountTimeseriesShardingCurve,
+  useGetV2BotServerRoster,
+  useGetV2BotUsageSummary,
+  useGetV2CommandUsageBreakdown,
+  useGetV2TopServersByActivity,
+} from "@/app/api/__generated__/endpoints/admin/admin";
+import type { Platform } from "@/app/api/__generated__/models/platform";
+import { okData } from "@/app/api/helpers";
+
+export function useBotsContent() {
+  const [days, setDays] = useState(30);
+  const [platform, setPlatform] = useState("all");
+
+  const platformParam = platform === "all" ? undefined : (platform as Platform);
+  const windowParams = {
+    days,
+    ...(platformParam && { platform: platformParam }),
+  };
+
+  // NOTE: the `select: okData` option must be inlined per call — hoisting it to
+  // a shared const collapses okData's generic to `any` and loses response types.
+  const summary = useGetV2BotUsageSummary(windowParams, {
+    query: { select: okData },
+  });
+  const messages = useGetV2BotMessageTimeseries(windowParams, {
+    query: { select: okData },
+  });
+  const servers = useGetV2BotServerCountTimeseriesShardingCurve(windowParams, {
+    query: { select: okData },
+  });
+  const topServers = useGetV2TopServersByActivity(windowParams, {
+    query: { select: okData },
+  });
+  const commands = useGetV2CommandUsageBreakdown(windowParams, {
+    query: { select: okData },
+  });
+  const roster = useGetV2BotServerRoster(
+    platformParam ? { platform: platformParam } : {},
+    { query: { select: okData } },
+  );
+
+  return {
+    days,
+    setDays,
+    platform,
+    setPlatform,
+    summary: summary.data,
+    messages: messages.data ?? [],
+    servers: servers.data ?? [],
+    topServers: topServers.data ?? [],
+    commands: commands.data ?? [],
+    roster: roster.data ?? [],
+    isLoading: summary.isLoading || messages.isLoading || servers.isLoading,
+    isError: summary.isError || messages.isError,
+    error: summary.error || messages.error,
+  };
+}

--- a/autogpt_platform/frontend/src/app/(platform)/admin/bots/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/bots/page.tsx
@@ -1,5 +1,3 @@
-import { Suspense } from "react";
-
 import { withRoleAccess } from "@/lib/withRoleAccess";
 
 import { BotsContent } from "./components/BotsContent";
@@ -17,13 +15,7 @@ function BotsDashboard() {
           </p>
         </div>
 
-        <Suspense
-          fallback={
-            <div className="py-10 text-center">Loading bot analytics...</div>
-          }
-        >
-          <BotsContent />
-        </Suspense>
+        <BotsContent />
       </div>
     </div>
   );

--- a/autogpt_platform/frontend/src/app/(platform)/admin/bots/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/bots/page.tsx
@@ -1,0 +1,36 @@
+import { Suspense } from "react";
+
+import { withRoleAccess } from "@/lib/withRoleAccess";
+
+import { BotsContent } from "./components/BotsContent";
+
+function BotsDashboard() {
+  return (
+    <div className="mx-auto p-6">
+      <div className="flex flex-col gap-4">
+        <div>
+          <h1 className="text-3xl font-bold">Bot Analytics</h1>
+          <p className="text-muted-foreground">
+            Usage, reach and reliability across every live AutoPilot bot. No
+            message content or user identity is collected — only aggregate
+            counts and metrics.
+          </p>
+        </div>
+
+        <Suspense
+          fallback={
+            <div className="py-10 text-center">Loading bot analytics...</div>
+          }
+        >
+          <BotsContent />
+        </Suspense>
+      </div>
+    </div>
+  );
+}
+
+export default async function BotsPage() {
+  const withAdminAccess = await withRoleAccess(["admin"]);
+  const ProtectedDashboard = await withAdminAccess(BotsDashboard);
+  return <ProtectedDashboard />;
+}

--- a/autogpt_platform/frontend/src/app/(platform)/admin/layout.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/layout.tsx
@@ -8,7 +8,7 @@ import {
   FileText,
   Heartbeat,
   CalculatorIcon,
-  Robot,
+  RobotIcon,
 } from "@phosphor-icons/react/dist/ssr";
 
 import { IconSliders } from "@/components/__legacy__/ui/icons";
@@ -54,7 +54,7 @@ const sidebarLinkGroups = [
       {
         text: "Bot Analytics",
         href: "/admin/bots",
-        icon: <Robot className="h-6 w-6" />,
+        icon: <RobotIcon className="h-6 w-6" />,
       },
       {
         text: "Block Cost Estimates",

--- a/autogpt_platform/frontend/src/app/(platform)/admin/layout.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/layout.tsx
@@ -8,6 +8,7 @@ import {
   FileText,
   Heartbeat,
   CalculatorIcon,
+  Robot,
 } from "@phosphor-icons/react/dist/ssr";
 
 import { IconSliders } from "@/components/__legacy__/ui/icons";
@@ -49,6 +50,11 @@ const sidebarLinkGroups = [
         text: "Execution Analytics",
         href: "/admin/execution-analytics",
         icon: <FileText className="h-6 w-6" />,
+      },
+      {
+        text: "Bot Analytics",
+        href: "/admin/bots",
+        icon: <Robot className="h-6 w-6" />,
       },
       {
         text: "Block Cost Estimates",

--- a/autogpt_platform/frontend/src/app/api/openapi.json
+++ b/autogpt_platform/frontend/src/app/api/openapi.json
@@ -11901,7 +11901,11 @@
             "title": "Platform"
           },
           "window_days": { "type": "integer", "title": "Window Days" },
-          "live_servers": { "type": "integer", "title": "Live Servers" },
+          "live_servers": {
+            "type": "integer",
+            "title": "Live Servers",
+            "description": "Current count of servers the bot is in right now. Point-in-time gauge — intentionally ignores window_days. Use the server-count timeseries endpoint for the windowed growth curve."
+          },
           "messages_received": {
             "type": "integer",
             "title": "Messages Received"

--- a/autogpt_platform/frontend/src/app/api/openapi.json
+++ b/autogpt_platform/frontend/src/app/api/openapi.json
@@ -7,6 +7,382 @@
     "version": "0.1"
   },
   "paths": {
+    "/api/admin/bot-analytics/command-usage": {
+      "get": {
+        "tags": ["v2", "admin", "bot-analytics", "admin"],
+        "summary": "Command Usage Breakdown",
+        "operationId": "getV2Command usage breakdown",
+        "security": [{ "HTTPBearerJWT": [] }],
+        "parameters": [
+          {
+            "name": "platform",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                { "$ref": "#/components/schemas/Platform" },
+                { "type": "null" }
+              ],
+              "title": "Platform"
+            }
+          },
+          {
+            "name": "days",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 365,
+              "minimum": 1,
+              "default": 30,
+              "title": "Days"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/BotCommandUsage" },
+                  "title": "Response Getv2Command Usage Breakdown"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/bot-analytics/guilds": {
+      "get": {
+        "tags": ["v2", "admin", "bot-analytics", "admin"],
+        "summary": "Bot Server Roster",
+        "operationId": "getV2Bot server roster",
+        "security": [{ "HTTPBearerJWT": [] }],
+        "parameters": [
+          {
+            "name": "platform",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                { "$ref": "#/components/schemas/Platform" },
+                { "type": "null" }
+              ],
+              "title": "Platform"
+            }
+          },
+          {
+            "name": "include_left",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Include Left"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 2000,
+              "minimum": 1,
+              "default": 500,
+              "title": "Limit"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/BotGuildInfo" },
+                  "title": "Response Getv2Bot Server Roster"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/bot-analytics/server-timeseries": {
+      "get": {
+        "tags": ["v2", "admin", "bot-analytics", "admin"],
+        "summary": "Bot Server-Count Timeseries (sharding curve)",
+        "operationId": "getV2Bot server-count timeseries (sharding curve)",
+        "security": [{ "HTTPBearerJWT": [] }],
+        "parameters": [
+          {
+            "name": "platform",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                { "$ref": "#/components/schemas/Platform" },
+                { "type": "null" }
+              ],
+              "title": "Platform"
+            }
+          },
+          {
+            "name": "days",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 365,
+              "minimum": 1,
+              "default": 30,
+              "title": "Days"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/BotServerCountPoint"
+                  },
+                  "title": "Response Getv2Bot Server-Count Timeseries (Sharding Curve)"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/bot-analytics/summary": {
+      "get": {
+        "tags": ["v2", "admin", "bot-analytics", "admin"],
+        "summary": "Bot Usage Summary",
+        "operationId": "getV2Bot usage summary",
+        "security": [{ "HTTPBearerJWT": [] }],
+        "parameters": [
+          {
+            "name": "platform",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                { "$ref": "#/components/schemas/Platform" },
+                { "type": "null" }
+              ],
+              "title": "Platform"
+            }
+          },
+          {
+            "name": "days",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 365,
+              "minimum": 1,
+              "default": 30,
+              "title": "Days"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/BotAnalyticsSummary" }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/bot-analytics/timeseries": {
+      "get": {
+        "tags": ["v2", "admin", "bot-analytics", "admin"],
+        "summary": "Bot Message Timeseries",
+        "operationId": "getV2Bot message timeseries",
+        "security": [{ "HTTPBearerJWT": [] }],
+        "parameters": [
+          {
+            "name": "platform",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                { "$ref": "#/components/schemas/Platform" },
+                { "type": "null" }
+              ],
+              "title": "Platform"
+            }
+          },
+          {
+            "name": "days",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 365,
+              "minimum": 1,
+              "default": 30,
+              "title": "Days"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/BotTimeseriesPoint"
+                  },
+                  "title": "Response Getv2Bot Message Timeseries"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/bot-analytics/top-servers": {
+      "get": {
+        "tags": ["v2", "admin", "bot-analytics", "admin"],
+        "summary": "Top Servers by Activity",
+        "operationId": "getV2Top servers by activity",
+        "security": [{ "HTTPBearerJWT": [] }],
+        "parameters": [
+          {
+            "name": "platform",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                { "$ref": "#/components/schemas/Platform" },
+                { "type": "null" }
+              ],
+              "title": "Platform"
+            }
+          },
+          {
+            "name": "days",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 365,
+              "minimum": 1,
+              "default": 30,
+              "title": "Days"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 20,
+              "title": "Limit"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/BotServerActivity" },
+                  "title": "Response Getv2Top Servers By Activity"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/admin/blocks/cost-estimates": {
       "get": {
         "tags": ["v2", "admin", "admin", "blocks"],
@@ -10141,6 +10517,131 @@
   },
   "components": {
     "schemas": {
+      "Platform": {
+        "type": "string",
+        "enum": [
+          "DISCORD",
+          "TELEGRAM",
+          "SLACK",
+          "TEAMS",
+          "WHATSAPP",
+          "GITHUB",
+          "LINEAR"
+        ],
+        "title": "Platform",
+        "description": "Mirror of the Prisma PlatformType enum."
+      },
+      "BotAnalyticsSummary": {
+        "properties": {
+          "platform": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Platform"
+          },
+          "window_days": { "type": "integer", "title": "Window Days" },
+          "live_servers": { "type": "integer", "title": "Live Servers" },
+          "messages_received": {
+            "type": "integer",
+            "title": "Messages Received"
+          },
+          "replies_sent": { "type": "integer", "title": "Replies Sent" },
+          "commands_used": { "type": "integer", "title": "Commands Used" },
+          "stream_errors": { "type": "integer", "title": "Stream Errors" },
+          "avg_reply_ms": {
+            "anyOf": [{ "type": "number" }, { "type": "null" }],
+            "title": "Avg Reply Ms"
+          },
+          "error_rate": { "type": "number", "title": "Error Rate" }
+        },
+        "type": "object",
+        "required": [
+          "platform",
+          "window_days",
+          "live_servers",
+          "messages_received",
+          "replies_sent",
+          "commands_used",
+          "stream_errors",
+          "avg_reply_ms",
+          "error_rate"
+        ],
+        "title": "BotAnalyticsSummary"
+      },
+      "BotTimeseriesPoint": {
+        "properties": {
+          "date": { "type": "string", "format": "date-time", "title": "Date" },
+          "messages": { "type": "integer", "title": "Messages" },
+          "replies": { "type": "integer", "title": "Replies" },
+          "errors": { "type": "integer", "title": "Errors" }
+        },
+        "type": "object",
+        "required": ["date", "messages", "replies", "errors"],
+        "title": "BotTimeseriesPoint"
+      },
+      "BotServerCountPoint": {
+        "properties": {
+          "date": { "type": "string", "format": "date-time", "title": "Date" },
+          "server_count": { "type": "integer", "title": "Server Count" }
+        },
+        "type": "object",
+        "required": ["date", "server_count"],
+        "title": "BotServerCountPoint"
+      },
+      "BotServerActivity": {
+        "properties": {
+          "server_id": { "type": "string", "title": "Server Id" },
+          "name": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Name"
+          },
+          "messages": { "type": "integer", "title": "Messages" },
+          "commands": { "type": "integer", "title": "Commands" }
+        },
+        "type": "object",
+        "required": ["server_id", "name", "messages", "commands"],
+        "title": "BotServerActivity"
+      },
+      "BotCommandUsage": {
+        "properties": {
+          "command": { "type": "string", "title": "Command" },
+          "uses": { "type": "integer", "title": "Uses" }
+        },
+        "type": "object",
+        "required": ["command", "uses"],
+        "title": "BotCommandUsage"
+      },
+      "BotGuildInfo": {
+        "properties": {
+          "platform": { "type": "string", "title": "Platform" },
+          "server_id": { "type": "string", "title": "Server Id" },
+          "name": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Name"
+          },
+          "joined_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Joined At"
+          },
+          "left_at": {
+            "anyOf": [
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
+            ],
+            "title": "Left At"
+          },
+          "active": { "type": "boolean", "title": "Active" }
+        },
+        "type": "object",
+        "required": [
+          "platform",
+          "server_id",
+          "name",
+          "joined_at",
+          "left_at",
+          "active"
+        ],
+        "title": "BotGuildInfo"
+      },
       "APIKeyCredentials": {
         "properties": {
           "id": { "type": "string", "title": "Id" },

--- a/autogpt_platform/frontend/src/app/api/openapi.json
+++ b/autogpt_platform/frontend/src/app/api/openapi.json
@@ -7,9 +7,84 @@
     "version": "0.1"
   },
   "paths": {
+    "/api/admin/blocks/cost-estimates": {
+      "get": {
+        "tags": ["v2", "admin", "admin", "blocks"],
+        "summary": "Export Block Cost Estimates",
+        "description": "Aggregate per-block average credits-per-execution over [start, end].\n\nCapped at ANALYTICS_MAX_DAYS days. Returns only blocks whose current cost\ntype is dynamic (SECOND/ITEMS/COST_USD) — static-cost blocks already\ncharge correctly pre-flight and don't need an estimate override. TOKENS\nis excluded because `compute_token_credits` already supplies a per-model\nfloor at pre-flight; a per-block historical mean would lose that\ngranularity.",
+        "operationId": "getV2Export block cost estimates",
+        "security": [{ "HTTPBearerJWT": [] }],
+        "parameters": [
+          {
+            "name": "start",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                { "type": "string", "format": "date-time" },
+                { "type": "null" }
+              ],
+              "description": "ISO timestamp (inclusive)",
+              "title": "Start"
+            },
+            "description": "ISO timestamp (inclusive)"
+          },
+          {
+            "name": "end",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                { "type": "string", "format": "date-time" },
+                { "type": "null" }
+              ],
+              "description": "ISO timestamp (inclusive)",
+              "title": "End"
+            },
+            "description": "ISO timestamp (inclusive)"
+          },
+          {
+            "name": "min_samples",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Minimum executions per block to include",
+              "default": 10,
+              "title": "Min Samples"
+            },
+            "description": "Minimum executions per block to include"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BlockCostEstimatesResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/admin/bot-analytics/command-usage": {
       "get": {
-        "tags": ["v2", "admin", "bot-analytics", "admin"],
+        "tags": ["v2", "admin", "bot-analytics"],
         "summary": "Command Usage Breakdown",
         "operationId": "getV2Command usage breakdown",
         "security": [{ "HTTPBearerJWT": [] }],
@@ -68,7 +143,7 @@
     },
     "/api/admin/bot-analytics/guilds": {
       "get": {
-        "tags": ["v2", "admin", "bot-analytics", "admin"],
+        "tags": ["v2", "admin", "bot-analytics"],
         "summary": "Bot Server Roster",
         "operationId": "getV2Bot server roster",
         "security": [{ "HTTPBearerJWT": [] }],
@@ -137,7 +212,7 @@
     },
     "/api/admin/bot-analytics/server-timeseries": {
       "get": {
-        "tags": ["v2", "admin", "bot-analytics", "admin"],
+        "tags": ["v2", "admin", "bot-analytics"],
         "summary": "Bot Server-Count Timeseries (sharding curve)",
         "operationId": "getV2Bot server-count timeseries (sharding curve)",
         "security": [{ "HTTPBearerJWT": [] }],
@@ -198,7 +273,7 @@
     },
     "/api/admin/bot-analytics/summary": {
       "get": {
-        "tags": ["v2", "admin", "bot-analytics", "admin"],
+        "tags": ["v2", "admin", "bot-analytics"],
         "summary": "Bot Usage Summary",
         "operationId": "getV2Bot usage summary",
         "security": [{ "HTTPBearerJWT": [] }],
@@ -253,7 +328,7 @@
     },
     "/api/admin/bot-analytics/timeseries": {
       "get": {
-        "tags": ["v2", "admin", "bot-analytics", "admin"],
+        "tags": ["v2", "admin", "bot-analytics"],
         "summary": "Bot Message Timeseries",
         "operationId": "getV2Bot message timeseries",
         "security": [{ "HTTPBearerJWT": [] }],
@@ -314,7 +389,7 @@
     },
     "/api/admin/bot-analytics/top-servers": {
       "get": {
-        "tags": ["v2", "admin", "bot-analytics", "admin"],
+        "tags": ["v2", "admin", "bot-analytics"],
         "summary": "Top Servers by Activity",
         "operationId": "getV2Top servers by activity",
         "security": [{ "HTTPBearerJWT": [] }],
@@ -365,81 +440,6 @@
                   "type": "array",
                   "items": { "$ref": "#/components/schemas/BotServerActivity" },
                   "title": "Response Getv2Top Servers By Activity"
-                }
-              }
-            }
-          },
-          "401": {
-            "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/admin/blocks/cost-estimates": {
-      "get": {
-        "tags": ["v2", "admin", "admin", "blocks"],
-        "summary": "Export Block Cost Estimates",
-        "description": "Aggregate per-block average credits-per-execution over [start, end].\n\nCapped at ANALYTICS_MAX_DAYS days. Returns only blocks whose current cost\ntype is dynamic (SECOND/ITEMS/COST_USD) — static-cost blocks already\ncharge correctly pre-flight and don't need an estimate override. TOKENS\nis excluded because `compute_token_credits` already supplies a per-model\nfloor at pre-flight; a per-block historical mean would lose that\ngranularity.",
-        "operationId": "getV2Export block cost estimates",
-        "security": [{ "HTTPBearerJWT": [] }],
-        "parameters": [
-          {
-            "name": "start",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                { "type": "string", "format": "date-time" },
-                { "type": "null" }
-              ],
-              "description": "ISO timestamp (inclusive)",
-              "title": "Start"
-            },
-            "description": "ISO timestamp (inclusive)"
-          },
-          {
-            "name": "end",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                { "type": "string", "format": "date-time" },
-                { "type": "null" }
-              ],
-              "description": "ISO timestamp (inclusive)",
-              "title": "End"
-            },
-            "description": "ISO timestamp (inclusive)"
-          },
-          {
-            "name": "min_samples",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "description": "Minimum executions per block to include",
-              "default": 10,
-              "title": "Min Samples"
-            },
-            "description": "Minimum executions per block to include"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BlockCostEstimatesResponse"
                 }
               }
             }
@@ -10517,131 +10517,6 @@
   },
   "components": {
     "schemas": {
-      "Platform": {
-        "type": "string",
-        "enum": [
-          "DISCORD",
-          "TELEGRAM",
-          "SLACK",
-          "TEAMS",
-          "WHATSAPP",
-          "GITHUB",
-          "LINEAR"
-        ],
-        "title": "Platform",
-        "description": "Mirror of the Prisma PlatformType enum."
-      },
-      "BotAnalyticsSummary": {
-        "properties": {
-          "platform": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
-            "title": "Platform"
-          },
-          "window_days": { "type": "integer", "title": "Window Days" },
-          "live_servers": { "type": "integer", "title": "Live Servers" },
-          "messages_received": {
-            "type": "integer",
-            "title": "Messages Received"
-          },
-          "replies_sent": { "type": "integer", "title": "Replies Sent" },
-          "commands_used": { "type": "integer", "title": "Commands Used" },
-          "stream_errors": { "type": "integer", "title": "Stream Errors" },
-          "avg_reply_ms": {
-            "anyOf": [{ "type": "number" }, { "type": "null" }],
-            "title": "Avg Reply Ms"
-          },
-          "error_rate": { "type": "number", "title": "Error Rate" }
-        },
-        "type": "object",
-        "required": [
-          "platform",
-          "window_days",
-          "live_servers",
-          "messages_received",
-          "replies_sent",
-          "commands_used",
-          "stream_errors",
-          "avg_reply_ms",
-          "error_rate"
-        ],
-        "title": "BotAnalyticsSummary"
-      },
-      "BotTimeseriesPoint": {
-        "properties": {
-          "date": { "type": "string", "format": "date-time", "title": "Date" },
-          "messages": { "type": "integer", "title": "Messages" },
-          "replies": { "type": "integer", "title": "Replies" },
-          "errors": { "type": "integer", "title": "Errors" }
-        },
-        "type": "object",
-        "required": ["date", "messages", "replies", "errors"],
-        "title": "BotTimeseriesPoint"
-      },
-      "BotServerCountPoint": {
-        "properties": {
-          "date": { "type": "string", "format": "date-time", "title": "Date" },
-          "server_count": { "type": "integer", "title": "Server Count" }
-        },
-        "type": "object",
-        "required": ["date", "server_count"],
-        "title": "BotServerCountPoint"
-      },
-      "BotServerActivity": {
-        "properties": {
-          "server_id": { "type": "string", "title": "Server Id" },
-          "name": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
-            "title": "Name"
-          },
-          "messages": { "type": "integer", "title": "Messages" },
-          "commands": { "type": "integer", "title": "Commands" }
-        },
-        "type": "object",
-        "required": ["server_id", "name", "messages", "commands"],
-        "title": "BotServerActivity"
-      },
-      "BotCommandUsage": {
-        "properties": {
-          "command": { "type": "string", "title": "Command" },
-          "uses": { "type": "integer", "title": "Uses" }
-        },
-        "type": "object",
-        "required": ["command", "uses"],
-        "title": "BotCommandUsage"
-      },
-      "BotGuildInfo": {
-        "properties": {
-          "platform": { "type": "string", "title": "Platform" },
-          "server_id": { "type": "string", "title": "Server Id" },
-          "name": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
-            "title": "Name"
-          },
-          "joined_at": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Joined At"
-          },
-          "left_at": {
-            "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
-            ],
-            "title": "Left At"
-          },
-          "active": { "type": "boolean", "title": "Active" }
-        },
-        "type": "object",
-        "required": [
-          "platform",
-          "server_id",
-          "name",
-          "joined_at",
-          "left_at",
-          "active"
-        ],
-        "title": "BotGuildInfo"
-      },
       "APIKeyCredentials": {
         "properties": {
           "id": { "type": "string", "title": "Id" },
@@ -12019,6 +11894,83 @@
         "required": ["file"],
         "title": "Body_uploadWorkspaceFile"
       },
+      "BotAnalyticsSummary": {
+        "properties": {
+          "platform": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Platform"
+          },
+          "window_days": { "type": "integer", "title": "Window Days" },
+          "live_servers": { "type": "integer", "title": "Live Servers" },
+          "messages_received": {
+            "type": "integer",
+            "title": "Messages Received"
+          },
+          "replies_sent": { "type": "integer", "title": "Replies Sent" },
+          "commands_used": { "type": "integer", "title": "Commands Used" },
+          "stream_errors": { "type": "integer", "title": "Stream Errors" },
+          "avg_reply_ms": {
+            "anyOf": [{ "type": "number" }, { "type": "null" }],
+            "title": "Avg Reply Ms"
+          },
+          "error_rate": { "type": "number", "title": "Error Rate" }
+        },
+        "type": "object",
+        "required": [
+          "platform",
+          "window_days",
+          "live_servers",
+          "messages_received",
+          "replies_sent",
+          "commands_used",
+          "stream_errors",
+          "avg_reply_ms",
+          "error_rate"
+        ],
+        "title": "BotAnalyticsSummary"
+      },
+      "BotCommandUsage": {
+        "properties": {
+          "command": { "type": "string", "title": "Command" },
+          "uses": { "type": "integer", "title": "Uses" }
+        },
+        "type": "object",
+        "required": ["command", "uses"],
+        "title": "BotCommandUsage"
+      },
+      "BotGuildInfo": {
+        "properties": {
+          "platform": { "type": "string", "title": "Platform" },
+          "server_id": { "type": "string", "title": "Server Id" },
+          "name": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Name"
+          },
+          "joined_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Joined At"
+          },
+          "left_at": {
+            "anyOf": [
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
+            ],
+            "title": "Left At"
+          },
+          "active": { "type": "boolean", "title": "Active" }
+        },
+        "type": "object",
+        "required": [
+          "platform",
+          "server_id",
+          "name",
+          "joined_at",
+          "left_at",
+          "active"
+        ],
+        "title": "BotGuildInfo"
+      },
       "BotPlatformInfo": {
         "properties": {
           "platform": { "type": "string", "title": "Platform" },
@@ -12044,6 +11996,40 @@
         "required": ["platform", "display_name", "icon"],
         "title": "BotPlatformInfo",
         "description": "A bot platform enabled on this deployment plus the caller's links to it.\n\nPlatforms whose adapter isn't configured (missing token/credentials) are\nomitted from the response entirely — the Bots settings page hides them."
+      },
+      "BotServerActivity": {
+        "properties": {
+          "server_id": { "type": "string", "title": "Server Id" },
+          "name": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Name"
+          },
+          "messages": { "type": "integer", "title": "Messages" },
+          "commands": { "type": "integer", "title": "Commands" }
+        },
+        "type": "object",
+        "required": ["server_id", "name", "messages", "commands"],
+        "title": "BotServerActivity"
+      },
+      "BotServerCountPoint": {
+        "properties": {
+          "date": { "type": "string", "format": "date-time", "title": "Date" },
+          "server_count": { "type": "integer", "title": "Server Count" }
+        },
+        "type": "object",
+        "required": ["date", "server_count"],
+        "title": "BotServerCountPoint"
+      },
+      "BotTimeseriesPoint": {
+        "properties": {
+          "date": { "type": "string", "format": "date-time", "title": "Date" },
+          "messages": { "type": "integer", "title": "Messages" },
+          "replies": { "type": "integer", "title": "Replies" },
+          "errors": { "type": "integer", "title": "Errors" }
+        },
+        "type": "object",
+        "required": ["date", "messages", "replies", "errors"],
+        "title": "BotTimeseriesPoint"
       },
       "BulkMoveAgentsRequest": {
         "properties": {
@@ -16031,6 +16017,20 @@
         "required": ["access_token"],
         "title": "PickerTokenResponse",
         "description": "Short-lived OAuth access token shipped to the browser for rendering a\nprovider-hosted picker UI (e.g. Google Drive Picker). Deliberately narrow:\nonly the fields the client needs to initialize the picker widget. Issued\nfrom the user's own stored credential so ownership and scope gating are\nenforced by the credential lookup."
+      },
+      "Platform": {
+        "type": "string",
+        "enum": [
+          "DISCORD",
+          "TELEGRAM",
+          "SLACK",
+          "TEAMS",
+          "WHATSAPP",
+          "GITHUB",
+          "LINEAR"
+        ],
+        "title": "Platform",
+        "description": "Mirror of the Prisma PlatformType enum."
       },
       "PlatformCostDashboard": {
         "properties": {


### PR DESCRIPTION
### Why / What / How

> ⚠️ **Stacked on top of #13325 (writes).** Review/merge that one first. This PR's base is `feat/bot-analytics-backend`, so the diff here is only the read side. Once #13325 merges and GitHub retargets, this becomes a clean diff against `dev`.

**Why** — #13325 records the events but nothing surfaces them. We need an admin page that turns the raw `BotEvent`/`BotGuild` rows into something we can actually use: live server count vs the Discord sharding threshold, message volume + error rate over time, top servers, command-usage breakdown, server roster.

**What** — adds 6 admin-gated `GET /api/admin/bot-analytics/*` endpoints over the existing Prisma engine, regenerates the typed frontend client, and ships an `/admin/bots` page that consumes those endpoints.

**How** —
- **Reads** (`backend/data/bot_analytics_reads.py`) — six aggregate query functions using `query_raw_with_schema` (same pattern as `platform_cost`). Parameterized SQL, no injection surface; every result is a count, a duration, or a server row. Helper `_platform_filter` keeps the optional `platform=DISCORD` filter consistent across queries.
- **Routes** (`backend/api/features/admin/bot_analytics_routes.py`) — `APIRouter(prefix="/bot-analytics", dependencies=[Security(requires_admin_user)])` — admin-gating is router-level so it's impossible to add a public endpoint to this surface by accident. All `days` params are `Query(ge=1, le=365)` so the queries can't be coerced into scanning the whole table.
- **Frontend** (`(platform)/admin/bots/`) — `BotsContent` consumes the Orval-generated hooks via `useBotsContent` (each call inlines `select: okData` because hoisting that const collapses the generic). Recharts line chart for message volume, area chart for server growth with a reference line at the **2,500-server sharding threshold** (only shown once we're at ≥40 % of it so a handful of servers doesn't render as a flat baseline). Three `SimpleTable`s for top servers / command usage / server roster.
- **Sidebar** — `/admin/bots` linked from `admin/layout.tsx` as **Bot Analytics**.

### Endpoints

| Method | Path | Purpose |
|---|---|---|
| GET | `/api/admin/bot-analytics/summary` | Headline tile metrics (live servers, totals, error rate, avg reply ms) |
| GET | `/api/admin/bot-analytics/timeseries` | Daily messages / replies / errors |
| GET | `/api/admin/bot-analytics/server-timeseries` | Cumulative live-server count vs sharding threshold |
| GET | `/api/admin/bot-analytics/top-servers` | Top-N servers by activity |
| GET | `/api/admin/bot-analytics/command-usage` | Per-command invocation counts |
| GET | `/api/admin/bot-analytics/guilds` | Server roster (active or include-left) |

### Changes 🏗️

- `backend/data/bot_analytics_reads.py` — six aggregate read functions + their Pydantic response models
- `backend/api/features/admin/bot_analytics_routes.py` — admin router, six endpoints, validated `Query` params
- `backend/api/rest_api.py` — mounts the router at `/api/admin`
- `backend/api/features/admin/bot_analytics_routes_test.py` — auth, validation (422 on bad `platform`/`days`), shape
- `frontend/src/app/(platform)/admin/bots/page.tsx` + `components/` — `BotsContent`, `useBotsContent`, `MessageVolumeChart`, `ServerGrowthChart`, `SimpleTable`, `SummaryCard`, `helpers.ts`
- `frontend/src/app/(platform)/admin/bots/__tests__/main.test.tsx` — RTL + MSW integration test (mocks all 6 endpoints, asserts tiles + tables render)
- `frontend/src/app/(platform)/admin/layout.tsx` — sidebar link
- `frontend/src/app/api/openapi.json` — surgical splice of the 6 new bot paths and their 7 schemas (no spec-wide regeneration, +501/-0)

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Hit each endpoint as admin → 200; as non-admin → 403
  - [x] `days=9999` and `platform=MYSPACE` → 422 (covered by routes test)
  - [x] Loaded `/admin/bots` end-to-end against a local backend; tiles, charts and tables populate; platform/range filters reload the data
  - [x] Sharding threshold reference line only appears once peak is in range
  - [x] `pnpm types` clean on the bot files (other failures pre-exist on dev)
  - [x] `pnpm lint` clean on the bot files
  - [x] `pnpm test:unit` — `BotsContent` integration test 2/2 passing
  - [x] `black`, `isort`, `ruff`, `pyright` clean on the backend additions

#### For configuration changes:
- [x] `.env.default` is updated or already compatible with my changes (no env changes)
- [x] `docker-compose.yml` is updated or already compatible with my changes (no service changes)
- [x] I have included a list of my configuration changes in the PR description (under **Changes**) — none required

### Privacy

Read API mirrors the schema's privacy guarantee — every endpoint returns aggregates (counts, durations, server-level rows). There is no endpoint that could return message content or user identity because the underlying tables don't store either. The page copy makes this explicit to the admin viewing it.
