### PR TITLE
fix(copilot): explicitly list supported providers in connect_integration description

### DIFF
--- a/autogpt_platform/backend/backend/copilot/tools/connect_integration.py
+++ b/autogpt_platform/backend/backend/copilot/tools/connect_integration.py
@@ -34,7 +34,7 @@ class ConnectIntegrationTool(BaseTool):
 
     @property
     def description(self) -> str:
-        supported = ", ".join(f"\'{p}\'" for p in SUPPORTED_PROVIDERS)
+        supported = ", ".join(f"'{p}'" for p in SUPPORTED_PROVIDERS)
         return (
             f"Prompt the user to connect a required integration. "
             f"Supported providers: {supported}. "

--- a/autogpt_platform/backend/backend/copilot/tools/connect_integration.py
+++ b/autogpt_platform/backend/backend/copilot/tools/connect_integration.py
@@ -34,8 +34,12 @@ class ConnectIntegrationTool(BaseTool):
 
     @property
     def description(self) -> str:
+        supported = ", ".join(f"\'{p}\'" for p in SUPPORTED_PROVIDERS)
         return (
-            "Prompt the user to connect a required integration (e.g. GitHub). "
+            f"Prompt the user to connect a required integration. "
+            f"Supported providers: {supported}. "
+            "ONLY call this tool for one of the supported providers listed above — "
+            "do NOT call it for Google, Gmail, Slack, or any other provider not in the list. "
             "Call this when an external CLI or API call fails because the user "
             "has not connected the relevant account. "
             "The tool surfaces a credentials setup card in the chat so the user "


### PR DESCRIPTION
### Why / What / How

**Why:** The `connect_integration` tool description said *"e.g. GitHub"* — vague enough that the LLM called it for unsupported providers (Google, Gmail, Slack, etc.). When `provider='google'` is passed, the backend returns an `unknown_provider` error which Discord silently drops, leaving users with no sign-in card and no explanation.

Discovered during QA of #13350 (SECRT-2432 follow-up).

**What:** Make the description dynamically enumerate `SUPPORTED_PROVIDERS` and add an explicit instruction not to call it for unlisted providers.

**How:** Single-line change to the `description` property in `ConnectIntegrationTool` — it now builds the supported list at runtime from `SUPPORTED_PROVIDERS`, so adding a new provider there automatically surfaces it in the tool description with no extra work.

### Changes 🏗️

- `copilot/tools/connect_integration.py`: description now reads *"Supported providers: 'github'. ONLY call this tool for one of the supported providers listed above — do NOT call it for Google, Gmail, Slack, or any other provider not in the list."*

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Existing `connect_integration_test.py` tests still pass (no logic changed, description only)
  - [x] Manually verified the rendered description includes the provider list

🤖 Generated with [Claude Code](https://claude.com/claude-code)