### PR TITLE
refactor(frontend): split org settings into Profile / Members / Teams tabs

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/settings/organization/__tests__/page.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/organization/__tests__/page.test.tsx
@@ -36,6 +36,27 @@ import type { UserInvitationResponse } from "@/app/api/__generated__/models/user
 
 import OrganizationSettingsPage from "../page";
 
+// Allow per-test override of the search params Next.js exposes to the page so
+// the ?tab= deep-link can be exercised.
+const mockSearchParams = { current: new URLSearchParams() };
+vi.mock("next/navigation", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("next/navigation")>();
+  return {
+    ...actual,
+    useSearchParams: () => mockSearchParams.current,
+    useRouter: () => ({
+      push: vi.fn(),
+      replace: vi.fn(),
+      prefetch: vi.fn(),
+      back: vi.fn(),
+      forward: vi.fn(),
+      refresh: vi.fn(),
+    }),
+    usePathname: () => "/settings/organization",
+    useParams: () => ({}),
+  };
+});
+
 const OWNER_USER_ID = "user-owner";
 
 const toastSpy = vi.hoisted(() => vi.fn());
@@ -158,14 +179,22 @@ function mockTeamOrg({
     getGetV2GetOrganizationDetailsMockHandler(TEAM_ORG),
     getGetV2ListOrganizationMembersMockHandler(members),
     getGetV2ListOrganizationAliasesMockHandler([]),
+    getGetV2ListWorkspacesMockHandler([]),
     getGetV2ListPendingInvitationsMockHandler(orgInvitations),
     getGetV2ListPendingInvitationsForCurrentUserMockHandler(myInvitations),
   );
 }
 
