### PR TITLE
feat(frontend): expandable member lists on team rows

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/settings/organization/__tests__/teams.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/organization/__tests__/teams.test.tsx
@@ -8,6 +8,7 @@ import {
   within,
 } from "@/tests/integrations/test-utils";
 import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -196,6 +197,14 @@ async function openManagePanel(teamName: string) {
   await openTeamMenu(teamName);
   fireEvent.click(screen.getByRole("menuitem", { name: "Manage" }));
   return screen.findByTestId("team-manage-panel");
+}
+
+// Expanding a row lazily reveals its member list via the chevron toggle on the
+// row body. Returns the row so assertions can stay scoped to that team.
+async function expandTeamMembers(teamName: string) {
+  const row = await teamRow(teamName);
+  await userEvent.click(within(row).getByTestId("team-expand-button"));
+  return row;
 }
 
 describe("TeamsSection", () => {
@@ -506,5 +515,101 @@ describe("TeamsSection", () => {
       expect(leaveSpy).toHaveBeenCalledTimes(1);
     });
     expect(useOrgTeamStore.getState().activeTeamID).toBeNull();
+  });
+
+  it("keeps member lists collapsed until a row is expanded", async () => {
+    mockOrg();
+    server.use(
+      getGetV2ListWorkspaceMembersMockHandler([
+        teamMember({
+          user_id: "user-bob",
+          name: "Bob",
+          email: "bob@acme.test",
+        }),
+      ]),
+    );
+    render(<OrganizationSettingsPage />);
+
+    const section = await showTeamsTab();
+    await within(section).findByText("Marketing");
+
+    // Nothing is fetched or shown until the caller expands a row.
+    expect(within(section).queryByTestId("team-members-preview")).toBeNull();
+    expect(within(section).queryByText("bob@acme.test")).toBeNull();
+
+    const row = await expandTeamMembers("Marketing");
+    expect(await within(row).findByText("bob@acme.test")).toBeDefined();
+  });
+
+  it("reveals the team's members when a row is expanded", async () => {
+    mockOrg();
+    server.use(
+      getGetV2ListWorkspaceMembersMockHandler([
+        teamMember({
+          user_id: "user-bob",
+          name: "Bob",
+          email: "bob@acme.test",
+        }),
+        teamMember({
+          user_id: "user-carl",
+          name: "Carl",
+          email: "carl@acme.test",
+        }),
+      ]),
+    );
+    render(<OrganizationSettingsPage />);
+
+    await showTeamsTab();
+    const row = await expandTeamMembers("Marketing");
+
+    const preview = await within(row).findByTestId("team-members-preview");
+    expect(await within(preview).findByText("Bob")).toBeDefined();
+    expect(within(preview).getByText("Carl")).toBeDefined();
+    expect(within(preview).getByText("bob@acme.test")).toBeDefined();
+  });
+
+  it("badges admins in the expanded member list and leaves plain members unbadged", async () => {
+    mockOrg();
+    server.use(
+      getGetV2ListWorkspaceMembersMockHandler([
+        teamMember({ user_id: "user-bob", name: "Bob", is_admin: true }),
+        teamMember({ user_id: "user-carl", name: "Carl", is_admin: false }),
+      ]),
+    );
+    render(<OrganizationSettingsPage />);
+
+    await showTeamsTab();
+    const row = await expandTeamMembers("Marketing");
+
+    const bobRow = (await within(row).findByText("Bob")).closest(
+      "li",
+    ) as HTMLElement;
+    expect(within(bobRow).getByText("Admin")).toBeDefined();
+
+    const carlRow = within(row).getByText("Carl").closest("li") as HTMLElement;
+    expect(within(carlRow).queryByText("Admin")).toBeNull();
+  });
+
+  it("shows a muted private hint when the member list is forbidden", async () => {
+    mockOrg();
+    // The private-team gate returns 403 for a team the caller can't inspect;
+    // scope the override to the private team so open teams still resolve.
+    server.use(
+      http.get("*/api/orgs/:orgId/workspaces/team-private/members", () =>
+        HttpResponse.json({ detail: "Forbidden" }, { status: 403 }),
+      ),
+    );
+    render(<OrganizationSettingsPage />);
+
+    await showTeamsTab();
+    const row = await expandTeamMembers("Skunkworks");
+
+    expect(
+      await within(row).findByText(
+        "Private — join this team to see its members.",
+      ),
+    ).toBeDefined();
+    // A denied roster stays inline — no error toast or card.
+    expect(screen.queryByRole("alert")).toBeNull();
   });
 });

