### PR TITLE
feat(backend/copilot): bump default models to Claude Sonnet 5 / Opus 4.8

### DIFF
--- a/autogpt_platform/backend/backend/copilot/anthropic_rates.json
+++ b/autogpt_platform/backend/backend/copilot/anthropic_rates.json
@@ -442,6 +442,40 @@
       "supports_xhigh_reasoning_effort": true,
       "tool_use_system_prompt_tokens": 346
     },
+    "claude-opus-4-8": {
+      "cache_creation_input_token_cost": 6.25e-06,
+      "cache_creation_input_token_cost_above_1hr": 1e-05,
+      "cache_read_input_token_cost": 5e-07,
+      "input_cost_per_token": 5e-06,
+      "litellm_provider": "anthropic",
+      "max_input_tokens": 1000000,
+      "max_output_tokens": 128000,
+      "max_tokens": 128000,
+      "mode": "chat",
+      "output_cost_per_token": 2.5e-05,
+      "provider_specific_entry": {
+        "fast": 6.0,
+        "us": 1.1
+      },
+      "search_context_cost_per_query": {
+        "search_context_size_high": 0.01,
+        "search_context_size_low": 0.01,
+        "search_context_size_medium": 0.01
+      },
+      "supports_assistant_prefill": false,
+      "supports_computer_use": true,
+      "supports_function_calling": true,
+      "supports_max_reasoning_effort": true,
+      "supports_minimal_reasoning_effort": true,
+      "supports_pdf_input": true,
+      "supports_prompt_caching": true,
+      "supports_reasoning": true,
+      "supports_response_schema": true,
+      "supports_tool_choice": true,
+      "supports_vision": true,
+      "supports_xhigh_reasoning_effort": true,
+      "tool_use_system_prompt_tokens": 346
+    },
     "claude-sonnet-4-20250514": {
       "cache_creation_input_token_cost": 3.75e-06,
       "cache_creation_input_token_cost_above_1hr": 6e-06,
@@ -587,6 +621,35 @@
       "supports_tool_choice": true,
       "supports_vision": true,
       "tool_use_system_prompt_tokens": 346
+    },
+    "claude-sonnet-5": {
+      "cache_creation_input_token_cost": 3.75e-06,
+      "cache_read_input_token_cost": 3e-07,
+      "input_cost_per_token": 3e-06,
+      "litellm_provider": "anthropic",
+      "max_input_tokens": 1000000,
+      "max_output_tokens": 128000,
+      "max_tokens": 128000,
+      "mode": "chat",
+      "output_cost_per_token": 1.5e-05,
+      "search_context_cost_per_query": {
+        "search_context_size_high": 0.01,
+        "search_context_size_low": 0.01,
+        "search_context_size_medium": 0.01
+      },
+      "supports_assistant_prefill": false,
+      "supports_computer_use": true,
+      "supports_function_calling": true,
+      "supports_max_reasoning_effort": true,
+      "supports_minimal_reasoning_effort": true,
+      "supports_pdf_input": true,
+      "supports_prompt_caching": true,
+      "supports_reasoning": true,
+      "supports_response_schema": true,
+      "supports_tool_choice": true,
+      "supports_vision": true,
+      "tool_use_system_prompt_tokens": 346,
+      "supports_xhigh_reasoning_effort": true
     }
   }
 }

--- a/autogpt_platform/backend/backend/copilot/config.py
+++ b/autogpt_platform/backend/backend/copilot/config.py
@@ -53,7 +53,7 @@ _DEFAULT_SIMULATION_MODEL = "google/gemini-2.5-flash-lite"
 # at the cloud default" so it can rewrite to ``fast_standard_model`` under
 # local transport (otherwise an "advanced" tier request 404s against
 # Ollama's OpenAI shim — no ``anthropic/`` slugs there).
-_DEFAULT_FAST_ADVANCED_MODEL = "anthropic/claude-opus-4.7"
+_DEFAULT_FAST_ADVANCED_MODEL = "anthropic/claude-opus-4-8"
 
 TransportName = Literal["subscription", "openrouter", "direct_anthropic", "local"]
 
