### PR TITLE
fix(frontend): add baseline security response headers

### DIFF
--- a/autogpt_platform/frontend/next.config.mjs
+++ b/autogpt_platform/frontend/next.config.mjs
@@ -6,6 +6,8 @@ const enableSourceMaps = process.env.NEXT_PUBLIC_SOURCEMAPS !== "false";
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  // Suppress the "X-Powered-By: Next.js" header (framework fingerprinting).
+  poweredByHeader: false,
   productionBrowserSourceMaps: enableSourceMaps,
   // Externalize OpenTelemetry packages to fix Turbopack HMR issues
   serverExternalPackages: [
@@ -84,6 +86,21 @@ const nextConfig = {
   // Vercel has its own deployment mechanism and doesn't need standalone mode
   ...(process.env.VERCEL ? {} : { output: "standalone" }),
   transpilePackages: ["geist"],
+  // Baseline security response headers applied to every route. Defined here
+  // (rather than in the Sentry options) so they apply on all build paths.
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: [
+          { key: "X-Content-Type-Options", value: "nosniff" },
+          { key: "X-Frame-Options", value: "SAMEORIGIN" },
+          // Enables Sentry browser JS self-profiling.
+          { key: "Document-Policy", value: "js-profiling" },
+        ],
+      },
+    ];
+  },
 };
 
 // Only run the Sentry webpack plugin when we can actually upload source maps
@@ -149,18 +166,4 @@ export default skipSentryPlugin
       // https://docs.sentry.io/product/crons/
       // https://vercel.com/docs/cron-jobs
       automaticVercelMonitors: true,
-
-      async headers() {
-        return [
-          {
-            source: "/:path*",
-            headers: [
-              {
-                key: "Document-Policy",
-                value: "js-profiling",
-              },
-            ],
-          },
-        ];
-      },
     });


### PR DESCRIPTION
### Why / What / How

**Why:** A TAC Security CASA assessment (ESOF AppSec ADA) of `platform.agpt.co` flagged several missing/leaky HTTP response headers. None are critical (overall ESOF score 9.1/10, "Low"), but all must be remediated to pass the CASA Tier 2 & Tier 3 assessments. Verified live today: prod sends `X-Powered-By: Next.js` and is missing both `X-Frame-Options` and `X-Content-Type-Options`.

**What:** Adds baseline security response headers in the frontend Next.js config and disables the framework-fingerprinting header.

**How:** Defines the headers in `nextConfig.headers()` (applied to `/:path*`) and sets `poweredByHeader: false`. The existing `Document-Policy: js-profiling` header was previously nested inside the Sentry plugin options (2nd arg to `withSentryConfig`), where it does not apply on the non-Sentry build path — it's moved into the Next config so every build path emits the full header set.

### Changes 🏗️

- `autogpt_platform/frontend/next.config.mjs`:
  - `poweredByHeader: false` → removes `X-Powered-By: Next.js` (finding #5; partially addresses proxy disclosure #3)
  - `X-Frame-Options: SAMEORIGIN` → anti-clickjacking (finding #2)
  - `X-Content-Type-Options: nosniff` → anti-MIME-sniffing (finding #4)
  - Moved `Document-Policy: js-profiling` from the Sentry options into `nextConfig.headers()` so it (and the new headers) apply on all build paths

**Not addressed here (platform-level / separate):**
- CORS `Access-Control-Allow-Origin: *` on `/_next/static/media/*` fonts (#1) — injected by Vercel for font assets; overriding risks breaking Next's `crossorigin` font preloads. Needs a separate, deploy-verified change.
- `Server: Vercel` header and TRACE/TRACK methods (#3) — injected at the Vercel edge, no in-repo lever.
- Info-only items #6/#7/#8/#9 are scanner observations or already handled (backend cache-protection middleware sends `no-store` on sensitive routes).

`SAMEORIGIN` was chosen over `DENY` so same-origin embedding (share/preview flows) keeps working; easy to tighten if the app is never framed.

### Checklist 📋

#### For configuration changes:
- [x] `.env.default` is updated or already compatible with my changes (no env changes)
- [x] `docker-compose.yml` is updated or already compatible with my changes (no compose changes)
- [x] I have included a list of my configuration changes in the PR description (under **Changes**)

#### Test plan:
- [x] `pnpm format`, `pnpm lint`, `pnpm types` pass locally
- [ ] After deploy, verify response headers on `platform.agpt.co`:
  - [ ] `X-Frame-Options: SAMEORIGIN` present
  - [ ] `X-Content-Type-Options: nosniff` present
  - [ ] `X-Powered-By` absent
  - [ ] `Document-Policy: js-profiling` still present (Sentry profiling unaffected)
  - [ ] App still renders and fonts load (no clickjacking/embedding regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only HTTP header changes with no auth or data-path changes; `SAMEORIGIN` framing is a deliberate tradeoff that should be smoke-tested after deploy for embed/preview and font loading.
> 
> **Overview**
> Addresses CASA assessment gaps on the Next.js frontend by **disabling** `X-Powered-By: Next.js` via `poweredByHeader: false` and **adding** global response headers on `/:path*` through `nextConfig.headers()`: `X-Content-Type-Options: nosniff`, `X-Frame-Options: SAMEORIGIN`, and `Document-Policy: js-profiling`.
> 
> **`Document-Policy`** (and the new security headers) were previously defined only inside the optional `withSentryConfig` wrapper, so builds that skip the Sentry webpack plugin never emitted them. They now live on the base Next config so every build path gets the same header set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c6931ed72b490f1c92f2ffb1d1bf6c236e23b67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->