### PR TITLE
feat(frontend): one-click preview test-account login buttons

### DIFF
--- a/autogpt_platform/frontend/src/app/(no-navbar)/login/__tests__/preview-login-actions.test.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/login/__tests__/preview-login-actions.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  isPreviewLoginConfigured,
+  loginAsPreviewAccount,
+} from "../components/PreviewLoginButtons/actions";
+import {
+  PREVIEW_ROLES,
+  PreviewRole,
+} from "../components/PreviewLoginButtons/helpers";
+
+const mockGetPreviewStealingDev = vi.fn();
+vi.mock("@/services/environment", () => ({
+  environment: {
+    getPreviewStealingDev: () => mockGetPreviewStealingDev(),
+  },
+}));
+
+const mockLogin = vi.fn();
+vi.mock("../actions", () => ({
+  login: (email: string, password: string) => mockLogin(email, password),
+}));
+
+describe("preview login server actions", () => {
+  beforeEach(() => {
+    mockGetPreviewStealingDev.mockReset();
+    mockLogin.mockReset();
+    vi.stubEnv("PREVIEW_ACCOUNTS_PASSWORD", "test-password");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe("isPreviewLoginConfigured", () => {
+    test("is false outside a preview environment even with a password set", async () => {
+      mockGetPreviewStealingDev.mockReturnValue(null);
+
+      await expect(isPreviewLoginConfigured()).resolves.toBe(false);
+    });
+
+    test("is false in a preview environment without a password", async () => {
+      mockGetPreviewStealingDev.mockReturnValue("some-branch");
+      vi.stubEnv("PREVIEW_ACCOUNTS_PASSWORD", undefined);
+
+      await expect(isPreviewLoginConfigured()).resolves.toBe(false);
+    });
+
+    test("is true in a preview environment with a password", async () => {
+      mockGetPreviewStealingDev.mockReturnValue("some-branch");
+
+      await expect(isPreviewLoginConfigured()).resolves.toBe(true);
+    });
+  });
+
+  describe("loginAsPreviewAccount", () => {
+    test("is a no-op outside a preview environment even with a password set", async () => {
+      mockGetPreviewStealingDev.mockReturnValue(null);
+
+      const result = await loginAsPreviewAccount("admin");
+
+      expect(result).toEqual({
+        success: false,
+        error: "Preview login is not available",
+      });
+      expect(mockLogin).not.toHaveBeenCalled();
+    });
+
+    test("fails without logging in when the password is not configured", async () => {
+      mockGetPreviewStealingDev.mockReturnValue("some-branch");
+      vi.stubEnv("PREVIEW_ACCOUNTS_PASSWORD", undefined);
+
+      const result = await loginAsPreviewAccount("admin");
+
+      expect(result).toEqual({
+        success: false,
+        error: "Preview login is not configured",
+      });
+      expect(mockLogin).not.toHaveBeenCalled();
+    });
+
+    test("rejects roles outside the preview role list", async () => {
+      mockGetPreviewStealingDev.mockReturnValue("some-branch");
+
+      const result = await loginAsPreviewAccount(
+        "hacker" as unknown as PreviewRole,
+      );
+
+      expect(result).toEqual({
+        success: false,
+        error: "Unknown preview account",
+      });
+      expect(mockLogin).not.toHaveBeenCalled();
+    });
+
+    test("logs in with the mapped email and password for every role", async () => {
+      mockGetPreviewStealingDev.mockReturnValue("some-branch");
+      mockLogin.mockResolvedValue({ success: true, next: "/" });
+
+      for (const { role } of PREVIEW_ROLES) {
+        mockLogin.mockClear();
+
+        const result = await loginAsPreviewAccount(role);
+
+        expect(mockLogin).toHaveBeenCalledWith(
+          `preview-${role}@agpt.co`,
+          "test-password",
+        );
+        expect(result).toEqual({ success: true, next: "/" });
+      }
+    });
+  });
+});

--- a/autogpt_platform/frontend/src/app/(no-navbar)/login/__tests__/preview-login-buttons.test.tsx
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/login/__tests__/preview-login-buttons.test.tsx
@@ -16,8 +16,9 @@ vi.mock("../components/PreviewLoginButtons/actions", () => ({
   loginAsPreviewAccount: (role: string) => mockLoginAsPreviewAccount(role),
 }));
 
+let mockSearchParams = new URLSearchParams();
 vi.mock("next/navigation", () => ({
-  useSearchParams: () => new URLSearchParams(),
+  useSearchParams: () => mockSearchParams,
 }));
 
 const toastSpy = vi.fn();
@@ -43,6 +44,7 @@ describe("PreviewLoginButtons", () => {
     mockIsConfigured.mockReset();
     mockLoginAsPreviewAccount.mockReset();
     toastSpy.mockClear();
+    mockSearchParams = new URLSearchParams();
   });
 
   test("renders nothing outside a preview environment", () => {
@@ -108,6 +110,76 @@ describe("PreviewLoginButtons", () => {
     expect(getButton("Admin").disabled).toBe(true);
   });
 
+  test("navigates to the login result destination on success", async () => {
+    mockGetPreviewStealingDev.mockReturnValue("some-branch");
+    mockIsConfigured.mockResolvedValue(true);
+    mockLoginAsPreviewAccount.mockResolvedValue({
+      success: true,
+      next: "/marketplace",
+    });
+
+    render(<PreviewLoginButtons />);
+
+    await waitFor(() => expect(getButton("Admin").disabled).toBe(false));
+
+    fireEvent.click(getButton("Admin"));
+
+    await waitFor(() => expect(window.location.href).toContain("/marketplace"));
+    expect(toastSpy).not.toHaveBeenCalled();
+  });
+
+  test("prefers the sanitized next param over the login result destination", async () => {
+    mockGetPreviewStealingDev.mockReturnValue("some-branch");
+    mockIsConfigured.mockResolvedValue(true);
+    mockSearchParams = new URLSearchParams("next=/onboarding");
+    mockLoginAsPreviewAccount.mockResolvedValue({
+      success: true,
+      next: "/marketplace",
+    });
+
+    render(<PreviewLoginButtons />);
+
+    await waitFor(() => expect(getButton("Admin").disabled).toBe(false));
+
+    fireEvent.click(getButton("Admin"));
+
+    await waitFor(() => expect(window.location.pathname).toBe("/onboarding"));
+  });
+
+  test("navigates home when the login result has no destination", async () => {
+    mockGetPreviewStealingDev.mockReturnValue("some-branch");
+    mockIsConfigured.mockResolvedValue(true);
+    mockLoginAsPreviewAccount.mockResolvedValue({ success: true });
+
+    window.location.href = "http://localhost:3000/start";
+
+    render(<PreviewLoginButtons />);
+
+    await waitFor(() => expect(getButton("Admin").disabled).toBe(false));
+
+    fireEvent.click(getButton("Admin"));
+
+    await waitFor(() => expect(window.location.pathname).toBe("/"));
+  });
+
+  test("ignores the config result when unmounted before the check resolves", async () => {
+    mockGetPreviewStealingDev.mockReturnValue("some-branch");
+    let resolveConfig: (configured: boolean) => void = () => {};
+    mockIsConfigured.mockReturnValue(
+      new Promise<boolean>((resolve) => {
+        resolveConfig = resolve;
+      }),
+    );
+
+    const { unmount } = render(<PreviewLoginButtons />);
+    unmount();
+    resolveConfig(true);
+
+    await waitFor(() =>
+      expect(screen.queryByRole("button", { name: "Admin" })).toBeNull(),
+    );
+  });
+
   test("shows a toast when the preview login fails", async () => {
     mockGetPreviewStealingDev.mockReturnValue("some-branch");
     mockIsConfigured.mockResolvedValue(true);
@@ -130,5 +202,48 @@ describe("PreviewLoginButtons", () => {
         }),
       ),
     );
+  });
+
+  test("falls back to a generic toast when the failure has no error message", async () => {
+    mockGetPreviewStealingDev.mockReturnValue("some-branch");
+    mockIsConfigured.mockResolvedValue(true);
+    mockLoginAsPreviewAccount.mockResolvedValue({ success: false });
+
+    render(<PreviewLoginButtons />);
+
+    await waitFor(() => expect(getButton("Admin").disabled).toBe(false));
+
+    fireEvent.click(getButton("Admin"));
+
+    await waitFor(() =>
+      expect(toastSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Preview login failed",
+          variant: "destructive",
+        }),
+      ),
+    );
+  });
+
+  test("shows a generic toast when the login action rejects with a non-Error", async () => {
+    mockGetPreviewStealingDev.mockReturnValue("some-branch");
+    mockIsConfigured.mockResolvedValue(true);
+    mockLoginAsPreviewAccount.mockRejectedValue("boom");
+
+    render(<PreviewLoginButtons />);
+
+    await waitFor(() => expect(getButton("Admin").disabled).toBe(false));
+
+    fireEvent.click(getButton("Admin"));
+
+    await waitFor(() =>
+      expect(toastSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Preview login failed",
+          variant: "destructive",
+        }),
+      ),
+    );
+    await waitFor(() => expect(getButton("Admin").disabled).toBe(false));
   });
 });

