### PR TITLE
feat(frontend): billing-manager role assignment on org members

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/settings/organization/__tests__/page.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/organization/__tests__/page.test.tsx
@@ -18,6 +18,7 @@ import {
   getGetV2ListOrganizationAliasesMockHandler,
   getGetV2ListOrganizationMembersMockHandler,
   getGetV2ListWorkspacesMockHandler,
+  getPatchV2UpdateMemberRoleMockHandler,
   getPatchV2UpdateOrganizationMockHandler,
   getPostV2TransferOrganizationOwnershipMockHandler,
   getPostV2TransferOrganizationOwnershipMockHandler422,
@@ -541,5 +542,55 @@ describe("OrganizationSettingsPage", () => {
     await waitFor(() => {
       expect(patchSpy).toHaveBeenCalledTimes(1);
     });
+  });
+
+  it("grants billing-manager to a member via an independent toggle (PATCHes is_billing_manager only)", async () => {
+    let sentBody: Record<string, unknown> | undefined;
+    mockTeamOrg();
+    server.use(
+      getPatchV2UpdateMemberRoleMockHandler(async (info) => {
+        sentBody = (await info.request.json()) as Record<string, unknown>;
+        return { ...PLAIN_MEMBER, is_billing_manager: true };
+      }),
+    );
+    render(<OrganizationSettingsPage />);
+
+    const bobRow = (await screen.findByText("Bob")).closest(
+      "li",
+    ) as HTMLElement;
+    await userEvent.click(
+      within(bobRow).getByRole("switch", { name: "Billing manager for Bob" }),
+    );
+
+    await waitFor(() => {
+      expect(sentBody).toBeDefined();
+    });
+    // Independent of the role Select — only the billing flag is sent.
+    expect(sentBody).toEqual({ is_billing_manager: true });
+    expect(toastSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ variant: "success" }),
+    );
+  });
+
+  it("shows a read-only Billing badge (not a toggle) to a plain member", async () => {
+    // Viewer is a plain member, so no row is manageable: the billing status
+    // renders as a badge rather than an editable switch.
+    server.use(
+      getGetV2GetOrganizationDetailsMockHandler(TEAM_ORG),
+      getGetV2ListOrganizationMembersMockHandler([
+        { ...OWNER_MEMBER, user_id: "someone-else", is_billing_manager: true },
+        { ...PLAIN_MEMBER, user_id: OWNER_USER_ID },
+      ]),
+      getGetV2ListOrganizationAliasesMockHandler([]),
+      getGetV2ListPendingInvitationsForCurrentUserMockHandler([]),
+    );
+    render(<OrganizationSettingsPage />);
+
+    const section = await screen.findByTestId("org-members-section");
+    const janeRow = (await within(section).findByText("Jane")).closest(
+      "li",
+    ) as HTMLElement;
+    expect(within(janeRow).getByText("Billing")).toBeDefined();
+    expect(within(janeRow).queryByRole("switch")).toBeNull();
   });
 });

