### PR TITLE
fix(backend): dream recombine dies on Anthropic temperature deprecation

### DIFF
--- a/autogpt_platform/backend/backend/util/llm/providers.py
+++ b/autogpt_platform/backend/backend/util/llm/providers.py
@@ -101,6 +101,27 @@ ExecutionMode = Literal["sync", "batch", "flex"]
 # sync fallback with a log line.
 _FLEX_SUPPORTED_PROVIDERS: set[str] = {"openai", "open_router"}
 
+# Anthropic deprecated ``temperature`` on its newest model generation —
+# the API rejects it outright with "`temperature` is deprecated for
+# this model." (verified live: opus-4-7 and opus-4-8 reject;
+# sonnet-4-6 accepts). Strip the param for known-rejecting families.
+# The sync path additionally retries once without it on that exact
+# error, so unknown future models self-heal; this list only matters
+# for batch submissions, whose errors come back hours later in the
+# result rows.
+_ANTHROPIC_TEMPERATURE_DEPRECATED_PREFIXES = (
+    "claude-opus-4-7",
+    "claude-opus-4-8",
+)
+
+
+def _anthropic_accepts_temperature(model: str) -> bool:
+    return not model.startswith(_ANTHROPIC_TEMPERATURE_DEPRECATED_PREFIXES)
+
+
+def _is_temperature_deprecation_error(exc: anthropic.BadRequestError) -> bool:
+    return "temperature" in str(exc) and "deprecated" in str(exc)
+
 
 # ---------------------------------------------------------------------------
 # Result + submission carriers
@@ -505,7 +526,7 @@ async def _call_anthropic_messages(
         tools=an_tools,
         timeout=timeout_seconds,
     )
-    if temperature is not None:
+    if temperature is not None and _anthropic_accepts_temperature(model):
         create_kwargs["temperature"] = temperature
     if tool_choice is not None:
         create_kwargs["tool_choice"] = tool_choice
@@ -520,7 +541,21 @@ async def _call_anthropic_messages(
             }
         ]
 
-    resp = await client.messages.create(**create_kwargs)
+    try:
+        resp = await client.messages.create(**create_kwargs)
+    except anthropic.BadRequestError as exc:
+        # Self-heal for models the deny-list doesn't know yet.
+        if "temperature" not in create_kwargs or not (
+            _is_temperature_deprecation_error(exc)
+        ):
+            raise
+        logger.warning(
+            "Anthropic model %s rejected temperature — retrying without it. "
+            "Add the model to _ANTHROPIC_TEMPERATURE_DEPRECATED_PREFIXES.",
+            model,
+        )
+        create_kwargs.pop("temperature")
+        resp = await client.messages.create(**create_kwargs)
     if not resp.content:
         raise ValueError("No content returned from Anthropic.")
 
@@ -1092,7 +1127,9 @@ async def _submit_anthropic_batch(
         "messages": anth_messages,
         "max_tokens": max_tokens,
     }
-    if temperature is not None:
+    # Batch errors surface hours later in the result rows — never submit
+    # temperature to models that reject it (no cheap retry exists here).
+    if temperature is not None and _anthropic_accepts_temperature(model):
         params["temperature"] = temperature
     # Only attach tools / tool_choice when the caller actually passed
     # them — Anthropic rejects empty arrays with HTTP 400.

--- a/autogpt_platform/backend/backend/util/llm/providers.py
+++ b/autogpt_platform/backend/backend/util/llm/providers.py
@@ -120,7 +120,8 @@ def _anthropic_accepts_temperature(model: str) -> bool:
 
 
 def _is_temperature_deprecation_error(exc: anthropic.BadRequestError) -> bool:
-    return "temperature" in str(exc) and "deprecated" in str(exc)
+    error_text = str(exc).lower()
+    return "temperature" in error_text and "deprecated" in error_text
 
 
 # ---------------------------------------------------------------------------

--- a/autogpt_platform/backend/backend/util/llm/providers_test.py
+++ b/autogpt_platform/backend/backend/util/llm/providers_test.py
@@ -1957,6 +1957,40 @@ class TestAnthropicTemperatureDeprecation:
         assert "temperature" not in second.kwargs
 
     @pytest.mark.asyncio
