### PR TITLE
fix(frontend/builder): highlight node output in builder tutorial run step

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/tutorial/steps/__tests__/run.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/tutorial/steps/__tests__/run.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock(
+  "@/app/(platform)/build/components/FlowEditor/tutorial/helpers",
+  () => ({
+    waitForElement: vi.fn(),
+    fitViewToScreen: vi.fn(),
+    highlightElement: vi.fn(),
+    removeAllHighlights: vi.fn(),
+  }),
+);
+
+// Must import after mocks
+import {
+  waitForElement,
+  fitViewToScreen,
+  highlightElement,
+  removeAllHighlights,
+} from "@/app/(platform)/build/components/FlowEditor/tutorial/helpers";
+import { createRunSteps } from "../run";
+
+const NODE_OUTPUT_SELECTOR = '[data-tutorial-id="node-output"]';
+
+type StepLike = {
+  id?: string;
+  beforeShowPromise?: () => Promise<unknown>;
+  when?: { show?: () => void; hide?: () => void };
+};
+
+function getStep(id: string): StepLike {
+  const tour = { next: vi.fn() };
+  const steps = createRunSteps(tour) as StepLike[];
+  const step = steps.find((s) => s.id === id);
+  if (!step) throw new Error(`step "${id}" not found`);
+  return step;
+}
+
+describe("createRunSteps – show-output step", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("waits for the animated fitView to settle before resolving", async () => {
+    vi.mocked(waitForElement).mockResolvedValue(document.createElement("div"));
+
+    const step = getStep("show-output");
+    const promise = step.beforeShowPromise!();
+
+    // fitView animates the viewport for 800ms; the step awaits a settle delay
+    // before resolving so Shepherd measures the output at its final position.
+    await vi.runAllTimersAsync();
+    await promise;
+
+    expect(waitForElement).toHaveBeenCalledWith(NODE_OUTPUT_SELECTOR, 20000);
+    expect(fitViewToScreen).toHaveBeenCalledTimes(1);
+  });
+
+  it("resolves without throwing when the output never appears", async () => {
+    vi.mocked(waitForElement).mockRejectedValue(new Error("not found"));
+
+    const step = getStep("show-output");
+
+    await expect(step.beforeShowPromise!()).resolves.toBeUndefined();
+    expect(fitViewToScreen).not.toHaveBeenCalled();
+  });
+
+  it("highlights the node output on show and clears it on hide", () => {
+    const step = getStep("show-output");
+
+    step.when!.show!();
+    expect(highlightElement).toHaveBeenCalledWith(NODE_OUTPUT_SELECTOR);
+
+    step.when!.hide!();
+    expect(removeAllHighlights).toHaveBeenCalled();
+  });
+});

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/tutorial/steps/run.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/tutorial/steps/run.ts
@@ -69,16 +69,16 @@ export const createRunSteps = (tour: any): StepOptions[] => [
       on: "top",
     },
     beforeShowPromise: () =>
-      new Promise((resolve) => {
-        setTimeout(() => {
-          waitForElement(TUTORIAL_SELECTORS.FIRST_CALCULATOR_NODE_OUTPUT, 5000)
-            .then(() => {
-              fitViewToScreen();
-              resolve(undefined);
-            })
-            .catch(resolve);
-        }, 300);
-      }),
+      waitForElement(TUTORIAL_SELECTORS.FIRST_CALCULATOR_NODE_OUTPUT, 20000)
+        .then(async () => {
+          fitViewToScreen();
+          // fitView animates the viewport over 800ms. Wait for it to settle so
+          // Shepherd measures the output at its final position before opening
+          // the overlay — otherwise the spotlight lands where the output used
+          // to be and the output stays hidden under the dimmed overlay.
+          await new Promise((resolve) => setTimeout(resolve, 900));
+        })
+        .catch(() => {}),
     when: {
       show: () => {
         highlightElement(TUTORIAL_SELECTORS.FIRST_CALCULATOR_NODE_OUTPUT);


### PR DESCRIPTION
### Why / What / How

**Why:** In the builder tutorial's final "View the Output" step, the block's node output was never highlighted — the popover showed centered over a fully dimmed canvas instead of spotlighting the output. **What:** The step's `beforeShowPromise` was resolving in the same tick it triggered the 800 ms animated `fitView`, so Shepherd measured the output's rect mid-animation and cut the spotlight hole at the wrong position, and its 5 s `waitForElement` timeout silently fell back to a target-less centered modal when execution output was slow. **How:** After calling `fitViewToScreen()` we now wait ~900 ms for the animated viewport transition to settle before resolving (so Shepherd measures the output at its final position), and bump the output wait timeout from 5 s to 20 s to cover slower executions.

### Changes 🏗️

- `FlowEditor/tutorial/steps/run.ts` — rework the `show-output` step's `beforeShowPromise`: await the fitView animation to settle before resolving, and raise the node-output `waitForElement` timeout to 20 s.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [ ] Run the builder tutorial to the end and confirm the "View the Output" step spotlights the first Calculator block's Node Output panel
  - [ ] Confirm the popover attaches above the output (not centered) and the rest of the canvas is dimmed
