### PR TITLE
fix(backend/copilot): make reasoning + community-rebuild tests transport-hermetic

### DIFF
--- a/autogpt_platform/backend/backend/copilot/baseline/service_unit_test.py
+++ b/autogpt_platform/backend/backend/copilot/baseline/service_unit_test.py
@@ -2033,9 +2033,22 @@ class TestBaselineReasoningStreaming:
             return_value=_make_stream_mock()
         )
 
-        with patch(
-            "backend.copilot.baseline.service._get_main_client",
-            return_value=mock_client,
+        # Pin the OpenRouter transport so ``extra_body`` is always built:
+        # ``openrouter_active`` needs a non-empty ``api_key``, which on fork-PR
+        # CI is absent (secrets — incl. ``OPENAI_API_KEY`` — aren't exposed),
+        # flipping the transport to ``direct_anthropic`` and dropping
+        # ``extra_body`` entirely. Without this the assertion KeyErrors in CI.
+        with (
+            patch(
+                "backend.copilot.baseline.service._get_main_client",
+                return_value=mock_client,
+            ),
+            patch("backend.copilot.baseline.service.config.use_openrouter", True),
+            patch("backend.copilot.baseline.service.config.api_key", "or-key"),
+            patch(
+                "backend.copilot.baseline.service.config.base_url",
+                "https://openrouter.ai/api/v1",
+            ),
         ):
             await _baseline_llm_caller(
                 messages=[{"role": "user", "content": "hi"}],
@@ -2172,6 +2185,10 @@ class TestBaselineReasoningStreaming:
             return_value=_make_stream_mock()
         )
 
+        # Pin the OpenRouter transport so ``extra_body`` is always built (and
+        # the kill switch's suppression is observable on a populated dict) —
+        # fork-PR CI has no LLM creds, which would otherwise drop the transport
+        # to direct_anthropic and omit ``extra_body``, KeyErroring the assert.
         with (
             patch(
                 "backend.copilot.baseline.service._get_main_client",
@@ -2180,6 +2197,12 @@ class TestBaselineReasoningStreaming:
             patch(
                 "backend.copilot.baseline.service.config.claude_agent_max_thinking_tokens",
                 0,
+            ),
+            patch("backend.copilot.baseline.service.config.use_openrouter", True),
+            patch("backend.copilot.baseline.service.config.api_key", "or-key"),
+            patch(
+                "backend.copilot.baseline.service.config.base_url",
+                "https://openrouter.ai/api/v1",
             ),
         ):
             await _baseline_llm_caller(

--- a/autogpt_platform/backend/backend/copilot/graphiti/communities_test.py
+++ b/autogpt_platform/backend/backend/copilot/graphiti/communities_test.py
@@ -30,6 +30,30 @@ def _free_rebuild_lock():
         yield redis
 
 
+@pytest.fixture(autouse=True)
+def _pin_openrouter_transport():
+    """Pin the chat transport to OpenRouter so the flex-tier path is taken
+    deterministically. ``rebuild_communities_for_user`` only takes the flex
+    branch when ``chat_cfg.transport.supports_flex_tier`` is True, which holds
+    only for the OpenRouter transport. That resolves from
+    ``config.openrouter_active``, which needs a non-empty ``api_key`` — absent
+    on fork-PR CI, where repo secrets (incl. ``OPENAI_API_KEY``) aren't exposed.
+    Without this pin the transport silently drops to ``direct_anthropic`` (no
+    flex), and tests that only patch ``make_flex_graphiti_client`` fall through
+    to the real sync client. The flag-driven sync test patches
+    ``community_rebuild_use_flex_tier`` itself, so it still takes the sync path.
+    """
+    with (
+        patch("backend.copilot.sdk.env.config.use_openrouter", True),
+        patch("backend.copilot.sdk.env.config.api_key", "or-key"),
+        patch(
+            "backend.copilot.sdk.env.config.base_url",
+            "https://openrouter.ai/api/v1",
+        ),
+    ):
+        yield
+
+
 def _neighbor(uuid: str, edge_count: int = 1):
     """Mimic graphiti's Neighbor namedtuple — only attributes touched by LP."""
     return SimpleNamespace(node_uuid=uuid, edge_count=edge_count)


### PR DESCRIPTION
## Why

Six pre-existing copilot tests fail on **every fork PR** while staying green on `dev`:

- `backend/copilot/baseline/service_unit_test.py::TestBaselineReasoningStreaming::test_reasoning_param_absent_on_non_anthropic_routes`
- `…::test_reasoning_param_suppressed_when_thinking_tokens_zero`
- `backend/copilot/graphiti/communities_test.py::TestRebuildCommunitiesForUser::test_success_path_calls_detach_delete_then_build`
- `…::test_failure_path_returns_error_in_result`
- `…::TestRebuildForUserActivityGate::test_force_bypasses_gate`
- `…::TestRebuildPathSelection::test_uses_flex_client_by_default`

**Root cause:** these tests implicitly assume the ambient `ChatConfig` transport is `openrouter`. `openrouter_active` is only true when `api_key` is non-empty, and `api_key` falls back to `OPENAI_API_KEY`. GitHub Actions **withholds repository secrets from `pull_request` runs triggered by forks**, so `OPENAI_API_KEY` is empty there and the transport silently drops to `direct_anthropic`:

- graphiti: `use_flex = flex_requested and chat_cfg.transport.supports_flex_tier`; only `openrouter` has `supports_flex_tier=True`, so the sync path runs the *real* client and the tests that only patch `make_flex_graphiti_client` fall through (wrong shape / no error / `execution_path == "sync"`).
- baseline: without openrouter, `extra_body` isn't built → `KeyError: 'extra_body'`.

`dev` is green because its CI runs as `push` events, where secrets are present. This surfaced on the JSON-blocks PR (#13170) purely because it was a fork PR — its code changes are unrelated.

## What

Make the affected tests hermetic by pinning the OpenRouter transport, so they pass regardless of credential availability:

- **`service_unit_test.py`** — pin `use_openrouter` / `api_key` / `base_url` in the two reasoning tests that relied on `extra_body` being built (matching the existing sibling pattern, e.g. the Kimi test).
- **`communities_test.py`** — add an autouse fixture pinning the transport so the flex-tier path is taken deterministically. The flag-driven sync test (`test_uses_sync_client_when_flex_disabled`) is unaffected — it forces sync via `community_rebuild_use_flex_tier`, not the transport.

## How

Verified both files in both credential states (`-p no:cov`, 138 tests each):

```bash
# Fork-CI simulation (secrets cleared) — previously 6 failures, now:
env CHAT_API_KEY= CHAT_BASE_URL= OPENAI_API_KEY= OPEN_ROUTER_API_KEY= OPENAI_BASE_URL= \
  poetry run pytest backend/copilot/baseline/service_unit_test.py \
  backend/copilot/graphiti/communities_test.py
# -> 138 passed

# Normal env (creds present) — no regression:
poetry run pytest backend/copilot/baseline/service_unit_test.py \
  backend/copilot/graphiti/communities_test.py
# -> 138 passed
```

No production code changes — test-only.
