### PR TITLE
fix(frontend): hide sidebar collapse toggle in tour mode

### DIFF
--- a/autogpt_platform/frontend/src/app/(public)/tour/chat/components/TourChatSidebar/TourChatSidebar.tsx
+++ b/autogpt_platform/frontend/src/app/(public)/tour/chat/components/TourChatSidebar/TourChatSidebar.tsx
@@ -27,7 +27,7 @@ export function TourChatSidebar() {
     <Sidebar
       variant="inset"
       collapsible="none"
-      className="!top-0 !h-[100dvh] px-0 [&_[data-sidebar=sidebar]]:border-r [&_[data-sidebar=sidebar]]:border-r-[#80808017]"
+      className="!top-0 !h-[100dvh] px-0 [--sidebar-width:22rem] [&_[data-sidebar=sidebar]]:border-r [&_[data-sidebar=sidebar]]:border-r-[#80808017]"
     >
       <SidebarHeader className="shrink-0 px-4 pb-3 pt-3">
         <div className="flex flex-col gap-3 px-3">

--- a/autogpt_platform/frontend/src/app/(public)/tour/chat/components/TourChatSidebar/TourChatSidebar.tsx
+++ b/autogpt_platform/frontend/src/app/(public)/tour/chat/components/TourChatSidebar/TourChatSidebar.tsx
@@ -27,7 +27,7 @@ export function TourChatSidebar() {
     <Sidebar
       variant="inset"
       collapsible="none"
-      className="!top-0 !h-[100dvh] px-0 [--sidebar-width:22rem] [&_[data-sidebar=sidebar]]:border-r [&_[data-sidebar=sidebar]]:border-r-[#80808017]"
+      className="!top-0 !h-[100dvh] px-0 [--sidebar-width:26rem] [&_[data-sidebar=sidebar]]:border-r [&_[data-sidebar=sidebar]]:border-r-[#80808017]"
     >
       <SidebarHeader className="shrink-0 px-4 pb-3 pt-3">
         <div className="flex flex-col gap-3 px-3">

--- a/autogpt_platform/frontend/src/app/(public)/tour/chat/components/TourChatSidebar/TourChatSidebar.tsx
+++ b/autogpt_platform/frontend/src/app/(public)/tour/chat/components/TourChatSidebar/TourChatSidebar.tsx
@@ -9,7 +9,6 @@ import {
   Sidebar,
   SidebarContent,
   SidebarHeader,
-  SidebarTrigger,
 } from "@/components/ui/sidebar";
 import { cn } from "@/lib/utils";
 import {
@@ -27,7 +26,7 @@ export function TourChatSidebar() {
   return (
     <Sidebar
       variant="inset"
-      collapsible="icon"
+      collapsible="none"
       className="!top-0 !h-[100dvh] px-0 [&_[data-sidebar=sidebar]]:border-r [&_[data-sidebar=sidebar]]:border-r-[#80808017]"
     >
       <SidebarHeader className="shrink-0 px-4 pb-3 pt-3">
@@ -60,7 +59,6 @@ export function TourChatSidebar() {
               >
                 <FilesIcon className="!size-5" />
               </ShadcnButton>
-              <SidebarTrigger />
             </div>
           </div>
           <Button


### PR DESCRIPTION
## Why

On the public `/tour` demo, the sidebar is a static, guided surface (fixed set of demo chats, no real sessions). The collapse/expand toggle isn't meaningful there and just adds a confusing control.

## What

Hide the sidebar collapse/expand button in tour mode:
- Remove the `<SidebarTrigger />` from `TourChatSidebar`.
- Set the sidebar to `collapsible="none"` so it stays fully expanded (no toggle affordance).

Scope: one file, tour-only. No production copilot behavior changes.

## How

`TourChatSidebar` is the tour-specific sidebar; the change is limited to it. The existing tour integration test (`__tests__/main.test.tsx`) still passes, and `pnpm types`/`pnpm lint` are clean.

## Checklist

- [x] Lint, format, type-check pass locally
- [x] Tour integration tests pass (`pnpm test:unit .../tour/chat/__tests__/main.test.tsx`)
- [ ] No new protected routes / middleware changes (public route, unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
