### PR TITLE
fix(backend/copilot-bot): read the Discord context users point the bot at (links, replies, forwards), securely

### DIFF
--- a/autogpt_platform/backend/backend/copilot/bot/adapters/base.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/base.py
@@ -36,10 +36,13 @@ class ReferencedConversation:
     fetched by the bot via its own gateway so the model can read it directly
     instead of trying to web-fetch a JS-rendered Discord page.
 
+    ``channel_id`` ties this content back to the raw link/mention in the user's
+    message so the renderer can rewrite that link into a readable ``#name``.
     ``messages`` is in chronological order and already bounded to a char budget.
     """
 
     title: str
+    channel_id: str
     messages: tuple[MessageHistoryEntry, ...]
 
 

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/base.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/base.py
@@ -30,6 +30,19 @@ class MessageHistoryEntry:
     text: str
 
 
+@dataclass
+class ReferencedConversation:
+    """A different thread/channel the incoming message linked or @-referenced,
+    fetched by the bot via its own gateway so the model can read it directly
+    instead of trying to web-fetch a JS-rendered Discord page.
+
+    ``messages`` is in chronological order and already bounded to a char budget.
+    """
+
+    title: str
+    messages: tuple[MessageHistoryEntry, ...]
+
+
 class FileAttachment(BaseModel):
     """A workspace artifact ready to attach to a platform message.
 
@@ -89,6 +102,9 @@ class MessageContext:
     # `(display_name, platform_user_id)` pairs. Anyone not in this list won't
     # get pinged even if the LLM produces `@theirname` in its output.
     mentionable_users: tuple[tuple[str, str], ...] = ()
+    # Other threads/channels the message linked or @-referenced, fetched by the
+    # bot up-front so the model has their content without web-fetching Discord.
+    referenced_conversations: tuple[ReferencedConversation, ...] = ()
 
     @property
     def is_dm(self) -> bool:

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter.py
@@ -29,7 +29,7 @@ from ..base import (
     ReferencedConversation,
 )
 from . import commands, config, intro
-from .references import extract_referenced_channel_ids
+from .references import extract_referenced_channel_ids, replace_referenced_links
 
 logger = logging.getLogger(__name__)
 
@@ -421,6 +421,17 @@ class DiscordAdapter(PlatformAdapter):
                 thread_history = await self._thread_history(message)
 
             message_text = self._message_text(message)
+            referenced = await self._fetch_referenced_conversations(
+                message, message_text
+            )
+            if referenced:
+                # Swap the raw channel links/mentions for readable "#name"
+                # tokens — the fetched content is supplied under those names, so
+                # this stops the model from treating the paste as a URL it must
+                # open (and then claiming it can't access Discord).
+                message_text = replace_referenced_links(
+                    message_text, {c.channel_id: c.title for c in referenced}
+                )
             ctx = MessageContext(
                 platform="discord",
                 channel_type=channel_type,
@@ -433,9 +444,7 @@ class DiscordAdapter(PlatformAdapter):
                 bot_mentioned=bot_mentioned,
                 thread_history=thread_history,
                 mentionable_users=self._collect_mentionable_users(message),
-                referenced_conversations=await self._fetch_referenced_conversations(
-                    message, message_text
-                ),
+                referenced_conversations=referenced,
             )
             await self._on_message_callback(ctx, self)
 
@@ -644,7 +653,9 @@ class DiscordAdapter(PlatformAdapter):
             return None
         if not messages:
             return None
-        return ReferencedConversation(title=channel.name, messages=messages)
+        return ReferencedConversation(
+            title=channel.name, channel_id=channel_id, messages=messages
+        )
 
 
 def _truncate_to_budget(text: str, limit: int) -> str:

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter.py
@@ -615,10 +615,15 @@ class DiscordAdapter(PlatformAdapter):
     ) -> tuple[ReferencedConversation, ...]:
         """Fetch the recent content of any thread/channel ``text`` references.
 
-        Same-guild only: the bot never surfaces content from a server the
-        requester may not be in, even when its own gateway could read it.
+        Read as the *requesting member* would: same-guild only, and only
+        channels they can actually see. The bot's gateway can read more than
+        the user can, so we must never surface a private channel's history to
+        someone who lacks access to it themselves.
         """
         if message.guild is None:
+            return ()
+        requester = message.guild.get_member(message.author.id)
+        if requester is None:
             return ()
         channel_ids = extract_referenced_channel_ids(
             text,
@@ -627,19 +632,26 @@ class DiscordAdapter(PlatformAdapter):
         )
         conversations: list[ReferencedConversation] = []
         for channel_id in channel_ids:
-            convo = await self._fetch_one_referenced(message.guild, channel_id)
+            convo = await self._fetch_one_referenced(
+                message.guild, requester, channel_id
+            )
             if convo is not None:
                 conversations.append(convo)
         return tuple(conversations)
 
     async def _fetch_one_referenced(
-        self, guild: discord.Guild, channel_id: str
+        self, guild: discord.Guild, requester: discord.Member, channel_id: str
     ) -> Optional[ReferencedConversation]:
         channel = await self._resolve_channel(channel_id)
         if not isinstance(channel, (discord.TextChannel, discord.Thread)):
             return None
         if channel.guild.id != guild.id:
             # Cross-guild reference — don't read content from another server.
