### PR TITLE
feat(frontend): copilot artifact-panel file UX + unified banners

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/copilot/CopilotPage.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/CopilotPage.tsx
@@ -118,8 +118,10 @@ function MainArea({
           onFilesDropped={setDroppedFiles}
         >
           {isMobile && <MobileHeader />}
-          <LowCreditBanner className="px-4 pt-4" />
-          <NotificationBanner />
+          <div className="flex flex-col gap-3 px-4 pt-4 empty:hidden">
+            <LowCreditBanner />
+            <NotificationBanner />
+          </div>
           <CopilotChatHost
             key={`chat-host-${sessionId ?? "new"}`}
             droppedFiles={droppedFiles}

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ArtifactPanel/ArtifactPanel.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ArtifactPanel/ArtifactPanel.tsx
@@ -21,6 +21,7 @@ export function ArtifactPanel({ mobile }: Props) {
     setIsSourceView,
     clearArtifactPreview,
     goBackArtifact,
+    showFilesTab,
     canCopy,
     handleCopy,
     handleDownload,
@@ -84,6 +85,7 @@ export function ArtifactPanel({ mobile }: Props) {
               onClose={clearArtifactPreview}
               onCopy={handleCopy}
               onDownload={handleDownload}
+              onOpenFiles={showFilesTab}
               onSourceToggle={setIsSourceView}
             />
             <ArtifactContent
@@ -122,6 +124,7 @@ export function ArtifactPanel({ mobile }: Props) {
           onClose={clearArtifactPreview}
           onCopy={handleCopy}
           onDownload={handleDownload}
+          onOpenFiles={showFilesTab}
           onSourceToggle={setIsSourceView}
         />
         <ArtifactContent

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ArtifactPanel/components/ArtifactPanelHeader.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ArtifactPanel/components/ArtifactPanelHeader.tsx
@@ -1,10 +1,16 @@
 "use client";
 
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/atoms/Tooltip/BaseTooltip";
 import { cn } from "@/lib/utils";
 import {
   ArrowLeftIcon,
   CopyIcon,
   DownloadSimpleIcon,
+  FolderIcon,
   XIcon,
 } from "@phosphor-icons/react";
 import type { ArtifactRef } from "../../../store";
@@ -22,6 +28,7 @@ interface Props {
   onClose: () => void;
   onCopy: () => void;
   onDownload: () => void;
+  onOpenFiles: () => void;
   onSourceToggle: (isSource: boolean) => void;
 }
 
@@ -35,15 +42,19 @@ function HeaderButton({
   children: React.ReactNode;
 }) {
   return (
-    <button
-      type="button"
-      onClick={onClick}
-      title={title}
-      aria-label={title}
-      className="rounded p-1.5 text-zinc-500 transition-colors hover:bg-zinc-100 hover:text-zinc-700"
-    >
-      {children}
-    </button>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          onClick={onClick}
+          aria-label={title}
+          className="rounded p-1.5 text-zinc-500 transition-colors hover:bg-zinc-100 hover:text-zinc-700"
+        >
+          {children}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent>{title}</TooltipContent>
+    </Tooltip>
   );
 }
 
@@ -58,6 +69,7 @@ export function ArtifactPanelHeader({
   onClose,
   onCopy,
   onDownload,
+  onOpenFiles,
   onSourceToggle,
 }: Props) {
   const Icon = classification.icon;
@@ -99,6 +111,9 @@ export function ArtifactPanelHeader({
         )}
         <HeaderButton onClick={onDownload} title="Download">
           <DownloadSimpleIcon size={16} />
+        </HeaderButton>
+        <HeaderButton onClick={onOpenFiles} title="All files">
+          <FolderIcon size={16} />
         </HeaderButton>
         <HeaderButton onClick={onClose} title="Close">
           <XIcon size={16} />

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ArtifactPanel/components/ArtifactPanelHeader.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ArtifactPanel/components/ArtifactPanelHeader.tsx
@@ -53,7 +53,7 @@ function HeaderButton({
           {children}
         </button>
       </TooltipTrigger>
-      <TooltipContent>{title}</TooltipContent>
+      <TooltipContent side="bottom">{title}</TooltipContent>
     </Tooltip>
   );
 }

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ArtifactPanel/useArtifactPanel.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ArtifactPanel/useArtifactPanel.ts
@@ -11,6 +11,7 @@ export function useArtifactPanel() {
   const artifactPanel = useCopilotUIStore((s) => s.artifactPanel);
   const clearArtifactPreview = useCopilotUIStore((s) => s.clearArtifactPreview);
   const goBackArtifact = useCopilotUIStore((s) => s.goBackArtifact);
+  const showFilesTab = useCopilotUIStore((s) => s.showFilesTab);
   const artifactPanelWidth = useCopilotUIStore((s) => s.artifactPanelWidth);
   const setArtifactPanelWidth = useCopilotUIStore(
     (s) => s.setArtifactPanelWidth,
@@ -88,6 +89,7 @@ export function useArtifactPanel() {
     setIsSourceView,
     clearArtifactPreview,
     goBackArtifact,
+    showFilesTab,
     canCopy,
     handleCopy,
     handleDownload,

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ContextPanel/__tests__/ContextPanelAutoOpen.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ContextPanel/__tests__/ContextPanelAutoOpen.test.tsx
@@ -39,12 +39,14 @@ describe("ContextPanelAutoOpen", () => {
     }));
   });
 
-  test("opens the panel to the Files tab when the session has files", async () => {
+  test("opens the last generated file in the artifact panel when the session has files", async () => {
     server.use(getListWorkspaceFilesMockHandler200(withFiles()));
     render(<ContextPanelAutoOpen sessionId={SESSION} />);
     await waitFor(() =>
-      expect(useCopilotUIStore.getState().artifactPanel.isOpen).toBe(true),
+      expect(
+        useCopilotUIStore.getState().artifactPanel.activeArtifact?.id,
+      ).toBe("aaaaaaaa-0000-0000-0000-000000000001"),
     );
-    expect(useCopilotUIStore.getState().artifactPanel.activeTab).toBe("files");
+    expect(useCopilotUIStore.getState().artifactPanel.isOpen).toBe(true);
   });
 });

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ContextPanel/useAutoOpenForFiles.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ContextPanel/useAutoOpenForFiles.ts
@@ -2,18 +2,31 @@
 
 import { useEffect, useRef } from "react";
 import { useCopilotUIStore } from "../../store";
-import { useSessionFiles } from "./components/FilesTab/useSessionFiles";
+import { fileItemToArtifactRef } from "./components/FilesTab/helpers";
+import {
+  useSessionFiles,
+  type SessionFile,
+} from "./components/FilesTab/useSessionFiles";
+
+function getLastGeneratedFile(generated: SessionFile[]): SessionFile | null {
+  if (generated.length === 0) return null;
+  return generated.reduce((latest, file) =>
+    new Date(file.item.created_at).getTime() >
+    new Date(latest.item.created_at).getTime()
+      ? file
+      : latest,
+  );
+}
 
 /**
- * Opens the context panel to the Files tab the first time a session has files,
- * unless the user has explicitly closed it. Mirrors useAutoOpenArtifacts.
+ * The first time a session is found to have generated files, opens the Artifact
+ * panel directly on the most recently generated file (unless the user has
+ * explicitly closed the panel). Mirrors useAutoOpenForProgress.
  */
 export function useAutoOpenForFiles(sessionId: string | null) {
-  const openContextPanelForFiles = useCopilotUIStore(
-    (s) => s.openContextPanelForFiles,
-  );
-  const { uploaded, generated } = useSessionFiles(sessionId);
-  const hasFiles = uploaded.length + generated.length > 0;
+  const autoOpenArtifact = useCopilotUIStore((s) => s.autoOpenArtifact);
+  const { generated } = useSessionFiles(sessionId);
+  const lastGenerated = getLastGeneratedFile(generated);
   const triggered = useRef(false);
   const prevSessionIdRef = useRef(sessionId);
 
@@ -31,9 +44,9 @@ export function useAutoOpenForFiles(sessionId: string | null) {
   }, [sessionId]);
 
   useEffect(() => {
-    if (hasFiles && !triggered.current) {
+    if (lastGenerated && !triggered.current) {
       triggered.current = true;
-      openContextPanelForFiles();
+      autoOpenArtifact(fileItemToArtifactRef(lastGenerated.item));
     }
-  }, [hasFiles, openContextPanelForFiles]);
+  }, [lastGenerated, autoOpenArtifact]);
 }

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/NotificationBanner/NotificationBanner.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/NotificationBanner/NotificationBanner.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { Button } from "@/components/atoms/Button/Button";
-import { Text } from "@/components/atoms/Text/Text";
+import { Alert, AlertDescription } from "@/components/molecules/Alert/Alert";
 import { Key, storage } from "@/services/storage/local-storage";
-import { BellRinging, X } from "@phosphor-icons/react";
+import { BellRingingIcon, XIcon } from "@phosphor-icons/react";
 import { useEffect, useState } from "react";
 import { useCopilotUIStore } from "../../store";
 
@@ -53,22 +53,26 @@ export function NotificationBanner() {
   }
 
   return (
-    <div className="flex items-center gap-3 border-b border-amber-200 bg-amber-50 px-4 py-2.5">
-      <BellRinging className="h-5 w-5 shrink-0 text-amber-600" weight="fill" />
-      <Text variant="body" className="flex-1 text-sm text-amber-800">
-        Enable browser notifications to know when AutoPilot finishes working,
-        even when you switch tabs.
-      </Text>
-      <Button variant="primary" size="small" onClick={handleEnable}>
-        Enable
-      </Button>
-      <button
-        onClick={handleDismiss}
-        className="rounded p-1 text-amber-400 transition-colors hover:text-amber-600"
-        aria-label="Dismiss"
-      >
-        <X className="h-4 w-4" />
-      </button>
-    </div>
+    <Alert variant="warning" icon={BellRingingIcon} aria-live="polite">
+      <div className="flex flex-wrap items-center gap-3">
+        <AlertDescription className="min-w-[12rem] flex-1">
+          Enable browser notifications to know when AutoPilot finishes working,
+          even when you switch tabs.
+        </AlertDescription>
+        <Button variant="primary" size="small" onClick={handleEnable}>
+          Enable
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={handleDismiss}
+          aria-label="Dismiss"
+          title="Dismiss"
+          className="hover:border-[#FFE4BF] hover:bg-[#FFE4BF]"
+        >
+          <XIcon className="h-4 w-4" />
+        </Button>
+      </div>
+    </Alert>
   );
 }

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/store.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/store.ts
@@ -161,6 +161,8 @@ interface CopilotUIState {
   toggleContextPanel: () => void;
   openContextPanelForFiles: () => void;
   openContextPanelForProgress: () => void;
+  autoOpenArtifact: (ref: ArtifactRef) => void;
+  showFilesTab: () => void;
 
   // Card-based auto-open: ArtifactCard registers itself on mount, the store
   // decides whether to auto-open. Much simpler than message-scanning.
@@ -402,6 +404,39 @@ export const useCopilotUIStore = create<CopilotUIState>((set, get) => ({
         ...state.artifactPanel,
         isOpen: true,
         activeTab: "progress",
+        activeArtifact: null,
+        history: [],
+      },
+    }));
+  },
+
+  // Auto-open path for sessions that already have generated files: surfaces the
+  // last generated file directly in the Artifact panel. Respects the user's
+  // explicit close, mirroring openContextPanelForFiles' guard.
+  autoOpenArtifact: (ref) => {
+    if (_autoOpenUserClosed) return;
+    if (isClient) storage.set(Key.COPILOT_CONTEXT_PANEL_OPEN, "true");
+    set((state) => ({
+      artifactPanel: {
+        ...state.artifactPanel,
+        isOpen: true,
+        activeArtifact: ref,
+        history: [],
+      },
+    }));
+  },
+  // Explicit user action (Artifact panel folder button): always opens the
+  // Context panel on the Files tab, dropping any open artifact preview.
+  showFilesTab: () => {
+    if (isClient) {
+      storage.set(Key.COPILOT_CONTEXT_PANEL_OPEN, "true");
+      storage.set(Key.COPILOT_CONTEXT_PANEL_TAB, "files");
+    }
+    set((state) => ({
+      artifactPanel: {
+        ...state.artifactPanel,
+        isOpen: true,
+        activeTab: "files",
         activeArtifact: null,
         history: [],
       },

--- a/autogpt_platform/frontend/src/components/layout/TopUpPrompt/LowCreditBanner/LowCreditBanner.tsx
+++ b/autogpt_platform/frontend/src/components/layout/TopUpPrompt/LowCreditBanner/LowCreditBanner.tsx
@@ -23,12 +23,7 @@ export function LowCreditBanner({ className }: Props) {
           You&apos;re out of automation credits. Top up to keep your agents
           running.
         </AlertDescription>
-        <Button
-          variant="primary"
-          size="small"
-          onClick={openTopUp}
-          className="border-orange-600 bg-orange-600 hover:border-orange-700 hover:bg-orange-700"
-        >
+        <Button variant="primary" size="small" onClick={openTopUp}>
           Top up
         </Button>
         <Button

--- a/autogpt_platform/frontend/src/components/molecules/Alert/Alert.tsx
+++ b/autogpt_platform/frontend/src/components/molecules/Alert/Alert.tsx
@@ -32,12 +32,14 @@ interface AlertProps
   extends React.HTMLAttributes<HTMLDivElement>,
     VariantProps<typeof alertVariants> {
   children: React.ReactNode;
+  /** Override the default variant icon (e.g. a domain-specific icon). */
+  icon?: React.ComponentType<{ className?: string }>;
 }
 
 const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
-  ({ className, variant = "default", children, ...props }, ref) => {
+  ({ className, variant = "default", icon, children, ...props }, ref) => {
     const currentVariant = variant || "default";
-    const IconComponent = variantIcons[currentVariant];
+    const IconComponent = icon ?? variantIcons[currentVariant];
 
     return (
       <div


### PR DESCRIPTION
### Why / What / How

**Why:** Two adjacent Copilot UX rough edges:
- Entering a session that already has files auto-opened to the Context panel's "Files" tab — an extra click from actually seeing the most relevant output — and once an artifact was open there was no quick way back to the full files list. The header icon buttons also relied on native `title` tooltips.
- The "Enable browser notifications" banner and the "out of automation credits" banner looked inconsistent (full-width amber bar vs. bordered card, different buttons/icons) and sat flush against each other.

**What:**
- Auto-open the **last generated file** directly in the Artifact panel when a session already has generated files, instead of the Context panel Files tab.
- Add a folder button to the Artifact panel header (before the close "x") that opens the Context panel on the Files tab.
- Show design-system tooltips (positioned below the button) with the action name for all Artifact panel header icon buttons.
- Restyle the notification banner to match the low-credit banner (shared `Alert` molecule, `warning` variant), unify both action buttons to the default primary style, and add a gap between the two banners.

**How:**
- New store action `autoOpenArtifact(ref)` opens the Artifact panel on a given file, respecting the existing `_autoOpenUserClosed` guard. `useAutoOpenForFiles` now picks the most recently generated file (by `created_at`) and opens it via this action; the per-session `triggered` guard and session-change reset are preserved.
- New store action `showFilesTab()` is an explicit (un-guarded) open of the Context panel Files tab, wired through `useArtifactPanel` → `ArtifactPanel` → `ArtifactPanelHeader` as `onOpenFiles` (desktop + mobile).
- `HeaderButton` wraps its button in `Tooltip`/`TooltipTrigger`/`TooltipContent` (`side="bottom"`) from `atoms/Tooltip`, using the action name as content; native `title` replaced by the tooltip, `aria-label` kept for accessibility. A global `TooltipProvider` already wraps the app.
- `NotificationBanner` now renders via the `Alert` molecule. Added a small backward-compatible `icon?` override prop to `Alert` so the banner keeps its bell icon (defaults to the variant icon, so no existing `Alert` usage changes). Both banners use `<Button variant="primary" size="small">`, and `CopilotPage` wraps them in `flex flex-col gap-3 ... empty:hidden`.

### Changes 🏗️

**Artifact / Context panel**
- `copilot/store.ts`: add `autoOpenArtifact(ref)` and `showFilesTab()` actions.
- `ContextPanel/useAutoOpenForFiles.ts`: open the last generated file in the Artifact panel instead of the Context panel Files tab.
- `ArtifactPanel/components/ArtifactPanelHeader.tsx`: add folder button before close; wrap header icon buttons in tooltips positioned below.
- `ArtifactPanel/useArtifactPanel.ts` + `ArtifactPanel/ArtifactPanel.tsx`: expose and wire `showFilesTab` as `onOpenFiles`.
- `ContextPanel/__tests__/ContextPanelAutoOpen.test.tsx`: update assertion to the new artifact-open behavior.

**Banners**
- `copilot/components/NotificationBanner/NotificationBanner.tsx`: use the `Alert` molecule (warning variant) with the bell icon and a default-primary "Enable" button.
- `components/layout/TopUpPrompt/LowCreditBanner/LowCreditBanner.tsx`: drop the custom orange "Top up" button styling so it matches the default primary.
- `components/molecules/Alert/Alert.tsx`: add optional `icon` override prop.
- `copilot/CopilotPage.tsx`: wrap both banners in a flex column with a gap.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [ ] Open a session that already has generated files → the last generated file opens directly in the Artifact panel
  - [ ] Click the folder button in the Artifact panel header → Context panel opens on the Files tab
  - [ ] Hover each header icon button (Back, Copy, Download, All files, Close) → tooltip with the action name shows **below** the button
  - [ ] Explicitly close the panel, then re-enter the session → auto-open is suppressed (respects user close)
  - [ ] Verify behavior on mobile (folder button closes the artifact drawer and opens the Files sheet)
  - [ ] With low credits + notifications available, both banners render as matching bordered cards with a gap, identical primary buttons, and matching orange icons
