### PR TITLE
feat(platform): surface Slack on the Bots settings + admin analytics pages

### DIFF
--- a/autogpt_platform/backend/backend/api/features/admin/bot_analytics_routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/admin/bot_analytics_routes_test.py
@@ -74,7 +74,9 @@ def test_timeseries_returns_list(mocker):
 
 
 def test_command_usage_and_guilds(mocker):
-    mock_commands = AsyncMock(return_value=[BotCommandUsage(command="setup", uses=3)])
+    mock_commands = AsyncMock(
+        return_value=[BotCommandUsage(platform="DISCORD", command="setup", uses=3)]
+    )
     mock_guilds = AsyncMock(
         return_value=[
             BotGuildInfo(

--- a/autogpt_platform/backend/backend/api/features/platform_linking/registry.py
+++ b/autogpt_platform/backend/backend/api/features/platform_linking/registry.py
@@ -10,6 +10,7 @@ from urllib.parse import urlencode
 from pydantic import BaseModel, ConfigDict
 
 from backend.copilot.bot.adapters.discord import config as discord_config
+from backend.copilot.bot.adapters.slack import config as slack_config
 
 
 class PlatformMeta(BaseModel):
@@ -30,7 +31,7 @@ def enabled_platforms() -> list[PlatformMeta]:
     Platforms whose adapter isn't configured (missing credentials) are
     omitted entirely so the Bots page hides them.
     """
-    all_platforms = [_discord_meta()]
+    all_platforms = [_discord_meta(), _slack_meta()]
     return [platform for platform in all_platforms if platform.enabled]
 
 
@@ -42,6 +43,21 @@ def _discord_meta() -> PlatformMeta:
         icon="discord.png",
         enabled=enabled,
         add_bot_url=_discord_invite_url() if enabled else None,
+    )
+
+
+def _slack_meta() -> PlatformMeta:
+    # Slack has no Discord-style one-click invite for a self-hosted app — it's
+    # installed per-workspace via the app manifest, then linked with /setup — so
+    # there's no add_bot_url. Enabled once both the token and signing secret are
+    # set (the same gate the webhook adapter mounts on).
+    enabled = bool(slack_config.get_bot_token() and slack_config.get_signing_secret())
+    return PlatformMeta(
+        platform="SLACK",
+        display_name="Slack",
+        icon="slack.png",
+        enabled=enabled,
+        add_bot_url=None,
     )
 
 

--- a/autogpt_platform/backend/backend/api/features/platform_linking/registry_test.py
+++ b/autogpt_platform/backend/backend/api/features/platform_linking/registry_test.py
@@ -4,35 +4,35 @@ from unittest.mock import patch
 
 from backend.api.features.platform_linking.registry import enabled_platforms
 
+_REG = "backend.api.features.platform_linking.registry"
 
-def test_discord_excluded_when_bot_token_not_set():
-    with patch(
-        "backend.api.features.platform_linking.registry.discord_config.get_bot_token",
-        return_value="",
-    ):
+
+def _slack_off():
+    # Slack disabled unless a test opts in — keeps the Discord assertions from
+    # depending on whatever Slack creds happen to be in the environment.
+    return patch(f"{_REG}.slack_config.get_bot_token", return_value="")
+
+
+def _discord_off():
+    return patch(f"{_REG}.discord_config.get_bot_token", return_value="")
+
+
+def test_no_platforms_when_none_configured():
+    with _discord_off(), _slack_off():
         assert enabled_platforms() == []
 
 
 def test_discord_appears_with_invite_url_when_client_id_set():
     with (
-        patch(
-            "backend.api.features.platform_linking.registry.discord_config.get_bot_token",
-            return_value="token",
-        ),
-        patch(
-            "backend.api.features.platform_linking.registry.discord_config.get_client_id",
-            return_value="my-client-id",
-        ),
-        patch(
-            "backend.api.features.platform_linking.registry.discord_config.get_invite_permissions",
-            return_value="123",
-        ),
+        _slack_off(),
+        patch(f"{_REG}.discord_config.get_bot_token", return_value="token"),
+        patch(f"{_REG}.discord_config.get_client_id", return_value="my-client-id"),
+        patch(f"{_REG}.discord_config.get_invite_permissions", return_value="123"),
     ):
         platforms = enabled_platforms()
 
-    assert len(platforms) == 1
+    assert [p.platform for p in platforms] == ["DISCORD"]
     discord = platforms[0]
-    assert discord.platform == "DISCORD"
     assert discord.enabled is True
     assert discord.add_bot_url is not None
     assert "client_id=my-client-id" in discord.add_bot_url
@@ -41,17 +41,49 @@ def test_discord_appears_with_invite_url_when_client_id_set():
 
 def test_discord_appears_without_invite_url_when_client_id_missing():
     with (
-        patch(
-            "backend.api.features.platform_linking.registry.discord_config.get_bot_token",
-            return_value="token",
-        ),
-        patch(
-            "backend.api.features.platform_linking.registry.discord_config.get_client_id",
-            return_value="",
-        ),
+        _slack_off(),
+        patch(f"{_REG}.discord_config.get_bot_token", return_value="token"),
+        patch(f"{_REG}.discord_config.get_client_id", return_value=""),
     ):
         platforms = enabled_platforms()
 
-    assert len(platforms) == 1
-    assert platforms[0].enabled is True
+    assert [p.platform for p in platforms] == ["DISCORD"]
     assert platforms[0].add_bot_url is None
+
+
+def test_slack_appears_when_token_and_signing_secret_set():
+    with (
+        _discord_off(),
+        patch(f"{_REG}.slack_config.get_bot_token", return_value="xoxb-x"),
+        patch(f"{_REG}.slack_config.get_signing_secret", return_value="secret"),
+    ):
+        platforms = enabled_platforms()
+
+    assert [p.platform for p in platforms] == ["SLACK"]
+    slack = platforms[0]
+    assert slack.enabled is True
+    assert slack.display_name == "Slack"
+    assert slack.icon == "slack.png"
+    # Slack has no one-click invite for a self-hosted app.
+    assert slack.add_bot_url is None
+
+
+def test_slack_hidden_when_signing_secret_missing():
+    with (
+        _discord_off(),
+        patch(f"{_REG}.slack_config.get_bot_token", return_value="xoxb-x"),
+        patch(f"{_REG}.slack_config.get_signing_secret", return_value=""),
+    ):
+        assert enabled_platforms() == []
+
+
+def test_both_platforms_when_both_configured():
+    with (
+        patch(f"{_REG}.discord_config.get_bot_token", return_value="token"),
+        patch(f"{_REG}.discord_config.get_client_id", return_value=""),
+        patch(f"{_REG}.slack_config.get_bot_token", return_value="xoxb-x"),
+        patch(f"{_REG}.slack_config.get_signing_secret", return_value="secret"),
+    ):
+        platforms = enabled_platforms()
+
+    assert {p.platform for p in platforms} == {"DISCORD", "SLACK"}

--- a/autogpt_platform/backend/backend/data/bot_analytics_reads.py
+++ b/autogpt_platform/backend/backend/data/bot_analytics_reads.py
@@ -49,6 +49,7 @@ class BotServerCountPoint(BaseModel):
 
 
 class BotServerActivity(BaseModel):
+    platform: str
     server_id: str
     name: str | None
     messages: int
@@ -56,6 +57,7 @@ class BotServerActivity(BaseModel):
 
 
 class BotCommandUsage(BaseModel):
+    platform: str
     command: str
     uses: int
 
@@ -214,6 +216,7 @@ async def get_bot_top_servers(
         f"""
         SELECT
             e."serverId" AS server_id,
+            e."platform" AS platform,
             g."name" AS name,
             count(*) FILTER (WHERE e."eventType" = 'message_received') AS messages,
             count(*) FILTER (WHERE e."eventType" = 'command_used') AS commands
@@ -221,7 +224,7 @@ async def get_bot_top_servers(
         LEFT JOIN {{schema_prefix}}"BotGuild" g
             ON g."serverId" = e."serverId" AND g."platform" = e."platform"
         WHERE e."createdAt" >= $1::timestamptz AND e."serverId" IS NOT NULL {platform_filter}
-        GROUP BY e."serverId", g."name"
+        GROUP BY e."serverId", e."platform", g."name"
         ORDER BY messages DESC
         LIMIT ${len(params)}::int
         """,
@@ -229,6 +232,7 @@ async def get_bot_top_servers(
     )
     return [
         BotServerActivity(
+            platform=row["platform"],
             server_id=row["server_id"],
             name=row["name"],
             messages=int(row["messages"]),
@@ -245,18 +249,21 @@ async def get_bot_command_usage(
     platform_filter = _platform_filter(platform, params)
     rows = await query_raw_with_schema(
         f"""
-        SELECT "commandName" AS command, count(*) AS uses
+        SELECT "commandName" AS command, "platform" AS platform, count(*) AS uses
         FROM {{schema_prefix}}"BotEvent"
         WHERE "eventType" = 'command_used'
             AND "commandName" IS NOT NULL
             AND "createdAt" >= $1::timestamptz {platform_filter}
-        GROUP BY "commandName"
+        GROUP BY "commandName", "platform"
         ORDER BY uses DESC
         """,
         *params,
     )
     return [
-        BotCommandUsage(command=row["command"], uses=int(row["uses"])) for row in rows
+        BotCommandUsage(
+            platform=row["platform"], command=row["command"], uses=int(row["uses"])
+        )
+        for row in rows
     ]
 
 

--- a/autogpt_platform/frontend/src/app/(platform)/admin/bots/__tests__/main.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/bots/__tests__/main.test.tsx
@@ -99,4 +99,23 @@ describe("BotsContent", () => {
     ).toBeGreaterThanOrEqual(3);
     expect(await screen.findByText("Slack")).toBeDefined();
   });
+
+  it("falls back to the raw platform name for an unknown platform", async () => {
+    mockAllEndpoints();
+    server.use(
+      getGetV2TopServersByActivityMockHandler200([
+        {
+          platform: "TELEGRAM",
+          server_id: "tg1",
+          name: "Mystery",
+          messages: 1,
+          commands: 0,
+        },
+      ]),
+    );
+    render(<BotsContent />);
+
+    // No label entry exists for TELEGRAM, so the badge shows the raw key.
+    expect(await screen.findByText("TELEGRAM")).toBeDefined();
+  });
 });

--- a/autogpt_platform/frontend/src/app/(platform)/admin/bots/__tests__/main.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/bots/__tests__/main.test.tsx
@@ -38,10 +38,23 @@ function mockAllEndpoints() {
       { date: new Date("2026-06-01T00:00:00Z"), server_count: 42 },
     ]),
     getGetV2TopServersByActivityMockHandler200([
-      { server_id: "1", name: "Cool Guild", messages: 500, commands: 10 },
+      {
+        platform: "DISCORD",
+        server_id: "1",
+        name: "Cool Guild",
+        messages: 500,
+        commands: 10,
+      },
+      {
+        platform: "SLACK",
+        server_id: "T1",
+        name: "Cool Workspace",
+        messages: 300,
+        commands: 4,
+      },
     ]),
     getGetV2CommandUsageBreakdownMockHandler200([
-      { command: "setup", uses: 12 },
+      { platform: "DISCORD", command: "setup", uses: 12 },
     ]),
     getGetV2BotServerRosterMockHandler200([
       {
@@ -73,5 +86,17 @@ describe("BotsContent", () => {
     expect(await screen.findAllByText("Cool Guild")).toHaveLength(2);
     expect(await screen.findByText("/setup")).toBeDefined();
     expect(await screen.findByText("Active")).toBeDefined();
+  });
+
+  it("labels each row with its platform on the All platforms view", async () => {
+    mockAllEndpoints();
+    render(<BotsContent />);
+
+    // Discord appears in all three tables (top servers, command usage, roster);
+    // Slack only in the top-servers table — proving mixed rows are disambiguated.
+    expect(
+      (await screen.findAllByText("Discord")).length,
+    ).toBeGreaterThanOrEqual(3);
+    expect(await screen.findByText("Slack")).toBeDefined();
   });
 });

--- a/autogpt_platform/frontend/src/app/(platform)/admin/bots/components/BotsContent.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/bots/components/BotsContent.tsx
@@ -6,6 +6,7 @@ import { Select } from "@/components/atoms/Select/Select";
 import { Skeleton } from "@/components/atoms/Skeleton/Skeleton";
 
 import { MessageVolumeChart } from "./MessageVolumeChart";
+import { PlatformBadge } from "./PlatformBadge";
 import { ServerGrowthChart } from "./ServerGrowthChart";
 import { SimpleTable } from "./SimpleTable";
 import { SummaryCard } from "./SummaryCard";
@@ -22,6 +23,10 @@ import {
 export function BotsContent() {
   const state = useBotsContent();
   const { summary } = state;
+
+  // On "All platforms" the rows mix Discord and Slack, so lead each table with a
+  // platform badge. When a single platform is selected the column is redundant.
+  const showPlatform = state.platform === "all";
 
   const tiles = [
     { label: "Live servers", value: formatNumber(summary?.live_servers) },
@@ -107,8 +112,16 @@ export function BotsContent() {
               Top servers by activity
             </h2>
             <SimpleTable
-              columns={["Server", "Messages", "Commands"]}
+              columns={[
+                ...(showPlatform ? ["Platform"] : []),
+                "Server",
+                "Messages",
+                "Commands",
+              ]}
               rows={state.topServers.map((server) => [
+                ...(showPlatform
+                  ? [<PlatformBadge key="p" platform={server.platform} />]
+                  : []),
                 server.name || server.server_id,
                 formatNumber(server.messages),
                 formatNumber(server.commands),
@@ -120,8 +133,15 @@ export function BotsContent() {
             <Card>
               <h2 className="mb-4 text-xl font-semibold">Command usage</h2>
               <SimpleTable
-                columns={["Command", "Uses"]}
+                columns={[
+                  ...(showPlatform ? ["Platform"] : []),
+                  "Command",
+                  "Uses",
+                ]}
                 rows={state.commands.map((command) => [
+                  ...(showPlatform
+                    ? [<PlatformBadge key="p" platform={command.platform} />]
+                    : []),
                   `/${command.command}`,
                   formatNumber(command.uses),
                 ])}
@@ -131,8 +151,16 @@ export function BotsContent() {
             <Card>
               <h2 className="mb-4 text-xl font-semibold">Server roster</h2>
               <SimpleTable
-                columns={["Server", "Status", "Joined"]}
+                columns={[
+                  ...(showPlatform ? ["Platform"] : []),
+                  "Server",
+                  "Status",
+                  "Joined",
+                ]}
                 rows={state.roster.map((guild) => [
+                  ...(showPlatform
+                    ? [<PlatformBadge key="p" platform={guild.platform} />]
+                    : []),
                   guild.name || guild.server_id,
                   guild.active ? "Active" : "Left",
                   formatDate(guild.joined_at),

--- a/autogpt_platform/frontend/src/app/(platform)/admin/bots/components/PlatformBadge.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/bots/components/PlatformBadge.tsx
@@ -1,0 +1,28 @@
+import Image from "next/image";
+
+const PLATFORM_LABELS: Record<string, string> = {
+  DISCORD: "Discord",
+  SLACK: "Slack",
+};
+
+interface Props {
+  platform: string;
+}
+
+export function PlatformBadge({ platform }: Props) {
+  const key = platform.toUpperCase();
+  const label = PLATFORM_LABELS[key] ?? platform;
+
+  return (
+    <span className="inline-flex items-center gap-2 whitespace-nowrap">
+      <Image
+        src={`/integrations/${key.toLowerCase()}.png`}
+        alt={`${label} icon`}
+        width={16}
+        height={16}
+        className="rounded-sm"
+      />
+      {label}
+    </span>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/admin/bots/components/PlatformBadge.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/bots/components/PlatformBadge.tsx
@@ -1,9 +1,13 @@
 import Image from "next/image";
 
-const PLATFORM_LABELS: Record<string, string> = {
-  DISCORD: "Discord",
-  SLACK: "Slack",
-};
+import { PLATFORM_OPTIONS } from "./helpers";
+
+const PLATFORM_LABELS: Record<string, string> = Object.fromEntries(
+  PLATFORM_OPTIONS.filter((option) => option.value !== "all").map((option) => [
+    option.value.toUpperCase(),
+    option.label,
+  ]),
+);
 
 interface Props {
   platform: string;

--- a/autogpt_platform/frontend/src/app/(platform)/admin/bots/components/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/bots/components/helpers.ts
@@ -9,6 +9,7 @@ export const DAYS_OPTIONS = [
 export const PLATFORM_OPTIONS = [
   { value: "all", label: "All platforms" },
   { value: "DISCORD", label: "Discord" },
+  { value: "SLACK", label: "Slack" },
 ];
 
 export function formatNumber(value: number | null | undefined): string {

--- a/autogpt_platform/frontend/src/app/(platform)/settings/bots/__tests__/main.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/bots/__tests__/main.test.tsx
@@ -31,6 +31,20 @@ function discordPlatform(
   };
 }
 
+function slackPlatform(
+  overrides: Partial<BotPlatformInfo> = {},
+): BotPlatformInfo {
+  return {
+    platform: "SLACK",
+    display_name: "Slack",
+    icon: "slack.png",
+    add_bot_url: null, // Slack has no one-click invite for a self-hosted app
+    dm_link: undefined,
+    server_links: [],
+    ...overrides,
+  };
+}
+
 describe("SettingsBotsPage", () => {
   test("renders the header and the Discord card with an Add bot button", async () => {
     server.use(getListBotPlatformsMockHandler([discordPlatform()]));
@@ -46,6 +60,19 @@ describe("SettingsBotsPage", () => {
     expect(
       screen.getByRole("link", { name: /add bot to discord/i }),
     ).toBeDefined();
+  });
+
+  test("renders the Slack card without an Add bot button (no invite URL)", async () => {
+    server.use(getListBotPlatformsMockHandler([slackPlatform()]));
+
+    render(<SettingsBotsPage />);
+
+    expect(
+      await screen.findByRole("heading", { name: /slack/i }),
+    ).toBeDefined();
+    expect(
+      screen.queryByRole("link", { name: /add bot to slack/i }),
+    ).toBeNull();
   });
 
   test("shows the 'no bots enabled' empty state when no platforms are configured", async () => {

--- a/autogpt_platform/frontend/src/app/api/openapi.json
+++ b/autogpt_platform/frontend/src/app/api/openapi.json
@@ -4080,30 +4080,6 @@
         "security": [{ "HTTPBearerJWT": [] }]
       }
     },
-    "/api/copilot-webhooks/slack/commands": {
-      "post": {
-        "summary": " Handle Command Request",
-        "operationId": "_handle_command_request",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": { "application/json": { "schema": {} } }
-          }
-        }
-      }
-    },
-    "/api/copilot-webhooks/slack/events": {
-      "post": {
-        "summary": " Handle Event Request",
-        "operationId": "_handle_event_request",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": { "application/json": { "schema": {} } }
-          }
-        }
-      }
-    },
     "/api/copilot/admin/rate_limit": {
       "get": {
         "tags": ["v2", "admin", "copilot", "admin"],

--- a/autogpt_platform/frontend/src/app/api/openapi.json
+++ b/autogpt_platform/frontend/src/app/api/openapi.json
@@ -4080,6 +4080,30 @@
         "security": [{ "HTTPBearerJWT": [] }]
       }
     },
+    "/api/copilot-webhooks/slack/commands": {
+      "post": {
+        "summary": " Handle Command Request",
+        "operationId": "_handle_command_request",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          }
+        }
+      }
+    },
+    "/api/copilot-webhooks/slack/events": {
+      "post": {
+        "summary": " Handle Event Request",
+        "operationId": "_handle_event_request",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          }
+        }
+      }
+    },
     "/api/copilot/admin/rate_limit": {
       "get": {
         "tags": ["v2", "admin", "copilot", "admin"],
@@ -14375,11 +14399,12 @@
       },
       "BotCommandUsage": {
         "properties": {
+          "platform": { "type": "string", "title": "Platform" },
           "command": { "type": "string", "title": "Command" },
           "uses": { "type": "integer", "title": "Uses" }
         },
         "type": "object",
-        "required": ["command", "uses"],
+        "required": ["platform", "command", "uses"],
         "title": "BotCommandUsage"
       },
       "BotGuildInfo": {
@@ -14443,6 +14468,7 @@
       },
       "BotServerActivity": {
         "properties": {
+          "platform": { "type": "string", "title": "Platform" },
           "server_id": { "type": "string", "title": "Server Id" },
           "name": {
             "anyOf": [{ "type": "string" }, { "type": "null" }],
@@ -14452,7 +14478,7 @@
           "commands": { "type": "integer", "title": "Commands" }
         },
         "type": "object",
-        "required": ["server_id", "name", "messages", "commands"],
+        "required": ["platform", "server_id", "name", "messages", "commands"],
         "title": "BotServerActivity"
       },
       "BotServerCountPoint": {


### PR DESCRIPTION
### Why / What / How

**Why:** The Slack copilot-bot adapter (#13508) is functional, but the two user/admin-facing surfaces still only knew about Discord. The Bots settings page didn't list Slack, and the admin bot-analytics dashboard couldn't filter by Slack — and on its "All platforms" view, Discord and Slack rows were interleaved with no way to tell them apart.

**What:** Surfaces Slack across both pages:
- `platform.agpt.co/settings/bots` — Slack now appears as a bot card (data-driven from the platform registry).
- `platform.agpt.co/admin/bots` — Slack is selectable in the platform filter, and every analytics row is labelled with its platform.

**How:**
- `platform_linking/registry.py` gains `_slack_meta()` — Slack is enabled once its bot token + signing secret are set, with `add_bot_url=None` (self-hosted Slack apps have no one-click invite; they install via manifest + `/setup`). The settings page is already fully data-driven off `enabled_platforms()`, so the card renders automatically.
- Admin filter: `SLACK` added to `PLATFORM_OPTIONS`.
- Analytics rows: `get_bot_top_servers` and `get_bot_command_usage` now carry `platform` (SELECT + GROUP BY), so `BotServerActivity` / `BotCommandUsage` expose it alongside the existing `BotGuildInfo.platform`. A new `PlatformBadge` (icon + name) leads the top-servers, command-usage and server-roster tables — shown only on the "All platforms" view, where rows are actually mixed.

Stacked on #13508 (imports `slack_config`); retarget to `dev` once that merges.

### Changes 🏗️

- **backend** `registry.py`: `_slack_meta()` + Slack in `enabled_platforms()`; `registry_test.py` isolates both platforms.
- **backend** `bot_analytics_reads.py`: `platform` field on `BotServerActivity` / `BotCommandUsage`, threaded through both queries.
- **frontend** `settings/bots`: Slack card renders with no "Add bot" button (no invite URL); test added.
- **frontend** `admin/bots`: `SLACK` filter option; `PlatformBadge` component; Platform column on all three tables (All-platforms view only); test proving Discord/Slack rows are disambiguated.
- Regenerated `openapi.json` for the new `platform` fields + Slack webhook routes.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Backend: `bot_analytics_routes_test.py` (5) + `registry_test.py` (6) pass
  - [x] Frontend: `admin/bots` (3) + `settings/bots` (11) integration tests pass; `tsc` + `eslint` clean
  - [x] Live local run: settings page shows the Slack card; admin "All platforms" shows Discord + Slack rows each badged with their icon; single-platform filter drops the redundant column