+            return None
+        # Gate on the requester's own access, not the bot's: a private channel
+        # the bot can read must stay hidden from a user who couldn't read it.
+        perms = channel.permissions_for(requester)
+        if not (perms.view_channel and perms.read_message_history):
             return None
         try:
             messages = await self._budgeted_history(

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter.py
@@ -29,7 +29,11 @@ from ..base import (
     ReferencedConversation,
 )
 from . import commands, config, intro
-from .references import extract_referenced_channel_ids, replace_referenced_links
+from .references import (
+    ReferenceTarget,
+    extract_referenced_targets,
+    replace_referenced_links,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -50,6 +54,9 @@ _HISTORY_TRUNCATION_MARKER = "\n… [message truncated]"
 MAX_REFERENCED_CONVERSATIONS = 3
 REFERENCED_HISTORY_LIMIT = 200
 REFERENCED_CHAR_BUDGET = 8000
+# When a link names a specific message, fetch that message plus a little of the
+# conversation leading up to it (rather than the channel's latest activity).
+REFERENCED_MESSAGE_CONTEXT = 15
 
 
 class DiscordAdapter(PlatformAdapter):
@@ -666,49 +673,80 @@ class DiscordAdapter(PlatformAdapter):
         requester = message.guild.get_member(message.author.id)
         if requester is None:
             return ()
-        channel_ids = extract_referenced_channel_ids(
+        targets = extract_referenced_targets(
             text,
             exclude_channel_id=str(message.channel.id),
             limit=MAX_REFERENCED_CONVERSATIONS,
         )
         conversations: list[ReferencedConversation] = []
-        for channel_id in channel_ids:
-            convo = await self._fetch_one_referenced(
-                message.guild, requester, channel_id
-            )
+        for target in targets:
+            convo = await self._fetch_one_referenced(message.guild, requester, target)
             if convo is not None:
                 conversations.append(convo)
         return tuple(conversations)
 
     async def _fetch_one_referenced(
-        self, guild: discord.Guild, requester: discord.Member, channel_id: str
+        self, guild: discord.Guild, requester: discord.Member, target: ReferenceTarget
     ) -> Optional[ReferencedConversation]:
-        channel = await self._resolve_channel(channel_id)
+        channel = await self._resolve_channel(target.channel_id)
         if not isinstance(channel, (discord.TextChannel, discord.Thread)):
             return None
         if channel.guild.id != guild.id:
             # Cross-guild reference — don't read content from another server.
             return None
-        # Gate on the requester's own access, not the bot's: a private channel
-        # the bot can read must stay hidden from a user who couldn't read it.
-        perms = channel.permissions_for(requester)
-        if not (perms.view_channel and perms.read_message_history):
+        if not await self._can_requester_read(channel, requester):
             return None
         try:
-            messages = await self._budgeted_history(
-                channel.history(limit=REFERENCED_HISTORY_LIMIT, oldest_first=False),
-                REFERENCED_CHAR_BUDGET,
-            )
+            if target.message_id is not None:
+                # A permalink to a specific message: read that message and the
+                # turns leading up to it (``before`` the next snowflake includes
+                # the message itself), so "what was said here <link>" works even
+                # for an older message not in the channel's latest activity.
+                history = channel.history(
+                    limit=REFERENCED_MESSAGE_CONTEXT,
+                    before=discord.Object(id=int(target.message_id) + 1),
+                    oldest_first=False,
+                )
+            else:
+                history = channel.history(
+                    limit=REFERENCED_HISTORY_LIMIT, oldest_first=False
+                )
+            messages = await self._budgeted_history(history, REFERENCED_CHAR_BUDGET)
         except (discord.Forbidden, discord.HTTPException):
             logger.warning(
-                "Could not fetch referenced channel %s", channel_id, exc_info=True
+                "Could not fetch referenced channel %s",
+                target.channel_id,
+                exc_info=True,
             )
             return None
         if not messages:
             return None
         return ReferencedConversation(
-            title=channel.name, channel_id=channel_id, messages=messages
+            title=channel.name, channel_id=target.channel_id, messages=messages
         )
+
+    async def _can_requester_read(
+        self, channel: "discord.TextChannel | discord.Thread", requester: discord.Member
+    ) -> bool:
+        """Whether ``requester`` may read ``channel`` themselves.
+
+        Channel-level ``view_channel`` + ``read_message_history`` is the base
+        gate. For a *private* thread that is not enough — Discord requires the
+        member to actually be in the thread (``manage_threads`` bypasses, as it
+        does in the client), so check membership explicitly to avoid leaking a
+        private thread the bot happens to be in.
+        """
+        perms = channel.permissions_for(requester)
+        if not (perms.view_channel and perms.read_message_history):
+            return False
+        if isinstance(channel, discord.Thread) and channel.is_private():
+            if perms.manage_threads:
+                return True
+            try:
+                await channel.fetch_member(requester.id)
+            except (discord.NotFound, discord.Forbidden, discord.HTTPException):
+                return False
+        return True
 
 
 def _truncate_to_budget(text: str, limit: int) -> str:

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter.py
@@ -26,8 +26,10 @@ from ..base import (
     MessageHistoryEntry,
     PlatformAdapter,
     PostedRef,
+    ReferencedConversation,
 )
 from . import commands, config, intro
+from .references import extract_referenced_channel_ids
 
 logger = logging.getLogger(__name__)
 
@@ -40,6 +42,14 @@ logger = logging.getLogger(__name__)
 THREAD_HISTORY_LIMIT = 1000
 THREAD_HISTORY_CHAR_BUDGET = 24000
 _HISTORY_TRUNCATION_MARKER = "\n… [message truncated]"
+
+# When a message links or @-mentions other threads/channels, the bot fetches
+# their recent content up-front (same guild only) so the model can read it
+# instead of trying to web-fetch a JS-rendered Discord page. Bounded so a
+# link-heavy message can't fan out into many large reads.
+MAX_REFERENCED_CONVERSATIONS = 3
+REFERENCED_HISTORY_LIMIT = 200
+REFERENCED_CHAR_BUDGET = 8000
 
 
 class DiscordAdapter(PlatformAdapter):
@@ -410,6 +420,7 @@ class DiscordAdapter(PlatformAdapter):
             if channel_type == "thread" and bot_mentioned:
                 thread_history = await self._thread_history(message)
 
+            message_text = self._message_text(message)
             ctx = MessageContext(
                 platform="discord",
                 channel_type=channel_type,
@@ -418,10 +429,13 @@ class DiscordAdapter(PlatformAdapter):
                 message_id=str(message.id),
                 user_id=str(message.author.id),
                 username=message.author.display_name,
-                text=self._message_text(message),
+                text=message_text,
                 bot_mentioned=bot_mentioned,
                 thread_history=thread_history,
                 mentionable_users=self._collect_mentionable_users(message),
+                referenced_conversations=await self._fetch_referenced_conversations(
+                    message, message_text
+                ),
             )
             await self._on_message_callback(ctx, self)
 
@@ -533,57 +547,104 @@ class DiscordAdapter(PlatformAdapter):
     ) -> tuple[MessageHistoryEntry, ...]:
         if not isinstance(message.channel, discord.Thread):
             return ()
-
-        entries: list[MessageHistoryEntry] = []
-        used_chars = 0
-        bot_user_id = self._client.user.id if self._client.user else None
         try:
-            # Newest-first so that when a long thread exceeds the size budget we
-            # keep the most recent (most relevant) messages instead of the
-            # oldest; we reverse back to chronological order before returning.
-            async for prior in message.channel.history(
-                limit=THREAD_HISTORY_LIMIT,
-                before=message,
-                oldest_first=False,
-            ):
-                # Skip our own outputs — copilot has its own transcript for
-                # that side. Other bots' messages are kept as context.
-                if bot_user_id is not None and prior.author.id == bot_user_id:
-                    continue
-                text = self._strip_mentions(prior)
-                if not text:
-                    continue
-                remaining = THREAD_HISTORY_CHAR_BUDGET - used_chars
-                if remaining <= 0:
-                    break
-                oversized = len(text) > remaining
-                if oversized and entries:
-                    # No room for another whole message — stop and keep what we
-                    # have (the more recent messages).
-                    break
-                if oversized:
-                    # Lone most-recent message is itself over budget: keep a
-                    # truncated head of it.
-                    text = _truncate_to_budget(text, remaining)
-                used_chars += len(text)
-                entries.append(
-                    MessageHistoryEntry(
-                        username=prior.author.display_name,
-                        user_id=str(prior.author.id),
-                        text=text,
-                    )
-                )
-                if oversized:
-                    # We just truncated the newest message to the budget; older
-                    # messages are both less relevant and would otherwise sneak
-                    # into the whitespace `rstrip` freed up. Stop here.
-                    break
+            return await self._budgeted_history(
+                message.channel.history(
+                    limit=THREAD_HISTORY_LIMIT,
+                    before=message,
+                    oldest_first=False,
+                ),
+                THREAD_HISTORY_CHAR_BUDGET,
+            )
         except (discord.Forbidden, discord.HTTPException):
             logger.warning("Could not fetch Discord thread history", exc_info=True)
             return ()
 
+    async def _budgeted_history(
+        self, history, char_budget: int
+    ) -> tuple[MessageHistoryEntry, ...]:
+        """Drain a newest-first message iterator into chronological entries,
+        capped at ``char_budget`` chars (most-recent kept when over budget).
+
+        Skips the bot's own messages (copilot has its own transcript for those)
+        but keeps other bots' messages as context.
+        """
+        entries: list[MessageHistoryEntry] = []
+        used_chars = 0
+        bot_user_id = self._client.user.id if self._client.user else None
+        async for prior in history:
+            if bot_user_id is not None and prior.author.id == bot_user_id:
+                continue
+            text = self._strip_mentions(prior)
+            if not text:
+                continue
+            remaining = char_budget - used_chars
+            if remaining <= 0:
+                break
+            oversized = len(text) > remaining
+            if oversized and entries:
+                # No room for another whole message — keep what we have.
+                break
+            if oversized:
+                # Lone most-recent message is itself over budget: keep a head.
+                text = _truncate_to_budget(text, remaining)
+            used_chars += len(text)
+            entries.append(
+                MessageHistoryEntry(
+                    username=prior.author.display_name,
+                    user_id=str(prior.author.id),
+                    text=text,
+                )
+            )
+            if oversized:
+                break
         entries.reverse()  # chronological order for the prompt
         return tuple(entries)
+
+    async def _fetch_referenced_conversations(
+        self, message: discord.Message, text: str
+    ) -> tuple[ReferencedConversation, ...]:
+        """Fetch the recent content of any thread/channel ``text`` references.
+
+        Same-guild only: the bot never surfaces content from a server the
+        requester may not be in, even when its own gateway could read it.
+        """
+        if message.guild is None:
+            return ()
+        channel_ids = extract_referenced_channel_ids(
+            text,
+            exclude_channel_id=str(message.channel.id),
+            limit=MAX_REFERENCED_CONVERSATIONS,
+        )
+        conversations: list[ReferencedConversation] = []
+        for channel_id in channel_ids:
+            convo = await self._fetch_one_referenced(message.guild, channel_id)
+            if convo is not None:
+                conversations.append(convo)
+        return tuple(conversations)
+
+    async def _fetch_one_referenced(
+        self, guild: discord.Guild, channel_id: str
+    ) -> Optional[ReferencedConversation]:
+        channel = await self._resolve_channel(channel_id)
+        if not isinstance(channel, (discord.TextChannel, discord.Thread)):
+            return None
+        if channel.guild.id != guild.id:
+            # Cross-guild reference — don't read content from another server.
+            return None
+        try:
+            messages = await self._budgeted_history(
+                channel.history(limit=REFERENCED_HISTORY_LIMIT, oldest_first=False),
+                REFERENCED_CHAR_BUDGET,
+            )
+        except (discord.Forbidden, discord.HTTPException):
+            logger.warning(
+                "Could not fetch referenced channel %s", channel_id, exc_info=True
+            )
+            return None
+        if not messages:
+            return None
+        return ReferencedConversation(title=channel.name, messages=messages)
 
 
 def _truncate_to_budget(text: str, limit: int) -> str:

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter.py
@@ -427,23 +427,22 @@ class DiscordAdapter(PlatformAdapter):
             if channel_type == "thread" and bot_mentioned:
                 thread_history = await self._thread_history(message)
 
-            message_text = self._message_text(message)
-            # Scan only the user's own message for references — links inside a
-            # replied-to message are quoted context, not the user's request, so
-            # reference handling runs before reply context is prepended.
-            referenced = await self._fetch_referenced_conversations(
-                message, message_text
-            )
+            own_text = self._strip_mentions(message)
+            # Scan ONLY the user's own typed message for references. Links inside
+            # a forwarded or replied-to message are quoted context, not the
+            # user's request, so they must not be auto-fetched or rewritten.
+            referenced = await self._fetch_referenced_conversations(message, own_text)
             if referenced:
                 # Swap the raw channel links/mentions for readable "#name"
                 # tokens — the fetched content is supplied under those names, so
                 # this stops the model from treating the paste as a URL it must
                 # open (and then claiming it can't access Discord).
-                message_text = replace_referenced_links(
-                    message_text, {c.channel_id: c.title for c in referenced}
+                own_text = replace_referenced_links(
+                    own_text, {c.channel_id: c.title for c in referenced}
                 )
-            # Reply context is added last so its own links stay untouched —
-            # neither fetched nor rewritten.
+            # Fold in forwarded content and the replied-to message as quoted
+            # context — both verbatim, with their links left untouched.
+            message_text = self._compose_with_forward(message, own_text)
             message_text = await self._with_reply_context(message, message_text)
             ctx = MessageContext(
                 platform="discord",
@@ -513,7 +512,14 @@ class DiscordAdapter(PlatformAdapter):
         message entirely, so the LLM acts on just the comment and can badly
         misread the request. Stitch the forwarded content back in here.
         """
-        own = self._strip_mentions(message)
+        return self._compose_with_forward(message, self._strip_mentions(message))
+
+    def _compose_with_forward(self, message: discord.Message, own: str) -> str:
+        """Fold any forwarded snapshot content onto the user's own text.
+
+        Kept separate from reference scanning so forwarded content (quoted, not
+        the user's request) is never mined for channel links to auto-fetch.
+        """
         forwarded = self._forwarded_text(message)
         if not forwarded:
             return own

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter.py
@@ -670,7 +670,15 @@ class DiscordAdapter(PlatformAdapter):
         """
         if message.guild is None:
             return ()
-        requester = message.guild.get_member(message.author.id)
+        # ``message.author`` IS the guild Member (the gateway attaches it to the
+        # event); ``get_member`` only reads the cache, which is empty without the
+        # privileged members intent — so prefer the author and fall back to the
+        # cache only if it somehow isn't a Member (e.g. a webhook).
+        requester = (
+            message.author
+            if isinstance(message.author, discord.Member)
+            else message.guild.get_member(message.author.id)
+        )
         if requester is None:
             return ()
         targets = extract_referenced_targets(

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter.py
@@ -428,7 +428,9 @@ class DiscordAdapter(PlatformAdapter):
                 thread_history = await self._thread_history(message)
 
             message_text = self._message_text(message)
-            message_text = await self._with_reply_context(message, message_text)
+            # Scan only the user's own message for references — links inside a
+            # replied-to message are quoted context, not the user's request, so
+            # reference handling runs before reply context is prepended.
             referenced = await self._fetch_referenced_conversations(
                 message, message_text
             )
@@ -440,6 +442,9 @@ class DiscordAdapter(PlatformAdapter):
                 message_text = replace_referenced_links(
                     message_text, {c.channel_id: c.title for c in referenced}
                 )
+            # Reply context is added last so its own links stay untouched —
+            # neither fetched nor rewritten.
+            message_text = await self._with_reply_context(message, message_text)
             ctx = MessageContext(
                 platform="discord",
                 channel_type=channel_type,

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter.py
@@ -421,6 +421,7 @@ class DiscordAdapter(PlatformAdapter):
                 thread_history = await self._thread_history(message)
 
             message_text = self._message_text(message)
+            message_text = await self._with_reply_context(message, message_text)
             referenced = await self._fetch_referenced_conversations(
                 message, message_text
             )
@@ -507,6 +508,46 @@ class DiscordAdapter(PlatformAdapter):
         if own:
             return f"{own}\n\n[Forwarded message]\n{forwarded}"
         return f"[Forwarded message]\n{forwarded}"
+
+    async def _with_reply_context(
+        self, message: discord.Message, message_text: str
+    ) -> str:
+        """Prepend the replied-to message so the bot sees what's being answered.
+
+        A Discord reply (``message.reference``) only carries the short reply
+        text; the message it replies to holds the actual intent. It's always in
+        the same channel the user is already posting in, so surfacing it leaks
+        nothing they can't already see.
+        """
+        replied = await self._resolve_reply(message)
+        if replied is None:
+            return message_text
+        quoted = self._message_text(replied)
+        if not quoted:
+            return message_text
+        prefix = f"[Replying to {replied.author.display_name}]\n{quoted}"
+        return f"{prefix}\n\n{message_text}" if message_text else prefix
+
+    async def _resolve_reply(
+        self, message: discord.Message
+    ) -> Optional[discord.Message]:
+        ref = message.reference
+        if ref is None:
+            return None
+        # Forwards also use ``reference`` but carry their body in snapshots,
+        # which ``_message_text`` already stitches in — don't re-resolve those.
+        if getattr(message, "message_snapshots", None):
+            return None
+        if isinstance(ref.resolved, discord.Message):
+            return ref.resolved
+        if ref.message_id is None or not isinstance(
+            message.channel, discord.abc.Messageable
+        ):
+            return None
+        try:
+            return await message.channel.fetch_message(ref.message_id)
+        except (discord.NotFound, discord.Forbidden, discord.HTTPException):
+            return None
 
     @staticmethod
     def _forwarded_text(message: discord.Message) -> str:

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter_test.py
@@ -1002,6 +1002,7 @@ class TestFetchReferencedConversations:
 
         assert len(result) == 1
         assert result[0].title == "Release v0.6.61"
+        assert result[0].channel_id == "222"
         assert result[0].messages[0].text == "bump the version"
 
     @pytest.mark.asyncio

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter_test.py
@@ -953,6 +953,38 @@ class TestReplyContext:
         assert ctx.referenced_conversations == ()
         assert "https://discord.com/channels/111/222/333" in ctx.text
 
+    @pytest.mark.asyncio
+    async def test_links_inside_forwarded_message_are_not_fetched(self):
+        # A link that only appears in a forwarded message is quoted context,
+        # not the user's request — it must not be fetched or rewritten.
+        adapter, client = _bare_adapter(bot_id=1000)
+        callback = AsyncMock()
+        adapter.on_message(callback)
+        handlers = _register_events_with_mocked_decorator(adapter)
+
+        guild = MagicMock(id=111)
+        guild.get_member = MagicMock(return_value=MagicMock(spec=discord.Member))
+        msg = MagicMock()
+        msg.id = 999
+        msg.author = MagicMock(id=2000, bot=False, display_name="Bently")
+        msg.guild = guild
+        msg.channel = MagicMock(id=555)
+        msg.content = "<@1000> look at this"  # no link of its own
+        msg.mentions = [_mention(1000, "AutoPilot")]
+        msg.message_snapshots = [
+            _snapshot("see https://discord.com/channels/111/222/333")
+        ]
+        msg.reference = None
+
+        await handlers["on_message"](msg)
+
+        callback.assert_awaited_once()
+        ctx = callback.await_args.args[0]
+        client.get_channel.assert_not_called()
+        assert ctx.referenced_conversations == ()
+        assert "[Forwarded message]" in ctx.text
+        assert "https://discord.com/channels/111/222/333" in ctx.text
+
 
 # ── Proactive output (backend → platform) ──────────────────────────────
 

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter_test.py
@@ -919,6 +919,40 @@ class TestReplyContext:
         assert "fact about space" in ctx.text
         assert "can you tell me?" in ctx.text
 
+    @pytest.mark.asyncio
+    async def test_links_inside_replied_message_are_not_fetched(self):
+        # A link that only appears in the quoted reply (not the user's own
+        # message) is context, not a request — it must not trigger a fetch or
+        # get rewritten. Guards against scanning the combined text.
+        adapter, client = _bare_adapter(bot_id=1000)
+        callback = AsyncMock()
+        adapter.on_message(callback)
+        handlers = _register_events_with_mocked_decorator(adapter)
+
+        replied = self._replied(
+            "see https://discord.com/channels/111/222/333", author_name="Krz"
+        )
+        guild = MagicMock(id=111)
+        guild.get_member = MagicMock(return_value=MagicMock(spec=discord.Member))
+        msg = MagicMock()
+        msg.id = 999
+        msg.author = MagicMock(id=2000, bot=False, display_name="Bently")
+        msg.guild = guild
+        msg.channel = MagicMock(id=555)
+        msg.content = "<@1000> thanks!"  # no link of its own
+        msg.mentions = [_mention(1000, "AutoPilot")]
+        msg.message_snapshots = []
+        msg.reference = MagicMock(resolved=replied)
+
+        await handlers["on_message"](msg)
+
+        callback.assert_awaited_once()
+        ctx = callback.await_args.args[0]
+        # No channel history fetched, and the quoted link is left as-is.
+        client.get_channel.assert_not_called()
+        assert ctx.referenced_conversations == ()
+        assert "https://discord.com/channels/111/222/333" in ctx.text
+
 
 # ── Proactive output (backend → platform) ──────────────────────────────
 

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter_test.py
@@ -789,6 +789,41 @@ class TestLockedThread:
 
         callback.assert_awaited_once()
 
+    @pytest.mark.asyncio
+    async def test_on_message_rewrites_referenced_links_in_text(self):
+        # End-to-end through on_message: a channel @mention linking another
+        # channel attaches that conversation and rewrites the raw link into a
+        # readable #name in the forwarded text.
+        adapter, client = _bare_adapter(bot_id=1000)
+        callback = AsyncMock()
+        adapter.on_message(callback)
+        handlers = _register_events_with_mocked_decorator(adapter)
+
+        ref = _referenced_channel(
+            "general", 111, [_prior(2000, "Krz", "the decision was X")]
+        )
+        client.get_channel.return_value = ref
+
+        guild = MagicMock(id=111)
+        guild.get_member = MagicMock(return_value=MagicMock(spec=discord.Member))
+        msg = MagicMock()
+        msg.id = 999
+        msg.author = MagicMock(id=2000, bot=False, display_name="Bently")
+        msg.guild = guild
+        msg.channel = MagicMock(id=555)  # a normal channel, not a Thread
+        msg.content = "<@1000> read https://discord.com/channels/111/222/333"
+        msg.mentions = [_mention(1000, "AutoPilot")]
+        msg.message_snapshots = []
+
+        await handlers["on_message"](msg)
+
+        callback.assert_awaited_once()
+        ctx = callback.await_args.args[0]
+        assert len(ctx.referenced_conversations) == 1
+        assert ctx.referenced_conversations[0].title == "general"
+        assert "#general" in ctx.text
+        assert "discord.com/channels" not in ctx.text
+
 
 # ── Proactive output (backend → platform) ──────────────────────────────
 
@@ -1075,3 +1110,35 @@ class TestFetchReferencedConversations:
         )
         assert result == ()
         client.get_channel.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_skips_non_text_channel(self):
+        # A reference that resolves to e.g. a voice/category channel — not
+        # something we can read history from.
+        adapter, client = _bare_adapter()
+        client.get_channel.return_value = MagicMock()  # not a TextChannel/Thread
+        result = await adapter._fetch_referenced_conversations(
+            _incoming(111, 555), "https://discord.com/channels/111/222/333"
+        )
+        assert result == ()
+
+    @pytest.mark.asyncio
+    async def test_returns_nothing_when_history_errors(self):
+        adapter, client = _bare_adapter()
+        ref = _referenced_channel("Boom", 111, [])
+        ref.history = MagicMock(side_effect=discord.HTTPException(MagicMock(), "boom"))
+        client.get_channel.return_value = ref
+        result = await adapter._fetch_referenced_conversations(
+            _incoming(111, 555), "https://discord.com/channels/111/222/333"
+        )
+        assert result == ()
+
+    @pytest.mark.asyncio
+    async def test_skips_channel_with_no_readable_messages(self):
+        adapter, client = _bare_adapter()
+        ref = _referenced_channel("Empty", 111, [])
+        client.get_channel.return_value = ref
+        result = await adapter._fetch_referenced_conversations(
+            _incoming(111, 555), "https://discord.com/channels/111/222/333"
+        )
+        assert result == ()

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter_test.py
@@ -825,6 +825,101 @@ class TestLockedThread:
         assert "discord.com/channels" not in ctx.text
 
 
+class TestReplyContext:
+    @staticmethod
+    def _replied(content: str, author_name: str = "Bently") -> MagicMock:
+        replied = MagicMock(spec=discord.Message)
+        replied.content = content
+        replied.mentions = []
+        replied.message_snapshots = []
+        replied.author = MagicMock(display_name=author_name)
+        return replied
+
+    @pytest.mark.asyncio
+    async def test_resolve_reply_uses_resolved_message(self):
+        adapter, _ = _bare_adapter()
+        replied = self._replied("fact about space")
+        msg = MagicMock()
+        msg.message_snapshots = []
+        msg.reference = MagicMock(resolved=replied)
+        assert await adapter._resolve_reply(msg) is replied
+
+    @pytest.mark.asyncio
+    async def test_no_reference_resolves_to_none(self):
+        adapter, _ = _bare_adapter()
+        msg = MagicMock()
+        msg.reference = None
+        assert await adapter._resolve_reply(msg) is None
+
+    @pytest.mark.asyncio
+    async def test_forward_is_not_treated_as_reply(self):
+        # A forward also populates ``reference`` but is handled via snapshots.
+        adapter, _ = _bare_adapter()
+        msg = MagicMock()
+        msg.message_snapshots = [MagicMock()]
+        msg.reference = MagicMock(resolved=self._replied("x"))
+        assert await adapter._resolve_reply(msg) is None
+
+    @pytest.mark.asyncio
+    async def test_fetches_reply_when_not_resolved(self):
+        adapter, _ = _bare_adapter()
+        replied = self._replied("fetched body")
+        channel = MagicMock(spec=discord.TextChannel)
+        channel.fetch_message = AsyncMock(return_value=replied)
+        msg = MagicMock()
+        msg.message_snapshots = []
+        msg.reference = MagicMock(resolved=None, message_id=42)
+        msg.channel = channel
+        assert await adapter._resolve_reply(msg) is replied
+        channel.fetch_message.assert_awaited_once_with(42)
+
+    @pytest.mark.asyncio
+    async def test_with_reply_context_prepends_quoted_message(self):
+        adapter, _ = _bare_adapter()
+        replied = self._replied("fact about space", author_name="AutoBoostBot")
+        msg = MagicMock()
+        msg.message_snapshots = []
+        msg.reference = MagicMock(resolved=replied)
+        out = await adapter._with_reply_context(msg, "can you tell me?")
+        assert "[Replying to AutoBoostBot]" in out
+        assert "fact about space" in out
+        assert out.endswith("can you tell me?")
+
+    @pytest.mark.asyncio
+    async def test_with_reply_context_noop_without_reply(self):
+        adapter, _ = _bare_adapter()
+        msg = MagicMock()
+        msg.reference = None
+        assert await adapter._with_reply_context(msg, "hi") == "hi"
+
+    @pytest.mark.asyncio
+    async def test_on_message_includes_replied_message(self):
+        adapter, _ = _bare_adapter(bot_id=1000)
+        callback = AsyncMock()
+        adapter.on_message(callback)
+        handlers = _register_events_with_mocked_decorator(adapter)
+
+        replied = self._replied("fact about space", author_name="AutoBoostBot")
+        guild = MagicMock(id=111)
+        guild.get_member = MagicMock(return_value=MagicMock(spec=discord.Member))
+        msg = MagicMock()
+        msg.id = 999
+        msg.author = MagicMock(id=2000, bot=False, display_name="Bently")
+        msg.guild = guild
+        msg.channel = MagicMock(id=555)  # a normal channel, not a Thread
+        msg.content = "<@1000> can you tell me?"
+        msg.mentions = [_mention(1000, "AutoPilot")]
+        msg.message_snapshots = []
+        msg.reference = MagicMock(resolved=replied)
+
+        await handlers["on_message"](msg)
+
+        callback.assert_awaited_once()
+        ctx = callback.await_args.args[0]
+        assert "fact about space" in ctx.text
+        assert "can you tell me?" in ctx.text
+
+
 # ── Proactive output (backend → platform) ──────────────────────────────
 
 

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter_test.py
@@ -1174,6 +1174,25 @@ class TestFetchReferencedConversations:
         assert result[0].messages[0].text == "bump the version"
 
     @pytest.mark.asyncio
+    async def test_uses_message_author_when_member_cache_is_empty(self):
+        # The bot runs without the privileged members intent, so
+        # guild.get_member can return None. message.author is the authoritative
+        # Member for guild messages and must be used instead.
+        adapter, client = _bare_adapter()
+        ref = _referenced_channel("general", 111, [_prior(1, "A", "hi there")])
+        client.get_channel.return_value = ref
+        message = _incoming(111, 555)
+        message.guild.get_member = MagicMock(return_value=None)  # cache miss
+        message.author = MagicMock(spec=discord.Member, id=42)
+
+        result = await adapter._fetch_referenced_conversations(
+            message, "https://discord.com/channels/111/222/333"
+        )
+
+        assert len(result) == 1
+        assert result[0].messages[0].text == "hi there"
+
+    @pytest.mark.asyncio
     async def test_fetches_specific_message_in_current_channel(self):
         # A permalink to a specific message in the channel the user is posting
         # in is a real "read this exact message" request, not redundant context.

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter_test.py
@@ -958,3 +958,78 @@ class TestProactiveOutput:
 
         assert ref is not None
         assert ref.id == "777"
+
+
+# ── Referenced-conversation fetch ──────────────────────────────────────
+
+
+def _referenced_channel(name: str, guild_id: int, priors: list[MagicMock]) -> MagicMock:
+    channel = MagicMock(spec=discord.TextChannel)
+    channel.name = name
+    channel.guild = MagicMock(id=guild_id)
+    channel.history = MagicMock(return_value=_AsyncHistory(priors))
+    return channel
+
+
+def _prior(author_id: int, display_name: str, content: str) -> MagicMock:
+    msg = MagicMock()
+    msg.author = MagicMock(id=author_id, display_name=display_name)
+    msg.content = content
+    msg.mentions = []
+    return msg
+
+
+def _incoming(guild_id: int | None, channel_id: int) -> MagicMock:
+    message = MagicMock()
+    message.guild = MagicMock(id=guild_id) if guild_id is not None else None
+    message.channel = MagicMock(id=channel_id)
+    return message
+
+
+class TestFetchReferencedConversations:
+    @pytest.mark.asyncio
+    async def test_fetches_same_guild_referenced_thread(self):
+        adapter, client = _bare_adapter()
+        ref = _referenced_channel(
+            "Release v0.6.61", 111, [_prior(2000, "Krz", "bump the version")]
+        )
+        client.get_channel.return_value = ref
+
+        result = await adapter._fetch_referenced_conversations(
+            _incoming(111, 555),
+            "find my mentions in https://discord.com/channels/111/222/333",
+        )
+
+        assert len(result) == 1
+        assert result[0].title == "Release v0.6.61"
+        assert result[0].messages[0].text == "bump the version"
+
+    @pytest.mark.asyncio
+    async def test_skips_cross_guild_reference(self):
+        adapter, client = _bare_adapter()
+        ref = _referenced_channel("Other", 999, [_prior(2000, "X", "secret")])
+        client.get_channel.return_value = ref
+
+        result = await adapter._fetch_referenced_conversations(
+            _incoming(111, 555), "https://discord.com/channels/999/222/333"
+        )
+
+        assert result == ()
+
+    @pytest.mark.asyncio
+    async def test_no_reference_makes_no_fetch(self):
+        adapter, client = _bare_adapter()
+        result = await adapter._fetch_referenced_conversations(
+            _incoming(111, 555), "just a normal message"
+        )
+        assert result == ()
+        client.get_channel.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_dm_with_no_guild_skips(self):
+        adapter, client = _bare_adapter()
+        result = await adapter._fetch_referenced_conversations(
+            _incoming(None, 555), "<#222>"
+        )
+        assert result == ()
+        client.get_channel.assert_not_called()

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter_test.py
@@ -1105,6 +1105,32 @@ def _referenced_channel(
     return channel
 
 
+def _referenced_thread(
+    guild_id: int,
+    priors: list[MagicMock],
+    *,
+    is_private: bool = True,
+    is_member: bool = True,
+    manage_threads: bool = False,
+) -> MagicMock:
+    thread = MagicMock(spec=discord.Thread)
+    thread.name = "secret-thread"
+    thread.guild = MagicMock(id=guild_id)
+    thread.history = MagicMock(return_value=_AsyncHistory(priors))
+    thread.is_private = MagicMock(return_value=is_private)
+    perms = MagicMock(
+        view_channel=True, read_message_history=True, manage_threads=manage_threads
+    )
+    thread.permissions_for = MagicMock(return_value=perms)
+    if is_member:
+        thread.fetch_member = AsyncMock(return_value=MagicMock())
+    else:
+        thread.fetch_member = AsyncMock(
+            side_effect=discord.NotFound(MagicMock(status=404), "not a member")
+        )
+    return thread
+
+
 def _prior(author_id: int, display_name: str, content: str) -> MagicMock:
     msg = MagicMock()
     msg.author = MagicMock(id=author_id, display_name=display_name)
@@ -1146,6 +1172,64 @@ class TestFetchReferencedConversations:
         assert result[0].title == "Release v0.6.61"
         assert result[0].channel_id == "222"
         assert result[0].messages[0].text == "bump the version"
+
+    @pytest.mark.asyncio
+    async def test_fetches_specific_message_in_current_channel(self):
+        # A permalink to a specific message in the channel the user is posting
+        # in is a real "read this exact message" request, not redundant context.
+        adapter, client = _bare_adapter()
+        ref = _referenced_channel("autopilot", 111, [_prior(1, "A", "the answer")])
+        client.get_channel.return_value = ref
+
+        result = await adapter._fetch_referenced_conversations(
+            _incoming(111, 222),  # current channel == the linked channel
+            "https://discord.com/channels/111/222/333",
+        )
+
+        assert len(result) == 1
+        assert result[0].messages[0].text == "the answer"
+
+    @pytest.mark.asyncio
+    async def test_skips_private_thread_when_requester_not_member(self):
+        # The bot is in the private thread, but the requester isn't — its
+        # content must not leak to them.
+        adapter, client = _bare_adapter()
+        thread = _referenced_thread(111, [_prior(1, "A", "secret")], is_member=False)
+        client.get_channel.return_value = thread
+
+        result = await adapter._fetch_referenced_conversations(
+            _incoming(111, 555), "https://discord.com/channels/111/222/333"
+        )
+
+        assert result == ()
+
+    @pytest.mark.asyncio
+    async def test_reads_private_thread_when_requester_is_member(self):
+        adapter, client = _bare_adapter()
+        thread = _referenced_thread(111, [_prior(1, "A", "secret")], is_member=True)
+        client.get_channel.return_value = thread
+
+        result = await adapter._fetch_referenced_conversations(
+            _incoming(111, 555), "https://discord.com/channels/111/222/333"
+        )
+
+        assert len(result) == 1
+        assert result[0].messages[0].text == "secret"
+
+    @pytest.mark.asyncio
+    async def test_reads_private_thread_with_manage_threads(self):
+        # manage_threads grants access like it does in the Discord client.
+        adapter, client = _bare_adapter()
+        thread = _referenced_thread(
+            111, [_prior(1, "A", "secret")], is_member=False, manage_threads=True
+        )
+        client.get_channel.return_value = thread
+
+        result = await adapter._fetch_referenced_conversations(
+            _incoming(111, 555), "https://discord.com/channels/111/222/333"
+        )
+
+        assert len(result) == 1
 
     @pytest.mark.asyncio
     async def test_skips_cross_guild_reference(self):

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter_test.py
@@ -963,11 +963,15 @@ class TestProactiveOutput:
 # ── Referenced-conversation fetch ──────────────────────────────────────
 
 
-def _referenced_channel(name: str, guild_id: int, priors: list[MagicMock]) -> MagicMock:
+def _referenced_channel(
+    name: str, guild_id: int, priors: list[MagicMock], *, can_access: bool = True
+) -> MagicMock:
     channel = MagicMock(spec=discord.TextChannel)
     channel.name = name
     channel.guild = MagicMock(id=guild_id)
     channel.history = MagicMock(return_value=_AsyncHistory(priors))
+    perms = MagicMock(view_channel=can_access, read_message_history=can_access)
+    channel.permissions_for = MagicMock(return_value=perms)
     return channel
 
 
@@ -981,8 +985,16 @@ def _prior(author_id: int, display_name: str, content: str) -> MagicMock:
 
 def _incoming(guild_id: int | None, channel_id: int) -> MagicMock:
     message = MagicMock()
-    message.guild = MagicMock(id=guild_id) if guild_id is not None else None
     message.channel = MagicMock(id=channel_id)
+    message.author = MagicMock(id=42)
+    if guild_id is None:
+        message.guild = None
+    else:
+        guild = MagicMock(id=guild_id)
+        # By default the requester is a member of the guild; tests override
+        # get_member / channel perms to exercise the access checks.
+        guild.get_member = MagicMock(return_value=MagicMock(spec=discord.Member))
+        message.guild = guild
     return message
 
 
@@ -1016,6 +1028,35 @@ class TestFetchReferencedConversations:
         )
 
         assert result == ()
+
+    @pytest.mark.asyncio
+    async def test_skips_channel_requester_cannot_view(self):
+        # The bot's gateway can read this channel, but the requesting member
+        # can't — its history must not leak to them.
+        adapter, client = _bare_adapter()
+        ref = _referenced_channel(
+            "Private", 111, [_prior(2000, "X", "secret")], can_access=False
+        )
+        client.get_channel.return_value = ref
+
+        result = await adapter._fetch_referenced_conversations(
+            _incoming(111, 555), "https://discord.com/channels/111/222/333"
+        )
+
+        assert result == ()
+
+    @pytest.mark.asyncio
+    async def test_skips_when_requester_not_a_member(self):
+        adapter, client = _bare_adapter()
+        message = _incoming(111, 555)
+        message.guild.get_member = MagicMock(return_value=None)
+
+        result = await adapter._fetch_referenced_conversations(
+            message, "https://discord.com/channels/111/222/333"
+        )
+
+        assert result == ()
+        client.get_channel.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_no_reference_makes_no_fetch(self):

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/references.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/references.py
@@ -43,3 +43,20 @@ def extract_referenced_channel_ids(
         seen.add(channel_id)
         ids.append(channel_id)
     return ids[:limit]
+
+
+def replace_referenced_links(text: str, labels: dict[str, str]) -> str:
+    """Rewrite each channel link / ``<#id>`` mention into a readable ``#label``.
+
+    Only references whose channel ID is in ``labels`` (the ones we actually
+    fetched) are rewritten; anything else is left untouched. This keeps the
+    model from fixating on a raw URL it thinks it must open, when the linked
+    content has already been supplied to it under that ``#label``.
+    """
+
+    def _sub(match: "re.Match[str]") -> str:
+        channel_id = match.group(1) or match.group(2)
+        label = labels.get(channel_id)
+        return f"#{label}" if label else match.group(0)
+
+    return _REFERENCE_RE.sub(_sub, text)

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/references.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/references.py
@@ -1,0 +1,45 @@
+"""Parse Discord channel/thread references out of message text.
+
+A user often points the bot at another thread by pasting its link
+(``https://discord.com/channels/<guild>/<channel>/<message>``) or @-mentioning
+it (``<#channel_id>``). This module extracts the referenced channel/thread IDs
+so the adapter can fetch their content via the gateway — no parsing logic that
+needs a live Discord connection lives here, so it's cheap to test.
+"""
+
+import re
+
+# A single positional pass over either form so references are returned in the
+# order they appear in the text:
+#   - link group: discord.com / discordapp.com / canary. / ptb. channel link —
+#     the second path segment is the channel/thread ID (third, the message ID,
+#     is ignored).
+#   - mention group: ``<#channel_id>``, how "#frontend" serializes on the wire.
+_REFERENCE_RE = re.compile(
+    r"https?://(?:\w+\.)?discord(?:app)?\.com/channels/\d+/(\d+)(?:/\d+)?" r"|<#(\d+)>",
+    re.IGNORECASE,
+)
+
+
+def extract_referenced_channel_ids(
+    text: str,
+    *,
+    exclude_channel_id: str,
+    limit: int,
+) -> list[str]:
+    """Return de-duplicated channel/thread IDs referenced in ``text``.
+
+    Order follows first appearance in the text, the current channel is skipped
+    (its history is already supplied as thread context), and the result is
+    capped at ``limit`` so a message full of links can't trigger an unbounded
+    number of fetches.
+    """
+    seen: set[str] = {exclude_channel_id}
+    ids: list[str] = []
+    for match in _REFERENCE_RE.finditer(text):
+        channel_id = match.group(1) or match.group(2)
+        if channel_id in seen:
+            continue
+        seen.add(channel_id)
+        ids.append(channel_id)
+    return ids[:limit]

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/references.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/references.py
@@ -9,7 +9,8 @@ live Discord connection lives here, so it's cheap to test.
 """
 
 import re
-from dataclasses import dataclass
+
+from pydantic import BaseModel, ConfigDict
 
 # A single positional pass over either form so references are returned in the
 # order they appear in the text:
@@ -24,10 +25,11 @@ _REFERENCE_RE = re.compile(
 )
 
 
-@dataclass(frozen=True)
-class ReferenceTarget:
+class ReferenceTarget(BaseModel):
     """A channel/thread the message points at, plus the specific message ID
     when the link named one (a ``.../channel/message`` permalink)."""
+
+    model_config = ConfigDict(frozen=True)
 
     channel_id: str
     message_id: str | None

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/references.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/references.py
@@ -1,48 +1,71 @@
 """Parse Discord channel/thread references out of message text.
 
-A user often points the bot at another thread by pasting its link
+A user often points the bot at another conversation by pasting its link
 (``https://discord.com/channels/<guild>/<channel>/<message>``) or @-mentioning
-it (``<#channel_id>``). This module extracts the referenced channel/thread IDs
-so the adapter can fetch their content via the gateway — no parsing logic that
-needs a live Discord connection lives here, so it's cheap to test.
+a channel (``<#channel_id>``). This module extracts the referenced
+channel/thread (and the specific message, when the link names one) so the
+adapter can fetch their content via the gateway — no parsing logic that needs a
+live Discord connection lives here, so it's cheap to test.
 """
 
 import re
+from dataclasses import dataclass
 
 # A single positional pass over either form so references are returned in the
 # order they appear in the text:
 #   - link group: discord.com / discordapp.com / canary. / ptb. channel link —
-#     the second path segment is the channel/thread ID (third, the message ID,
-#     is ignored).
+#     the second path segment is the channel/thread ID, the optional third is a
+#     specific message ID.
 #   - mention group: ``<#channel_id>``, how "#frontend" serializes on the wire.
 _REFERENCE_RE = re.compile(
-    r"https?://(?:\w+\.)?discord(?:app)?\.com/channels/\d+/(\d+)(?:/\d+)?" r"|<#(\d+)>",
+    r"https?://(?:\w+\.)?discord(?:app)?\.com/channels/\d+/(\d+)(?:/(\d+))?"
+    r"|<#(\d+)>",
     re.IGNORECASE,
 )
 
 
-def extract_referenced_channel_ids(
+@dataclass(frozen=True)
+class ReferenceTarget:
+    """A channel/thread the message points at, plus the specific message ID
+    when the link named one (a ``.../channel/message`` permalink)."""
+
+    channel_id: str
+    message_id: str | None
+
+
+def _match_target(match: "re.Match[str]") -> ReferenceTarget:
+    # group(1)/group(2): channel + optional message from a permalink;
+    # group(3): channel from a ``<#id>`` mention (never names a message).
+    channel_id = match.group(1) or match.group(3)
+    return ReferenceTarget(channel_id=channel_id, message_id=match.group(2))
+
+
+def extract_referenced_targets(
     text: str,
     *,
     exclude_channel_id: str,
     limit: int,
-) -> list[str]:
-    """Return de-duplicated channel/thread IDs referenced in ``text``.
+) -> list[ReferenceTarget]:
+    """Return de-duplicated reference targets in ``text``, in first-seen order.
 
-    Order follows first appearance in the text, the current channel is skipped
-    (its history is already supplied as thread context), and the result is
-    capped at ``limit`` so a message full of links can't trigger an unbounded
-    number of fetches.
+    A bare channel reference to the *current* channel is skipped — its history
+    is already supplied as context. A permalink to a *specific message* is kept
+    even in the current channel: "what was said here <link>" is a request to
+    read that exact message, not redundant. Capped at ``limit`` so a link-heavy
+    message can't fan out into unbounded fetches.
     """
-    seen: set[str] = {exclude_channel_id}
-    ids: list[str] = []
+    seen: set[tuple[str, str | None]] = set()
+    targets: list[ReferenceTarget] = []
     for match in _REFERENCE_RE.finditer(text):
-        channel_id = match.group(1) or match.group(2)
-        if channel_id in seen:
+        target = _match_target(match)
+        if target.message_id is None and target.channel_id == exclude_channel_id:
             continue
-        seen.add(channel_id)
-        ids.append(channel_id)
-    return ids[:limit]
+        key = (target.channel_id, target.message_id)
+        if key in seen:
+            continue
+        seen.add(key)
+        targets.append(target)
+    return targets[:limit]
 
 
 def replace_referenced_links(text: str, labels: dict[str, str]) -> str:
@@ -55,7 +78,7 @@ def replace_referenced_links(text: str, labels: dict[str, str]) -> str:
     """
 
     def _sub(match: "re.Match[str]") -> str:
-        channel_id = match.group(1) or match.group(2)
+        channel_id = match.group(1) or match.group(3)
         label = labels.get(channel_id)
         return f"#{label}" if label else match.group(0)
 

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/references_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/references_test.py
@@ -89,6 +89,8 @@ def test_replace_without_labels_is_noop():
 
 
 def test_reference_target_is_hashable():
-    # Used in a set for de-duplication.
-    assert ReferenceTarget("1", None) == ReferenceTarget("1", None)
-    assert len({ReferenceTarget("1", "2"), ReferenceTarget("1", "2")}) == 1
+    # Frozen model — equal values compare equal and collapse in a set.
+    a = ReferenceTarget(channel_id="1", message_id="2")
+    b = ReferenceTarget(channel_id="1", message_id="2")
+    assert a == b
+    assert len({a, b}) == 1

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/references_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/references_test.py
@@ -2,6 +2,7 @@
 
 from backend.copilot.bot.adapters.discord.references import (
     extract_referenced_channel_ids,
+    replace_referenced_links,
 )
 
 
@@ -47,3 +48,30 @@ def test_respects_limit():
 
 def test_no_references_returns_empty():
     assert _extract("just a normal message, no links") == []
+
+
+# ── replace_referenced_links ───────────────────────────────────────────
+
+
+def test_replace_rewrites_link_to_readable_name():
+    text = "read into https://discord.com/channels/111/222/333 please"
+    out = replace_referenced_links(text, {"222": "Random Fact"})
+    assert out == "read into #Random Fact please"
+
+
+def test_replace_rewrites_channel_mention():
+    out = replace_referenced_links("look at <#999> ok", {"999": "standup"})
+    assert out == "look at #standup ok"
+
+
+def test_replace_leaves_unknown_references_untouched():
+    # Only channels we actually fetched (in the label map) get rewritten.
+    text = "https://discord.com/channels/1/222/3 and <#777>"
+    out = replace_referenced_links(text, {"222": "known"})
+    assert "#known" in out
+    assert "<#777>" in out
+
+
+def test_replace_without_labels_is_noop():
+    text = "https://discord.com/channels/1/2/3"
+    assert replace_referenced_links(text, {}) == text

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/references_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/references_test.py
@@ -1,0 +1,49 @@
+"""Tests for Discord reference extraction."""
+
+from backend.copilot.bot.adapters.discord.references import (
+    extract_referenced_channel_ids,
+)
+
+
+def _extract(text: str, exclude: str = "0", limit: int = 3) -> list[str]:
+    return extract_referenced_channel_ids(text, exclude_channel_id=exclude, limit=limit)
+
+
+def test_extracts_channel_id_from_thread_link():
+    text = "find my mentions in https://discord.com/channels/111/222/333 please"
+    assert _extract(text) == ["222"]
+
+
+def test_extracts_channel_mention():
+    assert _extract("can you help with <#999>?") == ["999"]
+
+
+def test_link_without_message_id():
+    assert _extract("https://discord.com/channels/111/222") == ["222"]
+
+
+def test_handles_subdomains_and_discordapp():
+    text = (
+        "old https://discordapp.com/channels/1/2/3 "
+        "canary https://canary.discord.com/channels/1/4/5"
+    )
+    assert _extract(text) == ["2", "4"]
+
+
+def test_dedupes_and_preserves_order():
+    text = "<#10> https://discord.com/channels/1/20/3 <#10> <#30>"
+    assert _extract(text) == ["10", "20", "30"]
+
+
+def test_excludes_current_channel():
+    text = "https://discord.com/channels/1/222/3 and <#222>"
+    assert _extract(text, exclude="222") == []
+
+
+def test_respects_limit():
+    text = "<#1> <#2> <#3> <#4> <#5>"
+    assert _extract(text, limit=2) == ["1", "2"]
+
+
+def test_no_references_returns_empty():
+    assert _extract("just a normal message, no links") == []

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/references_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/references_test.py
@@ -1,26 +1,30 @@
 """Tests for Discord reference extraction."""
 
 from backend.copilot.bot.adapters.discord.references import (
-    extract_referenced_channel_ids,
+    ReferenceTarget,
+    extract_referenced_targets,
     replace_referenced_links,
 )
 
 
-def _extract(text: str, exclude: str = "0", limit: int = 3) -> list[str]:
-    return extract_referenced_channel_ids(text, exclude_channel_id=exclude, limit=limit)
+def _extract(
+    text: str, exclude: str = "0", limit: int = 3
+) -> list[tuple[str, str | None]]:
+    targets = extract_referenced_targets(text, exclude_channel_id=exclude, limit=limit)
+    return [(t.channel_id, t.message_id) for t in targets]
 
 
-def test_extracts_channel_id_from_thread_link():
+def test_extracts_channel_and_message_from_permalink():
     text = "find my mentions in https://discord.com/channels/111/222/333 please"
-    assert _extract(text) == ["222"]
+    assert _extract(text) == [("222", "333")]
 
 
-def test_extracts_channel_mention():
-    assert _extract("can you help with <#999>?") == ["999"]
+def test_extracts_channel_mention_has_no_message():
+    assert _extract("can you help with <#999>?") == [("999", None)]
 
 
 def test_link_without_message_id():
-    assert _extract("https://discord.com/channels/111/222") == ["222"]
+    assert _extract("https://discord.com/channels/111/222") == [("222", None)]
 
 
 def test_handles_subdomains_and_discordapp():
@@ -28,22 +32,29 @@ def test_handles_subdomains_and_discordapp():
         "old https://discordapp.com/channels/1/2/3 "
         "canary https://canary.discord.com/channels/1/4/5"
     )
-    assert _extract(text) == ["2", "4"]
+    assert _extract(text) == [("2", "3"), ("4", "5")]
 
 
 def test_dedupes_and_preserves_order():
     text = "<#10> https://discord.com/channels/1/20/3 <#10> <#30>"
-    assert _extract(text) == ["10", "20", "30"]
+    assert _extract(text) == [("10", None), ("20", "3"), ("30", None)]
 
 
-def test_excludes_current_channel():
-    text = "https://discord.com/channels/1/222/3 and <#222>"
+def test_excludes_current_channel_for_bare_reference():
+    text = "https://discord.com/channels/1/222 and <#222>"
     assert _extract(text, exclude="222") == []
+
+
+def test_keeps_specific_message_even_in_current_channel():
+    # "what was said here <permalink>" targets one message, so a permalink to
+    # the current channel is a real request — not redundant context.
+    text = "https://discord.com/channels/1/222/333"
+    assert _extract(text, exclude="222") == [("222", "333")]
 
 
 def test_respects_limit():
     text = "<#1> <#2> <#3> <#4> <#5>"
-    assert _extract(text, limit=2) == ["1", "2"]
+    assert _extract(text, limit=2) == [("1", None), ("2", None)]
 
 
 def test_no_references_returns_empty():
@@ -75,3 +86,9 @@ def test_replace_leaves_unknown_references_untouched():
 def test_replace_without_labels_is_noop():
     text = "https://discord.com/channels/1/2/3"
     assert replace_referenced_links(text, {}) == text
+
+
+def test_reference_target_is_hashable():
+    # Used in a set for de-duplication.
+    assert ReferenceTarget("1", None) == ReferenceTarget("1", None)
+    assert len({ReferenceTarget("1", "2"), ReferenceTarget("1", "2")}) == 1

--- a/autogpt_platform/backend/backend/copilot/bot/handler.py
+++ b/autogpt_platform/backend/backend/copilot/bot/handler.py
@@ -104,7 +104,7 @@ class MessageHandler:
             char_count=len(ctx.text),
         )
 
-        message_text = self._message_text(ctx) if include_thread_history else ctx.text
+        message_text = self._message_text(ctx, include_thread_history)
         await self._enqueue_and_process(ctx, adapter, target_id, message_text)
 
     # -- Target resolution --
@@ -131,25 +131,36 @@ class MessageHandler:
 
     # -- Batched streaming --
 
-    def _message_text(self, ctx: MessageContext) -> str:
-        if not ctx.thread_history and not ctx.referenced_conversations:
+    def _message_text(self, ctx: MessageContext, include_thread_history: bool) -> str:
+        # Referenced conversations (links/@-mentions the user pasted) are always
+        # surfaced — that's the whole point of fetching them. Thread history is
+        # only included on the first @-into a thread we don't own; a subscribed
+        # thread's prior turns already live in the session.
+        thread_history = ctx.thread_history if include_thread_history else ()
+        if not thread_history and not ctx.referenced_conversations:
             return ctx.text
 
         platform_display = ctx.platform.capitalize()
         lines: list[str] = []
-        for convo in ctx.referenced_conversations:
-            # The bot already fetched this linked/@-referenced conversation via
-            # its own connection — tell the model so it reads the content below
-            # instead of trying to web-fetch the (JS-rendered) platform page.
+        if ctx.referenced_conversations:
+            # The user pointed at other channels/threads; their content is
+            # already fetched and inlined below. Lead with a firm instruction so
+            # the model answers from it instead of fixating on the link and
+            # claiming it can't access the platform.
             lines.append(
-                f"[Referenced {platform_display} conversation: {convo.title} — "
-                f"fetched for you; do not web-fetch {platform_display}]"
+                f"[The {platform_display} channel(s) the user referenced have "
+                f"already been read for you — their full content is included "
+                f"below under each #name. Answer directly from it. Do NOT say you "
+                f"can't open links or access {platform_display}; you already have "
+                f"the content.]"
             )
-            for entry in convo.messages:
-                lines.append(self._format_history_entry(entry, platform_display))
-        if ctx.thread_history:
-            lines.append("[Recent thread context before this message]")
-            for entry in ctx.thread_history:
+            for convo in ctx.referenced_conversations:
+                lines.append(f"\n[Content of #{convo.title}]")
+                for entry in convo.messages:
+                    lines.append(self._format_history_entry(entry, platform_display))
+        if thread_history:
+            lines.append("\n[Recent thread context before this message]")
+            for entry in thread_history:
                 lines.append(self._format_history_entry(entry, platform_display))
         lines.append(f"\n[Current message]\n{ctx.text}")
         return "\n".join(lines)

--- a/autogpt_platform/backend/backend/copilot/bot/handler.py
+++ b/autogpt_platform/backend/backend/copilot/bot/handler.py
@@ -25,7 +25,12 @@ from backend.util.exceptions import (
 from backend.util.settings import Settings
 
 from . import sessions, threads
-from .adapters.base import FileAttachment, MessageContext, PlatformAdapter
+from .adapters.base import (
+    FileAttachment,
+    MessageContext,
+    MessageHistoryEntry,
+    PlatformAdapter,
+)
 from .bot_backend import BotBackend, BotStreamError
 from .config import SESSION_TTL
 from .text import format_batch, split_at_boundary
@@ -127,20 +132,36 @@ class MessageHandler:
     # -- Batched streaming --
 
     def _message_text(self, ctx: MessageContext) -> str:
-        if not ctx.thread_history:
+        if not ctx.thread_history and not ctx.referenced_conversations:
             return ctx.text
 
         platform_display = ctx.platform.capitalize()
-        lines = ["[Recent thread context before this message]"]
-        for entry in ctx.thread_history:
-            user = (
-                f"{entry.username} ({platform_display} user ID: {entry.user_id})"
-                if entry.user_id
-                else entry.username
+        lines: list[str] = []
+        for convo in ctx.referenced_conversations:
+            # The bot already fetched this linked/@-referenced conversation via
+            # its own connection — tell the model so it reads the content below
+            # instead of trying to web-fetch the (JS-rendered) platform page.
+            lines.append(
+                f"[Referenced {platform_display} conversation: {convo.title} — "
+                f"fetched for you; do not web-fetch {platform_display}]"
             )
-            lines.append(f"\n[From {user}]\n{entry.text}")
+            for entry in convo.messages:
+                lines.append(self._format_history_entry(entry, platform_display))
+        if ctx.thread_history:
+            lines.append("[Recent thread context before this message]")
+            for entry in ctx.thread_history:
+                lines.append(self._format_history_entry(entry, platform_display))
         lines.append(f"\n[Current message]\n{ctx.text}")
         return "\n".join(lines)
+
+    @staticmethod
+    def _format_history_entry(entry: MessageHistoryEntry, platform_display: str) -> str:
+        user = (
+            f"{entry.username} ({platform_display} user ID: {entry.user_id})"
+            if entry.user_id
+            else entry.username
+        )
+        return f"\n[From {user}]\n{entry.text}"
 
     async def _enqueue_and_process(
         self,

--- a/autogpt_platform/backend/backend/copilot/bot/handler_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/handler_test.py
@@ -325,7 +325,8 @@ class TestThreadAdoption:
                     MessageHistoryEntry("Alice", "u-1", "I think option A"),
                     MessageHistoryEntry("Bob", "u-2", "Option B is safer"),
                 ),
-            )
+            ),
+            include_thread_history=True,
         )
 
         assert "Recent thread context" in text
@@ -333,6 +334,45 @@ class TestThreadAdoption:
         assert "I think option A" in text
         assert "Current message" in text
         assert "what should we do?" in text
+
+    @pytest.mark.asyncio
+    async def test_channel_mention_enqueues_referenced_conversation(self):
+        # A plain channel @mention (include_thread_history is False here) that
+        # references another conversation must still carry that fetched content
+        # into the enqueued prompt. Regression guard: the handler previously
+        # only rendered referenced conversations when pulling thread history,
+        # so channel mentions silently dropped them.
+        handler = MessageHandler(_api())
+        adapter = _adapter()
+        enqueue = AsyncMock()
+
+        with (
+            patch.object(handler, "_enqueue_and_process", new=enqueue),
+            patch("backend.copilot.bot.handler.threads.subscribe", new=AsyncMock()),
+        ):
+            await handler.handle(
+                _ctx(
+                    channel_type="channel",
+                    bot_mentioned=True,
+                    text="summarize the linked thread",
+                    referenced_conversations=(
+                        ReferencedConversation(
+                            title="Random Fact About Something",
+                            channel_id="c-1",
+                            messages=(
+                                MessageHistoryEntry("Krz", "u-2", "did you know X"),
+                            ),
+                        ),
+                    ),
+                ),
+                adapter,
+            )
+
+        enqueue.assert_awaited_once()
+        message_text = enqueue.await_args.args[3]
+        assert "[Content of #Random Fact About Something]" in message_text
+        assert "did you know X" in message_text
+        assert "can't open links or access Discord" in message_text
 
 
 class TestBatching:
@@ -832,15 +872,18 @@ class TestDeliverArtifact:
 class TestMessageTextReferencedConversations:
     def test_no_context_returns_bare_text(self):
         handler = MessageHandler(_api())
-        assert handler._message_text(_ctx(text="hi")) == "hi"
+        assert (
+            handler._message_text(_ctx(text="hi"), include_thread_history=False) == "hi"
+        )
 
-    def test_referenced_conversation_is_rendered_with_dont_webfetch_note(self):
+    def test_referenced_conversation_is_rendered_with_access_instruction(self):
         handler = MessageHandler(_api())
         ctx = _ctx(
             text="find my mentions",
             referenced_conversations=(
                 ReferencedConversation(
                     title="Release v0.6.61",
+                    channel_id="c-1",
                     messages=(
                         MessageHistoryEntry("Krz", "u-2", "remember to bump version"),
                         MessageHistoryEntry("Nick", "u-3", "and tag the release"),
@@ -848,9 +891,13 @@ class TestMessageTextReferencedConversations:
                 ),
             ),
         )
-        out = handler._message_text(ctx)
-        assert "Referenced Discord conversation: Release v0.6.61" in out
-        assert "do not web-fetch Discord" in out
+        # include_thread_history=False on purpose: a plain channel @mention must
+        # still surface referenced conversations (the bug this guards against).
+        out = handler._message_text(ctx, include_thread_history=False)
+        assert "[Content of #Release v0.6.61]" in out
+        # Firm instruction so the model answers from the supplied content instead
+        # of claiming it can't access the platform.
+        assert "can't open links or access Discord" in out
         assert "remember to bump version" in out
         assert "and tag the release" in out
         assert "[Current message]\nfind my mentions" in out
@@ -863,11 +910,12 @@ class TestMessageTextReferencedConversations:
             referenced_conversations=(
                 ReferencedConversation(
                     title="other-thread",
+                    channel_id="c-9",
                     messages=(MessageHistoryEntry("Bob", "u-9", "linked content"),),
                 ),
             ),
         )
-        out = handler._message_text(ctx)
+        out = handler._message_text(ctx, include_thread_history=True)
         assert "linked content" in out
         assert "Recent thread context" in out
         assert "earlier point" in out

--- a/autogpt_platform/backend/backend/copilot/bot/handler_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/handler_test.py
@@ -9,7 +9,12 @@ import pytest
 from backend.platform_linking.models import WorkspaceArtifact
 from backend.util.exceptions import DuplicateChatMessageError, NotFoundError
 
-from .adapters.base import ChannelType, MessageContext, MessageHistoryEntry
+from .adapters.base import (
+    ChannelType,
+    MessageContext,
+    MessageHistoryEntry,
+    ReferencedConversation,
+)
 from .bot_backend import LinkTokenResult, ResolveResult
 from .handler import MessageHandler, TargetState, build_thread_name, clamp_thread_name
 
@@ -25,6 +30,7 @@ def _ctx(
     text: str = "hello bot",
     bot_mentioned: bool = False,
     thread_history: tuple[MessageHistoryEntry, ...] = (),
+    referenced_conversations: tuple[ReferencedConversation, ...] = (),
 ) -> MessageContext:
     return MessageContext(
         platform="discord",
@@ -37,6 +43,7 @@ def _ctx(
         text=text,
         bot_mentioned=bot_mentioned,
         thread_history=thread_history,
+        referenced_conversations=referenced_conversations,
     )
 
 
@@ -820,3 +827,49 @@ class TestDeliverArtifact:
         adapter.send_file.assert_not_awaited()
         adapter.send_message.assert_awaited_once()
         assert "x.png" in adapter.send_message.await_args.args[1]
+
+
+class TestMessageTextReferencedConversations:
+    def test_no_context_returns_bare_text(self):
+        handler = MessageHandler(_api())
+        assert handler._message_text(_ctx(text="hi")) == "hi"
+
+    def test_referenced_conversation_is_rendered_with_dont_webfetch_note(self):
+        handler = MessageHandler(_api())
+        ctx = _ctx(
+            text="find my mentions",
+            referenced_conversations=(
+                ReferencedConversation(
+                    title="Release v0.6.61",
+                    messages=(
+                        MessageHistoryEntry("Krz", "u-2", "remember to bump version"),
+                        MessageHistoryEntry("Nick", "u-3", "and tag the release"),
+                    ),
+                ),
+            ),
+        )
+        out = handler._message_text(ctx)
+        assert "Referenced Discord conversation: Release v0.6.61" in out
+        assert "do not web-fetch Discord" in out
+        assert "remember to bump version" in out
+        assert "and tag the release" in out
+        assert "[Current message]\nfind my mentions" in out
+
+    def test_referenced_and_thread_history_both_rendered(self):
+        handler = MessageHandler(_api())
+        ctx = _ctx(
+            text="now",
+            thread_history=(MessageHistoryEntry("Alice", "u-1", "earlier point"),),
+            referenced_conversations=(
+                ReferencedConversation(
+                    title="other-thread",
+                    messages=(MessageHistoryEntry("Bob", "u-9", "linked content"),),
+                ),
+            ),
+        )
+        out = handler._message_text(ctx)
+        assert "linked content" in out
+        assert "Recent thread context" in out
+        assert "earlier point" in out
+        # Referenced block precedes the immediate thread context.
+        assert out.index("linked content") < out.index("earlier point")


### PR DESCRIPTION
### Why / What / How

**Why:** When a user pointed the Discord bot at an existing conversation — pasting a channel/message link, `<#>`-mentioning a channel, **replying** to a message, or **forwarding** one — the bot couldn't read it. It has no web access to Discord and would deflect: *"I can't open links / read Discord history — paste the text here."* But the bot is already on the gateway and can read anything it (and the user) has access to. The context was right there; we just weren't gathering it or handing it to the model.

**What:** The bot now gathers the conversation context a user points it at, from **every** way they can point at one, and feeds it into the AutoPilot turn — so it answers from the real conversation instead of deflecting. Every read is gated on the **requesting user's** own permissions, so the bot never surfaces anything the user couldn't already see.

**How:**
- A gateway-free `references.py` parses channel/thread IDs **and specific message IDs** out of message text (permalinks + `<#id>` mentions), de-duplicated and order-preserving.
- The Discord adapter fetches each referenced conversation via its own gateway connection:
  - **Channel/`<#>` reference** → recent history.
  - **Specific-message permalink** (`/channel/message`) → that exact message plus the turns leading up to it (works for old messages, and is kept even when it points at the current channel — "what was said here `<link>`").
- **Replies** (`message.reference`) and **forwards** (`message_snapshots`) are folded in as quoted context.
- The platform-agnostic handler renders the gathered conversations into the prompt and leads with a firm instruction that the content is *already supplied*, then rewrites the raw link into a readable `#channel-name` token so the model stops fixating on a URL it thinks it must open.

**Security model (every read gated on the requester, not the bot):**
- Same-guild only — never surfaces content from another server.
- Requester must have `view_channel` + `read_message_history` on the target.
- **Private threads** additionally require the requester to actually be a member (`manage_threads` bypasses, as in the client) — channel-level perms aren't enough.
- References are scanned **only from the user's own typed message** — links inside a forwarded/replied-to/quoted message are context, never auto-fetched or rewritten.
- Requester resolved from `message.author` (the bot runs without the privileged members intent, so the member cache is unreliable).
- Bounded: ≤3 conversations, ~8k chars each; LLM-produced mentions stay on an allowlist.

### Changes 🏗️

- **New** `adapters/discord/references.py`: `extract_referenced_targets()` (channel + optional message id), `replace_referenced_links()`, and a frozen `ReferenceTarget` pydantic model.
- **`adapters/base.py`**: `ReferencedConversation` (title, `channel_id`, messages) + `MessageContext.referenced_conversations`.
- **`adapters/discord/adapter.py`**: `_fetch_referenced_conversations` / `_fetch_one_referenced` (same-guild, requester-ACL, private-thread membership, specific-message vs recent-history fetch, budgeted), `_can_requester_read`, `_with_reply_context` / `_resolve_reply`, link-rewriting; reference scanning runs on the user's own text only.
- **`handler.py`**: always surfaces referenced conversations (channels, DMs, threads), gating only thread-history behind the first-@-into-thread flag; firm "you already have the content, don't deflect" framing.
- Comprehensive tests across `references_test.py`, `adapter_test.py`, `handler_test.py` (permalink parsing, ACL gates incl. private-thread membership, reply/forward context, "quoted links aren't fetched", requester-from-author, fail-safe paths).

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Unit/integration: 253 bot tests pass
  - [x] **Local end-to-end** against the live gateway: linked a channel and a specific-message permalink, replied to a message, forwarded a message — confirmed the bot reads the real content instead of deflecting
  - [x] Verified security gates: cross-guild skipped, private channel/thread without access skipped, links inside quoted (forward/reply) content not fetched