--- a/autogpt_platform/frontend/src/app/(platform)/settings/organization/components/DangerZoneSection/useDangerZoneSection.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/organization/components/DangerZoneSection/useDangerZoneSection.ts
@@ -58,7 +58,11 @@ export function useDangerZoneSection({ org, members, onTransferred }: Args) {
     });
 
   async function handleDeleteConfirmed() {
-    await deleteOrg({ orgId: org.id });
+    try {
+      await deleteOrg({ orgId: org.id });
+    } catch {
+      return;
+    }
     const remaining = orgs.filter((o) => o.id !== org.id);
     setOrgs(remaining);
     const personal = remaining.find((o) => o.isPersonal) ?? remaining[0];
@@ -72,10 +76,14 @@ export function useDangerZoneSection({ org, members, onTransferred }: Args) {
 
   async function handleTransferConfirmed() {
     if (!transferTarget) return;
-    await transferOwnership({
-      orgId: org.id,
-      data: { new_owner_id: transferTarget.user_id },
-    });
+    try {
+      await transferOwnership({
+        orgId: org.id,
+        data: { new_owner_id: transferTarget.user_id },
+      });
+    } catch {
+      return;
+    }
     toast({
       title: `${transferTarget.name || transferTarget.email} is now the owner of ${org.name}`,
       variant: "success",

--- a/autogpt_platform/frontend/src/app/(platform)/settings/organization/components/MembersSection/MembersSection.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/organization/components/MembersSection/MembersSection.tsx
@@ -5,6 +5,7 @@ import Avatar, { AvatarFallback } from "@/components/atoms/Avatar/Avatar";
 import { Badge } from "@/components/atoms/Badge/Badge";
 import { Button } from "@/components/atoms/Button/Button";
 import { Select } from "@/components/atoms/Select/Select";
+import { Switch } from "@/components/atoms/Switch/Switch";
 import { Text } from "@/components/atoms/Text/Text";
 import { Dialog } from "@/components/molecules/Dialog/Dialog";
 
@@ -36,6 +37,7 @@ export function MembersSection({
     isUpdatingRole,
     isRemoving,
     handleRoleChange,
+    handleBillingManagerChange,
     handleRemoveConfirmed,
   } = useMembersSection({ orgId, onChanged });
 
@@ -72,6 +74,9 @@ export function MembersSection({
               {!member.is_owner && member.is_admin && !canManage ? (
                 <Badge variant="info">Admin</Badge>
               ) : null}
+              {member.is_billing_manager && !canManage ? (
+                <Badge variant="info">Billing</Badge>
+              ) : null}
               {canManage ? (
                 <>
                   <Select
@@ -85,6 +90,17 @@ export function MembersSection({
                     options={ROLE_OPTIONS}
                     disabled={isUpdatingRole}
                   />
+                  <label className="flex shrink-0 items-center gap-1.5 text-xs text-zinc-500">
+                    Billing
+                    <Switch
+                      aria-label={`Billing manager for ${member.name || member.email}`}
+                      checked={member.is_billing_manager}
+                      onCheckedChange={(checked) =>
+                        handleBillingManagerChange(member, checked)
+                      }
+                      disabled={isUpdatingRole}
+                    />
+                  </label>
                   <Button
                     variant="ghost"
                     size="small"

--- a/autogpt_platform/frontend/src/app/(platform)/settings/organization/components/MembersSection/useMembersSection.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/organization/components/MembersSection/useMembersSection.ts
@@ -59,6 +59,26 @@ export function useMembersSection({ orgId, onChanged }: Args) {
     onChanged();
   }
 
+  async function handleBillingManagerChange(
+    member: OrgMemberResponse,
+    isBillingManager: boolean,
+  ) {
+    await updateRole({
+      orgId,
+      uid: member.user_id,
+      data: { is_billing_manager: isBillingManager },
+    });
+    toast({
+      title: `${member.name || member.email} ${
+        isBillingManager
+          ? "can now manage billing"
+          : "can no longer manage billing"
+      }`,
+      variant: "success",
+    });
+    onChanged();
+  }
+
   async function handleRemoveConfirmed() {
     if (!memberToRemove) return;
     await removeMember({ orgId, uid: memberToRemove.user_id });
@@ -76,6 +96,7 @@ export function useMembersSection({ orgId, onChanged }: Args) {
     isUpdatingRole,
     isRemoving,
     handleRoleChange,
+    handleBillingManagerChange,
     handleRemoveConfirmed,
   };
 }


### PR DESCRIPTION
> [!NOTE]
> Top of the org-UI stack: #13496 → #13528 → #13529 → #13531 → #13533 → this. Review the top commit only.

### Why / What / How

**Why:** #13527 gated all org billing reads behind owner/billing_manager, but the members UI only offers admin/member — so nobody except the owner could ever see org billing. Load-bearing gap (SECRT-2465).

**What:** An independent, admin-gated **Billing** switch per member row (billing-manager is not mutually exclusive with admin, so it deliberately doesn't join the role select) plus a "Billing" badge on holders. Owner/self protections mirror the existing role controls. Also quiets the danger-zone 422 tests' unhandled-rejection noise (handlers now stop after the error toast instead of re-throwing to the click handler).

**Deliberately absent:** the SECRT-2464 join-UX work scoped for this slice — the implementing agent correctly identified it can't be built truthfully against this chain's backend (private teams never appear in the list endpoint, and self-add needs #13524's target-team authorization). It ships after a small backend slice on the team-routes chain (list visibility for org admins + `is_member` flag) and the trains merging.

Linear: SECRT-2465

### Changes 🏗️

- `MembersSection/`: Billing switch + badge, `is_billing_manager` PATCH
- `useDangerZoneSection.ts`: swallow already-toasted rejections
- Tests: billing toggle asserts the PATCH body; badge render; 27/27 across page+teams suites, zero unhandled rejections

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `pnpm lint` / `pnpm types` clean; targeted suites 27/27, vitest exit 0

#### For configuration changes: n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jm3mCG9okfdGtAXtFaDF9A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes who can manage org billing via member flags (authorization-sensitive), though scope is limited to existing PATCH endpoints and admin-gated UI.
> 
> **Overview**
> Adds **billing manager** controls on the organization members settings so owners/admins can grant billing access without folding it into the admin/member role select.
> 
> For manageable member rows, a separate **Billing** switch PATCHes only `{ is_billing_manager }` via the existing update-member-role API; non-managers see a read-only **Billing** badge on holders (same gating as admin badges). Success toasts and member list refresh follow the existing role-change flow.
> 
> **Danger zone:** delete-org and transfer-ownership confirmations now catch failed mutations after the error toast so follow-up UI (store updates, success toast) does not run and tests no longer hit unhandled rejections.
> 
> New page tests cover the toggle request body and plain-member badge visibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4889db664d3296a4f68835b427498c3531b4e4d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->