### PR TITLE
fix(dx): batch bot — push rollup objects instead of refs-API update, fix add-then-list race

### DIFF
--- a/.github/batch-bot/batch.mjs
+++ b/.github/batch-bot/batch.mjs
@@ -137,17 +137,13 @@ function buildRollup(list) {
     );
   }
 
-  // Force-update the ephemeral, bot-owned rollup branch via the refs API. This is
-  // a non-ff update of a throwaway branch nobody builds on — protect it in branch
-  // settings so only the bot can push to it (see README).
-  const sha = git(["rev-parse", "HEAD"]);
-  const ref = `refs/heads/${ROLLUP}`;
-  const exists = tryGh(["api", `repos/${REPO}/git/${ref}`]).ok;
-  if (exists) {
-    gh(["api", "-X", "PATCH", `repos/${REPO}/git/${ref}`, "-f", `sha=${sha}`, "-F", "force=true"]);
-  } else {
-    gh(["api", "-X", "POST", `repos/${REPO}/git/refs`, "-f", `ref=${ref}`, "-f", `sha=${sha}`]);
-  }
+  // Force-push the ephemeral, bot-owned rollup branch. The refs API cannot be
+  // used here: the merge commits exist only in this runner's clone, and the
+  // API refuses to point a ref at objects the server has never received
+  // (422 "Object does not exist"). The push uploads the objects and creates
+  // or force-moves the branch in one step, authenticated as the bot via the
+  // checkout token — keep batch/rollup protected to bot-only pushes (README).
+  git(["push", "--force", "origin", `HEAD:refs/heads/${ROLLUP}`]);
   return { merged, ejected };
 }
 
@@ -229,8 +225,19 @@ function assertBatchable(pr) {
   return p;
 }
 
-function rebuildAndReport(actionNote) {
-  const { merged, ejected } = buildRollup(members());
+function rebuildAndReport(actionNote, ensureNumber = null) {
+  // GitHub's label index lags behind `pr edit --add-label`, so the very first
+  // /batch on a PR can list an empty batch and build nothing. When the caller
+  // just labeled a PR, fetch it directly and union it into the member list.
+  let list = members();
+  if (ensureNumber && !list.some((p) => p.number === ensureNumber)) {
+    const row = ghJSON([
+      "pr", "view", String(ensureNumber), "--repo", REPO,
+      "--json", "number,title,headRefName,headRefOid,url,labels,reviewDecision,mergeable,isDraft",
+    ]);
+    if (!row.labels.some((l) => l.name === NEVER)) list.push(row);
+  }
+  const { merged, ejected } = buildRollup(list);
   const pr = upsertRollupPR(merged, ejected);
   if (pr) deployRollup(pr); // (re)deploy the combined preview to reflect the new batch
   if (prNumber) {
@@ -250,7 +257,7 @@ function cmdBatch() {
   if (!prNumber) throw new Error("no PR number");
   assertBatchable(prNumber);
   gh(["pr", "edit", String(prNumber), "--repo", REPO, "--add-label", LABEL]);
-  rebuildAndReport(`Added #${prNumber} to the batch.`);
+  rebuildAndReport(`Added #${prNumber} to the batch.`, prNumber);
 }
 
 function cmdBatchRemove() {


### PR DESCRIPTION
### Why / What / How

**Why:** The batch bot's first live runs (today, batching the org/teams PR stacks) failed at the final step both times it got there:
1. `buildRollup` merges member branches into a **local** commit in the runner, then points the remote `batch/rollup` ref at that SHA via the git refs API — which 422s ("Object does not exist") because the server never received the merge objects. Hard blocker; the whole /batch flow dies here.
2. The first `/batch` on a PR reports "Current batch (0): none" — `cmdBatch` adds the label and immediately lists members, but GitHub's label search index lags `pr edit --add-label`, so the just-added PR is invisible to its own rebuild.

**What/How:**
- Replace the refs-API PATCH/POST dance with a single `git push --force origin HEAD:refs/heads/batch/rollup` — uploads the objects and creates/force-moves the branch in one step, authenticated as the bot via the checkout token (array-arg `execFileSync` like every other git call, no shell).
- `rebuildAndReport` takes an optional `ensureNumber`: when `cmdBatch` just labeled a PR, it's fetched directly (`gh pr view --json ...`) and unioned into the member list, so the first /batch builds immediately.

Targets `master` because issue_comment/repository_dispatch workflows execute the default branch's copy of the bot — a dev-only fix wouldn't take effect until the next release merge. Will forward-port to `dev` right after.

### Changes 🏗️
- `.github/batch-bot/batch.mjs`: force-push rollup branch; union just-added PR into the rebuild

### Checklist 📋
#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `node --check` clean; failure modes reproduced from live run logs (422 in run 29135797524, race in run 29135796249)
  - [ ] Real e2e: re-run `/batch` on the four stack tails after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jm3mCG9okfdGtAXtFaDF9A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the bot force-pushes the shared rollup branch and who is included in rebuilds; wrong behavior could break batched previews/merges, but scope is limited to the ephemeral `batch/rollup` workflow.
> 
> **Overview**
> Fixes two failures in the batch bot’s `/batch` flow in `batch.mjs`.
> 
> **Rollup publish:** After local merges, the bot no longer updates `batch/rollup` via the Git refs API (which 422’d because the server never had the merge objects). It now **`git push --force`** to `refs/heads/batch/rollup`, uploading objects and moving the branch in one step.
> 
> **First-add race:** `rebuildAndReport` accepts an optional **`ensureNumber`**. `cmdBatch` passes the PR it just labeled; if label search hasn’t indexed it yet, that PR is loaded with `gh pr view` and merged into the member list so the first `/batch` rebuilds a non-empty batch instead of reporting “Current batch (0)”.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f357bfe3af819b9df5b0ed36b49bbfa1003297e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->