### PR TITLE
fix(backend): Create User Profile in app layer instead of DB trigger

### DIFF
--- a/autogpt_platform/backend/backend/api/features/store/db.py
+++ b/autogpt_platform/backend/backend/api/features/store/db.py
@@ -1164,9 +1164,24 @@ async def update_profile(
             where={"userId": user_id}
         )
         if not existing_profile:
-            raise store_exceptions.ProfileNotFoundError(
-                f"Profile not found for user {user_id}. This should not be possible."
+            # No Profile yet (e.g. a user whose auto-creation never ran). This
+            # endpoint is the user's self-service path to a marketplace
+            # profile, so create one from the submitted data instead of
+            # failing — otherwise the user is left with no way to publish.
+            logger.info(
+                f"No profile for user {user_id}; creating one from submitted data"
             )
+            created_profile = await prisma.models.Profile.prisma().create(
+                data=prisma.types.ProfileCreateInput(
+                    userId=user_id,
+                    name=profile.name,
+                    username=username,
+                    description=profile.description,
+                    links=profile.links,
+                    avatarUrl=profile.avatar_url,
+                )
+            )
+            return store_model.ProfileDetails.from_db(created_profile)
 
         # Verify that the user is authorized to update this profile
         if existing_profile.userId != user_id:

--- a/autogpt_platform/backend/backend/api/features/store/db.py
+++ b/autogpt_platform/backend/backend/api/features/store/db.py
@@ -1171,17 +1171,27 @@ async def update_profile(
             logger.info(
                 f"No profile for user {user_id}; creating one from submitted data"
             )
-            created_profile = await prisma.models.Profile.prisma().create(
-                data=prisma.types.ProfileCreateInput(
-                    userId=user_id,
-                    name=profile.name,
-                    username=username,
-                    description=profile.description,
-                    links=profile.links,
-                    avatarUrl=profile.avatar_url,
+            try:
+                created_profile = await prisma.models.Profile.prisma().create(
+                    data=prisma.types.ProfileCreateInput(
+                        userId=user_id,
+                        name=profile.name,
+                        username=username,
+                        description=profile.description,
+                        links=profile.links,
+                        avatarUrl=profile.avatar_url,
+                    )
                 )
-            )
-            return store_model.ProfileDetails.from_db(created_profile)
+                return store_model.ProfileDetails.from_db(created_profile)
+            except prisma.errors.UniqueViolationError:
+                # A concurrent request (or get_or_create_user) created the
+                # Profile first. Re-fetch and fall through to update it with the
+                # submitted data rather than failing the save.
+                existing_profile = await prisma.models.Profile.prisma().find_first(
+                    where={"userId": user_id}
+                )
+                if not existing_profile:
+                    raise
 
         # Verify that the user is authorized to update this profile
         if existing_profile.userId != user_id:

--- a/autogpt_platform/backend/backend/api/features/store/db_test.py
+++ b/autogpt_platform/backend/backend/api/features/store/db_test.py
@@ -318,6 +318,45 @@ async def test_update_profile(mocker):
 
 
 @pytest.mark.asyncio(loop_scope="session")
+async def test_update_profile_creates_when_missing(mocker):
+    """When a user has no Profile yet, update_profile creates one from the
+    submitted data instead of raising — this is the user's self-service
+    recovery path."""
+    created_profile = prisma.models.Profile(
+        id="new-profile-id",
+        name="New Creator",
+        username="newcreator",
+        userId="user-id",
+        description="Fresh start",
+        links=[],
+        avatarUrl=None,
+        isFeatured=False,
+        createdAt=datetime.now(),
+        updatedAt=datetime.now(),
+    )
+
+    mock_profile_db = mocker.patch("prisma.models.Profile.prisma")
+    mock_profile_db.return_value.find_first = AsyncMock(return_value=None)
+    mock_profile_db.return_value.create = AsyncMock(return_value=created_profile)
+    mock_profile_db.return_value.update = AsyncMock()
+
+    profile = Profile(
+        name="New Creator",
+        username="newcreator",
+        description="Fresh start",
+        links=[],
+        avatar_url=None,
+    )
+
+    result = await db.update_profile("user-id", profile)
+
+    assert result.username == "newcreator"
+    assert result.name == "New Creator"
+    mock_profile_db.return_value.create.assert_called_once()
+    mock_profile_db.return_value.update.assert_not_called()
+
+
+@pytest.mark.asyncio(loop_scope="session")
 async def test_get_user_profile(mocker):
     # Mock data
     mock_profile = prisma.models.Profile(

--- a/autogpt_platform/backend/backend/api/features/store/db_test.py
+++ b/autogpt_platform/backend/backend/api/features/store/db_test.py
@@ -357,6 +357,61 @@ async def test_update_profile_creates_when_missing(mocker):
 
 
 @pytest.mark.asyncio(loop_scope="session")
+async def test_update_profile_tolerates_create_race(mocker):
+    """If a Profile is created concurrently between the existence check and our
+    create(), update_profile re-fetches and updates it rather than failing."""
+    raced_profile = prisma.models.Profile(
+        id="raced-id",
+        name="Old Name",
+        username="raced",
+        userId="user-id",
+        description="Old",
+        links=[],
+        avatarUrl=None,
+        isFeatured=False,
+        createdAt=datetime.now(),
+        updatedAt=datetime.now(),
+    )
+    updated_profile = prisma.models.Profile(
+        id="raced-id",
+        name="New Name",
+        username="raced",
+        userId="user-id",
+        description="New desc",
+        links=[],
+        avatarUrl=None,
+        isFeatured=False,
+        createdAt=datetime.now(),
+        updatedAt=datetime.now(),
+    )
+
+    mock_profile_db = mocker.patch("prisma.models.Profile.prisma")
+    # First existence check: no profile → enter the create branch. The create
+    # then loses the race (UniqueViolationError), so we re-fetch and find it.
+    mock_profile_db.return_value.find_first = AsyncMock(
+        side_effect=[None, raced_profile]
+    )
+    mock_profile_db.return_value.create = AsyncMock(
+        side_effect=prisma.errors.UniqueViolationError({})
+    )
+    mock_profile_db.return_value.update = AsyncMock(return_value=updated_profile)
+
+    profile = Profile(
+        name="New Name",
+        username="raced",
+        description="New desc",
+        links=[],
+        avatar_url=None,
+    )
+
+    result = await db.update_profile("user-id", profile)
+
+    assert result.name == "New Name"
+    mock_profile_db.return_value.create.assert_called_once()
+    mock_profile_db.return_value.update.assert_called_once()
+
+
+@pytest.mark.asyncio(loop_scope="session")
 async def test_get_user_profile(mocker):
     # Mock data
     mock_profile = prisma.models.Profile(

--- a/autogpt_platform/backend/backend/copilot/tools/_test_data.py
+++ b/autogpt_platform/backend/backend/copilot/tools/_test_data.py
@@ -105,14 +105,24 @@ async def setup_test_data(server):
 
     # 1b. Create a profile with username for the user (required for store agent lookup)
     username = user.email.split("@")[0]
-    await prisma.profile.create(
-        data=ProfileCreateInput(
-            userId=user.id,
-            username=username,
-            name=f"Test User {username}",
-            description="Test user profile",
-            links=[],  # Required field - empty array for test profiles
-        )
+    await prisma.profile.upsert(
+        where={"userId": user.id},
+        data={
+            # get_or_create_user auto-creates a default profile; tests need
+            # this specific username for store agent lookups.
+            "create": ProfileCreateInput(
+                userId=user.id,
+                username=username,
+                name=f"Test User {username}",
+                description="Test user profile",
+                links=[],
+            ),
+            "update": {
+                "username": username,
+                "name": f"Test User {username}",
+                "description": "Test user profile",
+            },
+        },
     )
 
     # 2. Create a test graph with agent input -> agent output
@@ -231,14 +241,24 @@ async def setup_llm_test_data(server):
 
     # 1b. Create a profile with username for the user (required for store agent lookup)
     username = user.email.split("@")[0]
-    await prisma.profile.create(
-        data=ProfileCreateInput(
-            userId=user.id,
-            username=username,
-            name=f"Test User {username}",
-            description="Test user profile for LLM tests",
-            links=[],  # Required field - empty array for test profiles
-        )
+    await prisma.profile.upsert(
+        where={"userId": user.id},
+        data={
+            # get_or_create_user auto-creates a default profile; tests need
+            # this specific username for store agent lookups.
+            "create": ProfileCreateInput(
+                userId=user.id,
+                username=username,
+                name=f"Test User {username}",
+                description="Test user profile for LLM tests",
+                links=[],
+            ),
+            "update": {
+                "username": username,
+                "name": f"Test User {username}",
+                "description": "Test user profile for LLM tests",
+            },
+        },
     )
 
     # 2. Create test OpenAI credentials for the user
@@ -394,14 +414,24 @@ async def setup_firecrawl_test_data(server):
 
     # 1b. Create a profile with username for the user (required for store agent lookup)
     username = user.email.split("@")[0]
-    await prisma.profile.create(
-        data=ProfileCreateInput(
-            userId=user.id,
-            username=username,
-            name=f"Test User {username}",
-            description="Test user profile for Firecrawl tests",
-            links=[],  # Required field - empty array for test profiles
-        )
+    await prisma.profile.upsert(
+        where={"userId": user.id},
+        data={
+            # get_or_create_user auto-creates a default profile; tests need
+            # this specific username for store agent lookups.
+            "create": ProfileCreateInput(
+                userId=user.id,
+                username=username,
+                name=f"Test User {username}",
+                description="Test user profile for Firecrawl tests",
+                links=[],
+            ),
+            "update": {
+                "username": username,
+                "name": f"Test User {username}",
+                "description": "Test user profile for Firecrawl tests",
+            },
+        },
     )
 
     # NOTE: We deliberately do NOT create Firecrawl credentials for this user

--- a/autogpt_platform/backend/backend/data/user.py
+++ b/autogpt_platform/backend/backend/data/user.py
@@ -62,14 +62,8 @@ async def get_or_create_user(user_data: dict) -> User:
             )
 
         # Ensure every user has a marketplace Profile (required to publish
-        # agents). This was historically created by a Postgres trigger on
-        # auth.users, but that trigger is unreliable — e.g. in preview
-        # environments a single shared auth.users trigger gets repointed at
-        # another schema, leaving platform users with no Profile and no way to
-        # publish. Do it here at the app layer, the one choke point every real
-        # user passes through. Best-effort: a failure must not block user
-        # resolution — the user self-heals on their next request or via the
-        # profile settings page.
+        # agents). Best-effort: a failure must not block user resolution — the
+        # user self-heals on their next request or via the profile settings page.
         try:
             await _ensure_user_profile(user.id, user.email)
         except Exception:

--- a/autogpt_platform/backend/backend/data/user.py
+++ b/autogpt_platform/backend/backend/data/user.py
@@ -110,30 +110,42 @@ _PROFILE_USERNAME_ANIMALS = (
 async def _ensure_user_profile(user_id: str, email: Optional[str]) -> None:
     """Create a default marketplace Profile for *user_id* if none exists.
 
-    Idempotent and race-safe: an existing Profile short-circuits, and a
-    concurrent insert that loses the unique(userId) constraint is treated as
-    success rather than an error.
+    Idempotent and race-safe. A UniqueViolationError has two possible sources:
+    a concurrent request that already created this user's Profile (done), or a
+    collision on the unique username with *another* user (retry with a fresh
+    handle — otherwise the user would be left without a Profile).
     """
-    existing = await prisma.profile.find_unique(where={"userId": user_id})
-    if existing:
+    if await prisma.profile.find_unique(where={"userId": user_id}):
         return
 
     name = (email or "").split("@", 1)[0] or "user"
-    try:
-        await prisma.profile.create(
-            data=ProfileCreateInput(
-                userId=user_id,
-                name=name,
-                username=await _generate_profile_username(),
-                description="I'm new here",
-                links=[],
-                avatarUrl="",
+    for _ in range(3):
+        try:
+            await prisma.profile.create(
+                data=ProfileCreateInput(
+                    userId=user_id,
+                    name=name,
+                    username=await _generate_profile_username(),
+                    description="I'm new here",
+                    links=[],
+                    avatarUrl="",
+                )
             )
-        )
-    except UniqueViolationError:
-        # Created concurrently (another in-flight request, or the legacy
-        # auth.users trigger). The Profile now exists — nothing to do.
-        logger.debug("Profile for user %s already created concurrently", user_id)
+            return
+        except UniqueViolationError:
+            if await prisma.profile.find_unique(where={"userId": user_id}):
+                # Another in-flight request (or the legacy auth.users trigger)
+                # created this user's Profile — nothing to do.
+                logger.debug(
+                    "Profile for user %s already created concurrently", user_id
+                )
+                return
+            # The generated username collided with another user — loop and
+            # retry with a fresh handle.
+    logger.warning(
+        "Failed to create a unique profile handle for user %s after retries",
+        user_id,
+    )
 
 
 async def _generate_profile_username() -> str:

--- a/autogpt_platform/backend/backend/data/user.py
+++ b/autogpt_platform/backend/backend/data/user.py
@@ -3,6 +3,8 @@ import base64
 import hashlib
 import hmac
 import logging
+import random
+import uuid
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Optional, cast
 from urllib.parse import quote_plus
@@ -10,8 +12,14 @@ from urllib.parse import quote_plus
 from autogpt_libs.auth.models import DEFAULT_USER_ID
 from fastapi import HTTPException
 from prisma.enums import NotificationType
+from prisma.errors import UniqueViolationError
 from prisma.models import User as PrismaUser
-from prisma.types import JsonFilter, UserCreateInput, UserUpdateInput
+from prisma.types import (
+    JsonFilter,
+    ProfileCreateInput,
+    UserCreateInput,
+    UserUpdateInput,
+)
 
 from backend.data.db import prisma
 from backend.data.model import User, UserIntegrations, UserMetadata
@@ -53,9 +61,103 @@ async def get_or_create_user(user_data: dict) -> User:
                 )
             )
 
+        # Ensure every user has a marketplace Profile (required to publish
+        # agents). This was historically created by a Postgres trigger on
+        # auth.users, but that trigger is unreliable — e.g. in preview
+        # environments a single shared auth.users trigger gets repointed at
+        # another schema, leaving platform users with no Profile and no way to
+        # publish. Do it here at the app layer, the one choke point every real
+        # user passes through. Best-effort: a failure must not block user
+        # resolution — the user self-heals on their next request or via the
+        # profile settings page.
+        try:
+            await _ensure_user_profile(user.id, user.email)
+        except Exception:
+            logger.warning(
+                "Failed to ensure marketplace profile for user %s",
+                user.id,
+                exc_info=True,
+            )
+
         return User.from_db(user)
     except Exception as e:
         raise DatabaseError(f"Failed to get or create user {user_data}: {e}") from e
+
+
+# Word lists mirror the legacy generate_username() SQL function so that app-
+# and DB-generated handles look consistent.
+_PROFILE_USERNAME_ADJECTIVES = (
+    "happy",
+    "clever",
+    "swift",
+    "bright",
+    "wise",
+    "funny",
+    "cool",
+    "awesome",
+    "amazing",
+    "fantastic",
+    "wonderful",
+)
+_PROFILE_USERNAME_ANIMALS = (
+    "fox",
+    "wolf",
+    "bear",
+    "eagle",
+    "owl",
+    "tiger",
+    "lion",
+    "elephant",
+    "giraffe",
+    "zebra",
+)
+
+
+async def _ensure_user_profile(user_id: str, email: Optional[str]) -> None:
+    """Create a default marketplace Profile for *user_id* if none exists.
+
+    Idempotent and race-safe: an existing Profile short-circuits, and a
+    concurrent insert that loses the unique(userId) constraint is treated as
+    success rather than an error.
+    """
+    existing = await prisma.profile.find_unique(where={"userId": user_id})
+    if existing:
+        return
+
+    name = (email or "").split("@", 1)[0] or "user"
+    try:
+        await prisma.profile.create(
+            data=ProfileCreateInput(
+                userId=user_id,
+                name=name,
+                username=await _generate_profile_username(),
+                description="I'm new here",
+                links=[],
+                avatarUrl="",
+            )
+        )
+    except UniqueViolationError:
+        # Created concurrently (another in-flight request, or the legacy
+        # auth.users trigger). The Profile now exists — nothing to do.
+        logger.debug("Profile for user %s already created concurrently", user_id)
+
+
+async def _generate_profile_username() -> str:
+    """Generate a human-friendly profile handle, avoiding obvious collisions.
+
+    The unique constraint on Profile.username is the real guarantee; this
+    pre-check just avoids retrying a create in the common case. Falls back to a
+    UUID-based handle if we can't find a free friendly name.
+    """
+    for _ in range(10):
+        candidate = (
+            f"{random.choice(_PROFILE_USERNAME_ADJECTIVES)}-"
+            f"{random.choice(_PROFILE_USERNAME_ANIMALS)}-"
+            f"{random.randint(10000, 99999)}"
+        )
+        if not await prisma.profile.find_unique(where={"username": candidate}):
+            return candidate
+    return f"user-{uuid.uuid4().hex[:12]}"
 
 
 @cache_user_lookup

--- a/autogpt_platform/backend/backend/data/user_test.py
+++ b/autogpt_platform/backend/backend/data/user_test.py
@@ -3,6 +3,7 @@
 import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import prisma.errors
 import pytest
 
 from backend.data import user as user_module
@@ -221,3 +222,29 @@ class TestGetOrCreateUserProfile:
 
         assert result is sentinel_user
         warn_mock.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_retries_profile_create_on_username_collision(self):
+        """A UniqueViolationError from a username clash (not a userId race)
+        must retry with a fresh handle so the user still gets a Profile."""
+        user_module.get_or_create_user.cache_clear()
+        db_user = MagicMock(id="user-clash", email="dave@example.com", name=None)
+
+        with (
+            patch.object(user_module, "prisma") as mock_prisma,
+            patch.object(user_module.User, "from_db", return_value=MagicMock()),
+        ):
+            mock_prisma.user.find_unique = AsyncMock(return_value=db_user)
+            # userId never resolves to a Profile (so the clash is on username),
+            # and generated usernames pre-check as free.
+            mock_prisma.profile.find_unique = AsyncMock(return_value=None)
+            # First create() collides on username, the retry succeeds.
+            mock_prisma.profile.create = AsyncMock(
+                side_effect=[prisma.errors.UniqueViolationError({}), None]
+            )
+
+            await user_module.get_or_create_user(
+                {"sub": "user-clash", "email": "dave@example.com"}
+            )
+
+        assert mock_prisma.profile.create.await_count == 2

--- a/autogpt_platform/backend/backend/data/user_test.py
+++ b/autogpt_platform/backend/backend/data/user_test.py
@@ -146,3 +146,78 @@ class TestUpdateUserTimezone:
         assert not user_module._background_tasks & set(spawned)
         warn_mock.assert_called_once()
         assert isinstance(warn_mock.call_args.kwargs["exc_info"], RuntimeError)
+
+
+class TestGetOrCreateUserProfile:
+    """get_or_create_user must guarantee a marketplace Profile exists, since
+    the auth.users trigger that used to do this is unreliable."""
+
+    @pytest.mark.asyncio
+    async def test_creates_profile_when_missing(self):
+        user_module.get_or_create_user.cache_clear()
+        db_user = MagicMock(id="user-new", email="alice@example.com", name=None)
+
+        with (
+            patch.object(user_module, "prisma") as mock_prisma,
+            patch.object(user_module.User, "from_db", return_value=MagicMock()),
+        ):
+            mock_prisma.user.find_unique = AsyncMock(return_value=db_user)
+            # No existing profile, and the generated username is free.
+            mock_prisma.profile.find_unique = AsyncMock(return_value=None)
+            mock_prisma.profile.create = AsyncMock()
+
+            await user_module.get_or_create_user(
+                {"sub": "user-new", "email": "alice@example.com"}
+            )
+
+        mock_prisma.profile.create.assert_awaited_once()
+        created = mock_prisma.profile.create.await_args.kwargs["data"]
+        assert created["userId"] == "user-new"
+        # name defaults to the email local-part
+        assert created["name"] == "alice"
+        assert created["username"]
+
+    @pytest.mark.asyncio
+    async def test_does_not_create_profile_when_one_exists(self):
+        user_module.get_or_create_user.cache_clear()
+        db_user = MagicMock(id="user-has", email="bob@example.com", name="Bob")
+
+        with (
+            patch.object(user_module, "prisma") as mock_prisma,
+            patch.object(user_module.User, "from_db", return_value=MagicMock()),
+        ):
+            mock_prisma.user.find_unique = AsyncMock(return_value=db_user)
+            mock_prisma.profile.find_unique = AsyncMock(return_value=MagicMock())
+            mock_prisma.profile.create = AsyncMock()
+
+            await user_module.get_or_create_user(
+                {"sub": "user-has", "email": "bob@example.com"}
+            )
+
+        mock_prisma.profile.create.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_profile_creation_failure_does_not_block_user(self):
+        """Profile creation is best-effort: a failure is logged but the user
+        is still resolved so login/auth isn't broken."""
+        user_module.get_or_create_user.cache_clear()
+        db_user = MagicMock(id="user-err", email="carol@example.com", name=None)
+        sentinel_user = MagicMock()
+
+        with (
+            patch.object(user_module, "prisma") as mock_prisma,
+            patch.object(user_module.User, "from_db", return_value=sentinel_user),
+            patch.object(user_module.logger, "warning") as warn_mock,
+        ):
+            mock_prisma.user.find_unique = AsyncMock(return_value=db_user)
+            mock_prisma.profile.find_unique = AsyncMock(return_value=None)
+            mock_prisma.profile.create = AsyncMock(
+                side_effect=RuntimeError("db hiccup")
+            )
+
+            result = await user_module.get_or_create_user(
+                {"sub": "user-err", "email": "carol@example.com"}
+            )
+
+        assert result is sentinel_user
+        warn_mock.assert_called_once()

--- a/autogpt_platform/frontend/src/app/(platform)/settings/profile/__tests__/main.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/profile/__tests__/main.test.tsx
@@ -1,3 +1,4 @@
+import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import {
@@ -131,6 +132,30 @@ describe("SettingsProfilePage - data loading", () => {
     expect(
       await screen.findByRole("heading", { name: /^profile$/i, level: 1 }),
     ).toBeDefined();
+  });
+
+  test("renders an empty form (not an error) when the user has no profile yet", async () => {
+    // A 404 from the profile endpoint means "no profile yet" — the page must
+    // render the empty form so the user can create one, not an error card.
+    server.use(
+      http.get("http://localhost:3000/api/proxy/api/store/profile", () =>
+        HttpResponse.json(
+          { detail: "User does not have a profile yet" },
+          { status: 404 },
+        ),
+      ),
+    );
+
+    render(<SettingsProfilePage />);
+
+    const nameInput = (await screen.findByLabelText(
+      /display name/i,
+    )) as HTMLInputElement;
+    expect(nameInput.value).toBe("");
+    expect((screen.getByLabelText(/^handle$/i) as HTMLInputElement).value).toBe(
+      "",
+    );
+    expect(screen.queryByText(/something went wrong/i)).toBeNull();
   });
 });
 

--- a/autogpt_platform/frontend/src/app/(platform)/settings/profile/useProfilePage.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/profile/useProfilePage.ts
@@ -11,7 +11,7 @@ import {
 } from "@/app/api/__generated__/endpoints/store/store";
 import type { ProfileDetails } from "@/app/api/__generated__/models/profileDetails";
 import { toast } from "@/components/molecules/Toast/use-toast";
-import { isLogoutInProgress } from "@/lib/autogpt-server-api/helpers";
+import { ApiError, isLogoutInProgress } from "@/lib/autogpt-server-api/helpers";
 import { useSupabase } from "@/lib/supabase/hooks/useSupabase";
 
 import {
@@ -47,6 +47,14 @@ export function useProfilePage() {
       },
     },
   });
+
+  // A 404 means the user simply has no marketplace profile yet — a valid state,
+  // not an error. Treat it as "empty profile" so the page renders the form
+  // (rather than an error card), letting the user create one on Save.
+  const isProfileNotFound =
+    profileQuery.isError &&
+    profileQuery.error instanceof ApiError &&
+    profileQuery.error.status === 404;
 
   const [formState, setFormState] = useState<ProfileFormState>(EMPTY_FORM);
   // Pristine baseline for dirty detection + Discard. Held as state (not a
@@ -202,7 +210,7 @@ export function useProfilePage() {
   return {
     user,
     isLoading: profileQuery.isLoading,
-    isError: profileQuery.isError,
+    isError: profileQuery.isError && !isProfileNotFound,
     error: profileQuery.error,
     refetch: profileQuery.refetch,
     formState,


### PR DESCRIPTION
### Why / What / How

**Why:** New users end up with **no `platform.Profile`**, which blocks publishing agents to the marketplace — and the `settings/profile` page offered no way to create one, so users had **no self-service recourse**.

Root cause: the *only* thing that creates a `Profile` for real users is a Postgres trigger (`user_added_to_platform` → `add_user_and_profile_to_platform()`) on `auth.users`. `get_or_create_user()` creates the `platform.User` row but **never** a Profile, so "User without Profile" is reachable whenever that trigger doesn't fire. On Dev it doesn't fire correctly: `auth.users` is **shared across every preview-env schema**, and a PR preview's migration (`CREATE TRIGGER ... ON auth.users`) repointed the single shared trigger at another schema (`pr_<n>`), so platform signups create their User+Profile rows in the *wrong* schema. Prod has no preview schemas, so its trigger still works — hence "breaks on Dev, fine on Prod".

**What:**
- Create the marketplace `Profile` at the **application layer**, so it no longer depends on the fragile cross-schema `auth.users` trigger.
- Make the "update profile" endpoint actually **create** a profile when one is missing (it previously raised `ProfileNotFoundError("…This should not be possible.")`).

**How:**
- `get_or_create_user()` (`backend/data/user.py`) now calls `_ensure_user_profile()` — the one choke point every real user passes through. It's **idempotent** (short-circuits if a Profile exists), **race-safe** (catches the `unique(userId)` violation from concurrent creation or the legacy trigger), and **best-effort** (a failure is logged but never blocks user resolution). Because it runs for existing users too, already-broken users **self-heal** on their next authenticated request.
- `update_profile()` (`store/db.py`) creates a Profile from the submitted data when none exists instead of raising, making `settings/profile` a genuine self-service recovery path.

### Changes 🏗️

- `backend/data/user.py`: add `_ensure_user_profile()` + `_generate_profile_username()`; call it from `get_or_create_user()`.
- `backend/api/features/store/db.py`: `update_profile()` creates a Profile when missing instead of raising.
- Tests: `user_test.py` (creates when missing / skips when present / failure is non-fatal) and `db_test.py` (`update_profile` creates when missing).

**`data/*.py` user-ID checks:** `_ensure_user_profile` only ever creates a Profile for the caller's own `user_id` (from the JWT `sub`) — no cross-user access. `update_profile`'s create path likewise uses the authenticated `user_id`; the existing ownership check on the update path is unchanged.

### Not in this PR (follow-ups)

- Backfilling the existing profile-less users is handled organically (they self-heal on next login); an immediate ops unblock can be done with a one-off `INSERT` if needed sooner.
- Dropping the now-redundant `auth.users` trigger, and migrating preview envs to **isolated Supabase branches** so a preview migration can't clobber shared `auth.users` again — tracked separately.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `poetry run pytest backend/data/user_test.py::TestGetOrCreateUserProfile` — new user gets a Profile; existing Profile isn't duplicated; profile-creation failure doesn't break user resolution
  - [x] `poetry run pytest backend/api/features/store/db_test.py::test_update_profile_creates_when_missing` — saving a profile with none existing creates one; existing `test_update_profile` still passes
  - [ ] Manual (pending): sign up a fresh user on a preview/dev env → confirm a Profile exists and they can publish to the marketplace *(not runnable in this environment)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