@@ -202,7 +202,7 @@ class ChatConfig(BaseSettings):
     # ``CHAT_FAST_MODEL``) are preserved via ``validation_alias`` so
     # existing deployments continue to override the same effective cell.
     fast_standard_model: str = Field(
-        default="anthropic/claude-sonnet-4-6",
+        default="anthropic/claude-sonnet-5",
         validation_alias=AliasChoices(
             "CHAT_FAST_STANDARD_MODEL",
             "CHAT_FAST_MODEL",
@@ -220,7 +220,7 @@ class ChatConfig(BaseSettings):
         "the cloud default — see ``_apply_local_aux_models``.",
     )
     thinking_standard_model: str = Field(
-        default="anthropic/claude-sonnet-4-6",
+        default="anthropic/claude-sonnet-5",
         validation_alias=AliasChoices(
             "CHAT_THINKING_STANDARD_MODEL",
             "CHAT_MODEL",
@@ -229,7 +229,7 @@ class ChatConfig(BaseSettings):
         "tier.  LD override: ``copilot-model-routing[thinking][standard]``.",
     )
     thinking_advanced_model: str = Field(
-        default="anthropic/claude-opus-4.7",
+        default="anthropic/claude-opus-4-8",
         validation_alias=AliasChoices(
             "CHAT_THINKING_ADVANCED_MODEL",
             "CHAT_ADVANCED_MODEL",
@@ -1050,7 +1050,7 @@ class ChatConfig(BaseSettings):
         when the transport asks for it.
 
         The cloud defaults are ``openai/gpt-4o-mini`` / ``google/gemini-...``
-        / ``anthropic/claude-opus-4.7`` — fine on OpenRouter, instant 404
+        / ``anthropic/claude-opus-4-8`` — fine on OpenRouter, instant 404
         on a local backend (no provider slugs there). Operators on the
         local transport otherwise have to repeat the same Ollama slug
         across half a dozen ``CHAT_*_MODEL`` envs. Only fires when the
@@ -1059,7 +1059,7 @@ class ChatConfig(BaseSettings):
         Covers ``title_model`` + ``simulation_model`` (aux call sites)
         AND ``fast_advanced_model`` (the "advanced" baseline tier);
         without the advanced derivation, a user clicking the advanced
-        toggle in the UI sends ``anthropic/claude-opus-4.7`` to Ollama
+        toggle in the UI sends ``anthropic/claude-opus-4-8`` to Ollama
         and gets a model-not-found 404. The boot-time vendor validator
         is skipped under local transport so this misconfig wouldn't
         surface until the first advanced-tier turn.

--- a/autogpt_platform/backend/backend/copilot/config_test.py
+++ b/autogpt_platform/backend/backend/copilot/config_test.py
@@ -245,7 +245,7 @@ class TestSdkModelVendorCompatibility:
             # aux check.
             aux_api_key="or-aux-key",
         )
-        assert cfg.thinking_standard_model == "anthropic/claude-sonnet-4-6"
+        assert cfg.thinking_standard_model == "anthropic/claude-sonnet-5"
 
     def test_openrouter_with_kimi_override_succeeds(self):
         """Kimi slug round-trips cleanly when OpenRouter is on — exercised
@@ -592,7 +592,7 @@ class TestLocalAuxModels:
     def test_cloud_transport_does_not_inherit(self):
         """Cloud transports leave the per-field cloud defaults alone — an
         operator might genuinely want gpt-4o-mini for titles even though
-        their primary model is anthropic/claude-sonnet-4-6."""
+        their primary model is anthropic/claude-sonnet-5."""
         cfg = ChatConfig(
             use_openrouter=True,
             api_key="or-key",
@@ -600,7 +600,7 @@ class TestLocalAuxModels:
         )
         assert cfg.title_model == "anthropic/claude-haiku-4-5"
         assert cfg.simulation_model == "google/gemini-2.5-flash-lite"
-        assert cfg.fast_advanced_model == "anthropic/claude-opus-4.7"
+        assert cfg.fast_advanced_model == "anthropic/claude-opus-4-8"
 
 
 class TestLocalRequirementsValidator:

--- a/autogpt_platform/frontend/src/app/api/openapi.json
+++ b/autogpt_platform/frontend/src/app/api/openapi.json
@@ -17905,10 +17905,6 @@
             "title": "Is Active",
             "default": true
           },
-          "webhook_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
-            "title": "Webhook Id"
-          },
           "id": { "type": "string", "title": "Id" },
           "user_id": { "type": "string", "title": "User Id" },
           "created_at": {
@@ -17928,6 +17924,10 @@
           "team_id": {
             "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Team Id"
+          },
+          "webhook_id": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Webhook Id"
           },
           "webhook": {
             "anyOf": [
@@ -17975,10 +17975,6 @@
             "type": "boolean",
             "title": "Is Active",
             "default": true
-          },
-          "webhook_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
-            "title": "Webhook Id"
           }
         },
         "type": "object",
