### PR TITLE
fix(frontend): keep Schedule Run button enabled when editing schedule name

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/modals/ScheduleAgentModal/components/ModalScheduleSection/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/modals/ScheduleAgentModal/components/ModalScheduleSection/helpers.ts
@@ -4,7 +4,7 @@ export const timeRegex = /^([01]?\d|2[0-3]):([0-5]\d)$/;
 
 export const scheduleFormSchema = z.object({
   scheduleName: z.string().trim().min(1, "Schedule name is required"),
-  time: z.string().trim().regex(timeRegex, "Use HH:MM (24h)"),
+  time: z.string().trim().regex(timeRegex, "Use HH:MM (24h)").optional(),
 });
 
 export type ScheduleFormValues = z.infer<typeof scheduleFormSchema>;
@@ -14,7 +14,7 @@ export function validateSchedule(
 ): Partial<Record<keyof ScheduleFormValues, string>> {
   const result = scheduleFormSchema.safeParse({
     scheduleName: values.scheduleName ?? "",
-    time: values.time ?? "",
+    ...(values.time !== undefined ? { time: values.time } : {}),
   });
 
   if (result.success) return {};


### PR DESCRIPTION
### Why / What / How

**Why:** In the **Schedule Run** dialog, editing the schedule name silently disabled the **Schedule** button — you couldn't create a schedule after typing a name.

**What:** The Schedule Run form shares its Zod validation schema with the Edit Schedule modal (which has an HH:MM `time` input). The Schedule Run form has no time field — its time comes from the cron scheduler — so validating the name never supplied `time`, the required regex failed, and the button was disabled after the first keystroke.

**How:** Made `time` optional in the shared schema and only validated it when the caller actually provides it, so Edit Schedule keeps its HH:MM validation while Schedule Run validates only the name.

### Changes 🏗️

- `ModalScheduleSection/helpers.ts`: `time` is now `.optional()` in `scheduleFormSchema`, and `validateSchedule` only includes `time` in the parse when it is provided.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Open the Schedule Run dialog, edit the schedule name, confirm the Schedule button stays enabled and the schedule can be created
  - [x] Clear the name and confirm the button disables with a "Schedule name is required" error
  - [x] Open the Edit Schedule modal, enter an invalid time, confirm HH:MM validation still fires
  - [x] `pnpm types` and schedule unit tests (`ScheduleAgentModal`, `EditScheduleModal`) pass
