### PR TITLE
fix(frontend): cut auth panel vortex animation cost to stop page-wide jank

### DIFF
--- a/autogpt_platform/frontend/src/components/ui/__tests__/vortex.test.tsx
+++ b/autogpt_platform/frontend/src/components/ui/__tests__/vortex.test.tsx
@@ -1,0 +1,156 @@
+import { render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { Vortex } from "../vortex";
+
+type ObserverCallback = (entries: Array<{ isIntersecting: boolean }>) => void;
+
+const rafCallbacks = new Map<number, FrameRequestCallback>();
+let rafId = 0;
+const intersectionCallbacks: ObserverCallback[] = [];
+const resizeCallbacks: Array<() => void> = [];
+const disconnectSpy = vi.fn();
+let mockSize = { width: 800, height: 600 };
+let mockCtx: ReturnType<typeof createMockContext>;
+
+function createMockContext() {
+  return {
+    clearRect: vi.fn(),
+    fillRect: vi.fn(),
+    beginPath: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    stroke: vi.fn(),
+    fillStyle: "",
+    strokeStyle: "",
+    lineCap: "",
+    lineWidth: 0,
+    globalCompositeOperation: "",
+  };
+}
+
+function flushFrames(count = 1) {
+  for (let i = 0; i < count; i++) {
+    const pending = Array.from(rafCallbacks.values());
+    rafCallbacks.clear();
+    for (const callback of pending) callback(performance.now());
+  }
+}
+
+function setReducedMotion(matches: boolean) {
+  vi.stubGlobal("matchMedia", vi.fn().mockReturnValue({ matches }));
+}
+
+beforeEach(() => {
+  rafCallbacks.clear();
+  rafId = 0;
+  intersectionCallbacks.length = 0;
+  resizeCallbacks.length = 0;
+  disconnectSpy.mockClear();
+  mockSize = { width: 800, height: 600 };
+  mockCtx = createMockContext();
+
+  vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+    rafCallbacks.set(++rafId, cb);
+    return rafId;
+  });
+  vi.stubGlobal("cancelAnimationFrame", (id: number) => {
+    rafCallbacks.delete(id);
+  });
+  vi.stubGlobal(
+    "IntersectionObserver",
+    class {
+      constructor(cb: ObserverCallback) {
+        intersectionCallbacks.push(cb);
+      }
+      observe() {}
+      disconnect = disconnectSpy;
+    },
+  );
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      constructor(cb: () => void) {
+        resizeCallbacks.push(cb);
+      }
+      observe() {
+        for (const cb of resizeCallbacks) cb();
+      }
+      disconnect = disconnectSpy;
+    },
+  );
+  setReducedMotion(false);
+
+  vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(
+    mockCtx as unknown as CanvasRenderingContext2D,
+  );
+  Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+    configurable: true,
+    get: () => mockSize.width,
+  });
+  Object.defineProperty(HTMLElement.prototype, "clientHeight", {
+    configurable: true,
+    get: () => mockSize.height,
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("Vortex", () => {
+  test("animates while visible and stops when hidden", () => {
+    render(<Vortex particleCount={10} />);
+
+    const [onIntersection] = intersectionCallbacks;
+    onIntersection([{ isIntersecting: true }]);
+    flushFrames(2);
+    expect(mockCtx.stroke).toHaveBeenCalled();
+
+    onIntersection([{ isIntersecting: false }]);
+    expect(rafCallbacks.size).toBe(0);
+  });
+
+  test("acts on the last entry when intersection records are batched", () => {
+    render(<Vortex particleCount={10} />);
+
+    intersectionCallbacks[0]([
+      { isIntersecting: true },
+      { isIntersecting: false },
+    ]);
+    expect(rafCallbacks.size).toBe(0);
+    expect(mockCtx.stroke).not.toHaveBeenCalled();
+  });
+
+  test("renders a single static frame under prefers-reduced-motion", () => {
+    setReducedMotion(true);
+    render(<Vortex particleCount={10} />);
+
+    expect(intersectionCallbacks.length).toBe(0);
+    flushFrames(1);
+    expect(mockCtx.stroke).toHaveBeenCalled();
+    expect(rafCallbacks.size).toBe(0);
+  });
+
+  test("sizes the canvas to its container and follows resizes", () => {
+    mockSize = { width: 0, height: 0 };
+    const { container } = render(<Vortex particleCount={10} />);
+    const canvas = container.querySelector("canvas");
+
+    expect(canvas?.width).toBe(0);
+
+    mockSize = { width: 640, height: 480 };
+    for (const cb of resizeCallbacks) cb();
+    expect(canvas?.width).toBe(640);
+    expect(canvas?.height).toBe(480);
+  });
+
+  test("disconnects observers and cancels frames on unmount", () => {
+    const { unmount } = render(<Vortex particleCount={10} />);
+    intersectionCallbacks[0]([{ isIntersecting: true }]);
+
+    unmount();
+    expect(disconnectSpy).toHaveBeenCalledTimes(2);
+    expect(rafCallbacks.size).toBe(0);
+  });
+});

--- a/autogpt_platform/frontend/src/components/ui/__tests__/vortex.test.tsx
+++ b/autogpt_platform/frontend/src/components/ui/__tests__/vortex.test.tsx
@@ -96,6 +96,8 @@ beforeEach(() => {
 afterEach(() => {
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
+  Reflect.deleteProperty(HTMLElement.prototype, "clientWidth");
+  Reflect.deleteProperty(HTMLElement.prototype, "clientHeight");
 });
 
 describe("Vortex", () => {

--- a/autogpt_platform/frontend/src/components/ui/vortex.tsx
+++ b/autogpt_platform/frontend/src/components/ui/vortex.tsx
@@ -1,8 +1,9 @@
 "use client";
 import { cn } from "@/lib/utils";
-import React, { ReactNode, useEffect, useRef } from "react";
+import { ReactNode, useRef } from "react";
 import { createNoise3D } from "simplex-noise";
 import { motion } from "motion/react";
+import { useMountEffect } from "@/hooks/useMountEffect";
 
 interface VortexProps {
   children?: ReactNode;
@@ -20,7 +21,7 @@ interface VortexProps {
 
 export function Vortex(props: VortexProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
-  const containerRef = useRef(null);
+  const containerRef = useRef<HTMLDivElement>(null);
   const animationFrameId = useRef<number>();
   const particleCount = props.particleCount || 700;
   const particlePropCount = 9;
@@ -42,6 +43,7 @@ export function Vortex(props: VortexProps) {
   let tick = 0;
   let lastTime = 0;
   let dtFrames = 1;
+  let isRunning = false;
   const noise3D = createNoise3D();
   let particleProps = new Float32Array(particlePropsLength);
   const center: [number, number] = [0, 0];
@@ -63,21 +65,6 @@ export function Vortex(props: VortexProps) {
 
   function lerp(n1: number, n2: number, speed: number): number {
     return (1 - speed) * n1 + speed * n2;
-  }
-
-  function setup() {
-    const canvas = canvasRef.current;
-    const container = containerRef.current;
-    if (canvas && container) {
-      const ctx = canvas.getContext("2d");
-
-      if (ctx) {
-        resize(canvas);
-        initParticles();
-        lastTime = performance.now();
-        draw(canvas, ctx);
-      }
-    }
   }
 
   function initParticles() {
@@ -106,34 +93,75 @@ export function Vortex(props: VortexProps) {
     particleProps.set([x, y, vx, vy, life, ttl, speed, radius, hue], i);
   }
 
-  function draw(canvas: HTMLCanvasElement, ctx: CanvasRenderingContext2D) {
+  function startLoop() {
+    const canvas = canvasRef.current;
+    const ctx = canvas?.getContext("2d");
+    if (!canvas || !ctx || isRunning) return;
+
+    isRunning = true;
+    lastTime = performance.now();
+    animationFrameId.current = window.requestAnimationFrame(() =>
+      loop(canvas, ctx),
+    );
+  }
+
+  function stopLoop() {
+    isRunning = false;
+    if (animationFrameId.current) {
+      window.cancelAnimationFrame(animationFrameId.current);
+    }
+  }
+
+  function loop(canvas: HTMLCanvasElement, ctx: CanvasRenderingContext2D) {
     const now = performance.now();
     const dt = Math.min((now - lastTime) / 1000, 1 / 30);
     lastTime = now;
     dtFrames = dt * 60;
     tick += dtFrames;
 
+    renderFrame(canvas, ctx);
+
+    if (isRunning) {
+      animationFrameId.current = window.requestAnimationFrame(() =>
+        loop(canvas, ctx),
+      );
+    }
+  }
+
+  function renderFrame(
+    canvas: HTMLCanvasElement,
+    ctx: CanvasRenderingContext2D,
+  ) {
     ctx.clearRect(0, 0, canvas.width, canvas.height);
 
     ctx.fillStyle = backgroundColor;
     ctx.fillRect(0, 0, canvas.width, canvas.height);
 
-    drawParticles(ctx);
-    renderGlow(canvas, ctx);
-    renderToScreen(canvas, ctx);
-
-    animationFrameId.current = window.requestAnimationFrame(() =>
-      draw(canvas, ctx),
-    );
+    ctx.lineCap = "round";
+    ctx.globalCompositeOperation = "lighter";
+    stepParticles(ctx);
+    ctx.globalCompositeOperation = "source-over";
   }
 
-  function drawParticles(ctx: CanvasRenderingContext2D) {
+  function drawStaticFrame(
+    canvas: HTMLCanvasElement,
+    ctx: CanvasRenderingContext2D,
+  ) {
+    dtFrames = 1;
+    for (let i = 0; i < 90; i++) {
+      tick += 1;
+      stepParticles(null);
+    }
+    renderFrame(canvas, ctx);
+  }
+
+  function stepParticles(ctx: CanvasRenderingContext2D | null) {
     for (let i = 0; i < particlePropsLength; i += particlePropCount) {
       updateParticle(i, ctx);
     }
   }
 
-  function updateParticle(i: number, ctx: CanvasRenderingContext2D) {
+  function updateParticle(i: number, ctx: CanvasRenderingContext2D | null) {
     const canvas = canvasRef.current;
     if (!canvas) return;
 
@@ -160,7 +188,9 @@ export function Vortex(props: VortexProps) {
     const radius = particleProps[i8];
     const hue = particleProps[i9];
 
-    drawParticle(x, y, x2, y2, life, ttl, radius, hue, ctx);
+    if (ctx) {
+      drawParticle(x, y, x2, y2, life, ttl, radius, hue, ctx);
+    }
 
     life += dtFrames;
 
@@ -186,77 +216,67 @@ export function Vortex(props: VortexProps) {
     hue: number,
     ctx: CanvasRenderingContext2D,
   ) {
-    ctx.save();
-    ctx.lineCap = "round";
-    ctx.lineWidth = radius;
-    ctx.strokeStyle = `hsla(${hue},100%,60%,${fadeInOut(life, ttl)})`;
+    const alpha = fadeInOut(life, ttl);
+
     ctx.beginPath();
     ctx.moveTo(x, y);
     ctx.lineTo(x2, y2);
+    ctx.lineWidth = radius * 3;
+    ctx.strokeStyle = `hsla(${hue},100%,60%,${0.3 * alpha})`;
     ctx.stroke();
-    ctx.closePath();
-    ctx.restore();
+
+    ctx.beginPath();
+    ctx.moveTo(x, y);
+    ctx.lineTo(x2, y2);
+    ctx.lineWidth = radius;
+    ctx.strokeStyle = `hsla(${hue},100%,70%,${alpha})`;
+    ctx.stroke();
   }
 
   function checkBounds(x: number, y: number, canvas: HTMLCanvasElement) {
     return x > canvas.width || x < 0 || y > canvas.height || y < 0;
   }
 
-  function resize(canvas: HTMLCanvasElement) {
-    const { innerWidth, innerHeight } = window;
-
-    canvas.width = innerWidth;
-    canvas.height = innerHeight;
+  function resize(canvas: HTMLCanvasElement, container: HTMLElement) {
+    canvas.width = container.clientWidth;
+    canvas.height = container.clientHeight;
 
     center[0] = 0.5 * canvas.width;
     center[1] = 0.5 * canvas.height;
   }
 
-  function renderGlow(
-    canvas: HTMLCanvasElement,
-    ctx: CanvasRenderingContext2D,
-  ) {
-    ctx.save();
-    ctx.filter = "blur(8px) brightness(200%)";
-    ctx.globalCompositeOperation = "lighter";
-    ctx.drawImage(canvas, 0, 0);
-    ctx.restore();
-
-    ctx.save();
-    ctx.filter = "blur(4px) brightness(200%)";
-    ctx.globalCompositeOperation = "lighter";
-    ctx.drawImage(canvas, 0, 0);
-    ctx.restore();
-  }
-
-  function renderToScreen(
-    canvas: HTMLCanvasElement,
-    ctx: CanvasRenderingContext2D,
-  ) {
-    ctx.save();
-    ctx.globalCompositeOperation = "lighter";
-    ctx.drawImage(canvas, 0, 0);
-    ctx.restore();
-  }
-
-  function handleResize() {
+  useMountEffect(() => {
     const canvas = canvasRef.current;
-    if (canvas) {
-      resize(canvas);
-    }
-  }
+    const container = containerRef.current;
+    const ctx = canvas?.getContext("2d");
+    if (!canvas || !container || !ctx) return;
 
-  useEffect(() => {
-    setup();
-    window.addEventListener("resize", handleResize);
+    resize(canvas, container);
+    initParticles();
+
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+      drawStaticFrame(canvas, ctx);
+      return;
+    }
+
+    const resizeObserver = new ResizeObserver(() => resize(canvas, container));
+    resizeObserver.observe(container);
+
+    const intersectionObserver = new IntersectionObserver(([entry]) => {
+      if (entry.isIntersecting) {
+        startLoop();
+      } else {
+        stopLoop();
+      }
+    });
+    intersectionObserver.observe(container);
 
     return () => {
-      window.removeEventListener("resize", handleResize);
-      if (animationFrameId.current) {
-        cancelAnimationFrame(animationFrameId.current);
-      }
+      resizeObserver.disconnect();
+      intersectionObserver.disconnect();
+      stopLoop();
     };
-  }, []);
+  });
 
   return (
     <div className={cn("relative h-full w-full", props.containerClassName)}>

--- a/autogpt_platform/frontend/src/components/ui/vortex.tsx
+++ b/autogpt_platform/frontend/src/components/ui/vortex.tsx
@@ -255,14 +255,20 @@ export function Vortex(props: VortexProps) {
     initParticles();
 
     if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
-      drawStaticFrame(canvas, ctx);
+      let staticRedrawFrame: number | undefined;
       const staticResizeObserver = new ResizeObserver(() => {
-        resize(canvas, container);
-        initParticles();
-        drawStaticFrame(canvas, ctx);
+        if (staticRedrawFrame) window.cancelAnimationFrame(staticRedrawFrame);
+        staticRedrawFrame = window.requestAnimationFrame(() => {
+          resize(canvas, container);
+          initParticles();
+          drawStaticFrame(canvas, ctx);
+        });
       });
       staticResizeObserver.observe(container);
-      return () => staticResizeObserver.disconnect();
+      return () => {
+        if (staticRedrawFrame) window.cancelAnimationFrame(staticRedrawFrame);
+        staticResizeObserver.disconnect();
+      };
     }
 
     const resizeObserver = new ResizeObserver(() => {

--- a/autogpt_platform/frontend/src/components/ui/vortex.tsx
+++ b/autogpt_platform/frontend/src/components/ui/vortex.tsx
@@ -256,13 +256,26 @@ export function Vortex(props: VortexProps) {
 
     if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
       drawStaticFrame(canvas, ctx);
-      return;
+      const staticResizeObserver = new ResizeObserver(() => {
+        resize(canvas, container);
+        initParticles();
+        drawStaticFrame(canvas, ctx);
+      });
+      staticResizeObserver.observe(container);
+      return () => staticResizeObserver.disconnect();
     }
 
-    const resizeObserver = new ResizeObserver(() => resize(canvas, container));
+    const resizeObserver = new ResizeObserver(() => {
+      const wasEmpty = canvas.width === 0 || canvas.height === 0;
+      resize(canvas, container);
+      if (wasEmpty && canvas.width > 0 && canvas.height > 0) {
+        initParticles();
+      }
+    });
     resizeObserver.observe(container);
 
-    const intersectionObserver = new IntersectionObserver(([entry]) => {
+    const intersectionObserver = new IntersectionObserver((entries) => {
+      const entry = entries[entries.length - 1];
       if (entry.isIntersecting) {
         startLoop();
       } else {


### PR DESCRIPTION
### Why / What / How

**Why:** A user reported that animations on the login page are slow — including the input focus border transition on the form side. The cause is the `Vortex` canvas background on the auth marketing panel: every frame it re-drew the full canvas onto itself three times, two of those through `ctx.filter = "blur(8px|4px) brightness(200%)"`. Full-resolution canvas blur composites are extremely expensive, and because the simulation timestep is clamped at 1/30s, any machine that can't hold 30fps sees the animation play in slow motion. The rAF loop also starves the main thread, so every paint-bound CSS transition on the page (e.g. the input focus ring) drops to the same low frame rate.

**What:** Removes the full-canvas blur glow passes, sizes the canvas to its container instead of the whole window, pauses the loop when the panel is not visible, and renders a single static frame when `prefers-reduced-motion` is set.

**How:**
- The glow effect is now approximated per particle with a second, wider translucent stroke drawn under the core stroke with `globalCompositeOperation: "lighter"` — two cheap strokes per particle instead of three full-canvas composites (two of them blurred) per frame.
- Canvas is sized to the container (via `ResizeObserver`) rather than `window.innerWidth/Height`, halving the rasterized area on the split layout.
- An `IntersectionObserver` starts/stops the rAF loop, so the animation doesn't burn CPU/GPU when the panel is hidden (mobile `hidden lg:flex`) or off-screen.
- With `prefers-reduced-motion: reduce`, the simulation is warmed up off-screen and a single static frame is drawn — no animation loop at all.
- Per-particle `save()/restore()` churn removed; shared canvas state is set once per frame.

Visual result is nearly identical (same particle field, slightly tighter glow), but frame cost drops by roughly an order of magnitude.

### Changes 🏗️

- `frontend/src/components/ui/vortex.tsx`:
  - Removed `renderGlow`/`renderToScreen` full-canvas blur+brightness composite passes; glow now drawn per particle (halo stroke + core stroke, additive compositing)
  - Canvas sized to container with `ResizeObserver` instead of window size + resize listener
  - rAF loop gated by `IntersectionObserver` (pauses when panel hidden/off-screen) with proper start/stop and cleanup
  - `prefers-reduced-motion` renders one static frame instead of looping
  - Replaced raw `useEffect` with `useMountEffect`

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [ ] Login/signup pages render the animated particle background as before on desktop
  - [ ] With DevTools CPU throttling (6x), the input focus border transition stays smooth
  - [ ] Resize the window — canvas follows the panel size
  - [ ] Enable "Emulate CSS prefers-reduced-motion: reduce" — a static particle frame renders, no rAF loop in the Performance panel
  - [ ] On a <lg viewport (panel hidden), no rAF loop runs

#### For configuration changes:

- [ ] `.env.default` is updated or already compatible with my changes
- [ ] `docker-compose.yml` is updated or already compatible with my changes
- [ ] I have included a list of my configuration changes in the PR description (under **Changes**)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
