### PR TITLE
fix(frontend/marketplace): Use agent name in graph download filename

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/admin/marketplace/components/DownloadAgentButton.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/marketplace/components/DownloadAgentButton.tsx
@@ -2,6 +2,7 @@
 
 import { downloadAsAdmin } from "@/app/(platform)/admin/marketplace/actions";
 import { Button } from "@/components/__legacy__/ui/button";
+import { agentGraphExportFilename, exportAsJSONFile } from "@/lib/utils";
 import { ExternalLink } from "lucide-react";
 import { useState } from "react";
 
@@ -18,25 +19,7 @@ export function DownloadAgentAdminButton({
       // Call the server action to get the data
       const fileData = await downloadAsAdmin(storeListingVersionId);
 
-      // Client-side download logic
-      const jsonData = JSON.stringify(fileData, null, 2);
-      const blob = new Blob([jsonData], { type: "application/json" });
-
-      // Create a temporary URL for the Blob
-      const url = window.URL.createObjectURL(blob);
-
-      // Create a temporary anchor element
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = `agent_${storeListingVersionId}.json`;
-
-      // Append the anchor to the body, click it, and remove it
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-
-      // Revoke the temporary URL
-      window.URL.revokeObjectURL(url);
+      exportAsJSONFile(fileData as object, agentGraphExportFilename(fileData));
     } catch (error) {
       console.error("Download failed:", error);
     } finally {

--- a/autogpt_platform/frontend/src/app/(platform)/marketplace/components/AgentInfo/useAgentInfo.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/marketplace/components/AgentInfo/useAgentInfo.ts
@@ -8,6 +8,7 @@ import * as Sentry from "@sentry/nextjs";
 import { useGetV2DownloadAgentFile } from "@/app/api/__generated__/endpoints/store/store";
 import { analytics } from "@/services/analytics";
 import { LibraryAgent } from "@/app/api/__generated__/models/libraryAgent";
+import { agentGraphExportFilename, exportAsJSONFile } from "@/lib/utils";
 import { useQueryClient } from "@tanstack/react-query";
 
 interface UseAgentInfoProps {
@@ -79,19 +80,10 @@ export const useAgentInfo = ({ storeListingVersionId }: UseAgentInfoProps) => {
     try {
       const { data: file } = await downloadAgent();
 
-      const jsonData = JSON.stringify(file, null, 2);
-      const blob = new Blob([jsonData], { type: "application/json" });
-      const url = window.URL.createObjectURL(blob);
-
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = `agent_${storeListingVersionId}.json`;
-
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-
-      window.URL.revokeObjectURL(url);
+      exportAsJSONFile(
+        file as object,
+        agentGraphExportFilename(file, agentName),
+      );
 
       analytics.sendDatafastEvent("download_agent", {
         name: agentName,

--- a/autogpt_platform/frontend/src/lib/__tests__/utils.test.ts
+++ b/autogpt_platform/frontend/src/lib/__tests__/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { setNestedProperty } from "../utils";
+import { agentGraphExportFilename, setNestedProperty } from "../utils";
 
 const testCases = [
   {
@@ -93,5 +93,41 @@ describe("setNestedProperty", () => {
     }).toThrow("Invalid property name: __proto__");
 
     expect(({} as { polluted?: boolean }).polluted).toBeUndefined();
+  });
+});
+
+describe("agentGraphExportFilename", () => {
+  test("uses the graph's name and version", () => {
+    const graph = { name: "Email Digest", version: 3 };
+    expect(agentGraphExportFilename(graph)).toBe("Email Digest_v3.json");
+  });
+
+  test("omits the version suffix when the graph has no version", () => {
+    expect(agentGraphExportFilename({ name: "Email Digest" })).toBe(
+      "Email Digest.json",
+    );
+  });
+
+  test("falls back to the given name when the graph has none", () => {
+    expect(agentGraphExportFilename({ version: 2 }, "Store Agent")).toBe(
+      "Store Agent_v2.json",
+    );
+  });
+
+  test("replaces filesystem-hostile characters in the name", () => {
+    expect(
+      agentGraphExportFilename({ name: 'A/B: "test" <agent>?', version: 1 }),
+    ).toBe("A_B_ _test_ _agent_v1.json");
+  });
+
+  test('falls back to "agent" for non-object graphs without a fallback name', () => {
+    expect(agentGraphExportFilename(null)).toBe("agent.json");
+    expect(agentGraphExportFilename("nope")).toBe("agent.json");
+  });
+
+  test("ignores blank names", () => {
+    expect(agentGraphExportFilename({ name: "   ", version: 1 }, "  ")).toBe(
+      "agent_v1.json",
+    );
   });
 });

--- a/autogpt_platform/frontend/src/lib/utils.ts
+++ b/autogpt_platform/frontend/src/lib/utils.ts
@@ -194,6 +194,24 @@ export function exportAsJSONFile(obj: object, filename: string): void {
   URL.revokeObjectURL(url);
 }
 
+export function agentGraphExportFilename(
+  graph: unknown,
+  fallbackName = "agent",
+): string {
+  const { name, version } = (
+    typeof graph === "object" && graph !== null ? graph : {}
+  ) as { name?: unknown; version?: unknown };
+  const rawName = typeof name === "string" && name.trim() ? name : fallbackName;
+  const safeName =
+    rawName
+      .trim()
+      .replace(/[\\/:*?"<>|\x00-\x1f]/g, "_")
+      .replace(/[_ ]+$/, "") || "agent";
+  return typeof version === "number"
+    ? `${safeName}_v${version}.json`
+    : `${safeName}.json`;
+}
+
 export function setNestedProperty(obj: any, path: string, value: any) {
   if (!obj || typeof obj !== "object") {
     throw new Error("Target must be a non-null object");


### PR DESCRIPTION
### Why / What / How

**Why:** Downloading an agent from the Marketplace (or the admin dashboard) saves it as `agent_{storeListingVersionId}.json` — a UUID that's meaningless to the user and makes downloaded agents impossible to tell apart. Reported during v0.6.66 release QA.

**What:** Downloaded agent files are now named after the agent, e.g. `Email Digest_v3.json`, matching the existing library-export convention (`{name}_v{graph_version}.json`).

**How:** New `agentGraphExportFilename(graph, fallbackName?)` helper in `lib/utils.ts` next to `exportAsJSONFile`: it takes the agent name and version from the downloaded graph JSON (the endpoint response is untyped), sanitizes filesystem-hostile characters, and falls back to the passed name / `"agent"` when missing. Both download call sites now use it — and both had hand-rolled copies of the blob-download logic, which are replaced with the existing `exportAsJSONFile` helper.

### Changes 🏗️

- Resolves #13518 (OPEN-3201)
- `lib/utils.ts`: add `agentGraphExportFilename` (name+version extraction, sanitization, fallbacks) with unit tests
- `marketplace/components/AgentInfo/useAgentInfo.ts`: name the download after the agent; replace manual blob code with `exportAsJSONFile`
- `admin/marketplace/components/DownloadAgentButton.tsx`: same

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] TDD: helper unit tests written first (name+version, no version, fallbacks, sanitization)
  - [x] Affected test suites + `pnpm format`/`lint`/`types` — clean
  - [x] `pnpm test:unit` full suite
  - [x] Manual: download an agent from the Marketplace and check the filename