### PR TITLE
feat(backend/copilot-bot): outbound channel/thread delivery RPC

### DIFF
--- a/autogpt_platform/backend/backend/copilot/bot/adapters/base.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/base.py
@@ -44,6 +44,32 @@ class FileAttachment(BaseModel):
     content: bytes
 
 
+class ChannelInfo(BaseModel):
+    """A channel the bot can post to, scoped to a server it's connected to.
+
+    Returned by ``list_text_channels`` so the proactive-output path (and the
+    copilot tool above it) can resolve a human channel reference like
+    ``#announcements`` to a concrete ``id`` and present a picker.
+    """
+
+    id: str
+    name: str
+    server_id: str
+    server_name: Optional[str] = None
+
+
+class PostedRef(BaseModel):
+    """Pointer to something the bot just created on the platform.
+
+    ``url`` is a best-effort permalink (Discord ``jump_url``) so callers can
+    surface a clickable link in their confirmation; platforms without
+    permalinks leave it ``None``.
+    """
+
+    id: str
+    url: Optional[str] = None
+
+
 @dataclass
 class MessageContext:
     """Everything the core handler needs to know about an incoming message."""
@@ -177,5 +203,55 @@ class PlatformAdapter(ABC):
 
         Callers must ensure ``len(file.content) <= max_attachment_bytes`` —
         the handler enforces that upstream via the workspace fetch path.
+        """
+        ...
+
+    # -- Proactive output (backend → platform) ----------------------------
+    # These power scheduled / autopilot-initiated posts, where the bot speaks
+    # without a triggering user message. Authorization (which servers a user
+    # may post to) is enforced one layer up; adapters here only translate an
+    # already-authorized request into platform API calls.
+
+    @abstractmethod
+    async def list_text_channels(
+        self, server_ids: tuple[str, ...]
+    ) -> list[ChannelInfo]:
+        """List the text channels the bot can post to across ``server_ids``.
+
+        Only channels the bot can actually send in should be returned, so the
+        caller's picker never offers a channel the post would fail on.
+        """
+        ...
+
+    @abstractmethod
+    async def get_channel_server_id(self, channel_id: str) -> Optional[str]:
+        """Return the server (guild) ID a channel belongs to, or ``None``.
+
+        Used to authorize a post target given a raw channel ID without
+        enumerating every channel first.
+        """
+        ...
+
+    @abstractmethod
+    async def post_channel_message(
+        self, channel_id: str, text: str
+    ) -> Optional[PostedRef]:
+        """Post a standalone message to ``channel_id``.
+
+        Distinct from ``send_message`` (the streaming-reply path): this
+        returns a ``PostedRef`` so proactive callers can report what was
+        created. Returns ``None`` if the channel can't be posted to.
+        """
+        ...
+
+    @abstractmethod
+    async def create_channel_thread(
+        self, channel_id: str, name: str, text: str
+    ) -> Optional[PostedRef]:
+        """Create a standalone thread in ``channel_id`` and post ``text`` in it.
+
+        "Standalone" = not anchored to a pre-existing message (unlike
+        ``create_thread``). Returns the thread's ``PostedRef``, or ``None`` if
+        the platform/channel doesn't support it.
         """
         ...

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter.py
@@ -15,14 +15,17 @@ from discord import app_commands
 
 from backend.copilot.bot import threads
 from backend.copilot.bot.bot_backend import BotBackend
+from backend.copilot.bot.text import split_at_boundary
 
 from ..base import (
+    ChannelInfo,
     ChannelType,
     FileAttachment,
     MessageCallback,
     MessageContext,
     MessageHistoryEntry,
     PlatformAdapter,
+    PostedRef,
 )
 from . import commands, config, intro
 
@@ -199,6 +202,89 @@ class DiscordAdapter(PlatformAdapter):
         except discord.HTTPException:
             logger.exception("Failed to rename thread %s", thread_id)
             return False
+
+    # -- Proactive output --
+
+    async def list_text_channels(
+        self, server_ids: tuple[str, ...]
+    ) -> list[ChannelInfo]:
+        wanted = set(server_ids)
+        channels: list[ChannelInfo] = []
+        for guild in self._client.guilds:
+            if str(guild.id) not in wanted:
+                continue
+            me = guild.me
+            for channel in guild.text_channels:
+                # Only surface channels the bot can actually post in, so the
+                # picker upstream never offers a target that would 403 on send.
+                if me is not None and not channel.permissions_for(me).send_messages:
+                    continue
+                channels.append(
+                    ChannelInfo(
+                        id=str(channel.id),
+                        name=channel.name,
+                        server_id=str(guild.id),
+                        server_name=guild.name,
+                    )
+                )
+        return channels
+
+    async def get_channel_server_id(self, channel_id: str) -> Optional[str]:
+        channel = await self._resolve_channel(channel_id)
+        guild = getattr(channel, "guild", None)
+        return str(guild.id) if guild is not None else None
+
+    async def post_channel_message(
+        self, channel_id: str, text: str
+    ) -> Optional[PostedRef]:
+        channel = await self._resolve_channel(channel_id)
+        if channel is None or not isinstance(channel, discord.abc.Messageable):
+            logger.warning("Cannot post to non-messageable channel %s", channel_id)
+            return None
+        try:
+            first = await self._send_chunked(channel, text)
+        except discord.HTTPException:
+            logger.exception("Failed to post message to channel %s", channel_id)
+            return None
+        if first is None:
+            return None
+        return PostedRef(id=str(first.id), url=first.jump_url)
+
+    async def create_channel_thread(
+        self, channel_id: str, name: str, text: str
+    ) -> Optional[PostedRef]:
+        channel = await self._resolve_channel(channel_id)
+        if channel is None or not isinstance(channel, discord.TextChannel):
+            logger.warning("Cannot create thread in non-text channel %s", channel_id)
+            return None
+        try:
+            thread = await channel.create_thread(
+                name=name[:100],
+                type=discord.ChannelType.public_thread,
+            )
+            await self._send_chunked(thread, text)
+        except discord.HTTPException:
+            logger.exception("Failed to create thread in channel %s", channel_id)
+            return None
+        return PostedRef(id=str(thread.id), url=thread.jump_url)
+
+    async def _send_chunked(
+        self, channel: discord.abc.Messageable, text: str
+    ) -> Optional[discord.Message]:
+        """Send ``text`` to ``channel``, splitting at natural boundaries to stay
+        under Discord's per-message cap. Returns the first message sent (the one
+        callers permalink to), or ``None`` if there was nothing to send.
+        """
+        remaining = text.strip()
+        first: Optional[discord.Message] = None
+        while remaining:
+            chunk, remaining = split_at_boundary(remaining, config.CHUNK_FLUSH_AT)
+            if not chunk:
+                break
+            msg = await channel.send(chunk, tts=False)
+            if first is None:
+                first = msg
+        return first
 
     # -- Internal --
 

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter.py
@@ -268,10 +268,18 @@ class DiscordAdapter(PlatformAdapter):
                 name=name[:100],
                 type=discord.ChannelType.public_thread,
             )
-            await self._send_chunked(thread, text)
         except discord.HTTPException:
             logger.exception("Failed to create thread in channel %s", channel_id)
             return None
+        # The thread now exists on Discord. Surface its ref even if posting the
+        # body fails, so the caller reports partial success and doesn't retry
+        # into a duplicate thread.
+        try:
+            await self._send_chunked(thread, text)
+        except discord.HTTPException:
+            logger.exception(
+                "Thread %s created but posting its content failed", thread.id
+            )
         return PostedRef(id=str(thread.id), url=thread.jump_url)
 
     async def _send_chunked(
@@ -280,6 +288,10 @@ class DiscordAdapter(PlatformAdapter):
         """Send ``text`` to ``channel``, splitting at natural boundaries to stay
         under Discord's per-message cap. Returns the first message sent (the one
         callers permalink to), or ``None`` if there was nothing to send.
