### PR TITLE
fix(frontend/marketplace): unstick publish submit after adding image and cut success-screen lag

### DIFF
--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentInfoStep/__tests__/useAgentInfoStep.test.ts
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentInfoStep/__tests__/useAgentInfoStep.test.ts
@@ -39,9 +39,7 @@ describe("useAgentInfoStep", () => {
     // Adding an image must clear the stale error, otherwise the submit button
     // stays disabled forever and the user is stuck.
     act(() => {
-      result.current.step.handleImagesChange([
-        "https://example.com/thumb.png",
-      ]);
+      result.current.step.handleImagesChange(["https://example.com/thumb.png"]);
     });
 
     expect(result.current.rootError).toBeUndefined();

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentInfoStep/__tests__/useAgentInfoStep.test.ts
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentInfoStep/__tests__/useAgentInfoStep.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+
+vi.mock("@sentry/nextjs", () => ({
+  captureException: vi.fn(),
+}));
+
+import { useAgentInfoStep } from "../useAgentInfoStep";
+
+describe("useAgentInfoStep", () => {
+  const baseArgs = {
+    onBack: vi.fn(),
+    onSuccess: vi.fn(),
+    selectedAgentId: "graph-1",
+    selectedAgentVersion: 1,
+  };
+
+  it("clears the image-required error once an image is added so submit re-enables", () => {
+    const { result } = renderHook(() => useAgentInfoStep(baseArgs));
+
+    // Simulate submitting without a thumbnail: the form marks the root error.
+    act(() => {
+      result.current.form.setError("root", {
+        type: "manual",
+        message: "At least one image is required",
+      });
+    });
+    expect(result.current.form.formState.errors.root).toBeDefined();
+
+    // Adding an image must clear the stale error, otherwise the submit button
+    // stays disabled forever and the user is stuck.
+    act(() => {
+      result.current.handleImagesChange(["https://example.com/thumb.png"]);
+    });
+
+    expect(result.current.form.formState.errors.root).toBeUndefined();
+    expect(result.current.images).toEqual(["https://example.com/thumb.png"]);
+  });
+
+  it("keeps the error while there are still no images", () => {
+    const { result } = renderHook(() => useAgentInfoStep(baseArgs));
+
+    act(() => {
+      result.current.form.setError("root", {
+        type: "manual",
+        message: "At least one image is required",
+      });
+    });
+
+    act(() => {
+      result.current.handleImagesChange([]);
+    });
+
+    expect(result.current.form.formState.errors.root).toBeDefined();
+  });
+});

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentInfoStep/__tests__/useAgentInfoStep.test.ts
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentInfoStep/__tests__/useAgentInfoStep.test.ts
@@ -15,42 +15,55 @@ describe("useAgentInfoStep", () => {
     selectedAgentVersion: 1,
   };
 
+  // react-hook-form's formState is a subscription proxy: errors only update
+  // when read during render, so expose them from the render callback.
+  function renderInfoStepHook() {
+    return renderHook(() => {
+      const step = useAgentInfoStep(baseArgs);
+      return { step, rootError: step.form.formState.errors.root };
+    });
+  }
+
   it("clears the image-required error once an image is added so submit re-enables", () => {
-    const { result } = renderHook(() => useAgentInfoStep(baseArgs));
+    const { result } = renderInfoStepHook();
 
     // Simulate submitting without a thumbnail: the form marks the root error.
     act(() => {
-      result.current.form.setError("root", {
+      result.current.step.form.setError("root", {
         type: "manual",
         message: "At least one image is required",
       });
     });
-    expect(result.current.form.formState.errors.root).toBeDefined();
+    expect(result.current.rootError).toBeDefined();
 
     // Adding an image must clear the stale error, otherwise the submit button
     // stays disabled forever and the user is stuck.
     act(() => {
-      result.current.handleImagesChange(["https://example.com/thumb.png"]);
+      result.current.step.handleImagesChange([
+        "https://example.com/thumb.png",
+      ]);
     });
 
-    expect(result.current.form.formState.errors.root).toBeUndefined();
-    expect(result.current.images).toEqual(["https://example.com/thumb.png"]);
+    expect(result.current.rootError).toBeUndefined();
+    expect(result.current.step.images).toEqual([
+      "https://example.com/thumb.png",
+    ]);
   });
 
   it("keeps the error while there are still no images", () => {
-    const { result } = renderHook(() => useAgentInfoStep(baseArgs));
+    const { result } = renderInfoStepHook();
 
     act(() => {
-      result.current.form.setError("root", {
+      result.current.step.form.setError("root", {
         type: "manual",
         message: "At least one image is required",
       });
     });
 
     act(() => {
-      result.current.handleImagesChange([]);
+      result.current.step.handleImagesChange([]);
     });
 
-    expect(result.current.form.formState.errors.root).toBeDefined();
+    expect(result.current.rootError).toBeDefined();
   });
 });

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentInfoStep/useAgentInfoStep.ts
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentInfoStep/useAgentInfoStep.ts
@@ -85,9 +85,15 @@ export function useAgentInfoStep({
     }
   }, [selectedAgentId, agentId]);
 
-  const handleImagesChange = useCallback((newImages: string[]) => {
-    setImages(newImages);
-  }, []);
+  const handleImagesChange = useCallback(
+    (newImages: string[]) => {
+      setImages(newImages);
+      if (newImages.length > 0) {
+        form.clearErrors("root");
+      }
+    },
+    [form],
+  );
 
   async function handleFormSubmit(data: PublishAgentFormData) {
     // Validate that at least one image is present

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/ReviewHero.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/ReviewHero.tsx
@@ -35,9 +35,10 @@ export function ReviewHero({
       {showConfetti && !shouldReduceMotion ? (
         <Confetti
           options={{
-            particleCount: 80,
+            particleCount: 50,
             spread: 70,
             startVelocity: 35,
+            ticks: 120,
             origin: { y: 0.3 },
           }}
         />
@@ -53,7 +54,7 @@ export function ReviewHero({
               transition={{
                 duration: 1.6,
                 ease: "easeOut",
-                repeat: Infinity,
+                repeat: 3,
                 repeatDelay: 0.4,
               }}
               className={cn(
@@ -68,7 +69,7 @@ export function ReviewHero({
               transition={{
                 duration: 1.6,
                 ease: "easeOut",
-                repeat: Infinity,
+                repeat: 3,
                 repeatDelay: 0.4,
                 delay: 0.5,
               }}

--- a/autogpt_platform/frontend/src/components/molecules/Confetti/Confetti.tsx
+++ b/autogpt_platform/frontend/src/components/molecules/Confetti/Confetti.tsx
@@ -58,29 +58,6 @@ const ConfettiComponent = forwardRef<ConfettiRef, Props>(
 
     const canvasElRef = useRef<HTMLCanvasElement | null>(null);
     const instanceRef = useRef<ConfettiInstance | null>(null);
-    const hasAutoStartedRef = useRef(false);
-
-    // Create the confetti instance once after mount via useEffect,
-    // so React never re-fires a callback ref on re-renders.
-    useEffect(() => {
-      const node = canvasElRef.current;
-      if (!node || instanceRef.current) return;
-
-      const dpr = window.devicePixelRatio || 1;
-      node.width = node.offsetWidth * dpr;
-      node.height = node.offsetHeight * dpr;
-
-      instanceRef.current = confetti.create(node, {
-        resize: true,
-        useWorker: false,
-        ...globalOptions,
-      });
-
-      return () => {
-        instanceRef.current?.reset();
-        instanceRef.current = null;
-      };
-    }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
     const fire = useMemo(
       () =>
@@ -102,11 +79,35 @@ const ConfettiComponent = forwardRef<ConfettiRef, Props>(
 
     useImperativeHandle(ref, () => api, [api]);
 
+    // Create the confetti instance once after mount via useEffect,
+    // so React never re-fires a callback ref on re-renders. Auto-fire is
+    // tied to instance creation so StrictMode's remount (which resets the
+    // instance) still produces a visible burst.
     useEffect(() => {
-      if (manualstart || hasAutoStartedRef.current) return;
-      hasAutoStartedRef.current = true;
-      void fire();
-    }, [manualstart, fire]);
+      const node = canvasElRef.current;
+      if (!node || instanceRef.current) return;
+
+      // Cap DPR: full-resolution canvases on 2-3x displays multiply the
+      // pixels the main thread has to paint each frame for little visual gain.
+      const dpr = Math.min(window.devicePixelRatio || 1, 1.5);
+      node.width = node.offsetWidth * dpr;
+      node.height = node.offsetHeight * dpr;
+
+      instanceRef.current = confetti.create(node, {
+        resize: true,
+        useWorker: false,
+        ...globalOptions,
+      });
+
+      if (!manualstart) {
+        void fire();
+      }
+
+      return () => {
+        instanceRef.current?.reset();
+        instanceRef.current = null;
+      };
+    }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
     return (
       <ConfettiContext.Provider value={api}>

--- a/autogpt_platform/frontend/src/components/molecules/Confetti/Confetti.tsx
+++ b/autogpt_platform/frontend/src/components/molecules/Confetti/Confetti.tsx
@@ -79,6 +79,18 @@ const ConfettiComponent = forwardRef<ConfettiRef, Props>(
 
     useImperativeHandle(ref, () => api, [api]);
 
+    // Mirror the latest props into refs so the mount-only effect below can read
+    // current values without listing them as dependencies. `fire`'s identity
+    // changes whenever `options` changes (a new object literal every render at
+    // most call sites), so depending on it would tear down and re-fire the
+    // instance on every re-render.
+    const manualstartRef = useRef(manualstart);
+    manualstartRef.current = manualstart;
+    const globalOptionsRef = useRef(globalOptions);
+    globalOptionsRef.current = globalOptions;
+    const fireRef = useRef(fire);
+    fireRef.current = fire;
+
     // Create the confetti instance once after mount via useEffect,
     // so React never re-fires a callback ref on re-renders. Auto-fire is
     // tied to instance creation so StrictMode's remount (which resets the
@@ -89,25 +101,27 @@ const ConfettiComponent = forwardRef<ConfettiRef, Props>(
 
       // Cap DPR: full-resolution canvases on 2-3x displays multiply the
       // pixels the main thread has to paint each frame for little visual gain.
+      // `resize: false` keeps this capped sizing — canvas-confetti's own resize
+      // handling ignores devicePixelRatio and would drop the cap on any resize.
       const dpr = Math.min(window.devicePixelRatio || 1, 1.5);
       node.width = node.offsetWidth * dpr;
       node.height = node.offsetHeight * dpr;
 
       instanceRef.current = confetti.create(node, {
-        resize: true,
+        resize: false,
         useWorker: false,
-        ...globalOptions,
+        ...globalOptionsRef.current,
       });
 
-      if (!manualstart) {
-        void fire();
+      if (!manualstartRef.current) {
+        void fireRef.current();
       }
 
       return () => {
         instanceRef.current?.reset();
         instanceRef.current = null;
       };
-    }, []); // eslint-disable-line react-hooks/exhaustive-deps
+    }, []);
 
     return (
       <ConfettiContext.Provider value={api}>

--- a/autogpt_platform/frontend/src/components/molecules/Confetti/__tests__/Confetti.test.tsx
+++ b/autogpt_platform/frontend/src/components/molecules/Confetti/__tests__/Confetti.test.tsx
@@ -1,0 +1,78 @@
+import { createRef } from "react";
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { Confetti, type ConfettiRef } from "../Confetti";
+
+const fireInstance = vi.fn().mockResolvedValue(undefined);
+const resetInstance = vi.fn();
+const createInstance = vi.fn();
+
+vi.mock("canvas-confetti", () => ({
+  default: {
+    create: (...args: unknown[]) => {
+      createInstance(...args);
+      return Object.assign(fireInstance, { reset: resetInstance });
+    },
+  },
+}));
+
+describe("Confetti", () => {
+  beforeEach(() => {
+    fireInstance.mockClear();
+    resetInstance.mockClear();
+    createInstance.mockClear();
+  });
+
+  it("creates an instance and auto-fires once on mount", () => {
+    render(<Confetti />);
+
+    expect(createInstance).toHaveBeenCalledTimes(1);
+    expect(fireInstance).toHaveBeenCalledTimes(1);
+  });
+
+  it("caps the device pixel ratio when sizing the canvas", () => {
+    const original = window.devicePixelRatio;
+    Object.defineProperty(window, "devicePixelRatio", {
+      value: 3,
+      configurable: true,
+    });
+
+    render(<Confetti data-testid="confetti-canvas" />);
+
+    // With offsetWidth/Height of 0 in happy-dom the size stays 0, but the
+    // create call still happens with the capped DPR path exercised.
+    expect(createInstance).toHaveBeenCalledTimes(1);
+
+    Object.defineProperty(window, "devicePixelRatio", {
+      value: original,
+      configurable: true,
+    });
+  });
+
+  it("does not auto-fire when manualstart is set", () => {
+    render(<Confetti manualstart />);
+
+    expect(createInstance).toHaveBeenCalledTimes(1);
+    expect(fireInstance).not.toHaveBeenCalled();
+  });
+
+  it("fires via the imperative ref handle", async () => {
+    const ref = createRef<ConfettiRef>();
+    render(<Confetti manualstart ref={ref} />);
+
+    expect(fireInstance).not.toHaveBeenCalled();
+
+    await ref.current?.fire();
+
+    expect(fireInstance).toHaveBeenCalledTimes(1);
+  });
+
+  it("resets the instance on unmount", () => {
+    const { unmount } = render(<Confetti manualstart />);
+
+    unmount();
+
+    expect(resetInstance).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
### Why / What / How

**Why:** Two UX-breaking bugs in the agent publish flow: (1) submitting without a thumbnail set a `root` form error that was never cleared when an image was later added, leaving the Submit button permanently disabled and forcing users to close the modal and redo the whole flow; (2) the "Submission received" screen lagged the entire browser because its two pulse-ring animations ran with `repeat: Infinity` for as long as the modal stayed open, on top of a heavy confetti burst.

**What:** Clears the image-required error as soon as an image is added, makes the celebration animations finite and cheaper, and fixes a StrictMode bug in `Confetti` where the auto-fire guard (`hasAutoStartedRef`) survived the dev remount while the confetti instance did not — so no confetti ever rendered in dev.

**How:** `handleImagesChange` now calls `form.clearErrors("root")` when images are present. The pulse rings use `repeat: 3`, the confetti burst is trimmed (`particleCount` 80→50, `ticks: 120`), and the canvas DPR is capped at 1.5 to reduce per-frame paint cost on high-DPR/low-power devices. In `Confetti`, auto-fire moved into the instance-creation effect so every (re)created instance fires once.

### Changes 🏗️

- `useAgentInfoStep.ts`: clear the `root` (image-required) error in `handleImagesChange` when at least one image is present, so Submit re-enables
- `ReviewHero.tsx`: pulse rings `repeat: Infinity` → `repeat: 3`; confetti `particleCount` 80 → 50 with `ticks: 120`
- `Confetti.tsx`: merge auto-fire into the instance-creation effect (removes `hasAutoStartedRef`, fixes invisible confetti under React StrictMode); cap canvas DPR at 1.5
- New regression test `__tests__/useAgentInfoStep.test.ts`: error clears once an image is added, and persists while images remain empty

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Publish an agent, press Continue/Submit with no image → error shows; add an image → Submit re-enables and submission succeeds
  - [x] "Submission received" screen: confetti fires once, pulse rings stop after 3 cycles, no sustained browser lag
  - [x] Confetti visible in dev (StrictMode) and unaffected by reduced-motion preference handling
  - [x] `useAgentInfoStep` unit tests pass

<details>
  <summary>Example test plan</summary>

  - [ ] Create from scratch and execute an agent with at least 3 blocks
  - [ ] Import an agent from file upload, and confirm it executes correctly
  - [ ] Upload agent to marketplace
  - [ ] Import an agent from marketplace and confirm it executes correctly
  - [ ] Edit an agent from monitor, and confirm it executes correctly
</details>

#### For configuration changes:

- [ ] `.env.default` is updated or already compatible with my changes
- [ ] `docker-compose.yml` is updated or already compatible with my changes
- [ ] I have included a list of my configuration changes in the PR description (under **Changes**)

<details>
  <summary>Examples of configuration changes</summary>

  - Changing ports
  - Adding new services that need to communicate with each other
  - Secrets or environment variable changes
  - New or infrastructure changes such as databases
</details>
