### PR TITLE
fix(frontend): de-flake PaywallModal upgrade-mutation tests

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/PaywallGate/__tests__/PaywallModal.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/PaywallGate/__tests__/PaywallModal.test.tsx
@@ -47,6 +47,15 @@ vi.mock("@/lib/supabase/hooks/useSupabase", () => ({
   }),
 }));
 
+// The shared test wrapper mounts OnboardingProvider, which asynchronously
+// checks onboarding completion and can fire router.replace("/onboarding").
+// That shares this file's mocked next/navigation replace, so the stray
+// redirect races into assertions that the paywall did NOT navigate. Render
+// children directly to keep navigation owned solely by PaywallModal.
+vi.mock("@/providers/onboarding/onboarding-provider", () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
 const mockReplace = vi.fn();
 vi.mock("next/navigation", () => ({
   useRouter: () => ({


### PR DESCRIPTION
### Why / What / How

**Why:** The `PaywallModal` integration test `non-401 ApiError surfaces a toast and stays on the paywall` was flaky, intermittently failing because `mockReplace` was called with `/onboarding` when the test asserts the paywall does not navigate.

**What:** Mock out `OnboardingProvider` in `PaywallModal.test.tsx` so it renders its children directly.

**How:** The shared test wrapper (`test-utils.tsx`) mounts `OnboardingProvider`, which asynchronously checks onboarding completion and can fire `router.replace("/onboarding")`. Because it consumes the same mocked `next/navigation` `replace` as the test, that stray redirect raced into the navigation assertions. `PaywallModal` itself only ever navigates to `/login` or `/logout`, so mocking the provider keeps navigation owned solely by the component under test — the same pattern already used across other suites in the repo.

### Changes 🏗️

- Add a `vi.mock` for `@/providers/onboarding/onboarding-provider` in `PaywallModal.test.tsx` that renders children directly, eliminating the cross-component `/onboarding` redirect race.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [x] Ran `pnpm test:unit` on `PaywallModal.test.tsx` — all 23 tests pass
  - [x] Ran the file 5 consecutive times to confirm the race is gone (5/5 green)

#### For configuration changes:

- [ ] `.env.default` is updated or already compatible with my changes
- [ ] `docker-compose.yml` is updated or already compatible with my changes
- [ ] I have included a list of my configuration changes in the PR description (under **Changes**)
