### PR TITLE
fix(frontend/copilot): Use onboarding "call you" name in copilot greeting

### DIFF
--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/__tests__/page.test.tsx
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/__tests__/page.test.tsx
@@ -5,6 +5,8 @@ import {
   screen,
   waitFor,
 } from "@/tests/integrations/test-utils";
+import { server } from "@/mocks/mock-server";
+import { http, HttpResponse } from "msw";
 import OnboardingPage from "../page";
 import { useOnboardingWizardStore } from "../store";
 
@@ -39,16 +41,27 @@ vi.mock("next/navigation", () => ({
 }));
 
 let mockSupabaseState = { isLoggedIn: true, isUserLoading: false };
-const mockUpdateUser = vi.fn(() => Promise.resolve({ error: null }));
 const mockRefreshSession = vi.fn(() => Promise.resolve({ user: null }));
 vi.mock("@/lib/supabase/hooks/useSupabase", () => ({
   useSupabase: () => ({
     ...mockSupabaseState,
     user: null,
-    supabase: { auth: { updateUser: mockUpdateUser } },
     refreshSession: mockRefreshSession,
   }),
 }));
+
+// The onboarding page writes preferred_name through the server route (the
+// browser Supabase client has no session — persistSession: false — so
+// client-side auth.updateUser silently fails; regression caught in manual QA).
+const authUserPutBodies: unknown[] = [];
+function mockAuthUserRoute() {
+  server.use(
+    http.put("/api/auth/user", async ({ request }) => {
+      authUserPutBodies.push(await request.json());
+      return HttpResponse.json({ user: { id: "u1" } });
+    }),
+  );
+}
 
 vi.mock("@/app/api/__generated__/endpoints/onboarding/onboarding", () => ({
   getV1OnboardingState: () =>
@@ -96,7 +109,8 @@ beforeEach(() => {
   mockFlagValue = false;
   mockSubscriptionTier = "NO_TIER";
   mockSupabaseState = { isLoggedIn: true, isUserLoading: false };
-  mockUpdateUser.mockClear();
+  authUserPutBodies.length = 0;
+  mockAuthUserRoute();
   mockRefreshSession.mockClear();
   routerReplace.mockClear();
   useOnboardingWizardStore.getState().reset();
@@ -289,9 +303,7 @@ describe("OnboardingPage — flag-gated SubscriptionStep", () => {
     render(<OnboardingPage />);
     expect(await screen.findByTestId("step-preparing")).toBeDefined();
     await waitFor(() => {
-      expect(mockUpdateUser).toHaveBeenCalledWith({
-        data: { preferred_name: "Reinier" },
-      });
+      expect(authUserPutBodies).toEqual([{ preferred_name: "Reinier" }]);
     });
     await waitFor(() => {
       expect(mockRefreshSession).toHaveBeenCalled();
@@ -304,7 +316,7 @@ describe("OnboardingPage — flag-gated SubscriptionStep", () => {
     currentSearchParams = new URLSearchParams("step=4");
     render(<OnboardingPage />);
     expect(await screen.findByTestId("step-preparing")).toBeDefined();
-    expect(mockUpdateUser).not.toHaveBeenCalled();
+    expect(authUserPutBodies).toEqual([]);
   });
 
   it("preserves form data on mount (zustand persist; no reset-on-init)", async () => {

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/__tests__/page.test.tsx
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/__tests__/page.test.tsx
@@ -1,5 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { cleanup, render, screen } from "@/tests/integrations/test-utils";
+import {
+  cleanup,
+  render,
+  screen,
+  waitFor,
+} from "@/tests/integrations/test-utils";
 import OnboardingPage from "../page";
 import { useOnboardingWizardStore } from "../store";
 
@@ -34,8 +39,15 @@ vi.mock("next/navigation", () => ({
 }));
 
 let mockSupabaseState = { isLoggedIn: true, isUserLoading: false };
+const mockUpdateUser = vi.fn(() => Promise.resolve({ error: null }));
+const mockRefreshSession = vi.fn(() => Promise.resolve({ user: null }));
 vi.mock("@/lib/supabase/hooks/useSupabase", () => ({
-  useSupabase: () => ({ ...mockSupabaseState, user: null }),
+  useSupabase: () => ({
+    ...mockSupabaseState,
+    user: null,
+    supabase: { auth: { updateUser: mockUpdateUser } },
+    refreshSession: mockRefreshSession,
+  }),
 }));
 
 vi.mock("@/app/api/__generated__/endpoints/onboarding/onboarding", () => ({
@@ -84,6 +96,8 @@ beforeEach(() => {
   mockFlagValue = false;
   mockSubscriptionTier = "NO_TIER";
   mockSupabaseState = { isLoggedIn: true, isUserLoading: false };
+  mockUpdateUser.mockClear();
+  mockRefreshSession.mockClear();
   routerReplace.mockClear();
   useOnboardingWizardStore.getState().reset();
   window.sessionStorage.removeItem(STEP_STORAGE_KEY);
@@ -258,6 +272,39 @@ describe("OnboardingPage — flag-gated SubscriptionStep", () => {
     // After init defers (auth not ready), currentStep stays at the
     // store default of 1 — no premature jump to 5.
     expect(useOnboardingWizardStore.getState().currentStep).toBe(1);
+  });
+
+  it("saves the onboarding name to auth metadata on Preparing-step submit", async () => {
+    // Regression for OPEN-3200: the "what should I call you?" answer was
+    // only sent to the business-understanding store, so the copilot
+    // greeting (which reads auth user_metadata) never used it.
+    mockFlagValue = false;
+    window.sessionStorage.setItem(STEP_STORAGE_KEY, "4");
+    useOnboardingWizardStore.setState({
+      name: "Reinier",
+      role: "Engineering",
+      painPoints: [],
+    });
+    currentSearchParams = new URLSearchParams("step=4");
+    render(<OnboardingPage />);
+    expect(await screen.findByTestId("step-preparing")).toBeDefined();
+    await waitFor(() => {
+      expect(mockUpdateUser).toHaveBeenCalledWith({
+        data: { preferred_name: "Reinier" },
+      });
+    });
+    await waitFor(() => {
+      expect(mockRefreshSession).toHaveBeenCalled();
+    });
+  });
+
+  it("does not touch auth metadata when the wizard has no name", async () => {
+    mockFlagValue = false;
+    window.sessionStorage.setItem(STEP_STORAGE_KEY, "4");
+    currentSearchParams = new URLSearchParams("step=4");
+    render(<OnboardingPage />);
+    expect(await screen.findByTestId("step-preparing")).toBeDefined();
+    expect(mockUpdateUser).not.toHaveBeenCalled();
   });
 
   it("preserves form data on mount (zustand persist; no reset-on-init)", async () => {

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/__tests__/page.test.tsx
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/__tests__/page.test.tsx
@@ -281,7 +281,7 @@ describe("OnboardingPage — flag-gated SubscriptionStep", () => {
     mockFlagValue = false;
     window.sessionStorage.setItem(STEP_STORAGE_KEY, "4");
     useOnboardingWizardStore.setState({
-      name: "Reinier",
+      name: "  Reinier  ",
       role: "Engineering",
       painPoints: [],
     });

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/useOnboardingPage.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/useOnboardingPage.ts
@@ -200,10 +200,11 @@ export function useOnboardingPage() {
     // the profile is only ever submitted here, once, on reaching Preparing.
     // Guard against an empty name so a stray Preparing visit can't blank a
     // previously-saved profile.
-    if (!name.trim()) return;
+    const trimmedName = name.trim();
+    if (!trimmedName) return;
 
     postV1SubmitOnboardingProfile({
-      user_name: name,
+      user_name: trimmedName,
       user_role: role,
       pain_points: painPoints,
     }).catch(() => {
@@ -214,7 +215,7 @@ export function useOnboardingPage() {
     // greeting (getGreetingName) uses it; refresh the cached session user
     // so the new name shows up right after onboarding without a reload.
     supabase?.auth
-      .updateUser({ data: { preferred_name: name } })
+      .updateUser({ data: { preferred_name: trimmedName } })
       .then(() => refreshSession())
       .catch(() => {
         // Best effort — the greeting falls back to existing metadata

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/useOnboardingPage.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/useOnboardingPage.ts
@@ -54,7 +54,7 @@ function clearHighestStep() {
 export function useOnboardingPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const { isLoggedIn, isUserLoading, supabase, refreshSession } = useSupabase();
+  const { isLoggedIn, isUserLoading, refreshSession } = useSupabase();
   const currentStep = useOnboardingWizardStore((s) => s.currentStep);
   const goToStep = useOnboardingWizardStore((s) => s.goToStep);
 
@@ -214,13 +214,18 @@ export function useOnboardingPage() {
     // Also store the chosen name in auth user_metadata so the copilot
     // greeting (getGreetingName) uses it; refresh the cached session user
     // so the new name shows up right after onboarding without a reload.
-    supabase?.auth
-      .updateUser({ data: { preferred_name: trimmedName } })
-      .then(() => refreshSession())
+    // Goes through the server route because the browser Supabase client has
+    // no session (persistSession: false) and can't call auth.updateUser.
+    fetch("/api/auth/user", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ preferred_name: trimmedName }),
+    })
+      .then((res) => (res.ok ? refreshSession() : undefined))
       .catch(() => {
         // Best effort — the greeting falls back to existing metadata
       });
-  }, [currentStep, preparingStep, supabase, refreshSession]);
+  }, [currentStep, preparingStep, refreshSession]);
 
   async function handlePreparingComplete() {
     for (let attempt = 0; attempt < 3; attempt++) {

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/useOnboardingPage.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/useOnboardingPage.ts
@@ -54,7 +54,7 @@ function clearHighestStep() {
 export function useOnboardingPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const { isLoggedIn, isUserLoading } = useSupabase();
+  const { isLoggedIn, isUserLoading, supabase, refreshSession } = useSupabase();
   const currentStep = useOnboardingWizardStore((s) => s.currentStep);
   const goToStep = useOnboardingWizardStore((s) => s.goToStep);
 
@@ -209,7 +209,17 @@ export function useOnboardingPage() {
     }).catch(() => {
       // Best effort — profile data is non-critical for accessing copilot
     });
-  }, [currentStep, preparingStep]);
+
+    // Also store the chosen name in auth user_metadata so the copilot
+    // greeting (getGreetingName) uses it; refresh the cached session user
+    // so the new name shows up right after onboarding without a reload.
+    supabase?.auth
+      .updateUser({ data: { preferred_name: name } })
+      .then(() => refreshSession())
+      .catch(() => {
+        // Best effort — the greeting falls back to existing metadata
+      });
+  }, [currentStep, preparingStep, supabase, refreshSession]);
 
   async function handlePreparingComplete() {
     for (let attempt = 0; attempt < 3; attempt++) {

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/EmptySession/__tests__/helpers.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/EmptySession/__tests__/helpers.test.ts
@@ -1,0 +1,42 @@
+import type { User } from "@supabase/supabase-js";
+import { describe, expect, it } from "vitest";
+import { getGreetingName } from "../helpers";
+
+function makeUser(metadata: Record<string, unknown>, email?: string): User {
+  return { user_metadata: metadata, email } as unknown as User;
+}
+
+describe("getGreetingName", () => {
+  it("prefers the name chosen during onboarding (preferred_name)", () => {
+    const user = makeUser(
+      { preferred_name: "Reinier", full_name: "R. van der Leer" },
+      "reinier@example.com",
+    );
+    expect(getGreetingName(user)).toBe("Reinier");
+  });
+
+  it("ignores a blank preferred_name", () => {
+    const user = makeUser({ preferred_name: "  ", full_name: "Jane Doe" });
+    expect(getGreetingName(user)).toBe("Jane");
+  });
+
+  it("uses the first name from full_name when no preferred_name is set", () => {
+    const user = makeUser({ full_name: "Jane Doe" });
+    expect(getGreetingName(user)).toBe("Jane");
+  });
+
+  it("falls back to the name metadata field", () => {
+    const user = makeUser({ name: "John Smith" });
+    expect(getGreetingName(user)).toBe("John");
+  });
+
+  it("falls back to the email prefix when metadata has no name", () => {
+    const user = makeUser({}, "jane.doe@example.com");
+    expect(getGreetingName(user)).toBe("jane.doe");
+  });
+
+  it('falls back to "there" without a user', () => {
+    expect(getGreetingName(null)).toBe("there");
+    expect(getGreetingName(undefined)).toBe("there");
+  });
+});

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/EmptySession/components/EditNameDialog/EditNameDialog.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/EmptySession/components/EditNameDialog/EditNameDialog.tsx
@@ -30,10 +30,13 @@ export function EditNameDialog({ currentName }: Props) {
 
     setIsSaving(true);
     try {
+      // preferred_name is the metadata key the greeting prefers — it's also
+      // written by onboarding's "What should I call you?". Writing full_name
+      // here would be shadowed whenever a preferred_name is already set.
       const res = await fetch("/api/auth/user", {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ full_name: trimmed }),
+        body: JSON.stringify({ preferred_name: trimmed }),
       });
 
       if (!res.ok) {

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/EmptySession/components/EditNameDialog/EditNameDialog.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/EmptySession/components/EditNameDialog/EditNameDialog.tsx
@@ -30,9 +30,7 @@ export function EditNameDialog({ currentName }: Props) {
 
     setIsSaving(true);
     try {
-      // preferred_name is the metadata key the greeting prefers — it's also
-      // written by onboarding's "What should I call you?". Writing full_name
-      // here would be shadowed whenever a preferred_name is already set.
+      // preferred_name is also written by onboarding's "What should I call you?"
       const res = await fetch("/api/auth/user", {
         method: "PUT",
         headers: { "Content-Type": "application/json" },

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/EmptySession/components/EditNameDialog/__tests__/EditNameDialog.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/EmptySession/components/EditNameDialog/__tests__/EditNameDialog.test.tsx
@@ -69,9 +69,7 @@ describe("EditNameDialog", () => {
   });
 
   test("saves the name as preferred_name via API route and closes dialog", async () => {
-    // preferred_name is the key the copilot greeting prefers (also written
-    // by onboarding); writing full_name here would be shadowed by any
-    // previously-set preferred_name and the edit would appear to not work.
+    // preferred_name is also written by onboarding's "What should I call you?"
     let requestBody: unknown;
     mockUpdateNameSuccess((body) => {
       requestBody = body;

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/EmptySession/components/EditNameDialog/__tests__/EditNameDialog.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/EmptySession/components/EditNameDialog/__tests__/EditNameDialog.test.tsx
@@ -22,9 +22,10 @@ vi.mock("@/lib/supabase/hooks/useSupabase", () => ({
   }),
 }));
 
-function mockUpdateNameSuccess() {
+function mockUpdateNameSuccess(onBody?: (body: unknown) => void) {
   server.use(
-    http.put("/api/auth/user", () => {
+    http.put("/api/auth/user", async ({ request }) => {
+      onBody?.(await request.json());
       return HttpResponse.json({ user: { id: "u1" } });
     }),
   );
@@ -67,8 +68,14 @@ describe("EditNameDialog", () => {
     expect(input.value).toBe("Alice");
   });
 
-  test("saves name via API route and closes dialog", async () => {
-    mockUpdateNameSuccess();
+  test("saves the name as preferred_name via API route and closes dialog", async () => {
+    // preferred_name is the key the copilot greeting prefers (also written
+    // by onboarding); writing full_name here would be shadowed by any
+    // previously-set preferred_name and the edit would appear to not work.
+    let requestBody: unknown;
+    mockUpdateNameSuccess((body) => {
+      requestBody = body;
+    });
     render(<EditNameDialog currentName="Alice" />);
 
     const input = await openDialogAndGetInput();
@@ -78,6 +85,7 @@ describe("EditNameDialog", () => {
     await waitFor(() => {
       expect(mockRefreshSession).toHaveBeenCalled();
     });
+    expect(requestBody).toEqual({ preferred_name: "Bob" });
     expect(mockToast).toHaveBeenCalledWith({ title: "Name updated" });
   });
 

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/EmptySession/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/EmptySession/helpers.ts
@@ -98,8 +98,14 @@ export function getSuggestionThemes(
 export function getGreetingName(user?: User | null) {
   if (!user) return "there";
   const metadata = user.user_metadata as Record<string, unknown> | undefined;
+  // preferred_name is what the user answered to onboarding's "What should I
+  // call you?" — it wins over provider-supplied names, and is used verbatim.
+  const preferredName = metadata?.preferred_name;
   const fullName = metadata?.full_name;
   const name = metadata?.name;
+  if (typeof preferredName === "string" && preferredName.trim()) {
+    return preferredName.trim();
+  }
   if (typeof fullName === "string" && fullName.trim()) {
     return fullName.split(" ")[0];
   }

--- a/autogpt_platform/frontend/src/app/api/auth/user/__tests__/route.test.ts
+++ b/autogpt_platform/frontend/src/app/api/auth/user/__tests__/route.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockUpdateUser = vi.hoisted(() =>
+  vi.fn(() => Promise.resolve({ data: { user: { id: "u1" } }, error: null })),
+);
+
+vi.mock("@/lib/supabase/server/getServerSupabase", () => ({
+  getServerSupabase: () =>
+    Promise.resolve({ auth: { updateUser: mockUpdateUser } }),
+}));
+
+import { PUT } from "../route";
+
+function makeRequest(body: unknown) {
+  return new Request("http://localhost/api/auth/user", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("PUT /api/auth/user", () => {
+  beforeEach(() => {
+    mockUpdateUser.mockClear();
+  });
+
+  it("updates preferred_name metadata", async () => {
+    const res = await PUT(makeRequest({ preferred_name: " Rein " }));
+    expect(res.status).toBe(200);
+    expect(mockUpdateUser).toHaveBeenCalledWith({
+      data: { preferred_name: "Rein" },
+    });
+  });
+
+  it("still updates full_name metadata", async () => {
+    const res = await PUT(makeRequest({ full_name: "Jane Doe" }));
+    expect(res.status).toBe(200);
+    expect(mockUpdateUser).toHaveBeenCalledWith({
+      data: { full_name: "Jane Doe" },
+    });
+  });
+
+  it("still updates email", async () => {
+    const res = await PUT(makeRequest({ email: "new@example.com" }));
+    expect(res.status).toBe(200);
+    expect(mockUpdateUser).toHaveBeenCalledWith({ email: "new@example.com" });
+  });
+
+  it("rejects a body without any supported field", async () => {
+    const res = await PUT(makeRequest({ something: "else" }));
+    expect(res.status).toBe(400);
+    expect(mockUpdateUser).not.toHaveBeenCalled();
+  });
+});

--- a/autogpt_platform/frontend/src/app/api/auth/user/route.ts
+++ b/autogpt_platform/frontend/src/app/api/auth/user/route.ts
@@ -23,25 +23,39 @@ export async function PUT(request: Request) {
       return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
     }
 
-    const { email: rawEmail, full_name: rawFullName } = body as {
+    const {
+      email: rawEmail,
+      full_name: rawFullName,
+      preferred_name: rawPreferredName,
+    } = body as {
       email?: unknown;
       full_name?: unknown;
+      preferred_name?: unknown;
     };
 
     const email = typeof rawEmail === "string" ? rawEmail.trim() : undefined;
     const fullName =
       typeof rawFullName === "string" ? rawFullName.trim() : undefined;
+    const preferredName =
+      typeof rawPreferredName === "string"
+        ? rawPreferredName.trim()
+        : undefined;
 
-    if (!email && !fullName) {
+    if (!email && !fullName && !preferredName) {
       return NextResponse.json(
-        { error: "Email or full_name is required" },
+        { error: "Email, full_name or preferred_name is required" },
         { status: 400 },
       );
     }
 
     const updatePayload: Parameters<typeof supabase.auth.updateUser>[0] = {};
     if (email) updatePayload.email = email;
-    if (fullName) updatePayload.data = { full_name: fullName };
+    if (fullName || preferredName) {
+      updatePayload.data = {
+        ...(fullName && { full_name: fullName }),
+        ...(preferredName && { preferred_name: preferredName }),
+      };
+    }
 
     const { data, error } = await supabase.auth.updateUser(updatePayload);
 


### PR DESCRIPTION
### Why / What / How

**Why:** During onboarding, the first question asks "What should I call you?" — but the answer was only sent to the copilot business-understanding store (`CoPilotUnderstanding`). The AutoPilot home screen greeting reads the auth user's `user_metadata` (`full_name`/`name`, falling back to the email prefix), so the name the user explicitly chose was never actually used. Reported in #breakage during v0.6.66 QA.

**What:** The chosen name now lands in auth `user_metadata` as `preferred_name`, the copilot greeting prefers it over provider-supplied names, and the greeting's edit-name dialog is unified on the same key.

**How:**
- On the Preparing-step profile submit in `useOnboardingPage` (the single place the profile is posted), we additionally store the trimmed name via `PUT /api/auth/user { preferred_name }` (best-effort, like the profile POST) and then refresh the cached session user so the greeting is correct immediately after onboarding without a reload. The write goes through the server route because the browser Supabase client is created with `persistSession: false` — it holds no session, so client-side `auth.updateUser()` fails silently (caught in manual QA).
- `getGreetingName` checks `preferred_name` first and uses it verbatim — unlike `full_name`/`name` it isn't split on spaces, since it's literally what the user asked to be called.
- `EditNameDialog` (the pencil next to the greeting) previously wrote `full_name`; with `preferred_name` outranking it, an edit made there would have been shadowed by a stale onboarding name and appear to do nothing. It now writes `preferred_name` via the same route.
- `PUT /api/auth/user` accepts the new `preferred_name` field (`full_name` and `email` update paths unchanged — `email` is what the settings pages use).

### Changes 🏗️

- Resolves #13517 (OPEN-3200)
- `onboarding/useOnboardingPage.ts`: store the onboarding name as `user_metadata.preferred_name` via `PUT /api/auth/user` + refresh the session user on Preparing-step submit
- `copilot/components/EmptySession/helpers.ts`: `getGreetingName` prefers `preferred_name` over `full_name`/`name`/email prefix
- `copilot/.../EditNameDialog.tsx`: write `preferred_name` instead of `full_name` so manual edits and the onboarding answer converge on one key
- `app/api/auth/user/route.ts`: `PUT` accepts `preferred_name` (existing `email`/`full_name` handling unchanged)
- Tests: new `EmptySession/__tests__/helpers.test.ts` (greeting preference order) and `app/api/auth/user/__tests__/route.test.ts` (route field handling); extended `onboarding/__tests__/page.test.tsx` (asserts the actual HTTP request via MSW — a client-level mock originally hid the `persistSession: false` failure) and `EditNameDialog.test.tsx` (asserts the request body)

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] TDD: new tests fail on `dev`'s behavior, pass with this change
  - [x] `pnpm test:unit` — full suite green
  - [x] `pnpm format`, `pnpm lint`, `pnpm types` — clean
  - [x] Manual E2E (Reinier): complete onboarding with a fresh account and confirm the greeting uses the entered name