### PR TITLE
feat(frontend): LaunchDarkly per-platform visibility for Settings → Bots

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/settings/bots/__tests__/visibility.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/bots/__tests__/visibility.test.tsx
@@ -1,0 +1,44 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { render, screen } from "@/tests/integrations/test-utils";
+import { server } from "@/mocks/mock-server";
+import { getListBotPlatformsMockHandler } from "@/app/api/__generated__/endpoints/platform-linking/platform-linking.msw";
+
+import SettingsBotsPage from "../page";
+
+vi.mock("@/services/feature-flags/use-get-flag", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@/services/feature-flags/use-get-flag")
+    >();
+  return {
+    ...actual,
+    useGetFlag: vi.fn(() => ({ slack: false })),
+  };
+});
+
+function platform(name: string) {
+  return {
+    platform: name.toUpperCase(),
+    display_name: name,
+    icon: `${name.toLowerCase()}.png`,
+    add_bot_url: null,
+    dm_link: undefined,
+    server_links: [],
+  };
+}
+
+describe("SettingsBotsPage platform visibility flag", () => {
+  test("hides platforms the copilot-bot-platforms flag marks false", async () => {
+    server.use(
+      getListBotPlatformsMockHandler([platform("Discord"), platform("Slack")]),
+    );
+
+    render(<SettingsBotsPage />);
+
+    expect(
+      await screen.findByRole("heading", { name: /discord/i }),
+    ).toBeDefined();
+    expect(screen.queryByRole("heading", { name: /slack/i })).toBeNull();
+  });
+});

--- a/autogpt_platform/frontend/src/app/(platform)/settings/bots/components/BotsList/BotsList.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/bots/components/BotsList/BotsList.tsx
@@ -39,8 +39,7 @@ export function BotsList() {
           No bots enabled
         </Text>
         <Text variant="body" className="max-w-[360px] text-zinc-500">
-          No chat-bot platforms are configured on this deployment. Ask an
-          administrator to enable Discord, Slack, or another adapter.
+          No chat-bot platforms are available on this deployment right now.
         </Text>
       </div>
     );

--- a/autogpt_platform/frontend/src/app/(platform)/settings/bots/components/BotsList/useBotsList.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/bots/components/BotsList/useBotsList.ts
@@ -1,12 +1,19 @@
 import { useListBotPlatforms } from "@/app/api/__generated__/endpoints/platform-linking/platform-linking";
