### PR TITLE
fix(frontend): smoother, lighter copilot tool-call animations

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/MorphingTextAnimation/MorphingTextAnimation.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/MorphingTextAnimation/MorphingTextAnimation.tsx
@@ -1,58 +1,34 @@
 import { cn } from "@/lib/utils";
-import { AnimatePresence, motion } from "framer-motion";
+import { motion, useReducedMotion } from "framer-motion";
 
 interface Props {
   text: string;
   className?: string;
+  // Only fade in for live, actively-streaming tool calls. Historical lines
+  // (e.g. on page reload) render static so we don't replay an entrance for
+  // every past tool call at once.
+  animate?: boolean;
 }
 
-export function MorphingTextAnimation({ text, className }: Props) {
-  const letters = text.split("");
+export function MorphingTextAnimation({
+  text,
+  className,
+  animate = false,
+}: Props) {
+  const reduceMotion = useReducedMotion();
+  const shouldAnimate = animate && !reduceMotion;
 
   return (
-    // min-w-0 + overflow-hidden lets the parent flex item shrink and clip;
-    // the inner whitespace-nowrap keeps the per-character animation on one
-    // line without forcing the chat column wider than the viewport on long
-    // command strings.
-    <div className={cn("min-w-0 overflow-hidden", className)}>
-      <AnimatePresence mode="popLayout" initial={false}>
-        <motion.div key={text} className="truncate whitespace-nowrap">
-          <motion.span className="inline-flex overflow-hidden">
-            {letters.map((char, index) => (
-              <motion.span
-                key={`${text}-${index}`}
-                initial={{
-                  opacity: 0,
-                  y: 8,
-                  rotateX: "80deg",
-                  filter: "blur(6px)",
-                }}
-                animate={{
-                  opacity: 1,
-                  y: 0,
-                  rotateX: "0deg",
-                  filter: "blur(0px)",
-                }}
-                exit={{
-                  opacity: 0,
-                  y: -8,
-                  rotateX: "-80deg",
-                  filter: "blur(6px)",
-                }}
-                style={{ willChange: "transform" }}
-                transition={{
-                  delay: 0.015 * index,
-                  type: "spring",
-                  bounce: 0.5,
-                }}
-                className="inline-block"
-              >
-                {char === " " ? "\u00A0" : char}
-              </motion.span>
-            ))}
-          </motion.span>
-        </motion.div>
-      </AnimatePresence>
-    </div>
+    // No key on `text`: the element stays mounted while the line streams in, so
+    // the fade plays once on appear instead of restarting on every token.
+    <motion.div
+      className={cn("min-w-0 truncate whitespace-nowrap", className)}
+      aria-label={text}
+      initial={shouldAnimate ? { opacity: 0 } : false}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.4, ease: "easeOut" }}
+    >
+      {text}
+    </motion.div>
   );
 }

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolAccordion/AccordionContent.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolAccordion/AccordionContent.tsx
@@ -151,7 +151,7 @@ export function ContentCodeBlock({
   return (
     <pre
       className={cn(
-        "whitespace-pre-wrap rounded-lg border bg-black p-3 text-xs text-neutral-200",
+        "whitespace-pre-wrap rounded-lg border bg-neutral-100 p-3 text-xs text-neutral-800",
         className,
       )}
     >

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolAccordion/ToolAccordion.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolAccordion/ToolAccordion.tsx
@@ -79,18 +79,20 @@ export function ToolAccordion({
         {isExpanded && (
           <motion.div
             id={contentId}
-            initial={{ height: 0, opacity: 0, filter: "blur(10px)" }}
+            initial={{ height: 0, opacity: 0, filter: "blur(4px)" }}
             animate={{ height: "auto", opacity: 1, filter: "blur(0px)" }}
-            exit={{ height: 0, opacity: 0, filter: "blur(10px)" }}
+            exit={{ height: 0, opacity: 0, filter: "blur(4px)" }}
             transition={
               shouldReduceMotion
                 ? { duration: 0 }
-                : { type: "spring", bounce: 0.35, duration: 0.55 }
+                : { duration: 0.4, ease: [0.16, 1, 0.3, 1] }
             }
             className="overflow-hidden"
             style={{ willChange: "height, opacity, filter" }}
           >
-            <div className="pb-2 pt-3">{children}</div>
+            <div className="max-h-[24rem] overflow-y-auto pb-2 pt-3">
+              {children}
+            </div>
           </motion.div>
         )}
       </AnimatePresence>

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/tools/GenericTool/GenericTool.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/tools/GenericTool/GenericTool.tsx
@@ -789,6 +789,7 @@ export function GenericTool({ part }: Props) {
         />
         <MorphingTextAnimation
           text={text}
+          animate={isStreaming}
           className={cn("min-w-0 flex-1", isError ? "text-red-500" : undefined)}
         />
       </div>


### PR DESCRIPTION
### Why / What / How

**Why:** The copilot tool-call UI animations were heavy and broken — the status line did a per-character 3D-spring-blur stagger that re-ran on every streamed token (leaving "gray blurry lines" for seconds and replaying for every line on reload), and the result accordion expanded with a springy bounce into an unbounded, black code block that could swallow the page.

**What:** Reworked the tool-call status line, the result accordion, and the code block styling for a faster, calmer, light-mode feel.

**How:** `MorphingTextAnimation` now renders crisp text with a single opacity-only fade gated to live streaming (`animate={isStreaming}`), so historical lines stay static on reload and nothing smears mid-stream; the `ToolAccordion` expand swaps the spring for a no-bounce ease-out tween with a softer blur bridge; and the expanded content is capped at `max-h-[24rem]` with `overflow-y-auto` while `ContentCodeBlock` moves from black to a light `bg-neutral-100`.

### Changes 🏗️

- `MorphingTextAnimation`: removed per-character 3D/spring/blur stagger → single opacity fade, only for actively-streaming tool calls; respects `prefers-reduced-motion`.
- `ToolAccordion`: replaced springy bounce with ease-out tween, reduced blur bridge, capped content height with a scroller so long output can't cover the page.
- `ContentCodeBlock`: switched from black to light mode (`bg-neutral-100` / `text-neutral-800`).

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Run a copilot session with tool calls; confirm status lines fade in once (no per-char/blur smear) while streaming
  - [x] Reload a session with past tool calls; confirm lines render static with no entrance replay
  - [x] Expand a tool result accordion; confirm smooth ease-out (no bounce) and long output scrolls within a bounded height
  - [x] Confirm the code block renders in light mode