--- a/autogpt_platform/frontend/src/app/(no-navbar)/login/__tests__/preview-login-buttons.test.tsx
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/login/__tests__/preview-login-buttons.test.tsx
@@ -1,0 +1,100 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { PreviewLoginButtons } from "../components/PreviewLoginButtons/PreviewLoginButtons";
+
+const mockGetPreviewStealingDev = vi.fn();
+vi.mock("@/services/environment", () => ({
+  environment: {
+    getPreviewStealingDev: () => mockGetPreviewStealingDev(),
+  },
+}));
+
+const mockIsConfigured = vi.fn();
+const mockLoginAsPreviewAccount = vi.fn();
+vi.mock("../components/PreviewLoginButtons/actions", () => ({
+  isPreviewLoginConfigured: () => mockIsConfigured(),
+  loginAsPreviewAccount: (role: string) => mockLoginAsPreviewAccount(role),
+}));
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+const toastSpy = vi.fn();
+vi.mock("@/components/molecules/Toast/use-toast", () => ({
+  useToast: () => ({ toast: toastSpy }),
+}));
+
+const ROLE_LABELS = [
+  "Admin",
+  "Existing user",
+  "Clean user",
+  "Pro",
+  "Enterprise",
+];
+
+function getButton(label: string) {
+  return screen.getByRole("button", { name: label }) as HTMLButtonElement;
+}
+
+describe("PreviewLoginButtons", () => {
+  beforeEach(() => {
+    mockGetPreviewStealingDev.mockReset();
+    mockIsConfigured.mockReset();
+    mockLoginAsPreviewAccount.mockReset();
+    toastSpy.mockClear();
+  });
+
+  test("renders nothing outside a preview environment", () => {
+    mockGetPreviewStealingDev.mockReturnValue(null);
+    mockIsConfigured.mockResolvedValue(true);
+
+    render(<PreviewLoginButtons />);
+
+    expect(screen.queryByText(/Preview test accounts/i)).toBeNull();
+    expect(screen.queryByRole("button", { name: "Admin" })).toBeNull();
+  });
+
+  test("shows all role buttons enabled in a configured preview environment", async () => {
+    mockGetPreviewStealingDev.mockReturnValue("some-branch");
+    mockIsConfigured.mockResolvedValue(true);
+
+    render(<PreviewLoginButtons />);
+
+    expect(screen.getByText(/Preview test accounts/i)).toBeTruthy();
+    for (const label of ROLE_LABELS) {
+      expect(getButton(label)).toBeTruthy();
+    }
+
+    await waitFor(() => expect(getButton("Admin").disabled).toBe(false));
+    expect(screen.queryByText(/PREVIEW_ACCOUNTS_PASSWORD/i)).toBeNull();
+  });
+
+  test("clicking a role button logs in as that role", async () => {
+    mockGetPreviewStealingDev.mockReturnValue("some-branch");
+    mockIsConfigured.mockResolvedValue(true);
+    // Never resolves so the handler does not attempt a navigation in jsdom.
+    mockLoginAsPreviewAccount.mockReturnValue(new Promise(() => {}));
+
+    render(<PreviewLoginButtons />);
+
+    await waitFor(() => expect(getButton("Pro").disabled).toBe(false));
+
+    fireEvent.click(getButton("Pro"));
+
+    expect(mockLoginAsPreviewAccount).toHaveBeenCalledWith("pro");
+  });
+
+  test("renders a disabled state with a hint when the password is not configured", async () => {
+    mockGetPreviewStealingDev.mockReturnValue("some-branch");
+    mockIsConfigured.mockResolvedValue(false);
+
+    render(<PreviewLoginButtons />);
+
+    await waitFor(() => expect(mockIsConfigured).toHaveBeenCalled());
+
+    expect(screen.getByText(/PREVIEW_ACCOUNTS_PASSWORD/i)).toBeTruthy();
+    expect(getButton("Admin").disabled).toBe(true);
+    expect(mockLoginAsPreviewAccount).not.toHaveBeenCalled();
+  });
+});