+    async def test_sync_retry_detection_is_case_insensitive(self):
+        """The deprecation message wording/casing isn't contractual — a
+        future model returning 'Temperature ... Deprecated' must still
+        trigger the self-healing retry, not fall through and fail."""
+        import httpx
+
+        err = anthropic.BadRequestError(
+            message="Temperature is Deprecated for this model.",
+            response=httpx.Response(
+                400, request=httpx.Request("POST", "https://api.anthropic.com")
+            ),
+            body={"error": {"message": "Temperature is Deprecated for this model."}},
+        )
+        async_create = AsyncMock(side_effect=[err, self._fake_response()])
+        fake_client = SimpleNamespace(messages=SimpleNamespace(create=async_create))
+        with patch(
+            "backend.util.llm.providers.anthropic.AsyncAnthropic",
+            return_value=fake_client,
+        ):
+            result = await call_provider(
+                provider="anthropic",
+                model="claude-sonnet-9-9",
+                api_key="sk-test",
+                messages=[_msg("user", "hi")],
+                max_tokens=10,
+                temperature=0.9,
+            )
+        assert isinstance(result, ProviderResponse)
+        assert async_create.await_count == 2
+        first, second = async_create.await_args_list
+        assert first.kwargs["temperature"] == 0.9
+        assert "temperature" not in second.kwargs
+
+    @pytest.mark.asyncio
     async def test_batch_omits_temperature_for_deprecating_model(self):
         """Batch errors come back hours later in the result rows — the
         param must never be submitted for known-rejecting models."""

--- a/autogpt_platform/backend/backend/util/llm/providers_test.py
+++ b/autogpt_platform/backend/backend/util/llm/providers_test.py
@@ -13,6 +13,7 @@ from contextlib import contextmanager
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import anthropic
 import pytest
 
 from backend.util.llm.providers import (
@@ -1887,3 +1888,120 @@ class TestCancelBatch:
                 provider="anthropic", provider_batch_id="b1", api_key="sk-test"
             )
         assert ok is False
+
+
+class TestAnthropicTemperatureDeprecation:
+    """Anthropic rejects ``temperature`` on its newest models with
+    '`temperature` is deprecated for this model.' (verified live:
+    claude-opus-4-7 and claude-opus-4-8 reject; sonnet-4-6 accepts).
+    The dream pass's recombine phase died on this nightly — the param
+    must be stripped for known-rejecting models, and the sync path
+    must self-heal for unknown future ones."""
+
+    def _fake_response(self):
+        return SimpleNamespace(
+            content=[SimpleNamespace(type="text", text="ok")],
+            usage=SimpleNamespace(input_tokens=1, output_tokens=1),
+            stop_reason="end_turn",
+        )
+
+    @pytest.mark.asyncio
+    async def test_sync_omits_temperature_for_deprecating_model(self):
+        async_create = AsyncMock(return_value=self._fake_response())
+        fake_client = SimpleNamespace(messages=SimpleNamespace(create=async_create))
+        with patch(
+            "backend.util.llm.providers.anthropic.AsyncAnthropic",
+            return_value=fake_client,
+        ):
+            await call_provider(
+                provider="anthropic",
+                model="claude-opus-4-7",
+                api_key="sk-test",
+                messages=[_msg("user", "hi")],
+                max_tokens=10,
+                temperature=0.9,
+            )
+        assert "temperature" not in async_create.call_args.kwargs
+
+    @pytest.mark.asyncio
+    async def test_sync_retries_without_temperature_on_deprecation_error(self):
+        """Self-healing for future models the deny-list doesn't know:
+        one retry without the param, same call otherwise."""
+        import httpx
+
+        err = anthropic.BadRequestError(
+            message="`temperature` is deprecated for this model.",
+            response=httpx.Response(
+                400, request=httpx.Request("POST", "https://api.anthropic.com")
+            ),
+            body={"error": {"message": "`temperature` is deprecated for this model."}},
+        )
+        async_create = AsyncMock(side_effect=[err, self._fake_response()])
+        fake_client = SimpleNamespace(messages=SimpleNamespace(create=async_create))
+        with patch(
+            "backend.util.llm.providers.anthropic.AsyncAnthropic",
+            return_value=fake_client,
+        ):
+            result = await call_provider(
+                provider="anthropic",
+                model="claude-sonnet-9-9",
+                api_key="sk-test",
+                messages=[_msg("user", "hi")],
+                max_tokens=10,
+                temperature=0.9,
+            )
+        assert isinstance(result, ProviderResponse)
+        assert async_create.await_count == 2
+        first, second = async_create.await_args_list
+        assert first.kwargs["temperature"] == 0.9
+        assert "temperature" not in second.kwargs
+
+    @pytest.mark.asyncio
+    async def test_batch_omits_temperature_for_deprecating_model(self):
+        """Batch errors come back hours later in the result rows — the
+        param must never be submitted for known-rejecting models."""
+        fake_batch = SimpleNamespace(id="msgbatch_x")
+        async_create = AsyncMock(return_value=fake_batch)
+        fake_client = SimpleNamespace(
+            messages=SimpleNamespace(batches=SimpleNamespace(create=async_create)),
+        )
+        with patch(
+            "backend.util.llm.providers.anthropic.AsyncAnthropic",
+            return_value=fake_client,
+        ):
+            await call_provider(
+                provider="anthropic",
+                model="claude-opus-4-7",
+                api_key="sk-ant-test",
+                messages=[_msg("user", "recombine this")],
+                max_tokens=100,
+                temperature=0.9,
+                execution_mode="batch",
+                custom_id="p1_recombine",
+            )
+        params = async_create.call_args.kwargs["requests"][0]["params"]
+        assert "temperature" not in params
+
+    @pytest.mark.asyncio
+    async def test_batch_keeps_temperature_for_supporting_model(self):
+        fake_batch = SimpleNamespace(id="msgbatch_y")
+        async_create = AsyncMock(return_value=fake_batch)
+        fake_client = SimpleNamespace(
+            messages=SimpleNamespace(batches=SimpleNamespace(create=async_create)),
+        )
+        with patch(
+            "backend.util.llm.providers.anthropic.AsyncAnthropic",
+            return_value=fake_client,
+        ):
+            await call_provider(
+                provider="anthropic",
+                model="claude-sonnet-4-6",
+                api_key="sk-ant-test",
+                messages=[_msg("user", "consolidate this")],
+                max_tokens=100,
+                temperature=0.2,
+                execution_mode="batch",
+                custom_id="p1_consolidate",
+            )
+        params = async_create.call_args.kwargs["requests"][0]["params"]
+        assert params["temperature"] == 0.2


