### PR TITLE
fix(infra): harden batch-bot merge gate + migrate to a GitHub App identity (follow-up to #13465)

### DIFF
--- a/.github/batch-bot/README.md
+++ b/.github/batch-bot/README.md
@@ -81,7 +81,8 @@ suggestions:
    Postgres schema `pr_<n>`, and URLs — non-prod and per-PR isolated. Confirm those
    previews use non-prod secrets (they do by design). Nuance: isolation is
    schema-level within a shared preview Postgres cluster, not separate DB servers —
-   fine for non-prod previews. Optionally set `BATCH_REQUIRE_APPROVAL=1` to require
+   fine for non-prod previews. Optionally set the repository variable
+   `BATCH_REQUIRE_APPROVAL=1` (wired into `batch-command-handler.yml`) to require
    an approval before a PR can be added to the batch.
 4. **Pinned actions.** All actions are pinned to commit SHAs (`slash-command-dispatch`,
    `checkout`, `setup-node`); keep them pinned when bumping.

--- a/.github/batch-bot/README.md
+++ b/.github/batch-bot/README.md
@@ -113,9 +113,9 @@ permissions:
 
 Store the App's **App ID** as the repo variable `BATCH_BOT_APP_ID` and its **private
 key** (`.pem` contents) as the secret `BATCH_BOT_PRIVATE_KEY`, then **install the App
-on this repo**. Do **not** grant admin or a review-bypass — that would turn the token
-into a review-bypass primitive. (A fine-grained, single-repo PAT with an expiry,
-stored as `BATCH_BOT_TOKEN` and added as a write collaborator, works as a fallback.)
+on this repo**. All three workflows (listener, handler, reconcile) mint their token
+from these — there is no PAT fallback. Do **not** grant admin or a review-bypass —
+that would turn the token into a review-bypass primitive.
 
 Optional repo **variables**: `BATCH_BASE_BRANCH` (default `dev`), `BATCH_BOT_NAME`,
 `BATCH_BOT_EMAIL`.

--- a/.github/batch-bot/README.md
+++ b/.github/batch-bot/README.md
@@ -92,16 +92,16 @@ suggestions:
 
 ## Setup
 
-### 1. Bot token — `BATCH_BOT_TOKEN` (repo secret)
+### 1. Bot identity — GitHub App (`BATCH_BOT_APP_ID` variable + `BATCH_BOT_PRIVATE_KEY` secret)
 
-Needed (not just `GITHUB_TOKEN`) because a `repository_dispatch` made with
-`GITHUB_TOKEN` won't trigger the handler, and pushes by `GITHUB_TOKEN` won't
-trigger the preview-deploy — and the payoff is the rollup push kicking off one
-preview.
+Both workflows mint a short-lived installation token per run via
+`actions/create-github-app-token`. A real identity (not `GITHUB_TOKEN`) is required
+because a `repository_dispatch` made with `GITHUB_TOKEN` won't trigger the handler,
+and pushes by `GITHUB_TOKEN` won't trigger the preview-deploy — the payoff is the
+rollup push kicking off one preview.
 
-**Prefer a GitHub App installation token** (short-lived, auto-rotating,
-repo-scoped) over a PAT. If you must use a PAT, make it **fine-grained,
-single-repo, with an expiry** — never a classic PAT. Either way grant only:
+Create a **GitHub App** (org-owned preferred) and grant only these **repository**
+permissions:
 
 | Permission | Level | Why |
 |---|---|---|
@@ -111,8 +111,11 @@ single-repo, with an expiry** — never a classic PAT. Either way grant only:
 | Actions | Read | read member CI status before batch/merge |
 | Metadata | Read | required baseline |
 
-Add the identity as a **write collaborator**. Do **not** grant admin or a
-review-bypass — that would turn the token into a review-bypass primitive.
+Store the App's **App ID** as the repo variable `BATCH_BOT_APP_ID` and its **private
+key** (`.pem` contents) as the secret `BATCH_BOT_PRIVATE_KEY`, then **install the App
+on this repo**. Do **not** grant admin or a review-bypass — that would turn the token
+into a review-bypass primitive. (A fine-grained, single-repo PAT with an expiry,
+stored as `BATCH_BOT_TOKEN` and added as a write collaborator, works as a fallback.)
 
 Optional repo **variables**: `BATCH_BASE_BRANCH` (default `dev`), `BATCH_BOT_NAME`,
 `BATCH_BOT_EMAIL`.
@@ -123,9 +126,10 @@ No new preview infra needed — the bot reuses the repo's existing per-PR previe
 system by posting `!deploy` on the rollup PR (handled by
 `platform-dev-deploy-event-dispatcher.yml` → `AutoGPT_cloud_infrastructure`'s
 `autogpt-platform-preview-env-cd.yml`). Two prerequisites: that per-PR preview
-system is enabled, and the bot identity is a **write collaborator** so the deploy
-dispatcher honors its `!deploy`/`!undeploy` comments (the dispatcher gates on the
-commenter's `author_association`).
+system is enabled, and the App bot's `!deploy`/`!undeploy` comments clear the deploy
+dispatcher's gate on the commenter's `author_association` — verify this end-to-end,
+since an App bot comment can read as `NONE`; if it doesn't qualify, add the bot to
+the dispatcher's allowlist (or keep the write-collaborator PAT fallback for deploys).
 
 ## Opt-out
 

--- a/.github/batch-bot/batch.mjs
+++ b/.github/batch-bot/batch.mjs
@@ -281,6 +281,9 @@ function checkBlockers(p) {
     }
   }
   if (rows === null) return [`#${p.number} check status could not be determined`];
+  // Zero reported checks can't be confirmed green — block (fail closed) rather
+  // than let a PR with no CI slip through the gate on an empty array.
+  if (rows.length === 0) return [`#${p.number} has no reported checks — cannot confirm green`];
   const bad = rows.filter((c) => c.bucket !== "pass" && c.bucket !== "skipping");
   if (!bad.length) return [];
   const buckets = [...new Set(bad.map((c) => c.bucket))].sort().join(", ");

--- a/.github/batch-bot/batch.mjs
+++ b/.github/batch-bot/batch.mjs
@@ -42,7 +42,7 @@ const prNumber = process.env.PR_NUMBER ? Number(process.env.PR_NUMBER) : null;
 const arg1 = (process.env.ARG1 || "").trim();
 const rollupUrl = process.env.ROLLUP_URL || "";
 const rollupPr = process.env.ROLLUP_PR ? Number(process.env.ROLLUP_PR) : null;
-const SAFE_REF = /^[\w./-]+$/; // git ref chars we allow through, defense-in-depth
+const SAFE_REF = /^[\w./][\w./-]*$/; // allowed git ref chars, no leading dash (arg-injection guard)
 
 function req(name) {
   const v = process.env[name];
@@ -142,7 +142,9 @@ function buildRollup(list) {
   // settings so only the bot can push to it (see README).
   const sha = git(["rev-parse", "HEAD"]);
   const ref = `refs/heads/${ROLLUP}`;
-  const exists = tryGh(["api", `repos/${REPO}/git/${ref}`]).ok;
+  // Exact-match existence check via the singular `git/ref/…`; the plural
+  // `git/refs/…` prefix-matches and can false-positive on a sibling branch.
+  const exists = tryGh(["api", `repos/${REPO}/git/ref/heads/${ROLLUP}`]).ok;
   if (exists) {
     gh(["api", "-X", "PATCH", `repos/${REPO}/git/${ref}`, "-f", `sha=${sha}`, "-F", "force=true"]);
   } else {
@@ -259,6 +261,32 @@ function cmdBatchRemove() {
   rebuildAndReport(`Removed #${prNumber} from the batch.`);
 }
 
+// Returns merge-blocker strings for a member's CI. `gh pr checks --json` exits
+// non-zero when checks are failing (1) or still pending (8) but STILL prints the
+// JSON to stdout, so we must read the output regardless of exit code — gating on
+// the exit code alone silently skips CI for that member. Only `pass`/`skipping`
+// count as green; fail, cancel, pending, or an unreadable/empty response all
+// block. Fail closed: a member must be provably green to land.
+function checkBlockers(p) {
+  const raw = tryGh(["pr", "checks", String(p.number), "--repo", REPO, "--json", "bucket"]).out || "";
+  // tryGh folds stderr into `out` on non-zero exit, so extract just the array.
+  const start = raw.indexOf("[");
+  const end = raw.lastIndexOf("]");
+  let rows = null;
+  if (start !== -1 && end > start) {
+    try {
+      rows = JSON.parse(raw.slice(start, end + 1));
+    } catch {
+      rows = null;
+    }
+  }
+  if (rows === null) return [`#${p.number} check status could not be determined`];
+  const bad = rows.filter((c) => c.bucket !== "pass" && c.bucket !== "skipping");
+  if (!bad.length) return [];
+  const buckets = [...new Set(bad.map((c) => c.bucket))].sort().join(", ");
+  return [`#${p.number} not green (${buckets})`];
+}
+
 function cmdBatchMerge() {
   const list = members();
   if (list.length === 0) {
@@ -271,15 +299,21 @@ function cmdBatchMerge() {
   for (const p of list) {
     if (p.reviewDecision !== "APPROVED")
       blockers.push(`#${p.number} not approved (${p.reviewDecision || "no reviews"})`);
-    const checks = tryGh(["pr", "checks", String(p.number), "--repo", REPO, "--json", "bucket"]);
-    if (checks.ok) {
-      const bad = JSON.parse(checks.out).filter((c) => c.bucket === "fail" || c.bucket === "cancel");
-      if (bad.length) blockers.push(`#${p.number} has failing checks`);
-    }
+    blockers.push(...checkBlockers(p));
   }
   const { merged, ejected } = buildRollup(list);
   const pr = upsertRollupPR(merged, ejected);
-  if (!pr) throw new Error("rollup PR missing after build");
+  if (!pr) {
+    // Every member was ejected during assembly (conflict / fork / unsafe ref), so
+    // upsertRollupPR closed the rollup PR. Report cleanly instead of throwing.
+    if (prNumber)
+      comment(prNumber, `${MARKER}\n🤖 Every batched PR was ejected during assembly — nothing left to merge.`);
+    return;
+  }
+  // Refresh the combined preview so a maintainer approves what will actually land.
+  // buildRollup only updates the branch ref; the preview redeploys on an explicit
+  // `!deploy`, and enabling auto-merge below never triggers one on its own.
+  deployRollup(pr);
   if (blockers.length) {
     comment(prNumber || pr.number, `${MARKER}\n🤖 Not merging — resolve first:\n- ${blockers.join("\n- ")}`);
     return;

--- a/.github/batch-bot/batch.mjs
+++ b/.github/batch-bot/batch.mjs
@@ -293,14 +293,6 @@ function cmdBatchMerge() {
     if (prNumber) comment(prNumber, `${MARKER}\n🤖 The batch is empty — nothing to merge.`);
     return;
   }
-  // Every member must be explicitly approved and green. `reviewDecision` must be
-  // exactly APPROVED — null / REVIEW_REQUIRED / CHANGES_REQUESTED all block.
-  const blockers = [];
-  for (const p of list) {
-    if (p.reviewDecision !== "APPROVED")
-      blockers.push(`#${p.number} not approved (${p.reviewDecision || "no reviews"})`);
-    blockers.push(...checkBlockers(p));
-  }
   const { merged, ejected } = buildRollup(list);
   const pr = upsertRollupPR(merged, ejected);
   if (!pr) {
@@ -314,6 +306,17 @@ function cmdBatchMerge() {
   // buildRollup only updates the branch ref; the preview redeploys on an explicit
   // `!deploy`, and enabling auto-merge below never triggers one on its own.
   deployRollup(pr);
+  // Gate on the PRs that actually made it into the rollup — assembly may have
+  // ejected members, and an ejected PR's CI must not block a rollup it's no longer
+  // part of. Each remaining member must be explicitly approved and green:
+  // `reviewDecision` must be exactly APPROVED (null / REVIEW_REQUIRED /
+  // CHANGES_REQUESTED all block).
+  const blockers = [];
+  for (const p of merged) {
+    if (p.reviewDecision !== "APPROVED")
+      blockers.push(`#${p.number} not approved (${p.reviewDecision || "no reviews"})`);
+    blockers.push(...checkBlockers(p));
+  }
   if (blockers.length) {
     comment(prNumber || pr.number, `${MARKER}\n🤖 Not merging — resolve first:\n- ${blockers.join("\n- ")}`);
     return;

--- a/.github/workflows/batch-command-handler.yml
+++ b/.github/workflows/batch-command-handler.yml
@@ -24,6 +24,9 @@ concurrency:
 jobs:
   handle:
     runs-on: ubuntu-latest
+    # Cap the run so a stuck git/gh call can't hold the serialized `batch-bot`
+    # concurrency group (and every queued /batch* command) for the default 6h.
+    timeout-minutes: 15
     env:
       GH_TOKEN: ${{ secrets.BATCH_BOT_TOKEN }}
       REPO: ${{ github.repository }}
@@ -31,6 +34,9 @@ jobs:
       COMMAND: ${{ github.event.action }}
       PR_NUMBER: ${{ github.event.client_payload.slash_command.args.named.pr }}
       ARG1: ${{ github.event.client_payload.slash_command.args.unnamed.arg1 }}
+      # Set repo variable BATCH_REQUIRE_APPROVAL=1 to gate `/batch` on an approval
+      # (it deploys pre-code-review); batch.mjs reads it, so it must be exported here.
+      BATCH_REQUIRE_APPROVAL: ${{ vars.BATCH_REQUIRE_APPROVAL }}
       BOT_NAME: ${{ vars.BATCH_BOT_NAME || 'autogpt-batch-bot' }}
       BOT_EMAIL: ${{ vars.BATCH_BOT_EMAIL || 'autogpt-batch-bot@users.noreply.github.com' }}
     steps:

--- a/.github/workflows/batch-command-handler.yml
+++ b/.github/workflows/batch-command-handler.yml
@@ -5,7 +5,8 @@ name: batch-command-handler
 # `git` + `gh` via array-arg execFileSync — no shell). repository_dispatch always
 # checks out the DEFAULT branch, so this workflow never runs PR-controlled code;
 # member branches are only ever `git merge`d (data), never executed here.
-# Runs under BATCH_BOT_TOKEN so the rollup-branch push triggers the preview deploy
+# Runs under a GitHub App installation token (minted per-run from BATCH_BOT_APP_ID
+# + BATCH_BOT_PRIVATE_KEY) so the rollup-branch push triggers the preview deploy
 # (GITHUB_TOKEN pushes do not trigger other workflows).
 on:
   repository_dispatch:
@@ -28,7 +29,6 @@ jobs:
     # concurrency group (and every queued /batch* command) for the default 6h.
     timeout-minutes: 15
     env:
-      GH_TOKEN: ${{ secrets.BATCH_BOT_TOKEN }}
       REPO: ${{ github.repository }}
       BASE: ${{ vars.BATCH_BASE_BRANCH || 'dev' }}
       COMMAND: ${{ github.event.action }}
@@ -40,10 +40,19 @@ jobs:
       BOT_NAME: ${{ vars.BATCH_BOT_NAME || 'autogpt-batch-bot' }}
       BOT_EMAIL: ${{ vars.BATCH_BOT_EMAIL || 'autogpt-batch-bot@users.noreply.github.com' }}
     steps:
+      # Mint a short-lived installation token for the batch-bot GitHub App. Pushes
+      # made with it DO trigger the preview-deploy workflow (unlike GITHUB_TOKEN),
+      # and the App identity can be precisely push-restricted on batch/rollup.
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          app-id: ${{ vars.BATCH_BOT_APP_ID }}
+          private-key: ${{ secrets.BATCH_BOT_PRIVATE_KEY }}
+
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.BATCH_BOT_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
@@ -55,4 +64,6 @@ jobs:
           git config user.email "$BOT_EMAIL"
 
       - name: Run batch bot
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: node .github/batch-bot/batch.mjs

--- a/.github/workflows/batch-command-handler.yml
+++ b/.github/workflows/batch-command-handler.yml
@@ -48,6 +48,11 @@ jobs:
         with:
           app-id: ${{ vars.BATCH_BOT_APP_ID }}
           private-key: ${{ secrets.BATCH_BOT_PRIVATE_KEY }}
+          # Scope the minted token to only what batch.mjs needs (not blanket install).
+          permission-contents: write # create/force-update/delete batch/rollup
+          permission-pull-requests: write # open/update/merge rollup PR, comment
+          permission-issues: write # labels + PR conversation comments
+          permission-actions: read # read member CI status before merge
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:

--- a/.github/workflows/batch-command-listener.yml
+++ b/.github/workflows/batch-command-listener.yml
@@ -30,6 +30,11 @@ jobs:
         with:
           app-id: ${{ vars.BATCH_BOT_APP_ID }}
           private-key: ${{ secrets.BATCH_BOT_PRIVATE_KEY }}
+          # Only what slash-command-dispatch needs: create the repository_dispatch
+          # (contents) and react to the triggering comment (issues/pull-requests).
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
 
       - name: Slash command dispatch
         uses: peter-evans/slash-command-dispatch@0683e68ce8b375f2dc24214e065a3ae1ef93040e # v5

--- a/.github/workflows/batch-command-listener.yml
+++ b/.github/workflows/batch-command-listener.yml
@@ -3,11 +3,11 @@ name: batch-command-listener
 # Turns `/batch`, `/batch-remove`, `/batch-merge` PR comments into repository_dispatch
 # events handled by batch-command-handler.yml. Deterministic ChatOps — no AI.
 #
-# Why a bot token (BATCH_BOT_TOKEN) and not GITHUB_TOKEN:
+# Why a GitHub App token and not GITHUB_TOKEN:
 #   A repository_dispatch created with GITHUB_TOKEN does NOT trigger the handler
 #   workflow (GitHub suppresses workflow-triggered-by-GITHUB_TOKEN to avoid loops).
-#   The dispatch must be made by a real identity (PAT on a bot account, or a
-#   GitHub App token) for the handler to run.
+#   The dispatch must be made by a real identity — here a GitHub App installation
+#   token minted per-run from BATCH_BOT_APP_ID + BATCH_BOT_PRIVATE_KEY.
 on:
   issue_comment:
     types: [created]
@@ -25,10 +25,16 @@ jobs:
       startsWith(github.event.comment.body, '/batch')
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          app-id: ${{ vars.BATCH_BOT_APP_ID }}
+          private-key: ${{ secrets.BATCH_BOT_PRIVATE_KEY }}
+
       - name: Slash command dispatch
         uses: peter-evans/slash-command-dispatch@0683e68ce8b375f2dc24214e065a3ae1ef93040e # v5
         with:
-          token: ${{ secrets.BATCH_BOT_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           issue-type: pull-request
           permission: write
           commands: |

--- a/.github/workflows/batch-reconcile.yml
+++ b/.github/workflows/batch-reconcile.yml
@@ -20,17 +20,29 @@ jobs:
       github.event.pull_request.head.ref == 'batch/rollup'
     runs-on: ubuntu-latest
     env:
-      GH_TOKEN: ${{ secrets.BATCH_BOT_TOKEN }}
       REPO: ${{ github.repository }}
       BASE: ${{ vars.BATCH_BASE_BRANCH || 'dev' }}
       COMMAND: reconcile
       ROLLUP_URL: ${{ github.event.pull_request.html_url }}
       ROLLUP_PR: ${{ github.event.pull_request.number }}
     steps:
+      # Mint the batch-bot App token (same identity as the listener/handler) so
+      # reconcile can close members and delete batch/rollup — the branch delete is
+      # push-restricted to the App, so it must run as the App, not a PAT.
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          app-id: ${{ vars.BATCH_BOT_APP_ID }}
+          private-key: ${{ secrets.BATCH_BOT_PRIVATE_KEY }}
+          permission-contents: write # delete batch/rollup
+          permission-pull-requests: write # close member PRs + !undeploy comment
+          permission-issues: write # member comments/labels
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          token: ${{ secrets.BATCH_BOT_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "20"
-      - run: node .github/batch-bot/batch.mjs
+      - env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: node .github/batch-bot/batch.mjs


### PR DESCRIPTION
### Why / What / How

**Why:** #13465 (the batch-deploy bot) merged with review-bot findings unresolved and a long-lived-PAT identity. This follow-up (a) fixes the correctness bugs that made `/batch-merge`'s "approved + green" guarantee unsound, and (b) migrates the bot from a static `BATCH_BOT_TOKEN` PAT to a per-run **GitHub App** installation token so the identity can be precisely push-restricted on `batch/rollup`.

### Merge-gate correctness — `batch.mjs`

- 🔴 **CI gate no longer skips when a member isn't green.** `gh pr checks --json` exits non-zero on failing (1) / pending (8) checks but still prints the JSON; the old `if (checks.ok)` only parsed on exit 0, silently skipping the gate for exactly the un-green members. New `checkBlockers()` parses regardless of exit code and **fails closed** — only `pass`/`skipping` count as green; `fail`/`cancel`/`pending`/unreadable/**empty** all block.
- 🟠 **`/batch-merge` redeploys the rollup** before enabling auto-merge, so the maintainer approves the combined preview that will actually land (was auto-merging against a possibly-stale preview).
- 🟡 **Gate the *merged* set, not the full labeled batch** — a member ejected during assembly no longer blocks a rollup it isn't part of.
- 🟡 **All-ejected** posts a clean "nothing left to merge" instead of throwing `rollup PR missing after build`.
- 🔵 `SAFE_REF` rejects a leading dash (git arg-injection guard); exact-match `git/ref/heads/…` existence probe.

### Bot identity → GitHub App — workflows

- All three workflows (`batch-command-listener`, `batch-command-handler`, `batch-reconcile`) mint a short-lived installation token **per run** via `actions/create-github-app-token` (pinned `v3.2.0`) from `BATCH_BOT_APP_ID` + `BATCH_BOT_PRIVATE_KEY`, replacing the static `secrets.BATCH_BOT_TOKEN`.
- Each minted token is **scoped** with `permission-*` to only what that workflow needs — no blanket installation perms (handler: contents/PRs/issues write + actions read; listener: contents/issues/PRs write; reconcile: contents/PRs/issues write).
- Installation-token pushes/dispatches still trigger the preview-deploy and handler (`GITHUB_TOKEN` doesn't), and the App is a distinct identity, so `batch/rollup` pushes can be ruleset-restricted to it precisely (a personal PAT can't be — it acts as the human, an admin).
- Also: `BATCH_REQUIRE_APPROVAL` wired into the handler env (was a no-op), `timeout-minutes: 15` on the handler job, and the README rewritten to the App-based setup.

### Enablement checklist (operational — outside this diff)

- [x] GitHub App created (org-owned, **only** the 5 repo perms), installed on the repo; `BATCH_BOT_APP_ID` variable + `BATCH_BOT_PRIVATE_KEY` secret stored
- [x] `batch/rollup` ruleset — restrict create/update/delete; bypass = the App + repo admin; enforcement active
- [x] `dev` already requires 1 approval + dismiss-stale-reviews on push
- [ ] **Merge this PR**, then delete the now-unused `BATCH_BOT_TOKEN` secret
- [ ] Smoke-test `/batch` → `/batch-merge` end-to-end; verify the App-bot's `!deploy` clears the deploy dispatcher's `author_association` gate (an App-bot comment can read as `NONE` — add the bot to the dispatcher allowlist if the preview doesn't spin up)

### Review

All Cursor + CodeRabbit threads addressed/resolved: merge-gate CI-skip, ejected-member gating, reconcile still on the PAT, blanket token perms, stale README fallback, and empty-checks fail-closed — plus one **verified false-positive** on the `git/ref` probe (returns 200 for slashed branch names).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
