### PR TITLE
fix(backend/copilot): dream crons never register — timezone lookup crashes in Prisma-less processes

### DIFF
--- a/autogpt_platform/backend/backend/copilot/dream/scheduling.py
+++ b/autogpt_platform/backend/backend/copilot/dream/scheduling.py
@@ -171,15 +171,24 @@ async def _resolve_user_timezone(user_id: str) -> str | None:
     Single DB call — cached at the helper level for the duration of
     one ``ensure_dream_system_scheduled`` invocation so registering
     multiple crons doesn't take multiple round-trips.
+
+    Routes through the ``user_db()`` accessor, NOT ``User.prisma()``:
+    this runs in the copilot-executor and scheduler processes, which
+    never connect a local Prisma client. A direct Prisma call raises
+    ``ClientNotConnectedError`` on every invocation there — a
+    *permanent* failure the keep-existing-schedules fallback was never
+    designed for, which silently prevented dream crons from ever being
+    registered. The accessor falls back to the DatabaseManager RPC in
+    Prisma-less processes (same pattern as ``dream/apply.py``).
     """
     try:
-        from prisma import Prisma  # noqa: F401 — ensures registry
-        from prisma.models import User
-
+        from backend.data.db_accessors import user_db
         from backend.data.model import USER_TIMEZONE_NOT_SET
 
-        user = await User.prisma().find_unique(where={"id": user_id})
-        if user is None:
+        try:
+            user = await user_db().get_user_by_id(user_id)
+        except ValueError:
+            # Authoritative: the user row doesn't exist.
             return "UTC"
         tz = (user.timezone or "").strip()
         if not tz or tz == USER_TIMEZONE_NOT_SET:

--- a/autogpt_platform/backend/backend/copilot/dream/scheduling_test.py
+++ b/autogpt_platform/backend/backend/copilot/dream/scheduling_test.py
@@ -398,10 +398,39 @@ async def test_force_refresh_with_failed_tz_lookup_still_skips_re_registration()
 
 
 @pytest.mark.asyncio
+async def test_resolve_user_timezone_works_without_local_prisma_connection():
+    """Dev outage AUTOGPT: the resolver ran in the copilot-executor
+    process, which never connects a local Prisma client — a direct
+    ``User.prisma()`` call raised ``ClientNotConnectedError`` on every
+    invocation, so dream crons were never registered for anyone. The
+    lookup must route through the ``user_db()`` accessor, which falls
+    back to the DatabaseManager RPC in Prisma-less processes."""
+    accessor = MagicMock()
+    accessor.get_user_by_id = AsyncMock(
+        return_value=MagicMock(timezone="Europe/Madrid")
+    )
+    with patch("backend.data.db_accessors.user_db", return_value=accessor):
+        assert await scheduling._resolve_user_timezone("abc") == "Europe/Madrid"
+    accessor.get_user_by_id.assert_awaited_once_with("abc")
+
+
+@pytest.mark.asyncio
+async def test_resolve_user_timezone_missing_user_is_authoritative_utc():
+    """get_user_by_id raises ValueError for a missing row — that's an
+    authoritative answer (UTC), not a lookup failure (None)."""
+    accessor = MagicMock()
+    accessor.get_user_by_id = AsyncMock(side_effect=ValueError("User not found"))
+    with patch("backend.data.db_accessors.user_db", return_value=accessor):
+        assert await scheduling._resolve_user_timezone("abc") == "UTC"
+
+
+@pytest.mark.asyncio
 async def test_resolve_user_timezone_returns_none_when_db_lookup_fails():
     """The resolver distinguishes 'lookup failed' (None) from
     'genuinely unset' (UTC)."""
-    with patch("prisma.models.User.prisma", side_effect=RuntimeError("db down")):
+    accessor = MagicMock()
+    accessor.get_user_by_id = AsyncMock(side_effect=ConnectionError("db down"))
+    with patch("backend.data.db_accessors.user_db", return_value=accessor):
         assert await scheduling._resolve_user_timezone("abc") is None
 
 
@@ -411,11 +440,11 @@ async def test_resolve_user_timezone_unset_value_falls_back_to_utc():
     UTC — only lookup FAILURES return None."""
     from backend.data.model import USER_TIMEZONE_NOT_SET
 
-    prisma_stub = MagicMock()
-    prisma_stub.find_unique = AsyncMock(
+    accessor = MagicMock()
+    accessor.get_user_by_id = AsyncMock(
         return_value=MagicMock(timezone=USER_TIMEZONE_NOT_SET)
     )
-    with patch("prisma.models.User.prisma", return_value=prisma_stub):
+    with patch("backend.data.db_accessors.user_db", return_value=accessor):
         assert await scheduling._resolve_user_timezone("abc") == "UTC"
 
 


### PR DESCRIPTION
## Why

Dream passes have never run for anyone on dev despite `dream-pass-enabled` being on. Dev cluster logs show every schedule-registration attempt over 48h failing identically: `_resolve_user_timezone` → `prisma.errors.ClientNotConnectedError` → "leaving existing dream-system schedules untouched this cycle" → no crons exist to leave untouched → nothing ever registers, for any user, every cycle.

## What

`_resolve_user_timezone` now routes through the `user_db()` accessor (DatabaseManager RPC in Prisma-less processes) instead of calling `User.prisma().find_unique` directly. Missing user (`ValueError`) maps to the authoritative UTC default; lookup failures still return `None` (keep existing schedules).

## How

The function runs in the copilot-executor (lazy registration on chat activity) and scheduler processes — neither connects a local Prisma client, by design. The repo pattern for cross-process DB reads is the `db_accessors` layer (`dream/apply.py` documents this exact trap); `get_user_by_id` is already exposed on the DatabaseManager RPC. The keep-existing-on-failure fallback was designed for *transient* DB blips and is correct — the bug was the permanently-failing lookup underneath it.

TDD: `test_resolve_user_timezone_works_without_local_prisma_connection` reproduces the outage shape (accessor-routed lookup must succeed with no local Prisma) and fails on the old code; missing-user/unset-timezone/lookup-failure semantics are pinned by sibling tests.

## Checklist

- [x] Failing test first, then fix (22 passing in scheduling_test.py)
- [x] `poetry run format` clean
- [x] No out-of-scope changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches dream cron registration and timezone semantics (missing user vs transient failure); behavior change is narrow but affects when per-user schedules are created.
> 
> **Overview**
> **`_resolve_user_timezone`** no longer calls **`User.prisma().find_unique`** in copilot-executor/scheduler processes (no local Prisma). It uses **`user_db().get_user_by_id`**, which uses DatabaseManager RPC where Prisma isn’t connected, so dream cron registration can resolve timezones instead of hitting **`ClientNotConnectedError`** every cycle and skipping registration.
> 
> **`ValueError`** from a missing user is treated as authoritative **UTC**; other lookup failures still return **`None`** (keep existing schedules). Tests mock **`user_db`** and add coverage for Prisma-less success, missing user, connection errors, and unset timezone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aededc9efb447b4f3aef42bc1aaa3b9d94dba71a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->