### PR TITLE
fix(frontend): global search loading state, drop jittery item animation

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/components/GlobalSearchModal/useGlobalSearch.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/components/GlobalSearchModal/useGlobalSearch.ts
@@ -47,6 +47,15 @@ export function useGlobalSearch(isOpen: boolean) {
   const response =
     data?.status === 200 ? (data.data as GlobalSearchResponse) : undefined;
 
+  // First fetch after opening: no results have landed yet (``placeholderData``
+  // keeps the previous response on every later fetch, so ``response`` is only
+  // undefined here). Suppress the instant command buckets too while this is
+  // true — otherwise navigation/actions render immediately, the modal looks
+  // "done", and the async results pop in a second later and shove everything
+  // down. Returning no buckets lets the modal show its loading skeleton, then
+  // results + commands appear together with no re-layout.
+  const isInitialLoading = isFetching && !response;
+
   const { buckets: searchBuckets, itemsById } =
     buildBucketsFromResponse(response);
 
@@ -66,7 +75,9 @@ export function useGlobalSearch(isOpen: boolean) {
     entry.bucket && !entry.isExactMatch ? [entry.bucket] : [],
   );
 
-  const buckets = [...topBuckets, ...searchBuckets, ...bottomBuckets];
+  const buckets = isInitialLoading
+    ? []
+    : [...topBuckets, ...searchBuckets, ...bottomBuckets];
 
   return {
     query,

--- a/autogpt_platform/frontend/src/components/organisms/SearchCommandModal/SearchCommandResultItem.tsx
+++ b/autogpt_platform/frontend/src/components/organisms/SearchCommandModal/SearchCommandResultItem.tsx
@@ -15,16 +15,7 @@ interface Props {
   highlightedRef?: MutableRefObject<HTMLButtonElement | null>;
   onHighlight: () => void;
   onSelect: () => void;
-  /** Zero-based position used to stagger the enter animation. */
-  enterIndex?: number;
 }
-
-// Per Emil Kowalski's "faster is better" rule: keep the stagger tight
-// so the list never feels like it's *waiting* to render. 35ms × 12
-// items ≈ 420ms total before the last item finishes its own 180ms
-// animation, which stays under the 300ms perceived-snappy budget for
-// the typical first-visible row.
-const ENTER_STAGGER_MS = 35;
 
 export function SearchCommandResultItem({
   item,
@@ -35,7 +26,6 @@ export function SearchCommandResultItem({
   highlightedRef,
   onHighlight,
   onSelect,
-  enterIndex = 0,
 }: Props) {
   const Icon = item.icon;
 
@@ -49,10 +39,8 @@ export function SearchCommandResultItem({
       aria-selected={isHighlighted}
       onMouseEnter={onHighlight}
       onClick={onSelect}
-      style={{ animationDelay: `${enterIndex * ENTER_STAGGER_MS}ms` }}
       className={cn(
         "relative h-auto w-full justify-start rounded-md px-3 py-2 text-left transition-colors duration-150",
-        "motion-safe:animate-search-item-in",
         isHighlighted ? "bg-zinc-100 hover:bg-zinc-100" : "hover:bg-zinc-50",
       )}
     >

--- a/autogpt_platform/frontend/src/components/organisms/SearchCommandModal/SearchCommandResults.tsx
+++ b/autogpt_platform/frontend/src/components/organisms/SearchCommandModal/SearchCommandResults.tsx
@@ -67,10 +67,6 @@ export function SearchCommandResults({
                   }
                   onHighlight={() => onHighlight(entry.index)}
                   onSelect={() => onSelect(entry.item, entry.bucketKey)}
-                  // Absolute index across all buckets so the stagger
-                  // cascades naturally section-by-section instead of
-                  // restarting at each header.
-                  enterIndex={entry.index}
                 />
               ))}
             </div>

--- a/autogpt_platform/frontend/src/components/organisms/SearchCommandModal/SearchCommandSkeleton.tsx
+++ b/autogpt_platform/frontend/src/components/organisms/SearchCommandModal/SearchCommandSkeleton.tsx
@@ -6,8 +6,6 @@ interface Props {
   rows?: number;
 }
 
-const STAGGER_MS = 35;
-
 export function SearchCommandSkeleton({ rows = 4 }: Props) {
   return (
     <div
@@ -23,8 +21,7 @@ export function SearchCommandSkeleton({ rows = 4 }: Props) {
         {Array.from({ length: rows }, (_, idx) => (
           <div
             key={idx}
-            className="flex items-center gap-2.5 rounded-md px-3 py-2 motion-safe:animate-search-item-in"
-            style={{ animationDelay: `${idx * STAGGER_MS}ms` }}
+            className="flex items-center gap-2.5 rounded-md px-3 py-2"
           >
             <Skeleton className="h-4 w-4 rounded" />
             <div className="flex min-w-0 flex-1 flex-col gap-1">

--- a/autogpt_platform/frontend/tailwind.config.ts
+++ b/autogpt_platform/frontend/tailwind.config.ts
@@ -159,19 +159,6 @@ const config = {
             opacity: "1",
           },
         },
-        // Emil Kowalski enter pattern: translate from below + fade,
-        // ease-out, under 300ms. Driven by inline ``animation-delay``
-        // for per-item staggering.
-        "search-item-in": {
-          "0%": {
-            opacity: "0",
-            transform: "translateY(4px)",
-          },
-          "100%": {
-            opacity: "1",
-            transform: "translateY(0)",
-          },
-        },
         shimmer: {
           "0%": {
             backgroundPosition: "200% 0",
@@ -212,12 +199,6 @@ const config = {
         "accordion-down": "accordion-down 0.2s ease-out",
         "accordion-up": "accordion-up 0.2s ease-out",
         "fade-in": "fade-in 0.2s ease-out",
-        // 180ms / ease-out keeps the entry inside Emil Kowalski's
-        // "faster is better" UI budget. Backwards mode so the item
-        // stays invisible until its staggered delay elapses, instead
-        // of flashing at frame zero.
-        "search-item-in":
-          "search-item-in 180ms cubic-bezier(0.16, 1, 0.3, 1) both",
         shimmer: "shimmer 4s ease-in-out infinite",
         loader: "loader 1s infinite",
         shake: "shake 0.5s ease-in-out",


### PR DESCRIPTION
### Why / What / How

**Why:** Feedback on the CMD+K global search ([PR #13360](https://github.com/Significant-Gravitas/AutoGPT/pull/13360)): the modal felt "extremely stuttery" and recent items popped in ~1s after opening with no loading state, causing an unexpected re-layout.

**What:** Adds a real loading state on first open and removes the jittery per-item enter animation.

**How:** The skeleton gate was `totalCount === 0 && isLoading`, but the instant client-side nav/action buckets kept `totalCount > 0`, so the skeleton never showed and the async recent-items shoved the list down when they landed. `useGlobalSearch` now suppresses all buckets while `isFetching && !response` (first fetch only — `placeholderData` keeps prior results on later fetches), so the modal shows its skeleton and then renders results + commands together. The staggered `search-item-in` animation (which re-fired on every keystroke) is removed from the result items, skeleton, and the now-unused Tailwind keyframe.

### Changes 🏗️

- `useGlobalSearch.ts` — suppress buckets during the initial in-flight fetch so the skeleton shows and content lands without re-layout.
- `SearchCommandResultItem.tsx` / `SearchCommandResults.tsx` — drop the `enterIndex` stagger and `motion-safe:animate-search-item-in` enter animation.
- `SearchCommandSkeleton.tsx` — render static skeleton rows (no stagger).
- `tailwind.config.ts` — remove the now-unused `search-item-in` keyframe + animation.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [ ] Open CMD+K on a cold cache → skeleton shows, then results + Navigate/Actions appear together (no downward jump)
  - [ ] Type a query → results update smoothly with no per-item flicker/stutter; previous results stay visible while fetching
  - [ ] Reopen within ~10s → cached results show instantly, no skeleton flash
  - [ ] Empty result set → "No recent items" / "No results found" still render correctly
