### PR TITLE
fix(copilot): Clarify StoreValueBlock vs PersistInformationBlock

### DIFF
--- a/autogpt_platform/backend/backend/blocks/basic.py
+++ b/autogpt_platform/backend/backend/blocks/basic.py
@@ -68,9 +68,10 @@ class FileStoreBlock(Block):
 
 class StoreValueBlock(Block):
     """
-    This block allows you to provide a constant value as a block, in a stateless manner.
-    The common use-case is simply pass the `input` data, it will `output` the same data.
-    The block output will be static, the output can be consumed multiple times.
+    Holds a constant value within a single run and forwards it to multiple blocks.
+    The value is ephemeral — it exists only for the duration of one execution and
+    is NOT persisted across runs. To store data that survives between runs, use
+    PersistInformationBlock (writer) and RetrieveInformationBlock (reader) instead.
     """
 
     class Input(BlockSchemaInput):
@@ -90,7 +91,12 @@ class StoreValueBlock(Block):
     def __init__(self):
         super().__init__(
             id="1ff065e9-88e8-4358-9d82-8dc91f622ba9",
-            description="A basic block that stores and forwards a value throughout workflows, allowing it to be reused without changes across multiple blocks.",
+            description=(
+                "Holds a constant value within a single run and forwards it to multiple "
+                "blocks. Ephemeral: the value lives only for one execution and is NOT "
+                "saved between runs. To persist data across runs use "
+                "PersistInformationBlock (write) + RetrieveInformationBlock (read)."
+            ),
             categories={BlockCategory.BASIC},
             input_schema=StoreValueBlock.Input,
             output_schema=StoreValueBlock.Output,

--- a/autogpt_platform/backend/backend/blocks/basic.py
+++ b/autogpt_platform/backend/backend/blocks/basic.py
@@ -68,10 +68,12 @@ class FileStoreBlock(Block):
 
 class StoreValueBlock(Block):
     """
-    Holds a constant value within a single run and forwards it to multiple blocks.
-    The value is ephemeral — it exists only for the duration of one execution and
-    is NOT persisted across runs. To store data that survives between runs, use
-    PersistInformationBlock (writer) and RetrieveInformationBlock (reader) instead.
+    Holds or receives a value and outputs it statically so that it can be used multiple
+    times within the same agent run. Whenever consumed, the output value reflects the
+    last input value that was received.
+
+    NOTE: The value is NOT persisted across runs. To store data that survives between
+    runs, use PersistInformationBlock and RetrieveInformationBlock instead.
     """
 
     class Input(BlockSchemaInput):
@@ -91,12 +93,7 @@ class StoreValueBlock(Block):
     def __init__(self):
         super().__init__(
             id="1ff065e9-88e8-4358-9d82-8dc91f622ba9",
-            description=(
-                "Holds a constant value within a single run and forwards it to multiple "
-                "blocks. Ephemeral: the value lives only for one execution and is NOT "
-                "saved between runs. To persist data across runs use "
-                "PersistInformationBlock (write) + RetrieveInformationBlock (read)."
-            ),
+            description=StoreValueBlock.__doc__,
             categories={BlockCategory.BASIC},
             input_schema=StoreValueBlock.Input,
             output_schema=StoreValueBlock.Output,

--- a/autogpt_platform/backend/backend/blocks/basic.py
+++ b/autogpt_platform/backend/backend/blocks/basic.py
@@ -1,4 +1,5 @@
 import enum
+import inspect
 from typing import Any
 
 from backend.blocks._base import (
@@ -93,7 +94,7 @@ class StoreValueBlock(Block):
     def __init__(self):
         super().__init__(
             id="1ff065e9-88e8-4358-9d82-8dc91f622ba9",
-            description=StoreValueBlock.__doc__ or "",
+            description=inspect.cleandoc(StoreValueBlock.__doc__ or ""),
             categories={BlockCategory.BASIC},
             input_schema=StoreValueBlock.Input,
             output_schema=StoreValueBlock.Output,

--- a/autogpt_platform/backend/backend/blocks/basic.py
+++ b/autogpt_platform/backend/backend/blocks/basic.py
@@ -93,7 +93,7 @@ class StoreValueBlock(Block):
     def __init__(self):
         super().__init__(
             id="1ff065e9-88e8-4358-9d82-8dc91f622ba9",
-            description=StoreValueBlock.__doc__,
+            description=StoreValueBlock.__doc__ or "",
             categories={BlockCategory.BASIC},
             input_schema=StoreValueBlock.Input,
             output_schema=StoreValueBlock.Output,

--- a/autogpt_platform/backend/backend/blocks/persistence.py
+++ b/autogpt_platform/backend/backend/blocks/persistence.py
@@ -1,3 +1,4 @@
+import inspect
 import logging
 from typing import Any, Literal
 
@@ -52,7 +53,7 @@ class PersistInformationBlock(Block):
     def __init__(self):
         super().__init__(
             id="1d055e55-a2b9-4547-8311-907d05b0304d",
-            description=PersistInformationBlock.__doc__ or "",
+            description=inspect.cleandoc(PersistInformationBlock.__doc__ or ""),
             categories={BlockCategory.DATA},
             input_schema=PersistInformationBlock.Input,
             output_schema=PersistInformationBlock.Output,
@@ -126,7 +127,7 @@ class RetrieveInformationBlock(Block):
     def __init__(self):
         super().__init__(
             id="d8710fc9-6e29-481e-a7d5-165eb16f8471",
-            description=RetrieveInformationBlock.__doc__ or "",
+            description=inspect.cleandoc(RetrieveInformationBlock.__doc__ or ""),
             categories={BlockCategory.DATA},
             input_schema=RetrieveInformationBlock.Input,
             output_schema=RetrieveInformationBlock.Output,

--- a/autogpt_platform/backend/backend/blocks/persistence.py
+++ b/autogpt_platform/backend/backend/blocks/persistence.py
@@ -26,13 +26,23 @@ def get_storage_key(key: str, scope: StorageScope, graph_id: str) -> str:
 
 
 class PersistInformationBlock(Block):
-    """Block for persisting key-value data for the current user with configurable scope"""
+    """
+    Saves a key-value pair that survives across multiple runs of an agent.
+    Unlike StoreValueBlock (which only holds a value for the current run),
+    data written here is durable and can be read back in future runs via
+    RetrieveInformationBlock. Use this when you need memory that persists
+    between executions, e.g. counters, last-seen state, user preferences.
+    """
 
     class Input(BlockSchemaInput):
         key: str = SchemaField(description="Key to store the information under")
         value: Any = SchemaField(description="Value to store")
         scope: StorageScope = SchemaField(
-            description="Scope of persistence: within_agent (shared across all runs of this agent) or across_agents (shared across all agents for this user)",
+            description=(
+                "Scope of persistence: "
+                "'within_agent' — shared across all runs of this agent; "
+                "'across_agents' — shared across all agents for this user"
+            ),
             default="within_agent",
         )
 
@@ -42,7 +52,13 @@ class PersistInformationBlock(Block):
     def __init__(self):
         super().__init__(
             id="1d055e55-a2b9-4547-8311-907d05b0304d",
-            description="Persist key-value information for the current user",
+            description=(
+                "Saves a key-value pair that persists across multiple runs. "
+                "Use to store state, counters, or memory that must survive between "
+                "executions. Pair with RetrieveInformationBlock to read the value back "
+                "in a later run. For temporary within-run value passing, use "
+                "StoreValueBlock instead."
+            ),
             categories={BlockCategory.DATA},
             input_schema=PersistInformationBlock.Input,
             output_schema=PersistInformationBlock.Output,
@@ -94,12 +110,21 @@ class PersistInformationBlock(Block):
 
 
 class RetrieveInformationBlock(Block):
-    """Block for retrieving key-value data for the current user with configurable scope"""
+    """
+    Reads back a key-value pair previously saved by PersistInformationBlock.
+    The value is durable across runs — use this to recall state, counters, or
+    memory from a prior execution. This block does NOT read values set by
+    StoreValueBlock (which are ephemeral and limited to a single run).
+    """
 
     class Input(BlockSchemaInput):
         key: str = SchemaField(description="Key to retrieve the information for")
         scope: StorageScope = SchemaField(
-            description="Scope of persistence: within_agent (shared across all runs of this agent) or across_agents (shared across all agents for this user)",
+            description=(
+                "Scope of persistence: "
+                "'within_agent' — shared across all runs of this agent; "
+                "'across_agents' — shared across all agents for this user"
+            ),
             default="within_agent",
         )
         default_value: Any = SchemaField(
@@ -112,7 +137,12 @@ class RetrieveInformationBlock(Block):
     def __init__(self):
         super().__init__(
             id="d8710fc9-6e29-481e-a7d5-165eb16f8471",
-            description="Retrieve key-value information for the current user",
+            description=(
+                "Reads back a key-value pair previously saved by PersistInformationBlock. "
+                "Returns data that persists across runs. Use with PersistInformationBlock "
+                "to build durable memory, counters, or state. Does NOT retrieve values "
+                "from StoreValueBlock (those are ephemeral, within-run only)."
+            ),
             categories={BlockCategory.DATA},
             input_schema=RetrieveInformationBlock.Input,
             output_schema=RetrieveInformationBlock.Output,

--- a/autogpt_platform/backend/backend/blocks/persistence.py
+++ b/autogpt_platform/backend/backend/blocks/persistence.py
@@ -27,11 +27,11 @@ def get_storage_key(key: str, scope: StorageScope, graph_id: str) -> str:
 
 class PersistInformationBlock(Block):
     """
-    Saves a key-value pair that survives across multiple runs of an agent.
-    Unlike StoreValueBlock (which only holds a value for the current run),
-    data written here is durable and can be read back in future runs via
-    RetrieveInformationBlock. Use this when you need memory that persists
-    between executions, e.g. counters, last-seen state, user preferences.
+    Persists a key-value pair for use across multiple runs of an agent. Use this when
+    you need memory that persists between executions, e.g. last-seen state, counters,
+    accumulated data.
+
+    Beware of read->write race conditions for parallel use of the same key.
     """
 
     class Input(BlockSchemaInput):
@@ -52,13 +52,7 @@ class PersistInformationBlock(Block):
     def __init__(self):
         super().__init__(
             id="1d055e55-a2b9-4547-8311-907d05b0304d",
-            description=(
-                "Saves a key-value pair that persists across multiple runs. "
-                "Use to store state, counters, or memory that must survive between "
-                "executions. Pair with RetrieveInformationBlock to read the value back "
-                "in a later run. For temporary within-run value passing, use "
-                "StoreValueBlock instead."
-            ),
+            description=PersistInformationBlock.__doc__,
             categories={BlockCategory.DATA},
             input_schema=PersistInformationBlock.Input,
             output_schema=PersistInformationBlock.Output,
@@ -110,12 +104,7 @@ class PersistInformationBlock(Block):
 
 
 class RetrieveInformationBlock(Block):
-    """
-    Reads back a key-value pair previously saved by PersistInformationBlock.
-    The value is durable across runs — use this to recall state, counters, or
-    memory from a prior execution. This block does NOT read values set by
-    StoreValueBlock (which are ephemeral and limited to a single run).
-    """
+    """Reads back a key-value pair previously saved by PersistInformationBlock."""
 
     class Input(BlockSchemaInput):
         key: str = SchemaField(description="Key to retrieve the information for")
@@ -137,12 +126,7 @@ class RetrieveInformationBlock(Block):
     def __init__(self):
         super().__init__(
             id="d8710fc9-6e29-481e-a7d5-165eb16f8471",
-            description=(
-                "Reads back a key-value pair previously saved by PersistInformationBlock. "
-                "Returns data that persists across runs. Use with PersistInformationBlock "
-                "to build durable memory, counters, or state. Does NOT retrieve values "
-                "from StoreValueBlock (those are ephemeral, within-run only)."
-            ),
+            description=RetrieveInformationBlock.__doc__,
             categories={BlockCategory.DATA},
             input_schema=RetrieveInformationBlock.Input,
             output_schema=RetrieveInformationBlock.Output,

--- a/autogpt_platform/backend/backend/blocks/persistence.py
+++ b/autogpt_platform/backend/backend/blocks/persistence.py
@@ -52,7 +52,7 @@ class PersistInformationBlock(Block):
     def __init__(self):
         super().__init__(
             id="1d055e55-a2b9-4547-8311-907d05b0304d",
-            description=PersistInformationBlock.__doc__,
+            description=PersistInformationBlock.__doc__ or "",
             categories={BlockCategory.DATA},
             input_schema=PersistInformationBlock.Input,
             output_schema=PersistInformationBlock.Output,
@@ -126,7 +126,7 @@ class RetrieveInformationBlock(Block):
     def __init__(self):
         super().__init__(
             id="d8710fc9-6e29-481e-a7d5-165eb16f8471",
-            description=RetrieveInformationBlock.__doc__,
+            description=RetrieveInformationBlock.__doc__ or "",
             categories={BlockCategory.DATA},
             input_schema=RetrieveInformationBlock.Input,
             output_schema=RetrieveInformationBlock.Output,

--- a/autogpt_platform/backend/backend/copilot/sdk/agent_generation_guide.md
+++ b/autogpt_platform/backend/backend/copilot/sdk/agent_generation_guide.md
@@ -190,8 +190,8 @@ descriptions; read and follow those when `find_block` surfaces a match.
 - **ConditionBlock**: Needs a `StoreValueBlock` wired to its `value2` input.
 - **StoreValueBlock vs PersistInformationBlock** — these are NOT interchangeable:
   - `StoreValueBlock` (ID: `1ff065e9-88e8-4358-9d82-8dc91f622ba9`) — holds a
-    constant **within one run only** (ephemeral). Use it to fan a value out to
-    multiple blocks in the same execution, or as a prerequisite for ConditionBlock.
+    constant **within one run only** (ephemeral). Use it to reuse a single output value
+    as input for multiple node runs (within the same agent run).
   - `PersistInformationBlock` (ID: `1d055e55-a2b9-4547-8311-907d05b0304d`) +
     `RetrieveInformationBlock` (ID: `d8710fc9-6e29-481e-a7d5-165eb16f8471`) —
     write/read values that **survive across runs**. Use these whenever you need

--- a/autogpt_platform/backend/backend/copilot/sdk/agent_generation_guide.md
+++ b/autogpt_platform/backend/backend/copilot/sdk/agent_generation_guide.md
@@ -188,6 +188,15 @@ descriptions; read and follow those when `find_block` surfaces a match.
 - **is_static links**: Set `is_static: true` when the link carries a
   design-time constant (matches a field in inputSchema with a default).
 - **ConditionBlock**: Needs a `StoreValueBlock` wired to its `value2` input.
+- **StoreValueBlock vs PersistInformationBlock** — these are NOT interchangeable:
+  - `StoreValueBlock` (ID: `1ff065e9-88e8-4358-9d82-8dc91f622ba9`) — holds a
+    constant **within one run only** (ephemeral). Use it to fan a value out to
+    multiple blocks in the same execution, or as a prerequisite for ConditionBlock.
+  - `PersistInformationBlock` (ID: `1d055e55-a2b9-4547-8311-907d05b0304d`) +
+    `RetrieveInformationBlock` (ID: `d8710fc9-6e29-481e-a7d5-165eb16f8471`) —
+    write/read values that **survive across runs**. Use these whenever you need
+    memory, counters, last-seen state, or any data that must outlast a single
+    execution.
 - **Prompt templates**: Use `{{variable}}` (double curly braces) for
   literal braces in prompt strings — single `{` and `}` are for
   template variables.

--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -85,7 +85,7 @@ Below is a comprehensive list of all available blocks, categorized by their prim
 | [Slant3D Get Orders](block-integrations/slant3d/order.md#slant3d-get-orders) | Get all orders for the account |
 | [Slant3D Slicer](block-integrations/slant3d/slicing.md#slant3d-slicer) | Slice a 3D model file and get pricing information |
 | [Slant3D Tracking](block-integrations/slant3d/order.md#slant3d-tracking) | Track order status and shipping |
-| [Store Value](block-integrations/basic.md#store-value) | A basic block that stores and forwards a value throughout workflows, allowing it to be reused without changes across multiple blocks |
+| [Store Value](block-integrations/basic.md#store-value) | Holds or receives a value and outputs it statically so that it can be used multiple times within the same agent run |
 | [Universal Type Converter](block-integrations/basic.md#universal-type-converter) | This block is used to convert a value to a universal type |
 | [XML Parser](block-integrations/basic.md#xml-parser) | Parses XML using gravitasml to tokenize and coverts it to dict |
 | [Zip Lists](block-integrations/basic.md#zip-lists) | Zips multiple lists together into a list of grouped elements |
@@ -179,10 +179,10 @@ Below is a comprehensive list of all available blocks, categorized by their prim
 | [JSON Decoder](block-integrations/data.md#json-decoder) | Decodes a JSON string into the value or data structure, it represents, e |
 | [JSON Encoder](block-integrations/data.md#json-encoder) | Encodes any value or data structure into a JSON string |
 | [Keyword Suggestion Extractor](block-integrations/dataforseo/keyword_suggestions.md#keyword-suggestion-extractor) | Extract individual fields from a KeywordSuggestion object |
-| [Persist Information](block-integrations/data.md#persist-information) | Persist key-value information for the current user |
+| [Persist Information](block-integrations/data.md#persist-information) | Persists a key-value pair for use across multiple runs of an agent |
 | [Read Spreadsheet](block-integrations/data.md#read-spreadsheet) | Reads CSV and Excel files and outputs the data as a list of dictionaries and individual rows |
 | [Related Keyword Extractor](block-integrations/dataforseo/related_keywords.md#related-keyword-extractor) | Extract individual fields from a RelatedKeyword object |
-| [Retrieve Information](block-integrations/data.md#retrieve-information) | Retrieve key-value information for the current user |
+| [Retrieve Information](block-integrations/data.md#retrieve-information) | Reads back a key-value pair previously saved by PersistInformationBlock |
 | [SQL Query](block-integrations/data.md#sql-query) | Execute a SQL query |
 | [Screenshot Web Page](block-integrations/data.md#screenshot-web-page) | Takes a screenshot of a specified website using ScreenshotOne API |
 

--- a/docs/integrations/block-integrations/basic.md
+++ b/docs/integrations/block-integrations/basic.md
@@ -1496,7 +1496,12 @@ The search is performed against the Mem0 memory store and returns memories ranke
 ## Store Value
 
 ### What it is
-A basic block that stores and forwards a value throughout workflows, allowing it to be reused without changes across multiple blocks.
+Holds or receives a value and outputs it statically so that it can be used multiple
+times within the same agent run. Whenever consumed, the output value reflects the
+last input value that was received.
+
+NOTE: The value is NOT persisted across runs. To store data that survives between
+runs, use PersistInformationBlock and RetrieveInformationBlock instead.
 
 ### How it works
 <!-- MANUAL: how_it_works -->

--- a/docs/integrations/block-integrations/data.md
+++ b/docs/integrations/block-integrations/data.md
@@ -193,7 +193,11 @@ Before outputting, the block validates JSON-serializability. If an unsupported t
 ## Persist Information
 
 ### What it is
-Persist key-value information for the current user
+Persists a key-value pair for use across multiple runs of an agent. Use this when
+you need memory that persists between executions, e.g. last-seen state, counters,
+accumulated data.
+
+Beware of read->write race conditions for parallel use of the same key.
 
 ### How it works
 <!-- MANUAL: how_it_works -->
@@ -208,7 +212,7 @@ The stored data remains available until explicitly overwritten, enabling state m
 |-------|-------------|------|----------|
 | key | Key to store the information under | str | Yes |
 | value | Value to store | Value | Yes |
-| scope | Scope of persistence: within_agent (shared across all runs of this agent) or across_agents (shared across all agents for this user) | "within_agent" \| "across_agents" | No |
+| scope | Scope of persistence: 'within_agent' — shared across all runs of this agent; 'across_agents' — shared across all agents for this user | "within_agent" \| "across_agents" | No |
 
 ### Outputs
 
@@ -277,7 +281,7 @@ Configure delimiter, quote character, and escape character for proper CSV parsin
 ## Retrieve Information
 
 ### What it is
-Retrieve key-value information for the current user
+Reads back a key-value pair previously saved by PersistInformationBlock.
 
 ### How it works
 <!-- MANUAL: how_it_works -->
@@ -291,7 +295,7 @@ Use within_agent scope for agent-specific data or across_agents for data shared 
 | Input | Description | Type | Required |
 |-------|-------------|------|----------|
 | key | Key to retrieve the information for | str | Yes |
-| scope | Scope of persistence: within_agent (shared across all runs of this agent) or across_agents (shared across all agents for this user) | "within_agent" \| "across_agents" | No |
+| scope | Scope of persistence: 'within_agent' — shared across all runs of this agent; 'across_agents' — shared across all agents for this user | "within_agent" \| "across_agents" | No |
 | default_value | Default value to return if key is not found | Default Value | No |
 
 ### Outputs


### PR DESCRIPTION
## Problem

AutoPilot (and agents in general) confused **StoreValueBlock** with **PersistInformationBlock** when searching for "store value state". The descriptions didn't make the key distinction clear:

- **StoreValueBlock** — holds a constant value **within a single run only** (ephemeral)
- **PersistInformationBlock** — **saves** a value that **survives across runs**
- **RetrieveInformationBlock** — **reads back** a value saved by PersistInformationBlock in a prior run

## Changes

### `blocks/basic.py` — StoreValueBlock
- Added class docstring explicitly stating it is **ephemeral / within-run only**, with a direct pointer to PersistInformationBlock + RetrieveInformationBlock for cross-run use cases
- Uses `inspect.cleandoc(StoreValueBlock.__doc__ or "")` to populate `description`

### `blocks/persistence.py` — PersistInformationBlock & RetrieveInformationBlock
- Added class docstrings clearly stating data **persists across runs**
- Improved `scope` field description (quoted literals with plain-English meaning)
- Uses `inspect.cleandoc(ClassName.__doc__ or "")` to populate `description`

### `copilot/sdk/agent_generation_guide.md`
- Added a **StoreValueBlock vs PersistInformationBlock** disambiguation bullet in the Key Rules section, including block IDs for both, so AutoPilot picks the right one at agent-build time

### `docs/integrations/block-integrations/basic.md` + `data.md`
- Regenerated auto-generated sections to match the updated block descriptions

## Why this matters

Block descriptions are the primary signal used by AutoPilot's block search. Without the ephemeral/persistent contrast in the text, queries like "store state", "remember value", or "persist across runs" surface the wrong block. The agent generation guide amendment closes the same gap at the AutoPilot reasoning layer.