--- a/autogpt_platform/frontend/src/app/(no-navbar)/login/__tests__/preview-login-buttons.test.tsx
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/login/__tests__/preview-login-buttons.test.tsx
@@ -91,10 +91,44 @@ describe("PreviewLoginButtons", () => {
 
     render(<PreviewLoginButtons />);
 
-    await waitFor(() => expect(mockIsConfigured).toHaveBeenCalled());
-
-    expect(screen.getByText(/PREVIEW_ACCOUNTS_PASSWORD/i)).toBeTruthy();
+    expect(await screen.findByText(/PREVIEW_ACCOUNTS_PASSWORD/i)).toBeTruthy();
     expect(getButton("Admin").disabled).toBe(true);
     expect(mockLoginAsPreviewAccount).not.toHaveBeenCalled();
+  });
+
+  test("does not show the setup hint while the config check is loading", () => {
+    mockGetPreviewStealingDev.mockReturnValue("some-branch");
+    // Never resolves so the component stays in its initial checking state.
+    mockIsConfigured.mockReturnValue(new Promise(() => {}));
+
+    render(<PreviewLoginButtons />);
+
+    expect(screen.getByText(/Preview test accounts/i)).toBeTruthy();
+    expect(screen.queryByText(/PREVIEW_ACCOUNTS_PASSWORD/i)).toBeNull();
+    expect(getButton("Admin").disabled).toBe(true);
+  });
+
+  test("shows a toast when the preview login fails", async () => {
+    mockGetPreviewStealingDev.mockReturnValue("some-branch");
+    mockIsConfigured.mockResolvedValue(true);
+    mockLoginAsPreviewAccount.mockResolvedValue({
+      success: false,
+      error: "Preview login is not available",
+    });
+
+    render(<PreviewLoginButtons />);
+
+    await waitFor(() => expect(getButton("Admin").disabled).toBe(false));
+
+    fireEvent.click(getButton("Admin"));
+
+    await waitFor(() =>
+      expect(toastSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Preview login is not available",
+          variant: "destructive",
+        }),
+      ),
+    );
   });
 });

