### PR TITLE
docs: link backend readmes to platform docs

### DIFF
--- a/autogpt_platform/backend/README.advanced.md
+++ b/autogpt_platform/backend/README.advanced.md
@@ -2,7 +2,7 @@
 
 The advanced backend setup guide is maintained in the platform documentation so this README stays in sync with the published docs.
 
-- Released/master documentation: https://docs.agpt.co/platform/advanced_setup/#autogpt_agent_server_advanced_set_up
-- Dev branch documentation: https://dev-docs.agpt.co/platform/advanced_setup/#autogpt_agent_server_advanced_set_up
+- Advanced self-hosting setup: https://agpt.co/docs/platform/self-hosting/advanced_setup/
+- Platform documentation: https://agpt.co/docs/platform/
 
-Use `docs.agpt.co` for the released/master branch and `dev-docs.agpt.co` for the dev branch.
+For the basic self-hosting walkthrough, see [README.md](./README.md).

--- a/autogpt_platform/backend/README.advanced.md
+++ b/autogpt_platform/backend/README.advanced.md
@@ -1,1 +1,8 @@
-[Advanced Setup (Dev Branch)](https://dev-docs.agpt.co/platform/advanced_setup/#autogpt_agent_server_advanced_set_up)
+# AutoGPT Platform Backend Advanced Setup
+
+The advanced backend setup guide is maintained in the platform documentation so this README stays in sync with the published docs.
+
+- Released/master documentation: https://docs.agpt.co/platform/advanced_setup/#autogpt_agent_server_advanced_set_up
+- Dev branch documentation: https://dev-docs.agpt.co/platform/advanced_setup/#autogpt_agent_server_advanced_set_up
+
+Use `docs.agpt.co` for the released/master branch and `dev-docs.agpt.co` for the dev branch.

--- a/autogpt_platform/backend/README.md
+++ b/autogpt_platform/backend/README.md
@@ -2,7 +2,7 @@
 
 The backend getting started guide is maintained in the platform documentation so this README stays in sync with the published docs.
 
-- Released/master documentation: https://docs.agpt.co/platform/getting-started/#autogpt_agent_server
-- Dev branch documentation: https://dev-docs.agpt.co/platform/getting-started/#autogpt_agent_server
+- Self-hosting getting started: https://agpt.co/docs/platform/self-hosting/getting-started/
+- Platform documentation: https://agpt.co/docs/platform/
 
-Use `docs.agpt.co` for the released/master branch and `dev-docs.agpt.co` for the dev branch.
+For advanced self-hosting configuration, see [README.advanced.md](./README.advanced.md).

--- a/autogpt_platform/backend/README.md
+++ b/autogpt_platform/backend/README.md
@@ -1,3 +1,8 @@
-# AutoGPT Platform — Backend
+# AutoGPT Platform Backend
 
-[Getting Started (Released)](https://docs.agpt.co/platform/getting-started/#autogpt_agent_server)
+The backend getting started guide is maintained in the platform documentation so this README stays in sync with the published docs.
+
+- Released/master documentation: https://docs.agpt.co/platform/getting-started/#autogpt_agent_server
+- Dev branch documentation: https://dev-docs.agpt.co/platform/getting-started/#autogpt_agent_server
+
+Use `docs.agpt.co` for the released/master branch and `dev-docs.agpt.co` for the dev branch.


### PR DESCRIPTION
## Summary
- Replace backend README one-line links with short documentation routing pages
- Call out both released/master and dev branch documentation URLs
- Keep backend setup details centralized in the platform docs

Fixes #8887

## Testing
- Not run; documentation-only change.
