### PR TITLE
fix(backend): binary bot file content crashes the JSON service RPC

### DIFF
--- a/autogpt_platform/backend/backend/platform_linking/models.py
+++ b/autogpt_platform/backend/backend/platform_linking/models.py
@@ -1,10 +1,21 @@
 """Pydantic models for platform_linking requests and responses."""
 
+import base64
 from datetime import datetime
 from enum import Enum
-from typing import Literal
+from typing import Annotated, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, BeforeValidator, Field, PlainSerializer
+
+# File content that survives the JSON service RPC. Raw bytes stay bytes
+# in-process, but the wire format is base64 — plain ``bytes`` fields are
+# UTF-8-decoded by JSON serialization, which crashes on binary content
+# (0xff in a JPEG took down the fetch_workspace_artifact endpoint).
+Base64EncodedBytes = Annotated[
+    bytes,
+    BeforeValidator(lambda v: base64.b64decode(v) if isinstance(v, str) else v),
+    PlainSerializer(lambda v: base64.b64encode(v).decode("ascii"), when_used="json"),
+]
 
 # Hard cap on the assembled bot prompt. The chat bots build a prompt from the
 # user's message plus channel history / referenced conversations, which on a
@@ -139,7 +150,7 @@ class WorkspaceUploadRequest(BaseModel):
     platform_user_id: str = Field(min_length=1, max_length=255)
     filename: str = Field(min_length=1, max_length=512)
     mime_type: str = Field(min_length=1, max_length=255)
-    content: bytes
+    content: Base64EncodedBytes
     # Write into this session's folder (/sessions/<id>/) so AutoPilot reads the
     # file during the turn, same as a web upload. Resolved by the caller before
     # uploading (see ``ensure_chat_session``).
@@ -297,7 +308,7 @@ class WorkspaceArtifact(BaseModel):
     filename: str
     mime_type: str
     size_bytes: int
-    content: bytes
+    content: Base64EncodedBytes
 
 
 class BotEventInput(BaseModel):

--- a/autogpt_platform/backend/backend/platform_linking/models.py
+++ b/autogpt_platform/backend/backend/platform_linking/models.py
@@ -9,8 +9,9 @@ from pydantic import BaseModel, BeforeValidator, Field, PlainSerializer
 
 # File content that survives the JSON service RPC. Raw bytes stay bytes
 # in-process, but the wire format is base64 — plain ``bytes`` fields are