+import { Flag, useGetFlag } from "@/services/feature-flags/use-get-flag";
 
 export function useBotsList() {
   const { data, isLoading, isSuccess, isError, error, refetch } =
     useListBotPlatforms({
       query: { retry: false },
     });
+  const visibility = useGetFlag(Flag.COPILOT_BOT_PLATFORMS);
 
-  const platforms = data?.status === 200 ? data.data : [];
+  const allPlatforms = data?.status === 200 ? data.data : [];
+  // Only an explicit false hides a platform, so a missing flag key (or a
+  // LaunchDarkly outage) fails open to visible.
+  const platforms = allPlatforms.filter(
+    (platform) => visibility[platform.platform.toLowerCase()] !== false,
+  );
 
   return {
     platforms,

--- a/autogpt_platform/frontend/src/services/feature-flags/use-get-flag.ts
+++ b/autogpt_platform/frontend/src/services/feature-flags/use-get-flag.ts
@@ -34,6 +34,11 @@ export enum Flag {
   DREAM_PASS_ENABLED = "dream-pass-enabled",
   DREAM_PASS_WEB_FACT_CHECK = "dream-pass-web-fact-check",
   DREAM_PASS_INVALIDATE_ENTITY = "dream-pass-invalidate-entity",
+  // JSON flag mapping copilot-bot platform key (lowercase) -> visible on the
+  // Bots settings page. Lets ops hide a platform (e.g. Slack while its
+  // Marketplace review is pending) without a deploy. Missing keys default to
+  // visible — only an explicit ``false`` hides a card.
+  COPILOT_BOT_PLATFORMS = "copilot-bot-platforms",
 }
 
 const isPwMockEnabled = process.env.NEXT_PUBLIC_PW_TEST === "true";
@@ -59,6 +64,7 @@ const defaultFlags = {
   [Flag.DREAM_PASS_ENABLED]: false,
   [Flag.DREAM_PASS_WEB_FACT_CHECK]: false,
   [Flag.DREAM_PASS_INVALIDATE_ENTITY]: false,
+  [Flag.COPILOT_BOT_PLATFORMS]: {} as Record<string, boolean>,
 };
 
 type FlagValues = typeof defaultFlags;
@@ -122,6 +128,8 @@ function readEnvOverride(flag: Flag): string | undefined {
       return process.env.NEXT_PUBLIC_FORCE_FLAG_DREAM_PASS_WEB_FACT_CHECK;
     case Flag.DREAM_PASS_INVALIDATE_ENTITY:
       return process.env.NEXT_PUBLIC_FORCE_FLAG_DREAM_PASS_INVALIDATE_ENTITY;
+    case Flag.COPILOT_BOT_PLATFORMS:
+      return undefined;
   }
 }
 
@@ -133,6 +141,7 @@ function readEnvOverride(flag: Flag): string | undefined {
 const ARRAY_TYPED_FLAGS: ReadonlySet<Flag> = new Set([
   Flag.BETA_BLOCKS,
   Flag.MARKETPLACE_SEARCH_TERMS,
+  Flag.COPILOT_BOT_PLATFORMS,
 ]);
 
 export function envFlagOverride<T extends Flag>(


### PR DESCRIPTION
### Why / What / How

**Why:** Slack's copilot-bot can't be publicly used until Slack approves the Marketplace listing (their 2025/2026 distribution policy), but its card renders on **Settings → Bots** wherever Slack creds are configured — prod users would find a bot that can't actually be installed. We need per-platform visibility control without deploys, and instant un-hiding when reviews clear.

**What:** One JSON LaunchDarkly flag, `copilot-bot-platforms`, mapping platform key (lowercase) → visible. `BotsList` filters the platform cards by it. Semantics are deliberately fail-open: **only an explicit `false` hides** — a missing key, missing flag, or LaunchDarkly outage leaves every platform visible, so Discord/Telegram can never vanish by accident. Works for any current or future platform with zero code changes. The empty-state copy is platform-neutral so an all-hidden deployment doesn't claim nothing is "configured".

**How:** flag added to the `Flag` enum + defaults (`{}`) + the non-boolean-override set; single filter in `useBotsList`. This only gates the *settings card* (discovery) — existing linked servers/DMs keep working and admin analytics are unaffected, which is right for a temporarily-hidden-but-functional platform.

**LaunchDarkly — configured and live** (`copilot-bot-platforms`, client-side SDKs enabled):
- Two variations: **All visible** `{}` and **Custom visibility** — an editable per-platform checklist, currently:
  ```json
  { "discord": true, "slack": false, "telegram": true }
  ```
- Targeting: Local/Dev/Test **off** (off-variation = All visible); **Production on**, serving Custom visibility.
- Ops flow: toggling any platform = edit the Custom visibility JSON in LD, save — live in seconds, no deploy.

### Changes 🏗️

- `use-get-flag.ts` — new `COPILOT_BOT_PLATFORMS` JSON flag
- `useBotsList.ts` — visibility filter
- `BotsList.tsx` — neutral empty-state copy
- `visibility.test.tsx` — hides flagged-off platform, keeps others

### Checklist 📋

- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Settings bots suite 11/11 (10 existing unaffected by the fail-open default + new visibility test)
  - [x] prettier / eslint / tsc clean
  - [x] LaunchDarkly flag created + targeted per environment (screenshots in review thread)
