### PR TITLE
feat(frontend): make View Submission modal state-aware with real content

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/__tests__/helpers.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/__tests__/helpers.test.ts
@@ -5,6 +5,7 @@ import type { StoreSubmission } from "@/app/api/__generated__/models/storeSubmis
 
 import {
   applyFiltersAndSort,
+  buildEditPayload,
   EMPTY_DASHBOARD_STATS,
   filterSubmissions,
   formatRuns,
@@ -346,6 +347,41 @@ describe("creator-dashboard helpers", () => {
       const unknown = "ARCHIVED" as unknown as SubmissionStatus;
       expect(getStatusVisual(unknown)).toBe(
         STATUS_VISUAL[SubmissionStatus.DRAFT],
+      );
+    });
+  });
+
+  describe("buildEditPayload", () => {
+    test("maps a submission to an edit request payload", () => {
+      const submission = makeSubmission({
+        name: "My Agent",
+        sub_heading: "Does things",
+        description: "A description",
+        image_urls: ["a.png", "b.png"],
+        video_url: "https://youtu.be/x",
+        categories: ["Productivity"],
+        changes_summary: "Fixed a bug",
+        listing_version_id: "lv-42",
+        graph_id: "graph-42",
+      });
+
+      expect(buildEditPayload(submission)).toEqual({
+        name: "My Agent",
+        sub_heading: "Does things",
+        description: "A description",
+        image_urls: ["a.png", "b.png"],
+        video_url: "https://youtu.be/x",
+        categories: ["Productivity"],
+        changes_summary: "Fixed a bug",
+        store_listing_version_id: "lv-42",
+        graph_id: "graph-42",
+      });
+    });
+
+    test("defaults an empty changes summary to 'Update Submission'", () => {
+      const submission = makeSubmission({ changes_summary: null });
+      expect(buildEditPayload(submission).changes_summary).toBe(
+        "Update Submission",
       );
     });
   });

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/DashboardHeader/DashboardHeader.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/DashboardHeader/DashboardHeader.tsx
@@ -6,15 +6,10 @@ import { motion, useReducedMotion } from "framer-motion";
 import { Button } from "@/components/atoms/Button/Button";
 import { Text } from "@/components/atoms/Text/Text";
 import { PublishAgentModal } from "@/components/contextual/PublishAgentModal/PublishAgentModal";
+import type { PublishState } from "@/components/contextual/PublishAgentModal/usePublishAgentModal";
 import type { StoreSubmission } from "@/app/api/__generated__/models/storeSubmission";
 
 import { EASE_OUT } from "../../helpers";
