### PR TITLE
fix(dx): batch bot — findRollupPR head filter matches nothing after first rollup

### DIFF
--- a/.github/batch-bot/batch.mjs
+++ b/.github/batch-bot/batch.mjs
@@ -150,9 +150,12 @@ function buildRollup(list) {
 // --- rollup PR (sticky status + deploy + merge target) -------------------
 
 function findRollupPR() {
-  const owner = REPO.split("/")[0];
+  // Plain branch name only: `gh pr list --head` does NOT understand the
+  // owner-qualified `owner:branch` form (that's a `pr create` convention) —
+  // it silently matches nothing, which made every rebuild after the first
+  // try to create a duplicate rollup PR and die on "already exists".
   const rows = ghJSON([
-    "pr", "list", "--repo", REPO, "--head", `${owner}:${ROLLUP}`, "--base", BASE, "--state", "open",
+    "pr", "list", "--repo", REPO, "--head", ROLLUP, "--base", BASE, "--state", "open",
     "--json", "number,url",
   ]);
   return rows[0] || null;


### PR DESCRIPTION
Third live bug from tonight's batch runs (after #13536): the force-push fix worked — the rollup branch built with all 4 members — but `findRollupPR` queries `gh pr list --head "Significant-Gravitas:batch/rollup"`, and `pr list` does not understand the owner-qualified head form (that's a `pr create` convention). It silently returns `[]`, so every rebuild after the rollup PR exists tries to CREATE a duplicate and dies on "already exists" (run 29136339645) — branch updated, PR body/deploy stale.

Verified live: owner-qualified → `[]`; plain `batch/rollup` → finds #13537.

### Changes 🏗️
- `.github/batch-bot/batch.mjs`: `findRollupPR` uses the plain branch name

### Checklist 📋
- [x] `node --check` clean; failure reproduced from run 29136339645; both filter forms tested against the live rollup PR
- [ ] e2e: re-trigger `/batch` after merge — should update #13537's body to 4 members and redeploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jm3mCG9okfdGtAXtFaDF9A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line CLI filter fix in the batch bot with no auth, data, or production runtime impact.
> 
> **Overview**
> Fixes batch rebuilds failing after the first rollup PR exists: **`findRollupPR`** now passes the plain branch name (`batch/rollup`) to **`gh pr list --head`** instead of **`owner:branch`**, which **`pr list` ignores** and returns no rows.
> 
> With an empty lookup, **`upsertRollupPR`** treated every rebuild as “no rollup PR” and tried **`pr create`** again, hitting **“already exists”** while the branch still updated—leaving the rollup PR body and **`!deploy`** stale.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2505e33ffcea775995c687d808123e0f5996aca4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->