### PR TITLE
feat(frontend): teams CRUD UI — TeamsSection, manage panel, provider wiring

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/settings/organization/__tests__/teams.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/organization/__tests__/teams.test.tsx
@@ -1,0 +1,455 @@
+import { useOrgTeamStore } from "@/services/org-team/store";
+import { server } from "@/mocks/mock-server";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@/tests/integrations/test-utils";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  getDeleteV2DeleteWorkspaceMockHandler,
+  getDeleteV2RemoveMemberFromWorkspaceMockHandler,
+  getGetV2GetOrganizationDetailsMockHandler,
+  getGetV2ListOrganizationMembersMockHandler,
+  getGetV2ListWorkspaceMembersMockHandler,
+  getGetV2ListWorkspacesMockHandler,
+  getPatchV2UpdateWorkspaceMockHandler,
+  getPostV2AddMemberToWorkspaceMockHandler,
+  getPostV2CreateWorkspaceMockHandler,
+  getPostV2LeaveWorkspaceMockHandler,
+  getPostV2SelfJoinOpenWorkspaceMockHandler,
+} from "@/app/api/__generated__/endpoints/orgs/orgs.msw";
+import {
+  getGetV2ListPendingInvitationsForCurrentUserMockHandler,
+  getGetV2ListPendingInvitationsMockHandler,
+} from "@/app/api/__generated__/endpoints/invitations/invitations.msw";
+import type { OrgMemberResponse } from "@/app/api/__generated__/models/orgMemberResponse";
+import type { TeamMemberResponse } from "@/app/api/__generated__/models/teamMemberResponse";
+import type { TeamResponse } from "@/app/api/__generated__/models/teamResponse";
+
+import OrganizationSettingsPage from "../page";
+
+const OWNER_USER_ID = "user-owner";
+
+vi.mock("@/lib/supabase/hooks/useSupabase", () => ({
+  useSupabase: () => ({ user: { id: OWNER_USER_ID } }),
+}));
+
+const TEAM_ORG = {
+  id: "org-company",
+  name: "Acme Inc",
+  slug: "acme",
+  avatar_url: null,
+  description: "We make everything",
+  is_personal: false,
+  member_count: 3,
+  created_at: new Date("2026-01-01T00:00:00Z"),
+};
+
+const OWNER_MEMBER: OrgMemberResponse = {
+  id: "m-1",
+  user_id: OWNER_USER_ID,
+  email: "jane@acme.test",
+  name: "Jane",
+  is_owner: true,
+  is_admin: true,
+  is_billing_manager: false,
+  joined_at: new Date("2026-01-01T00:00:00Z"),
+};
+
+const BOB_MEMBER: OrgMemberResponse = {
+  ...OWNER_MEMBER,
+  id: "m-2",
+  user_id: "user-bob",
+  email: "bob@acme.test",
+  name: "Bob",
+  is_owner: false,
+  is_admin: false,
+};
+
+const CARL_MEMBER: OrgMemberResponse = {
+  ...BOB_MEMBER,
+  id: "m-3",
+  user_id: "user-carl",
+  email: "carl@acme.test",
+  name: "Carl",
+};
+
+const DEFAULT_TEAM: TeamResponse = {
+  id: "team-default",
+  name: "General",
+  slug: "general",
+  description: null,
+  is_default: true,
+  join_policy: "OPEN",
+  org_id: TEAM_ORG.id,
+  member_count: 2,
+  created_at: new Date("2026-01-01T00:00:00Z"),
+};
+
+const OPEN_TEAM: TeamResponse = {
+  ...DEFAULT_TEAM,
+  id: "team-open",
+  name: "Marketing",
+  slug: "marketing",
+  is_default: false,
+  join_policy: "OPEN",
+  member_count: 4,
+};
+
+const PRIVATE_TEAM: TeamResponse = {
+  ...DEFAULT_TEAM,
+  id: "team-private",
+  name: "Skunkworks",
+  slug: null,
+  is_default: false,
+  join_policy: "PRIVATE",
+  member_count: 1,
+};
+
+function teamMember(over: Partial<TeamMemberResponse>): TeamMemberResponse {
+  return {
+    id: `tm-${over.user_id}`,
+    user_id: "user-x",
+    email: "x@acme.test",
+    name: "X",
+    is_admin: false,
+    is_billing_manager: false,
+    joined_at: new Date("2026-01-01T00:00:00Z"),
+    ...over,
+  };
+}
+
+function seedActiveOrg() {
+  useOrgTeamStore.setState({
+    activeOrgID: TEAM_ORG.id,
+    activeTeamID: null,
+    orgs: [
+      {
+        id: TEAM_ORG.id,
+        name: TEAM_ORG.name,
+        slug: TEAM_ORG.slug,
+        avatarUrl: null,
+        isPersonal: false,
+        memberCount: 3,
+      },
+    ],
+    teams: [],
+    isLoaded: true,
+  });
+}
+
+interface MockOrgArgs {
+  members?: OrgMemberResponse[];
+  teams?: TeamResponse[];
+}
+
+function mockOrg({
+  members = [OWNER_MEMBER, BOB_MEMBER, CARL_MEMBER],
+  teams = [DEFAULT_TEAM, OPEN_TEAM, PRIVATE_TEAM],
+}: MockOrgArgs = {}) {
+  server.use(
+    getGetV2GetOrganizationDetailsMockHandler(TEAM_ORG),
+    getGetV2ListOrganizationMembersMockHandler(members),
+    getGetV2ListWorkspacesMockHandler(teams),
+    getGetV2ListPendingInvitationsMockHandler([]),
+    getGetV2ListPendingInvitationsForCurrentUserMockHandler([]),
+  );
+}
+
+// The teams list resolves from its own query, a tick after the page's
+// org/members queries settle the section. Await the row before using it.
+async function teamRow(teamName: string) {
+  const label = await screen.findByText(teamName);
+  return label.closest("li") as HTMLElement;
+}
+
+async function openManagePanel(teamName: string) {
+  const row = await teamRow(teamName);
+  await userEvent.click(within(row).getByTestId("manage-team-button"));
+  return screen.findByTestId("team-manage-panel");
+}
+
+describe("TeamsSection", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    seedActiveOrg();
+  });
+
+  it("lists teams with default, open and private badges", async () => {
+    mockOrg();
+    render(<OrganizationSettingsPage />);
+
+    const section = await screen.findByTestId("org-teams-section");
+    await within(section).findByText("Marketing");
+    expect(within(section).getByText("Teams (3)")).toBeDefined();
+    expect(within(section).getAllByTestId("org-team-row")).toHaveLength(3);
+    expect(within(section).getByText("General")).toBeDefined();
+    expect(within(section).getByText("Marketing")).toBeDefined();
+    expect(within(section).getByText("Skunkworks")).toBeDefined();
+    expect(within(section).getByText("Default")).toBeDefined();
+    expect(within(section).getAllByText("Open")).toHaveLength(2);
+    expect(within(section).getByText("Private")).toBeDefined();
+    expect(within(section).getByText("4 members")).toBeDefined();
+  });
+
+  it("creates a team from the dialog (posts to the API)", async () => {
+    const createSpy = vi.fn();
+    mockOrg();
+    server.use(
+      getPostV2CreateWorkspaceMockHandler(() => {
+        createSpy();
+        return { ...OPEN_TEAM, id: "team-new", name: "Engineering" };
+      }),
+    );
+    render(<OrganizationSettingsPage />);
+
+    await screen.findByTestId("org-teams-section");
+    await userEvent.click(screen.getByTestId("create-team-button"));
+
+    const dialog = await screen.findByRole("dialog");
+    await userEvent.type(
+      within(dialog).getByPlaceholderText("Engineering"),
+      "Engineering",
+    );
+    await userEvent.click(
+      within(dialog).getByRole("button", { name: "Create team" }),
+    );
+
+    await waitFor(() => {
+      expect(createSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("joins an open team from its row", async () => {
+    const joinSpy = vi.fn();
+    mockOrg();
+    server.use(
+      getPostV2SelfJoinOpenWorkspaceMockHandler(() => {
+        joinSpy();
+        return OPEN_TEAM;
+      }),
+    );
+    render(<OrganizationSettingsPage />);
+
+    await screen.findByTestId("org-teams-section");
+    const row = await teamRow("Marketing");
+    await userEvent.click(within(row).getByRole("button", { name: "Join" }));
+
+    await waitFor(() => {
+      expect(joinSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("deletes a non-default team after confirmation", async () => {
+    const deleteSpy = vi.fn();
+    mockOrg();
+    server.use(
+      getDeleteV2DeleteWorkspaceMockHandler(() => {
+        deleteSpy();
+      }),
+    );
+    render(<OrganizationSettingsPage />);
+
+    await screen.findByTestId("org-teams-section");
+    const row = await teamRow("Skunkworks");
+    await userEvent.click(within(row).getByRole("button", { name: "Delete" }));
+
+    const dialog = await screen.findByRole("dialog");
+    await userEvent.click(
+      within(dialog).getByRole("button", { name: "Delete team" }),
+    );
+
+    await waitFor(() => {
+      expect(deleteSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("hides create and delete controls from a plain org member", async () => {
+    mockOrg({
+      members: [
+        { ...OWNER_MEMBER, user_id: "someone-else" },
+        { ...BOB_MEMBER, user_id: OWNER_USER_ID },
+      ],
+    });
+    render(<OrganizationSettingsPage />);
+
+    const section = await screen.findByTestId("org-teams-section");
+    expect(screen.queryByTestId("create-team-button")).toBeNull();
+    expect(
+      within(section).queryByRole("button", { name: "Delete" }),
+    ).toBeNull();
+  });
+
+  it("shows admin management affordances in the manage panel for a team admin", async () => {
+    mockOrg();
+    server.use(
+      getGetV2ListWorkspaceMembersMockHandler([
+        teamMember({ user_id: OWNER_USER_ID, name: "Jane", is_admin: true }),
+      ]),
+    );
+    render(<OrganizationSettingsPage />);
+
+    await screen.findByTestId("org-teams-section");
+    const panel = await openManagePanel("Marketing");
+
+    expect(
+      await within(panel).findByRole("button", { name: "Save changes" }),
+    ).toBeDefined();
+    expect(
+      within(panel).getByRole("combobox", { name: "Add a member" }),
+    ).toBeDefined();
+    expect(within(panel).queryByTestId("team-leave-button")).toBeNull();
+  });
+
+  it("shows a read-only view with a Leave action for a non-admin member", async () => {
+    mockOrg();
+    server.use(
+      getGetV2ListWorkspaceMembersMockHandler([
+        teamMember({ user_id: OWNER_USER_ID, name: "Jane", is_admin: false }),
+        teamMember({ user_id: "user-carl", name: "Carl", is_admin: true }),
+      ]),
+    );
+    render(<OrganizationSettingsPage />);
+
+    await screen.findByTestId("org-teams-section");
+    const panel = await openManagePanel("Marketing");
+
+    expect(await within(panel).findByTestId("team-leave-button")).toBeDefined();
+    expect(
+      within(panel).queryByRole("button", { name: "Save changes" }),
+    ).toBeNull();
+    expect(
+      within(panel).queryByRole("combobox", { name: "Add a member" }),
+    ).toBeNull();
+  });
+
+  it("renames a team and sends the X-Team-Id header for the target team", async () => {
+    const patchSpy = vi.fn();
+    let sentTeamHeader: string | null = null;
+    mockOrg();
+    server.use(
+      getGetV2ListWorkspaceMembersMockHandler([
+        teamMember({ user_id: OWNER_USER_ID, name: "Jane", is_admin: true }),
+      ]),
+      getPatchV2UpdateWorkspaceMockHandler((info) => {
+        patchSpy();
+        sentTeamHeader = info.request.headers.get("X-Team-Id");
+        return { ...OPEN_TEAM, name: "Growth" };
+      }),
+    );
+    render(<OrganizationSettingsPage />);
+
+    await screen.findByTestId("org-teams-section");
+    const panel = await openManagePanel("Marketing");
+
+    const nameInput = await within(panel).findByLabelText("Name");
+    await userEvent.clear(nameInput);
+    await userEvent.type(nameInput, "Growth");
+    await userEvent.click(
+      within(panel).getByRole("button", { name: "Save changes" }),
+    );
+
+    await waitFor(() => {
+      expect(patchSpy).toHaveBeenCalledTimes(1);
+    });
+    expect(sentTeamHeader).toBe(OPEN_TEAM.id);
+  });
+
+  it("adds an org member to the team from the manage panel", async () => {
+    const addSpy = vi.fn();
+    mockOrg();
+    server.use(
+      getGetV2ListWorkspaceMembersMockHandler([
+        teamMember({ user_id: OWNER_USER_ID, name: "Jane", is_admin: true }),
+      ]),
+      getPostV2AddMemberToWorkspaceMockHandler(() => {
+        addSpy();
+        return teamMember({ user_id: "user-bob", name: "Bob" });
+      }),
+    );
+    render(<OrganizationSettingsPage />);
+
+    await screen.findByTestId("org-teams-section");
+    const panel = await openManagePanel("Marketing");
+
+    const combo = await within(panel).findByRole("combobox", {
+      name: "Add a member",
+    });
+    fireEvent.click(combo);
+    fireEvent.click(await screen.findByRole("option", { name: "Bob" }));
+    await userEvent.click(within(panel).getByRole("button", { name: "Add" }));
+
+    await waitFor(() => {
+      expect(addSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("removes a team member after confirmation", async () => {
+    const removeSpy = vi.fn();
+    mockOrg();
+    server.use(
+      getGetV2ListWorkspaceMembersMockHandler([
+        teamMember({ user_id: OWNER_USER_ID, name: "Jane", is_admin: true }),
+        teamMember({ user_id: "user-carl", name: "Carl" }),
+      ]),
+      getDeleteV2RemoveMemberFromWorkspaceMockHandler(() => {
+        removeSpy();
+      }),
+    );
+    render(<OrganizationSettingsPage />);
+
+    await screen.findByTestId("org-teams-section");
+    const panel = await openManagePanel("Marketing");
+
+    const carlRow = (await within(panel).findByText("Carl")).closest(
+      "li",
+    ) as HTMLElement;
+    await userEvent.click(
+      within(carlRow).getByRole("button", { name: "Remove" }),
+    );
+
+    const dialog = await screen.findByRole("dialog");
+    await userEvent.click(
+      within(dialog).getByRole("button", { name: "Remove member" }),
+    );
+
+    await waitFor(() => {
+      expect(removeSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("lets a non-admin leave a team without touching global active-team state", async () => {
+    const leaveSpy = vi.fn();
+    mockOrg();
+    server.use(
+      getGetV2ListWorkspaceMembersMockHandler([
+        teamMember({ user_id: OWNER_USER_ID, name: "Jane", is_admin: false }),
+      ]),
+      getPostV2LeaveWorkspaceMockHandler(() => {
+        leaveSpy();
+      }),
+    );
+    render(<OrganizationSettingsPage />);
+
+    await screen.findByTestId("org-teams-section");
+    const panel = await openManagePanel("Marketing");
+
+    await userEvent.click(
+      await within(panel).findByTestId("team-leave-button"),
+    );
+    const dialog = await screen.findByRole("dialog");
+    await userEvent.click(
+      within(dialog).getByRole("button", { name: "Leave team" }),
+    );
+
+    await waitFor(() => {
+      expect(leaveSpy).toHaveBeenCalledTimes(1);
+    });
+    expect(useOrgTeamStore.getState().activeTeamID).toBeNull();
+  });
+});

--- a/autogpt_platform/frontend/src/app/(platform)/settings/organization/components/TeamsSection/TeamsSection.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/organization/components/TeamsSection/TeamsSection.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import type { OrgMemberResponse } from "@/app/api/__generated__/models/orgMemberResponse";
+import { Badge } from "@/components/atoms/Badge/Badge";
+import { Button } from "@/components/atoms/Button/Button";
+import { Text } from "@/components/atoms/Text/Text";
+import { Dialog } from "@/components/molecules/Dialog/Dialog";
+import { PlusIcon } from "@phosphor-icons/react";
+
+import { CreateTeamDialog } from "./components/CreateTeamDialog/CreateTeamDialog";
+import { TeamManagePanel } from "./components/TeamManagePanel/TeamManagePanel";
+import { useTeamsSection } from "./useTeamsSection";
+
+interface Props {
+  orgId: string;
+  orgMembers: OrgMemberResponse[];
+  currentMember: OrgMemberResponse | null;
+}
+
+export function TeamsSection({ orgId, orgMembers, currentMember }: Props) {
+  const {
+    teams,
+    isLoading,
+    expandedTeamId,
+    toggleExpanded,
+    teamToDelete,
+    setTeamToDelete,
+    isJoining,
+    isDeleting,
+    handleJoin,
+    handleDeleteConfirmed,
+    isCreateOpen,
+    setIsCreateOpen,
+    refetch,
+  } = useTeamsSection({ orgId });
+
+  const canCreate = Boolean(
+    currentMember?.is_owner ||
+      currentMember?.is_admin ||
+      currentMember?.is_billing_manager,
+  );
+  const canDelete = Boolean(currentMember?.is_owner || currentMember?.is_admin);
+
+  return (
+    <section className="flex flex-col gap-4" data-testid="org-teams-section">
+      <div className="flex items-center justify-between">
+        <Text variant="h4" as="h2">
+          Teams ({teams.length})
+        </Text>
+        {canCreate ? (
+          <Button
+            variant="secondary"
+            size="small"
+            onClick={() => setIsCreateOpen(true)}
+            data-testid="create-team-button"
+          >
+            <PlusIcon size={14} />
+            New team
+          </Button>
+        ) : null}
+      </div>
+
+      {isLoading ? (
+        <Text variant="small" className="text-zinc-500">
+          Loading teams…
+        </Text>
+      ) : teams.length === 0 ? (
+        <Text variant="small" className="text-zinc-500">
+          This organization has no teams yet.
+        </Text>
+      ) : (
+        <ul className="flex flex-col divide-y divide-zinc-100">
+          {teams.map((team) => {
+            const isExpanded = expandedTeamId === team.id;
+            return (
+              <li
+                key={team.id}
+                className="flex flex-col gap-3 py-3"
+                data-testid="org-team-row"
+              >
+                <div className="flex items-center gap-3">
+                  <div className="flex min-w-0 flex-1 flex-col">
+                    <span className="truncate text-sm font-medium">
+                      {team.name}
+                    </span>
+                    <span className="text-xs text-zinc-500">
+                      {team.member_count}{" "}
+                      {team.member_count === 1 ? "member" : "members"}
+                    </span>
+                  </div>
+                  {team.is_default ? (
+                    <Badge variant="info">Default</Badge>
+                  ) : null}
+                  {team.join_policy === "OPEN" ? (
+                    <Badge variant="success">Open</Badge>
+                  ) : (
+                    <Badge variant="info">Private</Badge>
+                  )}
+                  {team.join_policy === "OPEN" ? (
+                    <Button
+                      variant="ghost"
+                      size="small"
+                      loading={isJoining}
+                      onClick={() => handleJoin(team)}
+                    >
+                      Join
+                    </Button>
+                  ) : null}
+                  <Button
+                    variant="ghost"
+                    size="small"
+                    onClick={() => toggleExpanded(team.id)}
+                    data-testid="manage-team-button"
+                  >
+                    {isExpanded ? "Close" : "Manage"}
+                  </Button>
+                  {canDelete && !team.is_default ? (
+                    <Button
+                      variant="ghost"
+                      size="small"
+                      onClick={() => setTeamToDelete(team)}
+                    >
+                      Delete
+                    </Button>
+                  ) : null}
+                </div>
+
+                {isExpanded ? (
+                  <TeamManagePanel
+                    orgId={orgId}
+                    team={team}
+                    orgMembers={orgMembers}
+                    currentUserId={currentMember?.user_id}
+                    onChanged={refetch}
+                    onLeft={() => {
+                      toggleExpanded(team.id);
+                      refetch();
+                    }}
+                  />
+                ) : null}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      <CreateTeamDialog
+        orgId={orgId}
+        open={isCreateOpen}
+        onOpenChange={setIsCreateOpen}
+        onCreated={refetch}
+      />
+
+      <Dialog
+        title="Delete team"
+        styling={{ maxWidth: "26rem" }}
+        controlled={{
+          isOpen: Boolean(teamToDelete),
+          set: (open) => {
+            if (!open && !isDeleting) setTeamToDelete(null);
+          },
+        }}
+      >
+        <Dialog.Content>
+          <Text variant="body">
+            Delete {teamToDelete?.name}? This removes the team and its members
+            from the organization. This can’t be undone.
+          </Text>
+          <div className="flex justify-end gap-2 pt-4">
+            <Button
+              variant="secondary"
+              onClick={() => setTeamToDelete(null)}
+              disabled={isDeleting}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              loading={isDeleting}
+              onClick={handleDeleteConfirmed}
+            >
+              Delete team
+            </Button>
+          </div>
+        </Dialog.Content>
+      </Dialog>
+    </section>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/settings/organization/components/TeamsSection/components/CreateTeamDialog/CreateTeamDialog.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/organization/components/TeamsSection/components/CreateTeamDialog/CreateTeamDialog.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { Button } from "@/components/atoms/Button/Button";
+import { Input } from "@/components/atoms/Input/Input";
+import { Select } from "@/components/atoms/Select/Select";
+import { Dialog } from "@/components/molecules/Dialog/Dialog";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormMessage,
+} from "@/components/molecules/Form/Form";
+
+import { JOIN_POLICY_OPTIONS } from "./schema";
+import { useCreateTeamDialog } from "./useCreateTeamDialog";
+
+interface Props {
+  orgId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onCreated: () => void;
+}
+
+export function CreateTeamDialog({
+  orgId,
+  open,
+  onOpenChange,
+  onCreated,
+}: Props) {
+  const { form, isPending, handleSubmit, handleClose } = useCreateTeamDialog({
+    orgId,
+    onCreated,
+    onClose: () => onOpenChange(false),
+  });
+
+  return (
+    <Dialog
+      title="Create team"
+      styling={{ maxWidth: "30rem" }}
+      controlled={{
+        isOpen: open,
+        set: (next) => {
+          if (next) {
+            onOpenChange(true);
+            return;
+          }
+          if (isPending) return;
+          handleClose();
+        },
+      }}
+    >
+      <Dialog.Content>
+        <Form
+          form={form}
+          onSubmit={handleSubmit}
+          className="flex flex-col gap-4 px-1"
+        >
+          <FormField
+            control={form.control}
+            name="name"
+            render={({ field }) => (
+              <FormItem>
+                <FormControl>
+                  <Input
+                    {...field}
+                    id={field.name}
+                    label="Name"
+                    placeholder="Engineering"
+                    wrapperClassName="!mb-0"
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="description"
+            render={({ field }) => (
+              <FormItem>
+                <FormControl>
+                  <Input
+                    {...field}
+                    id={field.name}
+                    label="Description (optional)"
+                    placeholder="What is this team for?"
+                    wrapperClassName="!mb-0"
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="join_policy"
+            render={({ field }) => (
+              <FormItem>
+                <FormControl>
+                  <Select
+                    id={field.name}
+                    label="Join policy"
+                    value={field.value}
+                    onValueChange={field.onChange}
+                    options={JOIN_POLICY_OPTIONS}
+                    wrapperClassName="!mb-0"
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <div className="flex justify-end gap-2 pt-2">
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={handleClose}
+              disabled={isPending}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" loading={isPending}>
+              Create team
+            </Button>
+          </div>
+        </Form>
+      </Dialog.Content>
+    </Dialog>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/settings/organization/components/TeamsSection/components/CreateTeamDialog/schema.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/organization/components/TeamsSection/components/CreateTeamDialog/schema.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+
+export const createTeamSchema = z.object({
+  name: z
+    .string()
+    .trim()
+    .min(1, "Name is required")
+    .max(100, "Name must be 100 characters or less"),
+  description: z
+    .string()
+    .trim()
+    .max(500, "Description must be 500 characters or less")
+    .optional(),
+  join_policy: z.enum(["OPEN", "PRIVATE"]),
+});
+
+export type CreateTeamFormValues = z.infer<typeof createTeamSchema>;
+
+export const JOIN_POLICY_OPTIONS = [
+  { value: "OPEN", label: "Open — anyone in the org can join" },
+  { value: "PRIVATE", label: "Private — invite only" },
+];

--- a/autogpt_platform/frontend/src/app/(platform)/settings/organization/components/TeamsSection/components/CreateTeamDialog/useCreateTeamDialog.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/organization/components/TeamsSection/components/CreateTeamDialog/useCreateTeamDialog.ts
@@ -1,0 +1,78 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+
+import { usePostV2CreateWorkspace } from "@/app/api/__generated__/endpoints/orgs/orgs";
+import type { TeamResponse } from "@/app/api/__generated__/models/teamResponse";
+import { toast } from "@/components/molecules/Toast/use-toast";
+import { useOrgTeamStore } from "@/services/org-team/store";
+
+import { createTeamSchema, type CreateTeamFormValues } from "./schema";
+
+interface Args {
+  orgId: string;
+  onCreated: () => void;
+  onClose: () => void;
+}
+
+export function useCreateTeamDialog({ orgId, onCreated, onClose }: Args) {
+  const { teams, setTeams } = useOrgTeamStore();
+
+  const form = useForm<CreateTeamFormValues>({
+    resolver: zodResolver(createTeamSchema),
+    defaultValues: { name: "", description: "", join_policy: "OPEN" },
+    mode: "onChange",
+  });
+
+  const { mutateAsync: createTeam, isPending } = usePostV2CreateWorkspace({
+    mutation: {
+      onError: (error) => {
+        toast({
+          title: "Failed to create team",
+          description:
+            error instanceof Error ? error.message : "Please try again.",
+          variant: "destructive",
+        });
+      },
+    },
+  });
+
+  async function handleSubmit(values: CreateTeamFormValues) {
+    const response = await createTeam({
+      orgId,
+      data: {
+        name: values.name,
+        description: values.description || null,
+        join_policy: values.join_policy,
+      },
+    });
+    const team = response.data as TeamResponse;
+    setTeams([
+      ...teams,
+      {
+        id: team.id,
+        name: team.name,
+        slug: team.slug,
+        isDefault: team.is_default,
+        joinPolicy: team.join_policy,
+        orgId: team.org_id,
+      },
+    ]);
+    toast({ title: `Team "${team.name}" created`, variant: "success" });
+    onCreated();
+    handleClose();
+  }
+
+  function handleClose() {
+    form.reset();
+    onClose();
+  }
+
+  return {
+    form,
+    isPending,
+    handleSubmit,
+    handleClose,
+  };
+}

--- a/autogpt_platform/frontend/src/app/(platform)/settings/organization/components/TeamsSection/components/TeamManagePanel/TeamManagePanel.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/organization/components/TeamsSection/components/TeamManagePanel/TeamManagePanel.tsx
@@ -1,0 +1,247 @@
+"use client";
+
+import { useState } from "react";
+
+import type { OrgMemberResponse } from "@/app/api/__generated__/models/orgMemberResponse";
+import type { TeamResponse } from "@/app/api/__generated__/models/teamResponse";
+import { Badge } from "@/components/atoms/Badge/Badge";
+import { Button } from "@/components/atoms/Button/Button";
+import { Select } from "@/components/atoms/Select/Select";
+import { Text } from "@/components/atoms/Text/Text";
+import { Dialog } from "@/components/molecules/Dialog/Dialog";
+
+import { TeamProfileForm } from "./TeamProfileForm";
+import { useTeamManagePanel } from "./useTeamManagePanel";
+
+const ROLE_OPTIONS = [
+  { value: "member", label: "Member" },
+  { value: "admin", label: "Admin" },
+];
+
+interface Props {
+  orgId: string;
+  team: TeamResponse;
+  orgMembers: OrgMemberResponse[];
+  currentUserId: string | undefined;
+  onChanged: () => void;
+  onLeft: () => void;
+}
+
+export function TeamManagePanel({
+  orgId,
+  team,
+  orgMembers,
+  currentUserId,
+  onChanged,
+  onLeft,
+}: Props) {
+  const [selectedUserId, setSelectedUserId] = useState("");
+  const {
+    members,
+    isLoading,
+    isTeamAdmin,
+    memberToRemove,
+    setMemberToRemove,
+    isLeaveOpen,
+    setIsLeaveOpen,
+    isAdding,
+    isUpdatingRole,
+    isRemoving,
+    isLeaving,
+    handleAddMember,
+    handleRoleChange,
+    handleRemoveConfirmed,
+    handleLeaveConfirmed,
+  } = useTeamManagePanel({
+    orgId,
+    wsId: team.id,
+    currentUserId,
+    onChanged,
+    onLeft,
+  });
+
+  const availableMembers = orgMembers.filter(
+    (om) => !members.some((tm) => tm.user_id === om.user_id),
+  );
+  const addOptions = availableMembers.map((om) => ({
+    value: om.user_id,
+    label: om.name || om.email,
+  }));
+
+  function handleAdd() {
+    const picked = addOptions.find((o) => o.value === selectedUserId);
+    if (!picked) return;
+    handleAddMember(picked.value, picked.label);
+    setSelectedUserId("");
+  }
+
+  return (
+    <div
+      className="flex flex-col gap-4 rounded-lg bg-zinc-50 p-4"
+      data-testid="team-manage-panel"
+    >
+      {isTeamAdmin ? (
+        <TeamProfileForm orgId={orgId} team={team} onSaved={onChanged} />
+      ) : null}
+
+      <div className="flex flex-col gap-2">
+        <Text variant="large-medium" as="h4">
+          Team members ({members.length})
+        </Text>
+        {isLoading ? (
+          <Text variant="small" className="text-zinc-500">
+            Loading members…
+          </Text>
+        ) : (
+          <ul className="flex flex-col divide-y divide-zinc-100">
+            {members.map((member) => {
+              const isSelf = member.user_id === currentUserId;
+              return (
+                <li
+                  key={member.user_id}
+                  className="flex items-center gap-3 py-2"
+                  data-testid="team-member-row"
+                >
+                  <div className="flex min-w-0 flex-1 flex-col">
+                    <span className="truncate text-sm font-medium">
+                      {member.name || member.email}
+                      {isSelf ? " (you)" : ""}
+                    </span>
+                    <span className="truncate text-xs text-zinc-500">
+                      {member.email}
+                    </span>
+                  </div>
+                  {isTeamAdmin && !isSelf ? (
+                    <>
+                      <Select
+                        id={`team-role-${team.id}-${member.user_id}`}
+                        label=""
+                        hideLabel
+                        size="small"
+                        wrapperClassName="!mb-0 w-32"
+                        value={member.is_admin ? "admin" : "member"}
+                        onValueChange={(role) => handleRoleChange(member, role)}
+                        options={ROLE_OPTIONS}
+                        disabled={isUpdatingRole}
+                      />
+                      <Button
+                        variant="ghost"
+                        size="small"
+                        onClick={() => setMemberToRemove(member)}
+                      >
+                        Remove
+                      </Button>
+                    </>
+                  ) : member.is_admin ? (
+                    <Badge variant="info">Admin</Badge>
+                  ) : null}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+
+      {isTeamAdmin && addOptions.length > 0 ? (
+        <div className="flex items-end gap-2">
+          <Select
+            id={`team-add-member-${team.id}`}
+            label="Add a member"
+            placeholder="Select an org member"
+            wrapperClassName="!mb-0 w-64"
+            value={selectedUserId}
+            onValueChange={setSelectedUserId}
+            options={addOptions}
+          />
+          <Button
+            variant="secondary"
+            onClick={handleAdd}
+            loading={isAdding}
+            disabled={!selectedUserId}
+          >
+            Add
+          </Button>
+        </div>
+      ) : null}
+
+      {!isTeamAdmin && !team.is_default ? (
+        <div>
+          <Button
+            variant="secondary"
+            onClick={() => setIsLeaveOpen(true)}
+            data-testid="team-leave-button"
+          >
+            Leave team
+          </Button>
+        </div>
+      ) : null}
+
+      <Dialog
+        title="Remove member"
+        styling={{ maxWidth: "26rem" }}
+        controlled={{
+          isOpen: Boolean(memberToRemove),
+          set: (open) => {
+            if (!open && !isRemoving) setMemberToRemove(null);
+          },
+        }}
+      >
+        <Dialog.Content>
+          <Text variant="body">
+            Remove {memberToRemove?.name || memberToRemove?.email} from{" "}
+            {team.name}?
+          </Text>
+          <div className="flex justify-end gap-2 pt-4">
+            <Button
+              variant="secondary"
+              onClick={() => setMemberToRemove(null)}
+              disabled={isRemoving}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              loading={isRemoving}
+              onClick={handleRemoveConfirmed}
+            >
+              Remove member
+            </Button>
+          </div>
+        </Dialog.Content>
+      </Dialog>
+
+      <Dialog
+        title="Leave team"
+        styling={{ maxWidth: "26rem" }}
+        controlled={{
+          isOpen: isLeaveOpen,
+          set: (open) => {
+            if (!open && !isLeaving) setIsLeaveOpen(false);
+          },
+        }}
+      >
+        <Dialog.Content>
+          <Text variant="body">
+            Leave {team.name}? You will lose access to its resources.
+          </Text>
+          <div className="flex justify-end gap-2 pt-4">
+            <Button
+              variant="secondary"
+              onClick={() => setIsLeaveOpen(false)}
+              disabled={isLeaving}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              loading={isLeaving}
+              onClick={handleLeaveConfirmed}
+            >
+              Leave team
+            </Button>
+          </div>
+        </Dialog.Content>
+      </Dialog>
+    </div>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/settings/organization/components/TeamsSection/components/TeamManagePanel/TeamProfileForm.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/organization/components/TeamsSection/components/TeamManagePanel/TeamProfileForm.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import type { TeamResponse } from "@/app/api/__generated__/models/teamResponse";
+import { Button } from "@/components/atoms/Button/Button";
+import { Input } from "@/components/atoms/Input/Input";
+import { Select } from "@/components/atoms/Select/Select";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormMessage,
+} from "@/components/molecules/Form/Form";
+
+import { JOIN_POLICY_OPTIONS } from "../CreateTeamDialog/schema";
+import { useTeamProfileForm } from "./useTeamProfileForm";
+
+interface Props {
+  orgId: string;
+  team: TeamResponse;
+  onSaved: () => void;
+}
+
+export function TeamProfileForm({ orgId, team, onSaved }: Props) {
+  const { form, isPending, isDirty, handleSubmit } = useTeamProfileForm({
+    orgId,
+    team,
+    onSaved,
+  });
+
+  return (
+    <Form
+      form={form}
+      onSubmit={handleSubmit}
+      className="flex max-w-lg flex-col gap-4"
+    >
+      <FormField
+        control={form.control}
+        name="name"
+        render={({ field }) => (
+          <FormItem>
+            <FormControl>
+              <Input
+                {...field}
+                id={`team-name-${team.id}`}
+                label="Name"
+                wrapperClassName="!mb-0"
+              />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+      <FormField
+        control={form.control}
+        name="description"
+        render={({ field }) => (
+          <FormItem>
+            <FormControl>
+              <Input
+                {...field}
+                id={`team-description-${team.id}`}
+                label="Description"
+                wrapperClassName="!mb-0"
+              />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+      <FormField
+        control={form.control}
+        name="join_policy"
+        render={({ field }) => (
+          <FormItem>
+            <FormControl>
+              <Select
+                id={`team-join-policy-${team.id}`}
+                label="Join policy"
+                value={field.value}
+                onValueChange={field.onChange}
+                options={JOIN_POLICY_OPTIONS}
+                disabled={team.is_default}
+                wrapperClassName="!mb-0"
+              />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+      <div>
+        <Button type="submit" loading={isPending} disabled={!isDirty}>
+          Save changes
+        </Button>
+      </div>
+    </Form>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/settings/organization/components/TeamsSection/components/TeamManagePanel/useTeamManagePanel.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/organization/components/TeamsSection/components/TeamManagePanel/useTeamManagePanel.ts
@@ -1,0 +1,167 @@
+"use client";
+
+import { useState } from "react";
+
+import {
+  useDeleteV2RemoveMemberFromWorkspace,
+  useGetV2ListWorkspaceMembers,
+  usePatchV2UpdateWorkspaceMemberRole,
+  usePostV2AddMemberToWorkspace,
+  usePostV2LeaveWorkspace,
+} from "@/app/api/__generated__/endpoints/orgs/orgs";
+import type { TeamMemberResponse } from "@/app/api/__generated__/models/teamMemberResponse";
+import { toast } from "@/components/molecules/Toast/use-toast";
+import { TEAM_HEADER_NAME } from "@/services/org-team/headers";
+
+interface Args {
+  orgId: string;
+  wsId: string;
+  currentUserId: string | undefined;
+  onChanged: () => void;
+  onLeft: () => void;
+}
+
+export function useTeamManagePanel({
+  orgId,
+  wsId,
+  currentUserId,
+  onChanged,
+  onLeft,
+}: Args) {
+  const [memberToRemove, setMemberToRemove] =
+    useState<TeamMemberResponse | null>(null);
+  const [isLeaveOpen, setIsLeaveOpen] = useState(false);
+
+  const request = { headers: { [TEAM_HEADER_NAME]: wsId } };
+
+  const membersQuery = useGetV2ListWorkspaceMembers(orgId, wsId, {
+    query: {
+      enabled: Boolean(orgId && wsId),
+      select: (res) => res.data as TeamMemberResponse[],
+    },
+    request,
+  });
+
+  const members = membersQuery.data ?? [];
+  const currentTeamMember =
+    members.find((m) => m.user_id === currentUserId) ?? null;
+  const isTeamAdmin = Boolean(currentTeamMember?.is_admin);
+
+  const { mutateAsync: addMember, isPending: isAdding } =
+    usePostV2AddMemberToWorkspace({
+      mutation: {
+        onError: (error) => {
+          toast({
+            title: "Failed to add member",
+            description:
+              error instanceof Error ? error.message : "Please try again.",
+            variant: "destructive",
+          });
+        },
+      },
+      request,
+    });
+
+  const { mutateAsync: updateRole, isPending: isUpdatingRole } =
+    usePatchV2UpdateWorkspaceMemberRole({
+      mutation: {
+        onError: (error) => {
+          toast({
+            title: "Failed to update role",
+            description:
+              error instanceof Error ? error.message : "Please try again.",
+            variant: "destructive",
+          });
+        },
+      },
+      request,
+    });
+
+  const { mutateAsync: removeMember, isPending: isRemoving } =
+    useDeleteV2RemoveMemberFromWorkspace({
+      mutation: {
+        onError: (error) => {
+          toast({
+            title: "Failed to remove member",
+            description:
+              error instanceof Error ? error.message : "Please try again.",
+            variant: "destructive",
+          });
+        },
+      },
+      request,
+    });
+
+  const { mutateAsync: leaveTeam, isPending: isLeaving } =
+    usePostV2LeaveWorkspace({
+      mutation: {
+        onError: (error) => {
+          toast({
+            title: "Failed to leave team",
+            description:
+              error instanceof Error ? error.message : "Please try again.",
+            variant: "destructive",
+          });
+        },
+      },
+      request,
+    });
+
+  async function handleAddMember(userId: string, label: string) {
+    await addMember({ orgId, wsId, data: { user_id: userId } });
+    toast({ title: `Added ${label}`, variant: "success" });
+    membersQuery.refetch();
+    onChanged();
+  }
+
+  async function handleRoleChange(member: TeamMemberResponse, role: string) {
+    await updateRole({
+      orgId,
+      wsId,
+      uid: member.user_id,
+      data: { is_admin: role === "admin" },
+    });
+    toast({
+      title: `${member.name || member.email} is now ${role === "admin" ? "an admin" : "a member"}`,
+      variant: "success",
+    });
+    membersQuery.refetch();
+  }
+
+  async function handleRemoveConfirmed() {
+    if (!memberToRemove) return;
+    await removeMember({ orgId, wsId, uid: memberToRemove.user_id });
+    toast({
+      title: `Removed ${memberToRemove.name || memberToRemove.email}`,
+      variant: "success",
+    });
+    setMemberToRemove(null);
+    membersQuery.refetch();
+    onChanged();
+  }
+
+  async function handleLeaveConfirmed() {
+    await leaveTeam({ orgId, wsId });
+    toast({ title: "You left the team", variant: "success" });
+    setIsLeaveOpen(false);
+    onLeft();
+  }
+
+  return {
+    members,
+    isLoading: membersQuery.isLoading,
+    isTeamAdmin,
+    memberToRemove,
+    setMemberToRemove,
+    isLeaveOpen,
+    setIsLeaveOpen,
+    isAdding,
+    isUpdatingRole,
+    isRemoving,
+    isLeaving,
+    handleAddMember,
+    handleRoleChange,
+    handleRemoveConfirmed,
+    handleLeaveConfirmed,
+  };
+}

--- a/autogpt_platform/frontend/src/app/(platform)/settings/organization/components/TeamsSection/components/TeamManagePanel/useTeamProfileForm.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/organization/components/TeamsSection/components/TeamManagePanel/useTeamProfileForm.ts
@@ -1,0 +1,91 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+
+import { usePatchV2UpdateWorkspace } from "@/app/api/__generated__/endpoints/orgs/orgs";
+import type { TeamResponse } from "@/app/api/__generated__/models/teamResponse";
+import { toast } from "@/components/molecules/Toast/use-toast";
+import { TEAM_HEADER_NAME } from "@/services/org-team/headers";
+
+const teamProfileSchema = z.object({
+  name: z
+    .string()
+    .trim()
+    .min(1, "Name is required")
+    .max(100, "Name must be 100 characters or less"),
+  description: z
+    .string()
+    .trim()
+    .max(500, "Description must be 500 characters or less")
+    .optional(),
+  join_policy: z.enum(["OPEN", "PRIVATE"]),
+});
+
+export type TeamProfileFormValues = z.infer<typeof teamProfileSchema>;
+
+interface Args {
+  orgId: string;
+  team: TeamResponse;
+  onSaved: () => void;
+}
+
+export function useTeamProfileForm({ orgId, team, onSaved }: Args) {
+  const form = useForm<TeamProfileFormValues>({
+    resolver: zodResolver(teamProfileSchema),
+    defaultValues: {
+      name: team.name,
+      description: team.description ?? "",
+      join_policy: team.join_policy === "PRIVATE" ? "PRIVATE" : "OPEN",
+    },
+    mode: "onChange",
+  });
+
+  const { mutateAsync: updateTeam, isPending } = usePatchV2UpdateWorkspace({
+    mutation: {
+      onError: (error) => {
+        toast({
+          title: "Failed to update team",
+          description:
+            error instanceof Error ? error.message : "Please try again.",
+          variant: "destructive",
+        });
+      },
+    },
+    request: { headers: { [TEAM_HEADER_NAME]: team.id } },
+  });
+
+  async function handleSubmit(values: TeamProfileFormValues) {
+    const response = await updateTeam({
+      orgId,
+      wsId: team.id,
+      data: {
+        name: values.name !== team.name ? values.name : undefined,
+        description:
+          (values.description || "") !== (team.description ?? "")
+            ? values.description || null
+            : undefined,
+        join_policy:
+          values.join_policy !== team.join_policy
+            ? values.join_policy
+            : undefined,
+      },
+    });
+    const updated = response.data as TeamResponse;
+    form.reset({
+      name: updated.name,
+      description: updated.description ?? "",
+      join_policy: updated.join_policy === "PRIVATE" ? "PRIVATE" : "OPEN",
+    });
+    toast({ title: "Team updated", variant: "success" });
+    onSaved();
+  }
+
+  return {
+    form,
+    isPending,
+    isDirty: form.formState.isDirty,
+    handleSubmit,
+  };
+}

--- a/autogpt_platform/frontend/src/app/(platform)/settings/organization/components/TeamsSection/useTeamsSection.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/organization/components/TeamsSection/useTeamsSection.ts
@@ -1,0 +1,97 @@
+"use client";
+
+import { useState } from "react";
+
+import {
+  useDeleteV2DeleteWorkspace,
+  useGetV2ListWorkspaces,
+  usePostV2SelfJoinOpenWorkspace,
+} from "@/app/api/__generated__/endpoints/orgs/orgs";
+import type { TeamResponse } from "@/app/api/__generated__/models/teamResponse";
+import { toast } from "@/components/molecules/Toast/use-toast";
+
+interface Args {
+  orgId: string;
+}
+
+export function useTeamsSection({ orgId }: Args) {
+  const [expandedTeamId, setExpandedTeamId] = useState<string | null>(null);
+  const [teamToDelete, setTeamToDelete] = useState<TeamResponse | null>(null);
+  const [isCreateOpen, setIsCreateOpen] = useState(false);
+
+  const teamsQuery = useGetV2ListWorkspaces(orgId, {
+    query: {
+      enabled: Boolean(orgId),
+      select: (res) => res.data as TeamResponse[],
+    },
+  });
+
+  const teams = teamsQuery.data ?? [];
+
+  const { mutateAsync: joinTeam, isPending: isJoining } =
+    usePostV2SelfJoinOpenWorkspace({
+      mutation: {
+        onError: (error) => {
+          toast({
+            title: "Couldn't join team",
+            description:
+              error instanceof Error ? error.message : "Please try again.",
+            variant: "destructive",
+          });
+        },
+      },
+    });
+
+  const { mutateAsync: deleteTeam, isPending: isDeleting } =
+    useDeleteV2DeleteWorkspace({
+      mutation: {
+        onError: (error) => {
+          toast({
+            title: "Failed to delete team",
+            description:
+              error instanceof Error ? error.message : "Please try again.",
+            variant: "destructive",
+          });
+        },
+      },
+    });
+
+  async function handleJoin(team: TeamResponse) {
+    await joinTeam({ orgId, wsId: team.id });
+    toast({ title: `Joined ${team.name}`, variant: "success" });
+    teamsQuery.refetch();
+  }
+
+  async function handleDeleteConfirmed() {
+    if (!teamToDelete) return;
+    await deleteTeam({ orgId, wsId: teamToDelete.id });
+    toast({ title: `Deleted ${teamToDelete.name}`, variant: "success" });
+    if (expandedTeamId === teamToDelete.id) {
+      setExpandedTeamId(null);
+    }
+    setTeamToDelete(null);
+    teamsQuery.refetch();
+  }
+
+  function toggleExpanded(teamId: string) {
+    setExpandedTeamId((current) => (current === teamId ? null : teamId));
+  }
+
+  return {
+    teams,
+    isLoading: teamsQuery.isLoading,
+    isError: teamsQuery.isError,
+    refetch: teamsQuery.refetch,
+    expandedTeamId,
+    toggleExpanded,
+    setExpandedTeamId,
+    teamToDelete,
+    setTeamToDelete,
+    isJoining,
+    isDeleting,
+    handleJoin,
+    handleDeleteConfirmed,
+    isCreateOpen,
+    setIsCreateOpen,
+  };
+}

--- a/autogpt_platform/frontend/src/app/(platform)/settings/organization/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/organization/page.tsx
@@ -9,6 +9,7 @@ import { InvitationsSection } from "./components/InvitationsSection/InvitationsS
 import { MembersSection } from "./components/MembersSection/MembersSection";
 import { MyInvitationsSection } from "./components/MyInvitationsSection/MyInvitationsSection";
 import { OrgProfileSection } from "./components/OrgProfileSection/OrgProfileSection";
+import { TeamsSection } from "./components/TeamsSection/TeamsSection";
 import { useOrganizationSettingsPage } from "./useOrganizationSettingsPage";
 
 export default function OrganizationSettingsPage() {
@@ -69,6 +70,11 @@ export default function OrganizationSettingsPage() {
             currentMember={currentMember}
             isAdmin={isAdmin}
             onChanged={refetchMembers}
+          />
+          <TeamsSection
+            orgId={org.id}
+            orgMembers={members}
+            currentMember={currentMember}
           />
           <InvitationsSection orgId={org.id} isAdmin={isAdmin} />
           <DangerZoneSection org={org} currentMember={currentMember} />

--- a/autogpt_platform/frontend/src/components/layout/AppSidebar/components/SidebarOrgSwitcher/SidebarOrgSwitcher.tsx
+++ b/autogpt_platform/frontend/src/components/layout/AppSidebar/components/SidebarOrgSwitcher/SidebarOrgSwitcher.tsx
@@ -37,15 +37,7 @@ import { useOrgTeamSwitcher } from "@/components/layout/Navbar/components/OrgTea
 export function SidebarOrgSwitcher() {
   const router = useRouter();
   const [isCreateOpen, setIsCreateOpen] = useState(false);
-  const {
-    orgs,
-    teams,
-    activeOrg,
-    activeTeam,
-    switchOrg,
-    switchTeam,
-    isLoaded,
-  } = useOrgTeamSwitcher();
+  const { orgs, activeOrg, switchOrg, isLoaded } = useOrgTeamSwitcher();
 
   if (!isLoaded || orgs.length === 0) {
     return null;
@@ -78,11 +70,6 @@ export function SidebarOrgSwitcher() {
                   <span className="truncate text-sm font-medium">
                     {activeOrg?.name}
                   </span>
-                  {activeTeam ? (
-                    <span className="truncate text-xs text-zinc-500">
-                      {activeTeam.name}
-                    </span>
-                  ) : null}
                 </div>
                 <CaretUpDownIcon className="ml-auto size-4 shrink-0 text-zinc-500" />
               </SidebarMenuButton>
@@ -118,30 +105,6 @@ export function SidebarOrgSwitcher() {
                   ) : null}
                 </DropdownMenuItem>
               ))}
-
-              {teams.length > 0 ? (
-                <>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuLabel className="text-xs uppercase text-zinc-400">
-                    Teams
-                  </DropdownMenuLabel>
-                  {teams.map((team) => (
-                    <DropdownMenuItem
-                      key={team.id}
-                      onClick={() => switchTeam(team.id)}
-                      className="gap-2"
-                    >
-                      <span className="flex-1 truncate">{team.name}</span>
-                      {team.joinPolicy === "PRIVATE" ? (
-                        <span className="text-xs text-zinc-400">Private</span>
-                      ) : null}
-                      {team.id === activeTeam?.id ? (
-                        <CheckIcon className="size-4 text-green-600" />
-                      ) : null}
-                    </DropdownMenuItem>
-                  ))}
-                </>
-              ) : null}
 
               <DropdownMenuSeparator />
               <DropdownMenuItem

--- a/autogpt_platform/frontend/src/components/layout/AppSidebar/components/SidebarOrgSwitcher/__tests__/SidebarOrgSwitcher.test.tsx
+++ b/autogpt_platform/frontend/src/components/layout/AppSidebar/components/SidebarOrgSwitcher/__tests__/SidebarOrgSwitcher.test.tsx
@@ -90,15 +90,15 @@ describe("SidebarOrgSwitcher", () => {
     expect(screen.queryByTestId("sidebar-org-switcher-trigger")).toBeNull();
   });
 
-  it("shows the active org and team on the trigger", () => {
+  it("shows the active org on the trigger without a team subtitle", () => {
     seedStore();
     renderSwitcher();
     const trigger = screen.getByTestId("sidebar-org-switcher-trigger");
     expect(trigger.textContent).toContain(COMPANY_ORG.name);
-    expect(trigger.textContent).toContain(DEFAULT_TEAM.name);
+    expect(trigger.textContent).not.toContain(DEFAULT_TEAM.name);
   });
 
-  it("lists every org and team with badges when opened", async () => {
+  it("lists every org with badges but no team-switching section", async () => {
     seedStore();
     renderSwitcher();
     await openSwitcher();
@@ -106,8 +106,8 @@ describe("SidebarOrgSwitcher", () => {
     expect(screen.getByText(PERSONAL_ORG.name)).toBeDefined();
     expect(screen.getAllByText(COMPANY_ORG.name).length).toBeGreaterThan(0);
     expect(screen.getByText("Personal")).toBeDefined();
-    expect(screen.getByText(PRIVATE_TEAM.name)).toBeDefined();
-    expect(screen.getByText("Private")).toBeDefined();
+    expect(screen.queryByText("Teams")).toBeNull();
+    expect(screen.queryByText(PRIVATE_TEAM.name)).toBeNull();
   });
 
   it("surfaces Manage + Create organization actions", async () => {

--- a/autogpt_platform/frontend/src/components/layout/Navbar/components/OrgTeamSwitcher/OrgTeamSwitcher.tsx
+++ b/autogpt_platform/frontend/src/components/layout/Navbar/components/OrgTeamSwitcher/OrgTeamSwitcher.tsx
@@ -20,15 +20,7 @@ import { useState } from "react";
 
 export function OrgTeamSwitcher() {
   const [isCreateOpen, setIsCreateOpen] = useState(false);
-  const {
-    orgs,
-    teams,
-    activeOrg,
-    activeTeam,
-    switchOrg,
-    switchTeam,
-    isLoaded,
-  } = useOrgTeamSwitcher();
+  const { orgs, activeOrg, switchOrg, isLoaded } = useOrgTeamSwitcher();
 
   if (!isLoaded || orgs.length === 0) {
     return null;
@@ -92,34 +84,6 @@ export function OrgTeamSwitcher() {
               </button>
             ))}
           </div>
-
-          {/* Team list (only if orgs exist) */}
-          {teams.length > 0 && (
-            <>
-              <div className="border-t border-neutral-100" />
-              <div className="flex flex-col gap-0.5">
-                <span className="px-2 py-1 text-xs font-medium uppercase text-neutral-400">
-                  Teams
-                </span>
-                {teams.map((ws) => (
-                  <button
-                    key={ws.id}
-                    type="button"
-                    className="flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-sm hover:bg-neutral-100"
-                    onClick={() => switchTeam(ws.id)}
-                  >
-                    <span className="flex-1 truncate text-left">{ws.name}</span>
-                    {ws.joinPolicy === "PRIVATE" && (
-                      <span className="text-xs text-neutral-400">Private</span>
-                    )}
-                    {ws.id === activeTeam?.id && (
-                      <CheckIcon size={14} className="text-green-600" />
-                    )}
-                  </button>
-                ))}
-              </div>
-            </>
-          )}
 
           <div className="border-t border-neutral-100" />
           <div className="flex flex-col gap-0.5">

--- a/autogpt_platform/frontend/src/components/layout/Navbar/components/OrgTeamSwitcher/__tests__/OrgTeamSwitcher.test.tsx
+++ b/autogpt_platform/frontend/src/components/layout/Navbar/components/OrgTeamSwitcher/__tests__/OrgTeamSwitcher.test.tsx
@@ -106,25 +106,16 @@ describe("OrgTeamSwitcher", () => {
     expect(screen.getByTestId("org-switcher-manage")).toBeDefined();
   });
 
-  it("lists teams with a Private badge on invite-only teams", async () => {
+  it("does not render a team-switching section (teams are badges, not context)", async () => {
     seedStore();
     render(<OrgTeamSwitcher />);
 
     await openSwitcher();
 
-    expect(screen.getByText(DEFAULT_TEAM.name)).toBeDefined();
-    expect(screen.getByText(PRIVATE_TEAM.name)).toBeDefined();
-    expect(screen.getByText("Private")).toBeDefined();
-    expect(screen.getByText("Manage organization")).toBeDefined();
-  });
-
-  it("hides the team section when the org has no teams", async () => {
-    seedStore({ teams: [] });
-    render(<OrgTeamSwitcher />);
-
-    await openSwitcher();
-
     expect(screen.queryByText("Teams")).toBeNull();
+    expect(screen.queryByText(DEFAULT_TEAM.name)).toBeNull();
+    expect(screen.queryByText(PRIVATE_TEAM.name)).toBeNull();
+    expect(screen.getByText("Manage organization")).toBeDefined();
   });
 
   it("switching org updates the store and resets the active team", async () => {
@@ -136,17 +127,6 @@ describe("OrgTeamSwitcher", () => {
 
     expect(useOrgTeamStore.getState().activeOrgID).toBe(PERSONAL_ORG.id);
     expect(useOrgTeamStore.getState().activeTeamID).toBeNull();
-  });
-
-  it("switching team updates the store without touching the active org", async () => {
-    seedStore();
-    render(<OrgTeamSwitcher />);
-
-    await openSwitcher();
-    await userEvent.click(screen.getByText(PRIVATE_TEAM.name));
-
-    expect(useOrgTeamStore.getState().activeTeamID).toBe(PRIVATE_TEAM.id);
-    expect(useOrgTeamStore.getState().activeOrgID).toBe(COMPANY_ORG.id);
   });
 
   it("re-selecting the already-active org leaves state untouched", async () => {

--- a/autogpt_platform/frontend/src/components/layout/Navbar/components/OrgTeamSwitcher/useOrgTeamSwitcher.ts
+++ b/autogpt_platform/frontend/src/components/layout/Navbar/components/OrgTeamSwitcher/useOrgTeamSwitcher.ts
@@ -2,18 +2,9 @@ import { useOrgTeamStore } from "@/services/org-team/store";
 import { getQueryClient } from "@/lib/react-query/queryClient";
 
 export function useOrgTeamSwitcher() {
-  const {
-    orgs,
-    teams,
-    activeOrgID,
-    activeTeamID,
-    setActiveOrg,
-    setActiveTeam,
-    isLoaded,
-  } = useOrgTeamStore();
+  const { orgs, activeOrgID, setActiveOrg, isLoaded } = useOrgTeamStore();
 
   const activeOrg = orgs.find((o) => o.id === activeOrgID) || null;
-  const activeTeam = teams.find((w) => w.id === activeTeamID) || null;
 
   function switchOrg(orgID: string) {
     if (orgID === activeOrgID) return;
@@ -25,20 +16,10 @@ export function useOrgTeamSwitcher() {
     queryClient.resetQueries();
   }
 
-  function switchTeam(teamID: string) {
-    if (teamID === activeTeamID) return;
-    setActiveTeam(teamID);
-    const queryClient = getQueryClient();
-    queryClient.resetQueries();
-  }
-
   return {
     orgs,
-    teams,
     activeOrg,
-    activeTeam,
     switchOrg,
-    switchTeam,
     isLoaded,
   };
 }

--- a/autogpt_platform/frontend/src/providers/org-team/OrgTeamProvider.tsx
+++ b/autogpt_platform/frontend/src/providers/org-team/OrgTeamProvider.tsx
@@ -9,20 +9,46 @@ interface Props {
   children: React.ReactNode;
 }
 
+interface TeamApiShape {
+  id: string;
+  name: string;
+  slug: string | null;
+  is_default: boolean;
+  join_policy: string;
+  org_id: string;
+}
+
+function mapTeam(team: TeamApiShape) {
+  return {
+    id: team.id,
+    name: team.name,
+    slug: team.slug,
+    isDefault: team.is_default,
+    joinPolicy: team.join_policy,
+    orgId: team.org_id,
+  };
+}
+
 /**
  * Initializes org/team context on login and clears it on logout.
  *
  * On mount (when logged in):
  * 1. Fetches the user's org list from GET /api/orgs
  * 2. If no activeOrgID is stored, sets the personal org as default
- * 3. Fetches teams for the active org
+ * 3. Fetches the active org's teams so badges/filters have data
  *
- * On org/team switch: clears React Query cache to force refetch.
+ * On org switch: refetches the org's teams and resets the query cache.
  */
 export default function OrgTeamProvider({ children }: Props) {
   const { isLoggedIn, user, isUserLoading } = useSupabase();
-  const { activeOrgID, setActiveOrg, setOrgs, setLoaded, clearContext } =
-    useOrgTeamStore();
+  const {
+    activeOrgID,
+    setActiveOrg,
+    setOrgs,
+    setTeams,
+    setLoaded,
+    clearContext,
+  } = useOrgTeamStore();
 
   const prevOrgID = useRef(activeOrgID);
 
@@ -74,6 +100,41 @@ export default function OrgTeamProvider({ children }: Props) {
 
     loadOrgs();
   }, [isLoggedIn, user, isUserLoading]);
+
+  // Load the active org's teams so filters/badges have data. Teams are
+  // no longer a context switch, so this never selects an active team —
+  // activeTeamID stays null unless a screen sets it explicitly.
+  useEffect(() => {
+    if (isUserLoading || !isLoggedIn || !user || !activeOrgID) {
+      return;
+    }
+
+    let cancelled = false;
+
+    async function loadTeams(orgID: string) {
+      try {
+        const res = await fetch(`/api/proxy/api/orgs/${orgID}/workspaces`, {
+          headers: { "Content-Type": "application/json" },
+        });
+        if (!res.ok) {
+          return;
+        }
+        const data = await res.json();
+        const teams: TeamApiShape[] = data.data || data;
+        if (!cancelled) {
+          setTeams(teams.map(mapTeam));
+        }
+      } catch {
+        // Teams are non-blocking; leave the list empty on failure.
+      }
+    }
+
+    loadTeams(activeOrgID);
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isLoggedIn, user, isUserLoading, activeOrgID]);
 
   // Drop org-scoped data when the org switches. resetQueries (NOT
   // clear) — clear() removes queries without notifying mounted

--- a/autogpt_platform/frontend/src/providers/org-team/__tests__/OrgTeamProvider.test.tsx
+++ b/autogpt_platform/frontend/src/providers/org-team/__tests__/OrgTeamProvider.test.tsx
@@ -54,11 +54,19 @@ function mockSessionHydrating() {
   });
 }
 
+function isWorkspacesUrl(url: unknown) {
+  return typeof url === "string" && url.includes("/workspaces");
+}
+
+// The provider fetches orgs first, then the active org's teams. Route by
+// URL so a single stub serves both without teams polluting the org list.
 function mockOrgsResponse(orgs: unknown, ok = true) {
-  const fetchMock = vi.fn().mockResolvedValue({
-    ok,
-    json: async () => ({ data: orgs }),
-  });
+  const fetchMock = vi.fn().mockImplementation((url: unknown) =>
+    Promise.resolve({
+      ok,
+      json: async () => ({ data: isWorkspacesUrl(url) ? [] : orgs }),
+    }),
+  );
   vi.stubGlobal("fetch", fetchMock);
   return fetchMock;
 }
@@ -104,6 +112,107 @@ describe("OrgTeamProvider", () => {
     const state = useOrgTeamStore.getState();
     expect(state.orgs).toEqual([COMPANY_ORG, PERSONAL_ORG]);
     expect(state.activeOrgID).toBe(PERSONAL_ORG.id);
+  });
+
+  it("fetches the active org's teams and maps them into the store (camelCase, no active team)", async () => {
+    mockLoggedIn();
+    const fetchMock = vi.fn().mockImplementation((url: unknown) =>
+      Promise.resolve({
+        ok: true,
+        json: async () => ({
+          data: isWorkspacesUrl(url)
+            ? [
+                {
+                  id: "team-default",
+                  name: "General",
+                  slug: "general",
+                  description: null,
+                  is_default: true,
+                  join_policy: "OPEN",
+                  org_id: PERSONAL_ORG.id,
+                  member_count: 3,
+                  created_at: "2026-01-01T00:00:00Z",
+                },
+              ]
+            : [PERSONAL_ORG],
+        }),
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <OrgTeamProvider>
+        <span>app content</span>
+      </OrgTeamProvider>,
+    );
+
+    await waitFor(() => {
+      expect(useOrgTeamStore.getState().teams).toHaveLength(1);
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      `/api/proxy/api/orgs/${PERSONAL_ORG.id}/workspaces`,
+      expect.objectContaining({
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    const [team] = useOrgTeamStore.getState().teams;
+    expect(team).toEqual({
+      id: "team-default",
+      name: "General",
+      slug: "general",
+      isDefault: true,
+      joinPolicy: "OPEN",
+      orgId: PERSONAL_ORG.id,
+    });
+    // Teams are badges/filters now — the provider never auto-selects one.
+    expect(useOrgTeamStore.getState().activeTeamID).toBeNull();
+  });
+
+  it("leaves teams empty when the teams fetch fails or errors", async () => {
+    mockLoggedIn();
+    const fetchMock = vi.fn().mockImplementation((url: unknown) => {
+      if (isWorkspacesUrl(url)) {
+        return Promise.reject(new Error("offline"));
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({ data: [PERSONAL_ORG] }),
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <OrgTeamProvider>
+        <span>app content</span>
+      </OrgTeamProvider>,
+    );
+
+    await waitFor(() => {
+      expect(useOrgTeamStore.getState().activeOrgID).toBe(PERSONAL_ORG.id);
+    });
+    expect(useOrgTeamStore.getState().teams).toEqual([]);
+  });
+
+  it("leaves teams empty when the teams endpoint responds not-ok", async () => {
+    mockLoggedIn();
+    const fetchMock = vi.fn().mockImplementation((url: unknown) =>
+      Promise.resolve({
+        ok: !isWorkspacesUrl(url),
+        json: async () => ({ data: [PERSONAL_ORG] }),
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <OrgTeamProvider>
+        <span>app content</span>
+      </OrgTeamProvider>,
+    );
+
+    await waitFor(() => {
+      expect(useOrgTeamStore.getState().activeOrgID).toBe(PERSONAL_ORG.id);
+    });
+    expect(useOrgTeamStore.getState().teams).toEqual([]);
   });
 
   it("falls back to the first org when the user has no personal org", async () => {


### PR DESCRIPTION
> [!NOTE]
> Stacked on #13496 — review only the top commit until that merges, then this retargets to `dev`. Pairs with backend #13524 (manage-by-id): the manage panel works for any team you administer once that lands; until then the explicit per-request header keeps it working for the team being managed.

### Why / What / How

**Why:** PR2 shipped org management but no teams UI, and the org/team switcher's team list has always been empty — `OrgTeamProvider` claims to fetch teams but never did (`setTeams` had zero production callers). Product direction is teams as **badges/filters, not context switches**: you never "stand inside" a team, so there is no team-switching UX to build — teams are managed from org settings and (in later slices) filtered on list surfaces.

**What:**
- **Provider wiring**: `OrgTeamProvider` now fetches the active org's workspaces into the store (snake_case→camelCase mapping), refetching on org change. `activeTeamID` stays null — the active-team concept is retired from the UI.
- **Switchers**: team-switching sections removed from both the navbar and sidebar switchers (org switching, Manage organization, Create organization stay).
- **TeamsSection** on `/settings/organization` (non-personal orgs): team list with Default/Open/Private badges + member counts; CreateTeamDialog (org owner/admin/billing_manager; name/description/join policy — no slug, server generates); Join for OPEN teams; Delete with confirmation (org owner/admin, non-default).
- **Manage panel** per team: profile edit with join-policy select (team admins; default team's policy locked), members list with add (from org members not yet in the team), admin-role toggle, remove with confirmation, and Leave for non-default teams.
- Team-management mutations send an explicit per-request `X-Team-Id: <ws_id>` header — satisfies the current backend gate and stays harmless after #13524.

**How:** Follows the PR2 settings-section conventions exactly (section + hook + sub-components with own hooks, zod schema siblings, design-system Dialog/Form, mutateAsync + toast + refetch). All data access via generated orval hooks (`orgs` tag).

Linear: SECRT-2444

### Changes 🏗️

- `providers/org-team/OrgTeamProvider.tsx`: fetch + store the active org's teams
- `settings/organization/components/TeamsSection/**`: section, list, CreateTeamDialog, TeamManagePanel (profile form + members)
- `settings/organization/page.tsx`: render TeamsSection for non-personal orgs
- Navbar `OrgTeamSwitcher` + sidebar `SidebarOrgSwitcher`: team-switching sections removed; tests updated
- Tests: `__tests__/teams.test.tsx` (11 page-level integration tests: list/badges, create, join, delete-with-confirm, manage-panel gating, rename, member add/remove, leave), provider team-fetch tests (10)

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `pnpm lint` clean, `pnpm types` clean
  - [x] Targeted `pnpm test:unit` (teams, org settings page, both switchers, provider): 5 files, 43 tests, all passing
  - [ ] Live walkthrough on the PR preview after `!deploy`

#### For configuration changes: n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jm3mCG9okfdGtAXtFaDF9A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches org membership and team-admin flows in the UI (add/remove/roles/delete), but relies on existing APIs with role checks and broad unit/integration tests; no backend auth changes in this diff.
> 
> **Overview**
> Adds **team management** on organization settings for non-personal orgs: list with Default/Open/Private badges, create/join/delete flows, and an expandable **manage panel** (profile edits, members, roles, leave) gated by org and team-admin permissions. Workspace mutations that target a specific team send **`X-Team-Id`** on the request.
> 
> **Org/team context:** `OrgTeamProvider` now loads the active org’s workspaces into the store (mapped to camelCase) and **does not** set `activeTeamID`. Navbar and sidebar org switchers drop team lists and `switchTeam`; org switching still resets queries and clears the active team via `setActiveOrg`.
> 
> Coverage includes page-level `teams.test.tsx`, updated switcher tests, and provider team-fetch tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51328e5e0d43199974abf834781053b5d7df3ff0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->