### PR TITLE
fix(dx): batch bot — push rollup objects instead of refs-API update, fix add-then-list race

### DIFF
--- a/.github/batch-bot/batch.mjs
+++ b/.github/batch-bot/batch.mjs
@@ -137,17 +137,13 @@ function buildRollup(list) {
     );
   }
 
-  // Force-update the ephemeral, bot-owned rollup branch via the refs API. This is
-  // a non-ff update of a throwaway branch nobody builds on — protect it in branch
-  // settings so only the bot can push to it (see README).
-  const sha = git(["rev-parse", "HEAD"]);
-  const ref = `refs/heads/${ROLLUP}`;
-  const exists = tryGh(["api", `repos/${REPO}/git/${ref}`]).ok;
-  if (exists) {
-    gh(["api", "-X", "PATCH", `repos/${REPO}/git/${ref}`, "-f", `sha=${sha}`, "-F", "force=true"]);
-  } else {
-    gh(["api", "-X", "POST", `repos/${REPO}/git/refs`, "-f", `ref=${ref}`, "-f", `sha=${sha}`]);
-  }
+  // Force-push the ephemeral, bot-owned rollup branch. The refs API cannot be
+  // used here: the merge commits exist only in this runner's clone, and the
+  // API refuses to point a ref at objects the server has never received
+  // (422 "Object does not exist"). The push uploads the objects and creates
+  // or force-moves the branch in one step, authenticated as the bot via the
+  // checkout token — keep batch/rollup protected to bot-only pushes (README).
+  git(["push", "--force", "origin", `HEAD:refs/heads/${ROLLUP}`]);
   return { merged, ejected };
 }
 
@@ -229,8 +225,19 @@ function assertBatchable(pr) {
   return p;
 }
 
-function rebuildAndReport(actionNote) {
-  const { merged, ejected } = buildRollup(members());
+function rebuildAndReport(actionNote, ensureNumber = null) {
+  // GitHub's label index lags behind `pr edit --add-label`, so the very first
+  // /batch on a PR can list an empty batch and build nothing. When the caller
+  // just labeled a PR, fetch it directly and union it into the member list.
+  let list = members();
+  if (ensureNumber && !list.some((p) => p.number === ensureNumber)) {
+    const row = ghJSON([
+      "pr", "view", String(ensureNumber), "--repo", REPO,
+      "--json", "number,title,headRefName,headRefOid,url,labels,reviewDecision,mergeable,isDraft",
+    ]);
+    if (!row.labels.some((l) => l.name === NEVER)) list.push(row);
+  }
+  const { merged, ejected } = buildRollup(list);
   const pr = upsertRollupPR(merged, ejected);
   if (pr) deployRollup(pr); // (re)deploy the combined preview to reflect the new batch
   if (prNumber) {
@@ -250,7 +257,7 @@ function cmdBatch() {
   if (!prNumber) throw new Error("no PR number");
   assertBatchable(prNumber);
   gh(["pr", "edit", String(prNumber), "--repo", REPO, "--add-label", LABEL]);
-  rebuildAndReport(`Added #${prNumber} to the batch.`);
+  rebuildAndReport(`Added #${prNumber} to the batch.`, prNumber);
 }
 
 function cmdBatchRemove() {


### PR DESCRIPTION
Replaces #13534 (auto-repointed to dev by the base-branch enforcer — the branch needed a `hotfix/*` name to target master). Same commit. Dev forward-port: #13535.

### Why / What / How

**Why:** The batch bot's first live runs failed at the final step both times it got there:
1. `buildRollup` merges member branches into a **local** commit in the runner, then points the remote `batch/rollup` ref at that SHA via the git refs API — which 422s ("Object does not exist") because the server never received the merge objects. Hard blocker; the whole /batch flow dies here (live evidence: run 29135797524).
2. The first `/batch` on a PR reports "Current batch (0): none" — `cmdBatch` adds the label then immediately lists members, but GitHub's label index lags `pr edit --add-label` (live evidence: run 29135796249).

**What/How:**
- Replace the refs-API PATCH/POST dance with a single `git push --force origin HEAD:refs/heads/batch/rollup` — uploads objects and creates/force-moves the branch in one step under the bot's checkout token (array-arg `execFileSync`, no shell).
- `rebuildAndReport` takes an optional `ensureNumber`: the just-labeled PR is fetched directly and unioned into the member list so the first /batch builds immediately.

Targets `master` because issue_comment/repository_dispatch workflows execute the default branch's copy of the bot — a dev-only fix wouldn't take effect until the next release merge.

### Changes 🏗️
- `.github/batch-bot/batch.mjs`: force-push rollup branch; union just-added PR into the rebuild

### Checklist 📋
#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `node --check` clean; both failure modes reproduced from live run logs
  - [ ] Real e2e: re-trigger `/batch` after merge (batch labels already on #13533/#13526/#13530/#13532)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jm3mCG9okfdGtAXtFaDF9A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the bot-owned rollup branch is updated (force-push) and batch membership is assembled; limited to CI/batch-bot infrastructure but affects preview deploy and batch-merge flows.
> 
> **Overview**
> Fixes two production failures in the batch bot’s rollup publish and member listing.
> 
> **Rollup publish:** After local merges, the bot no longer updates `batch/rollup` via the Git refs API (which 422’d because the server never had the merge objects). It now **`git push --force`** to `HEAD:refs/heads/batch/rollup`, uploading objects and moving the branch in one step under the checkout token.
> 
> **First `/batch` race:** `rebuildAndReport` accepts an optional **`ensureNumber`**. When `/batch` adds a label, the just-labeled PR is fetched with `pr view` and merged into the member list if GitHub’s label index hasn’t caught up yet, so the first add doesn’t report “batch (0): none”.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f357bfe3af819b9df5b0ed36b49bbfa1003297e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->