### PR TITLE
fix(frontend): hide new app sidebar on unauthenticated platform pages

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/PlatformChrome/__tests__/usePlatformChrome.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/PlatformChrome/__tests__/usePlatformChrome.test.ts
@@ -62,6 +62,23 @@ describe("usePlatformChrome", () => {
     });
   });
 
+  it.each([
+    "/reset-password",
+    "/auth/auth-code-error",
+    "/error",
+    "/unauthorized",
+  ])(
+    "excludes the unauthenticated %s route from the new layout",
+    async (route) => {
+      pathnameMock.mockReturnValue(route);
+      const { result } = renderHook(() => usePlatformChrome());
+
+      await waitFor(() => {
+        expect(result.current.showNewLayout).toBe(false);
+      });
+    },
+  );
+
   it("passes the flag enum to useGetFlag", async () => {
     renderHook(() => usePlatformChrome());
     await waitFor(() => {

--- a/autogpt_platform/frontend/src/app/(platform)/PlatformChrome/usePlatformChrome.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/PlatformChrome/usePlatformChrome.ts
@@ -4,9 +4,16 @@ import { useEffect, useState } from "react";
 import { Flag, useGetFlag } from "@/services/feature-flags/use-get-flag";
 
 // Routes that must stay outside the new top-level sidebar layout. Login,
-// signup and onboarding already live in the (no-navbar) group, so settings
-// is the only (platform) route to exclude here.
-const NEW_LAYOUT_EXCLUDED_PREFIXES = ["/settings"];
+// signup and onboarding already live in the (no-navbar) group. These
+// (platform) routes should not show the app sidebar — reset-password and the
+// auth/error/unauthorized pages are all reachable while unauthenticated.
+const NEW_LAYOUT_EXCLUDED_PREFIXES = [
+  "/settings",
+  "/reset-password",
+  "/auth/auth-code-error",
+  "/error",
+  "/unauthorized",
+];
 
 export function usePlatformChrome() {
   const pathname = usePathname();


### PR DESCRIPTION
### Why / What / How

**Why:** The new app sidebar layout (behind the `autogpt-new-layout` flag) was applied to every `(platform)` route except `/settings`. This meant public, unauthenticated pages — most visibly `/reset-password` — rendered the full logged-in app navigation (Marketplace, Library, Copilot, etc.), which makes no sense for a logged-out user.

**What:** Exclude the unauthenticated `(platform)` pages from the new sidebar layout so they fall back to the plain shell, consistent with how `/settings` is already handled.

**How:** Added `/reset-password`, `/auth/auth-code-error`, `/error`, and `/unauthorized` to `NEW_LAYOUT_EXCLUDED_PREFIXES` in `usePlatformChrome.ts`, and added a parametrized test covering all four routes.

### Changes 🏗️

- `usePlatformChrome.ts`: extend `NEW_LAYOUT_EXCLUDED_PREFIXES` with the four unauthenticated routes.
- `usePlatformChrome.test.ts`: `it.each` test asserting `showNewLayout` is `false` for each excluded route.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `pnpm test:unit` passes (19 tests, incl. 4 new route-exclusion cases)
  - [x] `pnpm format`, `pnpm lint`, `pnpm types` all clean
  - [ ] Manually verify `/reset-password` shows no app sidebar with the flag on
