### PR TITLE
Increase skill description limit from 200 to 250 chars

### DIFF
--- a/autogpt_platform/backend/backend/copilot/tools/skills.py
+++ b/autogpt_platform/backend/backend/copilot/tools/skills.py
@@ -59,7 +59,7 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 MAX_USER_SKILLS = 50
 MAX_NAME_CHARS = 64
-MAX_DESCRIPTION_CHARS = 200
+MAX_DESCRIPTION_CHARS = 250
 MAX_BODY_CHARS = 20_000
 # Triggers appear inline in the per-turn ``<available_skills>`` index,
 # so an unbounded list (or one huge trigger) would balloon the prefix
@@ -926,7 +926,7 @@ class StoreSkillTool(BaseTool):
                 },
                 "description": {
                     "type": "string",
-                    "description": "One-line hook (≤200 chars).",
+                    "description": "One-line hook (≤250 chars).",
                 },
                 "body": {
                     "type": "string",

--- a/autogpt_platform/backend/backend/copilot/tools/skills.py
+++ b/autogpt_platform/backend/backend/copilot/tools/skills.py
@@ -926,7 +926,7 @@ class StoreSkillTool(BaseTool):
                 },
                 "description": {
                     "type": "string",
-                    "description": "One-line hook (≤250 chars).",
+                    "description": f"One-line hook (≤{MAX_DESCRIPTION_CHARS} chars).",
                 },
                 "body": {
                     "type": "string",

--- a/autogpt_platform/backend/backend/copilot/tools/skills_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/skills_test.py
@@ -179,7 +179,7 @@ def test_description_length_cap_enforced_by_validate_path():
     """The cap is enforced inside ``StoreSkillTool._execute`` (not by
     the dataclass), so this test just locks in the constant — bumping
     it requires conscious thought about per-turn token cost."""
-    assert MAX_DESCRIPTION_CHARS == 200
+    assert MAX_DESCRIPTION_CHARS == 250
 
 
 def test_trigger_caps_are_bounded():

--- a/autogpt_platform/frontend/src/app/(platform)/library/skills/__tests__/getSkillUploadError.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/library/skills/__tests__/getSkillUploadError.test.ts
@@ -23,7 +23,7 @@ describe("getSkillUploadError", () => {
   test("reports the exact length when description is too long", () => {
     const desc = "x".repeat(MAX_SKILL_DESCRIPTION_CHARS + 1);
     const err = getSkillUploadError(md(`name: ok_skill\ndescription: ${desc}`));
-    expect(err).toContain(`${MAX_SKILL_DESCRIPTION_CHARS + 1}/200`);
+    expect(err).toContain(`${MAX_SKILL_DESCRIPTION_CHARS + 1}/250`);
     expect(err).toContain("trim at least 1");
   });
 

--- a/autogpt_platform/frontend/src/app/(platform)/library/skills/__tests__/getSkillUploadError.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/library/skills/__tests__/getSkillUploadError.test.ts
@@ -23,7 +23,9 @@ describe("getSkillUploadError", () => {
   test("reports the exact length when description is too long", () => {
     const desc = "x".repeat(MAX_SKILL_DESCRIPTION_CHARS + 1);
     const err = getSkillUploadError(md(`name: ok_skill\ndescription: ${desc}`));
-    expect(err).toContain(`${MAX_SKILL_DESCRIPTION_CHARS + 1}/250`);
+    expect(err).toContain(
+      `${MAX_SKILL_DESCRIPTION_CHARS + 1}/${MAX_SKILL_DESCRIPTION_CHARS}`,
+    );
     expect(err).toContain("trim at least 1");
   });
 

--- a/autogpt_platform/frontend/src/app/(platform)/library/skills/__tests__/main.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/skills/__tests__/main.test.tsx
@@ -283,7 +283,7 @@ describe("SkillsPage", () => {
     await screen.findByTestId("skills-empty");
 
     const input = screen.getByTestId("skill-upload-input");
-    const longDescription = "x".repeat(201);
+    const longDescription = "x".repeat(251);
     const file = new File(
       [`---\nname: too_long\ndescription: ${longDescription}\n---\n\nbody`],
       "too_long.md",
@@ -295,7 +295,7 @@ describe("SkillsPage", () => {
       expect(toastMock).toHaveBeenCalledWith(
         expect.objectContaining({
           title: "Can't upload this skill",
-          description: expect.stringContaining("201/200"),
+          description: expect.stringContaining("251/250"),
           variant: "destructive",
         }),
       );

--- a/autogpt_platform/frontend/src/app/(platform)/library/skills/components/UploadSkillButton/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/library/skills/components/UploadSkillButton/helpers.ts
@@ -1,7 +1,7 @@
 // Mirrors backend limits in backend/copilot/tools/skills.py — kept in sync
 // manually. These bound the per-turn `<available_skills>` index the copilot
 // sees, so the cap is deliberate (see backend MAX_DESCRIPTION_CHARS).
-export const MAX_SKILL_DESCRIPTION_CHARS = 200;
+export const MAX_SKILL_DESCRIPTION_CHARS = 250;
 
 const FRONTMATTER_RE = /^---\n([\s\S]*?)\n---/;
 


### PR DESCRIPTION
## Summary

Raises the skill description character limit from 200 to 250, aligning with the industry-standard 250-character limit.

## Changes

- `backend/copilot/tools/skills.py`: `MAX_DESCRIPTION_CHARS` 200 → 250, schema docstring updated
- `frontend/.../UploadSkillButton/helpers.ts`: `MAX_SKILL_DESCRIPTION_CHARS` 200 → 250
- `frontend/.../getSkillUploadError.test.ts`: hardcoded `/200` assertion updated to `/250`

## Why

The 200-char cap was causing valid descriptions to be rejected. 250 chars is the accepted industry standard for single-line description fields and gives authors enough room to write a clear, scannable hook without bloating the per-turn skills index.