+
+        Raises only if the *first* chunk fails — once anything is delivered, a
+        later-chunk failure stops the send and keeps the partial result rather
+        than discarding what already posted (a retry would duplicate it).
         """
         remaining = text.strip()
         first: Optional[discord.Message] = None
@@ -287,7 +299,13 @@ class DiscordAdapter(PlatformAdapter):
             chunk, remaining = split_at_boundary(remaining, config.CHUNK_FLUSH_AT)
             if not chunk:
                 break
-            msg = await channel.send(chunk, tts=False)
+            try:
+                msg = await channel.send(chunk, tts=False)
+            except discord.HTTPException:
+                if first is None:
+                    raise
+                logger.exception("Dropping trailing chunk after partial send")
+                break
             if first is None:
                 first = msg
         return first

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter.py
@@ -217,6 +217,9 @@ class DiscordAdapter(PlatformAdapter):
             for channel in guild.text_channels:
                 # Only surface channels the bot can actually post in, so the
                 # picker upstream never offers a target that would 403 on send.
+                # If the bot member isn't cached (`me is None`) we can't check,
+                # so we surface the channel and let the eventual send fail
+                # loudly rather than hide everything.
                 if me is not None and not channel.permissions_for(me).send_messages:
                     continue
                 channels.append(
@@ -231,8 +234,11 @@ class DiscordAdapter(PlatformAdapter):
 
     async def get_channel_server_id(self, channel_id: str) -> Optional[str]:
         channel = await self._resolve_channel(channel_id)
-        guild = getattr(channel, "guild", None)
-        return str(guild.id) if guild is not None else None
+        # Guild channels and threads carry `.guild`; DM/group channels don't,
+        # so they resolve to None (never authorized for a server post).
+        if isinstance(channel, (discord.abc.GuildChannel, discord.Thread)):
+            return str(channel.guild.id)
+        return None
 
     async def post_channel_message(
         self, channel_id: str, text: str

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter_test.py
@@ -788,3 +788,122 @@ class TestLockedThread:
         await handlers["on_message"](msg)
 
         callback.assert_awaited_once()
+
+
+# ── Proactive output (backend → platform) ──────────────────────────────
+
+
+def _guild_channel(channel_id: int, name: str, can_send: bool) -> MagicMock:
+    channel = MagicMock(spec=discord.TextChannel)
+    channel.id = channel_id
+    channel.name = name
+    perms = MagicMock()
+    perms.send_messages = can_send
+    channel.permissions_for = MagicMock(return_value=perms)
+    return channel
+
+
+def _guild_with_channels(
+    guild_id: int, name: str, channels: list[MagicMock]
+) -> MagicMock:
+    guild = MagicMock()
+    guild.id = guild_id
+    guild.name = name
+    guild.me = MagicMock()
+    guild.text_channels = channels
+    return guild
+
+
+class TestProactiveOutput:
+    @pytest.mark.asyncio
+    async def test_list_text_channels_filters_servers_and_permissions(self):
+        adapter, client = _bare_adapter()
+        g1 = _guild_with_channels(
+            111,
+            "Guild One",
+            [
+                _guild_channel(10, "general", True),
+                _guild_channel(11, "locked", False),
+            ],
+        )
+        g2 = _guild_with_channels(222, "Guild Two", [_guild_channel(20, "other", True)])
+        client.guilds = [g1, g2]
+
+        result = await adapter.list_text_channels(("111",))
+
+        assert [(c.id, c.name, c.server_id) for c in result] == [
+            ("10", "general", "111")
+        ]
+
+    @pytest.mark.asyncio
+    async def test_get_channel_server_id_returns_guild(self):
+        adapter, client = _bare_adapter()
+        channel = MagicMock(spec=discord.TextChannel)
+        channel.guild = MagicMock(id=111)
+        client.get_channel.return_value = channel
+
+        assert await adapter.get_channel_server_id("10") == "111"
+
+    @pytest.mark.asyncio
+    async def test_get_channel_server_id_none_when_missing(self):
+        adapter, client = _bare_adapter()
+        client.get_channel.return_value = None
+        client.fetch_channel = AsyncMock(
+            side_effect=discord.NotFound(MagicMock(status=404), "gone")
+        )
+        assert await adapter.get_channel_server_id("10") is None
+
+    @pytest.mark.asyncio
+    async def test_post_channel_message_returns_ref_with_url(self):
+        adapter, client = _bare_adapter()
+        channel = MagicMock(spec=discord.TextChannel)
+        sent = MagicMock(id=999, jump_url="https://discord.com/channels/1/2/999")
+        channel.send = AsyncMock(return_value=sent)
+        client.get_channel.return_value = channel
+
+        ref = await adapter.post_channel_message("10", "hello")
+
+        assert ref is not None
+        assert ref.id == "999"
+        assert ref.url == "https://discord.com/channels/1/2/999"
+
+    @pytest.mark.asyncio
+    async def test_create_channel_thread_creates_and_posts(self):
+        adapter, client = _bare_adapter()
+        channel = MagicMock(spec=discord.TextChannel)
+        thread = MagicMock(spec=discord.Thread)
+        thread.id = 555
+        thread.jump_url = "https://discord.com/channels/1/555"
+        thread.send = AsyncMock()
+        channel.create_thread = AsyncMock(return_value=thread)
+        client.get_channel.return_value = channel
+
+        ref = await adapter.create_channel_thread("10", "Monday update", "body")
+
+        assert ref is not None
+        assert ref.id == "555"
+        channel.create_thread.assert_awaited_once()
+        thread.send.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_create_channel_thread_rejects_non_text_channel(self):
+        adapter, client = _bare_adapter()
+        client.get_channel.return_value = MagicMock(spec=discord.Thread)
+
+        assert await adapter.create_channel_thread("10", "x", "body") is None
+
+    @pytest.mark.asyncio
+    async def test_send_chunked_splits_long_text(self):
+        adapter, client = _bare_adapter()
+        channel = MagicMock(spec=discord.TextChannel)
+        channel.send = AsyncMock(
+            side_effect=lambda *a, **k: MagicMock(id=1, jump_url="u")
+        )
+        client.get_channel.return_value = channel
+
+        long_text = ("word " * 1000).strip()
+        ref = await adapter.post_channel_message("10", long_text)
+
+        assert ref is not None
+        # 5000 chars at ~1900/chunk → more than one send.
+        assert channel.send.await_count >= 2

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter_test.py
@@ -924,6 +924,9 @@ class TestProactiveOutput:
 
         assert ref is not None
         assert ref.id == "111"
+        # Prove the later (failing) chunk was actually reached, so chunk-sizing
+        # changes can't quietly turn this into a single-send happy path.
+        assert channel.send.await_count >= 2
 
     @pytest.mark.asyncio
     async def test_post_message_returns_none_when_first_chunk_fails(self):

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter_test.py
@@ -907,3 +907,51 @@ class TestProactiveOutput:
         assert ref is not None
         # 5000 chars at ~1900/chunk → more than one send.
         assert channel.send.await_count >= 2
+
+    @pytest.mark.asyncio
+    async def test_post_message_keeps_first_chunk_on_later_failure(self):
+        # First chunk posts, a later chunk 500s: the already-posted message is
+        # surfaced (partial success) rather than discarded into a retry-duplicate.
+        adapter, client = _bare_adapter()
+        channel = MagicMock(spec=discord.TextChannel)
+        first = MagicMock(id=111, jump_url="u1")
+        channel.send = AsyncMock(
+            side_effect=[first, discord.HTTPException(MagicMock(status=500), "boom")]
+        )
+        client.get_channel.return_value = channel
+
+        ref = await adapter.post_channel_message("10", ("word " * 1000).strip())
+
+        assert ref is not None
+        assert ref.id == "111"
+
+    @pytest.mark.asyncio
+    async def test_post_message_returns_none_when_first_chunk_fails(self):
+        adapter, client = _bare_adapter()
+        channel = MagicMock(spec=discord.TextChannel)
+        channel.send = AsyncMock(
+            side_effect=discord.HTTPException(MagicMock(status=500), "boom")
+        )
+        client.get_channel.return_value = channel
+
+        assert await adapter.post_channel_message("10", "hi") is None
+
+    @pytest.mark.asyncio
+    async def test_create_thread_returns_ref_when_content_post_fails(self):
+        # Thread created but posting body fails → still return the thread ref so
+        # the caller doesn't retry and spawn a duplicate thread.
+        adapter, client = _bare_adapter()
+        channel = MagicMock(spec=discord.TextChannel)
+        thread = MagicMock(spec=discord.Thread)
+        thread.id = 777
+        thread.jump_url = "https://discord.com/t/777"
+        thread.send = AsyncMock(
+            side_effect=discord.HTTPException(MagicMock(status=500), "boom")
+        )
+        channel.create_thread = AsyncMock(return_value=thread)
+        client.get_channel.return_value = channel
+
+        ref = await adapter.create_channel_thread("10", "Monday", "body")
+
+        assert ref is not None
+        assert ref.id == "777"

--- a/autogpt_platform/backend/backend/copilot/bot/app.py
+++ b/autogpt_platform/backend/backend/copilot/bot/app.py
@@ -17,11 +17,13 @@ from backend.util.service import (
 )
 from backend.util.settings import Settings
 
-from .adapters.base import PlatformAdapter
+from . import outbound
+from .adapters.base import ChannelInfo, PlatformAdapter
 from .adapters.discord import config as discord_config
 from .adapters.discord.adapter import DiscordAdapter
 from .bot_backend import BotBackend
 from .handler import MessageHandler
+from .outbound import DeliveryResult
 
 logger = logging.getLogger(__name__)
 
@@ -40,6 +42,12 @@ class CoPilotChatBridge(AppService):
         # for any reason. Consumed by `health_check` so orchestrators can
         # restart the pod when the bridge is dead-but-listening.
         self._adapters_healthy = False
+        # Populated by `_run_adapters` so the outbound RPC handlers can reach
+        # the live adapter (and its gateway connection) by platform name. The
+        # RPC handlers run on the same shared event loop as the adapters, so
+        # they can await adapter methods directly.
+        self._api: BotBackend | None = None
+        self._adapters_by_platform: dict[str, PlatformAdapter] = {}
 
     @classmethod
     def get_port(cls) -> int:
@@ -54,7 +62,9 @@ class CoPilotChatBridge(AppService):
 
     async def _run_adapters(self) -> None:
         api = BotBackend()
+        self._api = api
         adapters = _build_adapters(api)
+        self._adapters_by_platform = {a.platform_name: a for a in adapters}
 
         if not adapters:
             logger.info(
@@ -99,36 +109,66 @@ class CoPilotChatBridge(AppService):
             raise UnhealthyServiceError("CoPilotChatBridge adapter task is not running")
         return await super().health_check()
 
+    def _require(self, platform: Platform) -> tuple[PlatformAdapter, BotBackend]:
+        """Resolve the live adapter + backend for ``platform`` or raise.
+
+        Raises ``UnhealthyServiceError`` (a transient-shaped error) when the
+        bridge hasn't finished starting or the platform's adapter isn't
+        configured, so a retrying caller backs off instead of treating it as
+        a permanent failure.
+        """
+        adapter = self._adapters_by_platform.get(platform.value.lower())
+        if adapter is None or self._api is None:
+            raise UnhealthyServiceError(
+                f"No running adapter for platform {platform.value}"
+            )
+        return adapter, self._api
+
+    @expose
+    async def list_channels(
+        self,
+        platform: Platform,
+        user_id: str,
+    ) -> list[ChannelInfo]:
+        """List channels ``user_id`` may post to via the bot on ``platform``.
+
+        Backs channel-name resolution and the picker in the copilot tool.
+        """
+        adapter, api = self._require(platform)
+        return await outbound.list_channels(adapter, api, platform.value, user_id)
+
     @expose
     async def send_message_to_channel(
         self,
         platform: Platform,
-        channel_id: str,
+        user_id: str,
+        channel: str,
         content: str,
-    ) -> bool:
-        """Deliver a message to a channel on the given platform.
+    ) -> DeliveryResult:
+        """Post ``content`` to ``channel`` (name or ID) as a standalone message.
 
-        Stub — scaffolding for the inbound-RPC pattern (backend → chat
-        platform). Not yet wired to a concrete adapter. Callers must not use
-        ``request_retry=True`` on the client until this is implemented, since
-        ``ValueError`` crosses the RPC boundary as a client-side 4xx-ish error
-        rather than a transient 5xx.
+        ``user_id`` is the AutoGPT user the post acts on behalf of; delivery
+        is authorized against the servers that user has linked.
         """