-
-interface PublishState {
-  isOpen: boolean;
-  step: "select" | "info" | "review";
-  submissionData: StoreSubmission | null;
-}
 
 interface Props {
   publishState: PublishState;

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/DashboardHeader/DashboardHeader.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/DashboardHeader/DashboardHeader.tsx
@@ -6,27 +6,28 @@ import { motion, useReducedMotion } from "framer-motion";
 import { Button } from "@/components/atoms/Button/Button";
 import { Text } from "@/components/atoms/Text/Text";
 import { PublishAgentModal } from "@/components/contextual/PublishAgentModal/PublishAgentModal";
+import type { StoreSubmission } from "@/app/api/__generated__/models/storeSubmission";
 
 import { EASE_OUT } from "../../helpers";
 
 interface PublishState {
   isOpen: boolean;
   step: "select" | "info" | "review";
-  submissionData:
-    | import("@/app/api/__generated__/models/storeSubmission").StoreSubmission
-    | null;
+  submissionData: StoreSubmission | null;
 }
 
 interface Props {
   publishState: PublishState;
   onPublishStateChange: (state: PublishState) => void;
   onOpenSubmit: () => void;
+  onRequestEdit?: (submission: StoreSubmission) => void;
 }
 
 export function DashboardHeader({
   publishState,
   onPublishStateChange,
   onOpenSubmit,
+  onRequestEdit,
 }: Props) {
   const reduceMotion = useReducedMotion();
 
@@ -50,6 +51,7 @@ export function DashboardHeader({
       <PublishAgentModal
         targetState={publishState}
         onStateChange={onPublishStateChange}
+        onRequestEdit={onRequestEdit}
         trigger={
           <Button
             data-testid="submit-agent-button"

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/MobileSubmissionItem/MobileSubmissionItem.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/MobileSubmissionItem/MobileSubmissionItem.tsx
@@ -14,7 +14,6 @@ import {
 } from "@phosphor-icons/react";
 
 import type { StoreSubmission } from "@/app/api/__generated__/models/storeSubmission";
-import type { StoreSubmissionEditRequest } from "@/app/api/__generated__/models/storeSubmissionEditRequest";
 import { Button } from "@/components/atoms/Button/Button";
 import { Text } from "@/components/atoms/Text/Text";
 import { Dialog } from "@/components/molecules/Dialog/Dialog";
@@ -26,13 +25,9 @@ import {
   DropdownMenuTrigger,
 } from "@/components/molecules/DropdownMenu/DropdownMenu";
 
+import type { EditPayload } from "../../helpers";
 import { formatRuns, formatSubmittedAt, getStatusVisual } from "../../helpers";
 import { useSubmissionItem } from "../SubmissionItem/useSubmissionItem";
-
-interface EditPayload extends StoreSubmissionEditRequest {
-  store_listing_version_id: string;
-  graph_id: string;
-}
 
 interface Props {
   submission: StoreSubmission;

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/MobileSubmissionItem/MobileSubmissionItem.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/MobileSubmissionItem/MobileSubmissionItem.tsx
@@ -30,7 +30,7 @@ import { formatRuns, formatSubmittedAt, getStatusVisual } from "../../helpers";
 import { useSubmissionItem } from "../SubmissionItem/useSubmissionItem";
 
 interface EditPayload extends StoreSubmissionEditRequest {
-  store_listing_version_id: string | undefined;
+  store_listing_version_id: string;
   graph_id: string;
 }
 

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/MobileSubmissionsList/MobileSubmissionsList.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/MobileSubmissionsList/MobileSubmissionsList.tsx
@@ -22,7 +22,7 @@ import { SortColumnFilter } from "../SubmissionsList/columns/SortColumnFilter";
 import { StatusColumnFilter } from "../SubmissionsList/columns/StatusColumnFilter";
 
 interface EditPayload extends StoreSubmissionEditRequest {
-  store_listing_version_id: string | undefined;
+  store_listing_version_id: string;
   graph_id: string;
 }
 

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/SubmissionItem/SubmissionItem.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/SubmissionItem/SubmissionItem.tsx
@@ -29,7 +29,7 @@ import { formatRuns, formatSubmittedAt, getStatusVisual } from "../../helpers";
 import { useSubmissionItem } from "./useSubmissionItem";
 
 interface EditPayload extends StoreSubmissionEditRequest {
-  store_listing_version_id: string | undefined;
+  store_listing_version_id: string;
   graph_id: string;
 }
 

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/SubmissionItem/useSubmissionItem.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/SubmissionItem/useSubmissionItem.ts
@@ -4,6 +4,7 @@ import * as Sentry from "@sentry/nextjs";
 import { SubmissionStatus } from "@/app/api/__generated__/models/submissionStatus";
 import type { StoreSubmission } from "@/app/api/__generated__/models/storeSubmission";
 import { toast } from "@/components/molecules/Toast/use-toast";
+import { getApprovedMarketplaceUrl } from "@/lib/utils";
 
 import { buildEditPayload, type EditPayload } from "../../helpers";
 
@@ -27,10 +28,11 @@ export function useSubmissionItem({
 
   const canModify = submission.status === SubmissionStatus.PENDING;
   const isApproved = submission.status === SubmissionStatus.APPROVED;
-  const marketplaceUrl =
-    isApproved && creatorUsername && submission.slug
-      ? `/marketplace/agent/${encodeURIComponent(creatorUsername)}/${encodeURIComponent(submission.slug)}`
-      : undefined;
+  const marketplaceUrl = getApprovedMarketplaceUrl({
+    creatorUsername,
+    slug: submission.slug,
+    isApproved,
+  });
 
   function handleView() {
     onView(submission);

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/SubmissionItem/useSubmissionItem.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/SubmissionItem/useSubmissionItem.ts
@@ -3,13 +3,9 @@ import * as Sentry from "@sentry/nextjs";
 
 import { SubmissionStatus } from "@/app/api/__generated__/models/submissionStatus";
 import type { StoreSubmission } from "@/app/api/__generated__/models/storeSubmission";
-import type { StoreSubmissionEditRequest } from "@/app/api/__generated__/models/storeSubmissionEditRequest";
 import { toast } from "@/components/molecules/Toast/use-toast";
 
-interface EditPayload extends StoreSubmissionEditRequest {
-  store_listing_version_id: string | undefined;
-  graph_id: string;
-}
+import { buildEditPayload, type EditPayload } from "../../helpers";
 
 interface Args {
   submission: StoreSubmission;
@@ -41,17 +37,7 @@ export function useSubmissionItem({
   }
 
   function handleEdit() {
-    onEdit({
-      name: submission.name,
-      sub_heading: submission.sub_heading,
-      description: submission.description,
-      image_urls: submission.image_urls,
-      video_url: submission.video_url,
-      categories: submission.categories,
-      changes_summary: submission.changes_summary || "Update Submission",
-      store_listing_version_id: submission.listing_version_id,
-      graph_id: submission.graph_id,
-    });
+    onEdit(buildEditPayload(submission));
   }
 
   async function handleConfirmDelete() {

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/SubmissionsList/SubmissionsList.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/SubmissionsList/SubmissionsList.tsx
@@ -23,7 +23,7 @@ import { SortColumnFilter } from "./columns/SortColumnFilter";
 import { StatusColumnFilter } from "./columns/StatusColumnFilter";
 
 interface EditPayload extends StoreSubmissionEditRequest {
-  store_listing_version_id: string | undefined;
+  store_listing_version_id: string;
   graph_id: string;
 }
 

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/helpers.ts
@@ -12,7 +12,7 @@ import type { StoreSubmissionEditRequest } from "@/app/api/__generated__/models/
 import type { SubmissionStats } from "@/app/api/__generated__/models/submissionStats";
 
 export interface EditPayload extends StoreSubmissionEditRequest {
-  store_listing_version_id: string | undefined;
+  store_listing_version_id: string;
   graph_id: string;
 }
 

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/helpers.ts
@@ -8,7 +8,27 @@ import {
 
 import { SubmissionStatus } from "@/app/api/__generated__/models/submissionStatus";
 import type { StoreSubmission } from "@/app/api/__generated__/models/storeSubmission";
+import type { StoreSubmissionEditRequest } from "@/app/api/__generated__/models/storeSubmissionEditRequest";
 import type { SubmissionStats } from "@/app/api/__generated__/models/submissionStats";
+
+export interface EditPayload extends StoreSubmissionEditRequest {
+  store_listing_version_id: string | undefined;
+  graph_id: string;
+}
+
+export function buildEditPayload(submission: StoreSubmission): EditPayload {
+  return {
+    name: submission.name,
+    sub_heading: submission.sub_heading,
+    description: submission.description,
+    image_urls: submission.image_urls,
+    video_url: submission.video_url,
+    categories: submission.categories,
+    changes_summary: submission.changes_summary || "Update Submission",
+    store_listing_version_id: submission.listing_version_id,
+    graph_id: submission.graph_id,
+  };
+}
 
 export const EASE_OUT = [0.16, 1, 0.3, 1] as const;
 

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/page.tsx
@@ -40,6 +40,7 @@ export default function SettingsCreatorDashboardPage() {
     editState,
     onViewSubmission,
     onEditSubmission,
+    onEditFromReview,
     onEditSuccess,
     onEditClose,
     onDeleteSubmission,
@@ -73,6 +74,7 @@ export default function SettingsCreatorDashboardPage() {
         publishState={publishState}
         onPublishStateChange={onPublishStateChange}
         onOpenSubmit={openPublishModal}
+        onRequestEdit={onEditFromReview}
       />
 
       {isEmpty ? (

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/useCreatorDashboardPage.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/useCreatorDashboardPage.ts
@@ -175,6 +175,12 @@ export function useCreatorDashboardPage() {
   }
 
   function onEditFromReview(submission: StoreSubmission) {
+    if (!submission.listing_version_id) {
+      Sentry.captureException(
+        new Error("No store listing version ID found for submission"),
+      );
+      return;
+    }
     setPublishState({ isOpen: false, step: "select", submissionData: null });
     onEditSubmission(buildEditPayload(submission));
   }

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/useCreatorDashboardPage.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/useCreatorDashboardPage.ts
@@ -14,6 +14,7 @@ import type { StoreSubmissionsResponse } from "@/app/api/__generated__/models/st
 import { useDebouncedValue } from "@/hooks/useDebouncedValue";
 import { getQueryClient } from "@/lib/react-query/queryClient";
 import { useSupabase } from "@/lib/supabase/hooks/useSupabase";
+import type { PublishState } from "@/components/contextual/PublishAgentModal/usePublishAgentModal";
 
 import {
   buildEditPayload,
@@ -25,14 +26,6 @@ import {
 
 const PAGE_SIZE = 20;
 const SEARCH_QUERY_MAX_LENGTH = 100;
-
-type PublishStep = "select" | "info" | "review";
-
-interface PublishState {
-  isOpen: boolean;
-  step: PublishStep;
-  submissionData: StoreSubmission | null;
-}
 
 interface EditState {
   isOpen: boolean;

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/useCreatorDashboardPage.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/useCreatorDashboardPage.ts
@@ -10,15 +10,16 @@ import {
 } from "@/app/api/__generated__/endpoints/store/store";
 import type { ProfileDetails } from "@/app/api/__generated__/models/profileDetails";
 import type { StoreSubmission } from "@/app/api/__generated__/models/storeSubmission";
-import type { StoreSubmissionEditRequest } from "@/app/api/__generated__/models/storeSubmissionEditRequest";
 import type { StoreSubmissionsResponse } from "@/app/api/__generated__/models/storeSubmissionsResponse";
 import { useDebouncedValue } from "@/hooks/useDebouncedValue";
 import { getQueryClient } from "@/lib/react-query/queryClient";
 import { useSupabase } from "@/lib/supabase/hooks/useSupabase";
 
 import {
+  buildEditPayload,
   INITIAL_FILTER_STATE,
   toDashboardStats,
+  type EditPayload,
   type FilterState,
 } from "./helpers";
 
@@ -31,11 +32,6 @@ interface PublishState {
   isOpen: boolean;
   step: PublishStep;
   submissionData: StoreSubmission | null;
-}
-
-interface EditPayload extends StoreSubmissionEditRequest {
-  store_listing_version_id: string | undefined;
-  graph_id: string;
 }
 
 interface EditState {
@@ -185,6 +181,11 @@ export function useCreatorDashboardPage() {
     setEditState({ isOpen: true, submission });
   }
 
+  function onEditFromReview(submission: StoreSubmission) {
+    setPublishState({ isOpen: false, step: "select", submissionData: null });
+    onEditSubmission(buildEditPayload(submission));
+  }
+
   function onEditClose() {
     setEditState({ isOpen: false, submission: null });
   }
@@ -233,6 +234,7 @@ export function useCreatorDashboardPage() {
     editState,
     onViewSubmission,
     onEditSubmission,
+    onEditFromReview,
     onEditSuccess,
     onEditClose,
     onDeleteSubmission,

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/PublishAgentModal.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/PublishAgentModal.tsx
@@ -12,6 +12,7 @@ import { Button } from "@/components/atoms/Button/Button";
 import { Props, usePublishAgentModal } from "./usePublishAgentModal";
 import { SubmissionStatus } from "@/app/api/__generated__/models/submissionStatus";
 import { useSupabase } from "@/lib/supabase/hooks/useSupabase";
+import { getApprovedMarketplaceUrl } from "@/lib/utils";
 import {
   PublishAuthPrompt,
   PublishAuthPromptSkeleton,
@@ -95,13 +96,11 @@ export function PublishAgentModal({
         );
       case "review": {
         const submission = currentState.submissionData;
-        const marketplaceUrl =
-          submission &&
-          submission.status === SubmissionStatus.APPROVED &&
-          creatorUsername &&
-          submission.slug
-            ? `/marketplace/agent/${encodeURIComponent(creatorUsername)}/${encodeURIComponent(submission.slug)}`
-            : undefined;
+        const marketplaceUrl = getApprovedMarketplaceUrl({
+          creatorUsername,
+          slug: submission?.slug,
+          isApproved: submission?.status === SubmissionStatus.APPROVED,
+        });
         const onEdit =
           onRequestEdit &&
           submission &&

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/PublishAgentModal.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/PublishAgentModal.tsx
@@ -10,6 +10,7 @@ import { Dialog } from "@/components/molecules/Dialog/Dialog";
 import { Skeleton } from "@/components/__legacy__/ui/skeleton";
 import { Button } from "@/components/atoms/Button/Button";
 import { Props, usePublishAgentModal } from "./usePublishAgentModal";
+import { SubmissionStatus } from "@/app/api/__generated__/models/submissionStatus";
 import { useSupabase } from "@/lib/supabase/hooks/useSupabase";
 import {
   PublishAuthPrompt,
@@ -20,6 +21,7 @@ export function PublishAgentModal({
   trigger,
   targetState,
   onStateChange,
+  onRequestEdit,
   preSelectedAgentId,
   preSelectedAgentVersion,
   showTrigger = true,
@@ -31,6 +33,7 @@ export function PublishAgentModal({
     initialData,
     selectedAgentId,
     selectedAgentVersion,
+    creatorUsername,
     // Handlers
     handleClose,
     handleAgentSelect,
@@ -90,19 +93,39 @@ export function PublishAgentModal({
             isMarketplaceUpdate={!!currentState.submissionData}
           />
         );
-      case "review":
-        return currentState.submissionData &&
-          currentState.submissionData.name ? (
+      case "review": {
+        const submission = currentState.submissionData;
+        const marketplaceUrl =
+          submission &&
+          submission.status === SubmissionStatus.APPROVED &&
+          creatorUsername &&
+          submission.slug
+            ? `/marketplace/agent/${encodeURIComponent(creatorUsername)}/${encodeURIComponent(submission.slug)}`
+            : undefined;
+        const onEdit =
+          onRequestEdit &&
+          submission &&
+          submission.status !== SubmissionStatus.APPROVED
+            ? () => onRequestEdit(submission)
+            : undefined;
+        return submission && submission.name ? (
           <AgentReviewStep
-            agentName={currentState.submissionData.name}
-            subheader={currentState.submissionData.sub_heading}
-            description={currentState.submissionData.description || ""}
-            thumbnailSrc={currentState.submissionData.image_urls?.[0]}
-            status={currentState.submissionData.status}
-            reviewComments={currentState.submissionData.review_comments}
+            agentName={submission.name}
+            subheader={submission.sub_heading}
+            description={submission.description || ""}
+            thumbnailSrc={submission.image_urls?.[0]}
+            status={submission.status}
+            reviewComments={submission.review_comments}
+            version={submission.listing_version}
+            category={submission.categories?.[0]}
+            submittedAt={submission.submitted_at}
+            reviewedAt={submission.reviewed_at}
+            runCount={submission.run_count}
+            marketplaceUrl={marketplaceUrl}
             onClose={handleClose}
             onDone={handleClose}
             onViewProgress={() => handleGoToDashboard()}
+            onEdit={onEdit}
           />
         ) : (
           <div className="flex min-h-[60vh] flex-col items-center justify-center gap-8 space-y-2">
@@ -114,6 +137,7 @@ export function PublishAgentModal({
             <Skeleton className="h-8 w-full" />
           </div>
         );
+      }
     }
   }
 

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/__tests__/helpers.test.ts
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/__tests__/helpers.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SubmissionStatus } from "@/app/api/__generated__/models/submissionStatus";
+
+import {
+  formatRelativeDate,
+  formatSubmissionDate,
+  getSubmissionMeta,
+} from "../helpers";
+
+const NOW = new Date("2026-07-04T12:00:00Z");
+const DAY = 86_400_000;
+
+function daysAgo(days: number): string {
+  return new Date(NOW.getTime() - days * DAY).toISOString();
+}
+
+describe("PublishAgentModal helpers", () => {
+  describe("formatSubmissionDate", () => {
+    it("returns null for empty or invalid values", () => {
+      expect(formatSubmissionDate(null)).toBeNull();
+      expect(formatSubmissionDate(undefined)).toBeNull();
+      expect(formatSubmissionDate("not-a-date")).toBeNull();
+    });
+
+    it("formats a valid date", () => {
+      expect(formatSubmissionDate("2026-07-01T00:00:00Z")).toBeTruthy();
+    });
+  });
+
+  describe("formatRelativeDate", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(NOW);
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("returns null for empty or invalid values", () => {
+      expect(formatRelativeDate(null)).toBeNull();
+      expect(formatRelativeDate("nope")).toBeNull();
+    });
+
+    it("covers each relative bucket", () => {
+      expect(formatRelativeDate(daysAgo(0))).toBe("today");
+      expect(formatRelativeDate(daysAgo(-2))).toBe("today");
+      expect(formatRelativeDate(daysAgo(1))).toBe("yesterday");
+      expect(formatRelativeDate(daysAgo(3))).toBe("3 days ago");
+      expect(formatRelativeDate(daysAgo(8))).toBe("1 week ago");
+      expect(formatRelativeDate(daysAgo(15))).toBe("2 weeks ago");
+      expect(formatRelativeDate(daysAgo(40))).toBe("1 month ago");
+      expect(formatRelativeDate(daysAgo(70))).toBe("2 months ago");
+      expect(formatRelativeDate(daysAgo(400))).toBe("1 year ago");
+      expect(formatRelativeDate(daysAgo(800))).toBe("2 years ago");
+    });
+  });
+
+  describe("getSubmissionMeta", () => {
+    const base = {
+      version: undefined,
+      category: undefined,
+      submittedAt: undefined,
+      reviewedAt: undefined,
+      runCount: undefined,
+    };
+
+    it("includes version and category when present", () => {
+      const items = getSubmissionMeta({
+        ...base,
+        status: SubmissionStatus.PENDING,
+        version: 4,
+        category: "Marketing",
+      });
+      expect(items).toContainEqual({ label: "Version", value: "v4" });
+      expect(items).toContainEqual({ label: "Category", value: "Marketing" });
+    });
+
+    it("shows live-since date and runs for approved", () => {
+      const items = getSubmissionMeta({
+        ...base,
+        status: SubmissionStatus.APPROVED,
+        reviewedAt: "2026-07-02T00:00:00Z",
+        runCount: 4200,
+      });
+      expect(items.some((i) => i.label === "Live since")).toBe(true);
+      expect(items).toContainEqual({ label: "Runs", value: "4,200" });
+    });
+
+    it("shows reviewed date for rejected", () => {
+      const items = getSubmissionMeta({
+        ...base,
+        status: SubmissionStatus.REJECTED,
+        reviewedAt: "2026-07-02T00:00:00Z",
+      });
+      expect(items.some((i) => i.label === "Reviewed")).toBe(true);
+    });
+
+    it("shows 'Not submitted yet' for draft", () => {
+      const items = getSubmissionMeta({
+        ...base,
+        status: SubmissionStatus.DRAFT,
+      });
+      expect(items).toContainEqual({
+        label: "Status",
+        value: "Not submitted yet",
+      });
+    });
+
+    it("shows submitted date for pending", () => {
+      const items = getSubmissionMeta({
+        ...base,
+        status: SubmissionStatus.PENDING,
+        submittedAt: "2026-07-01T00:00:00Z",
+      });
+      expect(items.some((i) => i.label === "Submitted")).toBe(true);
+    });
+  });
+});

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentReviewStep.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentReviewStep.tsx
@@ -15,12 +15,15 @@ import {
   CheckIcon,
   ClockIcon,
   ImageBrokenIcon,
-  PaperPlaneTiltIcon,
-  RocketLaunchIcon,
+  NotePencilIcon,
+  StorefrontIcon,
   WarningCircleIcon,
   XIcon,
 } from "@phosphor-icons/react";
 import { cn } from "@/lib/utils";
+import { getSubmissionMeta } from "../helpers";
+import { ReviewStepper } from "./ReviewStepper";
+import { ShareLinkButton } from "./ShareLinkButton";
 
 interface Props {
   agentName: string;
@@ -29,9 +32,16 @@ interface Props {
   onClose: () => void;
   onDone: () => void;
   onViewProgress: () => void;
+  onEdit?: () => void;
   thumbnailSrc?: string;
   status?: SubmissionStatus;
   reviewComments?: string | null;
+  version?: number;
+  category?: string | null;
+  submittedAt?: string | Date | null;
+  reviewedAt?: string | Date | null;
+  runCount?: number;
+  marketplaceUrl?: string;
 }
 
 function getHeroContent(
@@ -57,6 +67,15 @@ function getHeroContent(
         ringClass: "bg-rose-50 ring-rose-100",
         iconClass: "bg-rose-500 text-white",
       };
+    case SubmissionStatus.DRAFT:
+      return {
+        title: "Draft saved",
+        description:
+          "This agent isn't submitted yet. Finish the details and submit it for review.",
+        Icon: NotePencilIcon,
+        ringClass: "bg-zinc-50 ring-zinc-100",
+        iconClass: "bg-zinc-500 text-white",
+      };
     default:
       return {
         title: "Submission received",
@@ -70,6 +89,25 @@ function getHeroContent(
   }
 }
 
+function getHeroAccent(iconClass: string) {
+  if (iconClass.includes("bg-emerald")) {
+    return {
+      pulse: "bg-emerald-400/40",
+      gradient: "from-emerald-400 to-emerald-600",
+    };
+  }
+  if (iconClass.includes("bg-rose")) {
+    return { pulse: "bg-rose-400/40", gradient: "from-rose-400 to-rose-600" };
+  }
+  if (iconClass.includes("bg-zinc")) {
+    return { pulse: "bg-zinc-400/40", gradient: "from-zinc-400 to-zinc-600" };
+  }
+  return {
+    pulse: "bg-purple-400/40",
+    gradient: "from-purple-400 to-purple-600",
+  };
+}
+
 export function AgentReviewStep({
   agentName,
   subheader,
@@ -77,20 +115,46 @@ export function AgentReviewStep({
   thumbnailSrc,
   onDone,
   onViewProgress,
+  onEdit,
   status,
   reviewComments,
+  version,
+  category,
+  submittedAt,
+  reviewedAt,
+  runCount,
+  marketplaceUrl,
 }: Props) {
   const pathname = usePathname();
   const isDashboardPage = pathname.includes("/settings/creator-dashboard");
   const hero = getHeroContent(status, isDashboardPage);
   const HeroIcon = hero.Icon;
+  const accent = getHeroAccent(hero.iconClass);
   const shouldReduceMotion = useReducedMotion();
-  const isPending =
-    status !== SubmissionStatus.APPROVED &&
-    status !== SubmissionStatus.REJECTED;
 
-  const showCelebration = status !== SubmissionStatus.REJECTED;
+  const isApproved = status === SubmissionStatus.APPROVED;
+  const isRejected = status === SubmissionStatus.REJECTED;
+  const isDraft = status === SubmissionStatus.DRAFT;
+  const isPending = !isApproved && !isRejected && !isDraft;
+
+  const showCelebration = isApproved || isPending;
   const showConfetti = showCelebration && !shouldReduceMotion;
+
+  const metaItems = getSubmissionMeta({
+    status,
+    version,
+    category,
+    submittedAt,
+    reviewedAt,
+    runCount,
+  });
+
+  const editLabel = isRejected
+    ? "Edit & resubmit"
+    : isDraft
+      ? "Continue editing"
+      : "Edit details";
+  const editIsPrimary = !!onEdit && (isRejected || isDraft);
 
   return (
     <div
@@ -123,11 +187,7 @@ export function AgentReviewStep({
               }}
               className={cn(
                 "absolute inline-block size-24 rounded-full",
-                hero.iconClass.includes("bg-emerald")
-                  ? "bg-emerald-400/40"
-                  : hero.iconClass.includes("bg-rose")
-                    ? "bg-rose-400/40"
-                    : "bg-purple-400/40",
+                accent.pulse,
               )}
             />
             <motion.span
@@ -143,11 +203,7 @@ export function AgentReviewStep({
               }}
               className={cn(
                 "absolute inline-block size-24 rounded-full",
-                hero.iconClass.includes("bg-emerald")
-                  ? "bg-emerald-400/40"
-                  : hero.iconClass.includes("bg-rose")
-                    ? "bg-rose-400/40"
-                    : "bg-purple-400/40",
+                accent.pulse,
               )}
             />
           </>
@@ -163,12 +219,8 @@ export function AgentReviewStep({
               : { type: "spring", stiffness: 280, damping: 20, delay: 0.05 }
           }
           className={cn(
-            "relative flex size-20 items-center justify-center rounded-full shadow-[0_8px_24px_-8px_rgba(119,51,245,0.45)]",
-            hero.iconClass.includes("bg-emerald")
-              ? "bg-gradient-to-br from-emerald-400 to-emerald-600"
-              : hero.iconClass.includes("bg-rose")
-                ? "bg-gradient-to-br from-rose-400 to-rose-600"
-                : "bg-gradient-to-br from-purple-400 to-purple-600",
+            "relative flex size-20 items-center justify-center rounded-full bg-gradient-to-br shadow-[0_8px_24px_-8px_rgba(119,51,245,0.45)]",
+            accent.gradient,
           )}
         >
           <span
@@ -259,6 +311,32 @@ export function AgentReviewStep({
         ) : null}
       </motion.div>
 
+      {metaItems.length > 0 ? (
+        <motion.div
+          initial={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, y: 8 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.24, ease: "easeOut", delay: 0.21 }}
+          className="mt-4 grid w-full max-w-md grid-cols-2 gap-x-4 gap-y-3 rounded-[14px] border border-zinc-200 bg-zinc-50/60 p-4"
+          data-testid="submission-meta"
+        >
+          {metaItems.map((item) => (
+            <div key={item.label} className="flex min-w-0 flex-col">
+              <Text variant="small" as="span" className="text-zinc-500">
+                {item.label}
+              </Text>
+              <Text
+                variant="small-medium"
+                as="span"
+                title={item.title}
+                className="truncate text-textBlack"
+              >
+                {item.value}
+              </Text>
+            </div>
+          ))}
+        </motion.div>
+      ) : null}
+
       {reviewComments && status === SubmissionStatus.REJECTED ? (
         <div className="mt-4 w-full max-w-md rounded-[14px] border border-rose-200 bg-rose-50 p-3">
           <div className="mb-1 flex items-center gap-2 text-rose-700">
@@ -273,95 +351,75 @@ export function AgentReviewStep({
         </div>
       ) : null}
 
-      {status !== SubmissionStatus.REJECTED ? (
-        <motion.div
-          initial={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, y: 8 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.24, ease: "easeOut", delay: 0.24 }}
-          className="mt-6 flex w-full max-w-md flex-col gap-3 px-2"
-        >
-          <Text variant="body-medium" as="span" className="text-textBlack">
-            What happens next
-          </Text>
-          <ol className="flex flex-col gap-3">
-            <li className="flex items-start gap-3">
-              <span className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-full bg-purple-50 text-purple-600">
-                <PaperPlaneTiltIcon size={14} weight="bold" />
-              </span>
-              <div className="flex min-w-0 flex-col">
-                <Text
-                  variant="small-medium"
-                  as="span"
-                  className="text-textBlack"
-                >
-                  Submitted for review
-                </Text>
-                <Text variant="small" className="text-zinc-500">
-                  Your listing is queued in the marketplace review pipeline.
-                </Text>
-              </div>
-            </li>
-            <li className="flex items-start gap-3">
-              <span className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-full bg-amber-50 text-amber-700">
-                <ClockIcon size={14} weight="bold" />
-              </span>
-              <div className="flex min-w-0 flex-col">
-                <Text
-                  variant="small-medium"
-                  as="span"
-                  className="text-textBlack"
-                >
-                  Reviewed soon
-                </Text>
-                <Text variant="small" className="text-zinc-500">
-                  Our team checks the details, media, and safety of your agent.
-                </Text>
-              </div>
-            </li>
-            <li className="flex items-start gap-3">
-              <span className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-full bg-emerald-50 text-emerald-700">
-                <RocketLaunchIcon size={14} weight="bold" />
-              </span>
-              <div className="flex min-w-0 flex-col">
-                <Text
-                  variant="small-medium"
-                  as="span"
-                  className="text-textBlack"
-                >
-                  Approved listings go live
-                </Text>
-                <Text variant="small" className="text-zinc-500">
-                  You&apos;ll get an email; rejected listings come back with
-                  feedback.
-                </Text>
-              </div>
-            </li>
-          </ol>
-        </motion.div>
+      {isPending ? (
+        <ReviewStepper shouldReduceMotion={!!shouldReduceMotion} />
+      ) : null}
+
+      {isApproved && marketplaceUrl ? (
+        <div className="mt-4 flex w-full max-w-md justify-center">
+          <ShareLinkButton url={marketplaceUrl} />
+        </div>
       ) : null}
 
       <div className="mt-8 w-full">
         <StepFooter
           secondary={
-            <Button
-              variant="secondary"
-              size="small"
-              onClick={onDone}
-              className="w-full sm:w-auto"
-            >
-              Done
-            </Button>
+            <>
+              {onEdit && isPending ? (
+                <Button
+                  variant="ghost"
+                  size="small"
+                  onClick={onEdit}
+                  className="w-full sm:w-auto"
+                  leftIcon={<NotePencilIcon size={14} weight="bold" />}
+                  data-testid="edit-submission-button"
+                >
+                  {editLabel}
+                </Button>
+              ) : null}
+              <Button
+                variant="secondary"
+                size="small"
+                onClick={onDone}
+                className="w-full sm:w-auto"
+              >
+                Done
+              </Button>
+            </>
           }
           primary={
-            <Button
-              size="small"
-              onClick={onViewProgress}
-              className="w-full sm:w-auto"
-              rightIcon={<ArrowRightIcon size={14} weight="bold" />}
-              data-testid="view-progress-button"
-            >
-              {isDashboardPage ? "View progress" : "Go to Creator Dashboard"}
-            </Button>
+            isApproved && marketplaceUrl ? (
+              <Button
+                as="NextLink"
+                href={marketplaceUrl}
+                size="small"
+                className="w-full sm:w-auto"
+                rightIcon={<StorefrontIcon size={14} weight="bold" />}
+                data-testid="view-marketplace-button"
+              >
+                View on marketplace
+              </Button>
+            ) : editIsPrimary ? (
+              <Button
+                size="small"
+                onClick={onEdit}
+                className="w-full sm:w-auto"
+                rightIcon={<NotePencilIcon size={14} weight="bold" />}
+                data-testid="edit-submission-button"
+              >
+                {editLabel}
+              </Button>
+            ) : (
+              <Button
+                size="small"
+                onClick={onViewProgress}
+                className="w-full sm:w-auto"
+                rightIcon={<ArrowRightIcon size={14} weight="bold" />}
+                data-testid="view-progress-button"
+              >
+                {isDashboardPage ? "View progress" : "Go to Creator Dashboard"}
+              </Button>
+            )
           }
         />
       </div>

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentReviewStep.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentReviewStep.tsx
@@ -1,29 +1,16 @@
 "use client";
 
-import * as React from "react";
+import { motion } from "framer-motion";
+import { WarningCircleIcon } from "@phosphor-icons/react";
 
-import Image from "next/image";
-import { motion, useReducedMotion } from "framer-motion";
-import { StepFooter } from "./StepFooter";
-import { Button } from "@/components/atoms/Button/Button";
 import { Text } from "@/components/atoms/Text/Text";
-import { Confetti } from "@/components/molecules/Confetti/Confetti";
-import { usePathname } from "next/navigation";
 import { SubmissionStatus } from "@/app/api/__generated__/models/submissionStatus";
-import {
-  ArrowRightIcon,
-  CheckIcon,
-  ClockIcon,
-  ImageBrokenIcon,
-  NotePencilIcon,
-  StorefrontIcon,
-  WarningCircleIcon,
-  XIcon,
-} from "@phosphor-icons/react";
-import { cn } from "@/lib/utils";
-import { getSubmissionMeta } from "../helpers";
 import { ReviewStepper } from "./ReviewStepper";
 import { ShareLinkButton } from "./ShareLinkButton";
+import { ReviewHero } from "./ReviewHero";
+import { SubmissionSummaryCard } from "./SubmissionSummaryCard";
+import { ReviewStepFooter } from "./ReviewStepFooter";
+import { useAgentReviewStep } from "./useAgentReviewStep";
 
 interface Props {
   agentName: string;
@@ -44,70 +31,6 @@ interface Props {
   marketplaceUrl?: string;
 }
 
-function getHeroContent(
-  status: SubmissionStatus | undefined,
-  isDashboardPage: boolean,
-) {
-  switch (status) {
-    case SubmissionStatus.APPROVED:
-      return {
-        title: "Agent approved",
-        description:
-          "Your agent has been approved and is now live on the AutoGPT marketplace.",
-        Icon: CheckIcon,
-        ringClass: "bg-emerald-50 ring-emerald-100",
-        iconClass: "bg-emerald-500 text-white",
-      };
-    case SubmissionStatus.REJECTED:
-      return {
-        title: "Agent needs changes",
-        description:
-          "Your submission was not approved. Review the feedback and resubmit.",
-        Icon: XIcon,
-        ringClass: "bg-rose-50 ring-rose-100",
-        iconClass: "bg-rose-500 text-white",
-      };
-    case SubmissionStatus.DRAFT:
-      return {
-        title: "Draft saved",
-        description:
-          "This agent isn't submitted yet. Finish the details and submit it for review.",
-        Icon: NotePencilIcon,
-        ringClass: "bg-zinc-50 ring-zinc-100",
-        iconClass: "bg-zinc-500 text-white",
-      };
-    default:
-      return {
-        title: "Submission received",
-        description: isDashboardPage
-          ? "We'll notify you once review is complete. Approved agents go live on the marketplace."
-          : "We'll notify you once review is complete. Track progress from the Creator Dashboard.",
-        Icon: CheckIcon,
-        ringClass: "bg-purple-50 ring-purple-100",
-        iconClass: "bg-purple-500 text-white",
-      };
-  }
-}
-
-function getHeroAccent(iconClass: string) {
-  if (iconClass.includes("bg-emerald")) {
-    return {
-      pulse: "bg-emerald-400/40",
-      gradient: "from-emerald-400 to-emerald-600",
-    };
-  }
-  if (iconClass.includes("bg-rose")) {
-    return { pulse: "bg-rose-400/40", gradient: "from-rose-400 to-rose-600" };
-  }
-  if (iconClass.includes("bg-zinc")) {
-    return { pulse: "bg-zinc-400/40", gradient: "from-zinc-400 to-zinc-600" };
-  }
-  return {
-    pulse: "bg-purple-400/40",
-    gradient: "from-purple-400 to-purple-600",
-  };
-}
-
 export function AgentReviewStep({
   agentName,
   subheader,
@@ -125,22 +48,18 @@ export function AgentReviewStep({
   runCount,
   marketplaceUrl,
 }: Props) {
-  const pathname = usePathname();
-  const isDashboardPage = pathname.includes("/settings/creator-dashboard");
-  const hero = getHeroContent(status, isDashboardPage);
-  const HeroIcon = hero.Icon;
-  const accent = getHeroAccent(hero.iconClass);
-  const shouldReduceMotion = useReducedMotion();
-
-  const isApproved = status === SubmissionStatus.APPROVED;
-  const isRejected = status === SubmissionStatus.REJECTED;
-  const isDraft = status === SubmissionStatus.DRAFT;
-  const isPending = !isApproved && !isRejected && !isDraft;
-
-  const showCelebration = isApproved || isPending;
-  const showConfetti = showCelebration && !shouldReduceMotion;
-
-  const metaItems = getSubmissionMeta({
+  const {
+    isDashboardPage,
+    hero,
+    shouldReduceMotion,
+    isApproved,
+    isRejected,
+    isDraft,
+    isPending,
+    showCelebration,
+    showConfetti,
+    metaItems,
+  } = useAgentReviewStep({
     status,
     version,
     category,
@@ -149,164 +68,25 @@ export function AgentReviewStep({
     runCount,
   });
 
-  // Editing is only supported for pending submissions; other states can't be
-  // edited in place, so we don't surface an edit action for them.
-  const editLabel = "Edit details";
-
   return (
     <div
       aria-labelledby="modal-title"
       className="relative flex flex-col items-center pb-4 pt-10"
     >
-      {showConfetti ? (
-        <Confetti
-          options={{
-            particleCount: 80,
-            spread: 70,
-            startVelocity: 35,
-            origin: { y: 0.3 },
-          }}
-        />
-      ) : null}
+      <ReviewHero
+        hero={hero}
+        showCelebration={showCelebration}
+        showConfetti={showConfetti}
+        shouldReduceMotion={!!shouldReduceMotion}
+      />
 
-      <div className="relative flex items-center justify-center">
-        {showCelebration && !shouldReduceMotion ? (
-          <>
-            <motion.span
-              aria-hidden
-              initial={{ opacity: 0.5, scale: 0.6 }}
-              animate={{ opacity: 0, scale: 1.6 }}
-              transition={{
-                duration: 1.6,
-                ease: "easeOut",
-                repeat: Infinity,
-                repeatDelay: 0.4,
-              }}
-              className={cn(
-                "absolute inline-block size-24 rounded-full",
-                accent.pulse,
-              )}
-            />
-            <motion.span
-              aria-hidden
-              initial={{ opacity: 0.4, scale: 0.7 }}
-              animate={{ opacity: 0, scale: 1.4 }}
-              transition={{
-                duration: 1.6,
-                ease: "easeOut",
-                repeat: Infinity,
-                repeatDelay: 0.4,
-                delay: 0.5,
-              }}
-              className={cn(
-                "absolute inline-block size-24 rounded-full",
-                accent.pulse,
-              )}
-            />
-          </>
-        ) : null}
-        <motion.div
-          initial={
-            shouldReduceMotion ? { opacity: 0 } : { opacity: 0, scale: 0.7 }
-          }
-          animate={{ opacity: 1, scale: 1 }}
-          transition={
-            shouldReduceMotion
-              ? { duration: 0 }
-              : { type: "spring", stiffness: 280, damping: 20, delay: 0.05 }
-          }
-          className={cn(
-            "relative flex size-20 items-center justify-center rounded-full bg-gradient-to-br shadow-[0_8px_24px_-8px_rgba(119,51,245,0.45)]",
-            accent.gradient,
-          )}
-        >
-          <span
-            aria-hidden
-            className="absolute inset-1 rounded-full bg-white/10"
-          />
-          <motion.span
-            initial={
-              shouldReduceMotion ? { opacity: 0 } : { scale: 0.4, opacity: 0 }
-            }
-            animate={{ scale: 1, opacity: 1 }}
-            transition={
-              shouldReduceMotion
-                ? { duration: 0 }
-                : {
-                    type: "spring",
-                    stiffness: 360,
-                    damping: 18,
-                    delay: 0.18,
-                  }
-            }
-            className="text-white"
-          >
-            <HeroIcon size={36} weight="bold" />
-          </motion.span>
-        </motion.div>
-      </div>
-
-      <motion.div
-        initial={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, y: 8 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.24, ease: "easeOut", delay: 0.12 }}
-        className="mt-5 flex max-w-md flex-col items-center gap-2 px-2 text-center"
-      >
-        <Text
-          variant="lead-medium"
-          as="h2"
-          className="text-textBlack"
-          data-testid="view-agent-name"
-        >
-          {hero.title}
-        </Text>
-        <Text variant="body" className="text-zinc-600">
-          {hero.description}
-        </Text>
-      </motion.div>
-
-      <motion.div
-        initial={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, y: 8 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.24, ease: "easeOut", delay: 0.18 }}
-        className="mt-6 flex w-full max-w-md items-center gap-3 rounded-[14px] border border-zinc-200 bg-white p-3 shadow-[0_1px_2px_rgba(15,15,20,0.04)]"
-      >
-        <div className="relative aspect-video h-12 shrink-0 overflow-hidden rounded-[8px] bg-zinc-100">
-          {thumbnailSrc ? (
-            <Image
-              src={thumbnailSrc}
-              alt=""
-              fill
-              sizes="86px"
-              className="object-cover"
-            />
-          ) : (
-            <div className="flex h-full w-full items-center justify-center text-zinc-400">
-              <ImageBrokenIcon size={20} weight="duotone" />
-            </div>
-          )}
-        </div>
-        <div className="flex min-w-0 flex-1 flex-col">
-          <Text
-            variant="body-medium"
-            as="span"
-            className="truncate text-textBlack"
-          >
-            {agentName}
-          </Text>
-          {subheader ? (
-            <Text variant="small" className="truncate text-zinc-500">
-              {subheader}
-            </Text>
-          ) : null}
-        </div>
-        {isPending ? (
-          <span className="inline-flex items-center gap-1.5 rounded-full bg-amber-50 px-2.5 py-1 text-[11px] font-medium text-amber-800">
-            <ClockIcon size={12} weight="duotone" />
-            In review
-          </span>
-        ) : null}
-      </motion.div>
+      <SubmissionSummaryCard
+        agentName={agentName}
+        subheader={subheader}
+        thumbnailSrc={thumbnailSrc}
+        isPending={isPending}
+        shouldReduceMotion={!!shouldReduceMotion}
+      />
 
       {metaItems.length > 0 ? (
         <motion.div
@@ -358,58 +138,17 @@ export function AgentReviewStep({
         </div>
       ) : null}
 
-      <div className="mt-8 w-full">
-        <StepFooter
-          secondary={
-            <>
-              {onEdit && isPending ? (
-                <Button
-                  variant="ghost"
-                  size="small"
-                  onClick={onEdit}
-                  className="w-full sm:w-auto"
-                  leftIcon={<NotePencilIcon size={14} weight="bold" />}
-                  data-testid="edit-submission-button"
-                >
-                  {editLabel}
-                </Button>
-              ) : null}
-              <Button
-                variant="secondary"
-                size="small"
-                onClick={onDone}
-                className="w-full sm:w-auto"
-              >
-                Done
-              </Button>
-            </>
-          }
-          primary={
-            isApproved && marketplaceUrl ? (
-              <Button
-                as="NextLink"
-                href={marketplaceUrl}
-                size="small"
-                className="w-full sm:w-auto"
-                rightIcon={<StorefrontIcon size={14} weight="bold" />}
-                data-testid="view-marketplace-button"
-              >
-                View on marketplace
-              </Button>
-            ) : isRejected || isDraft ? null : (
-              <Button
-                size="small"
-                onClick={onViewProgress}
-                className="w-full sm:w-auto"
-                rightIcon={<ArrowRightIcon size={14} weight="bold" />}
-                data-testid="view-progress-button"
-              >
-                {isDashboardPage ? "View progress" : "Go to Creator Dashboard"}
-              </Button>
-            )
-          }
-        />
-      </div>
+      <ReviewStepFooter
+        onDone={onDone}
+        onViewProgress={onViewProgress}
+        onEdit={onEdit}
+        isApproved={isApproved}
+        isRejected={isRejected}
+        isDraft={isDraft}
+        isPending={isPending}
+        isDashboardPage={isDashboardPage}
+        marketplaceUrl={marketplaceUrl}
+      />
     </div>
   );
 }

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentReviewStep.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentReviewStep.tsx
@@ -149,12 +149,9 @@ export function AgentReviewStep({
     runCount,
   });
 
-  const editLabel = isRejected
-    ? "Edit & resubmit"
-    : isDraft
-      ? "Continue editing"
-      : "Edit details";
-  const editIsPrimary = !!onEdit && (isRejected || isDraft);
+  // Editing is only supported for pending submissions; other states can't be
+  // edited in place, so we don't surface an edit action for them.
+  const editLabel = "Edit details";
 
   return (
     <div
@@ -399,17 +396,7 @@ export function AgentReviewStep({
               >
                 View on marketplace
               </Button>
-            ) : editIsPrimary ? (
-              <Button
-                size="small"
-                onClick={onEdit}
-                className="w-full sm:w-auto"
-                rightIcon={<NotePencilIcon size={14} weight="bold" />}
-                data-testid="edit-submission-button"
-              >
-                {editLabel}
-              </Button>
-            ) : (
+            ) : isRejected || isDraft ? null : (
               <Button
                 size="small"
                 onClick={onViewProgress}

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentReviewStep.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentReviewStep.tsx
@@ -1,14 +1,12 @@
 "use client";
 
-import { motion } from "framer-motion";
-import { WarningCircleIcon } from "@phosphor-icons/react";
-
-import { Text } from "@/components/atoms/Text/Text";
 import { SubmissionStatus } from "@/app/api/__generated__/models/submissionStatus";
 import { ReviewStepper } from "./ReviewStepper";
 import { ShareLinkButton } from "./ShareLinkButton";
 import { ReviewHero } from "./ReviewHero";
 import { SubmissionSummaryCard } from "./SubmissionSummaryCard";
+import { SubmissionMetaGrid } from "./SubmissionMetaGrid";
+import { RejectionFeedback } from "./RejectionFeedback";
 import { ReviewStepFooter } from "./ReviewStepFooter";
 import { useAgentReviewStep } from "./useAgentReviewStep";
 
@@ -88,44 +86,13 @@ export function AgentReviewStep({
         shouldReduceMotion={!!shouldReduceMotion}
       />
 
-      {metaItems.length > 0 ? (
-        <motion.div
-          initial={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, y: 8 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.24, ease: "easeOut", delay: 0.21 }}
-          className="mt-4 grid w-full max-w-md grid-cols-2 gap-x-4 gap-y-3 rounded-[14px] border border-zinc-200 bg-zinc-50/60 p-4"
-          data-testid="submission-meta"
-        >
-          {metaItems.map((item) => (
-            <div key={item.label} className="flex min-w-0 flex-col">
-              <Text variant="small" as="span" className="text-zinc-500">
-                {item.label}
-              </Text>
-              <Text
-                variant="small-medium"
-                as="span"
-                title={item.title}
-                className="truncate text-textBlack"
-              >
-                {item.value}
-              </Text>
-            </div>
-          ))}
-        </motion.div>
-      ) : null}
+      <SubmissionMetaGrid
+        items={metaItems}
+        shouldReduceMotion={!!shouldReduceMotion}
+      />
 
       {reviewComments && status === SubmissionStatus.REJECTED ? (
-        <div className="mt-4 w-full max-w-md rounded-[14px] border border-rose-200 bg-rose-50 p-3">
-          <div className="mb-1 flex items-center gap-2 text-rose-700">
-            <WarningCircleIcon size={16} weight="duotone" />
-            <Text variant="small-medium" as="span" className="!text-current">
-              Review feedback
-            </Text>
-          </div>
-          <Text variant="small" className="text-rose-700">
-            {reviewComments}
-          </Text>
-        </div>
+        <RejectionFeedback comments={reviewComments} />
       ) : null}
 
       {isPending ? (

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/RejectionFeedback.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/RejectionFeedback.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { WarningCircleIcon } from "@phosphor-icons/react";
+
+import { Text } from "@/components/atoms/Text/Text";
+
+interface Props {
+  comments: string;
+}
+
+export function RejectionFeedback({ comments }: Props) {
+  return (
+    <div className="mt-4 w-full max-w-md rounded-[14px] border border-rose-200 bg-rose-50 p-3">
+      <div className="mb-1 flex items-center gap-2 text-rose-700">
+        <WarningCircleIcon size={16} weight="duotone" />
+        <Text variant="small-medium" as="span" className="!text-current">
+          Review feedback
+        </Text>
+      </div>
+      <Text variant="small" className="text-rose-700">
+        {comments}
+      </Text>
+    </div>
+  );
+}

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/ReviewHero.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/ReviewHero.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { type Icon as PhosphorIcon } from "@phosphor-icons/react";
+
+import { Text } from "@/components/atoms/Text/Text";
+import { Confetti } from "@/components/molecules/Confetti/Confetti";
+import { cn } from "@/lib/utils";
+
+interface Hero {
+  title: string;
+  description: string;
+  Icon: PhosphorIcon;
+  pulse: string;
+  gradient: string;
+}
+
+interface Props {
+  hero: Hero;
+  showCelebration: boolean;
+  showConfetti: boolean;
+  shouldReduceMotion: boolean;
+}
+
+export function ReviewHero({
+  hero,
+  showCelebration,
+  showConfetti,
+  shouldReduceMotion,
+}: Props) {
+  const HeroIcon = hero.Icon;
+
+  return (
+    <>
+      {showConfetti ? (
+        <Confetti
+          options={{
+            particleCount: 80,
+            spread: 70,
+            startVelocity: 35,
+            origin: { y: 0.3 },
+          }}
+        />
+      ) : null}
+
+      <div className="relative flex items-center justify-center">
+        {showCelebration && !shouldReduceMotion ? (
+          <>
+            <motion.span
+              aria-hidden
+              initial={{ opacity: 0.5, scale: 0.6 }}
+              animate={{ opacity: 0, scale: 1.6 }}
+              transition={{
+                duration: 1.6,
+                ease: "easeOut",
+                repeat: Infinity,
+                repeatDelay: 0.4,
+              }}
+              className={cn(
+                "absolute inline-block size-24 rounded-full",
+                hero.pulse,
+              )}
+            />
+            <motion.span
+              aria-hidden
+              initial={{ opacity: 0.4, scale: 0.7 }}
+              animate={{ opacity: 0, scale: 1.4 }}
+              transition={{
+                duration: 1.6,
+                ease: "easeOut",
+                repeat: Infinity,
+                repeatDelay: 0.4,
+                delay: 0.5,
+              }}
+              className={cn(
+                "absolute inline-block size-24 rounded-full",
+                hero.pulse,
+              )}
+            />
+          </>
+        ) : null}
+        <motion.div
+          initial={
+            shouldReduceMotion ? { opacity: 0 } : { opacity: 0, scale: 0.7 }
+          }
+          animate={{ opacity: 1, scale: 1 }}
+          transition={
+            shouldReduceMotion
+              ? { duration: 0 }
+              : { type: "spring", stiffness: 280, damping: 20, delay: 0.05 }
+          }
+          className={cn(
+            "relative flex size-20 items-center justify-center rounded-full bg-gradient-to-br shadow-[0_8px_24px_-8px_rgba(119,51,245,0.45)]",
+            hero.gradient,
+          )}
+        >
+          <span
+            aria-hidden
+            className="absolute inset-1 rounded-full bg-white/10"
+          />
+          <motion.span
+            initial={
+              shouldReduceMotion ? { opacity: 0 } : { scale: 0.4, opacity: 0 }
+            }
+            animate={{ scale: 1, opacity: 1 }}
+            transition={
+              shouldReduceMotion
+                ? { duration: 0 }
+                : {
+                    type: "spring",
+                    stiffness: 360,
+                    damping: 18,
+                    delay: 0.18,
+                  }
+            }
+            className="text-white"
+          >
+            <HeroIcon size={36} weight="bold" />
+          </motion.span>
+        </motion.div>
+      </div>
+
+      <motion.div
+        initial={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, y: 8 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.24, ease: "easeOut", delay: 0.12 }}
+        className="mt-5 flex max-w-md flex-col items-center gap-2 px-2 text-center"
+      >
+        <Text
+          variant="lead-medium"
+          as="h2"
+          className="text-textBlack"
+          data-testid="view-agent-name"
+        >
+          {hero.title}
+        </Text>
+        <Text variant="body" className="text-zinc-600">
+          {hero.description}
+        </Text>
+      </motion.div>
+    </>
+  );
+}

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/ReviewHero.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/ReviewHero.tsx
@@ -32,7 +32,7 @@ export function ReviewHero({
 
   return (
     <>
-      {showConfetti ? (
+      {showConfetti && !shouldReduceMotion ? (
         <Confetti
           options={{
             particleCount: 80,

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/ReviewStepFooter.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/ReviewStepFooter.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import {
+  ArrowRightIcon,
+  NotePencilIcon,
+  StorefrontIcon,
+} from "@phosphor-icons/react";
+
+import { Button } from "@/components/atoms/Button/Button";
+import { StepFooter } from "./StepFooter";
+
+interface Props {
+  onDone: () => void;
+  onViewProgress: () => void;
+  onEdit?: () => void;
+  isApproved: boolean;
+  isRejected: boolean;
+  isDraft: boolean;
+  isPending: boolean;
+  isDashboardPage: boolean;
+  marketplaceUrl?: string;
+}
+
+export function ReviewStepFooter({
+  onDone,
+  onViewProgress,
+  onEdit,
+  isApproved,
+  isRejected,
+  isDraft,
+  isPending,
+  isDashboardPage,
+  marketplaceUrl,
+}: Props) {
+  return (
+    <div className="mt-8 w-full">
+      <StepFooter
+        secondary={
+          <>
+            {onEdit && isPending ? (
+              <Button
+                variant="ghost"
+                size="small"
+                onClick={onEdit}
+                className="w-full sm:w-auto"
+                leftIcon={<NotePencilIcon size={14} weight="bold" />}
+                data-testid="edit-submission-button"
+              >
+                Edit details
+              </Button>
+            ) : null}
+            <Button
+              variant="secondary"
+              size="small"
+              onClick={onDone}
+              className="w-full sm:w-auto"
+            >
+              Done
+            </Button>
+          </>
+        }
+        primary={
+          isApproved && marketplaceUrl ? (
+            <Button
+              as="NextLink"
+              href={marketplaceUrl}
+              size="small"
+              className="w-full sm:w-auto"
+              rightIcon={<StorefrontIcon size={14} weight="bold" />}
+              data-testid="view-marketplace-button"
+            >
+              View on marketplace
+            </Button>
+          ) : isRejected || isDraft ? null : (
+            <Button
+              size="small"
+              onClick={onViewProgress}
+              className="w-full sm:w-auto"
+              rightIcon={<ArrowRightIcon size={14} weight="bold" />}
+              data-testid="view-progress-button"
+            >
+              {isDashboardPage ? "View progress" : "Go to Creator Dashboard"}
+            </Button>
+          )
+        }
+      />
+    </div>
+  );
+}

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/ReviewStepFooter.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/ReviewStepFooter.tsx
@@ -71,7 +71,7 @@ export function ReviewStepFooter({
             >
               View on marketplace
             </Button>
-          ) : isRejected || isDraft ? null : (
+          ) : isRejected || isDraft || isDashboardPage ? null : (
             <Button
               size="small"
               onClick={onViewProgress}
@@ -79,7 +79,7 @@ export function ReviewStepFooter({
               rightIcon={<ArrowRightIcon size={14} weight="bold" />}
               data-testid="view-progress-button"
             >
-              {isDashboardPage ? "View progress" : "Go to Creator Dashboard"}
+              Go to Creator Dashboard
             </Button>
           )
         }

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/ReviewStepper.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/ReviewStepper.tsx
@@ -1,0 +1,139 @@
+import { motion } from "framer-motion";
+import {
+  CheckIcon,
+  ClockIcon,
+  RocketLaunchIcon,
+  type Icon as PhosphorIcon,
+} from "@phosphor-icons/react";
+
+import { Text } from "@/components/atoms/Text/Text";
+import { cn } from "@/lib/utils";
+
+type StepState = "done" | "current" | "upcoming";
+
+interface Step {
+  title: string;
+  description: string;
+  note?: string;
+  state: StepState;
+  Icon: PhosphorIcon;
+}
+
+const STEPS: Step[] = [
+  {
+    title: "Submitted for review",
+    description: "Your listing is queued in the marketplace review pipeline.",
+    state: "done",
+    Icon: CheckIcon,
+  },
+  {
+    title: "In review",
+    description:
+      "Our team checks the details, media, and safety of your agent.",
+    note: "Typically reviewed within 2–3 days.",
+    state: "current",
+    Icon: ClockIcon,
+  },
+  {
+    title: "Goes live",
+    description:
+      "You'll get an email once it's approved. Rejected listings come back with feedback.",
+    state: "upcoming",
+    Icon: RocketLaunchIcon,
+  },
+];
+
+const NODE_CLASS: Record<StepState, string> = {
+  done: "bg-emerald-500 text-white",
+  current: "bg-amber-50 text-amber-700 ring-2 ring-amber-300",
+  upcoming: "bg-zinc-100 text-zinc-400",
+};
+
+interface Props {
+  shouldReduceMotion: boolean;
+}
+
+export function ReviewStepper({ shouldReduceMotion }: Props) {
+  return (
+    <motion.div
+      initial={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.24, ease: "easeOut", delay: 0.24 }}
+      className="mt-6 flex w-full max-w-md flex-col gap-3 px-2"
+    >
+      <Text variant="body-medium" as="span" className="text-textBlack">
+        What happens next
+      </Text>
+      <ol className="flex flex-col">
+        {STEPS.map((step, index) => {
+          const isLast = index === STEPS.length - 1;
+          const StepIcon = step.Icon;
+          return (
+            <li key={step.title} className="flex gap-3">
+              <div className="flex flex-col items-center">
+                <span
+                  className={cn(
+                    "relative mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-full",
+                    NODE_CLASS[step.state],
+                  )}
+                >
+                  {step.state === "current" && !shouldReduceMotion ? (
+                    <motion.span
+                      aria-hidden
+                      initial={{ opacity: 0.5, scale: 0.9 }}
+                      animate={{ opacity: 0, scale: 1.7 }}
+                      transition={{
+                        duration: 1.6,
+                        ease: "easeOut",
+                        repeat: Infinity,
+                        repeatDelay: 0.3,
+                      }}
+                      className="absolute inset-0 rounded-full bg-amber-400/40"
+                    />
+                  ) : null}
+                  <StepIcon size={14} weight="bold" />
+                </span>
+                {!isLast ? (
+                  <span
+                    className={cn(
+                      "mt-1 min-h-[18px] w-px flex-1",
+                      step.state === "done" ? "bg-emerald-300" : "bg-zinc-200",
+                    )}
+                  />
+                ) : null}
+              </div>
+              <div className={cn("flex min-w-0 flex-col", !isLast && "pb-4")}>
+                <Text
+                  variant="small-medium"
+                  as="span"
+                  className={
+                    step.state === "upcoming"
+                      ? "text-zinc-400"
+                      : "text-textBlack"
+                  }
+                >
+                  {step.title}
+                </Text>
+                <Text
+                  variant="small"
+                  className={
+                    step.state === "upcoming"
+                      ? "text-zinc-400"
+                      : "text-zinc-500"
+                  }
+                >
+                  {step.description}
+                </Text>
+                {step.note ? (
+                  <Text variant="small" className="mt-1 text-amber-700">
+                    {step.note}
+                  </Text>
+                ) : null}
+              </div>
+            </li>
+          );
+        })}
+      </ol>
+    </motion.div>
+  );
+}

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/ReviewStepper.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/ReviewStepper.tsx
@@ -77,20 +77,6 @@ export function ReviewStepper({ shouldReduceMotion }: Props) {
                     NODE_CLASS[step.state],
                   )}
                 >
-                  {step.state === "current" && !shouldReduceMotion ? (
-                    <motion.span
-                      aria-hidden
-                      initial={{ opacity: 0.5, scale: 0.9 }}
-                      animate={{ opacity: 0, scale: 1.7 }}
-                      transition={{
-                        duration: 1.6,
-                        ease: "easeOut",
-                        repeat: Infinity,
-                        repeatDelay: 0.3,
-                      }}
-                      className="absolute inset-0 rounded-full bg-amber-400/40"
-                    />
-                  ) : null}
                   <StepIcon size={14} weight="bold" />
                 </span>
                 {!isLast ? (

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/ShareLinkButton.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/ShareLinkButton.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useState } from "react";
+import { CheckIcon, LinkIcon } from "@phosphor-icons/react";
+
+import { Button } from "@/components/atoms/Button/Button";
+import { toast } from "@/components/molecules/Toast/use-toast";
+
+interface Props {
+  url: string;
+}
+
+export function ShareLinkButton({ url }: Props) {
+  const [copied, setCopied] = useState(false);
+
+  async function handleCopy() {
+    const shareUrl =
+      typeof window !== "undefined" ? `${window.location.origin}${url}` : url;
+    try {
+      await navigator.clipboard.writeText(shareUrl);
+      setCopied(true);
+      toast({ title: "Link copied to clipboard" });
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      toast({
+        title: "Couldn't copy link",
+        variant: "destructive",
+      });
+    }
+  }
+
+  return (
+    <Button
+      variant="ghost"
+      size="small"
+      onClick={handleCopy}
+      leftIcon={
+        copied ? (
+          <CheckIcon size={14} weight="bold" />
+        ) : (
+          <LinkIcon size={14} weight="bold" />
+        )
+      }
+      className="w-full sm:w-auto"
+      data-testid="copy-share-link-button"
+    >
+      {copied ? "Copied" : "Copy share link"}
+    </Button>
+  );
+}

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/SubmissionMetaGrid.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/SubmissionMetaGrid.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { motion } from "framer-motion";
+
+import { Text } from "@/components/atoms/Text/Text";
+import type { SubmissionMetaItem } from "../helpers";
+
+interface Props {
+  items: SubmissionMetaItem[];
+  shouldReduceMotion: boolean;
+}
+
+export function SubmissionMetaGrid({ items, shouldReduceMotion }: Props) {
+  if (items.length === 0) return null;
+
+  return (
+    <motion.div
+      initial={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.24, ease: "easeOut", delay: 0.21 }}
+      className="mt-4 grid w-full max-w-md grid-cols-2 gap-x-4 gap-y-3 rounded-[14px] border border-zinc-200 bg-zinc-50/60 p-4"
+      data-testid="submission-meta"
+    >
+      {items.map((item) => (
+        <div key={item.label} className="flex min-w-0 flex-col">
+          <Text variant="small" as="span" className="text-zinc-500">
+            {item.label}
+          </Text>
+          <Text
+            variant="small-medium"
+            as="span"
+            title={item.title}
+            className="truncate text-textBlack"
+          >
+            {item.value}
+          </Text>
+        </div>
+      ))}
+    </motion.div>
+  );
+}

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/SubmissionSummaryCard.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/SubmissionSummaryCard.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import Image from "next/image";
+import { motion } from "framer-motion";
+import { ClockIcon, ImageBrokenIcon } from "@phosphor-icons/react";
+
+import { Text } from "@/components/atoms/Text/Text";
+
+interface Props {
+  agentName: string;
+  subheader: string;
+  thumbnailSrc?: string;
+  isPending: boolean;
+  shouldReduceMotion: boolean;
+}
+
+export function SubmissionSummaryCard({
+  agentName,
+  subheader,
+  thumbnailSrc,
+  isPending,
+  shouldReduceMotion,
+}: Props) {
+  return (
+    <motion.div
+      initial={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.24, ease: "easeOut", delay: 0.18 }}
+      className="mt-6 flex w-full max-w-md items-center gap-3 rounded-[14px] border border-zinc-200 bg-white p-3 shadow-[0_1px_2px_rgba(15,15,20,0.04)]"
+    >
+      <div className="relative aspect-video h-12 shrink-0 overflow-hidden rounded-[8px] bg-zinc-100">
+        {thumbnailSrc ? (
+          <Image
+            src={thumbnailSrc}
+            alt=""
+            fill
+            sizes="86px"
+            className="object-cover"
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center text-zinc-400">
+            <ImageBrokenIcon size={20} weight="duotone" />
+          </div>
+        )}
+      </div>
+      <div className="flex min-w-0 flex-1 flex-col">
+        <Text
+          variant="body-medium"
+          as="span"
+          className="truncate text-textBlack"
+        >
+          {agentName}
+        </Text>
+        {subheader ? (
+          <Text variant="small" className="truncate text-zinc-500">
+            {subheader}
+          </Text>
+        ) : null}
+      </div>
+      {isPending ? (
+        <span className="inline-flex items-center gap-1.5 rounded-full bg-amber-50 px-2.5 py-1 text-[11px] font-medium text-amber-800">
+          <ClockIcon size={12} weight="duotone" />
+          In review
+        </span>
+      ) : null}
+    </motion.div>
+  );
+}

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/__tests__/AgentReviewStep.test.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/__tests__/AgentReviewStep.test.tsx
@@ -136,7 +136,9 @@ describe("AgentReviewStep", () => {
     unmount();
 
     pathnameMock.current = "/settings/creator-dashboard";
-    render(<AgentReviewStep {...baseProps} status={SubmissionStatus.PENDING} />);
+    render(
+      <AgentReviewStep {...baseProps} status={SubmissionStatus.PENDING} />,
+    );
     // Viewing an existing pending submission should not throw confetti.
     expect(screen.queryByTestId("confetti")).toBeNull();
   });

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/__tests__/AgentReviewStep.test.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/__tests__/AgentReviewStep.test.tsx
@@ -1,9 +1,25 @@
+import type { ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { SubmissionStatus } from "@/app/api/__generated__/models/submissionStatus";
 
 vi.mock("next/navigation", () => ({
   usePathname: () => "/marketplace",
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string;
+    children: ReactNode;
+  }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
 }));
 
 vi.mock("@/components/molecules/Confetti/Confetti", () => ({
@@ -22,7 +38,7 @@ const baseProps = {
 };
 
 describe("AgentReviewStep", () => {
-  it("renders the pending hero, the timeline, and the footer", () => {
+  it("renders the pending hero, the review stepper, and the footer", () => {
     const onDone = vi.fn();
     const onViewProgress = vi.fn();
     render(
@@ -36,10 +52,13 @@ describe("AgentReviewStep", () => {
     expect(screen.getByText("Submission received")).toBeDefined();
     expect(screen.getByText("Test Agent")).toBeDefined();
 
-    // Timeline copy from the SECRT-2324 refresh.
+    // Stepper reflects the current step.
+    expect(screen.getByText("What happens next")).toBeDefined();
     expect(screen.getByText("Submitted for review")).toBeDefined();
-    expect(screen.getByText("Reviewed soon")).toBeDefined();
-    expect(screen.getByText("Approved listings go live")).toBeDefined();
+    expect(screen.getByText("Goes live")).toBeDefined();
+    expect(
+      screen.getByText("Typically reviewed within 2–3 days."),
+    ).toBeDefined();
 
     fireEvent.click(screen.getByRole("button", { name: "Done" }));
     expect(onDone).toHaveBeenCalled();
@@ -48,23 +67,114 @@ describe("AgentReviewStep", () => {
     expect(onViewProgress).toHaveBeenCalled();
   });
 
-  it("renders the approved hero when status is APPROVED", () => {
+  it("renders submission metadata (version, category, submitted date)", () => {
     render(
-      <AgentReviewStep {...baseProps} status={SubmissionStatus.APPROVED} />,
+      <AgentReviewStep
+        {...baseProps}
+        status={SubmissionStatus.PENDING}
+        version={3}
+        category="Productivity"
+        submittedAt="2026-07-01T10:00:00Z"
+      />,
     );
-    expect(screen.getByText("Agent approved")).toBeDefined();
+
+    expect(screen.getByTestId("submission-meta")).toBeDefined();
+    expect(screen.getByText("Version")).toBeDefined();
+    expect(screen.getByText("v3")).toBeDefined();
+    expect(screen.getByText("Category")).toBeDefined();
+    expect(screen.getByText("Productivity")).toBeDefined();
+    expect(screen.getByText("Submitted")).toBeDefined();
   });
 
-  it("renders the rejected hero + review comments and hides the timeline", () => {
+  it("shows an 'Edit details' action for pending submissions", () => {
+    const onEdit = vi.fn();
+    render(
+      <AgentReviewStep
+        {...baseProps}
+        status={SubmissionStatus.PENDING}
+        onEdit={onEdit}
+      />,
+    );
+    const edit = screen.getByTestId("edit-submission-button");
+    expect(edit.textContent).toContain("Edit details");
+    fireEvent.click(edit);
+    expect(onEdit).toHaveBeenCalled();
+    // View progress is still the primary action for pending.
+    expect(screen.getByTestId("view-progress-button")).toBeDefined();
+  });
+
+  it("renders the approved hero, hides the stepper, and shows runs + share link", () => {
+    render(
+      <AgentReviewStep
+        {...baseProps}
+        status={SubmissionStatus.APPROVED}
+        reviewedAt="2026-07-02T10:00:00Z"
+        runCount={1234}
+        marketplaceUrl="/marketplace/agent/creator/test-agent"
+      />,
+    );
+    expect(screen.getByText("Agent approved")).toBeDefined();
+    expect(screen.queryByText("What happens next")).toBeNull();
+    expect(screen.getByText("Live since")).toBeDefined();
+    expect(screen.getByText("Runs")).toBeDefined();
+    expect(screen.getByText("1,234")).toBeDefined();
+    expect(screen.getByTestId("copy-share-link-button")).toBeDefined();
+  });
+
+  it("shows a marketplace CTA when the submission is approved and live", () => {
+    render(
+      <AgentReviewStep
+        {...baseProps}
+        status={SubmissionStatus.APPROVED}
+        marketplaceUrl="/marketplace/agent/creator/test-agent"
+      />,
+    );
+    const cta = screen.getByTestId("view-marketplace-button");
+    expect(cta.getAttribute("href")).toBe(
+      "/marketplace/agent/creator/test-agent",
+    );
+    expect(screen.queryByTestId("view-progress-button")).toBeNull();
+  });
+
+  it("renders the draft hero with a 'Continue editing' primary CTA", () => {
+    const onEdit = vi.fn();
+    render(
+      <AgentReviewStep
+        {...baseProps}
+        status={SubmissionStatus.DRAFT}
+        onEdit={onEdit}
+      />,
+    );
+    expect(screen.getByText("Draft saved")).toBeDefined();
+    expect(screen.queryByText("What happens next")).toBeNull();
+    expect(screen.getByText("Not submitted yet")).toBeDefined();
+
+    const cta = screen.getByTestId("edit-submission-button");
+    expect(cta.textContent).toContain("Continue editing");
+    fireEvent.click(cta);
+    expect(onEdit).toHaveBeenCalled();
+    expect(screen.queryByTestId("view-progress-button")).toBeNull();
+  });
+
+  it("renders the rejected hero + feedback with an 'Edit & resubmit' CTA", () => {
+    const onEdit = vi.fn();
     render(
       <AgentReviewStep
         {...baseProps}
         status={SubmissionStatus.REJECTED}
         reviewComments="Please clarify your description."
+        reviewedAt="2026-07-03T10:00:00Z"
+        onEdit={onEdit}
       />,
     );
     expect(screen.getByText("Agent needs changes")).toBeDefined();
     expect(screen.getByText("Please clarify your description.")).toBeDefined();
     expect(screen.queryByText("What happens next")).toBeNull();
+    expect(screen.getByText("Reviewed")).toBeDefined();
+
+    const cta = screen.getByTestId("edit-submission-button");
+    expect(cta.textContent).toContain("Edit & resubmit");
+    fireEvent.click(cta);
+    expect(onEdit).toHaveBeenCalled();
   });
 });

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/__tests__/AgentReviewStep.test.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/__tests__/AgentReviewStep.test.tsx
@@ -1,11 +1,17 @@
 import type { ReactNode } from "react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { SubmissionStatus } from "@/app/api/__generated__/models/submissionStatus";
 
+const pathnameMock = vi.hoisted(() => ({ current: "/marketplace" }));
+
 vi.mock("next/navigation", () => ({
-  usePathname: () => "/marketplace",
+  usePathname: () => pathnameMock.current,
 }));
+
+afterEach(() => {
+  pathnameMock.current = "/marketplace";
+});
 
 vi.mock("next/link", () => ({
   default: ({
@@ -101,6 +107,24 @@ describe("AgentReviewStep", () => {
     expect(onEdit).toHaveBeenCalled();
     // View progress is still the primary action for pending.
     expect(screen.getByTestId("view-progress-button")).toBeDefined();
+  });
+
+  it("hides the redundant 'Go to Creator Dashboard' button on the dashboard", () => {
+    pathnameMock.current = "/settings/creator-dashboard";
+    const onEdit = vi.fn();
+    render(
+      <AgentReviewStep
+        {...baseProps}
+        status={SubmissionStatus.PENDING}
+        onEdit={onEdit}
+      />,
+    );
+
+    // On the dashboard the button would just navigate back to the same page,
+    // so it is hidden; editing and "Done" remain available.
+    expect(screen.queryByTestId("view-progress-button")).toBeNull();
+    expect(screen.getByTestId("edit-submission-button")).toBeDefined();
+    expect(screen.getByText("Done")).toBeDefined();
   });
 
   it("renders the approved hero, hides the stepper, and shows runs + share link", () => {

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/__tests__/AgentReviewStep.test.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/__tests__/AgentReviewStep.test.tsx
@@ -29,7 +29,7 @@ vi.mock("next/link", () => ({
 }));
 
 vi.mock("@/components/molecules/Confetti/Confetti", () => ({
-  Confetti: () => null,
+  Confetti: () => <div data-testid="confetti" />,
 }));
 
 import { AgentReviewStep } from "../AgentReviewStep";
@@ -125,6 +125,20 @@ describe("AgentReviewStep", () => {
     expect(screen.queryByTestId("view-progress-button")).toBeNull();
     expect(screen.getByTestId("edit-submission-button")).toBeDefined();
     expect(screen.getByText("Done")).toBeDefined();
+  });
+
+  it("celebrates a fresh pending submission but not one viewed on the dashboard", () => {
+    const { unmount } = render(
+      <AgentReviewStep {...baseProps} status={SubmissionStatus.PENDING} />,
+    );
+    // Post-publish (off-dashboard) pending keeps the celebration.
+    expect(screen.getByTestId("confetti")).toBeDefined();
+    unmount();
+
+    pathnameMock.current = "/settings/creator-dashboard";
+    render(<AgentReviewStep {...baseProps} status={SubmissionStatus.PENDING} />);
+    // Viewing an existing pending submission should not throw confetti.
+    expect(screen.queryByTestId("confetti")).toBeNull();
   });
 
   it("renders the approved hero, hides the stepper, and shows runs + share link", () => {

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/__tests__/AgentReviewStep.test.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/__tests__/AgentReviewStep.test.tsx
@@ -136,7 +136,7 @@ describe("AgentReviewStep", () => {
     expect(screen.queryByTestId("view-progress-button")).toBeNull();
   });
 
-  it("renders the draft hero with a 'Continue editing' primary CTA", () => {
+  it("renders the draft hero without an edit action", () => {
     const onEdit = vi.fn();
     render(
       <AgentReviewStep
@@ -149,14 +149,14 @@ describe("AgentReviewStep", () => {
     expect(screen.queryByText("What happens next")).toBeNull();
     expect(screen.getByText("Not submitted yet")).toBeDefined();
 
-    const cta = screen.getByTestId("edit-submission-button");
-    expect(cta.textContent).toContain("Continue editing");
-    fireEvent.click(cta);
-    expect(onEdit).toHaveBeenCalled();
+    // Editing is only supported for pending submissions, and "Done" is the only
+    // footer action.
+    expect(screen.queryByTestId("edit-submission-button")).toBeNull();
     expect(screen.queryByTestId("view-progress-button")).toBeNull();
+    expect(screen.getByText("Done")).toBeDefined();
   });
 
-  it("renders the rejected hero + feedback with an 'Edit & resubmit' CTA", () => {
+  it("renders the rejected hero + feedback without an edit action", () => {
     const onEdit = vi.fn();
     render(
       <AgentReviewStep
@@ -172,9 +172,10 @@ describe("AgentReviewStep", () => {
     expect(screen.queryByText("What happens next")).toBeNull();
     expect(screen.getByText("Reviewed")).toBeDefined();
 
-    const cta = screen.getByTestId("edit-submission-button");
-    expect(cta.textContent).toContain("Edit & resubmit");
-    fireEvent.click(cta);
-    expect(onEdit).toHaveBeenCalled();
+    // Editing is only supported for pending submissions, and "Done" is the only
+    // footer action.
+    expect(screen.queryByTestId("edit-submission-button")).toBeNull();
+    expect(screen.queryByTestId("view-progress-button")).toBeNull();
+    expect(screen.getByText("Done")).toBeDefined();
   });
 });

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/__tests__/ShareLinkButton.test.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/__tests__/ShareLinkButton.test.tsx
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+const toast = vi.fn();
+vi.mock("@/components/molecules/Toast/use-toast", () => ({
+  toast: (...args: unknown[]) => toast(...args),
+}));
+
+import { ShareLinkButton } from "../ShareLinkButton";
+
+function mockClipboard(writeText: () => Promise<void>) {
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText },
+    configurable: true,
+  });
+}
+
+describe("ShareLinkButton", () => {
+  afterEach(() => {
+    toast.mockClear();
+  });
+
+  it("copies the absolute URL and confirms with a toast", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    mockClipboard(writeText);
+
+    render(<ShareLinkButton url="/marketplace/agent/creator/test-agent" />);
+    fireEvent.click(screen.getByTestId("copy-share-link-button"));
+
+    await waitFor(() =>
+      expect(writeText).toHaveBeenCalledWith(
+        `${window.location.origin}/marketplace/agent/creator/test-agent`,
+      ),
+    );
+    expect(toast).toHaveBeenCalledWith({ title: "Link copied to clipboard" });
+    expect(await screen.findByText("Copied")).toBeDefined();
+  });
+
+  it("shows a destructive toast when copying fails", async () => {
+    mockClipboard(vi.fn().mockRejectedValue(new Error("denied")));
+
+    render(<ShareLinkButton url="/marketplace/agent/creator/test-agent" />);
+    fireEvent.click(screen.getByTestId("copy-share-link-button"));
+
+    await waitFor(() =>
+      expect(toast).toHaveBeenCalledWith({
+        title: "Couldn't copy link",
+        variant: "destructive",
+      }),
+    );
+  });
+});

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/useAgentReviewStep.ts
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/useAgentReviewStep.ts
@@ -1,0 +1,119 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { useReducedMotion } from "framer-motion";
+import {
+  CheckIcon,
+  NotePencilIcon,
+  XIcon,
+  type Icon as PhosphorIcon,
+} from "@phosphor-icons/react";
+
+import { SubmissionStatus } from "@/app/api/__generated__/models/submissionStatus";
+import { getSubmissionMeta } from "../helpers";
+
+interface HeroContent {
+  title: string;
+  description: string;
+  Icon: PhosphorIcon;
+  pulse: string;
+  gradient: string;
+}
+
+function getHeroContent(
+  status: SubmissionStatus | undefined,
+  isDashboardPage: boolean,
+): HeroContent {
+  switch (status) {
+    case SubmissionStatus.APPROVED:
+      return {
+        title: "Agent approved",
+        description:
+          "Your agent has been approved and is now live on the AutoGPT marketplace.",
+        Icon: CheckIcon,
+        pulse: "bg-emerald-400/40",
+        gradient: "from-emerald-400 to-emerald-600",
+      };
+    case SubmissionStatus.REJECTED:
+      return {
+        title: "Agent needs changes",
+        description:
+          "Your submission was not approved. Review the feedback and resubmit.",
+        Icon: XIcon,
+        pulse: "bg-rose-400/40",
+        gradient: "from-rose-400 to-rose-600",
+      };
+    case SubmissionStatus.DRAFT:
+      return {
+        title: "Draft saved",
+        description:
+          "This agent isn't submitted yet. Finish the details and submit it for review.",
+        Icon: NotePencilIcon,
+        pulse: "bg-zinc-400/40",
+        gradient: "from-zinc-400 to-zinc-600",
+      };
+    default:
+      return {
+        title: "Submission received",
+        description: isDashboardPage
+          ? "We'll notify you once review is complete. Approved agents go live on the marketplace."
+          : "We'll notify you once review is complete. Track progress from the Creator Dashboard.",
+        Icon: CheckIcon,
+        pulse: "bg-purple-400/40",
+        gradient: "from-purple-400 to-purple-600",
+      };
+  }
+}
+
+interface Args {
+  status: SubmissionStatus | undefined;
+  version: number | undefined;
+  category: string | null | undefined;
+  submittedAt: string | Date | null | undefined;
+  reviewedAt: string | Date | null | undefined;
+  runCount: number | undefined;
+}
+
+export function useAgentReviewStep({
+  status,
+  version,
+  category,
+  submittedAt,
+  reviewedAt,
+  runCount,
+}: Args) {
+  const pathname = usePathname();
+  const isDashboardPage = pathname.includes("/settings/creator-dashboard");
+  const hero = getHeroContent(status, isDashboardPage);
+  const shouldReduceMotion = useReducedMotion();
+
+  const isApproved = status === SubmissionStatus.APPROVED;
+  const isRejected = status === SubmissionStatus.REJECTED;
+  const isDraft = status === SubmissionStatus.DRAFT;
+  const isPending = !isApproved && !isRejected && !isDraft;
+
+  const showCelebration = isApproved || isPending;
+  const showConfetti = showCelebration && !shouldReduceMotion;
+
+  const metaItems = getSubmissionMeta({
+    status,
+    version,
+    category,
+    submittedAt,
+    reviewedAt,
+    runCount,
+  });
+
+  return {
+    isDashboardPage,
+    hero,
+    shouldReduceMotion,
+    isApproved,
+    isRejected,
+    isDraft,
+    isPending,
+    showCelebration,
+    showConfetti,
+    metaItems,
+  };
+}

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/useAgentReviewStep.ts
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/useAgentReviewStep.ts
@@ -92,7 +92,7 @@ export function useAgentReviewStep({
   const isDraft = status === SubmissionStatus.DRAFT;
   const isPending = !isApproved && !isRejected && !isDraft;
 
-  const showCelebration = isApproved || isPending;
+  const showCelebration = isApproved || (isPending && !isDashboardPage);
   const showConfetti = showCelebration && !shouldReduceMotion;
 
   const metaItems = getSubmissionMeta({

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/helpers.ts
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/helpers.ts
@@ -1,3 +1,5 @@
+import { SubmissionStatus } from "@/app/api/__generated__/models/submissionStatus";
+
 export const emptyModalState = {
   agent_id: "",
   title: "",
@@ -13,3 +15,105 @@ export const emptyModalState = {
   changesSummary: "",
   additionalImages: [],
 };
+
+export interface SubmissionMetaItem {
+  label: string;
+  value: string;
+  title?: string;
+}
+
+export function formatSubmissionDate(
+  value: string | Date | null | undefined,
+): string | null {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+const DAY_MS = 86_400_000;
+
+export function formatRelativeDate(
+  value: string | Date | null | undefined,
+): string | null {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+
+  const days = Math.floor((Date.now() - date.getTime()) / DAY_MS);
+  if (days <= 0) return "today";
+  if (days === 1) return "yesterday";
+  if (days < 7) return `${days} days ago`;
+  if (days < 30) {
+    const weeks = Math.floor(days / 7);
+    return `${weeks} week${weeks > 1 ? "s" : ""} ago`;
+  }
+  if (days < 365) {
+    const months = Math.floor(days / 30);
+    return `${months} month${months > 1 ? "s" : ""} ago`;
+  }
+  const years = Math.floor(days / 365);
+  return `${years} year${years > 1 ? "s" : ""} ago`;
+}
+
+function dateItem(
+  label: string,
+  value: string | Date | null | undefined,
+): SubmissionMetaItem | null {
+  const relative = formatRelativeDate(value);
+  if (!relative) return null;
+  return {
+    label,
+    value: relative,
+    title: formatSubmissionDate(value) ?? undefined,
+  };
+}
+
+interface SubmissionMetaArgs {
+  status: SubmissionStatus | undefined;
+  version: number | undefined;
+  category: string | null | undefined;
+  submittedAt: string | Date | null | undefined;
+  reviewedAt: string | Date | null | undefined;
+  runCount: number | undefined;
+}
+
+export function getSubmissionMeta({
+  status,
+  version,
+  category,
+  submittedAt,
+  reviewedAt,
+  runCount,
+}: SubmissionMetaArgs): SubmissionMetaItem[] {
+  const items: SubmissionMetaItem[] = [];
+
+  if (typeof version === "number") {
+    items.push({ label: "Version", value: `v${version}` });
+  }
+  if (category) {
+    items.push({ label: "Category", value: category });
+  }
+
+  if (status === SubmissionStatus.APPROVED) {
+    const liveSince = dateItem("Live since", reviewedAt);
+    if (liveSince) items.push(liveSince);
+    if (typeof runCount === "number") {
+      items.push({ label: "Runs", value: runCount.toLocaleString() });
+    }
+  } else if (status === SubmissionStatus.REJECTED) {
+    const reviewed = dateItem("Reviewed", reviewedAt);
+    if (reviewed) items.push(reviewed);
+  } else if (status === SubmissionStatus.DRAFT) {
+    items.push({ label: "Status", value: "Not submitted yet" });
+  } else {
+    const submitted = dateItem("Submitted", submittedAt);
+    if (submitted) items.push(submitted);
+  }
+
+  return items;
+}

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/usePublishAgentModal.ts
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/usePublishAgentModal.ts
@@ -5,11 +5,13 @@ import { useRouter } from "next/navigation";
 import { emptyModalState } from "./helpers";
 import {
   useGetV2GetMyAgents,
+  useGetV2GetUserProfile,
   useGetV2ListMySubmissions,
   getGetV2ListMySubmissionsQueryKey,
 } from "@/app/api/__generated__/endpoints/store/store";
 import { okData } from "@/app/api/helpers";
 import type { MyUnpublishedAgent } from "@/app/api/__generated__/models/myUnpublishedAgent";
+import type { ProfileDetails } from "@/app/api/__generated__/models/profileDetails";
 import { useQueryClient } from "@tanstack/react-query";
 import { useSupabase } from "@/lib/supabase/hooks/useSupabase";
 
@@ -31,6 +33,7 @@ export interface Props {
   trigger?: React.ReactNode;
   targetState?: PublishState;
   onStateChange?: (state: PublishState) => void;
+  onRequestEdit?: (submission: StoreSubmission) => void;
   preSelectedAgentId?: string;
   preSelectedAgentVersion?: number;
   showTrigger?: boolean;
@@ -82,6 +85,13 @@ export function usePublishAgentModal({
       enabled: isLoggedIn,
     },
   });
+  const { data: profile } = useGetV2GetUserProfile({
+    query: {
+      select: (x) => x.data as ProfileDetails,
+      enabled: isLoggedIn,
+    },
+  });
+  const creatorUsername = profile?.username;
 
   // Sync currentState with targetState when it changes from outside
   useEffect(() => {
@@ -314,5 +324,6 @@ export function usePublishAgentModal({
     initialData,
     selectedAgentId,
     selectedAgentVersion,
+    creatorUsername,
   };
 }

--- a/autogpt_platform/frontend/src/lib/utils.ts
+++ b/autogpt_platform/frontend/src/lib/utils.ts
@@ -426,3 +426,14 @@ export function isValidUUID(value: string): boolean {
     /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
   return uuidRegex.test(value);
 }
+
+export function getApprovedMarketplaceUrl(args: {
+  creatorUsername: string | null | undefined;
+  slug: string | null | undefined;
+  isApproved: boolean;
+}): string | undefined {
+  if (!args.isApproved || !args.creatorUsername || !args.slug) {
+    return undefined;
+  }
+  return `/marketplace/agent/${encodeURIComponent(args.creatorUsername)}/${encodeURIComponent(args.slug)}`;
+}


### PR DESCRIPTION
### Why / What / How

**Why:** The "View Submission" modal on the Creator Dashboard showed generic "submission received" copy and a "Reviewed soon" review timeline for *every* state — including already-approved agents — and surfaced no facts about the submission it claimed to be viewing.

**What:** Made the review step state-aware: correct hero per status, a submission metadata row, state-specific primary CTAs, a real pending status stepper, and edit actions wired into the existing edit flow.

**How:** `AgentReviewStep` now derives behavior from `SubmissionStatus` (gating the timeline on pending only), reads fields already returned by `StoreSubmission` (`listing_version`, `categories`, `submitted_at`/`reviewed_at`, `run_count`, `slug`), and receives an optional `onEdit` threaded from the dashboard via a new `onRequestEdit` prop; a shared `buildEditPayload` de-dupes edit-payload construction.

### Changes 🏗️

- Fix state leak: the "What happens next" timeline no longer renders for APPROVED (or DRAFT); gated on pending
- Add a submission metadata row (version, category, relative dates with exact-date tooltip, run count)
- APPROVED: "View on marketplace" CTA, "Copy share link" button (new `ShareLinkButton`), "Live since" date
- PENDING: real status stepper — Submitted ✓ / In review ● / Goes live ○ — plus estimated review time (new `ReviewStepper`)
- DRAFT: dedicated "Draft saved" hero; PENDING/REJECTED/DRAFT get edit CTAs ("Edit details" / "Edit & resubmit" / "Continue editing")
- Wire edit from the read-only modal into the existing edit flow via `onRequestEdit` → `onEditFromReview`; extract shared `EditPayload` + `buildEditPayload`

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [ ] Open "View submission" on an APPROVED agent → approved hero, no "Reviewed soon" timeline, "View on marketplace" + "Copy share link" work
  - [ ] Open a PENDING submission → stepper highlights "In review", "Edit details" opens the edit modal
  - [ ] Open a REJECTED submission → feedback shown, "Edit & resubmit" opens the edit modal
  - [ ] Open a DRAFT → "Draft saved" hero, "Continue editing" opens the edit modal
  - [ ] Metadata row shows version, category, and relative date across states

#### For configuration changes:
- [ ] N/A — no configuration changes
