### PR TITLE
feat(frontend): pre-assign teams on org invitations

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/settings/organization/__tests__/page.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/organization/__tests__/page.test.tsx
@@ -8,6 +8,7 @@ import {
   getDeleteV2RemoveMemberFromOrganizationMockHandler,
   getGetV2GetOrganizationDetailsMockHandler,
   getGetV2ListOrganizationMembersMockHandler,
+  getGetV2ListWorkspacesMockHandler,
   getPatchV2UpdateOrganizationMockHandler,
 } from "@/app/api/__generated__/endpoints/orgs/orgs.msw";
 import {
@@ -18,6 +19,7 @@ import {
 } from "@/app/api/__generated__/endpoints/invitations/invitations.msw";
 import type { InvitationResponse } from "@/app/api/__generated__/models/invitationResponse";
 import type { OrgMemberResponse } from "@/app/api/__generated__/models/orgMemberResponse";
+import type { TeamResponse } from "@/app/api/__generated__/models/teamResponse";
 import type { UserInvitationResponse } from "@/app/api/__generated__/models/userInvitationResponse";
 
 import OrganizationSettingsPage from "../page";
@@ -67,6 +69,34 @@ const PLAIN_MEMBER = {
   name: "Bob",
   is_owner: false,
   is_admin: false,
+};
+
+const DEFAULT_TEAM: TeamResponse = {
+  id: "team-default",
+  name: "General",
+  slug: "general",
+  description: null,
+  is_default: true,
+  join_policy: "OPEN",
+  org_id: TEAM_ORG.id,
+  member_count: 2,
+  created_at: new Date("2026-01-01T00:00:00Z"),
+};
+
+const MARKETING_TEAM: TeamResponse = {
+  ...DEFAULT_TEAM,
+  id: "team-marketing",
+  name: "Marketing",
+  slug: "marketing",
+  is_default: false,
+};
+
+const ENGINEERING_TEAM: TeamResponse = {
+  ...DEFAULT_TEAM,
+  id: "team-engineering",
+  name: "Engineering",
+  slug: "engineering",
+  is_default: false,
 };
 
 function seedActiveOrg(orgID: string) {
@@ -187,6 +217,68 @@ describe("OrganizationSettingsPage", () => {
     await waitFor(() => {
       expect(createSpy).toHaveBeenCalledTimes(1);
     });
+  });
+
+  it("pre-assigns the selected teams when sending an invitation", async () => {
+    let sentTeamIds: string[] | undefined;
+    mockTeamOrg();
+    server.use(
+      getGetV2ListWorkspacesMockHandler([
+        DEFAULT_TEAM,
+        MARKETING_TEAM,
+        ENGINEERING_TEAM,
+      ]),
+      getPostV2CreateInvitationMockHandler(async (info) => {
+        const body = (await info.request.json()) as { team_ids?: string[] };
+        sentTeamIds = body.team_ids;
+        return {
+          id: "inv-2",
+          email: "new@acme.test",
+          is_admin: false,
+          is_billing_manager: false,
+          token: "tok-2",
+          expires_at: new Date("2026-08-01T00:00:00Z"),
+          created_at: new Date("2026-07-01T00:00:00Z"),
+          team_ids: [MARKETING_TEAM.id, ENGINEERING_TEAM.id],
+        };
+      }),
+    );
+    render(<OrganizationSettingsPage />);
+
+    await userEvent.click(
+      await screen.findByRole("checkbox", { name: "Marketing" }),
+    );
+    await userEvent.click(
+      screen.getByRole("checkbox", { name: "Engineering" }),
+    );
+    await userEvent.type(
+      screen.getByPlaceholderText("teammate@example.com"),
+      "new@acme.test",
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Invite" }));
+
+    await waitFor(() => {
+      expect(sentTeamIds).toBeDefined();
+    });
+    expect(sentTeamIds).toEqual(
+      expect.arrayContaining([MARKETING_TEAM.id, ENGINEERING_TEAM.id]),
+    );
+    expect(sentTeamIds).toHaveLength(2);
+    expect(sentTeamIds).not.toContain(DEFAULT_TEAM.id);
+  });
+
+  it("hides the team selector when the org has only the default team", async () => {
+    mockTeamOrg();
+    server.use(getGetV2ListWorkspacesMockHandler([DEFAULT_TEAM]));
+    render(<OrganizationSettingsPage />);
+
+    // Wait for the workspaces query to settle (default team renders in the
+    // teams section) before asserting the selector never appears.
+    await screen.findByText("General");
+    expect(screen.queryByText("Pre-assign to teams")).toBeNull();
+    expect(
+      screen.queryByRole("group", { name: "Pre-assign to teams" }),
+    ).toBeNull();
   });
 
   it("accepts a pending invitation and switches to the inviting org", async () => {

--- a/autogpt_platform/frontend/src/app/(platform)/settings/organization/__tests__/teams.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/organization/__tests__/teams.test.tsx
@@ -163,8 +163,11 @@ function mockOrg({
 
 // The teams list resolves from its own query, a tick after the page's
 // org/members queries settle the section. Await the row before using it.
+// Scope to the teams section — the invitations section also lists team
+// names (its pre-assign selector), so a page-wide lookup is ambiguous.
 async function teamRow(teamName: string) {
-  const label = await screen.findByText(teamName);
+  const section = await screen.findByTestId("org-teams-section");
+  const label = await within(section).findByText(teamName);
   return label.closest("li") as HTMLElement;
 }
 

--- a/autogpt_platform/frontend/src/app/(platform)/settings/organization/components/InvitationsSection/InvitationsSection.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/organization/components/InvitationsSection/InvitationsSection.tsx
@@ -10,8 +10,10 @@ import {
   FormControl,
   FormField,
   FormItem,
+  FormLabel,
   FormMessage,
 } from "@/components/molecules/Form/Form";
+import { MultiToggle } from "@/components/molecules/MultiToggle/MultiToggle";
 
 import { useInvitationsSection } from "./useInvitationsSection";
 
@@ -24,6 +26,7 @@ export function InvitationsSection({ orgId, isAdmin }: Props) {
   const {
     form,
     invitations,
+    assignableTeams,
     isInviting,
     isRevoking,
     handleInvite,
@@ -46,47 +49,74 @@ export function InvitationsSection({ orgId, isAdmin }: Props) {
       <Form
         form={form}
         onSubmit={handleInvite}
-        className="flex max-w-xl items-start gap-3"
+        className="flex max-w-xl flex-col gap-3"
       >
-        <FormField
-          control={form.control}
-          name="email"
-          render={({ field }) => (
-            <FormItem className="flex-1">
-              <FormControl>
-                <Input
-                  {...field}
-                  id={field.name}
-                  label=""
-                  hideLabel
-                  placeholder="teammate@example.com"
-                  wrapperClassName="!mb-0"
-                />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-        <FormField
-          control={form.control}
-          name="isAdmin"
-          render={({ field }) => (
-            <FormItem>
-              <FormControl>
-                <label className="flex h-[2.875rem] items-center gap-2 text-sm text-zinc-600">
-                  <Switch
-                    checked={field.value}
-                    onCheckedChange={field.onChange}
+        <div className="flex items-start gap-3">
+          <FormField
+            control={form.control}
+            name="email"
+            render={({ field }) => (
+              <FormItem className="flex-1">
+                <FormControl>
+                  <Input
+                    {...field}
+                    id={field.name}
+                    label=""
+                    hideLabel
+                    placeholder="teammate@example.com"
+                    wrapperClassName="!mb-0"
                   />
-                  Admin
-                </label>
-              </FormControl>
-            </FormItem>
-          )}
-        />
-        <Button type="submit" loading={isInviting}>
-          Invite
-        </Button>
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="isAdmin"
+            render={({ field }) => (
+              <FormItem>
+                <FormControl>
+                  <label className="flex h-[2.875rem] items-center gap-2 text-sm text-zinc-600">
+                    <Switch
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                    />
+                    Admin
+                  </label>
+                </FormControl>
+              </FormItem>
+            )}
+          />
+          <Button type="submit" loading={isInviting}>
+            Invite
+          </Button>
+        </div>
+
+        {assignableTeams.length > 0 ? (
+          <FormField
+            control={form.control}
+            name="teamIds"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel className="text-xs text-zinc-500">
+                  Pre-assign to teams
+                </FormLabel>
+                <FormControl>
+                  <MultiToggle
+                    aria-label="Pre-assign to teams"
+                    items={assignableTeams.map((team) => ({
+                      value: team.id,
+                      label: team.name,
+                    }))}
+                    selectedValues={field.value}
+                    onChange={field.onChange}
+                  />
+                </FormControl>
+              </FormItem>
+            )}
+          />
+        ) : null}
       </Form>
 
       {invitations.length > 0 ? (
@@ -106,6 +136,12 @@ export function InvitationsSection({ orgId, isAdmin }: Props) {
                 </span>
               </div>
               {invitation.is_admin ? <Badge variant="info">Admin</Badge> : null}
+              {invitation.team_ids.length > 0 ? (
+                <Badge variant="info">
+                  +{invitation.team_ids.length}{" "}
+                  {invitation.team_ids.length === 1 ? "team" : "teams"}
+                </Badge>
+              ) : null}
               <Button
                 variant="ghost"
                 size="small"

--- a/autogpt_platform/frontend/src/app/(platform)/settings/organization/components/InvitationsSection/useInvitationsSection.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/organization/components/InvitationsSection/useInvitationsSection.ts
@@ -9,12 +9,15 @@ import {
   useGetV2ListPendingInvitations,
   usePostV2CreateInvitation,
 } from "@/app/api/__generated__/endpoints/invitations/invitations";
+import { useGetV2ListWorkspaces } from "@/app/api/__generated__/endpoints/orgs/orgs";
 import type { InvitationResponse } from "@/app/api/__generated__/models/invitationResponse";
+import type { TeamResponse } from "@/app/api/__generated__/models/teamResponse";
 import { toast } from "@/components/molecules/Toast/use-toast";
 
 const inviteSchema = z.object({
   email: z.string().trim().email("Enter a valid email address"),
   isAdmin: z.boolean(),
+  teamIds: z.array(z.string()),
 });
 
 export type InviteFormValues = z.infer<typeof inviteSchema>;
@@ -32,9 +35,22 @@ export function useInvitationsSection({ orgId, isAdmin }: Args) {
     },
   });
 
+  const teamsQuery = useGetV2ListWorkspaces(orgId, {
+    query: {
+      enabled: isAdmin && Boolean(orgId),
+      select: (res) => res.data as TeamResponse[],
+    },
+  });
+
+  // Everyone lands in the org's default team automatically on accept
+  // (add_org_member), so pre-assignment only makes sense for the other teams.
+  const assignableTeams = (teamsQuery.data ?? []).filter(
+    (team) => !team.is_default,
+  );
+
   const form = useForm<InviteFormValues>({
     resolver: zodResolver(inviteSchema),
-    defaultValues: { email: "", isAdmin: false },
+    defaultValues: { email: "", isAdmin: false, teamIds: [] },
     mode: "onChange",
   });
 
@@ -69,7 +85,11 @@ export function useInvitationsSection({ orgId, isAdmin }: Args) {
   async function handleInvite(values: InviteFormValues) {
     await createInvitation({
       orgId,
-      data: { email: values.email, is_admin: values.isAdmin },
+      data: {
+        email: values.email,
+        is_admin: values.isAdmin,
+        team_ids: values.teamIds,
+      },
     });
     toast({ title: `Invitation sent to ${values.email}`, variant: "success" });
     form.reset();
@@ -88,6 +108,7 @@ export function useInvitationsSection({ orgId, isAdmin }: Args) {
   return {
     form,
     invitations: invitationsQuery.data ?? [],
+    assignableTeams,
     isLoading: invitationsQuery.isLoading,
     isInviting,
     isRevoking,


### PR DESCRIPTION
> [!NOTE]
> Stacked on #13528 (teams CRUD UI) → #13496 (org management UI). Review only the top commit until those merge.

### Why / What / How

**Why:** The backend has always accepted `team_ids` on invitation create — the invitee joins those teams when they accept — but the invite dialog never exposed it. "Invite jane straight into Marketing" is the natural onboarding flow for department-shaped orgs; without this it's invite → wait for accept → manually add to each team.

**What:** A team multi-select (design-system `MultiToggle` chips) in the invite form, and a "+N teams" badge on pending-invitation rows. The selector only appears when the org has teams beyond the default, and the default team is excluded from the choices — `accept_invitation` → `add_org_member` already adds every new member to the default team unconditionally, so pre-assigning it is redundant.

**How:** `useInvitationsSection` fetches the org's workspaces with the same query TeamsSection uses (shared query key, dedupes to one request), filters to non-default teams, and wires `team_ids` into the create-invitation mutation via a `teamIds` field on the existing zod schema.

Linear: SECRT-2446

### Changes 🏗️

- `InvitationsSection/useInvitationsSection.ts`: workspaces fetch, `teamIds` schema field, `team_ids` on the mutation
- `InvitationsSection/InvitationsSection.tsx`: MultiToggle team selector + pending-row team-count badge
- Tests: invite-with-teams asserts the POST body contains exactly the selected non-default team ids; selector hidden for default-team-only orgs; teams-test helper scoped to its section to avoid cross-section name collisions

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `pnpm lint` / `pnpm types` clean
  - [x] `pnpm test:unit` on org settings page + teams suites: 20/20 passing

#### For configuration changes: n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jm3mCG9okfdGtAXtFaDF9A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only wiring to an existing invitation API field; no auth or backend changes, with unit test coverage for the new behavior.
> 
> **Overview**
> Org admins can **pre-assign non-default teams** when inviting someone. The invite form gains a **Pre-assign to teams** `MultiToggle` (only when the org has teams beyond the default); the default team is omitted because accept already adds members there. Create-invitation now sends **`team_ids`** from a new `teamIds` form field, backed by the same workspaces list query used elsewhere on the page.
> 
> Pending invitations show a **+N team(s)** badge when `team_ids` is non-empty. Tests cover POST body team selection, hiding the selector for default-only orgs, and scoping team-row lookups to the teams section so invitation team chips do not break tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25808e5bfcfc903eaf3b42d4825902cabfb20786. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->