### PR TITLE
Fix/9326 improve block placement

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/build/components/NewControlPanel/NewBlockMenu/AllBlocksContent/AllBlocksContent.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/NewControlPanel/NewBlockMenu/AllBlocksContent/AllBlocksContent.tsx
@@ -6,7 +6,6 @@ import { beautifyString } from "@/lib/utils";
 import { useAllBlockContent } from "./useAllBlockContent";
 import { ErrorCard } from "@/components/molecules/ErrorCard/ErrorCard";
 import { blockMenuContainerStyle } from "../style";
-import { useNodeStore } from "../../../../stores/nodeStore";
 
 export const AllBlocksContent = () => {
   const {
@@ -18,8 +17,6 @@ export const AllBlocksContent = () => {
     isLoadingMore,
     isErrorOnLoadingMore,
   } = useAllBlockContent();
-
-  const addBlock = useNodeStore((state) => state.addBlock);
 
   if (isLoading) {
     return (
@@ -74,7 +71,6 @@ export const AllBlocksContent = () => {
                   key={`${category.name}-${block.id}`}
                   title={block.name as string}
                   description={block.name as string}
-                  onClick={() => addBlock(block)}
                   blockData={block}
                 />
               ))}

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/NewControlPanel/NewBlockMenu/Block.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/NewControlPanel/NewBlockMenu/Block.tsx
@@ -1,14 +1,14 @@
 import { Button } from "@/components/__legacy__/ui/button";
 import { Skeleton } from "@/components/__legacy__/ui/skeleton";
 import { beautifyString, cn } from "@/lib/utils";
-import React, { ButtonHTMLAttributes, useCallback, useState } from "react";
+import React, { ButtonHTMLAttributes, useState } from "react";
 import { highlightText } from "./helpers";
 import { PlusIcon } from "@phosphor-icons/react";
 import { BlockInfo } from "@/app/api/__generated__/models/blockInfo";
 import { useControlPanelStore } from "../../../stores/controlPanelStore";
 import { blockDragPreviewStyle } from "./style";
-import { useReactFlow } from "@xyflow/react";
 import { useNodeStore } from "../../../stores/nodeStore";
+import { useAddBlockToBuilder } from "./hooks/useAddBlockToBuilder";
 import { BlockUIType, SpecialBlockID } from "@/lib/autogpt-server-api";
 import {
   MCPToolDialog,
@@ -37,34 +37,14 @@ export const Block: BlockComponent = ({
   const setBlockMenuOpen = useControlPanelStore(
     (state) => state.setBlockMenuOpen,
   );
-  const { setViewport } = useReactFlow();
-  const { addBlock } = useNodeStore();
+  const { addBlockWithPlacement } = useAddBlockToBuilder();
   const [mcpDialogOpen, setMcpDialogOpen] = useState(false);
 
   const isMCPBlock = blockData.uiType === BlockUIType.MCP_TOOL;
 
-  const addBlockAndCenter = useCallback(
-    (block: BlockInfo, hardcodedValues?: Record<string, any>) => {
-      const customNode = addBlock(block, hardcodedValues);
-      setTimeout(() => {
-        setViewport(
-          {
-            x: -customNode.position.x * 0.8 + window.innerWidth / 2,
-            y: -customNode.position.y * 0.8 + (window.innerHeight - 400) / 2,
-            zoom: 0.8,
-          },
-          { duration: 500 },
-        );
-      }, 50);
-      return customNode;
-    },
-    [addBlock, setViewport],
-  );
-
   const updateNodeData = useNodeStore((state) => state.updateNodeData);
 
-  const handleMCPToolConfirm = useCallback(
-    (result: MCPToolDialogResult) => {
+  function handleMCPToolConfirm(result: MCPToolDialogResult) {
       // Derive a display label: prefer server name, fall back to URL hostname.
       let serverLabel = result.serverName;
       if (!serverLabel) {
@@ -75,7 +55,7 @@ export const Block: BlockComponent = ({
         }
       }
 
-      const customNode = addBlockAndCenter(blockData, {
+      const customNode = addBlockWithPlacement(blockData, {
         server_url: result.serverUrl,
         server_name: serverLabel,
         selected_tool: result.selectedTool,
@@ -95,17 +75,15 @@ export const Block: BlockComponent = ({
           },
         });
       }
-      setMcpDialogOpen(false);
-    },
-    [addBlockAndCenter, blockData, updateNodeData],
-  );
+    setMcpDialogOpen(false);
+  }
 
-  const handleClick = () => {
+  function handleClick() {
     if (isMCPBlock) {
       setMcpDialogOpen(true);
       return;
     }
-    const customNode = addBlockAndCenter(blockData);
+    const customNode = addBlockWithPlacement(blockData);
     // Set customized_name for agent blocks so the agent's name persists
     if (customNode && blockData.id === SpecialBlockID.AGENT) {
       updateNodeData(customNode.id, {

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/NewControlPanel/NewBlockMenu/IntergrationBlock.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/NewControlPanel/NewBlockMenu/IntergrationBlock.tsx
@@ -6,8 +6,7 @@ import React, { ButtonHTMLAttributes } from "react";
 import { highlightText } from "./helpers";
 import { Button } from "@/components/atoms/Button/Button";
 import { useControlPanelStore } from "../../../stores/controlPanelStore";
-import { useReactFlow } from "@xyflow/react";
-import { useNodeStore } from "../../../stores/nodeStore";
+import { useAddBlockToBuilder } from "./hooks/useAddBlockToBuilder";
 import { BlockInfo } from "@/app/api/__generated__/models/blockInfo";
 import { blockDragPreviewStyle } from "./style";
 
@@ -35,22 +34,11 @@ export const IntegrationBlock: IntegrationBlockComponent = ({
   const setBlockMenuOpen = useControlPanelStore(
     (state) => state.setBlockMenuOpen,
   );
-  const { setViewport } = useReactFlow();
-  const { addBlock } = useNodeStore();
+  const { addBlockWithPlacement } = useAddBlockToBuilder();
 
-  const handleClick = () => {
-    const customNode = addBlock(blockData);
-    setTimeout(() => {
-      setViewport(
-        {
-          x: -customNode.position.x * 0.8 + window.innerWidth / 2,
-          y: -customNode.position.y * 0.8 + (window.innerHeight - 400) / 2,
-          zoom: 0.8,
-        },
-        { duration: 500 },
-      );
-    }, 50);
-  };
+  function handleClick() {
+    addBlockWithPlacement(blockData);
+  }
 
   const handleDragStart = (e: React.DragEvent<HTMLButtonElement>) => {
     e.dataTransfer.effectAllowed = "copy";

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/NewControlPanel/NewBlockMenu/hooks/useAddAgentToBuilder.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/NewControlPanel/NewBlockMenu/hooks/useAddAgentToBuilder.ts
@@ -1,15 +1,13 @@
 import { useNodeStore } from "@/app/(platform)/build/stores/nodeStore";
-import { useShallow } from "zustand/react/shallow";
-import { useReactFlow } from "@xyflow/react";
 import { convertLibraryAgentIntoCustomNode } from "../helpers";
 import { LibraryAgent } from "@/app/api/__generated__/models/libraryAgent";
 import { getV2GetLibraryAgent } from "@/app/api/__generated__/endpoints/library/library";
+import { useAddBlockToBuilder } from "./useAddBlockToBuilder";
 
-export const useAddAgentToBuilder = () => {
-  const addBlock = useNodeStore(useShallow((state) => state.addBlock));
-  const { setViewport } = useReactFlow();
+export function useAddAgentToBuilder() {
+  const { addBlockWithPlacement } = useAddBlockToBuilder();
 
-  const addAgentToBuilder = (libraryAgent: LibraryAgent) => {
+  function addAgentToBuilder(libraryAgent: LibraryAgent) {
     const { input_schema, output_schema } = libraryAgent;
 
     const { block, hardcodedValues } = convertLibraryAgentIntoCustomNode(
@@ -18,23 +16,10 @@ export const useAddAgentToBuilder = () => {
       output_schema,
     );
 
-    const customNode = addBlock(block, hardcodedValues);
+    return addBlockWithPlacement(block, hardcodedValues);
+  }
 
-    setTimeout(() => {
-      setViewport(
-        {
-          x: -customNode.position.x * 0.8 + window.innerWidth / 2,
-          y: -customNode.position.y * 0.8 + (window.innerHeight - 400) / 2,
-          zoom: 0.8,
-        },
-        { duration: 500 },
-      );
-    }, 50);
-
-    return customNode;
-  };
-
-  const addLibraryAgentToBuilder = async (agent: LibraryAgent) => {
+  async function addLibraryAgentToBuilder(agent: LibraryAgent) {
     const response = await getV2GetLibraryAgent(agent.id);
 
     if (!response.data) {
@@ -43,10 +28,10 @@ export const useAddAgentToBuilder = () => {
 
     const libraryAgent = response.data as LibraryAgent;
     return addAgentToBuilder(libraryAgent);
-  };
+  }
 
   return {
     addAgentToBuilder,
     addLibraryAgentToBuilder,
   };
-};
+}

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/NewControlPanel/NewBlockMenu/hooks/useAddBlockToBuilder.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/NewControlPanel/NewBlockMenu/hooks/useAddBlockToBuilder.ts
@@ -1,0 +1,53 @@
+import { BlockInfo } from "@/app/api/__generated__/models/blockInfo";
+import { useReactFlow } from "@xyflow/react";
+import { useNodeStore } from "@/app/(platform)/build/stores/nodeStore";
+import { BlockUIType } from "@/app/(platform)/build/components/types";
+import {
+  findFreePosition,
+  getFlowViewportBounds,
+} from "@/app/(platform)/build/components/placementHelpers";
+import { CustomNode } from "@/app/(platform)/build/components/FlowEditor/nodes/CustomNode/CustomNode";
+
+export function useAddBlockToBuilder() {
+  const addBlock = useNodeStore((state) => state.addBlock);
+  const nodes = useNodeStore((state) => state.nodes);
+  const { getViewport } = useReactFlow();
+
+  function addBlockWithPlacement(
+    block: BlockInfo,
+    hardcodedValues?: Record<string, unknown>,
+  ): CustomNode {
+    const viewport = getViewport();
+    const viewportBounds = getFlowViewportBounds(
+      viewport,
+      window.innerWidth,
+      window.innerHeight,
+    );
+    const isNote = block.uiType === BlockUIType.NOTE;
+    const newNodeWidth = isNote ? 300 : 400;
+    const newNodeHeight = isNote ? 300 : 400;
+
+    const existingNodes = nodes.map((node) => ({
+      position: node.position,
+      measured: {
+        width:
+          node.width ??
+          node.measured?.width ??
+          (node.data.uiType === BlockUIType.NOTE ? 300 : 500),
+        height: node.height ?? node.measured?.height ?? 400,
+      },
+    }));
+
+    const position = findFreePosition(
+      existingNodes,
+      newNodeWidth,
+      30,
+      viewportBounds,
+      newNodeHeight,
+    );
+
+    return addBlock(block, hardcodedValues, position);
+  }
+
+  return { addBlockWithPlacement };
+}

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/__tests__/placementHelpers.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/__tests__/placementHelpers.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import {
+  findFreePosition,
+  getFlowViewportBounds,
+  type ExistingNodeForPlacement,
+} from "../placementHelpers";
+
+const viewport = getFlowViewportBounds(
+  { x: 0, y: 0, zoom: 1 },
+  1000,
+  800,
+  0,
+);
+
+function node(
+  x: number,
+  y: number,
+  width = 500,
+  height = 400,
+): ExistingNodeForPlacement {
+  return {
+    position: { x, y },
+    measured: { width, height },
+  };
+}
+
+describe("getFlowViewportBounds", () => {
+  it("maps screen corners to flow coordinates", () => {
+    expect(
+      getFlowViewportBounds({ x: -100, y: -50, zoom: 0.5 }, 1200, 900, 0),
+    ).toEqual({
+      minX: 200,
+      minY: 100,
+      maxX: 2600,
+      maxY: 1900,
+    });
+  });
+});
+
+describe("findFreePosition", () => {
+  it("returns default origin when there are no nodes", () => {
+    expect(findFreePosition([])).toEqual({ x: 100, y: 100 });
+  });
+
+  it("places the first block inside the viewport when bounds are provided", () => {
+    expect(findFreePosition([], 400, 30, viewport)).toEqual({ x: 30, y: 30 });
+  });
+
+  it("places a block to the right of the most recent node when space is available", () => {
+    expect(findFreePosition([node(100, 100)], 400, 30)).toEqual({
+      x: 630,
+      y: 100,
+    });
+  });
+
+  it("prefers a visible grid slot over an off-screen adjacent slot", () => {
+    const crowdedCanvas = [node(5000, 5000)];
+
+    const position = findFreePosition(crowdedCanvas, 400, 30, viewport);
+
+    expect(position.x).toBeGreaterThanOrEqual(viewport.minX);
+    expect(position.y).toBeGreaterThanOrEqual(viewport.minY);
+    expect(position.x + 400).toBeLessThanOrEqual(viewport.maxX);
+    expect(position.y + 400).toBeLessThanOrEqual(viewport.maxY);
+  });
+
+  it("does not jump far to the right when the viewport is full", () => {
+    const gridNodes: ExistingNodeForPlacement[] = [];
+    for (let row = 0; row < 3; row++) {
+      for (let col = 0; col < 3; col++) {
+        gridNodes.push(node(col * 430, row * 430, 400, 400));
+      }
+    }
+
+    const position = findFreePosition(gridNodes, 400, 30, viewport);
+
+    expect(position).toEqual({ x: 30, y: 830 });
+  });
+
+  it("uses adjacent placement without viewport bounds when canvas is not crowded", () => {
+    expect(findFreePosition([node(200, 150)], 400, 30)).toEqual({
+      x: 730,
+      y: 150,
+    });
+  });
+});

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/helper.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/helper.ts
@@ -8,8 +8,6 @@ import { NodeModel } from "@/app/api/__generated__/models/nodeModel";
 import { NodeModelMetadata } from "@/app/api/__generated__/models/nodeModelMetadata";
 import { Link } from "@/app/api/__generated__/models/link";
 import { CustomEdge } from "./FlowEditor/edges/CustomEdge";
-import { XYPosition } from "@xyflow/react";
-
 export const convertBlockInfoIntoCustomNodeData = (
   block: BlockInfo,
   hardcodedValues: Record<string, any> = {},
@@ -123,106 +121,10 @@ export const isCostFilterMatch = (
     : costFilter === inputValues;
 };
 
-// ----- Position related helpers -----
-
-export interface NodeDimensions {
-  x: number;
-  y: number;
-  width: number;
-  height: number;
-}
-
-function rectanglesOverlap(
-  rect1: NodeDimensions,
-  rect2: NodeDimensions,
-): boolean {
-  const x1 = rect1.x,
-    y1 = rect1.y,
-    w1 = rect1.width,
-    h1 = rect1.height;
-  const x2 = rect2.x,
-    y2 = rect2.y,
-    w2 = rect2.width,
-    h2 = rect2.height;
-
-  return !(x1 + w1 <= x2 || x1 >= x2 + w2 || y1 + h1 <= y2 || y1 >= y2 + h2);
-}
-
-export function findFreePosition(
-  existingNodes: Array<{
-    position: XYPosition;
-    measured?: { width: number; height: number };
-  }>,
-  newNodeWidth: number = 500,
-  margin: number = 60,
-): XYPosition {
-  if (existingNodes.length === 0) {
-    return { x: 100, y: 100 }; // Default starting position
-  }
-
-  // Start from the most recently added node
-  for (let i = existingNodes.length - 1; i >= 0; i--) {
-    const lastNode = existingNodes[i];
-    const lastNodeWidth = lastNode.measured?.width ?? 500;
-    const lastNodeHeight = lastNode.measured?.height ?? 400;
-
-    // Try right
-    const candidate = {
-      x: lastNode.position.x + lastNodeWidth + margin,
-      y: lastNode.position.y,
-      width: newNodeWidth,
-      height: 400, // Estimated height
-    };
-
-    if (
-      !existingNodes.some((n) =>
-        rectanglesOverlap(candidate, {
-          x: n.position.x,
-          y: n.position.y,
-          width: n.measured?.width ?? 500,
-          height: n.measured?.height ?? 400,
-        }),
-      )
-    ) {
-      return { x: candidate.x, y: candidate.y };
-    }
-
-    // Try left
-    candidate.x = lastNode.position.x - newNodeWidth - margin;
-    if (
-      !existingNodes.some((n) =>
-        rectanglesOverlap(candidate, {
-          x: n.position.x,
-          y: n.position.y,
-          width: n.measured?.width ?? 500,
-          height: n.measured?.height ?? 400,
-        }),
-      )
-    ) {
-      return { x: candidate.x, y: candidate.y };
-    }
-
-    // Try below
-    candidate.x = lastNode.position.x;
-    candidate.y = lastNode.position.y + lastNodeHeight + margin;
-    if (
-      !existingNodes.some((n) =>
-        rectanglesOverlap(candidate, {
-          x: n.position.x,
-          y: n.position.y,
-          width: n.measured?.width ?? 500,
-          height: n.measured?.height ?? 400,
-        }),
-      )
-    ) {
-      return { x: candidate.x, y: candidate.y };
-    }
-  }
-
-  // Fallback: place it far to the right
-  const lastNode = existingNodes[existingNodes.length - 1];
-  return {
-    x: lastNode.position.x + 600,
-    y: lastNode.position.y,
-  };
-}
+export {
+  findFreePosition,
+  getFlowViewportBounds,
+  type ExistingNodeForPlacement,
+  type FlowViewportBounds,
+  type NodeDimensions,
+} from "./placementHelpers";

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/placementHelpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/placementHelpers.ts
@@ -1,0 +1,218 @@
+import { XYPosition } from "@xyflow/react";
+
+export interface NodeDimensions {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export type FlowViewportBounds = {
+  minX: number;
+  minY: number;
+  maxX: number;
+  maxY: number;
+};
+
+export type ExistingNodeForPlacement = {
+  position: XYPosition;
+  measured?: { width: number; height: number };
+};
+
+const DEFAULT_NODE_WIDTH = 500;
+const DEFAULT_NODE_HEIGHT = 400;
+
+function rectanglesOverlap(
+  rect1: NodeDimensions,
+  rect2: NodeDimensions,
+): boolean {
+  return !(
+    rect1.x + rect1.width <= rect2.x ||
+    rect1.x >= rect2.x + rect2.width ||
+    rect1.y + rect1.height <= rect2.y ||
+    rect1.y >= rect2.y + rect2.height
+  );
+}
+
+function toNodeRect(node: ExistingNodeForPlacement): NodeDimensions {
+  return {
+    x: node.position.x,
+    y: node.position.y,
+    width: node.measured?.width ?? DEFAULT_NODE_WIDTH,
+    height: node.measured?.height ?? DEFAULT_NODE_HEIGHT,
+  };
+}
+
+function candidateOverlapsAny(
+  candidate: NodeDimensions,
+  existingNodes: ExistingNodeForPlacement[],
+): boolean {
+  return existingNodes.some((node) =>
+    rectanglesOverlap(candidate, toNodeRect(node)),
+  );
+}
+
+function isInsideViewport(
+  candidate: NodeDimensions,
+  viewport: FlowViewportBounds,
+): boolean {
+  return (
+    candidate.x >= viewport.minX &&
+    candidate.y >= viewport.minY &&
+    candidate.x + candidate.width <= viewport.maxX &&
+    candidate.y + candidate.height <= viewport.maxY
+  );
+}
+
+export function getFlowViewportBounds(
+  viewport: { x: number; y: number; zoom: number },
+  width: number,
+  height: number,
+  padding = 40,
+): FlowViewportBounds {
+  return {
+    minX: (-viewport.x + padding) / viewport.zoom,
+    minY: (-viewport.y + padding) / viewport.zoom,
+    maxX: (width - viewport.x - padding) / viewport.zoom,
+    maxY: (height - viewport.y - padding) / viewport.zoom,
+  };
+}
+
+function findFreePositionInViewport(
+  existingNodes: ExistingNodeForPlacement[],
+  newNodeWidth: number,
+  newNodeHeight: number,
+  margin: number,
+  viewport: FlowViewportBounds,
+): XYPosition | null {
+  const stepX = newNodeWidth + margin;
+  const stepY = newNodeHeight + margin;
+
+  for (
+    let y = viewport.minY;
+    y + newNodeHeight <= viewport.maxY;
+    y += stepY
+  ) {
+    for (
+      let x = viewport.minX;
+      x + newNodeWidth <= viewport.maxX;
+      x += stepX
+    ) {
+      const candidate: NodeDimensions = {
+        x,
+        y,
+        width: newNodeWidth,
+        height: newNodeHeight,
+      };
+
+      if (!candidateOverlapsAny(candidate, existingNodes)) {
+        return { x, y };
+      }
+    }
+  }
+
+  return null;
+}
+
+function collectAdjacentCandidates(
+  existingNodes: ExistingNodeForPlacement[],
+  newNodeWidth: number,
+  newNodeHeight: number,
+  margin: number,
+): XYPosition[] {
+  const candidates: XYPosition[] = [];
+
+  for (let i = existingNodes.length - 1; i >= 0; i--) {
+    const lastRect = toNodeRect(existingNodes[i]);
+    const offsets = [
+      { x: lastRect.x + lastRect.width + margin, y: lastRect.y },
+      { x: lastRect.x - newNodeWidth - margin, y: lastRect.y },
+      { x: lastRect.x, y: lastRect.y + lastRect.height + margin },
+    ];
+
+    for (const offset of offsets) {
+      const candidate: NodeDimensions = {
+        x: offset.x,
+        y: offset.y,
+        width: newNodeWidth,
+        height: newNodeHeight,
+      };
+
+      if (!candidateOverlapsAny(candidate, existingNodes)) {
+        candidates.push({ x: offset.x, y: offset.y });
+      }
+    }
+  }
+
+  return candidates;
+}
+
+export function findFreePosition(
+  existingNodes: ExistingNodeForPlacement[],
+  newNodeWidth: number = DEFAULT_NODE_WIDTH,
+  margin: number = 60,
+  viewportBounds?: FlowViewportBounds,
+  newNodeHeight: number = DEFAULT_NODE_HEIGHT,
+): XYPosition {
+  if (existingNodes.length === 0) {
+    if (viewportBounds) {
+      return {
+        x: viewportBounds.minX + margin,
+        y: viewportBounds.minY + margin,
+      };
+    }
+    return { x: 100, y: 100 };
+  }
+
+  if (viewportBounds) {
+    const inViewport = findFreePositionInViewport(
+      existingNodes,
+      newNodeWidth,
+      newNodeHeight,
+      margin,
+      viewportBounds,
+    );
+    if (inViewport) {
+      return inViewport;
+    }
+  }
+
+  const adjacentCandidates = collectAdjacentCandidates(
+    existingNodes,
+    newNodeWidth,
+    newNodeHeight,
+    margin,
+  );
+
+  if (viewportBounds && adjacentCandidates.length > 0) {
+    for (const candidate of adjacentCandidates) {
+      if (
+        isInsideViewport(
+          {
+            ...candidate,
+            width: newNodeWidth,
+            height: newNodeHeight,
+          },
+          viewportBounds,
+        )
+      ) {
+        return candidate;
+      }
+    }
+  } else if (adjacentCandidates.length > 0) {
+    return adjacentCandidates[0];
+  }
+
+  if (viewportBounds) {
+    return {
+      x: viewportBounds.minX + margin,
+      y: viewportBounds.maxY + margin,
+    };
+  }
+
+  const lastRect = toNodeRect(existingNodes[existingNodes.length - 1]);
+  return {
+    x: lastRect.x + lastRect.width + margin,
+    y: lastRect.y,
+  };
+}


### PR DESCRIPTION
### Why / What / How

<!-- Why: Why does this PR exist? What problem does it solve, or what's broken/missing without it? -->
<!-- What: What does this PR change? Summarize the changes at a high level. -->
<!-- How: How does it work? Describe the approach, key implementation details, or architecture decisions. -->

Why

When you add a block from the builder menu by clicking, the canvas would jump and zoom would reset to ~80%. That’s disorienting when you’re already zoomed in or panning around a busy graph — especially once the canvas starts running out of space. This addresses [#9326](https://github.com/Significant-Gravitas/AutoGPT/issues/9326).

What

This PR stops the builder from forcing a viewport change on block click, and improves where new blocks get placed so they show up near what you’re actually looking at.

How

Removed the duplicated setViewport(..., zoom: 0.8) logic from the block menu click handlers.
Added a shared useAddBlockToBuilder hook that reads the current React Flow viewport and computes placement before adding the block.
Reworked findFreePosition into placementHelpers.ts: it first tries to find a free spot inside the visible canvas, then falls back to adjacent positions. If the viewport is full, the block is placed just below the visible area instead of far off-screen — without moving the camera.
Drag-and-drop behavior is unchanged (it already placed blocks at the cursor without touching zoom).

### Changes 🏗️

<!-- List the key changes. Keep it higher level than the diff but specific enough to highlight what's new/modified. -->

- Added `placementHelpers.ts` with viewport-aware block placement logic
- Added `useAddBlockToBuilder` hook to centralize click-to-add behavior
- Removed forced pan/zoom from `Block.tsx`, `IntegrationBlock.tsx`, and `useAddAgentToBuilder.ts`
- Fixed `AllBlocksContent.tsx` overriding Block’s click handler (which skipped the placement logic entirely)
- Added unit tests for the placement algorithm in `placementHelpers.test.ts`

### Checklist 📋

#### For code changes:

- [✓ ] I have clearly listed my changes in the PR description
- [ ✓]  I have made a test plan
- [ ✓]  I have tested my changes according to the test plan:
- [ ✓]  Open /build, zoom in to ~150%, click to add a block → zoom stays the same
- [ ✓]  Add 8–10 blocks via click → canvas no longer jumps to recenter each time
- [ ✓]  Pan to a specific area, add another block → viewport stays where I left it
- [ ✓]  Fill the visible canvas with blocks, add one more → view doesn’t fly off-screen; block is placed below the visible area
- [✓ ]  Drag a block from the menu onto the canvas → still works as before, no regression
- [✓ ]  pnpm test:unit — placement helper tests pass


#### For configuration changes:

- [ ✓] `.env.default` is updated or already compatible with my changes (no config changes needed)
- [ ✓] `docker-compose.yml` is updated or already compatible with my changes (no config changes needed)

[Screencast from 2026-06-30 12-09-51.webm](https://github.com/user-attachments/assets/1138e791-fb39-4f2c-a835-c11a5fd40fb2)
