### PR TITLE
fix(frontend): only treat user schedules as scheduled in library

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/library/hooks/executionHelpers.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/library/hooks/executionHelpers.test.ts
@@ -3,48 +3,14 @@ import { isAgentScheduled } from "./executionHelpers";
 
 describe("isAgentScheduled", () => {
   it("returns true when is_scheduled is set", () => {
-    expect(
-      isAgentScheduled({ is_scheduled: true, recommended_schedule_cron: null }),
-    ).toBe(true);
+    expect(isAgentScheduled({ is_scheduled: true })).toBe(true);
   });
 
-  it("returns true when recommended_schedule_cron is a non-empty string", () => {
-    expect(
-      isAgentScheduled({
-        is_scheduled: false,
-        recommended_schedule_cron: "0 9 * * *",
-      }),
-    ).toBe(true);
+  it("returns false when is_scheduled is false", () => {
+    expect(isAgentScheduled({ is_scheduled: false })).toBe(false);
   });
 
-  it("returns true when both flags are set", () => {
-    expect(
-      isAgentScheduled({
-        is_scheduled: true,
-        recommended_schedule_cron: "0 9 * * *",
-      }),
-    ).toBe(true);
-  });
-
-  it("returns false when neither flag is set", () => {
-    expect(
-      isAgentScheduled({
-        is_scheduled: false,
-        recommended_schedule_cron: null,
-      }),
-    ).toBe(false);
-  });
-
-  it("returns false when both fields are undefined", () => {
+  it("returns false when is_scheduled is undefined", () => {
     expect(isAgentScheduled({})).toBe(false);
-  });
-
-  it("returns false when recommended_schedule_cron is an empty string", () => {
-    expect(
-      isAgentScheduled({
-        is_scheduled: false,
-        recommended_schedule_cron: "",
-      }),
-    ).toBe(false);
   });
 });

--- a/autogpt_platform/frontend/src/app/(platform)/library/hooks/executionHelpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/library/hooks/executionHelpers.ts
@@ -7,9 +7,8 @@ export const SEVENTY_TWO_HOURS_MS = 72 * 60 * 60 * 1000;
 // list filter so the four call sites stay in lockstep.
 export function isAgentScheduled(agent: {
   is_scheduled?: boolean;
-  recommended_schedule_cron?: string | null;
 }): boolean {
-  return !!agent.is_scheduled || !!agent.recommended_schedule_cron;
+  return !!agent.is_scheduled;
 }
 
 export function isActive(status: string): boolean {


### PR DESCRIPTION
### Why / What / How

**Why:** Library agents (especially Marketplace installs) showed a "Scheduled" badge when the current user had never scheduled them, because `isAgentScheduled()` treated creator-defined `recommended_schedule_cron` as an active schedule. Fixes #13417.

**What:** `isAgentScheduled()` now keys only off user-scoped `is_scheduled`.

**How:** Drop the `recommended_schedule_cron` fallback so the predicate matches backend per-user schedule data.

> **Note:** The same fix already landed on `dev` via #13419 (with additional filter regression coverage). This PR is superseded and can be closed as a duplicate.

### Changes 🏗️

- `library/hooks/executionHelpers.ts` — `isAgentScheduled()` returns `!!agent.is_scheduled` only
- `library/hooks/executionHelpers.test.ts` — unit coverage for the scheduled predicate

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Unit tests for `isAgentScheduled` covering true/false/undefined
  - [x] Verified against #13419 which already merged the equivalent fix on `dev`

#### For configuration changes:

- [x] `.env.default` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes
- [x] I have included a list of my configuration changes in the PR description (under **Changes**)