### PR TITLE
fix(backend): OpenAI Responses calls crash with 'Omit' object is not a mapping

### DIFF
--- a/autogpt_platform/backend/backend/util/llm/providers.py
+++ b/autogpt_platform/backend/backend/util/llm/providers.py
@@ -422,7 +422,12 @@ async def _call_openai_responses(
         text=text_config,  # type: ignore[arg-type]
         store=False,
         timeout=timeout_seconds,
-        extra_body=extra_body or openai.omit,  # type: ignore[arg-type]
+        # ``omit`` is only valid for TYPED params — the SDK strips it
+        # there. ``extra_body`` flows raw into ``options.extra_json``
+        # (``make_request_options`` checks ``is not None``), and
+        # ``_merge_mappings`` raises ``TypeError: 'Omit' object is not a
+        # mapping`` on the sentinel. Absent extra_body must be ``None``.
+        extra_body=extra_body or None,
     )
 
     raw_tool_calls = extract_responses_tool_calls(response)

--- a/autogpt_platform/backend/backend/util/llm/providers_test.py
+++ b/autogpt_platform/backend/backend/util/llm/providers_test.py
@@ -131,6 +131,61 @@ class TestExecutionModeStubs:
         assert captured.get("extra_body") == {"service_tier": "flex"}
 
     @pytest.mark.asyncio
+    async def test_no_service_tier_passes_none_extra_body_not_omit_sentinel(self):
+        """Sentry AUTOGPT-SERVER-99S: ``extra_body=openai.omit`` crashes the
+        real SDK — ``make_request_options`` only checks ``is not None``, so
+        the Omit sentinel lands in ``options.extra_json`` and
+        ``_merge_mappings`` raises ``TypeError: 'Omit' object is not a
+        mapping`` on EVERY plain OpenAI Responses call (no service_tier).
+        ``omit`` is only valid for typed params; ``extra_body``'s absent
+        value is ``None``."""
+        from backend.util.llm.providers import _call_openai_responses
+
+        captured: dict[str, object] = {}
+
+        class _StubResponses:
+            async def create(self, **kwargs):
+                captured.update(kwargs)
+                resp = MagicMock()
+                resp.output = []
+                resp.usage = MagicMock(input_tokens=1, output_tokens=1)
+                return resp
+
+        class _StubClient:
+            def __init__(self, *args, **kwargs):
+                self.responses = _StubResponses()
+
+        with patch(
+            "backend.util.llm.providers.openai.AsyncOpenAI", new=_StubClient
+        ), patch(
+            "backend.util.llm.providers.extract_responses_content",
+            return_value="",
+        ), patch(
+            "backend.util.llm.providers.extract_responses_tool_calls",
+            return_value=[],
+        ), patch(
+            "backend.util.llm.providers.extract_responses_usage",
+            return_value=(1, 1),
+        ), patch(
+            "backend.util.llm.providers.extract_responses_reasoning",
+            return_value=None,
+        ):
+            await _call_openai_responses(
+                model="gpt-4o",
+                api_key="sk-test",
+                messages=[_msg("user", "hi")],
+                max_tokens=10,
+                temperature=None,
+                tools=None,
+                force_json_output=False,
+                parallel_tool_calls=False,
+                timeout_seconds=30.0,
+                service_tier=None,
+            )
+
+        assert captured.get("extra_body") is None
+
+    @pytest.mark.asyncio
     async def test_flex_mode_passes_service_tier_via_openrouter_extra_body(
         self,
     ):


### PR DESCRIPTION
## Why

[AUTOGPT-SERVER-99S](https://significant-gravitas.sentry.io/issues/7543181423/): every plain OpenAI Responses API call — any block or copilot path using an OpenAI model without `service_tier`, e.g. `AITextGeneratorBlock` — crashes with `TypeError: 'Omit' object is not a mapping`. 

## What

One line in `_call_openai_responses`: `extra_body=extra_body or openai.omit` → `extra_body=extra_body or None`, plus a regression test that pins `extra_body is None` on the no-service-tier path.

## How

`openai.omit` is only valid for **typed** SDK params (the SDK strips the sentinel there — our `temperature` guard on the line above is correct). `extra_body` is different: `make_request_options` only checks `extra_body is not None`, so the sentinel lands in `options.extra_json` and `_build_request` → `_merge_mappings` does `{**json_data, **Omit}` → TypeError. The absent value for `extra_body` is `None`. Verified against the installed SDK source; repo-wide grep confirms this was the only occurrence of the pattern. Tests didn't catch it because they stub the client before `_build_request` runs — the new test asserts on the captured kwarg instead (fails on the old code).

## Checklist

- [x] TDD: failing regression test first, then the fix
- [x] `poetry run format` clean; full providers suite green (60 passed)
- [x] No out-of-scope changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line behavioral fix in LLM provider glue with a targeted regression test; no auth, billing, or API contract changes beyond restoring broken OpenAI Responses calls.
> 
> **Overview**
> Fixes a production crash on **every OpenAI Responses API call** when `service_tier` is unset (e.g. `AITextGeneratorBlock`, copilot paths). `_call_openai_responses` was passing `extra_body=openai.omit` when there was no flex tier payload; unlike typed SDK kwargs, `extra_body` is merged raw and triggers `TypeError: 'Omit' object is not a mapping`.
> 
> The change uses **`extra_body=extra_body or None`** instead, with an inline comment explaining why `omit` must not be used here. A regression test asserts `extra_body is None` on the no-`service_tier` path (AUTOGPT-SERVER-99S).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62659a679c1fd9301558e4cad0015614a2cc584b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->