### PR TITLE
fix(backend/copilot-bot): separate AutoPilot text blocks so they don't run together in Discord

### DIFF
--- a/autogpt_platform/backend/backend/copilot/bot/bot_backend.py
+++ b/autogpt_platform/backend/backend/copilot/bot/bot_backend.py
@@ -369,6 +369,13 @@ class BotBackend:
 
         setup_notified = False
         setup_drop_notified = False
+        # Track which text block each delta belongs to. AutoPilot emits text in
+        # separate blocks around tool calls / reasoning (each with its own id);
+        # the frontend renders them as distinct parts, but here we concatenate
+        # into one message, so insert a paragraph break when the block changes —
+        # otherwise the end of one block and the start of the next run together
+        # ("…first thought.second thought…").
+        last_text_block_id: str | None = None
 
         try:
             while True:
@@ -388,6 +395,12 @@ class BotBackend:
                     )
                 if isinstance(chunk, StreamTextDelta):
                     if chunk.delta:
+                        if (
+                            last_text_block_id is not None
+                            and chunk.id != last_text_block_id
+                        ):
+                            yield "\n\n"
+                        last_text_block_id = chunk.id
                         yield chunk.delta
                 elif isinstance(chunk, StreamToolOutputAvailable):
                     setup_output = _extract_setup_requirements(chunk.output)

--- a/autogpt_platform/backend/backend/copilot/bot/bot_backend_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/bot_backend_test.py
@@ -154,8 +154,9 @@ class TestStreamChat:
         api._client.start_chat_turn = AsyncMock(return_value=handle)
 
         queue: asyncio.Queue = asyncio.Queue()
+        # Same block id — a continuous text stream, no separator inserted.
         await queue.put(StreamTextDelta(id="1", delta="Hello "))
-        await queue.put(StreamTextDelta(id="2", delta="world"))
+        await queue.put(StreamTextDelta(id="1", delta="world"))
         await queue.put(StreamFinish())
 
         captured_session_ids: list[str] = []
@@ -184,6 +185,40 @@ class TestStreamChat:
 
         assert "".join(chunks) == "Hello world"
         assert captured_session_ids == ["sess"]
+
+    @pytest.mark.asyncio
+    async def test_inserts_paragraph_break_between_text_blocks(self, api: BotBackend):
+        # AutoPilot emits text in separate blocks around tool calls / reasoning,
+        # each with its own id. Concatenating them without a separator runs the
+        # blocks together ("first thought.second thought"); a paragraph break
+        # keeps them readable, matching the frontend's distinct-part rendering.
+        handle = ChatTurnHandle(session_id="sess", turn_id="turn", user_id="u1")
+        api._client.start_chat_turn = AsyncMock(return_value=handle)
+
+        queue: asyncio.Queue = asyncio.Queue()
+        await queue.put(StreamTextDelta(id="1", delta="first thought."))
+        await queue.put(StreamTextDelta(id="2", delta="second thought."))
+        await queue.put(StreamFinish())
+
+        with (
+            patch(
+                "backend.copilot.bot.bot_backend.stream_registry.subscribe_to_session",
+                new=AsyncMock(return_value=queue),
+            ),
+            patch(
+                "backend.copilot.bot.bot_backend.stream_registry.unsubscribe_from_session",
+                new=AsyncMock(),
+            ),
+        ):
+            chunks: list[str] = []
+            async for chunk in api.stream_chat(
+                platform="discord",
+                platform_user_id="u1",
+                message="hi",
+            ):
+                chunks.append(chunk)
+
+        assert "".join(chunks) == "first thought.\n\nsecond thought."
 
     @pytest.mark.asyncio
     async def test_surfaces_stream_error(self, api: BotBackend):


### PR DESCRIPTION
### Why / What / How

**Why:** When AutoPilot replied in Discord, text around tool calls ran together with no spacing — e.g. `…checking the docs.Based on that, here's…` — looking broken (Toran reported it; the same reply renders fine on the web). It only happened on replies where AutoPilot actually *did* something (tool calls / reasoning), which was the giveaway.

**What:** Insert a paragraph break between AutoPilot's separate text blocks so they no longer concatenate into an unreadable run-on.

**How:** AutoPilot streams its reply in **separate text blocks** around tool calls and reasoning, each with its own `text_block_id` (the SDK closes one block and opens a new one). The frontend renders each block as a distinct part, so there's natural visual separation. The bot, however, concatenated every `StreamTextDelta.delta` into a single message with no separator — so the end of one block and the start of the next collided. The fix tracks the current block id in `stream_chat` and yields a `\n\n` paragraph break when it changes. It's not a newline-stripping bug — newlines *within* a block were always preserved; the issue was missing separators *between* blocks.

This lives in `bot_backend.stream_chat` (platform-agnostic), so future Slack/Telegram adapters get the fix for free. Any over-spacing self-normalizes via the existing `\n{3,}→\n\n` collapse in the send path.

### Changes 🏗️

- `bot/bot_backend.py`: track the text-block id across the stream; emit `\n\n` when it changes before yielding the next block's first delta.
- `bot/bot_backend_test.py`: continuous stream (same id → no separator) and block-boundary (different id → `\n\n` inserted) tests.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Unit: 254 bot tests pass, incl. the two new stream-separation tests
  - [x] **Local end-to-end** against the live gateway: sent AutoPilot a tool-call-heavy prompt and confirmed the text around each tool call is now cleanly separated instead of running together
