### PR TITLE
fix(frontend): don't bounce /reset-password to /onboarding for un-onboarded accounts

### DIFF
--- a/autogpt_platform/frontend/src/providers/onboarding/__tests__/onboarding-provider-routing.test.tsx
+++ b/autogpt_platform/frontend/src/providers/onboarding/__tests__/onboarding-provider-routing.test.tsx
@@ -140,6 +140,24 @@ describe("OnboardingProvider routing — logged-in user", () => {
     );
   });
 
+  test("incomplete user on /reset-password stays put (recovery session must set password first)", async () => {
+    // A Supabase recovery link signs the user in and lands them on
+    // /reset-password. Bouncing them to /onboarding would skip the password
+    // change entirely, turning the reset link into a one-time sign-in link.
+    mockPathname = "/reset-password";
+    mockIsCompleted = false;
+
+    render(
+      <OnboardingProvider>
+        <div data-testid="child" />
+      </OnboardingProvider>,
+    );
+
+    await new Promise((r) => setTimeout(r, 30));
+    expect(routerReplace).not.toHaveBeenCalled();
+    expect(completedCallCount.value).toBe(0);
+  });
+
   test("incomplete user already on /onboarding stays put", async () => {
     mockPathname = "/onboarding";
     mockIsCompleted = false;

--- a/autogpt_platform/frontend/src/providers/onboarding/onboarding-provider.tsx
+++ b/autogpt_platform/frontend/src/providers/onboarding/onboarding-provider.tsx
@@ -119,6 +119,11 @@ export default function OnboardingProvider({
   // trigger onboarding init/redirects (which would bounce a logged-in user with
   // incomplete onboarding out of the tour).
   const isOnPublicTour = pathname.startsWith("/tour");
+  // A Supabase recovery link signs the user in and lands them on
+  // /reset-password. They must stay there until the new password is set;
+  // bouncing an un-onboarded account to /onboarding would skip the password
+  // change and turn the reset link into a one-time sign-in link.
+  const isOnPasswordResetRoute = pathname.startsWith("/reset-password");
   // Logged-in users sitting on the auth pages need to be routed onward by us;
   // otherwise the signup/login pages show their `isLoggedIn` loader forever.
   // Handling them here (instead of in useSignupPage/useLoginPage) avoids the
@@ -154,8 +159,14 @@ export default function OnboardingProvider({
   }, [isLoggedIn, isOnAuthRoute]);
 
   useEffect(() => {
-    // Prevent multiple initializations
-    if (hasInitialized.current || !isLoggedIn || isOnPublicTour) {
+    // Prevent multiple initializations. Skipped routes don't mark
+    // hasInitialized, so init re-runs on the next pathname change.
+    if (
+      hasInitialized.current ||
+      !isLoggedIn ||
+      isOnPublicTour ||
+      isOnPasswordResetRoute
+    ) {
       return;
     }
 
@@ -221,6 +232,7 @@ export default function OnboardingProvider({
     isLoggedIn,
     pathname,
     isOnPublicTour,
+    isOnPasswordResetRoute,
   ]);
 
   const handleOnboardingNotification = useCallback(


### PR DESCRIPTION
### Why / What / How

**Why:** Clicking a password-reset email link on an account that hasn't completed onboarding redirects the user from `/reset-password` to `/onboarding` before they can set a new password. A Supabase recovery link signs the user in (that's how the recovery flow works), so `OnboardingProvider` sees a logged-in user with incomplete onboarding and yanks them into the onboarding wizard via `decideOnboardingRedirect` (`!isCompleted && !isOnOnboardingRoute → "/onboarding"`). The user completes onboarding and ends up logged in with their old password intact — the reset link effectively acts as a one-time sign-in link, and the password never gets reset.

**What:** Exempt `/reset-password` from onboarding initialization/redirects in `OnboardingProvider`, mirroring the existing `/tour` carve-out.

**How:** Add an `isOnPasswordResetRoute` check to the init-effect guard. Because the guard returns without setting `hasInitialized`, onboarding init still runs on the next pathname change — so after the user sets their password and navigates onward, an un-onboarded account is still routed to `/onboarding` as intended. Skipping the whole init (rather than adding a flag to `decideOnboardingRedirect`) also suppresses the secondary `shouldRedirectFromOnboarding` path and the onboarding-state fetch on that page.

### Changes 🏗️

- `OnboardingProvider`: skip onboarding init/redirects while on `/reset-password` (new `isOnPasswordResetRoute` guard, analogous to the `/tour` exemption)
- Regression test in `onboarding-provider-routing.test.tsx`: a logged-in user with incomplete onboarding on `/reset-password` is not redirected and the onboarding-completion API is not called

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] TDD: added the regression test first and confirmed it fails on `dev` behavior (provider redirects `/reset-password` → `/onboarding`)
  - [x] Confirmed the new test passes with the fix
  - [x] Ran the full onboarding provider suite (`pnpm test:unit src/providers/onboarding/` — 16/16 pass, includes existing /signup, /login, /onboarding, and deep-link routing cases)
  - [x] `pnpm types` passes