-        raise ValueError(f"send_message_to_channel not yet wired for {platform.value}")
+        adapter, api = self._require(platform)
+        return await outbound.deliver_message(
+            adapter, api, platform.value, user_id, channel, content
+        )
 
     @expose
-    async def send_dm(
+    async def create_thread_in_channel(
         self,
         platform: Platform,
-        platform_user_id: str,
+        user_id: str,
+        channel: str,
+        thread_name: str,
         content: str,
-    ) -> bool:
-        """Deliver a DM to a user on the given platform.
-
-        Stub — scaffolding for the inbound-RPC pattern. See
-        :meth:`send_message_to_channel` for the retry caveat.
-        """
-        raise ValueError(f"send_dm not yet wired for {platform.value}")
+    ) -> DeliveryResult:
+        """Create a standalone thread in ``channel`` and post ``content`` in it."""
+        adapter, api = self._require(platform)
+        return await outbound.create_thread(
+            adapter, api, platform.value, user_id, channel, thread_name, content
+        )
 
 
 class CoPilotChatBridgeClient(AppServiceClient):
@@ -136,10 +176,13 @@ class CoPilotChatBridgeClient(AppServiceClient):
     def get_service_type(cls):
         return CoPilotChatBridge
 
+    list_channels = endpoint_to_async(CoPilotChatBridge.list_channels)
     send_message_to_channel = endpoint_to_async(
         CoPilotChatBridge.send_message_to_channel
     )
