### PR TITLE
feat(frontend): polish artifacts page and sidebar for new AutoGPT layout

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/PlatformChrome/PlatformChrome.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/PlatformChrome/PlatformChrome.tsx
@@ -15,6 +15,7 @@ import { AdminImpersonationBanner } from "../admin/components/AdminImpersonation
 import { GlobalSearchOverlay } from "../components/GlobalSearchModal/GlobalSearchOverlay";
 import { PaywallGate } from "../PaywallGate/PaywallGate";
 import { InsetHeaderActions } from "./components/InsetHeaderActions/InsetHeaderActions";
+import { InsetHeaderTitle } from "./components/InsetHeaderTitle/InsetHeaderTitle";
 import { usePlatformChrome } from "./usePlatformChrome";
 
 interface Props {
@@ -34,12 +35,17 @@ export function PlatformChrome({ children }: Props) {
     return (
       <SidebarProvider style={{ "--sidebar-width": "19rem" } as CSSProperties}>
         <AppSidebar />
-        <SidebarInset className="bg-[#F8F8F9]">
-          <header className="flex h-12 shrink-0 items-center justify-end gap-2 px-4">
-            <div className="mr-auto md:hidden">
-              <SidebarTrigger />
+        <SidebarInset className="bg-[#f9f9f9]">
+          <header className="relative flex shrink-0 items-center pb-4 pt-6">
+            <div className="mx-auto flex w-full max-w-7xl items-center gap-2 px-6 md:px-8">
+              <div className="md:hidden">
+                <SidebarTrigger />
+              </div>
+              <InsetHeaderTitle />
             </div>
-            <InsetHeaderActions />
+            <div className="absolute inset-y-0 right-4 flex items-center">
+              <InsetHeaderActions />
+            </div>
           </header>
           <AdminImpersonationBanner />
           <GlobalSearchOverlay />

--- a/autogpt_platform/frontend/src/app/(platform)/PlatformChrome/components/InsetHeaderTitle/InsetHeaderTitle.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/PlatformChrome/components/InsetHeaderTitle/InsetHeaderTitle.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { Text } from "@/components/atoms/Text/Text";
+import { FolderIcon, type Icon } from "@phosphor-icons/react";
+import { usePathname } from "next/navigation";
+
+const ROUTE_TITLES: Record<string, { title: string; icon: Icon }> = {
+  "/artifacts": { title: "Files", icon: FolderIcon },
+};
+
+function getRouteTitle(pathname: string | null) {
+  if (!pathname) return null;
+  const match = Object.entries(ROUTE_TITLES).find(
+    ([href]) => pathname === href || pathname.startsWith(`${href}/`),
+  );
+  return match ? match[1] : null;
+}
+
+export function InsetHeaderTitle() {
+  const pathname = usePathname();
+  const entry = getRouteTitle(pathname);
+
+  if (!entry) return null;
+
+  const TitleIcon = entry.icon;
+
+  return (
+    <div className="flex items-center gap-2">
+      <TitleIcon className="size-5 text-zinc-800" />
+      <Text variant="large-medium">{entry.title}</Text>
+    </div>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/artifacts/__tests__/main.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/artifacts/__tests__/main.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, test, vi } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 
 import {
   fireEvent,
@@ -19,6 +19,12 @@ const { setFlagStatusMock } = vi.hoisted(() => {
   return {
     setFlagStatusMock: vi.fn(() => ({ enabled: true, ready: true })),
   };
+});
+
+// usePlatformChrome re-renders once on mount (isMounted guard), so per-test
+// flag overrides must persist across renders; restore the default afterward.
+afterEach(() => {
+  setFlagStatusMock.mockReturnValue({ enabled: true, ready: true });
 });
 
 vi.mock("@/services/feature-flags/use-get-flag", () => ({
@@ -219,7 +225,7 @@ describe("ArtifactsPage - search filter", () => {
 
 describe("ArtifactsPage - feature flag gating", () => {
   test("shows the flag-loading skeleton while LaunchDarkly is resolving", async () => {
-    setFlagStatusMock.mockReturnValueOnce({ enabled: false, ready: false });
+    setFlagStatusMock.mockReturnValue({ enabled: false, ready: false });
 
     render(<ArtifactsPage />);
 

--- a/autogpt_platform/frontend/src/app/(platform)/artifacts/__tests__/main.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/artifacts/__tests__/main.test.tsx
@@ -22,8 +22,11 @@ const { setFlagStatusMock } = vi.hoisted(() => {
 });
 
 vi.mock("@/services/feature-flags/use-get-flag", () => ({
-  Flag: { ARTIFACTS_PAGE: "artifacts-page" },
-  useGetFlag: () => true,
+  Flag: {
+    ARTIFACTS_PAGE: "artifacts-page",
+    AUTOGPT_NEW_LAYOUT: "autogpt-new-layout",
+  },
+  useGetFlag: (flag: string) => flag !== "autogpt-new-layout",
   useFlagStatus: () => setFlagStatusMock(),
 }));
 

--- a/autogpt_platform/frontend/src/app/(platform)/artifacts/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/artifacts/page.tsx
@@ -6,7 +6,11 @@ import { motion, useReducedMotion } from "framer-motion";
 import type { Transition, Variants } from "framer-motion";
 import { Skeleton } from "@/components/atoms/Skeleton/Skeleton";
 import { Text } from "@/components/atoms/Text/Text";
-import { Flag, useFlagStatus } from "@/services/feature-flags/use-get-flag";
+import {
+  Flag,
+  useFlagStatus,
+  useGetFlag,
+} from "@/services/feature-flags/use-get-flag";
 import { ArtifactsSearchBar } from "./components/ArtifactsSearchBar/ArtifactsSearchBar";
 import { ArtifactsList } from "./components/ArtifactsList/ArtifactsList";
 import { OriginFilter } from "./components/OriginFilter/OriginFilter";
@@ -33,10 +37,18 @@ const REDUCED_SECTION_VARIANTS: Variants = {
   show: { opacity: 1, transition: { duration: 0.2 } },
 };
 
+// The sidebar-inset dashboard layout the artifacts page was redesigned for.
+const NEW_LAYOUT_MAIN =
+  "mx-auto min-h-screen w-full max-w-7xl space-y-6 px-6 pb-20 pt-2 md:px-8";
+// Classic navbar layout — kept intact when the new-layout flag is off.
+const CLASSIC_MAIN =
+  "container min-h-screen space-y-6 pb-20 pt-16 sm:px-8 md:px-12";
+
 export default function ArtifactsPage() {
   const { enabled: isEnabled, ready: flagReady } = useFlagStatus(
     Flag.ARTIFACTS_PAGE,
   );
+  const showNewLayout = useGetFlag(Flag.AUTOGPT_NEW_LAYOUT);
   const reduceMotion = useReducedMotion();
   const {
     files,
@@ -64,7 +76,7 @@ export default function ArtifactsPage() {
   }, []);
 
   if (!flagReady) {
-    return <ArtifactsPageSkeleton />;
+    return <ArtifactsPageSkeleton showNewLayout={showNewLayout} />;
   }
   if (!isEnabled) {
     notFound();
@@ -73,7 +85,7 @@ export default function ArtifactsPage() {
   const variants = reduceMotion ? REDUCED_SECTION_VARIANTS : SECTION_VARIANTS;
 
   return (
-    <main className="container min-h-screen space-y-6 pb-20 pt-16 sm:px-8 md:px-12">
+    <main className={showNewLayout ? NEW_LAYOUT_MAIN : CLASSIC_MAIN}>
       <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
         <motion.div
           className="flex flex-col gap-1"
@@ -82,8 +94,11 @@ export default function ArtifactsPage() {
           animate="show"
           transition={{ delay: 0 }}
         >
-          <Text variant="h3">Files</Text>
-          <Text variant="body" className="max-w-prose text-zinc-600">
+          {!showNewLayout && <Text variant="h3">Files</Text>}
+          <Text
+            variant={showNewLayout ? "large" : "body"}
+            className="max-w-prose text-zinc-600"
+          >
             Every file your agents generate or use in the Builder lives here —
             ready to reuse, download, or share.
           </Text>
@@ -165,10 +180,10 @@ export default function ArtifactsPage() {
   );
 }
 
-function ArtifactsPageSkeleton() {
+function ArtifactsPageSkeleton({ showNewLayout }: { showNewLayout: boolean }) {
   return (
     <main
-      className="container min-h-screen space-y-6 pb-20 pt-16 sm:px-8 md:px-12"
+      className={showNewLayout ? NEW_LAYOUT_MAIN : CLASSIC_MAIN}
       data-testid="artifacts-flag-loading"
     >
       <Skeleton className="h-8 w-48 rounded-md" />

--- a/autogpt_platform/frontend/src/app/(platform)/artifacts/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/artifacts/page.tsx
@@ -6,11 +6,8 @@ import { motion, useReducedMotion } from "framer-motion";
 import type { Transition, Variants } from "framer-motion";
 import { Skeleton } from "@/components/atoms/Skeleton/Skeleton";
 import { Text } from "@/components/atoms/Text/Text";
-import {
-  Flag,
-  useFlagStatus,
-  useGetFlag,
-} from "@/services/feature-flags/use-get-flag";
+import { Flag, useFlagStatus } from "@/services/feature-flags/use-get-flag";
+import { usePlatformChrome } from "@/app/(platform)/PlatformChrome/usePlatformChrome";
 import { ArtifactsSearchBar } from "./components/ArtifactsSearchBar/ArtifactsSearchBar";
 import { ArtifactsList } from "./components/ArtifactsList/ArtifactsList";
 import { OriginFilter } from "./components/OriginFilter/OriginFilter";
@@ -48,7 +45,7 @@ export default function ArtifactsPage() {
   const { enabled: isEnabled, ready: flagReady } = useFlagStatus(
     Flag.ARTIFACTS_PAGE,
   );
-  const showNewLayout = useGetFlag(Flag.AUTOGPT_NEW_LAYOUT);
+  const { showNewLayout } = usePlatformChrome();
   const reduceMotion = useReducedMotion();
   const {
     files,

--- a/autogpt_platform/frontend/src/app/(platform)/artifacts/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/artifacts/page.tsx
@@ -177,7 +177,11 @@ export default function ArtifactsPage() {
   );
 }
 
-function ArtifactsPageSkeleton({ showNewLayout }: { showNewLayout: boolean }) {
+interface Props {
+  showNewLayout: boolean;
+}
+
+function ArtifactsPageSkeleton({ showNewLayout }: Props) {
   return (
     <main
       className={showNewLayout ? NEW_LAYOUT_MAIN : CLASSIC_MAIN}

--- a/autogpt_platform/frontend/src/components/layout/AppSidebar/AppSidebar.tsx
+++ b/autogpt_platform/frontend/src/components/layout/AppSidebar/AppSidebar.tsx
@@ -102,7 +102,7 @@ function NavMenu({
             asChild
             tooltip={link.name}
             isActive={isLinkActive(pathname, link.href)}
-            className="font-normal data-[active=true]:!bg-zinc-200 data-[active=true]:font-normal group-data-[collapsible=icon]:!p-1.5 hover:!bg-zinc-200 [&>svg]:size-5"
+            className="h-auto rounded-lg p-2 font-normal data-[active=true]:!bg-zinc-100 data-[active=true]:font-normal group-data-[collapsible=icon]:!p-1.5 hover:!bg-zinc-100 [&>svg]:size-5"
           >
             <Link href={link.href}>
               <link.icon className="size-5" />
@@ -176,7 +176,7 @@ export function AppSidebar(props: Props) {
     <Sidebar
       collapsible="icon"
       {...props}
-      className="[&_[data-sidebar=sidebar]]:bg-[#F3F3F4]"
+      className="[&_[data-sidebar=sidebar]]:bg-[#ffffff]"
     >
       <AppSidebarHeader />
 

--- a/autogpt_platform/frontend/src/components/layout/AppSidebar/components/RecentChats/RecentChats.tsx
+++ b/autogpt_platform/frontend/src/components/layout/AppSidebar/components/RecentChats/RecentChats.tsx
@@ -3,13 +3,7 @@
 import { DeleteChatDialog } from "@/app/(platform)/copilot/components/DeleteChatDialog/DeleteChatDialog";
 import { ShareChatDialog } from "@/app/(platform)/copilot/sharing/ShareChatDialog";
 import { LoadingSpinner } from "@/components/atoms/LoadingSpinner/LoadingSpinner";
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from "@/components/ui/collapsible";
 import { SidebarMenu } from "@/components/ui/sidebar";
-import { CaretDownIcon } from "@phosphor-icons/react";
 import { Flag, useGetFlag } from "@/services/feature-flags/use-get-flag";
 import { RecentChatItem } from "./components/RecentChatItem/RecentChatItem";
 import { groupSessionsByDate } from "./helpers";
@@ -79,20 +73,16 @@ export function RecentChats() {
 
   return (
     <>
-      {groupSessionsByDate(sessions).map((group) => (
-        <Collapsible key={group.label} defaultOpen className="group/day">
-          <CollapsibleTrigger className="flex w-full items-center gap-2 px-2 pb-1 pt-2 text-xs font-medium text-zinc-600">
-            <span>{group.label}</span>
-            <CaretDownIcon
-              weight="bold"
-              className="ease-[cubic-bezier(0.33,1,0.68,1)] ml-auto size-3.5 text-zinc-500 transition-transform duration-200 group-data-[state=open]/day:rotate-180 motion-reduce:transition-none"
-            />
-          </CollapsibleTrigger>
-          <CollapsibleContent className="overflow-hidden data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down motion-reduce:animate-none">
+      <div className="mt-2 flex flex-col gap-4">
+        {groupSessionsByDate(sessions).map((group) => (
+          <div key={group.label}>
+            <div className="px-2 pb-1 text-xs font-medium text-zinc-600">
+              {group.label}
+            </div>
             <SidebarMenu>{group.sessions.map(renderItem)}</SidebarMenu>
-          </CollapsibleContent>
-        </Collapsible>
-      ))}
+          </div>
+        ))}
+      </div>
 
       {hasMore && (
         <button


### PR DESCRIPTION
### Why / What / How

**Why:** The new AutoGPT sidebar-inset layout needed polish, and the artifacts page was still styled for the old top-navbar shell, so it looked off inside the sidebar layout.

**What:** Refines the sidebar and inset header, removes the per-day accordion in Recent chats, and reworks the artifacts page for the dashboard layout — all gated behind the `autogpt-new-layout` flag so the classic layout is untouched when it's off.

**How:** Sidebar/header changes live in the `showNewLayout` branch and sidebar-only components; the artifacts page branches on `useGetFlag(AUTOGPT_NEW_LAYOUT)` for its container/title/text (classic navbar styling preserved otherwise). The "Files" title (with icon) now renders in the inset header via a new route-mapped `InsetHeaderTitle`, aligned with the content's max-width. The `artifacts-page` and `autogpt-new-layout` flag defaults are flipped on.

### Changes 🏗️

- **Sidebar:** white background, rounder + roomier nav buttons, `zinc-100` active/hover state.
- **Recent chats:** removed the collapsible per-day accordion; added spacing between date groups and before the first group.
- **Inset header:** new `InsetHeaderTitle` (icon + page title) aligned with page content; actions pinned to the right edge; more top padding.
- **Artifacts page:** sidebar-inset dashboard layout (centered `max-w-7xl`, full-width, adjusted padding, larger description) behind the new-layout flag; classic navbar layout kept when the flag is off.
- **Flags:** `artifacts-page` and `autogpt-new-layout` enabled by default.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `pnpm format`, `pnpm lint`, `pnpm types` all pass
  - [x] `pnpm test:unit` — artifacts + AppSidebar suites pass (183 tests); updated the artifacts flag mock to keep the classic-layout heading test valid
  - [ ] Manually verify /artifacts renders correctly with the new layout (sidebar collapsed/expanded) and with the flag off (classic layout)
