### PR TITLE
fix(backend): configure Stripe SDK retries and timeout globally

### DIFF
--- a/autogpt_platform/backend/backend/data/credit.py
+++ b/autogpt_platform/backend/backend/data/credit.py
@@ -55,6 +55,12 @@ if TYPE_CHECKING:
 
 settings = Settings()
 stripe.api_key = settings.secrets.stripe_api_key
+# Reliability: retry transient Stripe failures (idempotency keys are attached to
+# retried writes) and cap the HTTP timeout so slow calls don't hang (~80s default).
+stripe.max_network_retries = settings.config.stripe_max_network_retries
+stripe.default_http_client = stripe.RequestsClient(
+    timeout=settings.config.stripe_client_timeout_seconds
+)
 if settings.secrets.posthog_api_key:
     posthog.api_key = settings.secrets.posthog_api_key
     posthog.host = settings.secrets.posthog_host

--- a/autogpt_platform/backend/backend/data/credit_stripe_config_test.py
+++ b/autogpt_platform/backend/backend/data/credit_stripe_config_test.py
@@ -1,0 +1,43 @@
+"""Stripe SDK global reliability configuration.
+
+Single transient blips (429s / connection resets) currently fail Stripe
+requests outright, and slow calls hang for the SDK default (~80s). These
+tests lock in the retry + client-timeout configuration that
+``backend.data.credit`` applies to the global ``stripe`` module at import
+time, and the settings that drive it.
+
+They are pure unit tests: they only inspect module-level state, so the
+DB-backed test server fixtures are overridden to no-ops below.
+"""
+
+import pytest
+import stripe
+
+from backend.util.settings import Settings
+
+
+@pytest.fixture(scope="session", autouse=True)
+def graph_cleanup():
+    # Override the autouse SpinTestServer-backed cleanup fixture from
+    # conftest.py so these tests do not require a test database.
+    yield
+
+
+def test_stripe_reliability_settings_have_defaults():
+    config = Settings().config
+    assert config.stripe_max_network_retries == 2
+    assert config.stripe_client_timeout_seconds == 20
+
+
+def test_credit_module_applies_stripe_sdk_config():
+    # Importing the credit module applies the SDK config as an import-time
+    # side effect; assert the global stripe client picked it up.
+    import backend.data.credit  # noqa: F401
+
+    config = Settings().config
+
+    assert stripe.max_network_retries == config.stripe_max_network_retries
+
+    client = stripe.default_http_client
+    assert isinstance(client, stripe.RequestsClient)
+    assert client._timeout == config.stripe_client_timeout_seconds

--- a/autogpt_platform/backend/backend/util/settings.py
+++ b/autogpt_platform/backend/backend/util/settings.py
@@ -155,6 +155,14 @@ class Config(UpdateTrackingModel["Config"], BaseSettings):
         default="%Y-%W",  # This will allow for weekly refunds per user.
         description="Time key format for refund requests.",
     )
+    stripe_max_network_retries: int = Field(
+        default=2,
+        description="Number of automatic Stripe SDK retries on transient failures; Stripe attaches idempotency keys to retried writes.",
+    )
+    stripe_client_timeout_seconds: int = Field(
+        default=20,
+        description="HTTP timeout for Stripe API calls; SDK default is ~80s which can hang requests.",
+    )
     execution_cost_count_threshold: int = Field(
         default=100,
         description="Number of executions after which the cost is calculated.",


### PR DESCRIPTION
### Why

The Stripe SDK is initialized in `backend/data/credit.py` with only `stripe.api_key` — no retry policy and no client HTTP timeout. This has two reliability consequences:

- **Single transient blips fail requests outright.** With retries left at 0, a single `429` (rate limit) or a connection reset makes the whole Stripe call fail rather than retrying. This is a root cause of unreliable account-detail pulls (customer/subscription/payment-method lookups) — a momentary blip surfaces to the user as a hard failure.
- **Slow calls hang for ~80s.** The SDK's default HTTP client timeout is ~80s, so a stuck/slow Stripe endpoint ties up a request/thread for well over a minute before giving up.

Configuring both globally at the SDK init site fixes every Stripe call in one place.

Retried writes are safe: the Stripe Python SDK automatically attaches an idempotency key to retried write requests, so an automatic retry cannot double-charge or duplicate a resource.

### What

- **`backend/util/settings.py`** — two new `Config` fields (with the file's existing `Field` style):
  - `stripe_max_network_retries: int = 2` — automatic Stripe SDK retries on transient failures.
  - `stripe_client_timeout_seconds: int = 20` — HTTP timeout for Stripe API calls (SDK default ~80s can hang requests).
- **`backend/data/credit.py`** — at the SDK init site, apply both settings globally:
  - `stripe.max_network_retries = settings.config.stripe_max_network_retries`
  - `stripe.default_http_client = stripe.RequestsClient(timeout=settings.config.stripe_client_timeout_seconds)`
- **`backend/data/credit_stripe_config_test.py`** — new unit tests asserting the settings defaults exist and that importing the credit module applies them to the global `stripe` module (retries value + a `RequestsClient` with the configured timeout). No network / no Stripe calls.

### How

The pinned SDK is `stripe==11.6.0`. Both `stripe.max_network_retries` (module attribute) and `stripe.default_http_client` (a `stripe.RequestsClient`, exposed at top level as `stripe.RequestsClient`) are the supported global-configuration mechanism for that version — verified against the installed package. `RequestsClient(timeout=...)` stores the value in `_timeout`, which the test asserts against.

Values are settings-driven so they can be tuned per environment without a code change.

Tested (targeted only, per RAM constraints — not the full suite):

```
poetry run pytest backend/data/credit_stripe_config_test.py
# 2 passed
```

`poetry run format` (ruff + isort + black + pyright) passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wj2E4V37tKjiGsXafYKDuk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Global Stripe client behavior changes for all calls after credit import (checkout, subscriptions, refunds); retries on writes rely on SDK idempotency keys, and a shorter timeout could surface more failures on genuinely slow Stripe responses.
> 
> **Overview**
> Configures the global Stripe Python SDK at **`backend/data/credit`** import time so billing-related API calls are more resilient and fail faster.
> 
> **`Config`** gains **`stripe_max_network_retries`** (default **2**) and **`stripe_client_timeout_seconds`** (default **20**), applied as **`stripe.max_network_retries`** and a **`stripe.RequestsClient`** with that timeout—replacing SDK defaults of no retries and ~**80s** hangs on slow responses.
> 
> New **`credit_stripe_config_test.py`** locks in the defaults and that importing the credit module updates the global **`stripe`** client.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43b5f1304024f64e8c6ee4c536997e0b850656af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->