### PR TITLE
fix(frontend): scope library "Scheduled" status to the user's own schedule

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/library/__tests__/filter.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/__tests__/filter.test.tsx
@@ -121,6 +121,40 @@ describe("LibraryAgentList — Scheduled status filter", () => {
     });
   });
 
+  test("excludes agents that only have recommended_schedule_cron (not actually scheduled by the user) from the scheduled filter", async () => {
+    setupHandlers([
+      makeAgent({
+        id: "a-recommendation-only",
+        graph_id: "g-recommendation-only",
+        name: "Recommendation Only Agent",
+        is_scheduled: false,
+        recommended_schedule_cron: "0 9 * * *",
+      }),
+    ]);
+
+    renderList("scheduled");
+
+    await waitFor(() => {
+      expect(screen.queryByText("Recommendation Only Agent")).toBeNull();
+    });
+  });
+
+  test("includes agents that only have recommended_schedule_cron in the idle filter", async () => {
+    setupHandlers([
+      makeAgent({
+        id: "a-recommendation-only",
+        graph_id: "g-recommendation-only",
+        name: "Recommendation Only Agent",
+        is_scheduled: false,
+        recommended_schedule_cron: "0 9 * * *",
+      }),
+    ]);
+
+    renderList("idle");
+
+    expect(await screen.findByText("Recommendation Only Agent")).toBeDefined();
+  });
+
   test("excludes idle agents (no schedule, no recommendation) from the scheduled filter", async () => {
     setupHandlers([
       makeAgent({

--- a/autogpt_platform/frontend/src/app/(platform)/library/hooks/executionHelpers.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/library/hooks/executionHelpers.test.ts
@@ -3,48 +3,22 @@ import { isAgentScheduled } from "./executionHelpers";
 
 describe("isAgentScheduled", () => {
   it("returns true when is_scheduled is set", () => {
-    expect(
-      isAgentScheduled({ is_scheduled: true, recommended_schedule_cron: null }),
-    ).toBe(true);
+    expect(isAgentScheduled({ is_scheduled: true })).toBe(true);
   });
 
-  it("returns true when recommended_schedule_cron is a non-empty string", () => {
-    expect(
-      isAgentScheduled({
-        is_scheduled: false,
-        recommended_schedule_cron: "0 9 * * *",
-      }),
-    ).toBe(true);
+  it("returns false when is_scheduled is false", () => {
+    expect(isAgentScheduled({ is_scheduled: false })).toBe(false);
   });
 
-  it("returns true when both flags are set", () => {
-    expect(
-      isAgentScheduled({
-        is_scheduled: true,
-        recommended_schedule_cron: "0 9 * * *",
-      }),
-    ).toBe(true);
-  });
-
-  it("returns false when neither flag is set", () => {
-    expect(
-      isAgentScheduled({
-        is_scheduled: false,
-        recommended_schedule_cron: null,
-      }),
-    ).toBe(false);
-  });
-
-  it("returns false when both fields are undefined", () => {
+  it("returns false when is_scheduled is undefined", () => {
     expect(isAgentScheduled({})).toBe(false);
   });
 
-  it("returns false when recommended_schedule_cron is an empty string", () => {
-    expect(
-      isAgentScheduled({
-        is_scheduled: false,
-        recommended_schedule_cron: "",
-      }),
-    ).toBe(false);
+  it("ignores recommended_schedule_cron (creator suggestion, not a user schedule)", () => {
+    const agentWithRecommendation = {
+      is_scheduled: false,
+      recommended_schedule_cron: "0 9 * * *",
+    };
+    expect(isAgentScheduled(agentWithRecommendation)).toBe(false);
   });
 });

--- a/autogpt_platform/frontend/src/app/(platform)/library/hooks/executionHelpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/library/hooks/executionHelpers.ts
@@ -4,12 +4,11 @@ import type { GraphExecutionMeta } from "@/app/api/__generated__/models/graphExe
 export const SEVENTY_TWO_HOURS_MS = 72 * 60 * 60 * 1000;
 
 // Shared scheduled-predicate used by fleet summary, sitrep, status-map, and the
-// list filter so the four call sites stay in lockstep.
-export function isAgentScheduled(agent: {
-  is_scheduled?: boolean;
-  recommended_schedule_cron?: string | null;
-}): boolean {
-  return !!agent.is_scheduled || !!agent.recommended_schedule_cron;
+// list filter so the four call sites stay in lockstep. Only the current user's
+// actual schedule (`is_scheduled`) counts — `recommended_schedule_cron` is a
+// creator-defined suggestion shared by every user, not an active schedule.
+export function isAgentScheduled(agent: { is_scheduled?: boolean }): boolean {
+  return !!agent.is_scheduled;
 }
 
 export function isActive(status: string): boolean {


### PR DESCRIPTION
### Why / What / How

**Why:** Agents in the Library — notably Marketplace-installed ones — showed a **"Scheduled"** status badge even when the current user had never scheduled them. The same flaw inflated the fleet-summary "scheduled" count. Reported as OPEN-3184.

**What:** The frontend scheduled-predicate `isAgentScheduled()` now keys solely off the user-scoped `is_scheduled` flag and no longer treats `recommended_schedule_cron` as an active schedule.

**How:** `recommended_schedule_cron` comes from `AgentGraph.recommendedScheduleCron` — a creator-defined *suggestion* attached to the graph and shared by every user who installs the agent. It is **not** evidence that the current user scheduled anything. The backend already computes `is_scheduled` correctly (per-user, via `_fetch_schedule_info(user_id=...)`); only the frontend predicate was wrong. Since the badge, fleet summary, sitrep, status-map, and list filter all funnel through this one predicate, the single-line change fixes every call site.

```ts
// before
return !!agent.is_scheduled || !!agent.recommended_schedule_cron;
// after
return !!agent.is_scheduled;
```

### Changes 🏗️

- `library/hooks/executionHelpers.ts` — `isAgentScheduled()` now returns `!!agent.is_scheduled` only; dropped `recommended_schedule_cron` from the predicate and its signature.
- `library/hooks/executionHelpers.test.ts` — updated unit tests; added a case asserting `recommended_schedule_cron` alone is ignored.
- `library/__tests__/filter.test.tsx` — added page-level regression tests: a recommendation-only agent is excluded from the "scheduled" filter and included in "idle".

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `pnpm vitest run executionHelpers.test.ts filter.test.tsx` — 9/9 pass (TDD: confirmed the new assertion failed against the old impl first)
  - [x] Full `src/app/(platform)/library` suite — 115/116 pass; the single failure is a pre-existing, timezone-dependent test in `followups/.../helpers.test.ts`, verified failing on the clean tree too and untouched by this change
  - [x] `pnpm format`, `pnpm lint` (only pre-existing warnings in unrelated files), `pnpm types` — all clean
