### PR TITLE
fix(frontend): reset tour chat dim when switching scenarios

### DIFF
--- a/autogpt_platform/frontend/src/app/(public)/tour/chat/__tests__/main.test.tsx
+++ b/autogpt_platform/frontend/src/app/(public)/tour/chat/__tests__/main.test.tsx
@@ -13,6 +13,7 @@ vi.mock("@/components/ui/dot-distortion-shader", () => ({
   DotDistortionShader: () => null,
 }));
 
+import { useCopilotUIStore } from "@/app/(platform)/copilot/store";
 import TourChatPage from "../page";
 import { DEFAULT_SCENARIO_ID } from "../script/tourScenarios";
 import { useTourStore } from "../tourStore";
@@ -59,6 +60,9 @@ describe("Tour chat scripted demo", () => {
       activeScenarioId: DEFAULT_SCENARIO_ID,
       isDemoComplete: false,
     });
+    // The artifact panel lives in the shared copilot UI store (also
+    // module-level) — a completed demo leaves it open across tests.
+    useCopilotUIStore.getState().closeArtifactPanel({ persist: false });
   });
 
   afterEach(() => {
@@ -156,6 +160,30 @@ describe("Tour chat scripted demo", () => {
 
     // Completion flips the store flag that turns on the card's animations.
     expect(useTourStore.getState().isDemoComplete).toBe(true);
+  });
+
+  test("switching scenario after a completed demo un-dims the chat column", async () => {
+    render(<TourChatPage />);
+
+    // Play the default demo through both turns so it completes and opens
+    // the payoff artifact panel — which dims the chat column behind it.
+    await advanceThroughTurn();
+    await pressEnterToSend();
+
+    expect(useTourStore.getState().isDemoComplete).toBe(true);
+    expect(document.querySelector(".transition-opacity.opacity-50")).not.toBe(
+      null,
+    );
+
+    // Picking another chat example from the sidebar must reset the dim —
+    // the artifact panel belongs to the finished demo, not the new one.
+    fireEvent.click(screen.getByRole("button", { name: "Daily brief" }));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(document.querySelector(".transition-opacity.opacity-50")).toBe(null);
+    expect(useCopilotUIStore.getState().artifactPanel.isOpen).toBe(false);
   });
 
   test("scenario chips switch the demo path", async () => {

--- a/autogpt_platform/frontend/src/app/(public)/tour/chat/components/TourSidebar/TourSidebar.tsx
+++ b/autogpt_platform/frontend/src/app/(public)/tour/chat/components/TourSidebar/TourSidebar.tsx
@@ -70,10 +70,14 @@ function TourSessionsMenu({ variant }: { variant: TourSidebarVariant }) {
   const router = useRouter();
   const activeScenarioId = useTourStore((s) => s.activeScenarioId);
   const setActiveScenario = useTourStore((s) => s.setActiveScenario);
-  const clearArtifactPreview = useCopilotUIStore((s) => s.clearArtifactPreview);
+  const closeArtifactPanel = useCopilotUIStore((s) => s.closeArtifactPanel);
 
   function selectScenario(id: string) {
-    clearArtifactPreview();
+    // Close (not just clear) the panel: a completed demo leaves
+    // artifactPanel.isOpen=true, which keeps the chat column dimmed at
+    // opacity-50 behind it. persist:false keeps the tour from leaking
+    // panel state into the real /copilot, same as TourCopilot's cleanup.
+    closeArtifactPanel({ persist: false });
     setActiveScenario(id);
     if (variant === "marketplace") router.push("/tour/chat");
   }


### PR DESCRIPTION
### Why / What / How

**Why:** On `/tour/chat`, when a scripted demo round finishes, the payoff artifact panel opens and the chat column intentionally fades to `opacity-50` so attention lands on the artifact. But clicking another chat example in the sidebar didn't reset that dim — the new demo played at half opacity, permanently.

**What:** Selecting a scenario in `TourSidebar` now fully closes the artifact panel instead of only clearing its preview.

**How:** The dim is driven by `artifactPanel.isOpen` in the shared copilot UI store (`TourCopilot` applies `opacity-50` while it's true). The sidebar's `selectScenario` called `clearArtifactPreview()`, which clears `activeArtifact`/history but leaves `isOpen: true`. It now calls `closeArtifactPanel({ persist: false })` — resetting `isOpen` while keeping the tour from leaking panel state into the real `/copilot` localStorage, matching `TourCopilot`'s existing unmount cleanup.

Note: the issue was originally suspected to live in `backend/api/features/chat/`, but the root cause is purely in the tour frontend — the backend chat routes are untouched.

### Changes 🏗️

- `TourSidebar.tsx`: `selectScenario` calls `closeArtifactPanel({ persist: false })` instead of `clearArtifactPreview()`.
- `main.test.tsx` (tour chat tests): new regression test — plays the demo to completion, asserts the chat column is dimmed, switches scenario via the sidebar, asserts the dim and panel-open state reset. Also resets the shared copilot UI store between tests so a completed demo can't leak panel state across cases.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] New regression test fails on `dev` (dim persists after scenario switch) and passes with the fix
  - [x] All tour chat integration tests pass (`main.test.tsx` + `app-shell.test.tsx`, 8/8)
  - [x] `pnpm format`, `pnpm lint`, `pnpm types` clean

#### For configuration changes:

- [ ] `.env.default` is updated or already compatible with my changes
- [ ] `docker-compose.yml` is updated or already compatible with my changes
- [ ] I have included a list of my configuration changes in the PR description (under **Changes**)

<details>
  <summary>Examples of configuration changes</summary>

  - Changing ports
  - Adding new services that need to communicate with each other
  - Secrets or environment variable changes
  - New or infrastructure changes such as databases
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