@@ -17991,7 +17987,7 @@
           "description"
         ],
         "title": "LibraryAgentPresetCreatable",
-        "description": "Request model used when creating a new preset for a library agent."
+        "description": "Request model used when creating a new preset for a library agent.\n\nA preset's webhook is never caller-specified here; webhook-triggered presets\nare created through ``POST /presets/setup-trigger``, which provisions a\nwebhook owned by the caller server-side."
       },
       "LibraryAgentPresetCreatableFromGraphExecution": {
         "properties": {


### PR DESCRIPTION
### Why / What / How

**Why**: AutoPilot's default model routing pins previous-generation models (`claude-sonnet-4-6` standard, `claude-opus-4.7` advanced) while Claude Sonnet 5 and Opus 4.8 are available — Sonnet 5 reaches near-Opus quality on coding/agentic work at Sonnet cost, which is exactly AutoPilot's workload profile. Additionally, the vendored Anthropic rate card had no entries for the new models, so any use of them (e.g. via LaunchDarkly routing) would over-bill at the opus-4-1 fallback rate ($15/$75) and cap output at the conservative 32K fallback.

**What**:
- Config defaults: `thinking_standard_model` + `fast_standard_model` → `anthropic/claude-sonnet-5`; `thinking_advanced_model` + `fast_advanced_model` → `anthropic/claude-opus-4-8`. `title_model` stays `anthropic/claude-haiku-4-5` (already latest). LaunchDarkly `copilot-model-routing` per-user overrides continue to take precedence.
- Rate card: add `claude-opus-4-8` ($5/$25, 1M in / 128K out, xhigh effort) and `claude-sonnet-5` ($3/$15 sticker — not the intro rate, per the card's over-bill-rather-than-under-bill policy; 1M in / 128K out, no assistant prefill, xhigh effort).

**How**: plain default swaps (dash-form slugs; `normalize_model_for_transport` already handles direct-transport conversion, OpenRouter passes them through). Rate entries mirror the 4.7/4.6 shapes with the fields that changed for the new generation. Updated the two tests asserting the old defaults.

### Changes 🏗️

- `backend/copilot/config.py`: four model-default bumps + docstring examples updated.
- `backend/copilot/anthropic_rates.json`: `claude-opus-4-8` and `claude-sonnet-5` entries.
- `backend/copilot/config_test.py`: default assertions updated.
- `frontend/src/app/api/openapi.json`: regenerated by pre-commit hook.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `config_test.py`, `model_router_test.py`, `model_normalize_test.py`, `transport_routing_test.py`, `anthropic_rate_card_test.py`, `moonshot_test.py` — 178 passed
  - [ ] Live smoke test of a copilot turn on the new defaults (needs a running stack; suggest before merge)

Note: the copilot CLI still runs with a 200K perceived window (`CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1` disables the 1M-context beta for OpenRouter compatibility) — the new models' 1M windows don't take effect through this change; that's a separate follow-up.
