### PR TITLE
fix(backend): Make connection retries abort on shutdown

### DIFF
--- a/autogpt_platform/backend/backend/util/process.py
+++ b/autogpt_platform/backend/backend/util/process.py
@@ -8,7 +8,7 @@ from typing import Optional
 
 from backend.util.logging import configure_logging
 from backend.util.metrics import sentry_init
-from backend.util.retry import request_shutdown
+from backend.util.retry import stop_retry_loops
 from backend.util.settings import set_service_name
 
 logger = logging.getLogger(__name__)
@@ -94,8 +94,7 @@ class AppProcess(ABC):
         os.write(sys.stdout.fileno(), (message + "\n").encode())
 
     def _self_terminate(self, signum: int, frame):
-        # Abort in-flight connection-retry loops so they don't block shutdown.
-        request_shutdown()
+        stop_retry_loops()
         if not self._shutting_down:
             self._shutting_down = True
             sys.exit(0)

--- a/autogpt_platform/backend/backend/util/process.py
+++ b/autogpt_platform/backend/backend/util/process.py
@@ -8,6 +8,7 @@ from typing import Optional
 
 from backend.util.logging import configure_logging
 from backend.util.metrics import sentry_init
+from backend.util.retry import request_shutdown
 from backend.util.settings import set_service_name
 
 logger = logging.getLogger(__name__)
@@ -93,6 +94,8 @@ class AppProcess(ABC):
         os.write(sys.stdout.fileno(), (message + "\n").encode())
 
     def _self_terminate(self, signum: int, frame):
+        # Abort in-flight connection-retry loops so they don't block shutdown.
+        request_shutdown()
         if not self._shutting_down:
             self._shutting_down = True
             sys.exit(0)

--- a/autogpt_platform/backend/backend/util/retry.py
+++ b/autogpt_platform/backend/backend/util/retry.py
@@ -341,7 +341,7 @@ def continuous_retry(*, retry_delay: float = 1.0):
         @wraps(func)
         def sync_wrapper(*args, **kwargs):
             counter = 0
-            while True:
+            while not is_shutting_down():
                 try:
                     return func(*args, **kwargs)
                 except Exception as exc:
@@ -357,12 +357,13 @@ def continuous_retry(*, retry_delay: float = 1.0):
                         str(exc) or type(exc).__name__,
                         retry_delay,
                     )
-                    time.sleep(retry_delay)
+                    _interruptible_sleep(retry_delay)
+            logger.info("%s stopped retrying: shutting down", func.__name__)
 
         @wraps(func)
         async def async_wrapper(*args, **kwargs):
             counter = 0
-            while True:
+            while not is_shutting_down():
                 try:
                     return await func(*args, **kwargs)
                 except Exception as exc:
@@ -378,7 +379,8 @@ def continuous_retry(*, retry_delay: float = 1.0):
                         str(exc) or type(exc).__name__,
                         retry_delay,
                     )
-                    await asyncio.sleep(retry_delay)
+                    await _interruptible_async_sleep(retry_delay)
+            logger.info("%s stopped retrying: shutting down", func.__name__)
 
         return async_wrapper if is_coroutine else sync_wrapper
 

--- a/autogpt_platform/backend/backend/util/retry.py
+++ b/autogpt_platform/backend/backend/util/retry.py
@@ -1,4 +1,5 @@
 import asyncio
+import inspect
 import logging
 import os
 import threading
@@ -22,16 +23,16 @@ logger = logging.getLogger(__name__)
 EXCESSIVE_RETRY_THRESHOLD = 50
 
 # Process-wide shutdown flag. The AppProcess/AppService signal handlers set this
