### PR TITLE
fix(frontend/builder): offset tutorial connection popover so handles stay draggable

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/tutorial/steps/connections.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/tutorial/steps/connections.test.ts
@@ -7,9 +7,9 @@ import {
 
 describe("connectionHandleOffset", () => {
   it("shifts left placements further left along x", () => {
-    expect(connectionHandleOffset({ placement: "left", x: 100, y: 50 })).toEqual(
-      { x: 100 - CONNECTION_STEP_OFFSET },
-    );
+    expect(
+      connectionHandleOffset({ placement: "left", x: 100, y: 50 }),
+    ).toEqual({ x: 100 - CONNECTION_STEP_OFFSET });
   });
 
   it("shifts right placements further right along x", () => {
@@ -19,9 +19,11 @@ describe("connectionHandleOffset", () => {
   });
 
   it("shifts top placements further up along y", () => {
-    expect(connectionHandleOffset({ placement: "top", x: 100, y: 50 })).toEqual({
-      y: 50 - CONNECTION_STEP_OFFSET,
-    });
+    expect(connectionHandleOffset({ placement: "top", x: 100, y: 50 })).toEqual(
+      {
+        y: 50 - CONNECTION_STEP_OFFSET,
+      },
+    );
   });
 
   it("shifts bottom placements further down along y", () => {

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/tutorial/steps/connections.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/tutorial/steps/connections.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import {
+  connectionHandleOffset,
+  CONNECTION_STEP_OFFSET,
+  createConnectionSteps,
+} from "./connections";
+
+describe("connectionHandleOffset", () => {
+  it("shifts left placements further left along x", () => {
+    expect(connectionHandleOffset({ placement: "left", x: 100, y: 50 })).toEqual(
+      { x: 100 - CONNECTION_STEP_OFFSET },
+    );
+  });
+
+  it("shifts right placements further right along x", () => {
+    expect(
+      connectionHandleOffset({ placement: "right", x: 100, y: 50 }),
+    ).toEqual({ x: 100 + CONNECTION_STEP_OFFSET });
+  });
+
+  it("shifts top placements further up along y", () => {
+    expect(connectionHandleOffset({ placement: "top", x: 100, y: 50 })).toEqual({
+      y: 50 - CONNECTION_STEP_OFFSET,
+    });
+  });
+
+  it("shifts bottom placements further down along y", () => {
+    expect(
+      connectionHandleOffset({ placement: "bottom", x: 100, y: 50 }),
+    ).toEqual({ y: 50 + CONNECTION_STEP_OFFSET });
+  });
+
+  it("respects the base side of aligned placements like left-start", () => {
+    expect(
+      connectionHandleOffset({ placement: "left-start", x: 100, y: 50 }),
+    ).toEqual({ x: 100 - CONNECTION_STEP_OFFSET });
+  });
+
+  it("returns no offset for unknown placements", () => {
+    expect(
+      connectionHandleOffset({ placement: "center", x: 100, y: 50 }),
+    ).toEqual({});
+  });
+});
+
+describe("createConnectionSteps floating offset", () => {
+  const tour = { next: () => {}, back: () => {}, show: () => {} };
+
+  it("attaches the connection offset middleware to the connect steps", () => {
+    const steps = createConnectionSteps(tour) as Array<{
+      id?: string;
+      floatingUIOptions?: {
+        middleware?: Array<{
+          name: string;
+          fn: (state: { placement: string; x: number; y: number }) => {
+            x?: number;
+            y?: number;
+          };
+        }>;
+      };
+    }>;
+
+    const output = steps.find((s) => s.id === "connect-blocks-output");
+    const input = steps.find((s) => s.id === "connect-blocks-input");
+
+    const middleware = output?.floatingUIOptions?.middleware?.[0];
+    expect(middleware?.name).toBe("connectionHandleOffset");
+    expect(input?.floatingUIOptions?.middleware?.[0]?.name).toBe(
+      "connectionHandleOffset",
+    );
+
+    // Invoking the middleware fn exercises the wiring to connectionHandleOffset.
+    expect(middleware?.fn({ placement: "left", x: 200, y: 30 })).toEqual({
+      x: 200 - CONNECTION_STEP_OFFSET,
+    });
+  });
+});

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/tutorial/steps/connections.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/tutorial/steps/connections.ts
@@ -47,20 +47,35 @@ const hasAnyEdge = (): boolean => {
 // Shepherd 14 positions the popover via @floating-ui/dom (absolute left/top),
 // so CSS margins don't move it. Use a floating-ui offset middleware to push the
 // popover away from the handle, leaving room to grab and drag the connection.
-const CONNECTION_STEP_OFFSET = 15;
+export const CONNECTION_STEP_OFFSET = 15;
+
+export const connectionHandleOffset = ({
+  placement,
+  x,
+  y,
+}: {
+  placement: string;
+  x: number;
+  y: number;
+}): { x?: number; y?: number } => {
+  const side = placement.split("-")[0];
+  if (side === "left") return { x: x - CONNECTION_STEP_OFFSET };
+  if (side === "right") return { x: x + CONNECTION_STEP_OFFSET };
+  if (side === "top") return { y: y - CONNECTION_STEP_OFFSET };
+  if (side === "bottom") return { y: y + CONNECTION_STEP_OFFSET };
+  return {};
+};
 
 const connectionFloatingOptions: StepOptions["floatingUIOptions"] = {
   middleware: [
     {
       name: "connectionHandleOffset",
-      fn(state) {
-        const side = state.placement.split("-")[0];
-        if (side === "left") return { x: state.x - CONNECTION_STEP_OFFSET };
-        if (side === "right") return { x: state.x + CONNECTION_STEP_OFFSET };
-        if (side === "top") return { y: state.y - CONNECTION_STEP_OFFSET };
-        if (side === "bottom") return { y: state.y + CONNECTION_STEP_OFFSET };
-        return {};
-      },
+      fn: (state) =>
+        connectionHandleOffset({
+          placement: state.placement,
+          x: state.x,
+          y: state.y,
+        }),
     },
   ],
 };

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/tutorial/steps/connections.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/tutorial/steps/connections.ts
@@ -44,6 +44,27 @@ const hasAnyEdge = (): boolean => {
   return useEdgeStore.getState().edges.length > 0;
 };
 
+// Shepherd 14 positions the popover via @floating-ui/dom (absolute left/top),
+// so CSS margins don't move it. Use a floating-ui offset middleware to push the
+// popover away from the handle, leaving room to grab and drag the connection.
+const CONNECTION_STEP_OFFSET = 15;
+
+const connectionFloatingOptions: StepOptions["floatingUIOptions"] = {
+  middleware: [
+    {
+      name: "connectionHandleOffset",
+      fn(state) {
+        const side = state.placement.split("-")[0];
+        if (side === "left") return { x: state.x - CONNECTION_STEP_OFFSET };
+        if (side === "right") return { x: state.x + CONNECTION_STEP_OFFSET };
+        if (side === "top") return { y: state.y - CONNECTION_STEP_OFFSET };
+        if (side === "bottom") return { y: state.y + CONNECTION_STEP_OFFSET };
+        return {};
+      },
+    },
+  ],
+};
+
 export const createConnectionSteps = (tour: any): StepOptions[] => {
   let isConnecting = false;
 
@@ -87,7 +108,7 @@ export const createConnectionSteps = (tour: any): StepOptions[] => {
         element: TUTORIAL_SELECTORS.FIRST_CALCULATOR_RESULT_OUTPUT_HANDLER,
         on: "left",
       },
-      classes: "new-builder-tour connection-tour-step",
+      floatingUIOptions: connectionFloatingOptions,
 
       when: {
         show: () => {
@@ -175,7 +196,7 @@ export const createConnectionSteps = (tour: any): StepOptions[] => {
         element: TUTORIAL_SELECTORS.SECOND_CALCULATOR_NUMBER_A_INPUT_HANDLER,
         on: "right",
       },
-      classes: "new-builder-tour connection-tour-step",
+      floatingUIOptions: connectionFloatingOptions,
       when: {
         show: () => {
           const inputSelector =

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/tutorial/steps/connections.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/tutorial/steps/connections.ts
@@ -47,7 +47,7 @@ const hasAnyEdge = (): boolean => {
 // Shepherd 14 positions the popover via @floating-ui/dom (absolute left/top),
 // so CSS margins don't move it. Use a floating-ui offset middleware to push the
 // popover away from the handle, leaving room to grab and drag the connection.
-export const CONNECTION_STEP_OFFSET = 15;
+export const CONNECTION_STEP_OFFSET = 72;
 
 export const connectionHandleOffset = ({
   placement,

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/tutorial/steps/connections.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/tutorial/steps/connections.ts
@@ -87,6 +87,7 @@ export const createConnectionSteps = (tour: any): StepOptions[] => {
         element: TUTORIAL_SELECTORS.FIRST_CALCULATOR_RESULT_OUTPUT_HANDLER,
         on: "left",
       },
+      classes: "new-builder-tour connection-tour-step",
 
       when: {
         show: () => {
@@ -174,6 +175,7 @@ export const createConnectionSteps = (tour: any): StepOptions[] => {
         element: TUTORIAL_SELECTORS.SECOND_CALCULATOR_NUMBER_A_INPUT_HANDLER,
         on: "right",
       },
+      classes: "new-builder-tour connection-tour-step",
       when: {
         show: () => {
           const inputSelector =

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/tutorial/tutorial.css
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/tutorial/tutorial.css
@@ -158,13 +158,3 @@
 .shepherd-element.new-builder-tour[data-popper-placement^="right"] {
   margin-left: 30px !important;
 }
-
-/* Connection steps: extra offset so the popover clears the output/input
-   handle and leaves room to grab and drag the connection. */
-.shepherd-element.new-builder-tour.connection-tour-step[data-popper-placement^="left"] {
-  margin-right: 72px !important;
-}
-
-.shepherd-element.new-builder-tour.connection-tour-step[data-popper-placement^="right"] {
-  margin-left: 72px !important;
-}

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/tutorial/tutorial.css
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/tutorial/tutorial.css
@@ -158,3 +158,13 @@
 .shepherd-element.new-builder-tour[data-popper-placement^="right"] {
   margin-left: 30px !important;
 }
+
+/* Connection steps: extra offset so the popover clears the output/input
+   handle and leaves room to grab and drag the connection. */
+.shepherd-element.new-builder-tour.connection-tour-step[data-popper-placement^="left"] {
+  margin-right: 72px !important;
+}
+
+.shepherd-element.new-builder-tour.connection-tour-step[data-popper-placement^="right"] {
+  margin-left: 72px !important;
+}


### PR DESCRIPTION
### Why / What / How

**Why:** In the builder onboarding tutorial, the "Connect the Blocks" steps attached the Shepherd popover right beside the output/input handles, so the tooltip crowded the handle and left too little room to grab and drag a connection.

**What:** Give the two connection tutorial steps extra breathing room around the highlighted handle.

**How:** Shepherd 14 positions the popover via `@floating-ui/dom` (absolute `left`/`top`), so CSS margins don't move it. Instead, both connection steps use a custom floating-ui `connectionHandleOffset` middleware that pushes the popover away from the handle along the main axis by `CONNECTION_STEP_OFFSET` (72px), based on the final placement (`left`/`right`/`top`/`bottom`).

### Changes 🏗️

- `tutorial/steps/connections.ts`: add the `connectionHandleOffset` middleware + `CONNECTION_STEP_OFFSET` (72px) and wire it into both connection steps via `floatingUIOptions`.
- `tutorial/steps/connections.test.ts`: unit-test the middleware offsets and its wiring into the connect steps.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [ ] Start the builder tutorial and reach the "Connect the Blocks: Output" step
  - [ ] Confirm the popover no longer overlaps the Result output handle and the connection can be dragged easily
  - [ ] Continue to the "Connect the Blocks: Input" step and confirm the same for input A