### PR TITLE
feat(frontend): org ownership transfer in the danger zone

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/settings/organization/__tests__/page.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/organization/__tests__/page.test.tsx
@@ -11,12 +11,15 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
+  getDeleteV2DeleteOrganizationMockHandler,
+  getDeleteV2DeleteOrganizationMockHandler422,
   getDeleteV2RemoveMemberFromOrganizationMockHandler,
   getGetV2GetOrganizationDetailsMockHandler,
   getGetV2ListOrganizationMembersMockHandler,
   getGetV2ListWorkspacesMockHandler,
   getPatchV2UpdateOrganizationMockHandler,
   getPostV2TransferOrganizationOwnershipMockHandler,
+  getPostV2TransferOrganizationOwnershipMockHandler422,
 } from "@/app/api/__generated__/endpoints/orgs/orgs.msw";
 import {
   getGetV2ListPendingInvitationsForCurrentUserMockHandler,
@@ -33,9 +36,22 @@ import OrganizationSettingsPage from "../page";
 
 const OWNER_USER_ID = "user-owner";
 
+const toastSpy = vi.hoisted(() => vi.fn());
+
 vi.mock("@/lib/supabase/hooks/useSupabase", () => ({
   useSupabase: () => ({ user: { id: OWNER_USER_ID } }),
 }));
+
+vi.mock("@/components/molecules/Toast/use-toast", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@/components/molecules/Toast/use-toast")
+    >();
+  return {
+    ...actual,
+    toast: (...args: Parameters<typeof actual.toast>) => toastSpy(...args),
+  };
+});
 
 const TEAM_ORG = {
   id: "org-company",
@@ -387,6 +403,110 @@ describe("OrganizationSettingsPage", () => {
     // The refetch re-runs role gating: the ex-owner loses the danger zone.
     await waitFor(() => {
       expect(screen.queryByTestId("org-danger-zone")).toBeNull();
+    });
+  });
+
+  it("deletes the organization and falls back to the personal org", async () => {
+    let deleteRequested = false;
+    useOrgTeamStore.setState({
+      orgs: [
+        {
+          id: TEAM_ORG.id,
+          name: TEAM_ORG.name,
+          slug: TEAM_ORG.slug,
+          avatarUrl: null,
+          isPersonal: false,
+          memberCount: 2,
+        },
+        {
+          id: PERSONAL_ORG.id,
+          name: PERSONAL_ORG.name,
+          slug: PERSONAL_ORG.slug,
+          avatarUrl: null,
+          isPersonal: true,
+          memberCount: 1,
+        },
+      ],
+    });
+    mockTeamOrg();
+    server.use(
+      getDeleteV2DeleteOrganizationMockHandler(() => {
+        deleteRequested = true;
+      }),
+    );
+    render(<OrganizationSettingsPage />);
+
+    const dangerZone = await screen.findByTestId("org-danger-zone");
+    await userEvent.click(
+      within(dangerZone).getByRole("button", { name: "Delete organization" }),
+    );
+    const dialog = await screen.findByRole("dialog");
+    await userEvent.click(
+      within(dialog).getByRole("button", { name: "Delete organization" }),
+    );
+
+    await waitFor(() => {
+      expect(deleteRequested).toBe(true);
+    });
+    await waitFor(() => {
+      expect(useOrgTeamStore.getState().activeOrgID).toBe(PERSONAL_ORG.id);
+    });
+    expect(useOrgTeamStore.getState().orgs.map((org) => org.id)).not.toContain(
+      TEAM_ORG.id,
+    );
+    expect(toastSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ variant: "success" }),
+    );
+  });
+
+  it("shows an error toast when deleting the organization fails", async () => {
+    mockTeamOrg();
+    server.use(getDeleteV2DeleteOrganizationMockHandler422());
+    render(<OrganizationSettingsPage />);
+
+    const dangerZone = await screen.findByTestId("org-danger-zone");
+    await userEvent.click(
+      within(dangerZone).getByRole("button", { name: "Delete organization" }),
+    );
+    const dialog = await screen.findByRole("dialog");
+    await userEvent.click(
+      within(dialog).getByRole("button", { name: "Delete organization" }),
+    );
+
+    await waitFor(() => {
+      expect(toastSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Failed to delete organization",
+          variant: "destructive",
+        }),
+      );
+    });
+  });
+
+  it("shows an error toast when the ownership transfer fails", async () => {
+    mockTeamOrg();
+    server.use(getPostV2TransferOrganizationOwnershipMockHandler422());
+    render(<OrganizationSettingsPage />);
+
+    const dangerZone = await screen.findByTestId("org-danger-zone");
+    fireEvent.click(
+      within(dangerZone).getByRole("combobox", { name: "New owner" }),
+    );
+    fireEvent.click(await screen.findByRole("option", { name: "Bob" }));
+    await userEvent.click(
+      within(dangerZone).getByRole("button", { name: "Transfer" }),
+    );
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Transfer ownership" }),
+    );
+
+    await waitFor(() => {
+      expect(toastSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Failed to transfer ownership",
+          variant: "destructive",
+        }),
+      );
     });
   });
 