-# (via request_shutdown) so in-flight retry loops abort promptly instead of
-# blocking shutdown for up to max_retry * max_wait seconds while the backing
-# service (Redis/RabbitMQ/RPC peer) stays unreachable.
+# (via stop_retry_loops) so in-flight retry loops abort promptly instead of
+# blocking shutdown for up to max_retry * max_wait seconds if e.g. a backing
+# service (Redis/RabbitMQ/RPC peer) is unreachable.
 _shutdown_event = threading.Event()
 
 # How often the async interruptible sleep re-checks the shutdown flag.
 _SHUTDOWN_POLL_INTERVAL = 0.5
 
 
-def request_shutdown() -> None:
+def stop_retry_loops() -> None:
     """Tell every retry loop in this process to stop ASAP.
 
     Safe to call from a signal handler: it only sets a ``threading.Event``.
@@ -41,38 +42,6 @@ def request_shutdown() -> None:
 
 def is_shutting_down() -> bool:
     return _shutdown_event.is_set()
-
-
-class _StopOnShutdown(stop_base):
-    """Tenacity stop condition that fires once a process shutdown is requested."""
-
-    def __call__(self, retry_state) -> bool:
-        return _shutdown_event.is_set()
-
-
-def _interruptible_sleep(seconds: float) -> None:
-    """``time.sleep`` replacement that wakes immediately on shutdown.
-
-    Worker threads don't receive SIGINT/SIGTERM (only the main thread does), so
-    a plain ``time.sleep`` here can't be interrupted; waiting on the shutdown
-    Event can.
-    """
-    _shutdown_event.wait(seconds)
-
-
-async def _interruptible_async_sleep(seconds: float) -> None:
-    """``asyncio.sleep`` replacement that returns early on shutdown.
-
-    Polls the shared shutdown flag so async retry loops on background event
-    loops (which nothing cancels on shutdown) don't sit through a full backoff.
-    """
-    loop = asyncio.get_running_loop()
-    end = loop.time() + seconds
-    while not _shutdown_event.is_set():
-        remaining = end - loop.time()
-        if remaining <= 0:
-            return
-        await asyncio.sleep(min(remaining, _SHUTDOWN_POLL_INTERVAL))
 
 
 # Rate limiting for alerts - track last alert time per function+error combination
@@ -208,7 +177,7 @@ def create_retry_decorator(
         # pending backoff doesn't keep the process alive after a shutdown signal.
         sleep = (
             _interruptible_async_sleep
-            if asyncio.iscoroutinefunction(func)
+            if inspect.iscoroutinefunction(func)
             else _interruptible_sleep
         )
         if retry_on is not None:
@@ -280,7 +249,7 @@ def conn_retry(
             )
 
     def decorator(func):
-        is_coroutine = asyncio.iscoroutinefunction(func)
+        is_coroutine = inspect.iscoroutinefunction(func)
         # Use static retry configuration. _StopOnShutdown + the interruptible
         # sleep let an in-flight retry bail out promptly on SIGINT/SIGTERM
         # instead of blocking shutdown for up to max_retry * max_wait seconds.
@@ -329,13 +298,45 @@ def conn_retry(
     return decorator
 
 
+class _StopOnShutdown(stop_base):
+    """Tenacity stop condition that fires once a process shutdown is requested."""
+
+    def __call__(self, retry_state) -> bool:
+        return _shutdown_event.is_set()
+
+
+def _interruptible_sleep(seconds: float) -> None:
+    """``time.sleep`` replacement that wakes immediately on shutdown.
+
+    Worker threads don't receive SIGINT/SIGTERM (only the main thread does), so
+    a plain ``time.sleep`` here can't be interrupted; waiting on the shutdown
+    Event can.
+    """
+    _shutdown_event.wait(seconds)
+
+
+async def _interruptible_async_sleep(seconds: float) -> None:
+    """``asyncio.sleep`` replacement that returns early on shutdown.
+
+    Polls the shared shutdown flag so async retry loops on background event
+    loops (which nothing cancels on shutdown) don't sit through a full backoff.
+    """
+    loop = asyncio.get_running_loop()
+    end = loop.time() + seconds
+    while not _shutdown_event.is_set():
+        remaining = end - loop.time()
+        if remaining <= 0:
+            return
+        await asyncio.sleep(min(remaining, _SHUTDOWN_POLL_INTERVAL))
+
+
 # Preconfigured retry decorator for general functions
 func_retry = create_retry_decorator(max_attempts=5)
 
 
 def continuous_retry(*, retry_delay: float = 1.0):
     def decorator(func):
-        is_coroutine = asyncio.iscoroutinefunction(func)
+        is_coroutine = inspect.iscoroutinefunction(func)
 
         @wraps(func)
         def sync_wrapper(*args, **kwargs):

--- a/autogpt_platform/backend/backend/util/retry.py
+++ b/autogpt_platform/backend/backend/util/retry.py
@@ -12,6 +12,7 @@ from tenacity import (
     stop_after_attempt,
     wait_exponential_jitter,
 )
+from tenacity.stop import stop_base
 
 from backend.util.settings import get_service_name
 
@@ -19,6 +20,60 @@ logger = logging.getLogger(__name__)
 
 # Alert threshold for excessive retries
 EXCESSIVE_RETRY_THRESHOLD = 50
+
+# Process-wide shutdown flag. The AppProcess/AppService signal handlers set this
+# (via request_shutdown) so in-flight retry loops abort promptly instead of
+# blocking shutdown for up to max_retry * max_wait seconds while the backing
+# service (Redis/RabbitMQ/RPC peer) stays unreachable.
+_shutdown_event = threading.Event()
+
+# How often the async interruptible sleep re-checks the shutdown flag.
+_SHUTDOWN_POLL_INTERVAL = 0.5
+
+
+def request_shutdown() -> None:
+    """Tell every retry loop in this process to stop ASAP.
+
+    Safe to call from a signal handler: it only sets a ``threading.Event``.
+    """
+    _shutdown_event.set()
+
+
+def is_shutting_down() -> bool:
+    return _shutdown_event.is_set()
+
+
+class _StopOnShutdown(stop_base):
+    """Tenacity stop condition that fires once a process shutdown is requested."""
+
+    def __call__(self, retry_state) -> bool:
+        return _shutdown_event.is_set()
+
+
+def _interruptible_sleep(seconds: float) -> None:
+    """``time.sleep`` replacement that wakes immediately on shutdown.
+
+    Worker threads don't receive SIGINT/SIGTERM (only the main thread does), so
+    a plain ``time.sleep`` here can't be interrupted; waiting on the shutdown
+    Event can.
+    """
+    _shutdown_event.wait(seconds)
+
+
+async def _interruptible_async_sleep(seconds: float) -> None:
+    """``asyncio.sleep`` replacement that returns early on shutdown.
+
+    Polls the shared shutdown flag so async retry loops on background event
+    loops (which nothing cancels on shutdown) don't sit through a full backoff.
+    """
+    loop = asyncio.get_running_loop()
+    end = loop.time() + seconds
+    while not _shutdown_event.is_set():
+        remaining = end - loop.time()
+        if remaining <= 0:
+            return
+        await asyncio.sleep(min(remaining, _SHUTDOWN_POLL_INTERVAL))
+
 
 # Rate limiting for alerts - track last alert time per function+error combination
 _alert_rate_limiter = {}
@@ -141,21 +196,39 @@ def create_retry_decorator(
     Returns:
         Configured retry decorator
     """