-    send_dm = endpoint_to_async(CoPilotChatBridge.send_dm)
+    create_thread_in_channel = endpoint_to_async(
+        CoPilotChatBridge.create_thread_in_channel
+    )
 
 
 def _build_adapters(api: BotBackend) -> list[PlatformAdapter]:

--- a/autogpt_platform/backend/backend/copilot/bot/app.py
+++ b/autogpt_platform/backend/backend/copilot/bot/app.py
@@ -98,6 +98,11 @@ class CoPilotChatBridge(AppService):
         cheerfully reporting OK on a dead bridge.
         """
         self._adapters_healthy = False
+        # Drop the adapter/api handles so outbound RPCs raise UnhealthyService
+        # instead of dispatching into an adapter whose gateway connection has
+        # already torn down.
+        self._adapters_by_platform = {}
+        self._api = None
         exc = future.exception()
         if exc is not None:
             logger.error("CoPilotChatBridge adapters crashed: %r", exc, exc_info=exc)
@@ -117,6 +122,8 @@ class CoPilotChatBridge(AppService):
         configured, so a retrying caller backs off instead of treating it as
         a permanent failure.
         """
+        if not self._adapters_healthy:
+            raise UnhealthyServiceError("CoPilotChatBridge adapter task is not running")
         adapter = self._adapters_by_platform.get(platform.value.lower())
         if adapter is None or self._api is None:
             raise UnhealthyServiceError(

--- a/autogpt_platform/backend/backend/copilot/bot/app_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/app_test.py
@@ -21,6 +21,7 @@ def _bridge(*, with_adapter: bool = True) -> tuple[CoPilotChatBridge, MagicMock]
     bridge = CoPilotChatBridge.__new__(CoPilotChatBridge)
     adapter = MagicMock()
     adapter.platform_name = "discord"
+    bridge._adapters_healthy = True
     bridge._api = MagicMock()
     bridge._adapters_by_platform = {"discord": adapter} if with_adapter else {}
     return bridge, adapter
@@ -29,6 +30,14 @@ def _bridge(*, with_adapter: bool = True) -> tuple[CoPilotChatBridge, MagicMock]
 @pytest.mark.asyncio
 async def test_require_raises_when_adapter_missing():
     bridge, _ = _bridge(with_adapter=False)
+    with pytest.raises(UnhealthyServiceError):
+        bridge._require(Platform.DISCORD)
+
+
+@pytest.mark.asyncio
+async def test_require_raises_when_unhealthy():
+    bridge, _ = _bridge()
+    bridge._adapters_healthy = False
     with pytest.raises(UnhealthyServiceError):
         bridge._require(Platform.DISCORD)
 

--- a/autogpt_platform/backend/backend/copilot/bot/app_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/app_test.py
@@ -1,0 +1,84 @@
+"""Tests for CoPilotChatBridge's outbound RPC dispatch.
+
+Covers the seam that maps a ``Platform`` enum to the live adapter and routes
+into ``outbound`` — including the casing round-trip (``platform.value`` vs
+``platform_name``) and the no-adapter guard.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from backend.platform_linking.models import Platform
+from backend.util.service import UnhealthyServiceError
+
+from .app import CoPilotChatBridge
+from .outbound import DeliveryResult
+
+
+def _bridge(*, with_adapter: bool = True) -> tuple[CoPilotChatBridge, MagicMock]:
+    """Build a bridge without AppService.__init__, with a stubbed adapter+api."""
+    bridge = CoPilotChatBridge.__new__(CoPilotChatBridge)
+    adapter = MagicMock()
+    adapter.platform_name = "discord"
+    bridge._api = MagicMock()
+    bridge._adapters_by_platform = {"discord": adapter} if with_adapter else {}
+    return bridge, adapter
+
+
+@pytest.mark.asyncio
+async def test_require_raises_when_adapter_missing():
+    bridge, _ = _bridge(with_adapter=False)
+    with pytest.raises(UnhealthyServiceError):
+        bridge._require(Platform.DISCORD)
+
+
+@pytest.mark.asyncio
+async def test_send_message_to_channel_routes_platform_value():
+    bridge, _ = _bridge()
+    expected = DeliveryResult(ok=True, kind="message", channel_id="42", ref_id="1")
+    with patch(
+        "backend.copilot.bot.app.outbound.deliver_message",
+        new=AsyncMock(return_value=expected),
+    ) as deliver:
+        result = await bridge.send_message_to_channel(
+            platform=Platform.DISCORD, user_id="u1", channel="#x", content="hi"
+        )
+    assert result is expected
+    # platform passed through as the string value the lower layers expect.
+    call = deliver.await_args
+    assert call is not None
+    _, _, platform_value, user_id, channel, content = call.args
+    assert platform_value == "DISCORD"
+    assert (user_id, channel, content) == ("u1", "#x", "hi")
+
+
+@pytest.mark.asyncio
+async def test_create_thread_in_channel_routes_to_outbound():
+    bridge, _ = _bridge()
+    expected = DeliveryResult(ok=True, kind="thread", channel_id="42", ref_id="t1")
+    with patch(
+        "backend.copilot.bot.app.outbound.create_thread",
+        new=AsyncMock(return_value=expected),
+    ) as create:
+        result = await bridge.create_thread_in_channel(
+            platform=Platform.DISCORD,
+            user_id="u1",
+            channel="#x",
+            thread_name="Monday",
+            content="body",
+        )
+    assert result is expected
+    create.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_list_channels_routes_to_outbound():
+    bridge, _ = _bridge()
+    with patch(
+        "backend.copilot.bot.app.outbound.list_channels",
+        new=AsyncMock(return_value=[]),
+    ) as lister:
+        result = await bridge.list_channels(platform=Platform.DISCORD, user_id="u1")
+    assert result == []
+    lister.assert_awaited_once()

--- a/autogpt_platform/backend/backend/copilot/bot/bot_backend.py
+++ b/autogpt_platform/backend/backend/copilot/bot/bot_backend.py
@@ -220,11 +220,10 @@ class BotBackend:
         Backs the proactive-output authorization check: a scheduled/autopilot
         post is only allowed into a channel whose server appears in this list.
         """
-        plat = Platform(platform.upper())
-        links = await self._client.list_server_links(user_id=user_id)
-        return [
-            link.platform_server_id for link in links if link.platform == plat.value
-        ]
+        return await self._client.list_user_server_ids(
+            platform=Platform(platform.upper()),
+            user_id=user_id,
+        )
 
     async def refresh_server_name(
         self, platform: str, platform_server_id: str, server_name: str

--- a/autogpt_platform/backend/backend/copilot/bot/bot_backend.py
+++ b/autogpt_platform/backend/backend/copilot/bot/bot_backend.py
@@ -214,6 +214,18 @@ class BotBackend:
         )
         return ResolveResult(linked=resp.linked)
 
+    async def list_linked_server_ids(self, platform: str, user_id: str) -> list[str]:
+        """Return the platform server (guild) IDs ``user_id`` has linked.
+
+        Backs the proactive-output authorization check: a scheduled/autopilot
+        post is only allowed into a channel whose server appears in this list.
+        """
+        plat = Platform(platform.upper())
+        links = await self._client.list_server_links(user_id=user_id)
+        return [
+            link.platform_server_id for link in links if link.platform == plat.value
+        ]
+
     async def refresh_server_name(
         self, platform: str, platform_server_id: str, server_name: str
     ) -> None:

--- a/autogpt_platform/backend/backend/copilot/bot/bot_backend_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/bot_backend_test.py
@@ -58,21 +58,17 @@ class TestResolve:
 
 class TestListLinkedServerIds:
     @pytest.mark.asyncio
-    async def test_returns_ids_for_matching_platform_only(self, api: BotBackend):
-        api._client.list_server_links = AsyncMock(
-            return_value=[
-                MagicMock(platform="DISCORD", platform_server_id="g1"),
-                MagicMock(platform="SLACK", platform_server_id="t1"),
-                MagicMock(platform="DISCORD", platform_server_id="g2"),
-            ]
-        )
+    async def test_forwards_uppercased_platform_and_returns_ids(self, api: BotBackend):
+        api._client.list_user_server_ids = AsyncMock(return_value=["g1", "g2"])
         result = await api.list_linked_server_ids("discord", "user-1")
         assert result == ["g1", "g2"]
-        api._client.list_server_links.assert_awaited_once_with(user_id="user-1")
+        api._client.list_user_server_ids.assert_awaited_once_with(
+            platform=Platform.DISCORD, user_id="user-1"
+        )
 
     @pytest.mark.asyncio
     async def test_empty_when_no_links(self, api: BotBackend):
-        api._client.list_server_links = AsyncMock(return_value=[])
+        api._client.list_user_server_ids = AsyncMock(return_value=[])
         assert await api.list_linked_server_ids("discord", "user-1") == []
 
 

--- a/autogpt_platform/backend/backend/copilot/bot/bot_backend_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/bot_backend_test.py
@@ -56,6 +56,26 @@ class TestResolve:
         assert result.linked is False
 
 
+class TestListLinkedServerIds:
+    @pytest.mark.asyncio
+    async def test_returns_ids_for_matching_platform_only(self, api: BotBackend):
+        api._client.list_server_links = AsyncMock(
+            return_value=[
+                MagicMock(platform="DISCORD", platform_server_id="g1"),
+                MagicMock(platform="SLACK", platform_server_id="t1"),
+                MagicMock(platform="DISCORD", platform_server_id="g2"),
+            ]
+        )
+        result = await api.list_linked_server_ids("discord", "user-1")
+        assert result == ["g1", "g2"]
+        api._client.list_server_links.assert_awaited_once_with(user_id="user-1")
+
+    @pytest.mark.asyncio
+    async def test_empty_when_no_links(self, api: BotBackend):
+        api._client.list_server_links = AsyncMock(return_value=[])
+        assert await api.list_linked_server_ids("discord", "user-1") == []
+
+
 class TestRefreshServerName:
     @pytest.mark.asyncio
     async def test_forwards_uppercased_platform(self, api: BotBackend):

--- a/autogpt_platform/backend/backend/copilot/bot/outbound.py
+++ b/autogpt_platform/backend/backend/copilot/bot/outbound.py
@@ -57,7 +57,15 @@ async def list_channels(
     server_ids = tuple(await api.list_linked_server_ids(platform, user_id))
     if not server_ids:
         return []
-    return await adapter.list_text_channels(server_ids)
+    # Re-filter the adapter's output against the linked-server allowlist so the
+    # picker can never surface a channel from an unlinked server, even if an
+    # adapter over-returns. Mirrors the same guard in `_resolve_target`.
+    allowed = set(server_ids)
+    return [
+        channel
+        for channel in await adapter.list_text_channels(server_ids)
+        if channel.server_id in allowed
+    ]
 
 
 async def deliver_message(

--- a/autogpt_platform/backend/backend/copilot/bot/outbound.py
+++ b/autogpt_platform/backend/backend/copilot/bot/outbound.py
@@ -1,0 +1,146 @@
+"""Proactive (backend → platform) message delivery.
+
+Turns an *already-authenticated* "post this to a channel" request into
+adapter calls. Two concerns live here, both platform-agnostic:
+
+- **Authorization** — a user may only post into channels that belong to a
+  server they've linked (``BotBackend.list_linked_server_ids``). Channel
+  resolution is funneled through that allowlist so an unauthorized target can
+  never be reached, whether referenced by ID or by name.
+- **Resolution** — a human channel reference (``#announcements``, a bare
+  name, or a raw snowflake ID) is mapped to a concrete channel ID.
+
+The adapter owns everything platform-specific (enumerating channels, sending,
+thread creation); this module never imports ``discord``.
+"""
+
+import logging
+import re
+from typing import Literal, Optional
+
+from pydantic import BaseModel
+
+from backend.copilot.bot.adapters.base import ChannelInfo, PlatformAdapter
+from backend.copilot.bot.bot_backend import BotBackend
+
+logger = logging.getLogger(__name__)
+
+# Discord snowflakes are 17-19 digits today; allow a little slack so the ID
+# path stays robust as the epoch advances rather than silently treating a
+# valid ID as a channel name.
+_SNOWFLAKE = re.compile(r"^\d{15,21}$")
+
+
+class DeliveryResult(BaseModel):
+    """Outcome of a proactive post, shaped for a tool/LLM to relay.
+
+    ``error`` is a stable machine code (e.g. ``not_authorized``) so the
+    caller can phrase its own user-facing message; ``ok`` is the only field
+    callers must branch on.
+    """
+
+    ok: bool
+    kind: Literal["message", "thread"]
+    channel_id: Optional[str] = None
+    ref_id: Optional[str] = None
+    url: Optional[str] = None
+    error: Optional[str] = None
+
+
+async def list_channels(
+    adapter: PlatformAdapter,
+    api: BotBackend,
+    platform: str,
+    user_id: str,
+) -> list[ChannelInfo]:
+    """List channels ``user_id`` may post to via the bot on ``platform``."""
+    server_ids = tuple(await api.list_linked_server_ids(platform, user_id))
+    if not server_ids:
+        return []
+    return await adapter.list_text_channels(server_ids)
+
+
+async def deliver_message(
+    adapter: PlatformAdapter,
+    api: BotBackend,
+    platform: str,
+    user_id: str,
+    channel: str,
+    content: str,
+) -> DeliveryResult:
+    """Post ``content`` to ``channel`` (name or ID) as a standalone message."""
+    channel_id, error = await _resolve_target(adapter, api, platform, user_id, channel)
+    if channel_id is None:
+        return DeliveryResult(ok=False, kind="message", error=error)
+    ref = await adapter.post_channel_message(channel_id, content)
+    if ref is None:
+        return DeliveryResult(
+            ok=False, kind="message", channel_id=channel_id, error="send_failed"
+        )
+    return DeliveryResult(
+        ok=True, kind="message", channel_id=channel_id, ref_id=ref.id, url=ref.url
+    )
+
+
+async def create_thread(
+    adapter: PlatformAdapter,
+    api: BotBackend,
+    platform: str,
+    user_id: str,
+    channel: str,
+    thread_name: str,
+    content: str,
+) -> DeliveryResult:
+    """Create a standalone thread in ``channel`` and post ``content`` in it."""
+    channel_id, error = await _resolve_target(adapter, api, platform, user_id, channel)
+    if channel_id is None:
+        return DeliveryResult(ok=False, kind="thread", error=error)
+    ref = await adapter.create_channel_thread(channel_id, thread_name, content)
+    if ref is None:
+        return DeliveryResult(
+            ok=False, kind="thread", channel_id=channel_id, error="thread_failed"
+        )
+    return DeliveryResult(
+        ok=True, kind="thread", channel_id=channel_id, ref_id=ref.id, url=ref.url
+    )
+
+
+async def _resolve_target(
+    adapter: PlatformAdapter,
+    api: BotBackend,
+    platform: str,
+    user_id: str,
+    channel: str,
+) -> tuple[Optional[str], Optional[str]]:
+    """Resolve a channel reference to an authorized channel ID.
+
+    Returns ``(channel_id, None)`` on success or ``(None, error_code)``. Both
+    the ID path and the name path are constrained to the user's linked
+    servers, so resolution and authorization are the same step.
+    """
+    server_ids = tuple(await api.list_linked_server_ids(platform, user_id))
+    if not server_ids:
+        return None, "no_linked_servers"
+
+    ref = channel.strip().lstrip("#").strip()
+    if not ref:
+        return None, "channel_not_found"
+
+    if _SNOWFLAKE.match(ref):
+        guild_id = await adapter.get_channel_server_id(ref)
+        if guild_id is None:
+            return None, "channel_not_found"
+        if guild_id not in server_ids:
+            return None, "not_authorized"
+        return ref, None
+
+    matches = [
+        c
+        for c in await adapter.list_text_channels(server_ids)
+        if c.name.lower() == ref.lower()
+    ]
+    if not matches:
+        return None, "channel_not_found"
+    if len(matches) > 1:
+        return None, "ambiguous_channel"
+    return matches[0].id, None

--- a/autogpt_platform/backend/backend/copilot/bot/outbound.py
+++ b/autogpt_platform/backend/backend/copilot/bot/outbound.py
@@ -77,6 +77,8 @@ async def deliver_message(
     content: str,
 ) -> DeliveryResult:
     """Post ``content`` to ``channel`` (name or ID) as a standalone message."""
+    if not content or not content.strip():
+        return DeliveryResult(ok=False, kind="message", error="empty_content")
     channel_id, error = await _resolve_target(adapter, api, platform, user_id, channel)
     if channel_id is None:
         return DeliveryResult(ok=False, kind="message", error=error)
@@ -100,6 +102,8 @@ async def create_thread(
     content: str,
 ) -> DeliveryResult:
     """Create a standalone thread in ``channel`` and post ``content`` in it."""
+    if not content or not content.strip():
+        return DeliveryResult(ok=False, kind="thread", error="empty_content")
     channel_id, error = await _resolve_target(adapter, api, platform, user_id, channel)
     if channel_id is None:
         return DeliveryResult(ok=False, kind="thread", error=error)

--- a/autogpt_platform/backend/backend/copilot/bot/outbound.py
+++ b/autogpt_platform/backend/backend/copilot/bot/outbound.py
@@ -134,10 +134,13 @@ async def _resolve_target(
             return None, "not_authorized"
         return ref, None
 
+    # `c.server_id in server_ids` is redundant with passing `server_ids` to
+    # the adapter, but re-asserting it here keeps authorization correct even
+    # if an adapter ever returns channels outside the requested servers.
     matches = [
         c
         for c in await adapter.list_text_channels(server_ids)
-        if c.name.lower() == ref.lower()
+        if c.name.lower() == ref.lower() and c.server_id in server_ids
     ]
     if not matches:
         return None, "channel_not_found"

--- a/autogpt_platform/backend/backend/copilot/bot/outbound_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/outbound_test.py
@@ -1,0 +1,165 @@
+"""Tests for proactive-output authorization + channel resolution."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from backend.copilot.bot import outbound
+from backend.copilot.bot.adapters.base import ChannelInfo, PostedRef
+
+
+def _api(server_ids: list[str]) -> AsyncMock:
+    api = AsyncMock()
+    api.list_linked_server_ids.return_value = server_ids
+    return api
+
+
+def _adapter(
+    *,
+    channels: list[ChannelInfo] | None = None,
+    channel_server: str | None = None,
+    posted: PostedRef | None = None,
+    thread: PostedRef | None = None,
+) -> AsyncMock:
+    adapter = AsyncMock()
+    adapter.list_text_channels.return_value = channels or []
+    adapter.get_channel_server_id.return_value = channel_server
+    adapter.post_channel_message.return_value = posted
+    adapter.create_channel_thread.return_value = thread
+    return adapter
+
+
+@pytest.mark.asyncio
+async def test_deliver_message_resolves_name_and_posts():
+    adapter = _adapter(
+        channels=[ChannelInfo(id="42", name="announcements", server_id="g1")],
+        posted=PostedRef(id="100", url="https://discord.com/x"),
+    )
+    result = await outbound.deliver_message(
+        adapter, _api(["g1"]), "discord", "user-1", "#announcements", "hi"
+    )
+    assert result.ok is True
+    assert result.kind == "message"
+    assert result.channel_id == "42"
+    assert result.ref_id == "100"
+    assert result.url == "https://discord.com/x"
+    adapter.post_channel_message.assert_awaited_once_with("42", "hi")
+
+
+@pytest.mark.asyncio
+async def test_deliver_message_by_authorized_id():
+    adapter = _adapter(channel_server="g1", posted=PostedRef(id="100"))
+    result = await outbound.deliver_message(
+        adapter, _api(["g1", "g2"]), "discord", "user-1", "999888777666555444", "hi"
+    )
+    assert result.ok is True
+    assert result.channel_id == "999888777666555444"
+    # ID path must not enumerate channels.
+    adapter.list_text_channels.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_deliver_message_id_in_unlinked_server_is_rejected():
+    adapter = _adapter(channel_server="other-guild", posted=PostedRef(id="100"))
+    result = await outbound.deliver_message(
+        adapter, _api(["g1"]), "discord", "user-1", "999888777666555444", "hi"
+    )
+    assert result.ok is False
+    assert result.error == "not_authorized"
+    adapter.post_channel_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_deliver_message_unknown_id_is_not_found():
+    adapter = _adapter(channel_server=None)
+    result = await outbound.deliver_message(
+        adapter, _api(["g1"]), "discord", "user-1", "999888777666555444", "hi"
+    )
+    assert result.ok is False
+    assert result.error == "channel_not_found"
+
+
+@pytest.mark.asyncio
+async def test_deliver_message_name_not_found():
+    adapter = _adapter(channels=[ChannelInfo(id="42", name="general", server_id="g1")])
+    result = await outbound.deliver_message(
+        adapter, _api(["g1"]), "discord", "user-1", "#announcements", "hi"
+    )
+    assert result.ok is False
+    assert result.error == "channel_not_found"
+
+
+@pytest.mark.asyncio
+async def test_deliver_message_ambiguous_name():
+    adapter = _adapter(
+        channels=[
+            ChannelInfo(id="42", name="general", server_id="g1"),
+            ChannelInfo(id="43", name="general", server_id="g2"),
+        ]
+    )
+    result = await outbound.deliver_message(
+        adapter, _api(["g1", "g2"]), "discord", "user-1", "general", "hi"
+    )
+    assert result.ok is False
+    assert result.error == "ambiguous_channel"
+
+
+@pytest.mark.asyncio
+async def test_no_linked_servers_short_circuits():
+    adapter = _adapter()
+    result = await outbound.deliver_message(
+        adapter, _api([]), "discord", "user-1", "#announcements", "hi"
+    )
+    assert result.ok is False
+    assert result.error == "no_linked_servers"
+    adapter.list_text_channels.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_deliver_message_send_failure():
+    adapter = _adapter(
+        channels=[ChannelInfo(id="42", name="announcements", server_id="g1")],
+        posted=None,
+    )
+    result = await outbound.deliver_message(
+        adapter, _api(["g1"]), "discord", "user-1", "#announcements", "hi"
+    )
+    assert result.ok is False
+    assert result.error == "send_failed"
+    assert result.channel_id == "42"
+
+
+@pytest.mark.asyncio
+async def test_create_thread_happy_path():
+    adapter = _adapter(
+        channels=[ChannelInfo(id="42", name="announcements", server_id="g1")],
+        thread=PostedRef(id="t1", url="https://discord.com/t"),
+    )
+    result = await outbound.create_thread(
+        adapter, _api(["g1"]), "discord", "user-1", "#announcements", "Monday", "body"
+    )
+    assert result.ok is True
+    assert result.kind == "thread"
+    assert result.ref_id == "t1"
+    adapter.create_channel_thread.assert_awaited_once_with("42", "Monday", "body")
+
+
+@pytest.mark.asyncio
+async def test_create_thread_failure():
+    adapter = _adapter(
+        channels=[ChannelInfo(id="42", name="announcements", server_id="g1")],
+        thread=None,
+    )
+    result = await outbound.create_thread(
+        adapter, _api(["g1"]), "discord", "user-1", "#announcements", "Monday", "body"
+    )
+    assert result.ok is False
+    assert result.error == "thread_failed"
+
+
+@pytest.mark.asyncio
+async def test_list_channels_empty_without_links():
+    adapter = _adapter(channels=[ChannelInfo(id="42", name="x", server_id="g1")])
+    result = await outbound.list_channels(adapter, _api([]), "discord", "user-1")
+    assert result == []
+    adapter.list_text_channels.assert_not_awaited()

--- a/autogpt_platform/backend/backend/copilot/bot/outbound_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/outbound_test.py
@@ -130,6 +130,30 @@ async def test_deliver_message_send_failure():
 
 
 @pytest.mark.asyncio
+async def test_deliver_message_empty_content_is_distinct_error():
+    adapter = _adapter()
+    result = await outbound.deliver_message(
+        adapter, _api(["g1"]), "discord", "user-1", "#x", "   "
+    )
+    assert result.ok is False
+    assert result.error == "empty_content"
+    # Nothing should be resolved or sent for empty content.
+    adapter.list_text_channels.assert_not_awaited()
+    adapter.post_channel_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_create_thread_empty_content_is_distinct_error():
+    adapter = _adapter()
+    result = await outbound.create_thread(
+        adapter, _api(["g1"]), "discord", "user-1", "#x", "Monday", ""
+    )
+    assert result.ok is False
+    assert result.error == "empty_content"
+    adapter.create_channel_thread.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_create_thread_happy_path():
     adapter = _adapter(
         channels=[ChannelInfo(id="42", name="announcements", server_id="g1")],

--- a/autogpt_platform/backend/backend/copilot/bot/outbound_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/outbound_test.py
@@ -163,3 +163,17 @@ async def test_list_channels_empty_without_links():
     result = await outbound.list_channels(adapter, _api([]), "discord", "user-1")
     assert result == []
     adapter.list_text_channels.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_list_channels_drops_unlinked_server_channels():
+    # Defense-in-depth: even if the adapter over-returns, channels outside the
+    # user's linked servers are filtered out of the picker.
+    adapter = _adapter(
+        channels=[
+            ChannelInfo(id="10", name="ours", server_id="g1"),
+            ChannelInfo(id="20", name="leaked", server_id="other"),
+        ]
+    )
+    result = await outbound.list_channels(adapter, _api(["g1"]), "discord", "user-1")
+    assert [c.id for c in result] == ["10"]

--- a/autogpt_platform/backend/backend/platform_linking/manager.py
+++ b/autogpt_platform/backend/backend/platform_linking/manager.py
@@ -18,6 +18,7 @@ from .models import (
     LinkTokenStatusResponse,
     ListUserChatsResponse,
     Platform,
+    PlatformLinkInfo,
     ResolveResponse,
     WorkspaceArtifact,
 )
@@ -61,6 +62,10 @@ class PlatformLinkingManager(AppService):
     @expose
     async def get_link_token_status(self, token: str) -> LinkTokenStatusResponse:
         return await platform_linking_db().get_link_token_status(token)
+
+    @expose
+    async def list_server_links(self, user_id: str) -> list[PlatformLinkInfo]:
+        return await platform_linking_db().list_server_links(user_id)
 
     @expose
     async def start_chat_turn(self, request: BotChatRequest) -> ChatTurnHandle:
@@ -127,6 +132,7 @@ class PlatformLinkingManagerClient(AppServiceClient):
     get_link_token_status = endpoint_to_async(
         PlatformLinkingManager.get_link_token_status
     )
+    list_server_links = endpoint_to_async(PlatformLinkingManager.list_server_links)
     start_chat_turn = endpoint_to_async(PlatformLinkingManager.start_chat_turn)
     refresh_server_link_name = endpoint_to_async(
         PlatformLinkingManager.refresh_server_link_name

--- a/autogpt_platform/backend/backend/platform_linking/manager.py
+++ b/autogpt_platform/backend/backend/platform_linking/manager.py
@@ -18,7 +18,6 @@ from .models import (
     LinkTokenStatusResponse,
     ListUserChatsResponse,
     Platform,
-    PlatformLinkInfo,
     ResolveResponse,
     WorkspaceArtifact,
 )
@@ -64,8 +63,17 @@ class PlatformLinkingManager(AppService):
         return await platform_linking_db().get_link_token_status(token)
 
     @expose
-    async def list_server_links(self, user_id: str) -> list[PlatformLinkInfo]:
-        return await platform_linking_db().list_server_links(user_id)
+    async def list_user_server_ids(self, platform: Platform, user_id: str) -> list[str]:
+        """Bot-scoped: the platform server IDs ``user_id`` has linked.
+
+        Deliberately returns only the IDs (not full ``PlatformLinkInfo``) so the
+        bot client stays a narrow surface — the user-facing ``list_server_links``
+        stays off the bot client. Backs proactive-output authorization.
+        """
+        links = await platform_linking_db().list_server_links(user_id)
+        return [
+            link.platform_server_id for link in links if link.platform == platform.value
+        ]
 
     @expose
     async def start_chat_turn(self, request: BotChatRequest) -> ChatTurnHandle:
@@ -132,7 +140,9 @@ class PlatformLinkingManagerClient(AppServiceClient):
     get_link_token_status = endpoint_to_async(
         PlatformLinkingManager.get_link_token_status
     )
-    list_server_links = endpoint_to_async(PlatformLinkingManager.list_server_links)
+    list_user_server_ids = endpoint_to_async(
+        PlatformLinkingManager.list_user_server_ids
+    )
     start_chat_turn = endpoint_to_async(PlatformLinkingManager.start_chat_turn)
     refresh_server_link_name = endpoint_to_async(
         PlatformLinkingManager.refresh_server_link_name

--- a/autogpt_platform/backend/backend/platform_linking/manager_test.py
+++ b/autogpt_platform/backend/backend/platform_linking/manager_test.py
@@ -41,6 +41,7 @@ class TestManagerWiring:
             "create_user_link_token",
             "get_link_token_status",
             "start_chat_turn",
+            "list_user_server_ids",
         }
         for name in expected:
             assert hasattr(


### PR DESCRIPTION
### Why / What / How

**Why** — AutoPilot could reply to a Discord user inside the bot's own thread, but it had no way to *initiate* output: post a message or open a thread in a chosen channel. This is the prerequisite for proactive/scheduled Discord output (e.g. "every Monday post the standup prompt in #standup"). The `CoPilotChatBridge` already had `send_message_to_channel`/`send_dm` stubs that only `raise ValueError` — this wires the real thing.

**What** — Implements the bot-side outbound delivery layer + authorization. New internal RPCs let a caller (the copilot tool in the stacked PR) post a message or create a standalone thread in a channel, on behalf of a specific AutoGPT user, restricted to Discord servers that user has linked.

**How**
- `adapters/base.py` — `ChannelInfo`/`PostedRef` models + 4 abstract adapter methods: `list_text_channels`, `get_channel_server_id`, `post_channel_message`, `create_channel_thread`.
- `adapters/discord/adapter.py` — Discord implementations, incl. standalone public-thread creation and a `_send_chunked` helper that respects the 2000-char cap (reuses `split_at_boundary`). Proactive posts inherit the client's `AllowedMentions.none()`, so they can't ping.
- `outbound.py` (new) — platform-agnostic authorization + channel resolution. A `DeliveryResult` with stable error codes. A target is only reachable if its server is in the user's linked servers; resolves `#name`, bare name, or raw channel ID. Both the ID and name paths are constrained to linked servers, so resolution and authz are the same step.
- `app.py` — replaces the `ValueError` stubs with `list_channels`, `send_message_to_channel`, `create_thread_in_channel` RPCs (now taking `user_id` for authz) + the client mappings; stores the live adapter registry.
- `platform_linking/manager.py` + `bot_backend.py` — expose `list_server_links`; add `BotBackend.list_linked_server_ids` so the bridge can resolve a user → their linked guilds.

This is the delivery layer only; the copilot `post_to_discord` tool that drives it is in the stacked follow-up PR.

### Changes 🏗️

- New `ChannelInfo` / `PostedRef` / `DeliveryResult` models and adapter methods for proactive (backend → platform) output
- Discord standalone-thread creation + chunked sends
- Authorization scoped to the user's linked servers (ID and name resolution both gated)
- `list_server_links` RPC exposed; `list_linked_server_ids` facade
- Unit tests for authz/resolution (`outbound_test.py`), the Discord adapter methods (`adapter_test.py`), the RPC seam (`app_test.py`), and the server-id filter (`bot_backend_test.py`)

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Unit tests pass (`outbound_test.py`, `adapter_test.py`, `app_test.py`, `bot_backend_test.py`)
  - [x] Verified end-to-end locally: DM the bot → AutoPilot calls the tool (stacked PR) → bridge `send_message_to_channel` → message posted to the channel
  - [x] Verified authz rejects channels in unlinked servers (`not_authorized`) and unknown channels (`channel_not_found`)