+// Sections live under tabs now; the invite flow and members list sit on the
+// Members tab, teams on the Teams tab. Profile is the default tab.
+async function goToTab(name: "Profile" | "Members" | "Teams") {
+  await userEvent.click(await screen.findByRole("tab", { name }));
+}
+
 describe("OrganizationSettingsPage", () => {
   beforeEach(() => {
     window.localStorage.clear();
+    mockSearchParams.current = new URLSearchParams();
     seedActiveOrg(TEAM_ORG.id);
   });
 
@@ -173,10 +202,14 @@ describe("OrganizationSettingsPage", () => {
     mockTeamOrg();
     render(<OrganizationSettingsPage />);
 
+    // Profile tab (default) owns the profile + danger-zone sections.
     expect(await screen.findByTestId("org-profile-section")).toBeDefined();
+    expect(screen.getByTestId("org-danger-zone")).toBeDefined();
+
+    // Members + invitations live on the Members tab.
+    await goToTab("Members");
     expect(await screen.findByText("Members (2)")).toBeDefined();
     expect(screen.getByTestId("org-invitations-section")).toBeDefined();
-    expect(screen.getByTestId("org-danger-zone")).toBeDefined();
     expect(screen.getAllByTestId("org-member-row")).toHaveLength(2);
     expect(screen.getByText("Bob")).toBeDefined();
   });
@@ -193,11 +226,16 @@ describe("OrganizationSettingsPage", () => {
     );
     render(<OrganizationSettingsPage />);
 
+    // Profile tab: no danger zone or profile-edit controls for a plain member.
     await screen.findByTestId("org-profile-section");
-    expect(screen.queryByTestId("org-invitations-section")).toBeNull();
     expect(screen.queryByTestId("org-danger-zone")).toBeNull();
     expect(screen.queryByRole("combobox", { name: "New owner" })).toBeNull();
     expect(screen.queryByText("Save changes")).toBeNull();
+
+    // Members tab shows the roster but hides the admin-only invitations section.
+    await goToTab("Members");
+    await screen.findByTestId("org-members-section");
+    expect(screen.queryByTestId("org-invitations-section")).toBeNull();
   });
 
   it("shows the solo note instead of members for a personal org", async () => {
@@ -237,6 +275,7 @@ describe("OrganizationSettingsPage", () => {
     );
     render(<OrganizationSettingsPage />);
 
+    await goToTab("Members");
     const emailInput = await screen.findByPlaceholderText(
       "teammate@example.com",
     );
@@ -274,6 +313,7 @@ describe("OrganizationSettingsPage", () => {
     );
     render(<OrganizationSettingsPage />);
 
+    await goToTab("Members");
     await userEvent.click(
       await screen.findByRole("checkbox", { name: "Marketing" }),
     );
@@ -301,9 +341,15 @@ describe("OrganizationSettingsPage", () => {
     server.use(getGetV2ListWorkspacesMockHandler([DEFAULT_TEAM]));
     render(<OrganizationSettingsPage />);
 
-    // Wait for the workspaces query to settle (default team renders in the
-    // teams section) before asserting the selector never appears.
+    // Resolve + cache the workspaces query via the Teams tab so the invite
+    // form on the Members tab reads a settled (default-only) team list.
+    await goToTab("Teams");
     await screen.findByText("General");
+
+    await goToTab("Members");
+    await screen.findByRole("button", { name: "Invite" });
+    // The default team is auto-joined, so with no other teams there is nothing
+    // to pre-assign — the selector must not render.
     expect(screen.queryByText("Pre-assign to teams")).toBeNull();
     expect(
       screen.queryByRole("group", { name: "Pre-assign to teams" }),
@@ -355,6 +401,7 @@ describe("OrganizationSettingsPage", () => {
     );
     render(<OrganizationSettingsPage />);
 
+    await goToTab("Members");
     await screen.findByText("Bob");
     await userEvent.click(screen.getByRole("button", { name: "Remove" }));
     await userEvent.click(
@@ -555,6 +602,7 @@ describe("OrganizationSettingsPage", () => {
     );
     render(<OrganizationSettingsPage />);
 
+    await goToTab("Members");
     const bobRow = (await screen.findByText("Bob")).closest(
       "li",
     ) as HTMLElement;
@@ -586,11 +634,94 @@ describe("OrganizationSettingsPage", () => {
     );
     render(<OrganizationSettingsPage />);
 
+    await goToTab("Members");
     const section = await screen.findByTestId("org-members-section");
     const janeRow = (await within(section).findByText("Jane")).closest(
       "li",
     ) as HTMLElement;
     expect(within(janeRow).getByText("Billing")).toBeDefined();
     expect(within(janeRow).queryByRole("switch")).toBeNull();
+  });
+
+  it("defaults to the Profile tab", async () => {
+    mockTeamOrg();
+    render(<OrganizationSettingsPage />);
+
+    const profileTab = await screen.findByRole("tab", { name: "Profile" });
+    expect(profileTab.getAttribute("data-state")).toBe("active");
+    expect(screen.getByTestId("org-profile-section")).toBeDefined();
+    // Inactive tabs' sections stay unmounted until selected.
+    expect(screen.queryByTestId("org-members-section")).toBeNull();
+    expect(screen.queryByTestId("org-teams-section")).toBeNull();
+  });
+
+  it("reveals members and invitations when the Members tab is selected", async () => {
+    mockTeamOrg();
+    render(<OrganizationSettingsPage />);
+
+    await screen.findByTestId("org-profile-section");
+    await goToTab("Members");
+
+    expect(await screen.findByTestId("org-members-section")).toBeDefined();
+    expect(screen.getByTestId("org-invitations-section")).toBeDefined();
+    expect(screen.getByPlaceholderText("teammate@example.com")).toBeDefined();
+  });
+
+  it("keeps the invitation banner visible from every tab", async () => {
+    mockTeamOrg({
+      myInvitations: [
+        {
+          id: "inv-banner",
+          token: "tok-banner",
+          org_id: "org-other",
+          org_name: "Other Corp",
+          org_slug: "other-corp",
+          is_admin: false,
+          is_billing_manager: false,
+          expires_at: new Date("2026-08-01T00:00:00Z"),
+          created_at: new Date("2026-07-01T00:00:00Z"),
+        },
+      ],
+    });
+    render(<OrganizationSettingsPage />);
+
+    expect(await screen.findByTestId("my-invitations-section")).toBeDefined();
+    await goToTab("Members");
+    expect(screen.getByTestId("my-invitations-section")).toBeDefined();
+    await goToTab("Teams");
+    expect(screen.getByTestId("my-invitations-section")).toBeDefined();
+  });
+
+  it("renders a personal org without tab chrome", async () => {
+    useOrgTeamStore.setState({ activeOrgID: PERSONAL_ORG.id });
+    server.use(
+      getGetV2GetOrganizationDetailsMockHandler(PERSONAL_ORG),
+      getGetV2ListOrganizationMembersMockHandler([OWNER_MEMBER]),
+      getGetV2ListPendingInvitationsForCurrentUserMockHandler([]),
+    );
+    render(<OrganizationSettingsPage />);
+
+    await screen.findByTestId("org-profile-section");
+    expect(screen.queryByRole("tablist")).toBeNull();
+    expect(screen.queryByRole("tab")).toBeNull();
+  });
+
+  it("opens the Teams tab from a ?tab=teams deep link", async () => {
+    mockTeamOrg();
+    mockSearchParams.current = new URLSearchParams({ tab: "teams" });
+    render(<OrganizationSettingsPage />);
+
+    const teamsTab = await screen.findByRole("tab", { name: "Teams" });
+    expect(teamsTab.getAttribute("data-state")).toBe("active");
+    expect(await screen.findByTestId("org-teams-section")).toBeDefined();
+  });
+
+  it("ignores an unknown ?tab= value and falls back to the Profile default", async () => {
+    mockTeamOrg();
+    mockSearchParams.current = new URLSearchParams({ tab: "bogus" });
+    render(<OrganizationSettingsPage />);
+
+    const profileTab = await screen.findByRole("tab", { name: "Profile" });
+    expect(profileTab.getAttribute("data-state")).toBe("active");
   });
 });

--- a/autogpt_platform/frontend/src/app/(platform)/settings/organization/__tests__/teams.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/organization/__tests__/teams.test.tsx
@@ -163,12 +163,20 @@ function mockOrg({
   );
 }
 
+// TeamsSection now lives on the "Teams" tab; activate it before reading the
+// section. Clicking again once active is a no-op, so this is safe to call from
+// every teams-section lookup.
+async function showTeamsTab() {
+  await userEvent.click(await screen.findByRole("tab", { name: "Teams" }));
+  return screen.findByTestId("org-teams-section");
+}
+
 // The teams list resolves from its own query, a tick after the page's
 // org/members queries settle the section. Await the row before using it.
 // Scope to the teams section — the invitations section also lists team
 // names (its pre-assign selector), so a page-wide lookup is ambiguous.
 async function teamRow(teamName: string) {
-  const section = await screen.findByTestId("org-teams-section");
+  const section = await showTeamsTab();
   const label = await within(section).findByText(teamName);
   return label.closest("li") as HTMLElement;
 }
@@ -189,7 +197,7 @@ describe("TeamsSection", () => {
     mockOrg();
     render(<OrganizationSettingsPage />);
 
-    const section = await screen.findByTestId("org-teams-section");
+    const section = await showTeamsTab();
     await within(section).findByText("Marketing");
     expect(within(section).getByText("Teams (3)")).toBeDefined();
     expect(within(section).getAllByTestId("org-team-row")).toHaveLength(3);
@@ -213,7 +221,7 @@ describe("TeamsSection", () => {
     );
     render(<OrganizationSettingsPage />);
 
-    await screen.findByTestId("org-teams-section");
+    await showTeamsTab();
     await userEvent.click(screen.getByTestId("create-team-button"));
 
     const dialog = await screen.findByRole("dialog");
@@ -241,7 +249,7 @@ describe("TeamsSection", () => {
     );
     render(<OrganizationSettingsPage />);
 
-    await screen.findByTestId("org-teams-section");
+    await showTeamsTab();
     const row = await teamRow("Marketing");
     await userEvent.click(within(row).getByRole("button", { name: "Join" }));
 
@@ -260,7 +268,7 @@ describe("TeamsSection", () => {
     );
     render(<OrganizationSettingsPage />);
 
-    await screen.findByTestId("org-teams-section");
+    await showTeamsTab();
     const row = await teamRow("Skunkworks");
     await userEvent.click(within(row).getByRole("button", { name: "Delete" }));
 
@@ -283,7 +291,7 @@ describe("TeamsSection", () => {
     });
     render(<OrganizationSettingsPage />);
 
-    const section = await screen.findByTestId("org-teams-section");
+    const section = await showTeamsTab();
     expect(screen.queryByTestId("create-team-button")).toBeNull();
     expect(
       within(section).queryByRole("button", { name: "Delete" }),
@@ -299,7 +307,7 @@ describe("TeamsSection", () => {
     );
     render(<OrganizationSettingsPage />);
 
-    await screen.findByTestId("org-teams-section");
+    await showTeamsTab();
     const panel = await openManagePanel("Marketing");
 
     expect(
@@ -321,7 +329,7 @@ describe("TeamsSection", () => {
     );
     render(<OrganizationSettingsPage />);
 
-    await screen.findByTestId("org-teams-section");
+    await showTeamsTab();
     const panel = await openManagePanel("Marketing");
 
     expect(await within(panel).findByTestId("team-leave-button")).toBeDefined();
@@ -349,7 +357,7 @@ describe("TeamsSection", () => {
     );
     render(<OrganizationSettingsPage />);
 
-    await screen.findByTestId("org-teams-section");
+    await showTeamsTab();
     const panel = await openManagePanel("Marketing");
 
     const nameInput = await within(panel).findByLabelText("Name");
@@ -379,7 +387,7 @@ describe("TeamsSection", () => {
     );
     render(<OrganizationSettingsPage />);
 
-    await screen.findByTestId("org-teams-section");
+    await showTeamsTab();
     const panel = await openManagePanel("Marketing");
 
     const combo = await within(panel).findByRole("combobox", {
@@ -408,7 +416,7 @@ describe("TeamsSection", () => {
     );
     render(<OrganizationSettingsPage />);
 
-    await screen.findByTestId("org-teams-section");
+    await showTeamsTab();
     const panel = await openManagePanel("Marketing");
 
     const carlRow = (await within(panel).findByText("Carl")).closest(
@@ -441,7 +449,7 @@ describe("TeamsSection", () => {
     );
     render(<OrganizationSettingsPage />);
 
-    await screen.findByTestId("org-teams-section");
+    await showTeamsTab();
     const panel = await openManagePanel("Marketing");
 
     await userEvent.click(

--- a/autogpt_platform/frontend/src/app/(platform)/settings/organization/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/organization/page.tsx
@@ -1,8 +1,17 @@
 "use client";
 
+import { useState } from "react";
+import { useSearchParams } from "next/navigation";
+
 import { Skeleton } from "@/components/atoms/Skeleton/Skeleton";
 import { Text } from "@/components/atoms/Text/Text";
 import { ErrorCard } from "@/components/molecules/ErrorCard/ErrorCard";
+import {
+  TabsLine,
+  TabsLineContent,
+  TabsLineList,
+  TabsLineTrigger,
+} from "@/components/molecules/TabsLine/TabsLine";
 
 import { AliasesSection } from "./components/AliasesSection/AliasesSection";
 import { DangerZoneSection } from "./components/DangerZoneSection/DangerZoneSection";
@@ -13,7 +22,20 @@ import { OrgProfileSection } from "./components/OrgProfileSection/OrgProfileSect
 import { TeamsSection } from "./components/TeamsSection/TeamsSection";
 import { useOrganizationSettingsPage } from "./useOrganizationSettingsPage";
 
+type OrgSettingsTab = "profile" | "members" | "teams";
+
+function isOrgSettingsTab(value: string): value is OrgSettingsTab {
+  return value === "profile" || value === "members" || value === "teams";
+}
+
+function resolveInitialTab(searchParams: URLSearchParams): OrgSettingsTab {
+  const tabParam = searchParams.get("tab");
+  if (tabParam && isOrgSettingsTab(tabParam)) return tabParam;
+  return "profile";
+}
+
 export default function OrganizationSettingsPage() {
+  const searchParams = useSearchParams();
   const {
     org,
     members,
@@ -24,6 +46,13 @@ export default function OrganizationSettingsPage() {
     refetchMembers,
     refetchOrg,
   } = useOrganizationSettingsPage();
+  const [activeTab, setActiveTab] = useState<OrgSettingsTab>(() =>
+    resolveInitialTab(searchParams),
+  );
+
+  function handleTabChange(value: string) {
+    if (isOrgSettingsTab(value)) setActiveTab(value);
+  }
 
   if (isLoading) {
     return (
@@ -47,37 +76,49 @@ export default function OrganizationSettingsPage() {
     );
   }
 
-  return (
-    <div className="flex flex-col gap-8 py-6">
-      <div>
-        <Text variant="h3" as="h1">
-          Organization
-        </Text>
+  const header = (
+    <div>
+      <Text variant="h3" as="h1">
+        Organization
+      </Text>
+      <Text variant="body" className="text-zinc-500">
+        Manage {org.name}
+        {org.is_personal ? " — your personal organization" : ""}
+      </Text>
+    </div>
+  );
+
+  // Personal orgs only have profile content, so a single-tab strip would be
+  // noise — render the profile directly, matching the pre-tabs layout.
+  if (org.is_personal) {
+    return (
+      <div className="flex flex-col gap-8 py-6">
+        {header}
+        <MyInvitationsSection />
+        <OrgProfileSection org={org} isAdmin={isAdmin} onSaved={refetchOrg} />
         <Text variant="body" className="text-zinc-500">
-          Manage {org.name}
-          {org.is_personal ? " — your personal organization" : ""}
+          Personal organizations have a single member. Create a team
+          organization from the switcher to invite others.
         </Text>
       </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-8 py-6">
+      {header}
 
       <MyInvitationsSection />
 
-      <OrgProfileSection org={org} isAdmin={isAdmin} onSaved={refetchOrg} />
+      <TabsLine value={activeTab} onValueChange={handleTabChange}>
+        <TabsLineList>
+          <TabsLineTrigger value="profile">Profile</TabsLineTrigger>
+          <TabsLineTrigger value="members">Members</TabsLineTrigger>
+          <TabsLineTrigger value="teams">Teams</TabsLineTrigger>
+        </TabsLineList>
 
-      {!org.is_personal ? (
-        <>
-          <MembersSection
-            orgId={org.id}
-            members={members}
-            currentMember={currentMember}
-            isAdmin={isAdmin}
-            onChanged={refetchMembers}
-          />
-          <TeamsSection
-            orgId={org.id}
-            orgMembers={members}
-            currentMember={currentMember}
-          />
-          <InvitationsSection orgId={org.id} isAdmin={isAdmin} />
+        <TabsLineContent value="profile" className="flex flex-col gap-8">
+          <OrgProfileSection org={org} isAdmin={isAdmin} onSaved={refetchOrg} />
           <AliasesSection orgId={org.id} isAdmin={isAdmin} />
           <DangerZoneSection
             org={org}
@@ -88,13 +129,27 @@ export default function OrganizationSettingsPage() {
               refetchOrg();
             }}
           />
-        </>
-      ) : (
-        <Text variant="body" className="text-zinc-500">
-          Personal organizations have a single member. Create a team
-          organization from the switcher to invite others.
-        </Text>
-      )}
+        </TabsLineContent>
+
+        <TabsLineContent value="members" className="flex flex-col gap-8">
+          <MembersSection
+            orgId={org.id}
+            members={members}
+            currentMember={currentMember}
+            isAdmin={isAdmin}
+            onChanged={refetchMembers}
+          />
+          <InvitationsSection orgId={org.id} isAdmin={isAdmin} />
+        </TabsLineContent>
+
+        <TabsLineContent value="teams">
+          <TeamsSection
+            orgId={org.id}
+            orgMembers={members}
+            currentMember={currentMember}
+          />
+        </TabsLineContent>
+      </TabsLine>
     </div>
   );
 }


### PR DESCRIPTION
> [!NOTE]
> Top of the org-UI stack: #13496 → #13528 → #13529 → #13531 → #13533 → #13539 → this. Review the top commit only.

### Why / What / How

**Why:** Preview feedback (SECRT-2463): `/settings/organization` is six stacked sections; inviting members and managing teams deserve their own tabs.

**What:** Re-layout into **Profile** (profile + aliases + danger zone) / **Members** (members + invitations) / **Teams** tabs using the design-system `TabsLine` molecule, with `?tab=` deep-linking (typed param guard, invalid values fall back to Profile). The "You've been invited" banner stays above the tabs on every view; personal orgs keep their untabbed profile+note layout (no single-tab chrome). No Billing tab scaffolded — it arrives with the spend page.

**How:** Pure page-level re-layout — every section component and hook is untouched; `useOrganizationSettingsPage` still owns the shared queries. Tests updated with a switch-tab helper plus new scenarios (default tab, tab switching reveals sections, banner cross-tab visibility, personal-org untabbed).

Linear: SECRT-2463

### Changes 🏗️

- `page.tsx`: TabsLine layout, `?tab=` resolution
- `__tests__/page.test.tsx`, `__tests__/teams.test.tsx`: tab-aware helpers + 6 new scenarios (36 total across the org settings suites, exit 0)

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `pnpm lint` / `pnpm types` clean; org settings suites 36/36, vitest exit 0

#### For configuration changes: n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jm3mCG9okfdGtAXtFaDF9A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only page re-layout with no API or permission logic changes; risk is mainly discoverability of actions that moved to other tabs.
> 
> **Overview**
> Team organization settings at `/settings/organization` move from one long scroll of sections to **Profile**, **Members**, and **Teams** tabs via `TabsLine`. **Profile** holds org profile, aliases, and danger zone; **Members** holds the roster and invitations; **Teams** holds workspace management. The “You've been invited” block stays above the tabs on every view.
> 
> Initial tab comes from `?tab=` (`profile` | `members` | `teams`), with invalid values defaulting to Profile. Personal orgs skip tab chrome and keep profile plus the solo-member note. Section components and data hooks are unchanged—only `page.tsx` layout and tests (`goToTab` / `showTeamsTab`, `next/navigation` mocks for deep links).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b01a6dc2de2211e7f9dc2c02f32200ac5adb11c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->