### PR TITLE
fix(backend/copilot): reference attached files via read_workspace_file, not a host path

### DIFF
--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -2894,11 +2894,16 @@ async def _prepare_file_attachments(
                     f"{file_info.size_bytes:,} bytes) [embedded as image]"
                 )
             else:
-                # Non-image files: save to sdk_cwd for Read tool access
-                local_path = _save_to_sdk_cwd(sdk_cwd, file_info.name, content)
+                # Non-image files: surface via read_workspace_file by file_id.
+                # In E2B mode (prod default) the model's file tools operate on
+                # the remote sandbox filesystem, so a host-side sdk_cwd path
+                # is unreadable there — the workspace tool works in both modes.
+                # A local copy is still written for non-E2B tooling, but the
+                # model is never pointed at that path.
+                _save_to_sdk_cwd(sdk_cwd, file_info.name, content)
                 file_descriptions.append(
                     f"- {file_info.name} ({mime}, "
-                    f"{file_info.size_bytes:,} bytes) saved to {local_path}"
+                    f"{file_info.size_bytes:,} bytes) file_id: {fid}"
                 )
         except Exception:
             logger.warning("Failed to prepare file %s", fid[:12], exc_info=True)
@@ -2908,7 +2913,12 @@ async def _prepare_file_attachments(
 
     noun = "file" if len(file_descriptions) == 1 else "files"
     has_non_images = len(file_descriptions) > len(image_blocks)
-    read_hint = " Use the Read tool to view non-image files." if has_non_images else ""
+    read_hint = (
+        " Use the read_workspace_file tool with the file_id to view non-image"
+        " files (pass save_to_path to copy one into the working directory)."
+        if has_non_images
+        else ""
+    )
     hint = (
         f"[The user attached {len(file_descriptions)} {noun}.{read_hint}\n"
         + "\n".join(file_descriptions)

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -2846,8 +2846,10 @@ async def _prepare_file_attachments(
     Images (PNG/JPEG/GIF/WebP) are embedded directly as vision content blocks
     in the user message so Claude can see them without tool calls.
 
-    Non-image files (PDFs, text, etc.) are saved to *sdk_cwd* so the CLI's
-    built-in Read tool can access them.
+    Non-image files (PDFs, text, etc.) are referenced by ``file_id`` so the
+    model retrieves them with ``read_workspace_file``, which works in every
+    execution mode. A copy is also written to *sdk_cwd* for non-E2B tooling,
+    but the model is never pointed at that host-side path.
 
     Returns a :class:`PreparedAttachments` with a text hint and any image
     content blocks.
@@ -2901,9 +2903,12 @@ async def _prepare_file_attachments(
                 # A local copy is still written for non-E2B tooling, but the
                 # model is never pointed at that path.
                 _save_to_sdk_cwd(sdk_cwd, file_info.name, content)
+                # ``file_id=<uuid>`` (not ``file_id:``) — chat-share
+                # allowlisting extracts references via _FILE_ID_RE, which
+                # matches exactly this shape (data/sharing/workspace_refs.py).
                 file_descriptions.append(
                     f"- {file_info.name} ({mime}, "
-                    f"{file_info.size_bytes:,} bytes) file_id: {fid}"
+                    f"{file_info.size_bytes:,} bytes) file_id={fid}"
                 )
         except Exception:
             logger.warning("Failed to prepare file %s", fid[:12], exc_info=True)

--- a/autogpt_platform/backend/backend/copilot/sdk/service_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service_test.py
@@ -84,8 +84,11 @@ class TestPrepareFileAttachments:
         assert not os.path.exists(os.path.join(tmp_path, "photo.jpg"))
 
     @pytest.mark.asyncio
-    async def test_pdf_saved_to_disk(self, tmp_path):
-        """PDFs should be saved to disk for Read tool access, not embedded."""
+    async def test_pdf_referenced_by_file_id(self, tmp_path):
+        """Non-images are surfaced via read_workspace_file by file_id — the
+        model's file tools run in the E2B sandbox in prod, where a host-side
+        sdk_cwd path doesn't exist. A local copy is still written for non-E2B
+        tooling, but the model must not be pointed at that path."""
         info = _FakeFileInfo("f1", "doc.pdf", "/doc.pdf", "application/pdf", 50)
         mgr = AsyncMock()
         mgr.get_file_info.return_value = info
@@ -98,7 +101,10 @@ class TestPrepareFileAttachments:
         saved = tmp_path / "doc.pdf"
         assert saved.exists()
         assert saved.read_bytes() == b"%PDF-1.4 fake"
-        assert str(saved) in result.hint
+        # The model is given the workspace identity, not the host path.
+        assert "file_id: f1" in result.hint
+        assert str(saved) not in result.hint
+        assert "read_workspace_file" in result.hint
 
     @pytest.mark.asyncio
     async def test_mixed_images_and_files(self, tmp_path):
@@ -127,8 +133,12 @@ class TestPrepareFileAttachments:
         # Non-image files should be on disk
         assert (tmp_path / "b.pdf").exists()
         assert (tmp_path / "c.txt").exists()
-        # Read tool hint should appear (has non-image files)
-        assert "Read tool" in result.hint
+        # Workspace-read hint should appear (has non-image files), and the
+        # model must NOT be told to use the (disallowed) built-in Read tool.
+        assert "read_workspace_file" in result.hint
+        assert "Use the Read tool" not in result.hint
+        assert "file_id: id2" in result.hint
+        assert "file_id: id3" in result.hint
 
     @pytest.mark.asyncio
     async def test_singular_noun(self, tmp_path):
@@ -157,7 +167,7 @@ class TestPrepareFileAttachments:
 
     @pytest.mark.asyncio
     async def test_image_only_no_read_hint(self, tmp_path):
-        """When all files are images, no Read tool hint should appear."""
+        """When all files are images, no read-tool hint should appear."""
         info = _FakeFileInfo("i1", "cat.png", "/cat.png", "image/png", 4)
         mgr = AsyncMock()
         mgr.get_file_info.return_value = info
@@ -166,7 +176,7 @@ class TestPrepareFileAttachments:
         with patch(_PATCH_TARGET, new_callable=AsyncMock, return_value=mgr):
             result = await _prepare_file_attachments(["i1"], "u", "s", str(tmp_path))
 
-        assert "Read tool" not in result.hint
+        assert "read_workspace_file" not in result.hint
         assert len(result.image_blocks) == 1
 
 

--- a/autogpt_platform/backend/backend/copilot/sdk/service_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service_test.py
@@ -12,6 +12,7 @@ import pytest
 from backend.copilot import config as cfg_mod
 from backend.copilot.builder_context import BUILDER_BLOCKED_TOOLS
 from backend.copilot.permissions import CopilotPermissions, all_known_tool_names
+from backend.data.sharing.workspace_refs import extract_workspace_file_ids
 
 from .service import (
     _HUNG_TOOL_CAP_SECONDS,
@@ -102,9 +103,25 @@ class TestPrepareFileAttachments:
         assert saved.exists()
         assert saved.read_bytes() == b"%PDF-1.4 fake"
         # The model is given the workspace identity, not the host path.
-        assert "file_id: f1" in result.hint
+        assert "file_id=f1" in result.hint
         assert str(saved) not in result.hint
         assert "read_workspace_file" in result.hint
+
+    @pytest.mark.asyncio
+    async def test_hint_file_ids_extractable_for_chat_sharing(self, tmp_path):
+        """Chat-share allowlisting parses ``file_id=<uuid>`` out of message
+        content with extract_workspace_file_ids; the hint must keep that exact
+        shape or shared chats lose access to their attachments."""
+        fid = "0f8fad5b-d9cb-469f-a165-70867728950e"
+        info = _FakeFileInfo(fid, "doc.pdf", "/doc.pdf", "application/pdf", 50)
+        mgr = AsyncMock()
+        mgr.get_file_info.return_value = info
+        mgr.read_file_by_id.return_value = b"%PDF-1.4 fake"
+
+        with patch(_PATCH_TARGET, new_callable=AsyncMock, return_value=mgr):
+            result = await _prepare_file_attachments([fid], "u", "s", str(tmp_path))
+
+        assert extract_workspace_file_ids(result.hint) == {fid}
 
     @pytest.mark.asyncio
     async def test_mixed_images_and_files(self, tmp_path):
@@ -137,8 +154,8 @@ class TestPrepareFileAttachments:
         # model must NOT be told to use the (disallowed) built-in Read tool.
         assert "read_workspace_file" in result.hint
         assert "Use the Read tool" not in result.hint
-        assert "file_id: id2" in result.hint
-        assert "file_id: id3" in result.hint
+        assert "file_id=id2" in result.hint
+        assert "file_id=id3" in result.hint
 
     @pytest.mark.asyncio
     async def test_singular_noun(self, tmp_path):


### PR DESCRIPTION
## Why

Discord-bot file attachments upload correctly — AV-scanned (ClamAV via `WorkspaceManager.write_file`), stored session-scoped at `/sessions/<session_id>/<name>` ([#13427](https://github.com/Significant-Gravitas/AutoGPT/pull/13427) + [#13464](https://github.com/Significant-Gravitas/AutoGPT/pull/13464) + infra GCS perms) — but AutoPilot **still can't read them**. From the model's own trace in dev:

> "The system says it was saved to `/tmp/copilot-804ca4e7-…/test.txt` but it doesn't exist."

Root cause (`sdk/service.py::_prepare_file_attachments`): non-image attachments are written to the **executor host's** `sdk_cwd` and the model is told *"saved to `<host path>`. Use the Read tool."* Two problems:

1. **In E2B mode (the prod/dev default — `use_e2b_sandbox=True`)** the model's file tools operate on the **remote E2B sandbox filesystem** (`e2b_file_tools.py` deliberately routes non-tool-result paths to `sandbox.files.read`). The host-side `sdk_cwd` file doesn't exist there.
2. The built-in `Read` tool the hint names is **disallowed** in every mode (`SDK_DISALLOWED_TOOLS`).

So the model is pointed at a path it cannot see, with a tool it cannot use. Web-uploaded files work because the model reads them via `read_workspace_file` (observed in production: `Read test.txt from workspace:/sessions/<id>/test.txt`) — which resolves by `file_id` from the workspace, independent of any local disk.

## What

Point the model at `read_workspace_file` with the `file_id` for non-image attachments, instead of a host path + the disallowed `Read` tool.

## How

In `_prepare_file_attachments`:
- Non-image file descriptions now carry `file_id: <id>` instead of the host path.
- The hint instructs `read_workspace_file` (with `save_to_path` mentioned for copying into the working directory) instead of "Use the Read tool".
- The `sdk_cwd` copy is **still written**, preserving the working-directory affordance for non-E2B tooling — the model just isn't pointed at it.

Blast radius: this function only runs for turns with attached `file_ids`. Web attachment turns get the same instruction that already matches their observed working behaviour; everything else is untouched.

Completes the bot file-upload chain: #13427 (upload pipeline) → infra#348 (GCS write perms) → #13464 (session-scoped storage) → **this** (readable reference).

## Testing

- TDD: updated/added tests in `sdk/service_test.py::TestPrepareFileAttachments` pinning the new hint (file_id present, host path absent, `read_workspace_file` named, no "Use the Read tool") — failed before the fix, 7/7 pass after.
- No-regression check: full `service_test.py` run compared against clean `dev` — identical pre-existing failure set (env-dependent tests under `--noconftest`), zero new failures.
- `ruff` / `black` / `isort` clean.
