### PR TITLE
feat(backend/copilot-bot): stream Telegram replies as live draft previews

### DIFF
--- a/autogpt_platform/backend/backend/copilot/bot/adapters/base.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/base.py
@@ -10,6 +10,7 @@ Telegram, Teams, WhatsApp).
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from enum import Enum
 from typing import Awaitable, Callable, Literal, Optional
 
 from fastapi import FastAPI, Request
@@ -18,6 +19,20 @@ from pydantic import BaseModel
 
 # Callback signature: (ctx, adapter) -> awaitable None
 MessageCallback = Callable[["MessageContext", "PlatformAdapter"], Awaitable[None]]
+
+
+class StreamDraftOutcome(Enum):
+    """Result of a live-preview draft update — see ``send_stream_draft``.
+
+    Three outcomes, not a bool: the streamer must tell a rendered preview
+    (advance the throttle) apart from a transient no-op it should retry next
+    chunk without burning the throttle, apart from a permanent stop.
+    """
+
+    SHOWN = "shown"
+    SKIPPED = "skipped"
+    STOPPED = "stopped"
+
 
 # Where the message came from:
 # - "dm"      — 1:1 conversation, reply in-place
@@ -216,17 +231,18 @@ class PlatformAdapter(ABC):
 
     async def send_stream_draft(
         self, channel_id: str, draft_id: int, text: str
-    ) -> bool:
+    ) -> StreamDraftOutcome:
         """Show/update an ephemeral preview of the reply being generated.
 
         Repeated calls with the same nonzero ``draft_id`` update the preview
         in place. The finished reply is still delivered through the normal
         send path, which supersedes the preview — a failed or skipped draft
-        never loses content. Returns False when the preview can't be shown
-        (unsupported chat, API error) so the caller stops drafting for the
-        turn. Default: unsupported.
+        never loses content. Returns ``SHOWN`` when the preview rendered,
+        ``SKIPPED`` for a transient no-op the caller should retry on the next
+        chunk, or ``STOPPED`` (unsupported chat, API error) to stop drafting
+        for the turn. Default: unsupported.
         """