### PR DESCRIPTION
## Why

Every dream pass dies at the recombine phase: Anthropic's newest models reject the `temperature` param outright (`temperature is deprecated for this model`). Verified live against the API: `claude-opus-4-7` and `claude-opus-4-8` reject it, `claude-sonnet-4-6` accepts it. Recombine runs on Opus → every pass errors before apply, on every transport that reaches the direct Anthropic API. Found by E2E-testing the combined dream fix PRs — this is the last blocker between the dream system and a completed end-to-end pass.

## What

- Known-rejecting model families are stripped of `temperature` at both Anthropic seams (sync `messages.create` and the batch request builder).
- The sync path retries once without the param when an unknown future model returns the exact deprecation error (self-healing; logs a warning telling us to extend the list).
- Batch submissions get no retry — their errors surface hours later in result rows, so the deny-list does the work there.

## How

TDD: four scenario tests written first and confirmed failing — sync strip, sync retry-on-unknown-model, batch strip, batch keeps-temperature-for-supporting-models. The phase temperature design (0.2/0.9/0.0) simply can't be honored on models that reject the param; prompt design carries the phase character there.

## Checklist

- [x] TDD; 64 passing in the providers suite
- [x] `poetry run format` clean
- [x] No out-of-scope changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Anthropic request shaping in the shared LLM helper; behavior change is omitting/retrying a rejected param, with tests locking sync and batch paths.
> 
> **Overview**
> Fixes dream-pass (and other) Anthropic calls that **400** when newer Opus models reject `temperature` (e.g. recombine at 0.9 on `claude-opus-4-7` / `4-8`).
> 
> In `providers.py`, adds a model-prefix deny list (`claude-opus-4-7`, `claude-opus-4-8`) and helpers so **`temperature` is omitted** for those families on both sync `messages.create` and batch request params. Sync calls **retry once** without `temperature` when Anthropic returns a temperature-deprecation `BadRequestError` (case-insensitive), with a warning to extend the list; batch has no retry path.
> 
> Adds `TestAnthropicTemperatureDeprecation` in `providers_test.py` covering sync omit, sync retry, batch omit, and batch still sending temperature for models like `claude-sonnet-4-6`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 068b2b79fbb8131a45f55a726bd5f1e28f8b56c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->