### PR TITLE
fix(backend): stop registering baseline-only MCP TodoWrite on the SDK server

### DIFF
--- a/autogpt_platform/backend/backend/copilot/permissions.py
+++ b/autogpt_platform/backend/backend/copilot/permissions.py
@@ -157,7 +157,8 @@ the model as available tools.
 # baseline mode ships an MCP-wrapped platform version
 # (``tools/todo_write.py``), while SDK mode still uses the CLI-native
 # original via ``_SDK_BUILTIN_ALWAYS`` in ``sdk/tool_adapter.py`` — the
-# MCP copy is filtered out there.  ``Task`` remains an SDK-only built-in
+# MCP copy is never registered there (``BASELINE_ONLY_MCP_TOOLS``).
+# ``Task`` remains an SDK-only built-in
 # (for queue-backed context-isolation on baseline, use ``run_sub_session``
 # instead).
 SDK_BUILTIN_TOOL_NAMES: frozenset[str] = frozenset(

--- a/autogpt_platform/backend/backend/copilot/sdk/tool_adapter.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/tool_adapter.py
@@ -854,7 +854,12 @@ def create_copilot_mcp_server(
     sdk_tools = []
 
     for tool_name, base_tool in TOOL_REGISTRY.items():
-        if tool_name in hidden:
+        # Baseline-only wrappers (TodoWrite) must not be registered here:
+        # SDK mode uses the CLI-native built-ins, and these names are
+        # excluded from ``allowed_tools`` — advertising an MCP copy the CLI
+        # can never approve makes the model call it, receive a permission
+        # denial, and silently abandon the feature (e.g. the task checklist).
+        if tool_name in hidden or tool_name in BASELINE_ONLY_MCP_TOOLS:
             continue
         handler = create_tool_handler(base_tool)
         schema = _build_input_schema(base_tool)
@@ -1066,10 +1071,14 @@ DANGEROUS_PATTERNS = [
 # Platform-tool names whose MCP wrappers must NOT be exposed to SDK mode.
 # Baseline ships an MCP ``TodoWrite`` for model-flexibility parity; SDK mode
 # keeps using the CLI-native built-in listed in ``_SDK_BUILTIN_ALWAYS`` so
-# there is no double exposure.  Public (no leading underscore) so a future
-# refactor renaming it is visible at both call sites —
-# ``permissions.apply_tool_permissions`` maps short tool names back to the
-# CLI built-in form for SDK mode.
+# there is no double exposure.  These names are both excluded from
+# ``allowed_tools`` (see ``_registry_mcp_tools``) AND skipped during MCP
+# server registration in ``create_copilot_mcp_server`` — filtering the
+# allowed list alone still advertises the tool to the model, which then
+# calls it and hits an unapprovable permission prompt.  Public (no leading
+# underscore) so a future refactor renaming it is visible at both call
+# sites — ``permissions.apply_tool_permissions`` maps short tool names back
+# to the CLI built-in form for SDK mode.
 BASELINE_ONLY_MCP_TOOLS: frozenset[str] = frozenset({"TodoWrite"})
 
 

--- a/autogpt_platform/backend/backend/copilot/sdk/tool_adapter_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/tool_adapter_test.py
@@ -18,6 +18,7 @@ from backend.util.truncate import truncate
 from .tool_adapter import (
     _MCP_MAX_CHARS,
     _STRIP_FROM_LLM,
+    BASELINE_ONLY_MCP_TOOLS,
     SDK_DISALLOWED_TOOLS,
     _make_truncating_wrapper,
     _strip_llm_fields,
@@ -1235,7 +1236,23 @@ class TestCreateCopilotMcpServerHidden:
         server = create_copilot_mcp_server()
         registered = await self._registered_tool_names(server)
         for short in TOOL_REGISTRY:
+            if short in BASELINE_ONLY_MCP_TOOLS:
+                continue
             assert short in registered
+
+    @pytest.mark.asyncio
+    async def test_baseline_only_tools_never_registered(self):
+        """Baseline-only MCP wrappers (TodoWrite) must not register on the
+        SDK server. They are excluded from ``allowed_tools`` (SDK mode uses
+        the CLI-native built-ins), so advertising them makes the model call
+        a tool the CLI can never approve — it answers "Claude requested
+        permissions to use mcp__copilot__TodoWrite, but you haven't granted
+        it yet" and the model silently abandons the checklist."""
+        assert "TodoWrite" in BASELINE_ONLY_MCP_TOOLS
+        for use_e2b in (False, True):
+            server = create_copilot_mcp_server(use_e2b=use_e2b)
+            registered = await self._registered_tool_names(server)
+            assert not BASELINE_ONLY_MCP_TOOLS & registered
 
     @pytest.mark.asyncio
     async def test_builder_blocked_tools_hidden(self):
@@ -1257,6 +1274,8 @@ class TestCreateCopilotMcpServerHidden:
         registered = await self._registered_tool_names(server)
         # All real tools still register.
         for short in TOOL_REGISTRY:
+            if short in BASELINE_ONLY_MCP_TOOLS:
+                continue
             assert short in registered
 
     @staticmethod

--- a/autogpt_platform/backend/backend/copilot/tools/todo_write.py
+++ b/autogpt_platform/backend/backend/copilot/tools/todo_write.py
@@ -9,7 +9,8 @@ on subsequent turns.
 Baseline needs this as a platform tool because OpenAI-compatible providers
 (Kimi, GPT, Grok, Gemini) do not ship a built-in equivalent. The SDK path
 continues to use the CLI's native ``TodoWrite`` — the MCP-wrapped version
-of this tool is filtered out of SDK's allowed_tools list (see
+of this tool is never registered on the SDK MCP server and is filtered out
+of SDK's allowed_tools list (see ``BASELINE_ONLY_MCP_TOOLS`` in
 ``sdk/tool_adapter.py``) to avoid name shadowing.
 """
 


### PR DESCRIPTION
### Why / What / How

**Why:** When AutoPilot (and any SDK copilot session) starts a multi-step workflow, the model often reaches for `mcp__copilot__TodoWrite` to create its task checklist. That tool call is blocked with *"Claude requested permissions to use mcp__copilot__TodoWrite, but you haven't granted it yet."* — the frontend has already rendered the checklist optimistically from the tool-call stream, so the user sees a task list appear, while the agent believes the call failed and silently abandons it. The checklist is never updated again and stays "in progress" forever.

**What:** Stop registering baseline-only MCP tool wrappers (`BASELINE_ONLY_MCP_TOOLS`, currently just `TodoWrite`) on the SDK's in-process MCP server, so the model never sees an un-approvable `mcp__copilot__TodoWrite` in its tool list.

**How:** The MCP `TodoWrite` wrapper exists only for baseline mode (OpenAI-compatible providers have no built-in equivalent). SDK mode deliberately uses the CLI-native `TodoWrite` built-in, which is already pre-granted via `_SDK_BUILTIN_ALWAYS`, and excludes the MCP copy from `allowed_tools` to avoid name shadowing. But `create_copilot_mcp_server` still *registered* the MCP copy — advertising a tool the CLI can never approve. Per the existing design note in `tool_adapter.py`, allow/deny lists only gate execution; hiding a tool from registration is the mechanism that stops the model from calling it. This PR applies that mechanism: `create_copilot_mcp_server` now skips `BASELINE_ONLY_MCP_TOOLS`, the model only ever sees the pre-granted built-in `TodoWrite`, and checklists keep working end-to-end in both SDK and baseline modes.

The ticket suggested allow-listing `mcp__copilot__TodoWrite` instead, but that would expose two duplicate todo tools to the model (built-in + MCP copy) — exactly the name shadowing the current design avoids, and it would split checklist state across two implementations.

### Changes 🏗️

- `copilot/sdk/tool_adapter.py`: `create_copilot_mcp_server` skips tools in `BASELINE_ONLY_MCP_TOOLS` during registration; expanded the constant's doc comment to state both exclusion sites.
- `copilot/sdk/tool_adapter_test.py`: new `test_baseline_only_tools_never_registered` (both e2b and non-e2b); adjusted the two registers-all assertions to account for the exclusion.
- `copilot/permissions.py`, `copilot/tools/todo_write.py`: updated stale doc comments that described the old filtered-from-allowed_tools-only mechanism.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `poetry run pytest backend/copilot/sdk/tool_adapter_test.py::TestCreateCopilotMcpServerHidden` — 5 passed, including the new regression test asserting `TodoWrite` is not registered on the SDK MCP server (e2b and non-e2b)
  - [x] `poetry run format` / `poetry run lint` clean

#### For configuration changes:

- [ ] `.env.default` is updated or already compatible with my changes
- [ ] `docker-compose.yml` is updated or already compatible with my changes
- [ ] I have included a list of my configuration changes in the PR description (under **Changes**)

<details>
  <summary>Examples of configuration changes</summary>

  - Changing ports
  - Adding new services that need to communicate with each other
  - Secrets or environment variable changes
  - New or infrastructure changes such as databases
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