-        return False
+        return StreamDraftOutcome.STOPPED
 
     @abstractmethod
     async def create_thread(

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/base.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/base.py
@@ -204,6 +204,30 @@ class PlatformAdapter(ABC):
     async def stop_typing(self, channel_id: str) -> None:
         """Clear the typing indicator. Default no-op (see ``start_typing``)."""
 
+    @property
+    def supports_stream_drafts(self) -> bool:
+        """Whether ``send_stream_draft`` can show a live in-progress preview.
+
+        Default False — only platforms with a native draft-streaming API
+        (Telegram ``sendMessageDraft``) override this. When False the shared
+        streamer never calls ``send_stream_draft``.
+        """
+        return False
+
+    async def send_stream_draft(
+        self, channel_id: str, draft_id: int, text: str
+    ) -> bool:
+        """Show/update an ephemeral preview of the reply being generated.
+
+        Repeated calls with the same nonzero ``draft_id`` update the preview
+        in place. The finished reply is still delivered through the normal
+        send path, which supersedes the preview — a failed or skipped draft
+        never loses content. Returns False when the preview can't be shown
+        (unsupported chat, API error) so the caller stops drafting for the
+        turn. Default: unsupported.
+        """
+        return False
+
     @abstractmethod
     async def create_thread(
         self, channel_id: str, message_id: str, name: str

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/telegram/adapter.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/telegram/adapter.py
@@ -401,6 +401,41 @@ class TelegramAdapter(WebhookAdapter):
         # Telegram has no ephemeral messages — send normally.
         await self.send_message(channel_id, text)
 
+    @property
+    def supports_stream_drafts(self) -> bool:
+        return True
+
+    async def send_stream_draft(
+        self, channel_id: str, draft_id: int, text: str
+    ) -> bool:
+        chat_id, thread_id = _decode_target(channel_id)
+        if chat_id.startswith("-"):
+            # sendMessageDraft only works in private chats — groups and
+            # supergroups (negative chat ids) keep typing + buffered sends.
+            return False
+        # localize_markup only rewrites complete constructs (closed code
+        # fences, **pairs**, [label](url)), so rendering a partial stream
+        # never produces unbalanced HTML — incomplete markdown just shows
+        # literally until the closing token streams in.
+        rendered = self.localize_markup(text)
+        if len(rendered) > config.MAX_MESSAGE_LENGTH:
+            # Over the draft cap right before a chunk flush — skip this
+            # update (the flush shrinks the buffer) but keep drafting.
+            return True
+        try:
+            await self._client.call(
+                "sendMessageDraft",
+                chat_id=int(chat_id),
+                draft_id=draft_id,
+                text=rendered,
+                parse_mode="HTML",
+                message_thread_id=thread_id,
+            )
+        except Exception:
+            logger.debug("Telegram sendMessageDraft failed", exc_info=True)
+            return False
+        return True
+
     async def start_typing(self, channel_id: str) -> None:
         chat_id, thread_id = _decode_target(channel_id)
         try:

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/telegram/adapter.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/telegram/adapter.py
@@ -30,6 +30,7 @@ from backend.copilot.bot.adapters.base import (
     MessageCallback,
     MessageContext,
     PostedRef,
+    StreamDraftOutcome,
     WebhookAdapter,
     read_verified_webhook_body,
     unauthorized_webhook_response,
@@ -407,21 +408,22 @@ class TelegramAdapter(WebhookAdapter):
 
     async def send_stream_draft(
         self, channel_id: str, draft_id: int, text: str
-    ) -> bool:
+    ) -> StreamDraftOutcome:
         chat_id, thread_id = _decode_target(channel_id)
         if chat_id.startswith("-"):
             # sendMessageDraft only works in private chats — groups and
             # supergroups (negative chat ids) keep typing + buffered sends.
-            return False
+            return StreamDraftOutcome.STOPPED
         # localize_markup only rewrites complete constructs (closed code
         # fences, **pairs**, [label](url)), so rendering a partial stream
         # never produces unbalanced HTML — incomplete markdown just shows
         # literally until the closing token streams in.
         rendered = self.localize_markup(text)
         if len(rendered) > config.MAX_MESSAGE_LENGTH:
-            # Over the draft cap right before a chunk flush — skip this
-            # update (the flush shrinks the buffer) but keep drafting.
-            return True
+            # Over the draft cap (HTML escaping can expand a near-flush
+            # buffer past it) — skip this one without an API call; the next
+            # chunk flush shrinks the buffer and drafting resumes.
+            return StreamDraftOutcome.SKIPPED
         try:
             await self._client.call(
                 "sendMessageDraft",
@@ -433,8 +435,8 @@ class TelegramAdapter(WebhookAdapter):
             )
         except Exception:
             logger.debug("Telegram sendMessageDraft failed", exc_info=True)
-            return False
-        return True
+            return StreamDraftOutcome.STOPPED
+        return StreamDraftOutcome.SHOWN
 
     async def start_typing(self, channel_id: str) -> None:
         chat_id, thread_id = _decode_target(channel_id)

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/telegram/adapter_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/telegram/adapter_test.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from backend.copilot.bot.adapters.base import FileAttachment
+from backend.copilot.bot.adapters.base import FileAttachment, StreamDraftOutcome
 
 from .adapter import (
     TelegramAdapter,
@@ -361,8 +361,8 @@ class TestStreamDrafts:
     @pytest.mark.asyncio
     async def test_draft_sends_rendered_html_to_private_chat(self):
         a = _adapter()
-        ok = await a.send_stream_draft("42", 7, "**bold** & partial")
-        assert ok is True
+        outcome = await a.send_stream_draft("42", 7, "**bold** & partial")
+        assert outcome is StreamDraftOutcome.SHOWN
         assert a._client.call.call_args.args == ("sendMessageDraft",)
         kwargs = a._client.call.call_args.kwargs
         assert kwargs["chat_id"] == 42
@@ -371,23 +371,28 @@ class TestStreamDrafts:
         assert kwargs["text"] == "<b>bold</b> &amp; partial"
 
     @pytest.mark.asyncio
-    async def test_draft_refused_for_group_chats(self):
+    async def test_draft_stopped_for_group_chats(self):
         # sendMessageDraft is private-chat only; groups (negative ids) must
         # opt out without an API call so the streamer stops drafting.
         a = _adapter()
-        assert await a.send_stream_draft("-100555|7", 7, "hi") is False
+        assert (
+            await a.send_stream_draft("-100555|7", 7, "hi")
+            is StreamDraftOutcome.STOPPED
+        )
         a._client.call.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_draft_api_error_returns_false(self):
+    async def test_draft_api_error_stops_drafting(self):
         a = _adapter()
         a._client.call = AsyncMock(side_effect=RuntimeError("boom"))
-        assert await a.send_stream_draft("42", 7, "hi") is False
+        assert await a.send_stream_draft("42", 7, "hi") is StreamDraftOutcome.STOPPED
 
     @pytest.mark.asyncio
-    async def test_oversized_draft_skipped_but_drafting_continues(self):
-        # Just before a chunk flush the buffer can exceed the 4096 cap —
-        # skip that update without disabling drafts for the turn.
+    async def test_oversized_draft_is_skipped_not_stopped(self):
+        # HTML escaping can push a near-flush buffer past the 4096 cap — skip
+        # that update (no API call) but keep drafting for the turn.
         a = _adapter()
-        assert await a.send_stream_draft("42", 7, "x" * 5000) is True
+        assert (
+            await a.send_stream_draft("42", 7, "x" * 5000) is StreamDraftOutcome.SKIPPED
+        )
         a._client.call.assert_not_awaited()

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/telegram/adapter_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/telegram/adapter_test.py
@@ -352,3 +352,42 @@ def test_collect_mentionable_users_only_text_mentions_with_ids():
 
 async def _noop() -> None:
     return None
+
+
+class TestStreamDrafts:
+    def test_supports_stream_drafts(self):
+        assert _adapter().supports_stream_drafts is True
+
+    @pytest.mark.asyncio
+    async def test_draft_sends_rendered_html_to_private_chat(self):
+        a = _adapter()
+        ok = await a.send_stream_draft("42", 7, "**bold** & partial")
+        assert ok is True
+        assert a._client.call.call_args.args == ("sendMessageDraft",)
+        kwargs = a._client.call.call_args.kwargs
+        assert kwargs["chat_id"] == 42
+        assert kwargs["draft_id"] == 7
+        assert kwargs["parse_mode"] == "HTML"
+        assert kwargs["text"] == "<b>bold</b> &amp; partial"
+
+    @pytest.mark.asyncio
+    async def test_draft_refused_for_group_chats(self):
+        # sendMessageDraft is private-chat only; groups (negative ids) must
+        # opt out without an API call so the streamer stops drafting.
+        a = _adapter()
+        assert await a.send_stream_draft("-100555|7", 7, "hi") is False
+        a._client.call.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_draft_api_error_returns_false(self):
+        a = _adapter()
+        a._client.call = AsyncMock(side_effect=RuntimeError("boom"))
+        assert await a.send_stream_draft("42", 7, "hi") is False
+
+    @pytest.mark.asyncio
+    async def test_oversized_draft_skipped_but_drafting_continues(self):
+        # Just before a chunk flush the buffer can exceed the 4096 cap —
+        # skip that update without disabling drafts for the turn.
+        a = _adapter()
+        assert await a.send_stream_draft("42", 7, "x" * 5000) is True
+        a._client.call.assert_not_awaited()

--- a/autogpt_platform/backend/backend/copilot/bot/handler_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/handler_test.py
@@ -70,6 +70,8 @@ def _adapter() -> MagicMock:
     adapter.send_file = AsyncMock()
     adapter.start_typing = AsyncMock()
     adapter.stop_typing = AsyncMock()
+    adapter.supports_stream_drafts = False
+    adapter.send_stream_draft = AsyncMock(return_value=False)
     adapter.create_thread = AsyncMock(return_value="thread-new")
     adapter.rename_thread = AsyncMock(return_value=True)
     return adapter

--- a/autogpt_platform/backend/backend/copilot/bot/turn_stream.py
+++ b/autogpt_platform/backend/backend/copilot/bot/turn_stream.py
@@ -24,7 +24,12 @@ from backend.util.exceptions import DuplicateChatMessageError, NotFoundError
 from backend.util.settings import Settings
 
 from . import sessions
-from .adapters.base import FileAttachment, MessageContext, PlatformAdapter
+from .adapters.base import (
+    FileAttachment,
+    MessageContext,
+    PlatformAdapter,
+    StreamDraftOutcome,
+)
 from .bot_backend import BotBackend, BotStreamError, ChatTurnDeniedError
 from .config import SESSION_TTL
 from .prompt import clamp_thread_name
@@ -69,17 +74,23 @@ class DraftStreamer:
         preview = text.strip()
         if not preview or preview == self._last_text:
             return
-        self._last_sent_at = now
-        self._last_text = preview
         try:
-            ok = await self._adapter.send_stream_draft(
+            outcome = await self._adapter.send_stream_draft(
                 self._target_id, self._draft_id, preview
             )
         except Exception:
             logger.debug("Stream draft update failed", exc_info=True)
-            ok = False
-        if not ok:
             self._enabled = False
+            return
+        if outcome is StreamDraftOutcome.STOPPED:
+            self._enabled = False
+            return
+        # SKIPPED = transient no-op (preview momentarily too long): leave the
+        # throttle untouched so the next chunk retries instead of eating a
+        # full interval of silence on a draft the user never saw.
+        if outcome is StreamDraftOutcome.SHOWN:
+            self._last_sent_at = now
+            self._last_text = preview
 
 
 async def send_denial(

--- a/autogpt_platform/backend/backend/copilot/bot/turn_stream.py
+++ b/autogpt_platform/backend/backend/copilot/bot/turn_stream.py
@@ -12,6 +12,7 @@ import logging
 import time
 from typing import Any
 from urllib.parse import quote
+from uuid import uuid4
 
 from backend.data.redis_client import get_redis_async
 from backend.data.sharing.workspace_refs import (
@@ -33,6 +34,52 @@ logger = logging.getLogger(__name__)
 
 TITLE_RENAME_ATTEMPTS = 5
 TITLE_RENAME_INTERVAL_SECONDS = 1.0
+
+# Cadence for live draft previews on platforms that support them — throttled
+# so a fast stream doesn't turn every chunk into an API call.
+DRAFT_UPDATE_INTERVAL_SECONDS = 1.0
+
+
+class DraftStreamer:
+    """Throttled live preview of the in-progress reply.
+
+    Purely additive on top of the buffered sends: drafts are ephemeral
+    previews (Telegram ``sendMessageDraft``), and the finished reply still
+    arrives via the normal send path, which supersedes them. Any failure
+    silently disables previews for the rest of the turn — content delivery
+    is never at stake.
+    """
+
+    def __init__(self, adapter: PlatformAdapter, target_id: str):
+        self._adapter = adapter
+        self._target_id = target_id
+        self._enabled = adapter.supports_stream_drafts
+        # Telegram requires a nonzero draft id; same id per turn = animated
+        # in-place updates.
+        self._draft_id = (uuid4().int & 0x7FFFFFFF) or 1
+        self._last_sent_at = 0.0
+        self._last_text = ""
+
+    async def update(self, text: str) -> None:
+        if not self._enabled:
+            return
+        now = time.monotonic()
+        if now - self._last_sent_at < DRAFT_UPDATE_INTERVAL_SECONDS:
+            return
+        preview = text.strip()
+        if not preview or preview == self._last_text:
+            return
+        self._last_sent_at = now
+        self._last_text = preview
+        try:
+            ok = await self._adapter.send_stream_draft(
+                self._target_id, self._draft_id, preview
+            )
+        except Exception:
+            logger.debug("Stream draft update failed", exc_info=True)
+            ok = False
+        if not ok:
+            self._enabled = False
 
 
 async def send_denial(
@@ -173,6 +220,7 @@ class TurnStreamer:
 
         started_at = time.monotonic()
         reply_chars = 0
+        draft = DraftStreamer(adapter, target_id)
         typing_task = asyncio.create_task(_keep_typing(adapter, target_id))
         try:
             async for chunk in self._api.stream_chat(
@@ -188,6 +236,7 @@ class TurnStreamer:
             ):
                 buffer += chunk
                 reply_chars += len(chunk)
+                await draft.update(buffer)
                 if len(buffer) >= flush_at:
                     post, buffer = split_at_boundary(buffer, flush_at)
                     if post and post.strip():

--- a/autogpt_platform/backend/backend/copilot/bot/turn_stream_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/turn_stream_test.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from .adapters.base import ChannelType, MessageContext
+from .adapters.base import ChannelType, MessageContext, StreamDraftOutcome
 from .turn_stream import DraftStreamer, TurnStreamer
 
 _MODULE = "backend.copilot.bot.turn_stream"
@@ -21,7 +21,8 @@ def _adapter(*, drafts: bool = False) -> MagicMock:
     adapter.stop_typing = AsyncMock()
     adapter.rename_thread = AsyncMock(return_value=True)
     adapter.supports_stream_drafts = drafts
-    adapter.send_stream_draft = AsyncMock(return_value=drafts)
+    outcome = StreamDraftOutcome.SHOWN if drafts else StreamDraftOutcome.STOPPED
+    adapter.send_stream_draft = AsyncMock(return_value=outcome)
     return adapter
 
 
@@ -102,14 +103,30 @@ class TestDraftStreamer:
         assert adapter.send_stream_draft.await_count == 1
 
     @pytest.mark.asyncio
-    async def test_failure_disables_drafting_for_the_turn(self):
+    async def test_stopped_disables_drafting_for_the_turn(self):
         adapter = _adapter(drafts=True)
-        adapter.send_stream_draft = AsyncMock(return_value=False)
+        adapter.send_stream_draft = AsyncMock(return_value=StreamDraftOutcome.STOPPED)
         draft = DraftStreamer(adapter, "42")
         with patch(f"{_MODULE}.time.monotonic", side_effect=[100.0, 200.0]):
             await draft.update("hello")
             await draft.update("hello world")
         assert adapter.send_stream_draft.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_skipped_keeps_drafting_without_burning_the_throttle(self):
+        # A SKIPPED update (preview momentarily too long) must not advance the
+        # throttle or last_text — the very next chunk should retry immediately.
+        adapter = _adapter(drafts=True)
+        adapter.send_stream_draft = AsyncMock(
+            side_effect=[StreamDraftOutcome.SKIPPED, StreamDraftOutcome.SHOWN]
+        )
+        draft = DraftStreamer(adapter, "42")
+        # Second call is only 0.1s later — it would be throttled if the SKIP
+        # had advanced _last_sent_at, but it must go through.
+        with patch(f"{_MODULE}.time.monotonic", side_effect=[100.0, 100.1]):
+            await draft.update("too-long-preview")
+            await draft.update("shorter now")
+        assert adapter.send_stream_draft.await_count == 2
 
     @pytest.mark.asyncio
     async def test_exception_disables_drafting_for_the_turn(self):

--- a/autogpt_platform/backend/backend/copilot/bot/turn_stream_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/turn_stream_test.py
@@ -1,0 +1,152 @@
+"""Tests for the per-turn streaming helpers, focused on live draft previews."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from .adapters.base import ChannelType, MessageContext
+from .turn_stream import DraftStreamer, TurnStreamer
+
+_MODULE = "backend.copilot.bot.turn_stream"
+
+
+def _adapter(*, drafts: bool = False) -> MagicMock:
+    adapter = MagicMock()
+    adapter.chunk_flush_at = 1900
+    adapter.typing_refresh_interval = 8.0
+    adapter.send_message = AsyncMock()
+    adapter.send_link = AsyncMock()
+    adapter.send_file = AsyncMock()
+    adapter.start_typing = AsyncMock()
+    adapter.stop_typing = AsyncMock()
+    adapter.rename_thread = AsyncMock(return_value=True)
+    adapter.supports_stream_drafts = drafts
+    adapter.send_stream_draft = AsyncMock(return_value=drafts)
+    return adapter
+
+
+def _ctx(channel_type: ChannelType = "dm") -> MessageContext:
+    return MessageContext(
+        platform="telegram",
+        channel_type=channel_type,
+        server_id=None,
+        channel_id="42",
+        message_id="msg-1",
+        user_id="user-1",
+        username="Bently",
+        text="hello",
+    )
+
+
+def _api(chunks: list[str]) -> MagicMock:
+    api = MagicMock()
+
+    async def _stream(*args, **kwargs):
+        for chunk in chunks:
+            yield chunk
+
+    api.stream_chat = _stream
+    return api
+
+
+def _patch_redis():
+    return patch(
+        f"{_MODULE}.get_redis_async",
+        new=AsyncMock(
+            return_value=AsyncMock(get=AsyncMock(return_value=None), set=AsyncMock())
+        ),
+    )
+
+
+class TestDraftStreamer:
+    @pytest.mark.asyncio
+    async def test_noop_when_adapter_does_not_support_drafts(self):
+        adapter = _adapter(drafts=False)
+        draft = DraftStreamer(adapter, "42")
+        await draft.update("hello")
+        adapter.send_stream_draft.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_sends_preview_with_stable_nonzero_draft_id(self):
+        adapter = _adapter(drafts=True)
+        draft = DraftStreamer(adapter, "42")
+        with patch(f"{_MODULE}.time.monotonic", side_effect=[100.0, 200.0]):
+            await draft.update("hello")
+            await draft.update("hello world")
+        assert adapter.send_stream_draft.await_count == 2
+        calls = adapter.send_stream_draft.await_args_list
+        first_id = calls[0].args[1]
+        assert first_id != 0
+        assert all(
+            c.args == ("42", first_id, t)
+            for c, t in zip(calls, ["hello", "hello world"])
+        )
+
+    @pytest.mark.asyncio
+    async def test_updates_are_throttled(self):
+        adapter = _adapter(drafts=True)
+        draft = DraftStreamer(adapter, "42")
+        with patch(f"{_MODULE}.time.monotonic", side_effect=[100.0, 100.5]):
+            await draft.update("hello")
+            await draft.update("hello world")
+        assert adapter.send_stream_draft.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_unchanged_or_empty_text_is_skipped(self):
+        adapter = _adapter(drafts=True)
+        draft = DraftStreamer(adapter, "42")
+        with patch(f"{_MODULE}.time.monotonic", side_effect=[100.0, 200.0, 300.0]):
+            await draft.update("   ")
+            await draft.update("hello")
+            await draft.update("hello ")  # same after strip
+        assert adapter.send_stream_draft.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_failure_disables_drafting_for_the_turn(self):
+        adapter = _adapter(drafts=True)
+        adapter.send_stream_draft = AsyncMock(return_value=False)
+        draft = DraftStreamer(adapter, "42")
+        with patch(f"{_MODULE}.time.monotonic", side_effect=[100.0, 200.0]):
+            await draft.update("hello")
+            await draft.update("hello world")
+        assert adapter.send_stream_draft.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_exception_disables_drafting_for_the_turn(self):
+        adapter = _adapter(drafts=True)
+        adapter.send_stream_draft = AsyncMock(side_effect=RuntimeError("boom"))
+        draft = DraftStreamer(adapter, "42")
+        with patch(f"{_MODULE}.time.monotonic", side_effect=[100.0, 200.0]):
+            await draft.update("hello")
+            await draft.update("hello world")
+        assert adapter.send_stream_draft.await_count == 1
+
+
+class TestStreamBatchDrafts:
+    @pytest.mark.asyncio
+    async def test_drafts_flow_during_stream_and_final_send_still_happens(self):
+        adapter = _adapter(drafts=True)
+        api = _api(["Hello", " world"])
+        with _patch_redis():
+            await TurnStreamer(api).stream_batch(
+                [("Bently", "user-1", "hi")], _ctx(), adapter, "42"
+            )
+        assert adapter.send_stream_draft.await_count >= 1
+        first = adapter.send_stream_draft.await_args_list[0]
+        assert first.args[0] == "42"
+        assert first.args[2] == "Hello"
+        # The buffered final send is untouched by drafting.
+        adapter.send_message.assert_awaited_once()
+        assert adapter.send_message.await_args.args[1] == "Hello world"
+
+    @pytest.mark.asyncio
+    async def test_non_drafting_adapters_are_byte_identical(self):
+        adapter = _adapter(drafts=False)
+        api = _api(["Hello", " world"])
+        with _patch_redis():
+            await TurnStreamer(api).stream_batch(
+                [("Bently", "user-1", "hi")], _ctx(), adapter, "42"
+            )
+        adapter.send_stream_draft.assert_not_awaited()
+        adapter.send_message.assert_awaited_once()
+        assert adapter.send_message.await_args.args[1] == "Hello world"


### PR DESCRIPTION
### Why / What / How

**Why:** The Telegram bot delivers replies as buffered chunks, so the user stares at a typing indicator until a full ~3800-char chunk (or the whole reply) is ready. Telegram Bot API 10.1 added `sendMessageDraft` — a native way for bots to stream partial replies as an animated, ephemeral preview — which is exactly the "ChatGPT-style" streaming UX users expect from an AI bot. No other platform we support has an equivalent, so this is a Telegram-specific enhancement layered on a platform-agnostic hook.

**What:** While a turn streams, Telegram DMs now show the reply typing itself out live (updated ~1×/second). The final message is still delivered through the existing buffered send path, which supersedes the preview — drafts are purely additive and content delivery is never at risk. Discord, Slack, and Telegram group chats are byte-identical to before.

**How:**
- `PlatformAdapter` gains an optional capability: `supports_stream_drafts` (default `False`) + `send_stream_draft(channel_id, draft_id, text) -> bool` (default unsupported). Non-Telegram adapters inherit the defaults, so the shared streamer never calls the new method for them.
- `turn_stream.DraftStreamer` pushes the current unsent buffer as a preview, throttled to 1/sec and deduped; any failure (API error or `False` return) silently disables drafting for the rest of the turn.
- `TelegramAdapter` implements it via `sendMessageDraft` with a per-turn nonzero `draft_id` (same id = animated in-place updates):
  - Private chats only per the Bot API — group/supergroup targets (negative chat ids) return `False` without an API call and keep the existing typing + buffered flow.
  - Previews render through the existing `to_html` localizer, which only rewrites *complete* constructs (closed code fences, `**pairs**`, `[label](url)`), so partial streams can't produce unbalanced HTML.
  - If the rendered buffer momentarily exceeds the 4096-char draft cap (right before a chunk flush), that update is skipped rather than erroring, and drafting continues.

### Changes 🏗️

- `copilot/bot/adapters/base.py`: optional `supports_stream_drafts` / `send_stream_draft` on the adapter contract (defaults: off / unsupported)
- `copilot/bot/turn_stream.py`: `DraftStreamer` — throttled, dedupe'd, fail-open draft preview loop wired into `stream_batch`
- `copilot/bot/adapters/telegram/adapter.py`: `sendMessageDraft` implementation (private chats only, HTML-rendered, size-capped)
- Tests: new `turn_stream_test.py` (8 tests: throttle, dedupe, disable-on-failure, `stream_batch` integration incl. proof that non-drafting adapters see zero draft calls) + 5 Telegram adapter tests; `handler_test.py` fake adapter made explicit about the new capability

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Full copilot-bot suite passes (438 tests: core + Telegram + new turn_stream) — Discord/Slack behavior unchanged
  - [x] Live E2E (local, real Telegram): DM reply streams as an animated draft preview and the final message supersedes it
  - [x] Live E2E: group @mention keeps the pre-existing typing + buffered behavior (no drafts)

#### For configuration changes:
- [x] `.env.default` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes
- [x] I have included a list of my configuration changes in the PR description (under **Changes**) — none needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
