### PR TITLE
fix(classic/forge): match shell denylist on the invoked program

### DIFF
--- a/classic/forge/forge/components/code_executor/code_executor.py
+++ b/classic/forge/forge/components/code_executor/code_executor.py
@@ -280,6 +280,21 @@ class CodeExecutorComponent(
         logger.debug("App is not running in a Docker container")
         return self._run_python_code_in_docker(file_path, args, timeout, env_vars)
 
+    @staticmethod
+    def _command_name_variants(command_token: str) -> set[str]:
+        """Return the spellings of an executable that a name list should match.
+
+        The program that actually runs is determined by the OS from the first
+        token of ``shlex.split(command_line)``. A denylist of bare command names
+        (e.g. ``rm``) must therefore be compared against both the raw first
+        token and its basename, so that a path- or ``./``-qualified spelling of
+        the same program (``/bin/rm``, ``/usr/bin/rm``, ``./rm``) cannot slip
+        past the filter. Returns the raw token and its basename.
+        """
+        variants = {command_token, os.path.basename(command_token)}
+        variants.discard("")
+        return variants
+
     def validate_command(self, command_line: str) -> tuple[bool, bool]:
         """Check whether a command is allowed and whether it may be executed in a shell.
 
@@ -297,12 +312,27 @@ class CodeExecutorComponent(
         if not command_line:
             return False, False
 
-        command_name = shlex.split(command_line)[0]
+        try:
+            tokens = shlex.split(command_line)
+        except ValueError:
+            # Unparsable command line (e.g. unbalanced quotes); fail closed.
+            return False, False
+        if not tokens:
+            return False, False
+
+        command_name = tokens[0]
 
         if self.config.shell_command_control == "allowlist":
+            # Allowlist stays a strict, fail-closed exact match on the invoked
+            # token: an operator must list exactly what they permit.
             return command_name in self.config.shell_allowlist, False
         elif self.config.shell_command_control == "denylist":
-            return command_name not in self.config.shell_denylist, False
+            # Match the denylist against both the raw first token and its
+            # basename, so a path-prefixed / "./"-qualified spelling of a denied
+            # program (e.g. "/bin/rm" vs "rm") cannot bypass the denylist.
+            command_names = self._command_name_variants(command_name)
+            denied = bool(command_names & set(self.config.shell_denylist))
+            return not denied, False
         else:
             return True, True
 

--- a/classic/forge/forge/components/code_executor/test_code_executor.py
+++ b/classic/forge/forge/components/code_executor/test_code_executor.py
@@ -159,3 +159,65 @@ def test_execute_shell_allowlist_should_allow(
 
     result = code_executor_component.execute_shell(f"echo 'Hello {random_string}!'")
     assert "Hello" in result and random_string in result
+
+
+@pytest.mark.parametrize(
+    "command_line",
+    [
+        "rm -rf workspace",  # plain name (already covered, baseline)
+        "/bin/rm -rf workspace",  # absolute path prefix
+        "/usr/bin/rm -rf workspace",  # different absolute path
+        "./rm -rf workspace",  # relative path prefix
+        "  /bin/rm -rf workspace",  # leading whitespace padding
+    ],
+)
+def test_execute_shell_denylist_blocks_path_prefixed_command(
+    code_executor_component: CodeExecutorComponent, command_line: str
+):
+    """A denied command must stay denied regardless of path-prefix spelling.
+
+    Regression test for the first-token-only denylist bypass: previously the
+    denylist was matched against the raw first token only, so "/bin/rm" slipped
+    past a denylist of ["rm"]. validate_command must now reject every spelling of
+    the denied program, and execute_shell must raise before running anything.
+    """
+    code_executor_component.config.shell_command_control = "denylist"
+    code_executor_component.config.shell_denylist = ["rm"]
+
+    allow_execute, allow_shell = code_executor_component.validate_command(command_line)
+    assert allow_execute is False, f"{command_line!r} should be denied"
+    assert allow_shell is False
+
+    with pytest.raises(OperationNotAllowedError, match="not allowed"):
+        code_executor_component.execute_shell(command_line)
+
+
+def test_execute_shell_denylist_still_allows_non_denied_command(
+    code_executor_component: CodeExecutorComponent, random_string: str
+):
+    """Basename matching must not over-block unrelated commands."""
+    code_executor_component.config.shell_command_control = "denylist"
+    code_executor_component.config.shell_denylist = ["rm"]
+
+    # "echo" shares no basename with "rm" and must still run.
+    result = code_executor_component.execute_shell(f"echo 'Hello {random_string}!'")
+    assert "Hello" in result and random_string in result
+
+    # A path-prefixed allowed command is also permitted by validate_command.
+    allow_execute, _ = code_executor_component.validate_command("/bin/echo hi")
+    assert allow_execute is True
+
+
+def test_validate_command_unbalanced_quotes_fails_closed(
+    code_executor_component: CodeExecutorComponent,
+):
+    """An unparsable command line must fail closed instead of raising."""
+    code_executor_component.config.shell_command_control = "denylist"
+    code_executor_component.config.shell_denylist = ["rm"]
+
+    # Unbalanced quote makes shlex.split raise ValueError; must be denied.
+    allow_execute, allow_shell = code_executor_component.validate_command(
+        'echo "unterminated'
+    )
+    assert allow_execute is False
+    assert allow_shell is False


### PR DESCRIPTION
### Why / What / How

<!-- Why: Why does this PR exist? What problem does it solve, or what's broken/missing without it? -->
<!-- What: What does this PR change? Summarize the changes at a high level. -->
<!-- How: How does it work? Describe the approach, key implementation details, or architecture decisions. -->

**Why.** In the classic code-executor component, `validate_command` enforces the
shell-command **denylist** by comparing it against only the first token of
`shlex.split(command_line)`. The program the OS actually runs is determined by
that first token, but a denylist of bare names (e.g. `["rm"]`) was matched
against the raw token *as written*. A path- or `./`-qualified spelling of a
denied program therefore slipped through: with `shell_command_control="denylist"`
and `shell_denylist=["rm"]`, a command line whose first token is `/bin/rm` is not
literally `rm`, so the gate returned "allowed" and the command was executed via
`subprocess.run`. When an operator opts into denylist mode to bound what the
model may run, that boundary could be evaded by simply prefixing a path.

Two adjacent fail-open behaviors on the same gate:
- An unparsable command line (e.g. unbalanced quotes) raised an uncaught
  `ValueError` out of `shlex.split`, which propagated out of `execute_shell`
  instead of being treated as "not allowed".
- An empty token list was not explicitly handled.

(When command control is active, `allow_shell` is always `False`, so commands run
as an argv list with `shell=False` — shell metacharacters are not interpreted.
This is a first-token policy evasion, **not** shell-metacharacter injection.)

**What.** Match the denylist against **both** the raw first token **and** its
basename, so every spelling of the denied program (`rm`, `/bin/rm`,
`/usr/bin/rm`, `./rm`) is rejected by a `["rm"]` denylist. Keep the policy check
aligned with the program the OS executes. Also fail closed on unparsable input
and on an empty token list.

**How.**
- New helper `_command_name_variants(token)` returns `{token, basename(token)}`
  (dropping empty strings).
- In denylist mode, `validate_command` now denies if **any** variant of the first
  token is in `shell_denylist`.
- `shlex.split` is wrapped in `try/except ValueError`; an unparsable command line
  now returns `(False, False)` (not allowed) instead of raising.
- An empty token list returns `(False, False)`.
- The **allowlist** path is intentionally left as a strict, fail-closed exact
  match on the invoked token. Broadening the allowlist on basename would *loosen*
  it (it could admit a same-named binary from an attacker-writable directory),
  which is the wrong direction; the empty-allowlist default already denies
  everything.
- `subprocess.run(..., shell=allow_shell)` is unchanged; `allow_shell` stays
  `False` whenever any control mode is active.

No public API signature changed, and behavior for the documented allow/deny
cases is unchanged.

### Changes 🏗️

<!-- List the key changes. Keep it higher level than the diff but specific enough to highlight what's new/modified. -->

`classic/forge/forge/components/code_executor/code_executor.py`
- Add `_command_name_variants()` (`{token, basename(token)}`).
- `validate_command`: wrap `shlex.split` in `try/except ValueError` (fail closed);
  treat an empty token list as not allowed; in denylist mode, deny if any variant
  of the first token is in `shell_denylist`.
- Allowlist mode unchanged (strict, fail-closed exact match).

`classic/forge/forge/components/code_executor/test_code_executor.py`
- Parametrized regression test: a denied command stays denied across path-prefixed
  (`/bin/rm`, `/usr/bin/rm`), relative (`./rm`), and whitespace-padded spellings —
  asserted for both `validate_command` and `execute_shell`.
- Test that basename matching does not over-block an unrelated command (`echo`,
  including a path-prefixed `/bin/echo`).
- Test that an unparsable command line fails closed.

**Affected site (decisive line).** This PR closes one exploit path through a
single hardened gate:
- `classic/forge/forge/components/code_executor/code_executor.py:368` —
  `subprocess.run(command_line if allow_shell else shlex.split(command_line), shell=allow_shell, ...)`
  reached via `execute_shell` → `validate_command`, whose first-token-only
  denylist (previously at `code_executor.py:305`) was the bypassable check.

**Backwards compatibility.** No public method signature changes. The default
configuration (allowlist mode with an empty allowlist) is unchanged and still
fails closed. Denylist behavior changes only in the direction of *correctly*
denying disguised spellings of an already-denied program, and of failing closed
on unparsable input.

**Notes.**
- This code lives under `classic/`, which the project marks as legacy/unsupported.
  The change is intentionally minimal and backward-compatible.
- A denylist of program *names* is inherently advisory: it cannot stop a renamed
  copy or a symlink of a binary. This change closes the concrete path-prefix /
  `./` evasion and fails closed on bad input; it does not turn the name denylist
  into a sandbox. The fail-closed **allowlist** mode remains the recommended
  configuration.
- Reachable only when an operator opts into `execute_local_commands=True` +
  `shell_command_control="denylist"` with a populated `shell_denylist`.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [x] Ran the new and existing `code_executor` denylist/allowlist tests against
        the component source: the new security tests fail before this change and
        pass after; the existing tests still pass.
  - [x] Confirmed the denied program stays denied across path-prefixed
        (`/bin/rm`, `/usr/bin/rm`), relative (`./rm`), and whitespace-padded
        spellings, and that `execute_shell` raises `OperationNotAllowedError`
        before running anything.
  - [x] Confirmed basename matching does not over-block an unrelated command
        (`echo`, `/bin/echo`) and that an unparsable command line returns
        "not allowed".
  - [x] Confirmed `black`, `isort`, and `flake8` are clean on the two changed
        files (repo-pinned versions).

<details>
  <summary>Example test plan</summary>
  
  - [ ] Create from scratch and execute an agent with at least 3 blocks
  - [ ] Import an agent from file upload, and confirm it executes correctly
  - [ ] Upload agent to marketplace
  - [ ] Import an agent from marketplace and confirm it executes correctly
  - [ ] Edit an agent from monitor, and confirm it executes correctly
</details>

#### For configuration changes:

- [ ] `.env.default` is updated or already compatible with my changes
- [ ] `docker-compose.yml` is updated or already compatible with my changes
- [ ] I have included a list of my configuration changes in the PR description (under **Changes**)

<!-- N/A — no configuration changes: this PR only touches component logic and its tests. -->

<details>
  <summary>Examples of configuration changes</summary>

  - Changing ports
  - Adding new services that need to communicate with each other
  - Secrets or environment variable changes
  - New or infrastructure changes such as databases
</details>