-    if exclude_exceptions:
-        return retry(
-            stop=stop_after_attempt(max_attempts),
-            wait=wait_exponential_jitter(max=max_wait),
-            before_sleep=_create_retry_callback(context),
-            reraise=reraise,
-            retry=retry_if_not_exception_type(exclude_exceptions),
+    stop = stop_after_attempt(max_attempts) | _StopOnShutdown()
+    wait = wait_exponential_jitter(max=max_wait)
+    before_sleep = _create_retry_callback(context)
+    retry_on = (
+        retry_if_not_exception_type(exclude_exceptions) if exclude_exceptions else None
+    )
+
+    def decorator(func):
+        # Pick the interruptible sleep matching the wrapped function so a
+        # pending backoff doesn't keep the process alive after a shutdown signal.
+        sleep = (
+            _interruptible_async_sleep
+            if asyncio.iscoroutinefunction(func)
+            else _interruptible_sleep
         )
-    else:
+        if retry_on is not None:
+            return retry(
+                sleep=sleep,
+                stop=stop,
+                wait=wait,
+                before_sleep=before_sleep,
+                reraise=reraise,
+                retry=retry_on,
+            )(func)
         return retry(
-            stop=stop_after_attempt(max_attempts),
-            wait=wait_exponential_jitter(max=max_wait),
-            before_sleep=_create_retry_callback(context),
+            sleep=sleep,
+            stop=stop,
+            wait=wait,
+            before_sleep=before_sleep,
             reraise=reraise,
-        )
+        )(func)
+
+    return decorator
 
 
 def _log_prefix(resource_name: str, conn_id: str):
