### PR TITLE
fix(backend/copilot-bot): clamp oversized bot prompts to the request cap

### DIFF
--- a/autogpt_platform/backend/backend/copilot/bot/bot_backend.py
+++ b/autogpt_platform/backend/backend/copilot/bot/bot_backend.py
@@ -24,6 +24,7 @@ from backend.copilot.response_model import (
     StreamToolOutputAvailable,
 )
 from backend.platform_linking.models import (
+    MAX_BOT_MESSAGE_CHARS,
     BotChatRequest,
     BotEventInput,
     BotGuildInput,
@@ -44,6 +45,7 @@ from backend.util.exceptions import (
 )
 
 from .adapters.base import InboundAttachment
+from .prompt import clamp_prompt
 
 # How long to wait for a single chunk from the copilot stream before giving
 # up. Covers the case where the backend crashes mid-stream and never sends
@@ -436,7 +438,10 @@ class BotBackend:
             request=BotChatRequest(
                 platform=Platform(platform.upper()),
                 platform_user_id=platform_user_id,
-                message=message,
+                # A long conversation's history can push the assembled prompt
+                # past the request cap; clamp here so it never fails validation
+                # (which the turn streamer would surface as a generic error).
+                message=clamp_prompt(message, MAX_BOT_MESSAGE_CHARS),
                 session_id=session_id,
                 platform_server_id=platform_server_id,
                 file_ids=file_ids or [],

--- a/autogpt_platform/backend/backend/copilot/bot/prompt.py
+++ b/autogpt_platform/backend/backend/copilot/bot/prompt.py
@@ -9,6 +9,27 @@ from .adapters.base import MessageContext, MessageHistoryEntry
 
 THREAD_NAME_PREFIX = "AutoGPT: "
 
+# Prepended when a prompt is clamped so the model knows context was elided.
+_TRUNCATION_NOTICE = "[Earlier context was truncated to fit the size limit.]\n\n"
+
+
+def clamp_prompt(message: str, max_chars: int) -> str:
+    """Clamp an assembled bot prompt to a hard character cap.
+
+    The current message sits at the *end* of the assembled prompt (after any
+    referenced-conversation content and thread history — see
+    ``build_message_text``), so we keep the tail and drop the older leading
+    context, marking the cut so the model doesn't treat the elided text as
+    missing. A no-op when the prompt already fits.
+    """
+    if len(message) <= max_chars:
+        return message
+    keep = max_chars - len(_TRUNCATION_NOTICE)
+    if keep <= 0:
+        # Pathologically tiny cap — can't even fit the notice; hard-cut.
+        return message[-max_chars:]
+    return _TRUNCATION_NOTICE + message[-keep:]
+
 
 def build_message_text(
     ctx: MessageContext,

--- a/autogpt_platform/backend/backend/copilot/bot/prompt_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/prompt_test.py
@@ -1,0 +1,51 @@
+"""Tests for prompt assembly helpers."""
+
+from backend.platform_linking.models import (
+    MAX_BOT_MESSAGE_CHARS,
+    BotChatRequest,
+    Platform,
+)
+
+from .prompt import _TRUNCATION_NOTICE, clamp_prompt
+
+
+def test_clamp_prompt_leaves_a_fitting_prompt_untouched():
+    message = "a" * (MAX_BOT_MESSAGE_CHARS - 1)
+    assert clamp_prompt(message, MAX_BOT_MESSAGE_CHARS) == message
+
+
+def test_clamp_prompt_leaves_an_exactly_capped_prompt_untouched():
+    message = "a" * MAX_BOT_MESSAGE_CHARS
+    assert clamp_prompt(message, MAX_BOT_MESSAGE_CHARS) == message
+
+
+def test_clamp_prompt_keeps_the_tail_and_marks_the_cut():
+    # The current message sits at the END of the assembled prompt, so the tail
+    # (not the head) must survive.
+    body = "OLD-CONTEXT" * 5000 + "THE ACTUAL QUESTION"
+    clamped = clamp_prompt(body, MAX_BOT_MESSAGE_CHARS)
+    assert len(clamped) == MAX_BOT_MESSAGE_CHARS
+    assert clamped.startswith(_TRUNCATION_NOTICE)
+    assert clamped.endswith("THE ACTUAL QUESTION")
+    assert "OLD-CONTEXT" * 5000 not in clamped  # older context was dropped
+
+
+def test_clamp_prompt_output_always_satisfies_bot_chat_request():
+    # Regression: a long conversation's assembled prompt used to exceed the
+    # request cap and raise a pydantic ValidationError mid-turn (surfaced to
+    # the user as a generic "Something went wrong").
+    oversized = "x" * (MAX_BOT_MESSAGE_CHARS * 3)
+    request = BotChatRequest(
+        platform=Platform.DISCORD,
+        platform_user_id="u-1",
+        message=clamp_prompt(oversized, MAX_BOT_MESSAGE_CHARS),
+    )
+    assert len(request.message) <= MAX_BOT_MESSAGE_CHARS
+
+
+def test_clamp_prompt_hard_cuts_when_cap_below_notice_width():
+    # Pathologically tiny cap can't fit the notice — still must respect it.
+    tiny = len(_TRUNCATION_NOTICE) - 5
+    clamped = clamp_prompt("z" * 100, tiny)
+    assert len(clamped) == tiny
+    assert clamped == "z" * tiny

--- a/autogpt_platform/backend/backend/platform_linking/models.py
+++ b/autogpt_platform/backend/backend/platform_linking/models.py
@@ -6,6 +6,12 @@ from typing import Literal
 
 from pydantic import BaseModel, Field
 
+# Hard cap on the assembled bot prompt. The chat bots build a prompt from the
+# user's message plus channel history / referenced conversations, which on a
+# very long conversation can blow past this — callers must clamp to it before
+# constructing a BotChatRequest (see bot.prompt.clamp_prompt).
+MAX_BOT_MESSAGE_CHARS = 32000
+
 
 class Platform(str, Enum):
     """Mirror of the Prisma PlatformType enum."""
@@ -106,7 +112,9 @@ class BotChatRequest(BaseModel):
         max_length=255,
     )
     message: str = Field(
-        description="The user's message", min_length=1, max_length=32000
+        description="The user's message",
+        min_length=1,
+        max_length=MAX_BOT_MESSAGE_CHARS,
     )
     session_id: str | None = Field(
         default=None,


### PR DESCRIPTION
### Why / What / How

**Why:** On the prod-canary Discord bot, an @-mention inside a very long thread (~500 messages) failed with a generic *"Something went wrong. Try again in a moment."* The `copilot-bot` traceback showed a pydantic `ValidationError` when constructing `BotChatRequest`:

```
message: String should have at most 32000 characters [type=string_too_long]
```

The chat bots assemble a prompt from the user's message plus budgeted thread history and referenced-conversation content, but nothing enforced that the **assembled** prompt fits the `BotChatRequest.message` cap (`max_length=32000`). Each context section is budgeted independently by the Discord adapter (`THREAD_HISTORY_CHAR_BUDGET = 24000`; `REFERENCED_CHAR_BUDGET = 8000` × up to 3), and those budgets are **not coordinated** against the request cap — so when a section (or the sum of sections) is large, the request exceeds 32000 and the turn streamer surfaces the validation error as a generic failure.

A compounding factor: `budget_history` counts only each message's **text**, not the per-entry label `format_history_entry` adds (`[From <name> (Discord user ID: …)]`, ~55 chars). On a thread of many *short* messages that label overhead is 50–60%, so a 24000-char text budget assembles to ~35–38000 chars — over the cap.

**What:** Clamp the assembled prompt to the request cap at the single point where the request is built (`BotBackend.stream_chat`), so an oversized prompt can never fail validation again — on any platform (Discord/Slack/Telegram) and regardless of how each tunes its budgets.

**How:**
- `MAX_BOT_MESSAGE_CHARS = 32000` is now a named constant in `platform_linking/models.py`, and `BotChatRequest.message`'s `max_length` references it — single source of truth, can't drift.
- `bot.prompt.clamp_prompt(message, max_chars)` — the current message sits at the **end** of the assembled prompt (after referenced content and thread history), so it keeps the **tail** and drops the older leading context, prepending a short truncation notice so the model doesn't treat the elided text as missing. No-op when the prompt already fits.
- Applied once in `stream_chat` just before `BotChatRequest(...)` — the choke point nothing bypasses.

Deliberately **not** included: retuning the per-section budgets. Coordinating N budgets across M platforms (with count-dependent label overhead) is fragile; the boundary clamp is the invariant that makes it safe regardless. The clamp preserves the current message plus the most recent context, so long threads still get a correct, working reply — they just no longer include the oldest history when it can't fit.

### Changes 🏗️

- `platform_linking/models.py`: extract `MAX_BOT_MESSAGE_CHARS` constant; `BotChatRequest.message` uses it.
- `copilot/bot/prompt.py`: add `clamp_prompt()` (tail-preserving, marked truncation, no-op when fitting).
- `copilot/bot/bot_backend.py`: clamp `message` in `stream_chat` before building the request.
- `copilot/bot/prompt_test.py`: 5 tests incl. the exact regression (clamped output always validates against `BotChatRequest`).

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] New `prompt_test.py`: fitting prompt untouched; exactly-capped untouched; oversized keeps the tail + marks the cut; clamped output satisfies `BotChatRequest`; tiny-cap hard-cut respects the limit
  - [x] Full `copilot/bot` + `platform_linking` suites pass (538 tests) — Discord/Slack/Telegram unaffected
  - [x] Root cause confirmed from the prod `copilot-bot` traceback (pydantic `string_too_long` on `BotChatRequest.message`)

#### For configuration changes:
- [x] `.env.default` / `docker-compose.yml` — no changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