--- a/autogpt_platform/frontend/src/app/(platform)/settings/organization/__tests__/page.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/organization/__tests__/page.test.tsx
@@ -1,6 +1,12 @@
 import { useOrgTeamStore } from "@/services/org-team/store";
 import { server } from "@/mocks/mock-server";
-import { render, screen, waitFor } from "@/tests/integrations/test-utils";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@/tests/integrations/test-utils";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -10,6 +16,7 @@ import {
   getGetV2ListOrganizationMembersMockHandler,
   getGetV2ListWorkspacesMockHandler,
   getPatchV2UpdateOrganizationMockHandler,
+  getPostV2TransferOrganizationOwnershipMockHandler,
 } from "@/app/api/__generated__/endpoints/orgs/orgs.msw";
 import {
   getGetV2ListPendingInvitationsForCurrentUserMockHandler,
@@ -169,6 +176,7 @@ describe("OrganizationSettingsPage", () => {
     await screen.findByTestId("org-profile-section");
     expect(screen.queryByTestId("org-invitations-section")).toBeNull();
     expect(screen.queryByTestId("org-danger-zone")).toBeNull();
+    expect(screen.queryByRole("combobox", { name: "New owner" })).toBeNull();
     expect(screen.queryByText("Save changes")).toBeNull();
   });
 
@@ -183,6 +191,7 @@ describe("OrganizationSettingsPage", () => {
 
     await screen.findByTestId("org-profile-section");
     expect(screen.queryByTestId("org-members-section")).toBeNull();
+    expect(screen.queryByTestId("org-danger-zone")).toBeNull();
     expect(
       screen.getByText(/Personal organizations have a single member/),
     ).toBeDefined();
@@ -335,6 +344,59 @@ describe("OrganizationSettingsPage", () => {
     await waitFor(() => {
       expect(removeSpy).toHaveBeenCalledTimes(1);
     });
+  });
+
+  it("transfers ownership to a selected member and drops the ex-owner's controls", async () => {
+    let sentNewOwnerId: string | undefined;
+    let ownershipTransferred = false;
+    mockTeamOrg();
+    server.use(
+      getGetV2ListOrganizationMembersMockHandler(() =>
+        ownershipTransferred
+          ? [
+              { ...OWNER_MEMBER, is_owner: false },
+              { ...PLAIN_MEMBER, is_owner: true, is_admin: true },
+            ]
+          : [OWNER_MEMBER, PLAIN_MEMBER],
+      ),
+      getPostV2TransferOrganizationOwnershipMockHandler(
+        async (info: { request: Request }) => {
+          const body = (await info.request.json()) as { new_owner_id?: string };
+          sentNewOwnerId = body.new_owner_id;
+          ownershipTransferred = true;
+        },
+      ),
+    );
+    render(<OrganizationSettingsPage />);
+
+    const dangerZone = await screen.findByTestId("org-danger-zone");
+    fireEvent.click(
+      within(dangerZone).getByRole("combobox", { name: "New owner" }),
+    );
+    fireEvent.click(await screen.findByRole("option", { name: "Bob" }));
+    await userEvent.click(
+      within(dangerZone).getByRole("button", { name: "Transfer" }),
+    );
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Transfer ownership" }),
+    );
+
+    await waitFor(() => {
+      expect(sentNewOwnerId).toBe(PLAIN_MEMBER.user_id);
+    });
+    // The refetch re-runs role gating: the ex-owner loses the danger zone.
+    await waitFor(() => {
+      expect(screen.queryByTestId("org-danger-zone")).toBeNull();
+    });
+  });
+
+  it("hides the transfer control when the owner is the only member", async () => {
+    mockTeamOrg({ members: [OWNER_MEMBER] });
+    render(<OrganizationSettingsPage />);
+
+    await screen.findByTestId("org-danger-zone");
+    expect(screen.queryByRole("combobox", { name: "New owner" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Transfer" })).toBeNull();
   });
 
   it("updates the org profile", async () => {

--- a/autogpt_platform/frontend/src/app/(platform)/settings/organization/components/DangerZoneSection/DangerZoneSection.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/organization/components/DangerZoneSection/DangerZoneSection.tsx
@@ -1,54 +1,44 @@
 "use client";
 
-import { useState } from "react";
-
-import { useDeleteV2DeleteOrganization } from "@/app/api/__generated__/endpoints/orgs/orgs";
 import type { OrgMemberResponse } from "@/app/api/__generated__/models/orgMemberResponse";
 import type { OrgResponse } from "@/app/api/__generated__/models/orgResponse";
 import { Button } from "@/components/atoms/Button/Button";
+import { Select } from "@/components/atoms/Select/Select";
 import { Text } from "@/components/atoms/Text/Text";
 import { Dialog } from "@/components/molecules/Dialog/Dialog";
-import { toast } from "@/components/molecules/Toast/use-toast";
-import { getQueryClient } from "@/lib/react-query/queryClient";
-import { useOrgTeamStore } from "@/services/org-team/store";
+
+import { useDangerZoneSection } from "./useDangerZoneSection";
 
 interface Props {
   org: OrgResponse;
+  members: OrgMemberResponse[];
   currentMember: OrgMemberResponse | null;
+  onTransferred: () => void;
 }
 
-export function DangerZoneSection({ org, currentMember }: Props) {
-  const [isConfirmOpen, setIsConfirmOpen] = useState(false);
-  const { orgs, setOrgs, setActiveOrg } = useOrgTeamStore();
-
-  const { mutateAsync: deleteOrg, isPending } = useDeleteV2DeleteOrganization({
-    mutation: {
-      onError: (error) => {
-        toast({
-          title: "Failed to delete organization",
-          description:
-            error instanceof Error ? error.message : "Please try again.",
-          variant: "destructive",
-        });
-      },
-    },
-  });
+export function DangerZoneSection({
+  org,
+  members,
+  currentMember,
+  onTransferred,
+}: Props) {
+  const {
+    isDeleteOpen,
+    setIsDeleteOpen,
+    isDeleting,
+    handleDeleteConfirmed,
+    transferableMembers,
+    transferTarget,
+    transferTargetId,
+    setTransferTargetId,
+    isTransferConfirmOpen,
+    setIsTransferConfirmOpen,
+    isTransferring,
+    handleTransferConfirmed,
+  } = useDangerZoneSection({ org, members, onTransferred });
 
   if (!currentMember?.is_owner) {
     return null;
-  }
-
-  async function handleDeleteConfirmed() {
-    await deleteOrg({ orgId: org.id });
-    const remaining = orgs.filter((o) => o.id !== org.id);
-    setOrgs(remaining);
-    const personal = remaining.find((o) => o.isPersonal) ?? remaining[0];
-    if (personal) {
-      setActiveOrg(personal.id);
-    }
-    getQueryClient().resetQueries();
-    toast({ title: `Organization "${org.name}" deleted`, variant: "success" });
-    setIsConfirmOpen(false);
   }
 
   return (
@@ -59,6 +49,40 @@ export function DangerZoneSection({ org, currentMember }: Props) {
       <Text variant="h4" as="h2">
         Danger zone
       </Text>
+
+      {transferableMembers.length > 0 ? (
+        <div className="flex items-center gap-3">
+          <div className="flex flex-1 flex-col">
+            <Text variant="body">Transfer ownership</Text>
+            <Text variant="small" className="text-zinc-500">
+              Hand this organization to another member. You will keep your
+              current access but stop being the owner.
+            </Text>
+          </div>
+          <Select
+            id="transfer-owner"
+            label="New owner"
+            hideLabel
+            size="small"
+            wrapperClassName="!mb-0 w-48"
+            placeholder="Select a member"
+            value={transferTargetId ?? undefined}
+            onValueChange={setTransferTargetId}
+            options={transferableMembers.map((member) => ({
+              value: member.user_id,
+              label: member.name || member.email,
+            }))}
+          />
+          <Button
+            variant="secondary"
+            disabled={!transferTarget}
+            onClick={() => setIsTransferConfirmOpen(true)}
+          >
+            Transfer
+          </Button>
+        </div>
+      ) : null}
+
       <div className="flex items-center gap-3">
         <div className="flex flex-1 flex-col">
           <Text variant="body">Delete this organization</Text>
@@ -66,18 +90,50 @@ export function DangerZoneSection({ org, currentMember }: Props) {
             Members lose access; financial records are retained.
           </Text>
         </div>
-        <Button variant="destructive" onClick={() => setIsConfirmOpen(true)}>
+        <Button variant="destructive" onClick={() => setIsDeleteOpen(true)}>
           Delete organization
         </Button>
       </div>
 
       <Dialog
+        title={`Transfer ownership of ${org.name}?`}
+        styling={{ maxWidth: "26rem" }}
+        controlled={{
+          isOpen: isTransferConfirmOpen,
+          set: (open) => {
+            if (!isTransferring) setIsTransferConfirmOpen(open);
+          },
+        }}
+      >
+        <Dialog.Content>
+          <Text variant="body">
+            {transferTarget?.name || transferTarget?.email} (
+            {transferTarget?.email}) will become the owner of {org.name} and
+            gain admin access. You will stop being the owner. This cannot be
+            undone from the UI.
+          </Text>
+          <div className="flex justify-end gap-2 pt-4">
+            <Button
+              variant="secondary"
+              onClick={() => setIsTransferConfirmOpen(false)}
+              disabled={isTransferring}
+            >
+              Cancel
+            </Button>
+            <Button loading={isTransferring} onClick={handleTransferConfirmed}>
+              Transfer ownership
+            </Button>
+          </div>
+        </Dialog.Content>
+      </Dialog>
+
+      <Dialog
         title={`Delete ${org.name}?`}
         styling={{ maxWidth: "26rem" }}
         controlled={{
-          isOpen: isConfirmOpen,
+          isOpen: isDeleteOpen,
           set: (open) => {
-            if (!isPending) setIsConfirmOpen(open);
+            if (!isDeleting) setIsDeleteOpen(open);
           },
         }}
       >
@@ -90,14 +146,14 @@ export function DangerZoneSection({ org, currentMember }: Props) {
           <div className="flex justify-end gap-2 pt-4">
             <Button
               variant="secondary"
-              onClick={() => setIsConfirmOpen(false)}
-              disabled={isPending}
+              onClick={() => setIsDeleteOpen(false)}
+              disabled={isDeleting}
             >
               Cancel
             </Button>
             <Button
               variant="destructive"
-              loading={isPending}
+              loading={isDeleting}
               onClick={handleDeleteConfirmed}
             >
               Delete organization

--- a/autogpt_platform/frontend/src/app/(platform)/settings/organization/components/DangerZoneSection/useDangerZoneSection.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/organization/components/DangerZoneSection/useDangerZoneSection.ts
@@ -1,0 +1,102 @@
+"use client";
+
+import { useState } from "react";
+
+import {
+  useDeleteV2DeleteOrganization,
+  usePostV2TransferOrganizationOwnership,
+} from "@/app/api/__generated__/endpoints/orgs/orgs";
+import type { OrgMemberResponse } from "@/app/api/__generated__/models/orgMemberResponse";
+import type { OrgResponse } from "@/app/api/__generated__/models/orgResponse";
+import { toast } from "@/components/molecules/Toast/use-toast";
+import { getQueryClient } from "@/lib/react-query/queryClient";
+import { useOrgTeamStore } from "@/services/org-team/store";
+
+interface Args {
+  org: OrgResponse;
+  members: OrgMemberResponse[];
+  onTransferred: () => void;
+}
+
+export function useDangerZoneSection({ org, members, onTransferred }: Args) {
+  const [isDeleteOpen, setIsDeleteOpen] = useState(false);
+  const [transferTargetId, setTransferTargetId] = useState<string | null>(null);
+  const [isTransferConfirmOpen, setIsTransferConfirmOpen] = useState(false);
+  const { orgs, setOrgs, setActiveOrg } = useOrgTeamStore();
+
+  const transferableMembers = members.filter((member) => !member.is_owner);
+  const transferTarget =
+    transferableMembers.find((member) => member.user_id === transferTargetId) ??
+    null;
+
+  const { mutateAsync: deleteOrg, isPending: isDeleting } =
+    useDeleteV2DeleteOrganization({
+      mutation: {
+        onError: (error) => {
+          toast({
+            title: "Failed to delete organization",
+            description:
+              error instanceof Error ? error.message : "Please try again.",
+            variant: "destructive",
+          });
+        },
+      },
+    });
+
+  const { mutateAsync: transferOwnership, isPending: isTransferring } =
+    usePostV2TransferOrganizationOwnership({
+      mutation: {
+        onError: (error) => {
+          toast({
+            title: "Failed to transfer ownership",
+            description:
+              error instanceof Error ? error.message : "Please try again.",
+            variant: "destructive",
+          });
+        },
+      },
+    });
+
+  async function handleDeleteConfirmed() {
+    await deleteOrg({ orgId: org.id });
+    const remaining = orgs.filter((o) => o.id !== org.id);
+    setOrgs(remaining);
+    const personal = remaining.find((o) => o.isPersonal) ?? remaining[0];
+    if (personal) {
+      setActiveOrg(personal.id);
+    }
+    getQueryClient().resetQueries();
+    toast({ title: `Organization "${org.name}" deleted`, variant: "success" });
+    setIsDeleteOpen(false);
+  }
+
+  async function handleTransferConfirmed() {
+    if (!transferTarget) return;
+    await transferOwnership({
+      orgId: org.id,
+      data: { new_owner_id: transferTarget.user_id },
+    });
+    toast({
+      title: `${transferTarget.name || transferTarget.email} is now the owner of ${org.name}`,
+      variant: "success",
+    });
+    setIsTransferConfirmOpen(false);
+    setTransferTargetId(null);
+    onTransferred();
+  }
+
+  return {
+    isDeleteOpen,
+    setIsDeleteOpen,
+    isDeleting,
+    handleDeleteConfirmed,
+    transferableMembers,
+    transferTarget,
+    transferTargetId,
+    setTransferTargetId,
+    isTransferConfirmOpen,
+    setIsTransferConfirmOpen,
+    isTransferring,
+    handleTransferConfirmed,
+  };
+}

--- a/autogpt_platform/frontend/src/app/(platform)/settings/organization/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/organization/page.tsx
@@ -77,7 +77,15 @@ export default function OrganizationSettingsPage() {
             currentMember={currentMember}
           />
           <InvitationsSection orgId={org.id} isAdmin={isAdmin} />
-          <DangerZoneSection org={org} currentMember={currentMember} />
+          <DangerZoneSection
+            org={org}
+            members={members}
+            currentMember={currentMember}
+            onTransferred={() => {
+              refetchMembers();
+              refetchOrg();
+            }}
+          />
         </>
       ) : (
         <Text variant="body" className="text-zinc-500">


### PR DESCRIPTION
> [!NOTE]
> Stacked on #13529 → #13528 → #13496. Review only the top commit until those merge. Resource transfers (move agent to org/team) are deliberately NOT in this slice — they ride with the badges/filters work.

### Why / What / How

**Why:** `POST /orgs/{org_id}/transfer-ownership` has existed since PR1 with no UI — an org owner who wants to hand off has no path except the API.

**What:** A "Transfer ownership" row in the org settings danger zone (owner-only, non-personal orgs, hidden when the owner is the only member): Select over non-owner members → confirm dialog naming the target and stating the consequences → transfer. On success the members/org queries refetch so role gating recomputes — the ex-owner keeps admin (backend leaves `isAdmin` untouched) but sees owner-only controls disappear immediately.

**How:** Follows the section conventions — extracted `useDangerZoneSection.ts` (the section previously inlined its logic; delete moved verbatim), design-system Select + Dialog, `mutateAsync` + toast + parent refetch callbacks. Backend semantics verified: gate is owner-level (`DELETE_ORG`), body is `{new_owner_id}`, target must already be a member, self-transfer rejected.

Linear: SECRT-2458 (ownership half)

### Changes 🏗️

- `DangerZoneSection/useDangerZoneSection.ts` (new): transfer + delete flows
- `DangerZoneSection/DangerZoneSection.tsx`: transfer row + confirm dialog; takes `members`/`onTransferred`
- `page.tsx`: wires members + refetch callbacks
- Tests: transfer flow asserts POST body + ex-owner's controls disappear after refetch; sole-owner org hides the control; non-owner/personal-org negative cases extended

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `pnpm lint` / `pnpm types` clean
  - [x] `pnpm test:unit` org settings + teams suites: 22/22 passing

#### For configuration changes: n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jm3mCG9okfdGtAXtFaDF9A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes organization ownership and delete flows in settings; mistakes could affect who controls an org, though behavior is gated to owners and covered by integration tests.
> 
> **Overview**
> Adds **transfer ownership** to org settings danger zone (owner-only, team orgs): pick a non-owner member, confirm in a dialog, then `POST` with `new_owner_id`. On success, members/org refetch so the ex-owner loses owner-only UI immediately.
> 
> Refactors danger-zone logic into **`useDangerZoneSection`** (delete unchanged; transfer + toasts/errors live there). **`DangerZoneSection`** now takes `members` and `onTransferred`; **`page.tsx`** wires refetch callbacks after transfer.
> 
> Transfer UI is hidden when the owner is the only member. Integration tests cover happy path, delete success/failure, transfer failure, role gating, and sole-owner case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d3375cfb372bbfd2d7d627602f05a02ef1499c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->