### PR TITLE
fix(copilot): stop leaking pending buffer on cancel + push SSE drain hint

### DIFF
--- a/autogpt_platform/backend/backend/api/features/chat/routes.py
+++ b/autogpt_platform/backend/backend/api/features/chat/routes.py
@@ -42,7 +42,10 @@ from backend.copilot.pending_message_helpers import (
     is_turn_in_flight,
     queue_pending_for_http,
 )
-from backend.copilot.pending_messages import peek_pending_messages
+from backend.copilot.pending_messages import (
+    clear_pending_messages_unsafe,
+    peek_pending_messages,
+)
 from backend.copilot.rate_limit import (
     CoPilotUsagePublic,
     RateLimitExceeded,
@@ -902,6 +905,22 @@ async def cancel_session_task(
       task status flips out of ``running`` or a 5 s timeout is hit.
     """
     await _validate_and_get_session(session_id, user_id)
+
+    # Cancelling discards any follow-ups the user queued for this turn:
+    # Stop means stop.  The pending buffer only exists to feed the
+    # *running* turn (drained at tool boundaries); once that turn is
+    # cancelled there is nothing left to feed it, so leaving entries
+    # behind would silently inject them into the next unrelated turn
+    # (up to the 1h buffer TTL).  Best-effort — a Redis hiccup here must
+    # not block the cancel itself, so we swallow and log.
+    try:
+        await clear_pending_messages_unsafe(session_id)
+    except Exception:
+        logger.warning(
+            "[CANCEL] Failed to clear pending buffer for session ...%s",
+            session_id[-8:],
+            exc_info=True,
+        )
 
     # Queued sessions: just flip back to idle.  The user clicked X
     # before any compute was spent; no executor involvement needed.

--- a/autogpt_platform/backend/backend/api/features/chat/routes.py
+++ b/autogpt_platform/backend/backend/api/features/chat/routes.py
@@ -885,6 +885,22 @@ async def reset_copilot_usage(
     )
 
 
+async def _clear_pending_best_effort(session_id: str) -> None:
+    """Drop the session's pending buffer, swallowing Redis errors.
+
+    Cancel cleanup must never block the cancel itself, so a transient
+    Redis failure is logged and ignored rather than raised.
+    """
+    try:
+        await clear_pending_messages_unsafe(session_id)
+    except Exception:
+        logger.warning(
+            "[CANCEL] Failed to clear pending buffer for session ...%s",
+            session_id[-8:],
+            exc_info=True,
+        )
+
+
 @router.post(
     "/sessions/{session_id}/cancel",
     status_code=200,
@@ -911,16 +927,17 @@ async def cancel_session_task(
     # *running* turn (drained at tool boundaries); once that turn is
     # cancelled there is nothing left to feed it, so leaving entries
     # behind would silently inject them into the next unrelated turn
-    # (up to the 1h buffer TTL).  Best-effort — a Redis hiccup here must
-    # not block the cancel itself, so we swallow and log.
-    try:
-        await clear_pending_messages_unsafe(session_id)
-    except Exception:
-        logger.warning(
-            "[CANCEL] Failed to clear pending buffer for session ...%s",
-            session_id[-8:],
-            exc_info=True,
-        )
+    # (up to the 1h buffer TTL).
+    #
+    # This first clear shrinks the window but doesn't close it: the HTTP
+    # pending-write path CAS-gates on stream meta ``status == "running"``
+    # (``push_pending_message_if_session_running``), so a follow-up queued
+    # after this clear but before the turn actually stops would still land.
+    # The running path below clears again once the turn is confirmed
+    # stopped — at which point the CAS gate rejects every new write, so the
+    # buffer stays empty.  Best-effort throughout: a Redis hiccup must not
+    # block the cancel itself, so we swallow and log.
+    await _clear_pending_best_effort(session_id)
 
     # Queued sessions: just flip back to idle.  The user clicked X
     # before any compute was spent; no executor involvement needed.
@@ -960,12 +977,19 @@ async def cancel_session_task(
                 f"[CANCEL] Session ...{session_id[-8:]} confirmed stopped "
                 f"(status={session_state.status if session_state else 'gone'}) after {waited:.1f}s"
             )
+            # Re-clear now the turn is no longer running: the CAS gate rejects
+            # any further pending writes, so this drops anything queued during
+            # the cancel window and closes the cross-turn leak for good.
+            await _clear_pending_best_effort(session_id)
             return CancelSessionResponse(cancelled=True)
 
     logger.warning(
         f"[CANCEL] Session ...{session_id[-8:]} not confirmed after {max_wait}s, force-completing"
     )
     await stream_registry.mark_session_completed(session_id, error_message="Cancelled")
+    # Status is now force-flipped out of "running"; re-clear to drop any
+    # follow-up that landed during the poll window.
+    await _clear_pending_best_effort(session_id)
     return CancelSessionResponse(cancelled=True)
 
 

--- a/autogpt_platform/backend/backend/api/features/chat/routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/chat/routes_test.py
@@ -1576,6 +1576,60 @@ def test_cancel_session_survives_pending_clear_failure(
     assert response.json()["cancelled"] is True
 
 
+def test_cancel_session_reclears_pending_buffer_after_running_settles(
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    """The running path must clear the buffer a second time after the turn
+    is confirmed stopped.  The first clear only drops what existed when
+    cancel started; a follow-up CAS-pushed during the 0-5s cancel window
+    (stream meta still ``status='running'``) would otherwise survive and
+    leak into the next turn.  Re-clearing once status flips out of running —
+    when the CAS gate rejects new writes — closes that race."""
+    from backend.copilot.stream_registry import ActiveSession
+
+    _mock_validate_session(mocker)
+    mocker.patch(
+        "backend.copilot.turn_queue.cancel_queued_turn",
+        new=AsyncMock(return_value=False),
+    )
+    active_session = ActiveSession(
+        session_id="sess-1",
+        user_id=TEST_USER_ID,
+        tool_call_id="chat_stream",
+        tool_name="chat",
+        turn_id="turn-1",
+        status="running",
+    )
+    stopped_session = ActiveSession(
+        session_id="sess-1",
+        user_id=TEST_USER_ID,
+        tool_call_id="chat_stream",
+        tool_name="chat",
+        turn_id="turn-1",
+        status="completed",
+    )
+    mock_registry = MagicMock()
+    mock_registry.get_active_session = AsyncMock(return_value=(active_session, "1-0"))
+    mock_registry.get_session = AsyncMock(return_value=stopped_session)
+    mocker.patch("backend.api.features.chat.routes.stream_registry", mock_registry)
+    mocker.patch(
+        "backend.api.features.chat.routes.enqueue_cancel_task",
+        new_callable=AsyncMock,
+    )
+    mock_clear = mocker.patch(
+        "backend.api.features.chat.routes.clear_pending_messages_unsafe",
+        new_callable=AsyncMock,
+    )
+
+    response = client.post("/sessions/sess-1/cancel")
+
+    assert response.status_code == 200
+    assert response.json()["cancelled"] is True
+    # Once up front, once after the turn settles.
+    assert mock_clear.await_count == 2
+    assert all(call.args == ("sess-1",) for call in mock_clear.await_args_list)
+
+
 # ─── session_assign_user ──────────────────────────────────────────────
 
 

--- a/autogpt_platform/backend/backend/api/features/chat/routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/chat/routes_test.py
@@ -1530,6 +1530,52 @@ def test_cancel_session_enqueues_cancel_and_confirms(
     mock_enqueue.assert_called_once_with("sess-1")
 
 
+def test_cancel_session_clears_pending_buffer(
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    """Cancelling a turn must drop any queued follow-ups so they don't
+    leak into the next unrelated turn (the pending buffer only exists to
+    feed the running turn).  Regression test for the orphan-pending bug:
+    before the fix, cancel published the executor event but left the
+    Redis buffer intact until its 1h TTL."""
+    _mock_validate_session(mocker)
+    mocker.patch(
+        "backend.copilot.turn_queue.cancel_queued_turn",
+        new=AsyncMock(return_value=True),
+    )
+    mock_clear = mocker.patch(
+        "backend.api.features.chat.routes.clear_pending_messages_unsafe",
+        new_callable=AsyncMock,
+    )
+
+    response = client.post("/sessions/sess-1/cancel")
+
+    assert response.status_code == 200
+    assert response.json()["cancelled"] is True
+    mock_clear.assert_awaited_once_with("sess-1")
+
+
+def test_cancel_session_survives_pending_clear_failure(
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    """A Redis hiccup while clearing the pending buffer must not block the
+    cancel itself — the clear is best-effort cleanup, the cancel is not."""
+    _mock_validate_session(mocker)
+    mocker.patch(
+        "backend.copilot.turn_queue.cancel_queued_turn",
+        new=AsyncMock(return_value=True),
+    )
+    mocker.patch(
+        "backend.api.features.chat.routes.clear_pending_messages_unsafe",
+        new=AsyncMock(side_effect=RuntimeError("redis down")),
+    )
+
+    response = client.post("/sessions/sess-1/cancel")
+
+    assert response.status_code == 200
+    assert response.json()["cancelled"] is True
+
+
 # ─── session_assign_user ──────────────────────────────────────────────
 
 

--- a/autogpt_platform/backend/backend/copilot/pending_messages.py
+++ b/autogpt_platform/backend/backend/copilot/pending_messages.py
@@ -28,6 +28,8 @@ from typing import Any, cast
 
 from pydantic import BaseModel, Field, ValidationError
 
+from backend.copilot.response_model import StreamPendingDrained
+from backend.copilot.stream_registry import get_session, publish_chunk
 from backend.data.redis_client import get_redis_async
 from backend.data.redis_helpers import capped_rpush, capped_rpush_if_hash_field
 
@@ -212,7 +214,36 @@ async def drain_pending_messages(session_id: str) -> list[PendingMessage]:
             len(messages),
             session_id,
         )
+        await _notify_pending_drained(session_id, len(messages))
     return messages
+
+
+async def _notify_pending_drained(session_id: str, drained_count: int) -> None:
+    """Emit a ``data-pending-drained`` hint onto the session's live SSE
+    stream so the frontend promotes its queued chips to bubbles right away
+    instead of waiting for its backstop poll.
+
+    Best-effort by design: the frontend re-reads the authoritative buffer
+    count on the hint (and keeps a slow poll as a safety net), so a failed
+    or dropped emit only delays the chip→bubble swap — it never loses data.
+    The active turn is looked up from the session so the chunk lands on the
+    correct per-turn Redis stream.
+    """
+    try:
+        active = await get_session(session_id)
+        if active is None or not active.turn_id:
+            return
+        await publish_chunk(
+            active.turn_id,
+            StreamPendingDrained(drainedCount=drained_count),
+            session_id=session_id,
+        )
+    except Exception:
+        logger.debug(
+            "pending_messages: drain hint emit failed for session=%s",
+            session_id,
+            exc_info=True,
+        )
 
 
 async def peek_pending_count(session_id: str) -> int:

--- a/autogpt_platform/backend/backend/copilot/pending_messages_test.py
+++ b/autogpt_platform/backend/backend/copilot/pending_messages_test.py
@@ -8,6 +8,7 @@ and pull in the full app startup).
 import asyncio
 import json
 from typing import Any
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -160,6 +161,16 @@ def fake_redis(monkeypatch: pytest.MonkeyPatch) -> _FakeRedis:
         return redis
 
     monkeypatch.setattr(pm_module, "get_redis_async", _get_redis_async)
+
+    # Isolate the mid-turn drain hint: by default there's no live turn, so
+    # ``drain_pending_messages`` must not reach the real stream registry.
+    # Stub the lookup to "no active turn" so the emit is a no-op; the
+    # dedicated emit tests below override these to assert the SSE hint.
+    async def _no_active_session(_session_id: str) -> None:
+        return None
+
+    monkeypatch.setattr(pm_module, "get_session", _no_active_session)
+    monkeypatch.setattr(pm_module, "publish_chunk", AsyncMock())
     return redis
 
 
@@ -190,6 +201,77 @@ async def test_push_and_drain_preserves_order(fake_redis: _FakeRedis) -> None:
 @pytest.mark.asyncio
 async def test_drain_empty_returns_empty_list(fake_redis: _FakeRedis) -> None:
     assert await drain_pending_messages("nope") == []
+
+
+# ── Mid-turn drain SSE hint ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_drain_emits_pending_drained_hint(
+    fake_redis: _FakeRedis, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A mid-turn drain pushes a ``data-pending-drained`` hint onto the
+    active turn's stream so the client promotes chips immediately instead
+    of waiting for its backstop poll."""
+    from backend.copilot.response_model import StreamPendingDrained
+    from backend.copilot.stream_registry import ActiveSession
+
+    await push_pending_message("sessHint", PendingMessage(content="hi"))
+
+    active = ActiveSession(
+        session_id="sessHint",
+        user_id="u1",
+        tool_call_id="chat_stream",
+        tool_name="chat",
+        turn_id="turn-xyz",
+        status="running",
+    )
+
+    async def _get_session(_session_id: str) -> ActiveSession:
+        return active
+
+    publish = AsyncMock()
+    monkeypatch.setattr(pm_module, "get_session", _get_session)
+    monkeypatch.setattr(pm_module, "publish_chunk", publish)
+
+    drained = await drain_pending_messages("sessHint")
+    assert len(drained) == 1
+
+    publish.assert_awaited_once()
+    args, kwargs = publish.call_args
+    assert args[0] == "turn-xyz"
+    assert isinstance(args[1], StreamPendingDrained)
+    assert args[1].drainedCount == 1
+    assert kwargs["session_id"] == "sessHint"
+
+
+@pytest.mark.asyncio
+async def test_drain_empty_does_not_emit_hint(
+    fake_redis: _FakeRedis, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No drain → no hint: an empty buffer must not emit a stream chunk."""
+    publish = AsyncMock()
+    monkeypatch.setattr(pm_module, "publish_chunk", publish)
+
+    assert await drain_pending_messages("emptySess") == []
+    publish.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_drain_hint_failure_does_not_break_drain(
+    fake_redis: _FakeRedis, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The hint is best-effort: a stream-registry hiccup while emitting it
+    must not lose the drained messages."""
+    await push_pending_message("sessBoom", PendingMessage(content="hi"))
+
+    async def _boom(_session_id: str) -> None:
+        raise RuntimeError("registry down")
+
+    monkeypatch.setattr(pm_module, "get_session", _boom)
+
+    drained = await drain_pending_messages("sessBoom")
+    assert [m.content for m in drained] == ["hi"]
 
 
 # ── Buffer cap ──────────────────────────────────────────────────────

--- a/autogpt_platform/backend/backend/copilot/response_model.py
+++ b/autogpt_platform/backend/backend/copilot/response_model.py
@@ -57,6 +57,10 @@ class ResponseType(str, Enum):
     # Dream/daydream pass snapshot — emitted from ``dream_events.py``.
     # Wired into the orchestrator in P6 (surface dreams) + P9 (daydreaming).
     DREAM_OPERATIONS = "data-dream-operations"
+    # Mid-turn hint: the executor just drained the session's pending-message
+    # buffer at a tool boundary. Lets the client promote queued chips to
+    # bubbles immediately instead of waiting for its backstop poll.
+    PENDING_DRAINED = "data-pending-drained"
 
 
 class StreamBaseResponse(BaseModel):
@@ -353,5 +357,33 @@ class StreamStatus(StreamBaseResponse):
         data = {
             "type": self.type.value,
             "data": {"message": self.message},
+        }
+        return f"data: {json.dumps(data)}\n\n"
+
+
+class StreamPendingDrained(StreamBaseResponse):
+    """Hint that the pending-message buffer was drained mid-turn.
+
+    Emitted at tool boundaries when the executor pulls queued user
+    follow-ups into the running turn. The frontend treats it as a pure
+    wake-up signal: on receipt it re-reads the authoritative buffer count
+    and promotes its queued chips to message bubbles, instead of waiting
+    for its slower backstop poll. ``drainedCount`` is informational only —
+    correctness comes from the client's re-read, so a dropped hint just
+    delays the chip→bubble swap until the next poll.
+    """
+
+    type: ResponseType = ResponseType.PENDING_DRAINED
+    drainedCount: int = Field(
+        default=0, description="How many messages were drained in this batch"
+    )
+
+    def to_sse(self) -> str:
+        """Emit as an AI SDK v5 data part (``type='data-pending-drained'``)
+        so the client surfaces it on ``message.parts`` rather than dropping
+        it as an unknown chunk type."""
+        data = {
+            "type": self.type.value,
+            "data": {"drainedCount": self.drainedCount},
         }
         return f"data: {json.dumps(data)}\n\n"

--- a/autogpt_platform/backend/backend/copilot/stream_registry.py
+++ b/autogpt_platform/backend/backend/copilot/stream_registry.py
@@ -47,6 +47,7 @@ from .response_model import (
     StreamFinish,
     StreamFinishStep,
     StreamHeartbeat,
+    StreamPendingDrained,
     StreamReasoningDelta,
     StreamReasoningEnd,
     StreamReasoningStart,
@@ -1167,6 +1168,7 @@ def _reconstruct_chunk(chunk_data: dict) -> StreamBaseResponse | None:
         ResponseType.HEARTBEAT.value: StreamHeartbeat,
         ResponseType.STATUS.value: StreamStatus,
         ResponseType.DREAM_OPERATIONS.value: StreamDreamOperations,
+        ResponseType.PENDING_DRAINED.value: StreamPendingDrained,
     }
 
     chunk_type = chunk_data.get("type")

--- a/autogpt_platform/backend/backend/copilot/stream_registry_test.py
+++ b/autogpt_platform/backend/backend/copilot/stream_registry_test.py
@@ -517,3 +517,20 @@ async def test_subscribe_to_session_replays_chunks_without_cursor_parts():
     assert isinstance(delivered[1], StreamTextDelta)
     assert isinstance(delivered[2], StreamTextEnd)
     assert isinstance(delivered[3], stream_registry.StreamFinish)
+
+
+def test_reconstruct_chunk_round_trips_pending_drained():
+    """The ``data-pending-drained`` hint must survive stream replay.  It is
+    published like any other chunk, so it has to be registered in
+    ``_reconstruct_chunk``; otherwise a client that reconnects mid-turn
+    silently drops the hint and falls back to the slow backstop poll."""
+    import orjson
+
+    from backend.copilot.response_model import StreamPendingDrained
+
+    stored = orjson.loads(StreamPendingDrained(drainedCount=3).model_dump_json())
+
+    chunk = stream_registry._reconstruct_chunk(stored)
+
+    assert isinstance(chunk, StreamPendingDrained)
+    assert chunk.drainedCount == 3

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/useCopilotPendingChips.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/useCopilotPendingChips.test.ts
@@ -1,0 +1,147 @@
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { UIDataTypes, UIMessage, UITools } from "ai";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getV2GetPendingMessages } from "@/app/api/__generated__/endpoints/chat/chat";
+import { useCopilotPendingChips } from "./useCopilotPendingChips";
+
+vi.mock("@/app/api/__generated__/endpoints/chat/chat", () => ({
+  getV2GetPendingMessages: vi.fn(),
+}));
+
+type Messages = UIMessage<unknown, UIDataTypes, UITools>[];
+
+const mockGetPending = vi.mocked(getV2GetPendingMessages);
+
+const ASSISTANT_ID = "assistant-stable-id";
+
+function assistantMessage(drainHints = 0): Messages[number] {
+  const parts: Messages[number]["parts"] = [
+    { type: "text", text: "working…", state: "done" },
+  ];
+  for (let i = 0; i < drainHints; i++) {
+    parts.push({
+      type: "data-pending-drained",
+      id: `hint-${i}`,
+      data: { drainedCount: 1 },
+    } as Messages[number]["parts"][number]);
+  }
+  return { id: ASSISTANT_ID, role: "assistant", parts };
+}
+
+// Server reports the buffer as fully drained (count 0) so the hook promotes
+// every locally-queued chip to a bubble.
+function mockBufferDrained() {
+  mockGetPending.mockResolvedValue({
+    status: 200,
+    data: { count: 0, messages: [] },
+    headers: new Headers(),
+  } as Awaited<ReturnType<typeof getV2GetPendingMessages>>);
+}
+
+function setupHook(initialMessages: Messages) {
+  let current: Messages = initialMessages;
+  const setMessages = vi.fn(
+    (updater: Messages | ((prev: Messages) => Messages)) => {
+      current = typeof updater === "function" ? updater(current) : updater;
+    },
+  );
+
+  const view = renderHook(
+    ({ messages }) =>
+      useCopilotPendingChips({
+        sessionId: "s1",
+        status: "streaming",
+        messages,
+        setMessages,
+      }),
+    { initialProps: { messages: initialMessages } },
+  );
+
+  return { view, setMessages, getMessages: () => current };
+}
+
+describe("useCopilotPendingChips", () => {
+  beforeEach(() => {
+    mockGetPending.mockReset();
+    mockBufferDrained();
+  });
+  afterEach(cleanup);
+
+  it("promotes a queued chip to a bubble the instant a data-pending-drained hint arrives", async () => {
+    const { view, getMessages } = setupHook([assistantMessage(0)]);
+
+    act(() => {
+      view.result.current.queueMessage("follow up");
+    });
+    expect(view.result.current.queuedMessages).toEqual(["follow up"]);
+
+    // The backend drains mid-turn and pushes the SSE hint: rerender with the
+    // new data-pending-drained part on the streaming assistant message.
+    await act(async () => {
+      view.rerender({ messages: [assistantMessage(1)] });
+    });
+
+    await waitFor(() => {
+      expect(mockGetPending).toHaveBeenCalledWith("s1");
+      // Chip cleared from the strip…
+      expect(view.result.current.queuedMessages).toEqual([]);
+    });
+
+    // …and promoted to a user bubble inserted before the streaming assistant.
+    const promoted = getMessages().find((m) =>
+      m.id.startsWith("promoted-midturn-pending-chip-"),
+    );
+    expect(promoted?.role).toBe("user");
+  });
+
+  it("does not promote when the backend buffer count still covers the local chips", async () => {
+    mockGetPending.mockResolvedValue({
+      status: 200,
+      data: { count: 1, messages: ["follow up"] },
+      headers: new Headers(),
+    } as Awaited<ReturnType<typeof getV2GetPendingMessages>>);
+
+    const { view, getMessages } = setupHook([assistantMessage(0)]);
+    act(() => {
+      view.result.current.queueMessage("follow up");
+    });
+
+    await act(async () => {
+      view.rerender({ messages: [assistantMessage(1)] });
+    });
+
+    await waitFor(() => expect(mockGetPending).toHaveBeenCalledWith("s1"));
+    expect(
+      getMessages().some((m) =>
+        m.id.startsWith("promoted-midturn-pending-chip-"),
+      ),
+    ).toBe(false);
+    expect(view.result.current.queuedMessages).toEqual(["follow up"]);
+  });
+
+  it("backstop poll promotes a chip even without an SSE hint", async () => {
+    vi.useFakeTimers();
+    try {
+      const { view, getMessages } = setupHook([assistantMessage(0)]);
+      act(() => {
+        view.result.current.queueMessage("follow up");
+      });
+
+      // No hint part is ever added; the slow backstop interval must still
+      // reconcile against the drained buffer.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(10_000);
+      });
+
+      expect(mockGetPending).toHaveBeenCalledWith("s1");
+      expect(
+        getMessages().some((m) =>
+          m.id.startsWith("promoted-midturn-pending-chip-"),
+        ),
+      ).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/useCopilotPendingChips.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/useCopilotPendingChips.test.ts
@@ -164,9 +164,7 @@ describe("useCopilotPendingChips", () => {
 
     // No mid-turn promotion of the old chip leaked into the new session.
     expect(
-      current.some((m) =>
-        m.id.startsWith("promoted-midturn-pending-chip-"),
-      ),
+      current.some((m) => m.id.startsWith("promoted-midturn-pending-chip-")),
     ).toBe(false);
   });
 

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/useCopilotPendingChips.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/useCopilotPendingChips.test.ts
@@ -120,6 +120,56 @@ describe("useCopilotPendingChips", () => {
     expect(view.result.current.queuedMessages).toEqual(["follow up"]);
   });
 
+  it("does not promote the previous session's chips after a session switch", async () => {
+    let current: Messages = [assistantMessage(0)];
+    const setMessages = vi.fn(
+      (updater: Messages | ((prev: Messages) => Messages)) => {
+        current = typeof updater === "function" ? updater(current) : updater;
+      },
+    );
+
+    const view = renderHook(
+      ({ messages, sessionId }) =>
+        useCopilotPendingChips({
+          sessionId,
+          status: "streaming",
+          messages,
+          setMessages,
+        }),
+      {
+        initialProps: {
+          messages: [assistantMessage(0)],
+          sessionId: "s1" as string,
+        },
+      },
+    );
+
+    act(() => {
+      view.result.current.queueMessage("old session chip");
+    });
+    expect(view.result.current.queuedMessages).toEqual(["old session chip"]);
+
+    // Switch to s2 with a HIGHER drain-hint count than s1's baseline while
+    // the old chip is still queued for this commit.  The drain effect must
+    // re-baseline on the session change and NOT promote the stale chip into
+    // the new chat.
+    await act(async () => {
+      view.rerender({ messages: [assistantMessage(1)], sessionId: "s2" });
+    });
+
+    // The session-switch peek rebases the strip to the new (empty) session.
+    await waitFor(() => {
+      expect(view.result.current.queuedMessages).toEqual([]);
+    });
+
+    // No mid-turn promotion of the old chip leaked into the new session.
+    expect(
+      current.some((m) =>
+        m.id.startsWith("promoted-midturn-pending-chip-"),
+      ),
+    ).toBe(false);
+  });
+
   it("backstop poll promotes a chip even without an SSE hint", async () => {
     vi.useFakeTimers();
     try {

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/useCopilotPendingChips.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/useCopilotPendingChips.ts
@@ -4,7 +4,10 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { makePromotedUserBubble } from "./helpers/makePromotedBubble";
 
-const MID_TURN_POLL_MS = 2_000;
+// Backstop only. Promotion is normally driven instantly by the backend's
+// ``data-pending-drained`` SSE hint (see ``useMidTurnDrainPromotion``); this
+// slow poll just catches a dropped hint so a chip can't get stuck mid-turn.
+const MID_TURN_BACKSTOP_POLL_MS = 10_000;
 
 type ChatStatus = "submitted" | "streaming" | "ready" | "error";
 
@@ -76,6 +79,7 @@ export function useCopilotPendingChips({
   useMidTurnDrainPromotion({
     sessionId,
     status,
+    messages,
     queue,
     setMessages,
     setQueue,
@@ -335,25 +339,28 @@ function promoteBeforeAssistant(
 }
 
 // ── 3. Mid-turn drain promotion ────────────────────────────────────────
-// The MCP tool wrapper can drain the buffer at a tool boundary without
-// emitting an SSE event, so the client doesn't know until we poll. On
-// every poll, if the backend count dropped below our local chip count,
-// promote the difference and keep the remainder as chips.
+// The executor drains the buffer at a tool boundary while the turn is
+// still streaming.  It now pushes a ``data-pending-drained`` SSE hint at
+// drain time, so the fast path promotes chips the instant the hint lands.
+// A slow backstop poll covers a dropped hint so a chip can't get stuck.
 //
-// TODO(followup): replace the 2s poll with an SSE event pushed from the
-// backend at drain time — the MCP wrapper already knows when it drains,
-// so a single "pending:drained" event would let us drop this effect
-// entirely.  Tracked separately from this PR.
+// Both paths funnel through the same ``pollBackendAndPromote`` (the GET
+// stays the source of truth: it re-reads the authoritative buffer count
+// and promotes only the difference).  Promotion dedupes bubbles by a
+// stable id, so the hint and the poll firing for the same drain is a
+// harmless no-op rather than a double-render.
 
 function useMidTurnDrainPromotion({
   sessionId,
   status,
+  messages,
   queue,
   setMessages,
   setQueue,
 }: {
   sessionId: string | null;
   status: ChatStatus;
+  messages: UIMessage[];
   queue: QueuedMessage[];
   setMessages: (updater: (prev: UIMessage[]) => UIMessage[]) => void;
   setQueue: (updater: QueueUpdater) => void;
@@ -368,6 +375,35 @@ function useMidTurnDrainPromotion({
     latestSessionIdRef.current = sessionId;
   }, [sessionId]);
 
+  // Fast path: promote the moment the backend signals a drain.  We count
+  // ``data-pending-drained`` parts across messages and react to the count
+  // increasing — replays (AI SDK resume re-emits the parts) leave the
+  // count unchanged on a stable render, and the GET re-read keeps a
+  // replayed hint idempotent regardless.
+  const drainHintCount = countPendingDrainedHints(messages);
+  const prevHintCountRef = useRef(drainHintCount);
+  useEffect(() => {
+    const isActive = status === "streaming" || status === "submitted";
+    if (!sessionId || !isActive || queue.length === 0) {
+      prevHintCountRef.current = drainHintCount;
+      return;
+    }
+    if (drainHintCount <= prevHintCountRef.current) return;
+    prevHintCountRef.current = drainHintCount;
+
+    const requestSessionId = sessionId;
+    const isCurrentSession = () =>
+      latestSessionIdRef.current === requestSessionId;
+    void pollBackendAndPromote(
+      sessionId,
+      queue,
+      setMessages,
+      setQueue,
+      isCurrentSession,
+    );
+  }, [drainHintCount, sessionId, status, queue, setMessages, setQueue]);
+
+  // Backstop: a slow poll that catches a dropped hint.
   useEffect(() => {
     if (!sessionId) return;
     const isActive = status === "streaming" || status === "submitted";
@@ -384,9 +420,22 @@ function useMidTurnDrainPromotion({
         setQueue,
         isCurrentSession,
       );
-    }, MID_TURN_POLL_MS);
+    }, MID_TURN_BACKSTOP_POLL_MS);
     return () => clearInterval(interval);
   }, [sessionId, status, queue, setMessages, setQueue]);
+}
+
+// Count ``data-pending-drained`` hint parts the backend emits at each
+// mid-turn drain.  A rising count across renders means a fresh drain the
+// fast path should react to.
+function countPendingDrainedHints(messages: UIMessage[]): number {
+  let count = 0;
+  for (const message of messages) {
+    for (const part of message.parts) {
+      if (part.type === "data-pending-drained") count++;
+    }
+  }
+  return count;
 }
 
 async function pollBackendAndPromote(

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/useCopilotPendingChips.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/useCopilotPendingChips.ts
@@ -381,15 +381,24 @@ function useMidTurnDrainPromotion({
   // count unchanged on a stable render, and the GET re-read keeps a
   // replayed hint idempotent regardless.
   const drainHintCount = countPendingDrainedHints(messages);
-  const prevHintCountRef = useRef(drainHintCount);
+  // Baseline is tracked per session: on a session switch the old session's
+  // chips can still be in `queue` for the current commit, so a higher hint
+  // count in the new session must not promote stale chips into the new chat.
+  // Re-baseline (and bail) when sessionId changes before comparing counts.
+  const prevHintStateRef = useRef({ sessionId, count: drainHintCount });
   useEffect(() => {
-    const isActive = status === "streaming" || status === "submitted";
-    if (!sessionId || !isActive || queue.length === 0) {
-      prevHintCountRef.current = drainHintCount;
+    if (prevHintStateRef.current.sessionId !== sessionId) {
+      prevHintStateRef.current = { sessionId, count: drainHintCount };
       return;
     }
-    if (drainHintCount <= prevHintCountRef.current) return;
-    prevHintCountRef.current = drainHintCount;
+
+    const isActive = status === "streaming" || status === "submitted";
+    if (!sessionId || !isActive || queue.length === 0) {
+      prevHintStateRef.current = { sessionId, count: drainHintCount };
+      return;
+    }
+    if (drainHintCount <= prevHintStateRef.current.count) return;
+    prevHintStateRef.current = { sessionId, count: drainHintCount };
 
     const requestSessionId = sessionId;
     const isCurrentSession = () =>


### PR DESCRIPTION
### Why / What / How

Two related changes that make the Copilot message queue more **stable and predictable** — one bug fix, one latency fix — both scoped to the existing queue/stream machinery (no new features).

**1. Cancel now clears the pending buffer.**
- *Why:* "Stop" published the executor cancel event but left the per-session pending-message buffer in Redis. That buffer only exists to feed the *running* turn (drained at tool boundaries → injected as `<user_follow_up>`). Once the turn is cancelled there's nothing to feed it, so queued follow-ups survived up to the 1h TTL and got injected into the **next, unrelated turn**. Stop didn't fully stop.
- *How:* Clear the buffer once at the top of `cancel_session_task`, before branching, so it covers every cancel path (`dequeued`, `orphan_released`, running). Best-effort: a Redis hiccup is swallowed so cleanup can't block the cancel.

**2. Mid-turn chip promotion is now SSE-driven, with the poll demoted to a backstop.**
- *Why:* The frontend learned about mid-turn buffer drains only by polling `GET /messages/pending` every 2s — the executor drained silently. This is the "instantaneous via SSE instead of polling" item.
- *How:* The executor emits a `data-pending-drained` hint on the live SSE stream at drain time. The frontend promotes queued chips to bubbles the instant the hint lands; the former 2s poll drops to a **10s backstop** that only catches a dropped hint.
- *Safety:* The `GET` stays source of truth (the hint is a pure wake-up signal), so a replayed hint on AI-SDK resume is idempotent. Promotion dedupes bubbles by stable id, so hint + backstop firing for the same drain is a no-op, not a double-render. The backend emit is best-effort and the backstop poll is retained, so the chip→bubble swap is **self-healing**: worst case a chip promotes late, never lost — the message itself is injected + persisted server-side regardless.

### Changes 🏗️

**Backend**
- `routes.py` — `cancel_session_task` clears `copilot:pending:{session}` (best-effort) before the cancel branches.
- `response_model.py` — new `StreamPendingDrained` chunk + `ResponseType.PENDING_DRAINED` (`data-pending-drained`), following the existing `data-status`/`data-cursor` data-part pattern.
- `pending_messages.py` — `drain_pending_messages` (the single chokepoint for both the SDK PostToolUse and baseline mid-loop drains) emits the hint via `publish_chunk`, looking up the active turn with `get_session(session_id)`. Best-effort.

**Frontend**
- `useCopilotPendingChips.ts` — new fast-path effect promotes chips when the `data-pending-drained` part count rises; reuses the existing `pollBackendAndPromote` (GET = truth); `MID_TURN_POLL_MS (2s)` → `MID_TURN_BACKSTOP_POLL_MS (10s)`.

### Tests

- `routes_test.py` — cancel clears the buffer; cancel still succeeds when the clear raises.
- `pending_messages_test.py` — drain emits the hint with the active turn id + `drainedCount`; empty drain emits nothing; a failing emit still returns the drained messages.
- Backend: `poetry run pytest backend/copilot/pending_messages_test.py backend/api/features/chat/routes_test.py -k "cancel or drain"` → 23 passed.
- Frontend types/lint/integration via `pnpm types && pnpm lint && pnpm test:unit` (run locally).

### Checklist

- [x] Changes listed in the PR description
- [x] Test plan made and executed (backend cancel + drain tests pass; new tests fail without their fixes)
- [ ] `pnpm types && pnpm lint && pnpm test:unit` (frontend)