--- a/autogpt_platform/frontend/src/app/(platform)/settings/organization/components/TeamsSection/TeamsSection.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/organization/components/TeamsSection/TeamsSection.tsx
@@ -11,10 +11,13 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/molecules/DropdownMenu/DropdownMenu";
-import { DotsThree, PlusIcon } from "@phosphor-icons/react";
+import { CaretDownIcon, DotsThree, PlusIcon } from "@phosphor-icons/react";
+
+import { cn } from "@/lib/utils";
 
 import { CreateTeamDialog } from "./components/CreateTeamDialog/CreateTeamDialog";
 import { TeamManagePanel } from "./components/TeamManagePanel/TeamManagePanel";
+import { TeamMembersPreview } from "./components/TeamMembersPreview/TeamMembersPreview";
 import { useTeamsSection } from "./useTeamsSection";
 
 interface Props {
@@ -29,6 +32,8 @@ export function TeamsSection({ orgId, orgMembers, currentMember }: Props) {
     isLoading,
     expandedTeamId,
     setExpandedTeamId,
+    openMemberTeamIds,
+    toggleMembers,
     teamToDelete,
     setTeamToDelete,
     isDeleting,
@@ -77,6 +82,7 @@ export function TeamsSection({ orgId, orgMembers, currentMember }: Props) {
         <ul className="flex flex-col divide-y divide-zinc-100">
           {teams.map((team) => {
             const isExpanded = expandedTeamId === team.id;
+            const isMembersOpen = openMemberTeamIds.has(team.id);
             return (
               <li
                 key={team.id}
@@ -84,15 +90,30 @@ export function TeamsSection({ orgId, orgMembers, currentMember }: Props) {
                 data-testid="org-team-row"
               >
                 <div className="flex items-center gap-3">
-                  <div className="flex min-w-0 flex-1 flex-col">
-                    <span className="truncate text-sm font-medium">
-                      {team.name}
+                  <button
+                    type="button"
+                    onClick={() => toggleMembers(team.id)}
+                    aria-expanded={isMembersOpen}
+                    aria-controls={`team-members-${team.id}`}
+                    className="flex min-w-0 flex-1 items-center gap-2 rounded text-left transition-colors hover:opacity-80"
+                    data-testid="team-expand-button"
+                  >
+                    <CaretDownIcon
+                      className={cn(
+                        "h-4 w-4 shrink-0 text-zinc-500 transition-transform duration-200",
+                        isMembersOpen && "rotate-180",
+                      )}
+                    />
+                    <span className="flex min-w-0 flex-col">
+                      <span className="truncate text-sm font-medium">
+                        {team.name}
+                      </span>
+                      <span className="text-xs text-zinc-500">
+                        {team.member_count}{" "}
+                        {team.member_count === 1 ? "member" : "members"}
+                      </span>
                     </span>
-                    <span className="text-xs text-zinc-500">
-                      {team.member_count}{" "}
-                      {team.member_count === 1 ? "member" : "members"}
-                    </span>
-                  </div>
+                  </button>
                   {team.is_default ? (
                     <Badge variant="info">Default</Badge>
                   ) : team.join_policy !== "OPEN" ? (
@@ -135,6 +156,10 @@ export function TeamsSection({ orgId, orgMembers, currentMember }: Props) {
                     </DropdownMenuContent>
                   </DropdownMenu>
                 </div>
+
+                {isMembersOpen ? (
+                  <TeamMembersPreview orgId={orgId} team={team} />
+                ) : null}
 
                 {isExpanded ? (
                   <TeamManagePanel

--- a/autogpt_platform/frontend/src/app/(platform)/settings/organization/components/TeamsSection/components/TeamMembersPreview/TeamMembersPreview.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/organization/components/TeamsSection/components/TeamMembersPreview/TeamMembersPreview.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import type { TeamResponse } from "@/app/api/__generated__/models/teamResponse";
+import Avatar, { AvatarFallback } from "@/components/atoms/Avatar/Avatar";
+import { Badge } from "@/components/atoms/Badge/Badge";
+import { Skeleton } from "@/components/atoms/Skeleton/Skeleton";
+import { Text } from "@/components/atoms/Text/Text";
+
+import { useTeamMembersPreview } from "./useTeamMembersPreview";
+
+interface Props {
+  orgId: string;
+  team: TeamResponse;
+}
+
+export function TeamMembersPreview({ orgId, team }: Props) {
+  const { members, isLoading, isError, isPrivate } = useTeamMembersPreview({
+    orgId,
+    wsId: team.id,
+  });
+
+  return (
+    <div
+      id={`team-members-${team.id}`}
+      className="rounded-lg bg-zinc-50 px-3 py-2"
+      data-testid="team-members-preview"
+    >
+      {isLoading ? (
+        <ul className="flex flex-col divide-y divide-zinc-100">
+          {[0, 1].map((i) => (
+            <li
+              key={i}
+              className="flex items-center gap-3 py-2"
+              data-testid="team-member-skeleton"
+            >
+              <Skeleton className="size-8 shrink-0 rounded-full" />
+              <div className="flex flex-1 flex-col gap-1.5">
+                <Skeleton className="h-3 w-32" />
+                <Skeleton className="h-3 w-44" />
+              </div>
+            </li>
+          ))}
+        </ul>
+      ) : isError ? (
+        <Text
+          variant="small"
+          className="text-zinc-500"
+          data-testid="team-members-hint"
+        >
+          {isPrivate
+            ? "Private — join this team to see its members."
+            : "Couldn't load members."}
+        </Text>
+      ) : members.length === 0 ? (
+        <Text variant="small" className="text-zinc-500">
+          This team has no members yet.
+        </Text>
+      ) : (
+        <ul className="flex flex-col divide-y divide-zinc-100">
+          {members.map((member) => (
+            <li
+              key={member.user_id}
+              className="flex items-center gap-3 py-2"
+              data-testid="team-member-preview-row"
+            >
+              <Avatar className="size-8 shrink-0">
+                <AvatarFallback className="text-xs">
+                  {(member.name || member.email).charAt(0).toUpperCase()}
+                </AvatarFallback>
+              </Avatar>
+              <div className="flex min-w-0 flex-1 flex-col">
+                <span className="truncate text-sm font-medium">
+                  {member.name || member.email}
+                </span>
+                <span className="truncate text-xs text-zinc-500">
+                  {member.email}
+                </span>
+              </div>
+              {member.is_admin ? <Badge variant="info">Admin</Badge> : null}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/settings/organization/components/TeamsSection/components/TeamMembersPreview/useTeamMembersPreview.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/organization/components/TeamsSection/components/TeamMembersPreview/useTeamMembersPreview.ts
@@ -1,0 +1,37 @@
+"use client";
+
+import { useGetV2ListWorkspaceMembers } from "@/app/api/__generated__/endpoints/orgs/orgs";
+import type { TeamMemberResponse } from "@/app/api/__generated__/models/teamMemberResponse";
+import { ApiError } from "@/lib/autogpt-server-api/helpers";
+import { TEAM_HEADER_NAME } from "@/services/org-team/headers";
+
+interface Args {
+  orgId: string;
+  wsId: string;
+}
+
+export function useTeamMembersPreview({ orgId, wsId }: Args) {
+  // Same hook (and query key) the manage panel uses, so an already-fetched
+  // roster is served from cache. Only mounted once the row is expanded, so the
+  // fetch is lazy. The private-team gate (403/404) lands on the team-routes
+  // chain; treat it as "you can't inspect this team" rather than a hard error.
+  const membersQuery = useGetV2ListWorkspaceMembers(orgId, wsId, {
+    query: {
+      enabled: Boolean(orgId && wsId),
+      select: (res) => res.data as TeamMemberResponse[],
+      retry: false,
+    },
+    request: { headers: { [TEAM_HEADER_NAME]: wsId } },
+  });
+
+  const error: unknown = membersQuery.error;
+  const status = error instanceof ApiError ? error.status : undefined;
+  const isPrivate = status === 403 || status === 404;
+
+  return {
+    members: membersQuery.data ?? [],
+    isLoading: membersQuery.isLoading,
+    isError: membersQuery.isError,
+    isPrivate,
+  };
+}

--- a/autogpt_platform/frontend/src/app/(platform)/settings/organization/components/TeamsSection/useTeamsSection.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/organization/components/TeamsSection/useTeamsSection.ts
@@ -16,6 +16,11 @@ interface Args {
 
 export function useTeamsSection({ orgId }: Args) {
   const [expandedTeamId, setExpandedTeamId] = useState<string | null>(null);
+  // Rows whose member list is expanded. Independent of the manage panel:
+  // per-row, multiple can be open at once, all collapsed by default.
+  const [openMemberTeamIds, setOpenMemberTeamIds] = useState<Set<string>>(
+    () => new Set(),
+  );
   const [teamToDelete, setTeamToDelete] = useState<TeamResponse | null>(null);
   const [isCreateOpen, setIsCreateOpen] = useState(false);
 
@@ -69,12 +74,30 @@ export function useTeamsSection({ orgId }: Args) {
     if (expandedTeamId === teamToDelete.id) {
       setExpandedTeamId(null);
     }
+    setOpenMemberTeamIds((current) => {
+      if (!current.has(teamToDelete.id)) return current;
+      const next = new Set(current);
+      next.delete(teamToDelete.id);
+      return next;
+    });
     setTeamToDelete(null);
     teamsQuery.refetch();
   }
 
   function toggleExpanded(teamId: string) {
     setExpandedTeamId((current) => (current === teamId ? null : teamId));
+  }
+
+  function toggleMembers(teamId: string) {
+    setOpenMemberTeamIds((current) => {
+      const next = new Set(current);
+      if (next.has(teamId)) {
+        next.delete(teamId);
+      } else {
+        next.add(teamId);
+      }
+      return next;
+    });
   }
 
   return {
@@ -85,6 +108,8 @@ export function useTeamsSection({ orgId }: Args) {
     expandedTeamId,
     toggleExpanded,
     setExpandedTeamId,
+    openMemberTeamIds,
+    toggleMembers,
     teamToDelete,
     setTeamToDelete,
     isJoining,


### PR DESCRIPTION
> [!NOTE]
> Top of the org-UI stack (#13496 → … → #13566 → this). Review the top commit only. Pairs with the roster-visibility gate added to #13541 — expanding a private team you can't inspect shows a muted join hint driven by that 403/404.

### Why / What / How

**Why:** Product ask — on the Teams tab you should be able to expand "Engineering (1 member)" and see who's in it, without opening the manage panel.

**What:** Each team row gains a chevron disclosure. Expanding lazily fetches the roster (same hook + query key as the manage panel — cache shared, no double fetch) and renders read-only compact member rows: avatar, name, email, neutral Admin badge. Loading = skeleton rows; private teams the caller can't inspect render "Private — join this team to see its members" inline (no toast/ErrorCard); other failures get a muted fallback. Multi-open, default collapsed.

**How:** Chevron disclosure button as a *sibling* of the kebab (the design-system Collapsible/Accordion use a single full-width Radix trigger button which can't host the kebab without button-in-button nesting; interaction/visuals mirror the molecule). New `TeamMembersPreview/` sub-component + hook per conventions.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `pnpm lint` / `pnpm types` clean; org settings suites 42/42, exit 0 (4 new scenarios: lazy fetch, roster render, admin badges, private hint)

#### For configuration changes: n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jm3mCG9okfdGtAXtFaDF9A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Org-settings UI only; reuses existing list-members API and query cache with no new auth or data-model changes.
> 
> **Overview**
> Adds **chevron disclosure** on each team row in org settings so users can see who’s on a team without opening **Manage**. Rows stay **collapsed by default**; several rows can be open at once, separate from the manage panel.
> 
> Expanding mounts **`TeamMembersPreview`**, which **lazily** loads the roster via the same workspace-members query as the manage panel (shared cache). The UI shows skeletons while loading, compact read-only rows (avatar, name, email, **Admin** badge), and for **403/404** a muted **“Private — join this team to see its members.”** hint inline instead of toasts or error cards.
> 
> Integration tests cover lazy fetch, roster display, admin badges, and the private-team hint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4739cd677eb0a1da435f69c5c1d8e083e48fe272. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->