@@ -208,14 +281,24 @@ def conn_retry(
 
     def decorator(func):
         is_coroutine = asyncio.iscoroutinefunction(func)
-        # Use static retry configuration
+        # Use static retry configuration. _StopOnShutdown + the interruptible
+        # sleep let an in-flight retry bail out promptly on SIGINT/SIGTERM
+        # instead of blocking shutdown for up to max_retry * max_wait seconds.
         retry_decorator = retry(
-            stop=stop_after_attempt(max_retry + 1),  # +1 for the initial attempt
+            stop=stop_after_attempt(max_retry + 1)  # +1 for the initial attempt
+            | _StopOnShutdown(),
             wait=wait_exponential_jitter(max=max_wait),
             before_sleep=on_retry,
             reraise=True,
+            sleep=_interruptible_async_sleep if is_coroutine else _interruptible_sleep,
         )
         wrapped_func = retry_decorator(func)
+
+        def _log_failure(prefix: str, error: Exception):
+            if is_shutting_down():
+                logger.info(f"{prefix} {action_name} aborted: shutting down")
+            else:
+                logger.warning(f"{prefix} {action_name} failed after retries: {error}")
 
         @wraps(func)
         def sync_wrapper(*args, **kwargs):
@@ -226,7 +309,7 @@ def conn_retry(
                 logger.info(f"{prefix} {action_name} completed successfully.")
                 return result
             except Exception as e:
-                logger.warning(f"{prefix} {action_name} failed after retries: {e}")
+                _log_failure(prefix, e)
                 raise
 
         @wraps(func)
@@ -238,7 +321,7 @@ def conn_retry(
                 logger.info(f"{prefix} {action_name} completed successfully.")
                 return result
             except Exception as e:
-                logger.warning(f"{prefix} {action_name} failed after retries: {e}")
+                _log_failure(prefix, e)
                 raise
 
         return async_wrapper if is_coroutine else sync_wrapper

--- a/autogpt_platform/backend/backend/util/retry_test.py
+++ b/autogpt_platform/backend/backend/util/retry_test.py
@@ -8,12 +8,25 @@ import pytest
 from backend.util.retry import (
     ALERT_RATE_LIMIT_SECONDS,
     _alert_rate_limiter,
+    _interruptible_async_sleep,
+    _interruptible_sleep,
     _rate_limiter_lock,
     _send_critical_retry_alert,
+    _shutdown_event,
     conn_retry,
     create_retry_decorator,
+    is_shutting_down,
+    request_shutdown,
     should_send_alert,
 )
+
+
+@pytest.fixture(autouse=True)
+def _reset_shutdown_event():
+    """Keep the process-wide shutdown flag from leaking between tests."""
+    _shutdown_event.clear()
+    yield
+    _shutdown_event.clear()
 
 
 def test_conn_retry_sync_function():
@@ -58,6 +71,74 @@ async def test_conn_retry_async_function():
     with pytest.raises(ValueError) as e:
         await test_function()
         assert str(e.value) == "Test error"
+
+
+def test_conn_retry_sync_aborts_on_shutdown():
+    """A shutdown request must stop the retry loop instead of exhausting it."""
+    attempts = 0
+
+    @conn_retry("Test", "Test function", max_retry=100, max_wait=30)
+    def test_function():
+        nonlocal attempts
+        attempts += 1
+        request_shutdown()  # signal shutdown mid-flight
+        raise ConnectionError("Redis down")
+
+    start = time.monotonic()
+    with pytest.raises(ConnectionError):
+        test_function()
+    # Bails out near-immediately rather than running ~101 attempts / waiting 30s.
+    assert attempts < 5
+    assert time.monotonic() - start < 5
+
+
+@pytest.mark.asyncio
+async def test_conn_retry_async_aborts_on_shutdown():
+    attempts = 0
+
+    @conn_retry("Test", "Test function", max_retry=100, max_wait=30)
+    async def test_function():
+        nonlocal attempts
+        attempts += 1
+        request_shutdown()
+        raise ConnectionError("Redis down")
+
+    start = time.monotonic()
+    with pytest.raises(ConnectionError):
+        await test_function()
+    assert attempts < 5
+    assert time.monotonic() - start < 5
+
+
+def test_create_retry_decorator_aborts_on_shutdown():
+    attempts = 0
+
+    @create_retry_decorator(max_attempts=100, max_wait=30)
+    def always_failing_function():
+        nonlocal attempts
+        attempts += 1
+        request_shutdown()
+        raise ValueError("persistent failure")
+
+    with pytest.raises(ValueError):
+        always_failing_function()
+    assert attempts < 5
+
+
+def test_interruptible_sleep_returns_early_on_shutdown():
+    request_shutdown()
+    assert is_shutting_down()
+    start = time.monotonic()
+    _interruptible_sleep(30)
+    assert time.monotonic() - start < 1
+
+
+@pytest.mark.asyncio
+async def test_interruptible_async_sleep_returns_early_on_shutdown():
+    request_shutdown()
+    start = time.monotonic()
+    await _interruptible_async_sleep(30)
+    assert time.monotonic() - start < 1
 
 
 class TestRetryRateLimiting:

--- a/autogpt_platform/backend/backend/util/retry_test.py
+++ b/autogpt_platform/backend/backend/util/retry_test.py
@@ -16,8 +16,8 @@ from backend.util.retry import (
     conn_retry,
     create_retry_decorator,
     is_shutting_down,
-    request_shutdown,
     should_send_alert,
+    stop_retry_loops,
 )
 
 
@@ -81,7 +81,7 @@ def test_conn_retry_sync_aborts_on_shutdown():
     def test_function():
         nonlocal attempts
         attempts += 1
-        request_shutdown()  # signal shutdown mid-flight
+        stop_retry_loops()  # signal shutdown mid-flight
         raise ConnectionError("Redis down")
 
     start = time.monotonic()
@@ -100,7 +100,7 @@ async def test_conn_retry_async_aborts_on_shutdown():
     async def test_function():
         nonlocal attempts
         attempts += 1
-        request_shutdown()
+        stop_retry_loops()
         raise ConnectionError("Redis down")
 
     start = time.monotonic()
@@ -117,7 +117,7 @@ def test_create_retry_decorator_aborts_on_shutdown():
     def always_failing_function():
         nonlocal attempts
         attempts += 1
-        request_shutdown()
+        stop_retry_loops()
         raise ValueError("persistent failure")
 
     with pytest.raises(ValueError):
@@ -126,7 +126,7 @@ def test_create_retry_decorator_aborts_on_shutdown():
 
 
 def test_interruptible_sleep_returns_early_on_shutdown():
-    request_shutdown()
+    stop_retry_loops()
     assert is_shutting_down()
     start = time.monotonic()
     _interruptible_sleep(30)
@@ -135,7 +135,7 @@ def test_interruptible_sleep_returns_early_on_shutdown():
 
 @pytest.mark.asyncio
 async def test_interruptible_async_sleep_returns_early_on_shutdown():
-    request_shutdown()
+    stop_retry_loops()
     start = time.monotonic()
     await _interruptible_async_sleep(30)
     assert time.monotonic() - start < 1

--- a/autogpt_platform/backend/backend/util/retry_test.py
+++ b/autogpt_platform/backend/backend/util/retry_test.py
@@ -14,6 +14,7 @@ from backend.util.retry import (
     _send_critical_retry_alert,
     _shutdown_event,
     conn_retry,
+    continuous_retry,
     create_retry_decorator,
     is_shutting_down,
     should_send_alert,
@@ -139,6 +140,41 @@ async def test_interruptible_async_sleep_returns_early_on_shutdown():
     start = time.monotonic()
     await _interruptible_async_sleep(30)
     assert time.monotonic() - start < 1
+
+
+def test_continuous_retry_sync_stops_on_shutdown():
+    """The infinite continuous_retry loop must exit when shutdown is requested."""
+    attempts = 0
+
+    @continuous_retry(retry_delay=30)
+    def always_failing_function():
+        nonlocal attempts
+        attempts += 1
+        stop_retry_loops()
+        raise RuntimeError("never recovers")
+
+    start = time.monotonic()
+    # Returns instead of looping forever; no exception propagates.
+    assert always_failing_function() is None
+    assert attempts < 5
+    assert time.monotonic() - start < 5
+
+
+@pytest.mark.asyncio
+async def test_continuous_retry_async_stops_on_shutdown():
+    attempts = 0
+
+    @continuous_retry(retry_delay=30)
+    async def always_failing_function():
+        nonlocal attempts
+        attempts += 1
+        stop_retry_loops()
+        raise RuntimeError("never recovers")
+
+    start = time.monotonic()
+    assert await always_failing_function() is None
+    assert attempts < 5
+    assert time.monotonic() - start < 5
 
 
 class TestRetryRateLimiting:

--- a/autogpt_platform/backend/backend/util/service.py
+++ b/autogpt_platform/backend/backend/util/service.py
@@ -39,7 +39,7 @@ from backend.monitoring.instrumentation import instrument_fastapi
 from backend.util.json import to_dict
 from backend.util.metrics import sentry_init
 from backend.util.process import AppProcess
-from backend.util.retry import conn_retry, create_retry_decorator
+from backend.util.retry import conn_retry, create_retry_decorator, request_shutdown
 from backend.util.settings import Config, get_service_name
 
 logger = logging.getLogger(__name__)
@@ -367,6 +367,10 @@ class AppService(BaseAppService, ABC):
 
     def _self_terminate(self, signum: int, frame):
         """Pass SIGTERM to Uvicorn so it can shut down gracefully"""
+        # Abort in-flight connection-retry loops (e.g. the eager Redis connect in
+        # `lifespan`) so they don't keep Uvicorn stuck in startup and block the
+        # graceful shutdown below.
+        request_shutdown()
         signame = signal.Signals(signum).name
         if not self._shutting_down:
             self._shutting_down = True

--- a/autogpt_platform/backend/backend/util/service.py
+++ b/autogpt_platform/backend/backend/util/service.py
@@ -39,7 +39,7 @@ from backend.monitoring.instrumentation import instrument_fastapi
 from backend.util.json import to_dict
 from backend.util.metrics import sentry_init
 from backend.util.process import AppProcess
-from backend.util.retry import conn_retry, create_retry_decorator, request_shutdown
+from backend.util.retry import conn_retry, create_retry_decorator, stop_retry_loops
 from backend.util.settings import Config, get_service_name
 
 logger = logging.getLogger(__name__)
@@ -367,10 +367,7 @@ class AppService(BaseAppService, ABC):
 
     def _self_terminate(self, signum: int, frame):
         """Pass SIGTERM to Uvicorn so it can shut down gracefully"""
-        # Abort in-flight connection-retry loops (e.g. the eager Redis connect in
-        # `lifespan`) so they don't keep Uvicorn stuck in startup and block the
-        # graceful shutdown below.
-        request_shutdown()
+        stop_retry_loops()
         signame = signal.Signals(signum).name
         if not self._shutting_down:
             self._shutting_down = True


### PR DESCRIPTION
### Why / What / How

**Why:** When a backing service (Redis cluster, RabbitMQ, an RPC peer) is unreachable, the connection-acquisition retry loops kept the whole backend from shutting down. `conn_retry` and `create_retry_decorator` retry up to ~100 times with 30s exponential backoff (`pyro_client_comm_retry=100`, `pyro_client_max_wait=30`) — roughly 50 minutes — with **no shutdown awareness**. The backoff sleeps run on worker/background-event-loop threads that never receive SIGINT/SIGTERM (only the main thread does), and the eager `await redis_client.get_redis_async()` in `AppService.lifespan` keeps Uvicorn stuck in *startup*, so its graceful-shutdown path never runs. Net effect: `Ctrl+C` is ignored while a service is retrying, and the logs spam "Acquiring connection failed … Retrying now…" indefinitely.

**What:** Make the retry loops abort promptly when the process receives a shutdown signal.

**How:**
- Added a process-wide shutdown flag in `backend/util/retry.py` — `request_shutdown()` / `is_shutting_down()` backed by a `threading.Event` (signal-safe: it only sets an event).
- Added a tenacity `_StopOnShutdown` stop condition (combined via `|` with the existing `stop_after_attempt`) so no new retry is attempted once shutdown is requested.
- Added interruptible sleeps (`_interruptible_sleep` / `_interruptible_async_sleep`) that wake immediately on shutdown instead of sleeping out the full backoff. `conn_retry` and `create_retry_decorator` pick the right one based on whether the wrapped function is sync or async.
- Both signal handlers — `AppProcess._self_terminate` and `AppService._self_terminate` — now call `request_shutdown()` first.

On the first `Ctrl+C`, the in-flight retry wakes from its backoff, the stop condition fires, `connect_async()` raises, the lifespan startup fails fast, Uvicorn proceeds to shut down, and the process exits.

### Changes 🏗️

- `backend/util/retry.py`: add `request_shutdown()`/`is_shutting_down()`, `_StopOnShutdown` tenacity stop condition, and `_interruptible_sleep`/`_interruptible_async_sleep`; wire them into `conn_retry` and `create_retry_decorator` (the latter now picks the sync/async interruptible sleep at decoration time). Final-failure log distinguishes "aborted: shutting down" from "failed after retries".
- `backend/util/process.py`: `AppProcess._self_terminate` calls `request_shutdown()`.
- `backend/util/service.py`: `AppService._self_terminate` calls `request_shutdown()` so the eager Redis connect in `lifespan` stops blocking Uvicorn startup.
- `backend/util/retry_test.py`: 5 new tests (sync/async `conn_retry` abort on shutdown, `create_retry_decorator` abort, both interruptible sleeps return early) + an autouse fixture that resets the shutdown flag between tests.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `poetry run pytest backend/util/retry_test.py` — 19 passed (14 existing + 5 new shutdown tests)
  - [x] `poetry run ruff check` + `poetry run pyright` clean on all changed files; pre-commit hooks (ruff/isort/black/pyright) pass
  - [x] `backend/util/service_test.py::test_graceful_shutdown`