-# UTF-8-decoded by JSON serialization, which crashes on binary content
-# (0xff in a JPEG took down the fetch_workspace_artifact endpoint).
+# strict-UTF-8-decoded by JSON serialization, which fails on binary content.
+# Matches how the platform encodes file bytes in JSON elsewhere (the
+# ``data:<mime>;base64,`` URIs from ``store_media_file``).
 Base64EncodedBytes = Annotated[
     bytes,
     BeforeValidator(lambda v: base64.b64decode(v) if isinstance(v, str) else v),

--- a/autogpt_platform/backend/backend/platform_linking/models_test.py
+++ b/autogpt_platform/backend/backend/platform_linking/models_test.py
@@ -3,6 +3,8 @@
 import pytest
 from pydantic import ValidationError
 
+from backend.util.json import to_dict
+
 from .models import (
     BotChatRequest,
     ConfirmLinkResponse,
@@ -12,6 +14,8 @@ from .models import (
     Platform,
     ResolveResponse,
     ResolveServerRequest,
+    WorkspaceArtifact,
+    WorkspaceUploadRequest,
 )
 
 
@@ -176,3 +180,53 @@ class TestResponseModels:
     def test_delete_link_response(self):
         resp = DeleteLinkResponse(success=True)
         assert resp.success is True
+
+
+class TestBinaryContentOverJsonRpc:
+    """Binary file bytes must survive the JSON service RPC.
+
+    Regression for the 2026-07-16 prod incident: plain ``bytes`` fields are
+    UTF-8-decoded by JSON serialization, so a binary artifact (JPEG starting
+    0xff) made ``fetch_workspace_artifact`` 500 permanently — which the
+    100-attempt client retry policy then turned into a retry storm.
+    """
+
+    # First bytes of a JPEG — not valid UTF-8, the exact prod payload shape.
+    _BINARY = b"\xff\xd8\xff\xe0" + bytes(range(256))
+
+    def _artifact(self) -> WorkspaceArtifact:
+        return WorkspaceArtifact(
+            file_id="f1",
+            filename="photo.jpg",
+            mime_type="image/jpeg",
+            size_bytes=len(self._BINARY),
+            content=self._BINARY,
+        )
+
+    def test_artifact_binary_content_survives_the_wire(self):
+        # Server response leg: FastAPI serializes via jsonable_encoder …
+        wire = to_dict(self._artifact())
+        assert isinstance(wire["content"], str)  # base64, JSON-safe
+        # … client leg: TypeAdapter validates the JSON back into the model.
+        restored = WorkspaceArtifact.model_validate(wire)
+        assert restored.content == self._BINARY
+
+    def test_upload_request_binary_content_survives_the_wire(self):
+        request = WorkspaceUploadRequest(
+            platform=Platform.TELEGRAM,
+            platform_user_id="u1",
+            filename="photo.jpg",
+            mime_type="image/jpeg",
+            content=self._BINARY,
+        )
+        wire = to_dict(request)
+        assert isinstance(wire["content"], str)
+        restored = WorkspaceUploadRequest.model_validate(wire)
+        assert restored.content == self._BINARY
+
+    def test_raw_bytes_stay_bytes_in_process(self):
+        # In-process consumers (adapters attach .content directly) must keep
+        # seeing raw bytes — only the JSON wire format is base64.
+        artifact = self._artifact()
+        assert artifact.content == self._BINARY
+        assert artifact.model_dump()["content"] == self._BINARY

--- a/autogpt_platform/backend/backend/platform_linking/models_test.py
+++ b/autogpt_platform/backend/backend/platform_linking/models_test.py
@@ -185,13 +185,12 @@ class TestResponseModels:
 class TestBinaryContentOverJsonRpc:
     """Binary file bytes must survive the JSON service RPC.
 
-    Regression for the 2026-07-16 prod incident: plain ``bytes`` fields are
-    UTF-8-decoded by JSON serialization, so a binary artifact (JPEG starting
-    0xff) made ``fetch_workspace_artifact`` 500 permanently — which the
-    100-attempt client retry policy then turned into a retry storm.
+    Plain ``bytes`` fields are strict-UTF-8-decoded by JSON serialization,
+    so a binary artifact (e.g. a JPEG starting 0xff) fails to serialize on
+    the ``fetch_workspace_artifact`` / ``upload_workspace_files`` hops.
     """
 
-    # First bytes of a JPEG — not valid UTF-8, the exact prod payload shape.
+    # First bytes of a JPEG — not valid UTF-8.
     _BINARY = b"\xff\xd8\xff\xe0" + bytes(range(256))
 
     def _artifact(self) -> WorkspaceArtifact:


### PR DESCRIPTION
### Why / What / How

**Why:** The bot workspace file models (`WorkspaceArtifact`, `WorkspaceUploadRequest`) carry file content as plain `bytes`, but every hop of the internal service RPC is JSON — requests via `jsonable_encoder`, responses via FastAPI `serialize_response`, client parsing via `TypeAdapter`. Pydantic's JSON mode strict-UTF-8-decodes `bytes`, so **binary file content (images, PDFs, etc.) fails to serialize on these hops** in both directions; only UTF-8 text files happen to work. This blocks bots from attaching binary `workspace://` artifacts and from ingesting binary user uploads whenever the call crosses the RPC boundary.

**What:** Binary file content now survives the RPC in both directions. In-process consumers are unaffected — `content` is still raw `bytes` everywhere in code.

**How:** A `Base64EncodedBytes` annotated type on the two wire models:
- `PlainSerializer(when_used="json")` → base64 string on the wire (covers `jsonable_encoder` requests and FastAPI responses),
- `BeforeValidator` → decodes base64 strings back to raw bytes at validation (covers FastAPI request parsing and the client's `TypeAdapter`), while raw-`bytes` construction passes through untouched.

This matches how the platform already moves file bytes everywhere else:
- **File bytes embedded in JSON** → base64, exactly like the `data:<mime>;base64,…` URIs `store_media_file()` produces for blocks/external APIs (`backend/util/file.py`).
- **Direct HTTP uploads** → multipart `UploadFile` (store media endpoints) — those transports are unaffected; this PR only brings the internal JSON RPC in line with the JSON-embedding convention.

Base64 is total over bytes (every possible content round-trips losslessly), so no file type can hit this failure mode again on these fields. An audit of the RPC-exposed surfaces (`platform_linking`, DatabaseManager-exposed workspace functions) confirmed these two fields were the only raw-bytes carriers — `WorkspaceFile` etc. are metadata-only models, with content moving in-process via GCS.

### Changes 🏗️

- `platform_linking/models.py`: `Base64EncodedBytes` annotated type; applied to `WorkspaceArtifact.content` and `WorkspaceUploadRequest.content`
- `platform_linking/models_test.py`: 3 regression tests — wire round-trip in both directions with binary content (fail with `UnicodeDecodeError` on the pre-fix models), plus a pin that in-process `bytes` semantics are unchanged

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] New wire-round-trip tests reproduce the failure on the pre-fix models and pass with the fix (verified both ways)
  - [x] Full `platform_linking` + `copilot/bot` suites pass (541 tests)
  - [ ] Live dev verification after merge: send an image to a bot, and have a bot deliver a binary `workspace://` artifact

#### For configuration changes:
- [x] `.env.default` / `docker-compose.yml` — no changes needed