### PR TITLE
fix(backend/copilot): `find_block` misses renamed blocks and exact class-name queries

### DIFF
--- a/autogpt_platform/backend/backend/api/features/search/content_handlers.py
+++ b/autogpt_platform/backend/backend/api/features/search/content_handlers.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import asyncio
 import functools
-import itertools
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
@@ -238,7 +237,14 @@ class BlockHandler(ContentHandler):
         return ContentType.BLOCK
 
     async def get_missing_items(self, batch_size: int) -> list[ContentItem]:
-        """Fetch blocks without embeddings."""
+        """Fetch blocks whose embedding is missing or stale.
+
+        Stale = the stored ``searchableText`` no longer matches the text built
+        from the current block definition (rename, description change, schema
+        drift). Without this check a renamed block keeps its old embedding
+        forever and becomes unfindable under its new name (e.g.
+        SmartDecisionMakerBlock → OrchestratorBlock).
+        """
         # to_thread keeps the first (heavy) call off the event loop.  On
         # subsequent calls the lru_cache makes this a dict lookup, so the
         # thread-pool overhead is negligible compared to the DB queries below.
@@ -248,11 +254,11 @@ class BlockHandler(ContentHandler):
 
         block_ids = list(enabled.keys())
 
-        # Query for existing embeddings
+        # Query for existing embeddings and their indexed text
         placeholders = ",".join([f"${i+1}" for i in range(len(block_ids))])
         existing_result = await query_raw_with_schema(
             f"""
-            SELECT "contentId"
+            SELECT "contentId", "searchableText"
             FROM {{schema_prefix}}"UnifiedContentEmbedding"
             WHERE "contentType" = 'BLOCK'::{{schema_prefix}}"ContentType"
             AND "contentId" = ANY(ARRAY[{placeholders}])
@@ -260,74 +266,27 @@ class BlockHandler(ContentHandler):
             *block_ids,
         )
 
-        existing_ids = {row["contentId"] for row in existing_result}
+        existing_text = {
+            row["contentId"]: row.get("searchableText") for row in existing_result
+        }
 
         # Convert to ContentItem — disabled filtering already done by
         # _get_enabled_blocks so batch_size won't be exhausted by disabled blocks.
-        missing = ((bid, b) for bid, b in enabled.items() if bid not in existing_ids)
-        items = []
-        for block_id, block in itertools.islice(missing, batch_size):
+        items: list[ContentItem] = []
+        for block_id, block in enabled.items():
+            if len(items) >= batch_size:
+                break
             try:
-                # Build searchable text from block metadata
-                if not block.name:
-                    logger.warning(
-                        f"Block {block_id} has no name — using block_id as fallback"
-                    )
-                display_name = split_camelcase(block.name) if block.name else ""
-                parts = []
-                if display_name:
-                    parts.append(display_name)
-                if block.description:
-                    parts.append(block.description)
-                if block.categories:
-                    parts.append(" ".join(str(cat.value) for cat in block.categories))
-
-                # Add input schema field descriptions
-                parts += [
-                    f"{field_name}: {field_info.description}"
-                    for field_name, field_info in block.input_schema.model_fields.items()
-                    if field_info.description
-                ]
-
-                searchable_text = " ".join(parts)
-
-                categories_list = (
-                    [cat.value for cat in block.categories] if block.categories else []
-                )
-
-                # Extract provider names from credentials fields
-                credentials_info = block.input_schema.get_credentials_fields_info()
-                is_integration = len(credentials_info) > 0
-                provider_names = [
-                    provider.value.lower()
-                    for info in credentials_info.values()
-                    for provider in info.provider
-                ]
-
-                # Check if block has LlmModel field in input schema
-                has_llm_model_field = any(
-                    _contains_type(field.annotation, LlmModel)
-                    for field in block.input_schema.model_fields.values()
-                )
-
-                items.append(
-                    ContentItem(
-                        content_id=block_id,
-                        content_type=ContentType.BLOCK,
-                        searchable_text=searchable_text,
-                        metadata={
-                            "name": display_name or block.name or block_id,
-                            "categories": categories_list,
-                            "providers": provider_names,
-                            "has_llm_model_field": has_llm_model_field,
-                            "is_integration": is_integration,
-                        },
-                        user_id=None,
-                    )
-                )
+                item = _build_block_content_item(block_id, block)
             except Exception as e:
                 logger.warning(f"Failed to process block {block_id}: {e}")
                 continue
+            if (
+                block_id in existing_text
+                and existing_text[block_id] == item.searchable_text
+            ):
+                continue  # embedding exists and is up to date
+            items.append(item)
 
         return items
 
@@ -366,6 +325,62 @@ class BlockHandler(ContentHandler):
         # longer a valid embedding target.
         enabled = await asyncio.to_thread(_get_enabled_blocks)
         return set(enabled.keys())
+
+
+def _build_block_content_item(block_id: str, block: AnyBlockSchema) -> ContentItem:
+    """Build the embeddable ContentItem for a block from its live definition."""
+    if not block.name:
+        logger.warning(f"Block {block_id} has no name — using block_id as fallback")
+    display_name = split_camelcase(block.name) if block.name else ""
+    parts = []
+    if display_name:
+        parts.append(display_name)
+    if block.description:
+        parts.append(block.description)
+    if block.categories:
+        parts.append(" ".join(str(cat.value) for cat in block.categories))
+
+    # Add input schema field descriptions
+    parts += [
+        f"{field_name}: {field_info.description}"
+        for field_name, field_info in block.input_schema.model_fields.items()
+        if field_info.description
+    ]
+
+    searchable_text = " ".join(parts)
+
+    categories_list = (
+        [cat.value for cat in block.categories] if block.categories else []
+    )
+
+    # Extract provider names from credentials fields
+    credentials_info = block.input_schema.get_credentials_fields_info()
+    is_integration = len(credentials_info) > 0
+    provider_names = [
+        provider.value.lower()
+        for info in credentials_info.values()
+        for provider in info.provider
+    ]
+
+    # Check if block has LlmModel field in input schema
+    has_llm_model_field = any(
+        _contains_type(field.annotation, LlmModel)
+        for field in block.input_schema.model_fields.values()
+    )
+
+    return ContentItem(
+        content_id=block_id,
+        content_type=ContentType.BLOCK,
+        searchable_text=searchable_text,
+        metadata={
+            "name": display_name or block.name or block_id,
+            "categories": categories_list,
+            "providers": provider_names,
+            "has_llm_model_field": has_llm_model_field,
+            "is_integration": is_integration,
+        },
+        user_id=None,
+    )
 
 
 @dataclass

--- a/autogpt_platform/backend/backend/api/features/search/content_handlers_test.py
+++ b/autogpt_platform/backend/backend/api/features/search/content_handlers_test.py
@@ -225,6 +225,53 @@ async def test_block_handler_get_missing_items_splits_camelcase():
 
 
 @pytest.mark.asyncio(loop_scope="session")
+async def test_block_handler_reembeds_stale_searchable_text():
+    """Blocks whose stored searchableText no longer matches their current
+    definition (e.g. renamed blocks) are returned for re-embedding, while
+    up-to-date blocks are skipped."""
+    handler = BlockHandler()
+
+    blocks = {
+        "renamed-block": _make_block_class(
+            name="OrchestratorBlock", description="Orchestrates tools"
+        ),
+        "fresh-block": _make_block_class(
+            name="CalculatorBlock", description="Performs calculations"
+        ),
+    }
+
+    with patch(
+        "backend.api.features.search.content_handlers.get_blocks", return_value=blocks
+    ):
+        # First pass with nothing embedded to learn the current text
+        with patch(
+            "backend.api.features.search.content_handlers.query_raw_with_schema",
+            return_value=[],
+        ):
+            baseline = await handler.get_missing_items(batch_size=10)
+        current_text = {item.content_id: item.searchable_text for item in baseline}
+        assert set(current_text) == {"renamed-block", "fresh-block"}
+
+        # Second pass: one row is stale (pre-rename text), one is current
+        with patch(
+            "backend.api.features.search.content_handlers.query_raw_with_schema",
+            return_value=[
+                {
+                    "contentId": "renamed-block",
+                    "searchableText": "Smart Decision Maker Block Uses AI to decide",
+                },
+                {
+                    "contentId": "fresh-block",
+                    "searchableText": current_text["fresh-block"],
+                },
+            ],
+        ):
+            items = await handler.get_missing_items(batch_size=10)
+
+    assert [item.content_id for item in items] == ["renamed-block"]
+
+
+@pytest.mark.asyncio(loop_scope="session")
 async def test_block_handler_get_missing_items_batch_size_zero():
     """batch_size=0 returns an empty list; the DB is still queried to find missing IDs."""
     handler = BlockHandler()

--- a/autogpt_platform/backend/backend/api/features/search/embeddings.py
+++ b/autogpt_platform/backend/backend/api/features/search/embeddings.py
@@ -464,7 +464,11 @@ async def backfill_all_content_types(batch_size: int = 10) -> dict[str, Any]:
                 }
                 continue
 
-            # Process embeddings concurrently for better performance
+            # Process embeddings concurrently for better performance.
+            # force=True: the handler's get_missing_items() is the source of
+            # truth for what needs (re-)embedding — it may return items whose
+            # row exists but is stale (e.g. a renamed block). Without force,
+            # ensure_content_embedding would skip those as "already embedded".
             embedding_tasks = [
                 ensure_content_embedding(
                     content_type=item.content_type,
@@ -472,6 +476,7 @@ async def backfill_all_content_types(batch_size: int = 10) -> dict[str, Any]:
                     searchable_text=item.searchable_text,
                     metadata=item.metadata,
                     user_id=item.user_id,
+                    force=True,
                 )
                 for item in missing_items
             ]

--- a/autogpt_platform/backend/backend/copilot/tools/find_block.py
+++ b/autogpt_platform/backend/backend/copilot/tools/find_block.py
@@ -1,9 +1,10 @@
 import logging
+import re
 from typing import Any
 
 from prisma.enums import ContentType
 
-from backend.blocks import get_block
+from backend.blocks import get_block, get_blocks
 from backend.blocks._base import BlockType
 from backend.copilot.context import get_current_permissions
 from backend.copilot.model import ChatSession
@@ -24,6 +25,8 @@ _TARGET_RESULTS = 10
 # Over-fetch to compensate for post-hoc filtering of graph-only blocks.
 # 40 is 2x current removed; speed of query 10 vs 40 is minimial
 _OVERFETCH_PAGE_SIZE = 40
+# Cap on registry hits for queries that name a block class directly.
+_MAX_EXACT_NAME_MATCHES = 3
 
 # Block types that only work within graphs and cannot run standalone in CoPilot.
 COPILOT_EXCLUDED_BLOCK_TYPES = {
@@ -218,6 +221,18 @@ class FindBlockTool(BaseTool):
                 page_size=_OVERFETCH_PAGE_SIZE,
             )
 
+            # Prepend exact class-name matches from the live registry. The
+            # hybrid search can miss or bury exact block names: CamelCase
+            # queries get no lexical signal (the index stores the split
+            # form), and index rows can lag behind block renames. Queries
+            # like "OrchestratorBlock" must always resolve.
+            exact_ids = _find_block_ids_by_name(query)
+            if exact_ids:
+                seen = set(exact_ids)
+                results = [{"content_id": bid} for bid in exact_ids] + [
+                    r for r in results if r["content_id"] not in seen
+                ]
+
             if not results:
                 return NoResultsResponse(
                     message=f"No blocks found for '{query}'",
@@ -308,3 +323,27 @@ class FindBlockTool(BaseTool):
                 error=str(e),
                 session_id=session_id,
             )
+
+
+def _find_block_ids_by_name(query: str) -> list[str]:
+    """Resolve a query that names a block class to its block ID(s).
+
+    Matches case-insensitively, ignoring spaces/punctuation, with an optional
+    "Block" suffix — so "OrchestratorBlock", "orchestrator block" and
+    "orchestrator" all resolve to OrchestratorBlock. Exclusion/permission
+    filtering is the caller's job (same path as regular search results).
+    """
+    normalized = _normalize_block_name(query)
+    if not normalized:
+        return []
+    matches = [
+        block_id
+        for block_id, block_cls in get_blocks().items()
+        if _normalize_block_name(block_cls.__name__)
+        in (normalized, f"{normalized}block")
+    ]
+    return matches[:_MAX_EXACT_NAME_MATCHES]
+
+
+def _normalize_block_name(text: str) -> str:
+    return re.sub(r"[^a-z0-9]", "", text.lower())

--- a/autogpt_platform/backend/backend/copilot/tools/find_block_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/find_block_test.py
@@ -11,6 +11,7 @@ from .find_block import (
     COPILOT_EXCLUDED_BLOCK_IDS,
     COPILOT_EXCLUDED_BLOCK_TYPES,
     FindBlockTool,
+    _find_block_ids_by_name,
 )
 from .models import BlockListResponse, NoResultsResponse
 
@@ -866,3 +867,109 @@ class TestFindBlockDirectLookup:
 
         assert isinstance(response, NoResultsResponse)
         assert "run_mcp_tool" in response.message
+
+
+class TestExactNameLookup:
+    """Tests for the exact class-name registry lookup that backstops search."""
+
+    def test_matches_class_name_in_common_spellings(self):
+        registry = {"orch-id": type("OrchestratorBlock", (), {})}
+        with patch(
+            "backend.copilot.tools.find_block.get_blocks", return_value=registry
+        ):
+            assert _find_block_ids_by_name("OrchestratorBlock") == ["orch-id"]
+            assert _find_block_ids_by_name("orchestrator block") == ["orch-id"]
+            assert _find_block_ids_by_name("orchestrator") == ["orch-id"]
+
+    def test_no_match_for_keyword_queries(self):
+        registry = {"orch-id": type("OrchestratorBlock", (), {})}
+        with patch(
+            "backend.copilot.tools.find_block.get_blocks", return_value=registry
+        ):
+            assert _find_block_ids_by_name("send email") == []
+            assert _find_block_ids_by_name("AI orchestrator agent mode") == []
+            assert _find_block_ids_by_name("") == []
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_exact_name_query_survives_bad_search_ranking(self):
+        """An exact class-name query returns the block even when hybrid
+        search misses it entirely (stale index row / CamelCase lexical gap)."""
+        session = make_session(user_id=_TEST_USER_ID)
+
+        # Hybrid search returns only unrelated junk — the real failure mode.
+        search_results = [{"content_id": "junk-id", "score": 0.9}]
+
+        orch_block = make_mock_block("orch-id", "OrchestratorBlock", BlockType.STANDARD)
+        junk_block = make_mock_block("junk-id", "JSONEncoderBlock", BlockType.STANDARD)
+        registry = {
+            "orch-id": type("OrchestratorBlock", (), {}),
+            "junk-id": type("JSONEncoderBlock", (), {}),
+        }
+
+        def mock_get_block(block_id):
+            return {"orch-id": orch_block, "junk-id": junk_block}.get(block_id)
+
+        mock_search_db = MagicMock()
+        mock_search_db.unified_hybrid_search = AsyncMock(
+            return_value=(search_results, 1)
+        )
+
+        with patch(
+            "backend.copilot.tools.find_block.search", return_value=mock_search_db
+        ):
+            with patch(
+                "backend.copilot.tools.find_block.get_block",
+                side_effect=mock_get_block,
+            ):
+                with patch(
+                    "backend.copilot.tools.find_block.get_blocks",
+                    return_value=registry,
+                ):
+                    tool = FindBlockTool()
+                    response = await tool._execute(
+                        user_id=_TEST_USER_ID,
+                        session=session,
+                        query="OrchestratorBlock",
+                        for_agent_generation=True,
+                    )
+
+        assert isinstance(response, BlockListResponse)
+        assert response.blocks[0].id == "orch-id"
+        assert [b.id for b in response.blocks] == ["orch-id", "junk-id"]
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_exact_name_match_still_filtered_in_copilot_mode(self):
+        """Exact-name hits go through the same exclusion filter: a graph-only
+        block resolved by name is still hidden without for_agent_generation."""
+        session = make_session(user_id=_TEST_USER_ID)
+
+        orchestrator_id = "3b191d9f-356f-482d-8238-ba04b6d18381"
+        assert orchestrator_id in COPILOT_EXCLUDED_BLOCK_IDS
+        orch_block = make_mock_block(
+            orchestrator_id, "OrchestratorBlock", BlockType.STANDARD
+        )
+        registry = {orchestrator_id: type("OrchestratorBlock", (), {})}
+
+        mock_search_db = MagicMock()
+        mock_search_db.unified_hybrid_search = AsyncMock(return_value=([], 0))
+
+        with patch(
+            "backend.copilot.tools.find_block.search", return_value=mock_search_db
+        ):
+            with patch(
+                "backend.copilot.tools.find_block.get_block",
+                return_value=orch_block,
+            ):
+                with patch(
+                    "backend.copilot.tools.find_block.get_blocks",
+                    return_value=registry,
+                ):
+                    tool = FindBlockTool()
+                    response = await tool._execute(
+                        user_id=_TEST_USER_ID,
+                        session=session,
+                        query="OrchestratorBlock",
+                        for_agent_generation=False,
+                    )
+
+        assert isinstance(response, NoResultsResponse)


### PR DESCRIPTION
### Why / What / How

**Why**: `find_block("OrchestratorBlock", for_agent_generation=true)` returned 10 unrelated blocks and not the OrchestratorBlock, derailing a copilot agent build (observed in a real session). Two independent causes: (1) OrchestratorBlock was renamed from SmartDecisionMakerBlock in #12511, but the embedding indexer only embeds blocks with **no existing row** — so its `UnifiedContentEmbedding` row still contained the old "Smart Decision Maker Block" text (verified: searching "smart decision maker" returned it at rank 1). 13/418 block rows have drifted text. (2) Even with a fresh index, CamelCase queries get zero lexical signal: `plainto_tsquery('OrchestratorBlock')` produces the single lexeme `orchestratorblock` while the index stores the split form (`orchestr`, `block`), so exact class-name queries ride on pure embedding similarity.

**What**:
1. `BlockHandler.get_missing_items` now also returns blocks whose stored `searchableText` differs from the text built from the current block definition, and the backfill passes `force=True` so those rows are actually regenerated (previously `ensure_content_embedding` short-circuited on existing rows).
2. `find_block` resolves queries that name a block class — case/spacing-insensitive, optional "Block" suffix — directly against the live registry and prepends those hits to the hybrid-search results. Exact-name hits pass through the same exclusion/permission filters as regular results.

**How**: staleness check compares against a `SELECT "contentId", "searchableText"` of existing BLOCK rows (the item-building logic is extracted to `_build_block_content_item`); the registry lookup normalizes `block_cls.__name__` (no instantiation) and merges by prepending + dedup before the existing filter loop, capped at 3 matches.

### Changes 🏗️

- `backend/api/features/search/content_handlers.py`: staleness-aware `get_missing_items`; item building extracted to `_build_block_content_item`.
- `backend/api/features/search/embeddings.py`: backfill calls `ensure_content_embedding(..., force=True)` — handlers' `get_missing_items` is the source of truth for what needs (re-)embedding.
- `backend/copilot/tools/find_block.py`: `_find_block_ids_by_name` registry lookup prepended to hybrid-search results.
- Tests: staleness case in `content_handlers_test.py`; exact-name lookup unit + tool-level tests in `find_block_test.py` (incl. exclusion-filter still applies to exact-name hits).

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `backend/api/features/search/content_handlers_test.py` — incl. new stale-text re-embedding test (pass)
  - [x] `backend/api/features/search/embeddings_test.py` — pass
  - [x] `backend/copilot/tools/find_block_test.py` — incl. 4 new exact-name lookup tests (pass; 56 total across the three files)
  - [x] Verified the stale row in a local dev DB (`searchableText` = "Smart Decision Maker Block …" for the orchestrator's content id) and that deleting it lets the backfill re-embed