--- a/autogpt_platform/frontend/src/app/(no-navbar)/login/components/PreviewLoginButtons/PreviewLoginButtons.tsx
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/login/components/PreviewLoginButtons/PreviewLoginButtons.tsx
@@ -8,8 +8,13 @@ import { PREVIEW_ROLES } from "./helpers";
 import { usePreviewLoginButtons } from "./usePreviewLoginButtons";
 
 export function PreviewLoginButtons() {
-  const { isPreview, isConfigured, loadingRole, handlePreviewLogin } =
-    usePreviewLoginButtons();
+  const {
+    isPreview,
+    isConfigured,
+    isCheckingConfig,
+    loadingRole,
+    handlePreviewLogin,
+  } = usePreviewLoginButtons();
 
   if (!isPreview) {
     return null;
@@ -26,7 +31,7 @@ export function PreviewLoginButtons() {
         </Text>
       </div>
 
-      {!isConfigured ? (
+      {!isCheckingConfig && !isConfigured ? (
         <Text variant="small" className="!text-slate-500">
           Set PREVIEW_ACCOUNTS_PASSWORD in the preview environment to enable
           one-click sign-in.

--- a/autogpt_platform/frontend/src/app/(no-navbar)/login/components/PreviewLoginButtons/PreviewLoginButtons.tsx
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/login/components/PreviewLoginButtons/PreviewLoginButtons.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { Button } from "@/components/atoms/Button/Button";
+import { Text } from "@/components/atoms/Text/Text";
+import { AuthDivider } from "@/components/auth/AuthSplitLayout/AuthDivider";
+import { FlaskIcon } from "@phosphor-icons/react/dist/ssr";
+import { PREVIEW_ROLES } from "./helpers";
+import { usePreviewLoginButtons } from "./usePreviewLoginButtons";
+
+export function PreviewLoginButtons() {
+  const { isPreview, isConfigured, loadingRole, handlePreviewLogin } =
+    usePreviewLoginButtons();
+
+  if (!isPreview) {
+    return null;
+  }
+
+  return (
+    <div className="mt-2 flex w-full flex-col gap-3">
+      <AuthDivider />
+
+      <div className="flex items-center gap-2">
+        <FlaskIcon size={16} weight="duotone" className="text-slate-500" />
+        <Text variant="small-medium" className="!text-slate-500">
+          Preview test accounts
+        </Text>
+      </div>
+
+      {!isConfigured ? (
+        <Text variant="small" className="!text-slate-500">
+          Set PREVIEW_ACCOUNTS_PASSWORD in the preview environment to enable
+          one-click sign-in.
+        </Text>
+      ) : null}
+
+      <div className="grid grid-cols-2 gap-2">
+        {PREVIEW_ROLES.map(({ role, label }) => (
+          <Button
+            key={role}
+            variant="secondary"
+            size="small"
+            className="w-full"
+            disabled={!isConfigured || loadingRole !== null}
+            loading={loadingRole === role}
+            onClick={() => handlePreviewLogin(role)}
+          >
+            {label}
+          </Button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(no-navbar)/login/components/PreviewLoginButtons/actions.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/login/components/PreviewLoginButtons/actions.ts
@@ -1,0 +1,29 @@
+"use server";
+
+import { login } from "../../actions";
+
+const PREVIEW_ACCOUNT_EMAILS: Record<string, string> = {
+  admin: "preview-admin@agpt.co",
+  existing: "preview-existing@agpt.co",
+  clean: "preview-clean@agpt.co",
+  pro: "preview-pro@agpt.co",
+  enterprise: "preview-enterprise@agpt.co",
+};
+
+export async function isPreviewLoginConfigured() {
+  return Boolean(process.env.PREVIEW_ACCOUNTS_PASSWORD);
+}
+
+export async function loginAsPreviewAccount(role: string) {
+  const email = PREVIEW_ACCOUNT_EMAILS[role];
+  if (!email) {
+    return { success: false, error: "Unknown preview account" };
+  }
+
+  const password = process.env.PREVIEW_ACCOUNTS_PASSWORD;
+  if (!password) {
+    return { success: false, error: "Preview login is not configured" };
+  }
+
+  return login(email, password);
+}

--- a/autogpt_platform/frontend/src/app/(no-navbar)/login/components/PreviewLoginButtons/actions.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/login/components/PreviewLoginButtons/actions.ts
@@ -1,8 +1,10 @@
 "use server";
 
+import { environment } from "@/services/environment";
 import { login } from "../../actions";
+import { PreviewRole } from "./helpers";
 
-const PREVIEW_ACCOUNT_EMAILS: Record<string, string> = {
+const PREVIEW_ACCOUNT_EMAILS: Record<PreviewRole, string> = {
   admin: "preview-admin@agpt.co",
   existing: "preview-existing@agpt.co",
   clean: "preview-clean@agpt.co",
@@ -10,11 +12,24 @@ const PREVIEW_ACCOUNT_EMAILS: Record<string, string> = {
   enterprise: "preview-enterprise@agpt.co",
 };
 
-export async function isPreviewLoginConfigured() {
-  return Boolean(process.env.PREVIEW_ACCOUNTS_PASSWORD);
+function isPreviewEnvironment() {
+  return Boolean(environment.getPreviewStealingDev());
 }
 
-export async function loginAsPreviewAccount(role: string) {
+export async function isPreviewLoginConfigured() {
+  return (
+    isPreviewEnvironment() && Boolean(process.env.PREVIEW_ACCOUNTS_PASSWORD)
+  );
+}
+
+export async function loginAsPreviewAccount(role: PreviewRole) {
+  // Gate the action server-side on the preview marker: it must be a no-op in any
+  // non-preview environment, regardless of what the client sends. Hiding the UI
+  // client-side is not enough since a server action is directly callable.
+  if (!isPreviewEnvironment()) {
+    return { success: false, error: "Preview login is not available" };
+  }
+
   const email = PREVIEW_ACCOUNT_EMAILS[role];
   if (!email) {
     return { success: false, error: "Unknown preview account" };

--- a/autogpt_platform/frontend/src/app/(no-navbar)/login/components/PreviewLoginButtons/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/login/components/PreviewLoginButtons/helpers.ts
@@ -1,0 +1,9 @@
+export const PREVIEW_ROLES = [
+  { role: "admin", label: "Admin" },
+  { role: "existing", label: "Existing user" },
+  { role: "clean", label: "Clean user" },
+  { role: "pro", label: "Pro" },
+  { role: "enterprise", label: "Enterprise" },
+] as const;
+
+export type PreviewRole = (typeof PREVIEW_ROLES)[number]["role"];

--- a/autogpt_platform/frontend/src/app/(no-navbar)/login/components/PreviewLoginButtons/usePreviewLoginButtons.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/login/components/PreviewLoginButtons/usePreviewLoginButtons.ts
@@ -1,0 +1,57 @@
+import { useToast } from "@/components/molecules/Toast/use-toast";
+import { sanitizeAuthNext } from "@/lib/auth-redirect";
+import { environment } from "@/services/environment";
+import { useSearchParams } from "next/navigation";
+import { useEffect, useState } from "react";
+import { isPreviewLoginConfigured, loginAsPreviewAccount } from "./actions";
+import { PreviewRole } from "./helpers";
+
+export function usePreviewLoginButtons() {
+  const isPreview = Boolean(environment.getPreviewStealingDev());
+  const [isConfigured, setIsConfigured] = useState(false);
+  const [loadingRole, setLoadingRole] = useState<PreviewRole | null>(null);
+  const { toast } = useToast();
+  const searchParams = useSearchParams();
+  const nextUrl = sanitizeAuthNext(searchParams.get("next"));
+
+  useEffect(() => {
+    if (!isPreview) return;
+
+    let active = true;
+    isPreviewLoginConfigured().then((configured) => {
+      if (active) setIsConfigured(configured);
+    });
+
+    return () => {
+      active = false;
+    };
+  }, [isPreview]);
+
+  async function handlePreviewLogin(role: PreviewRole) {
+    setLoadingRole(role);
+
+    try {
+      const result = await loginAsPreviewAccount(role);
+      if (!result.success) {
+        throw new Error(result.error || "Preview login failed");
+      }
+
+      // Full page navigation so middleware picks up the new auth cookies,
+      // mirroring the standard email/password login flow.
+      window.location.href = nextUrl || result.next || "/";
+    } catch (error) {
+      toast({
+        title: error instanceof Error ? error.message : "Preview login failed",
+        variant: "destructive",
+      });
+      setLoadingRole(null);
+    }
+  }
+
+  return {
+    isPreview,
+    isConfigured,
+    loadingRole,
+    handlePreviewLogin,
+  };
+}

--- a/autogpt_platform/frontend/src/app/(no-navbar)/login/components/PreviewLoginButtons/usePreviewLoginButtons.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/login/components/PreviewLoginButtons/usePreviewLoginButtons.ts
@@ -9,6 +9,7 @@ import { PreviewRole } from "./helpers";
 export function usePreviewLoginButtons() {
   const isPreview = Boolean(environment.getPreviewStealingDev());
   const [isConfigured, setIsConfigured] = useState(false);
+  const [isCheckingConfig, setIsCheckingConfig] = useState(true);
   const [loadingRole, setLoadingRole] = useState<PreviewRole | null>(null);
   const { toast } = useToast();
   const searchParams = useSearchParams();
@@ -19,7 +20,9 @@ export function usePreviewLoginButtons() {
 
     let active = true;
     isPreviewLoginConfigured().then((configured) => {
-      if (active) setIsConfigured(configured);
+      if (!active) return;
+      setIsConfigured(configured);
+      setIsCheckingConfig(false);
     });
 
     return () => {
@@ -51,6 +54,7 @@ export function usePreviewLoginButtons() {
   return {
     isPreview,
     isConfigured,
+    isCheckingConfig,
     loadingRole,
     handlePreviewLogin,
   };

--- a/autogpt_platform/frontend/src/app/(no-navbar)/login/page.tsx
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/login/page.tsx
@@ -14,6 +14,7 @@ import { environment } from "@/services/environment";
 import { useSearchParams } from "next/navigation";
 import { LoadingLogin } from "./components/LoadingLogin";
 import { LoginMarketingPanel } from "./components/LoginMarketingPanel";
+import { PreviewLoginButtons } from "./components/PreviewLoginButtons/PreviewLoginButtons";
 import { useLoginPage } from "./useLoginPage";
 
 export const dynamic = "force-dynamic";
@@ -139,6 +140,8 @@ export default function LoginPage() {
           Sign up
         </Link>
       </div>
+
+      <PreviewLoginButtons />
 
       <MobileWarningBanner />
       <EmailNotAllowedModal


### PR DESCRIPTION
### Why

Preview deployments run against a fresh dev-Supabase database. Signing in there is currently painful: the account-gating trigger on `auth.users` (see notes below) means the only way in is a real `@agpt.co` Google SSO account, and testers have to type credentials by hand. To exercise a preview end-to-end we want to jump straight into a known role (admin, existing user, clean user, pro, enterprise) with one click — without ever putting a password in the repo or shipping it to the browser.

### What

Adds a **"Preview test accounts"** section to the login page (`(no-navbar)/login`) with one-click sign-in buttons for five roles:

- Admin → `preview-admin@agpt.co`
- Existing user → `preview-existing@agpt.co`
- Clean user → `preview-clean@agpt.co`
- Pro → `preview-pro@agpt.co`
- Enterprise → `preview-enterprise@agpt.co`

New files under `login/components/PreviewLoginButtons/`:

- `PreviewLoginButtons.tsx` — the section (design-system `Button`/`Text`, Phosphor `FlaskIcon`, `AuthDivider`).
- `usePreviewLoginButtons.ts` — visibility + click/loading/redirect logic.
- `actions.ts` — server actions: `loginAsPreviewAccount(role)` and `isPreviewLoginConfigured()`.
- `helpers.ts` — the role→label list.
- `__tests__/preview-login-buttons.test.tsx` — integration tests.

`page.tsx` renders `<PreviewLoginButtons />` at the bottom of the login form.

### How

- **Visibility**: the section only renders when `environment.getPreviewStealingDev()` returns a non-empty preview marker (`NEXT_PUBLIC_PREVIEW_STEALING_DEV` on a non-`dev` branch while `NEXT_PUBLIC_APP_ENV === "dev"`). It **never** shows on real dev or prod.
- **Auth**: clicking a button calls the `loginAsPreviewAccount` **server action** with only the role name. The action maps the role to its `preview-<role>@agpt.co` email, reads the shared password **server-side** from `process.env.PREVIEW_ACCOUNTS_PASSWORD`, and reuses the existing `login()` action (`supabase.auth.signInWithPassword`). This bypasses the client-side `@agpt.co → use Google SSO` nudge in `useLoginPage`, which is intended for interactive staff login, not these seeded fixtures.
- **Secret handling**: `PREVIEW_ACCOUNTS_PASSWORD` is a Vercel env injected by the deploy pipeline. It is **not** `NEXT_PUBLIC`, never committed, and never sent to the client. The client only ever learns a boolean via `isPreviewLoginConfigured()`.
- **Disabled state**: if `PREVIEW_ACCOUNTS_PASSWORD` is unset, the buttons render disabled with a short hint instead of failing on click.

**Inert until infra is in place.** This does nothing until (1) the `PREVIEW_ACCOUNTS_PASSWORD` secret is added to the preview deploy pipeline and (2) the five `preview-*@agpt.co` accounts exist in the dev-Supabase project (and are allowed past the `auth.users` gating trigger). Until then the section is hidden (outside preview) or disabled (no password).

#### Note on the signup/login gate (research finding)

There is **no** waitlist/allowlist/email-domain gate in `autogpt_platform/backend` or `autogpt_libs`, and the docker/GoTrue stack defaults to **open signup** (`GOTRUE_DISABLE_SIGNUP: false`, `GOTRUE_EXTERNAL_EMAIL_ENABLED: true`). The observed "@agpt.co only" behavior comes from an **out-of-band Postgres trigger on `auth.users`** (raises `P0001 "… is not allowed to register"`) that is **not in this repo** — the frontend only *detects* it (`app/api/auth/utils.ts` `isWaitlistError`). The invite-system migrations that once added an `InvitedUser` table were fully reverted (`migrations/20260319120000_revert_invite_system`). So the five preview accounts must be created directly in the dev-Supabase auth DB (and whitelisted by whatever that trigger checks); nothing in this repo seeds them.

### Testing

Integration tests (`preview-login-buttons.test.tsx`, all passing):

- hidden when the preview marker is absent;
- all five buttons visible + enabled in a configured preview;
- clicking a button calls `loginAsPreviewAccount` with the right role;
- disabled + hint shown when `PREVIEW_ACCOUNTS_PASSWORD` is unset.

Ran from `autogpt_platform/frontend`: `pnpm format`, `pnpm lint`, `pnpm types` all clean; new test file passes (`4/4`). The only failing test in the full `test:unit` run is a pre-existing timezone-dependent date test (`ChatSearchModal/helpers.test.ts`) unrelated to this change.

### Checklist

- [x] Follows frontend conventions (design-system components, function declarations, `ComponentName/` + `useComponentName` pattern, Phosphor icons, no legacy components)
- [x] Tests added for new behavior
- [x] `pnpm format` / `pnpm lint` / `pnpm types` pass
- [x] No secrets committed; password read server-side only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wj2E4V37tKjiGsXafYKDuk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication via new server actions, but preview-only gating, role allowlisting, and server-only password keep exposure limited to preview infra.
> 
> **Overview**
> Adds **preview-only one-click sign-in** on the login page so testers can jump into fixed roles (admin, existing, clean, pro, enterprise) without typing credentials.
> 
> A new **Preview test accounts** block appears only when `environment.getPreviewStealingDev()` is set; it calls server actions that map each role to `preview-<role>@agpt.co` and sign in via the existing `login()` flow using **`PREVIEW_ACCOUNTS_PASSWORD` on the server only** (client gets a boolean from `isPreviewLoginConfigured()`). **`loginAsPreviewAccount`** is gated server-side on the preview marker and rejects unknown roles; buttons stay disabled with a setup hint when the password env is missing. Success uses full-page navigation (respecting sanitized `next`), with toasts on failure.
> 
> **`page.tsx`** mounts `<PreviewLoginButtons />` below the sign-up link. Unit/integration tests cover server actions and UI (visibility, config loading, navigation, errors).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91d7ce31464f3b65fb859f72da85f5b3605da1f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->