### PR TITLE
fix(backend/copilot): Stop losing tool calls from session history on mid-turn flush

### DIFF
--- a/autogpt_platform/backend/backend/copilot/db.py
+++ b/autogpt_platform/backend/backend/copilot/db.py
@@ -787,6 +787,46 @@ async def update_message_content_by_sequence(
         return False
 
 
+async def update_chat_message_tool_calls(
+    session_id: str,
+    sequence: int,
+    tool_calls: list[dict],
+) -> bool:
+    """Back-fill ``toolCalls`` on an already-persisted message row.
+
+    The streaming flush can persist an assistant row (assigning its sequence)
+    before the turn's tool_use blocks arrive; this updates the row so the tool
+    activity survives in session history. Same authorization reasoning as
+    ``update_message_content_by_sequence``.
+
+    Returns:
+        True if a message was updated, False otherwise.
+    """
+    try:
+        result = await PrismaChatMessage.prisma().update_many(
+            where={"sessionId": session_id, "sequence": sequence},
+            data={"toolCalls": SafeJson(tool_calls)},
+        )
+        if result == 0:
+            logger.warning(
+                f"No message found to update tool_calls for session "
+                f"{session_id}, sequence {sequence}"
+            )
+            return False
+        if result > 1:
+            logger.error(
+                f"update_chat_message_tool_calls touched {result} rows "
+                f"for session {session_id}, sequence {sequence} — expected 1"
+            )
+        return True
+    except Exception as e:
+        logger.error(
+            f"Failed to update tool_calls for session {session_id}, "
+            f"sequence {sequence}: {e}"
+        )
+        return False
+
+
 async def set_turn_duration(session_id: str, duration_ms: int) -> None:
     """Set durationMs on the last assistant message in a session.
 

--- a/autogpt_platform/backend/backend/copilot/db.py
+++ b/autogpt_platform/backend/backend/copilot/db.py
@@ -800,7 +800,11 @@ async def update_chat_message_tool_calls(
     ``update_message_content_by_sequence``.
 
     Returns:
-        True if a message was updated, False otherwise.
+        True if a message was updated, False if no row matched.
+
+    Raises:
+        Propagates Prisma/connection errors — the caller (the back-fill
+        loop in ``_save_session_to_db``) owns the retry policy.
     """
     result = await PrismaChatMessage.prisma().update(
         where={"sessionId_sequence": {"sessionId": session_id, "sequence": sequence}},

--- a/autogpt_platform/backend/backend/copilot/db.py
+++ b/autogpt_platform/backend/backend/copilot/db.py
@@ -802,33 +802,17 @@ async def update_chat_message_tool_calls(
     Returns:
         True if a message was updated, False otherwise.
     """
-    try:
-        result = await PrismaChatMessage.prisma().update_many(
-            where={"sessionId": session_id, "sequence": sequence},
-            data={"toolCalls": SafeJson(tool_calls)},
-        )
-        if result == 0:
-            logger.warning(
-                f"No message found to update tool_calls for session "
-                f"{session_id}, sequence {sequence}"
-            )
-            return False
-        if result > 1:
-            # Structurally impossible under the @@unique([sessionId, sequence])
-            # constraint — if it ever fires, data is corrupted; fail loudly
-            # instead of clearing the caller's dirty flag.
-            logger.error(
-                f"update_chat_message_tool_calls touched {result} rows "
-                f"for session {session_id}, sequence {sequence} — expected 1"
-            )
-            return False
-        return True
-    except Exception as e:
-        logger.error(
-            f"Failed to update tool_calls for session {session_id}, "
-            f"sequence {sequence}: {e}"
+    result = await PrismaChatMessage.prisma().update(
+        where={"sessionId_sequence": {"sessionId": session_id, "sequence": sequence}},
+        data={"toolCalls": SafeJson(tool_calls)},
+    )
+    if not result:
+        logger.warning(
+            f"No message found to update tool_calls for session "
+            f"{session_id}, sequence {sequence}"
         )
         return False
+    return True
 
 
 async def set_turn_duration(session_id: str, duration_ms: int) -> None:

--- a/autogpt_platform/backend/backend/copilot/db.py
+++ b/autogpt_platform/backend/backend/copilot/db.py
@@ -790,7 +790,7 @@ async def update_message_content_by_sequence(
 async def update_chat_message_tool_calls(
     session_id: str,
     sequence: int,
-    tool_calls: list[dict],
+    tool_calls: list[dict[str, Any]],
 ) -> bool:
     """Back-fill ``toolCalls`` on an already-persisted message row.
 
@@ -814,10 +814,14 @@ async def update_chat_message_tool_calls(
             )
             return False
         if result > 1:
+            # Structurally impossible under the @@unique([sessionId, sequence])
+            # constraint — if it ever fires, data is corrupted; fail loudly
+            # instead of clearing the caller's dirty flag.
             logger.error(
                 f"update_chat_message_tool_calls touched {result} rows "
                 f"for session {session_id}, sequence {sequence} — expected 1"
             )
+            return False
         return True
     except Exception as e:
         logger.error(

--- a/autogpt_platform/backend/backend/copilot/db_test.py
+++ b/autogpt_platform/backend/backend/copilot/db_test.py
@@ -889,7 +889,7 @@ async def test_update_chat_message_tool_calls_success():
 
 @pytest.mark.asyncio
 async def test_update_chat_message_tool_calls_not_found():
-    """Returns False (so the caller's dirty flag stays set) when no row matches."""
+    """Returns False (so the caller's pending-save flag stays set) when no row matches."""
     with (
         patch.object(PrismaChatMessage, "prisma") as mock_prisma,
         patch("backend.copilot.db.logger") as mock_logger,

--- a/autogpt_platform/backend/backend/copilot/db_test.py
+++ b/autogpt_platform/backend/backend/copilot/db_test.py
@@ -16,6 +16,7 @@ from backend.copilot.db import (
     get_chat_messages_paginated,
     get_user_chat_sessions,
     set_turn_duration,
+    update_chat_message_tool_calls,
     update_chat_session_pinned,
     update_message_content_by_sequence,
 )
@@ -858,3 +859,75 @@ async def test_add_chat_message_omits_metadata_when_none() -> None:
         )
     data = create.call_args.kwargs["data"]
     assert "metadata" not in data
+
+
+# ---------- update_chat_message_tool_calls ----------
+
+_TOOL_CALLS = [
+    {
+        "id": "c1",
+        "type": "function",
+        "function": {"name": "web_search", "arguments": "{}"},
+    }
+]
+
+
+@pytest.mark.asyncio
+async def test_update_chat_message_tool_calls_success():
+    """Returns True when update_many reports exactly one row updated."""
+    with patch.object(PrismaChatMessage, "prisma") as mock_prisma:
+        mock_prisma.return_value.update_many = AsyncMock(return_value=1)
+
+        result = await update_chat_message_tool_calls("sess-1", 7, _TOOL_CALLS)
+
+    assert result is True
+    where = mock_prisma.return_value.update_many.call_args.kwargs["where"]
+    assert where == {"sessionId": "sess-1", "sequence": 7}
+
+
+@pytest.mark.asyncio
+async def test_update_chat_message_tool_calls_not_found():
+    """Returns False (so the caller's dirty flag stays set) when no rows match."""
+    with (
+        patch.object(PrismaChatMessage, "prisma") as mock_prisma,
+        patch("backend.copilot.db.logger") as mock_logger,
+    ):
+        mock_prisma.return_value.update_many = AsyncMock(return_value=0)
+
+        result = await update_chat_message_tool_calls("sess-1", 99, _TOOL_CALLS)
+
+    assert result is False
+    mock_logger.warning.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_update_chat_message_tool_calls_multi_row_fails():
+    """>1 rows means the @@unique([sessionId, sequence]) invariant broke —
+    fail loudly instead of clearing the dirty flag."""
+    with (
+        patch.object(PrismaChatMessage, "prisma") as mock_prisma,
+        patch("backend.copilot.db.logger") as mock_logger,
+    ):
+        mock_prisma.return_value.update_many = AsyncMock(return_value=2)
+
+        result = await update_chat_message_tool_calls("sess-1", 7, _TOOL_CALLS)
+
+    assert result is False
+    mock_logger.error.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_update_chat_message_tool_calls_db_error():
+    """Returns False and logs when the DB raises."""
+    with (
+        patch.object(PrismaChatMessage, "prisma") as mock_prisma,
+        patch("backend.copilot.db.logger") as mock_logger,
+    ):
+        mock_prisma.return_value.update_many = AsyncMock(
+            side_effect=RuntimeError("boom")
+        )
+
+        result = await update_chat_message_tool_calls("sess-1", 7, _TOOL_CALLS)
+
+    assert result is False
+    mock_logger.error.assert_called_once()

--- a/autogpt_platform/backend/backend/copilot/db_test.py
+++ b/autogpt_platform/backend/backend/copilot/db_test.py
@@ -883,7 +883,8 @@ async def test_update_chat_message_tool_calls_success():
     assert result is True
     where = mock_prisma.return_value.update.call_args.kwargs["where"]
     assert where == {"sessionId_sequence": {"sessionId": "sess-1", "sequence": 7}}
-    assert "toolCalls" in mock_prisma.return_value.update.call_args.kwargs["data"]
+    payload = mock_prisma.return_value.update.call_args.kwargs["data"]["toolCalls"]
+    assert payload.data == _TOOL_CALLS
 
 
 @pytest.mark.asyncio

--- a/autogpt_platform/backend/backend/copilot/db_test.py
+++ b/autogpt_platform/backend/backend/copilot/db_test.py
@@ -874,60 +874,28 @@ _TOOL_CALLS = [
 
 @pytest.mark.asyncio
 async def test_update_chat_message_tool_calls_success():
-    """Returns True when update_many reports exactly one row updated."""
+    """Returns True when the unique-keyed update finds the row."""
     with patch.object(PrismaChatMessage, "prisma") as mock_prisma:
-        mock_prisma.return_value.update_many = AsyncMock(return_value=1)
+        mock_prisma.return_value.update = AsyncMock(return_value=object())
 
         result = await update_chat_message_tool_calls("sess-1", 7, _TOOL_CALLS)
 
     assert result is True
-    where = mock_prisma.return_value.update_many.call_args.kwargs["where"]
-    assert where == {"sessionId": "sess-1", "sequence": 7}
+    where = mock_prisma.return_value.update.call_args.kwargs["where"]
+    assert where == {"sessionId_sequence": {"sessionId": "sess-1", "sequence": 7}}
+    assert "toolCalls" in mock_prisma.return_value.update.call_args.kwargs["data"]
 
 
 @pytest.mark.asyncio
 async def test_update_chat_message_tool_calls_not_found():
-    """Returns False (so the caller's dirty flag stays set) when no rows match."""
+    """Returns False (so the caller's dirty flag stays set) when no row matches."""
     with (
         patch.object(PrismaChatMessage, "prisma") as mock_prisma,
         patch("backend.copilot.db.logger") as mock_logger,
     ):
-        mock_prisma.return_value.update_many = AsyncMock(return_value=0)
+        mock_prisma.return_value.update = AsyncMock(return_value=None)
 
         result = await update_chat_message_tool_calls("sess-1", 99, _TOOL_CALLS)
 
     assert result is False
     mock_logger.warning.assert_called_once()
-
-
-@pytest.mark.asyncio
-async def test_update_chat_message_tool_calls_multi_row_fails():
-    """>1 rows means the @@unique([sessionId, sequence]) invariant broke —
-    fail loudly instead of clearing the dirty flag."""
-    with (
-        patch.object(PrismaChatMessage, "prisma") as mock_prisma,
-        patch("backend.copilot.db.logger") as mock_logger,
-    ):
-        mock_prisma.return_value.update_many = AsyncMock(return_value=2)
-
-        result = await update_chat_message_tool_calls("sess-1", 7, _TOOL_CALLS)
-
-    assert result is False
-    mock_logger.error.assert_called_once()
-
-
-@pytest.mark.asyncio
-async def test_update_chat_message_tool_calls_db_error():
-    """Returns False and logs when the DB raises."""
-    with (
-        patch.object(PrismaChatMessage, "prisma") as mock_prisma,
-        patch("backend.copilot.db.logger") as mock_logger,
-    ):
-        mock_prisma.return_value.update_many = AsyncMock(
-            side_effect=RuntimeError("boom")
-        )
-
-        result = await update_chat_message_tool_calls("sess-1", 7, _TOOL_CALLS)
-
-    assert result is False
-    mock_logger.error.assert_called_once()

--- a/autogpt_platform/backend/backend/copilot/model.py
+++ b/autogpt_platform/backend/backend/copilot/model.py
@@ -115,6 +115,16 @@ class ChatMessage(BaseModel):
     becomes invisible in session history. ``_save_session_to_db`` back-fills
     rows flagged here and clears the flag."""
 
+    def mark_tool_calls_dirty(self) -> None:
+        """Flag this row for a toolCalls back-fill if it was already
+        persisted (has a sequence). The single invariant behind the
+        mid-turn-flush fix: any site that mutates ``tool_calls`` on a
+        possibly-sequenced message must call this — encapsulated here so a
+        future third mutation site can't silently reintroduce the
+        dropped-tool-calls bug."""
+        if self.sequence is not None:
+            self.tool_calls_pending_save = True
+
     # Owning session id and generic per-row JSONB bag.  Today the
     # dispatcher uses ``metadata`` to preserve the submit-time payload
     # (file_ids / mode / model / permissions / context / arrival_at)
@@ -419,10 +429,7 @@ class ChatSession(ChatSessionInfo):
                 if not msg.tool_calls:
                     msg.tool_calls = []
                 msg.tool_calls.append(tool_call)
-                if msg.sequence is not None:
-                    # Row already persisted without this call — flag it so
-                    # the next save back-fills toolCalls onto the row.
-                    msg.tool_calls_pending_save = True
+                msg.mark_tool_calls_dirty()
                 return
 
         self.messages.append(

--- a/autogpt_platform/backend/backend/copilot/model.py
+++ b/autogpt_platform/backend/backend/copilot/model.py
@@ -922,10 +922,8 @@ async def _save_session_to_db(
             msg.tool_calls_pending_save = False
         else:
             logger.warning(
-                "Failed to back-fill tool_calls for session %s seq %s "
-                "(row not found)",
-                session.session_id,
-                msg.sequence,
+                f"Failed to back-fill tool_calls for session "
+                f"{session.session_id} seq {msg.sequence} (row not found)"
             )
 
 

--- a/autogpt_platform/backend/backend/copilot/model.py
+++ b/autogpt_platform/backend/backend/copilot/model.py
@@ -924,11 +924,19 @@ async def _save_session_to_db(
 
     async def _backfill(msg: ChatMessage) -> None:
         assert msg.sequence is not None  # narrowed by the filter above
-        updated = await db.update_chat_message_tool_calls(
-            session_id=session.session_id,
-            sequence=msg.sequence,
-            tool_calls=msg.tool_calls or [],
-        )
+        try:
+            updated = await db.update_chat_message_tool_calls(
+                session_id=session.session_id,
+                sequence=msg.sequence,
+                tool_calls=msg.tool_calls or [],
+            )
+        except Exception as e:
+            logger.error(
+                f"Failed to back-fill tool_calls for session "
+                f"{session.session_id} seq {msg.sequence}: {e}"
+            )
+            return
+
         if updated:
             msg.tool_calls_pending_save = False
         else:

--- a/autogpt_platform/backend/backend/copilot/model.py
+++ b/autogpt_platform/backend/backend/copilot/model.py
@@ -122,7 +122,7 @@ class ChatMessage(BaseModel):
     window: a back-fill failure on the turn's final save is retried on any
     later save of the session, but not across a worker restart."""
 
-    def mark_tool_calls_dirty(self) -> None:
+    def mark_tool_calls_pending_save(self) -> None:
         """Flag this row for a toolCalls back-fill if it was already
         persisted (has a sequence). The single invariant behind the
         mid-turn-flush fix: any site that mutates ``tool_calls`` on a
@@ -436,7 +436,7 @@ class ChatSession(ChatSessionInfo):
                 if not msg.tool_calls:
                     msg.tool_calls = []
                 msg.tool_calls.append(tool_call)
-                msg.mark_tool_calls_dirty()
+                msg.mark_tool_calls_pending_save()
                 return
 
         self.messages.append(
@@ -930,7 +930,7 @@ async def _save_session_to_db(
     # save (every turn ends with save_chat_session, including the error paths
     # that append an error marker) — mid-turn flushes merely narrow the
     # window. On failure the flag stays set so any later save retries.
-    dirty = [
+    pending = [
         m
         for m in session.messages
         if m.tool_calls_pending_save and m.sequence is not None
@@ -959,8 +959,8 @@ async def _save_session_to_db(
                 f"{session.session_id} seq {msg.sequence} (row not found)"
             )
 
-    if dirty:
-        await asyncio.gather(*(_backfill(m) for m in dirty))
+    if pending:
+        await asyncio.gather(*(_backfill(m) for m in pending))
 
 
 async def append_and_save_message(

--- a/autogpt_platform/backend/backend/copilot/model.py
+++ b/autogpt_platform/backend/backend/copilot/model.py
@@ -113,7 +113,14 @@ class ChatMessage(BaseModel):
     save path only inserts ``sequence is None`` rows, so late-attached
     tool_calls would otherwise never reach the DB and the tool activity
     becomes invisible in session history. ``_save_session_to_db`` back-fills
-    rows flagged here and clears the flag."""
+    rows flagged here and clears the flag.
+
+    In-memory only (``exclude=True``) by necessity, not oversight: the flag
+    marks tool_calls content that exists ONLY in this process — if the
+    worker dies before a back-fill succeeds, the content is gone with it,
+    so a persisted flag would have nothing left to back-fill from. Residual
+    window: a back-fill failure on the turn's final save is retried on any
+    later save of the session, but not across a worker restart."""
 
     def mark_tool_calls_dirty(self) -> None:
         """Flag this row for a toolCalls back-fill if it was already

--- a/autogpt_platform/backend/backend/copilot/model.py
+++ b/autogpt_platform/backend/backend/copilot/model.py
@@ -21,7 +21,7 @@ from openai.types.chat.chat_completion_message_tool_call_param import (
 from prisma.errors import UniqueViolationError
 from prisma.models import ChatMessage as PrismaChatMessage
 from prisma.models import ChatSession as PrismaChatSession
-from pydantic import BaseModel, PrivateAttr
+from pydantic import BaseModel, Field, PrivateAttr
 
 from backend.data.db_accessors import chat_db, library_db
 from backend.data.graph import GraphSettings
@@ -103,6 +103,16 @@ class ChatMessage(BaseModel):
     sequence: int | None = None
     duration_ms: int | None = None
     created_at: datetime | None = None
+
+    tool_calls_pending_save: bool = Field(default=False, exclude=True)
+    """True when ``tool_calls`` mutated after this row was already persisted.
+
+    An assistant row is often flushed to the DB (getting its ``sequence``)
+    while its text streams, BEFORE the turn's tool_use blocks arrive — the
+    save path only inserts ``sequence is None`` rows, so late-attached
+    tool_calls would otherwise never reach the DB and the tool activity
+    becomes invisible in session history. ``_save_session_to_db`` back-fills
+    rows flagged here and clears the flag."""
 
     # Owning session id and generic per-row JSONB bag.  Today the
     # dispatcher uses ``metadata`` to preserve the submit-time payload
@@ -892,6 +902,31 @@ async def _save_session_to_db(
         )
         for i, msg in enumerate(new_messages):
             msg.sequence = actual_start + i
+            msg.tool_calls_pending_save = False
+
+    # Back-fill tool_calls onto rows that were flushed before their
+    # tool_use blocks arrived (see ChatMessage.tool_calls_pending_save).
+    dirty = [
+        m
+        for m in session.messages
+        if m.tool_calls_pending_save and m.sequence is not None
+    ]
+    for msg in dirty:
+        assert msg.sequence is not None
+        updated = await db.update_chat_message_tool_calls(
+            session_id=session.session_id,
+            sequence=msg.sequence,
+            tool_calls=msg.tool_calls or [],
+        )
+        if updated:
+            msg.tool_calls_pending_save = False
+        else:
+            logger.warning(
+                "Failed to back-fill tool_calls for session %s seq %s "
+                "(row not found)",
+                session.session_id,
+                msg.sequence,
+            )
 
 
 async def append_and_save_message(

--- a/autogpt_platform/backend/backend/copilot/model.py
+++ b/autogpt_platform/backend/backend/copilot/model.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import uuid
 from contextlib import asynccontextmanager
@@ -418,6 +419,10 @@ class ChatSession(ChatSessionInfo):
                 if not msg.tool_calls:
                     msg.tool_calls = []
                 msg.tool_calls.append(tool_call)
+                if msg.sequence is not None:
+                    # Row already persisted without this call — flag it so
+                    # the next save back-fills toolCalls onto the row.
+                    msg.tool_calls_pending_save = True
                 return
 
         self.messages.append(
@@ -906,13 +911,19 @@ async def _save_session_to_db(
 
     # Back-fill tool_calls onto rows that were flushed before their
     # tool_use blocks arrived (see ChatMessage.tool_calls_pending_save).
+    # Save-ordering invariant: this only repairs the row if a save runs
+    # AFTER the tool_use blocks arrive. That is guaranteed by the end-of-turn
+    # save (every turn ends with save_chat_session, including the error paths
+    # that append an error marker) — mid-turn flushes merely narrow the
+    # window. On failure the flag stays set so any later save retries.
     dirty = [
         m
         for m in session.messages
         if m.tool_calls_pending_save and m.sequence is not None
     ]
-    for msg in dirty:
-        assert msg.sequence is not None
+
+    async def _backfill(msg: ChatMessage) -> None:
+        assert msg.sequence is not None  # narrowed by the filter above
         updated = await db.update_chat_message_tool_calls(
             session_id=session.session_id,
             sequence=msg.sequence,
@@ -925,6 +936,9 @@ async def _save_session_to_db(
                 f"Failed to back-fill tool_calls for session "
                 f"{session.session_id} seq {msg.sequence} (row not found)"
             )
+
+    if dirty:
+        await asyncio.gather(*(_backfill(m) for m in dirty))
 
 
 async def append_and_save_message(

--- a/autogpt_platform/backend/backend/copilot/model_test.py
+++ b/autogpt_platform/backend/backend/copilot/model_test.py
@@ -1081,6 +1081,48 @@ async def test_save_session_to_db_new_rows_persist_tool_calls_without_backfill(
     assert new_msg.tool_calls_pending_save is False
 
 
+@pytest.mark.asyncio(loop_scope="session")
+async def test_save_session_to_db_backfill_failure_keeps_flag_set(
+    mocker: MockerFixture,
+) -> None:
+    """When the back-fill UPDATE fails, the dirty flag must stay set so a
+    later save retries — this retention-on-failure is the fix's safety net."""
+    calls = [
+        {
+            "id": "c3",
+            "type": "function",
+            "function": {"name": "web_search", "arguments": "{}"},
+        }
+    ]
+    flushed = ChatMessage(
+        role="assistant",
+        content="Searching...",
+        sequence=7,
+        tool_calls=calls,
+        tool_calls_pending_save=True,
+    )
+    session = _make_session_with_messages(flushed)
+
+    mock_db = mocker.MagicMock()
+    mock_db.update_chat_session = mocker.AsyncMock()
+    mock_db.add_chat_messages_batch = mocker.AsyncMock(return_value=8)
+    mock_db.update_chat_message_tool_calls = mocker.AsyncMock(return_value=False)
+    mocker.patch("backend.copilot.model.chat_db", return_value=mock_db)
+
+    await _save_session_to_db(
+        session, existing_message_count=8, skip_existence_check=True
+    )
+
+    assert flushed.tool_calls_pending_save is True
+
+    # A later save retries the back-fill; on success the flag clears.
+    mock_db.update_chat_message_tool_calls = mocker.AsyncMock(return_value=True)
+    await _save_session_to_db(
+        session, existing_message_count=8, skip_existence_check=True
+    )
+    assert flushed.tool_calls_pending_save is False
+
+
 # ─── _get_session_from_db cap-hit warning ──────────────────────────────
 
 

--- a/autogpt_platform/backend/backend/copilot/model_test.py
+++ b/autogpt_platform/backend/backend/copilot/model_test.py
@@ -1489,3 +1489,87 @@ def test_add_tool_call_to_sequenced_row_flags_backfill():
         {"id": "c2", "type": "function", "function": {"name": "f", "arguments": "{}"}}
     )
     assert fresh.messages[-1].tool_calls_pending_save is False
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_backfill_exception_keeps_flag_and_save_survives(
+    mocker: MockerFixture,
+) -> None:
+    """A raising back-fill must not fail the save, and the dirty flag stays
+    set so a later save retries — the retry safety net for the crash case."""
+    flushed = ChatMessage(
+        role="assistant",
+        content="working...",
+        sequence=7,
+        tool_calls=[
+            {
+                "id": "c1",
+                "type": "function",
+                "function": {"name": "f", "arguments": "{}"},
+            }
+        ],
+        tool_calls_pending_save=True,
+    )
+    session = _make_session_with_messages(flushed)
+
+    mock_db = mocker.MagicMock()
+    mock_db.update_chat_session = mocker.AsyncMock()
+    mock_db.add_chat_messages_batch = mocker.AsyncMock(return_value=8)
+    mock_db.update_chat_message_tool_calls = mocker.AsyncMock(
+        side_effect=RuntimeError("db down")
+    )
+    mocker.patch("backend.copilot.model.chat_db", return_value=mock_db)
+
+    await _save_session_to_db(
+        session, existing_message_count=8, skip_existence_check=True
+    )
+
+    assert flushed.tool_calls_pending_save is True
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_backfill_partial_failure_clears_only_successes(
+    mocker: MockerFixture,
+) -> None:
+    """Three dirty rows fan out concurrently; one raises, one reports
+    not-found — only the successful row's flag clears."""
+
+    def _msg(seq: int) -> ChatMessage:
+        return ChatMessage(
+            role="assistant",
+            content=f"m{seq}",
+            sequence=seq,
+            tool_calls=[
+                {
+                    "id": f"c{seq}",
+                    "type": "function",
+                    "function": {"name": "f", "arguments": "{}"},
+                }
+            ],
+            tool_calls_pending_save=True,
+        )
+
+    m1, m2, m3 = _msg(1), _msg(2), _msg(3)
+    session = _make_session_with_messages(m1, m2, m3)
+
+    async def _by_sequence(session_id: str, sequence: int, tool_calls):
+        if sequence == 1:
+            return True
+        if sequence == 2:
+            raise RuntimeError("db down")
+        return False
+
+    mock_db = mocker.MagicMock()
+    mock_db.update_chat_session = mocker.AsyncMock()
+    mock_db.add_chat_messages_batch = mocker.AsyncMock(return_value=4)
+    mock_db.update_chat_message_tool_calls = mocker.AsyncMock(side_effect=_by_sequence)
+    mocker.patch("backend.copilot.model.chat_db", return_value=mock_db)
+
+    await _save_session_to_db(
+        session, existing_message_count=4, skip_existence_check=True
+    )
+
+    assert m1.tool_calls_pending_save is False
+    assert m2.tool_calls_pending_save is True
+    assert m3.tool_calls_pending_save is True
+    assert mock_db.update_chat_message_tool_calls.await_count == 3

--- a/autogpt_platform/backend/backend/copilot/model_test.py
+++ b/autogpt_platform/backend/backend/copilot/model_test.py
@@ -1010,7 +1010,7 @@ async def test_save_session_to_db_backfills_late_tool_calls(
     mocker: MockerFixture,
 ) -> None:
     """An assistant row flushed before its tool_use blocks arrived gets its
-    toolCalls back-filled on the next save, and the dirty flag cleared."""
+    toolCalls back-filled on the next save, and the pending-save flag cleared."""
     calls = [
         {
             "id": "c1",
@@ -1085,7 +1085,7 @@ async def test_save_session_to_db_new_rows_persist_tool_calls_without_backfill(
 async def test_save_session_to_db_backfill_failure_keeps_flag_set(
     mocker: MockerFixture,
 ) -> None:
-    """When the back-fill UPDATE fails, the dirty flag must stay set so a
+    """When the back-fill UPDATE fails, the pending-save flag must stay set so a
     later save retries — this retention-on-failure is the fix's safety net."""
     calls = [
         {
@@ -1473,7 +1473,7 @@ def test_chat_session_new_carries_org_team():
 
 def test_add_tool_call_to_sequenced_row_flags_backfill():
     """Attaching a tool_call to an already-persisted assistant row must set
-    the dirty flag so the next save back-fills toolCalls (baseline path)."""
+    the pending-save flag so the next save back-fills toolCalls (baseline path)."""
     session = _make_session_with_messages(
         ChatMessage(role="assistant", content="working...", sequence=42)
     )
@@ -1495,7 +1495,7 @@ def test_add_tool_call_to_sequenced_row_flags_backfill():
 async def test_backfill_exception_keeps_flag_and_save_survives(
     mocker: MockerFixture,
 ) -> None:
-    """A raising back-fill must not fail the save, and the dirty flag stays
+    """A raising back-fill must not fail the save, and the pending-save flag stays
     set so a later save retries — the retry safety net for the crash case."""
     flushed = ChatMessage(
         role="assistant",
@@ -1531,7 +1531,7 @@ async def test_backfill_exception_keeps_flag_and_save_survives(
 async def test_backfill_partial_failure_clears_only_successes(
     mocker: MockerFixture,
 ) -> None:
-    """Three dirty rows fan out concurrently; one raises, one reports
+    """Three pending rows fan out concurrently; one raises, one reports
     not-found — only the successful row's flag clears."""
 
     def _msg(seq: int) -> ChatMessage:

--- a/autogpt_platform/backend/backend/copilot/model_test.py
+++ b/autogpt_platform/backend/backend/copilot/model_test.py
@@ -1469,3 +1469,23 @@ def test_chat_session_new_carries_org_team():
     tenantless = ChatSession.new("u1", dry_run=False)
     assert tenantless.organization_id is None
     assert tenantless.team_id is None
+
+
+def test_add_tool_call_to_sequenced_row_flags_backfill():
+    """Attaching a tool_call to an already-persisted assistant row must set
+    the dirty flag so the next save back-fills toolCalls (baseline path)."""
+    session = _make_session_with_messages(
+        ChatMessage(role="assistant", content="working...", sequence=42)
+    )
+    session.add_tool_call_to_current_turn(
+        {"id": "c1", "type": "function", "function": {"name": "f", "arguments": "{}"}}
+    )
+    assert session.messages[-1].tool_calls_pending_save is True
+
+    fresh = _make_session_with_messages(
+        ChatMessage(role="assistant", content="working...")
+    )
+    fresh.add_tool_call_to_current_turn(
+        {"id": "c2", "type": "function", "function": {"name": "f", "arguments": "{}"}}
+    )
+    assert fresh.messages[-1].tool_calls_pending_save is False

--- a/autogpt_platform/backend/backend/copilot/model_test.py
+++ b/autogpt_platform/backend/backend/copilot/model_test.py
@@ -1005,6 +1005,82 @@ async def test_save_session_to_db_persists_new_messages_when_windowed(
     assert new_msg.sequence == 1500
 
 
+@pytest.mark.asyncio(loop_scope="session")
+async def test_save_session_to_db_backfills_late_tool_calls(
+    mocker: MockerFixture,
+) -> None:
+    """An assistant row flushed before its tool_use blocks arrived gets its
+    toolCalls back-filled on the next save, and the dirty flag cleared."""
+    calls = [
+        {
+            "id": "c1",
+            "type": "function",
+            "function": {"name": "find_block", "arguments": "{}"},
+        }
+    ]
+    flushed = ChatMessage(
+        role="assistant",
+        content="Searching...",
+        sequence=7,
+        tool_calls=calls,
+        tool_calls_pending_save=True,
+    )
+    session = _make_session_with_messages(flushed)
+
+    mock_db = mocker.MagicMock()
+    mock_db.update_chat_session = mocker.AsyncMock()
+    mock_db.add_chat_messages_batch = mocker.AsyncMock(return_value=8)
+    mock_db.update_chat_message_tool_calls = mocker.AsyncMock(return_value=True)
+    mocker.patch("backend.copilot.model.chat_db", return_value=mock_db)
+
+    await _save_session_to_db(
+        session, existing_message_count=8, skip_existence_check=True
+    )
+
+    mock_db.add_chat_messages_batch.assert_not_awaited()
+    mock_db.update_chat_message_tool_calls.assert_awaited_once_with(
+        session_id=session.session_id, sequence=7, tool_calls=calls
+    )
+    assert flushed.tool_calls_pending_save is False
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_save_session_to_db_new_rows_persist_tool_calls_without_backfill(
+    mocker: MockerFixture,
+) -> None:
+    """A not-yet-saved row keeps its tool_calls on the normal insert path —
+    no back-fill update is issued and the flag is cleared by the save."""
+    calls = [
+        {
+            "id": "c2",
+            "type": "function",
+            "function": {"name": "bash_exec", "arguments": "{}"},
+        }
+    ]
+    new_msg = ChatMessage(
+        role="assistant",
+        content="Running...",
+        tool_calls=calls,
+        tool_calls_pending_save=True,
+    )
+    session = _make_session_with_messages(new_msg)
+
+    mock_db = mocker.MagicMock()
+    mock_db.update_chat_session = mocker.AsyncMock()
+    mock_db.add_chat_messages_batch = mocker.AsyncMock(return_value=0)
+    mock_db.update_chat_message_tool_calls = mocker.AsyncMock(return_value=True)
+    mocker.patch("backend.copilot.model.chat_db", return_value=mock_db)
+
+    await _save_session_to_db(
+        session, existing_message_count=0, skip_existence_check=True
+    )
+
+    saved = mock_db.add_chat_messages_batch.call_args.kwargs["messages"]
+    assert saved[0]["tool_calls"] == calls
+    mock_db.update_chat_message_tool_calls.assert_not_awaited()
+    assert new_msg.tool_calls_pending_save is False
+
+
 # ─── _get_session_from_db cap-hit warning ──────────────────────────────
 
 

--- a/autogpt_platform/backend/backend/copilot/sdk/interrupted_partial_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/interrupted_partial_test.py
@@ -224,6 +224,35 @@ class TestFlushOrphanToolUses:
         adapter.flush_unresolved_tool_calls.assert_not_called()
         assert events == []
 
+    def test_persists_tool_name_on_synthetic_rows(self):
+        session = _make_session()
+        state = _adapter_with_unresolved([_tool_output("t1", "r1")])
+        _flush_orphan_tool_uses_to_session(session, state)
+        assert session.messages[0].name == "t"
+
+    def test_nameless_output_falls_back_to_matching_tool_call(self):
+        session = _make_session(
+            [
+                ChatMessage(
+                    role="assistant",
+                    content="",
+                    tool_calls=[
+                        {
+                            "id": "t1",
+                            "type": "function",
+                            "function": {"name": "web_search", "arguments": "{}"},
+                        }
+                    ],
+                )
+            ]
+        )
+        flushed = [
+            StreamToolOutputAvailable(toolCallId="t1", toolName=None, output="r1")
+        ]
+        state = _adapter_with_unresolved(flushed)
+        _flush_orphan_tool_uses_to_session(session, state)
+        assert session.messages[-1].name == "web_search"
+
 
 class TestClassifyFinalFailure:
     """Ensures the history marker (via finalize) and the SSE StreamError yield

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -1557,7 +1557,14 @@ def _resolve_tool_result_name(
     for msg in reversed(session.messages):
         for tc in msg.tool_calls or []:
             if tc.get("id") == tool_call_id:
-                return tc.get("function", {}).get("name")
+                if name := tc.get("function", {}).get("name"):
+                    return name
+                logger.warning(
+                    f"Persisting nameless tool-result row for session "
+                    f"{session.session_id}: matching tool_call "
+                    f"{tool_call_id} has no function name"
+                )
+                return None
     logger.warning(
         f"Persisting nameless tool-result row for session {session.session_id}: "
         f"no name provided and no matching tool_call {tool_call_id} in history"

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -1532,7 +1532,12 @@ def _flush_orphan_tool_uses_to_session(
                 else json.dumps(resp.output, ensure_ascii=False)
             )
             session.messages.append(
-                ChatMessage(role="tool", content=content, tool_call_id=resp.toolCallId)
+                ChatMessage(
+                    role="tool",
+                    content=content,
+                    tool_call_id=resp.toolCallId,
+                    name=resp.toolName,
+                )
             )
     return safety
 
@@ -3069,6 +3074,10 @@ def _dispatch_response(
             }
         )
         acc.assistant_response.tool_calls = acc.accumulated_tool_calls
+        if acc.assistant_response.sequence is not None:
+            # Row already flushed to the DB without this call — flag it so
+            # the next save back-fills toolCalls instead of skipping the row.
+            acc.assistant_response.tool_calls_pending_save = True
         if not acc.has_appended_assistant:
             ctx.session.messages.append(acc.assistant_response)
             acc.has_appended_assistant = True
@@ -3107,6 +3116,7 @@ def _dispatch_response(
                 role="tool",
                 content=content,
                 tool_call_id=response.toolCallId,
+                name=response.toolName,
             )
         )
         if not entries_replaced:

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -1536,10 +1536,29 @@ def _flush_orphan_tool_uses_to_session(
                     role="tool",
                     content=content,
                     tool_call_id=resp.toolCallId,
-                    name=resp.toolName,
+                    name=_resolve_tool_result_name(
+                        session, resp.toolCallId, resp.toolName
+                    ),
                 )
             )
     return safety
+
+
+def _resolve_tool_result_name(
+    session: "ChatSession",
+    tool_call_id: str,
+    tool_name: str | None,
+) -> str | None:
+    """Name for a persisted tool-result row, falling back to the matching
+    assistant ``tool_call`` — a nameless row is unidentifiable in history,
+    which is the exact defect the ``name`` column exists to fix."""
+    if tool_name:
+        return tool_name
+    for msg in reversed(session.messages):
+        for tc in msg.tool_calls or []:
+            if tc.get("id") == tool_call_id:
+                return tc.get("function", {}).get("name")
+    return None
 
 
 @dataclass(frozen=True)
@@ -3116,7 +3135,9 @@ def _dispatch_response(
                 role="tool",
                 content=content,
                 tool_call_id=response.toolCallId,
-                name=response.toolName,
+                name=_resolve_tool_result_name(
+                    ctx.session, response.toolCallId, response.toolName
+                ),
             )
         )
         if not entries_replaced:

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -1558,6 +1558,10 @@ def _resolve_tool_result_name(
         for tc in msg.tool_calls or []:
             if tc.get("id") == tool_call_id:
                 return tc.get("function", {}).get("name")
+    logger.warning(
+        f"Persisting nameless tool-result row for session {session.session_id}: "
+        f"no name provided and no matching tool_call {tool_call_id} in history"
+    )
     return None
 
 

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -3093,10 +3093,7 @@ def _dispatch_response(
             }
         )
         acc.assistant_response.tool_calls = acc.accumulated_tool_calls
-        if acc.assistant_response.sequence is not None:
-            # Row already flushed to the DB without this call — flag it so
-            # the next save back-fills toolCalls instead of skipping the row.
-            acc.assistant_response.tool_calls_pending_save = True
+        acc.assistant_response.mark_tool_calls_dirty()
         if not acc.has_appended_assistant:
             ctx.session.messages.append(acc.assistant_response)
             acc.has_appended_assistant = True

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -3104,7 +3104,7 @@ def _dispatch_response(
             }
         )
         acc.assistant_response.tool_calls = acc.accumulated_tool_calls
-        acc.assistant_response.mark_tool_calls_dirty()
+        acc.assistant_response.mark_tool_calls_pending_save()
         if not acc.has_appended_assistant:
             ctx.session.messages.append(acc.assistant_response)
             acc.has_appended_assistant = True

--- a/autogpt_platform/backend/backend/copilot/sdk/session_persistence_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/session_persistence_test.py
@@ -16,8 +16,11 @@ state allows correct content accumulation by _dispatch_response.
 
 from __future__ import annotations
 
+import logging
 from datetime import datetime, timezone
 from unittest.mock import MagicMock
+
+import pytest
 
 from backend.copilot.constants import (
     STOPPED_BY_USER_MARKER,
@@ -34,6 +37,7 @@ from backend.copilot.response_model import (
 from backend.copilot.sdk.service import (
     _dispatch_response,
     _intermediate_flush_blocked,
+    _resolve_tool_result_name,
     _StreamAccumulator,
 )
 from backend.copilot.session_cleanup import prune_orphan_tool_calls
@@ -656,3 +660,53 @@ class TestLateToolCallPersistence:
         assert len(tool_rows) == 1
         assert tool_rows[0].name == "find_block"
         assert tool_rows[0].tool_call_id == "c1"
+
+    def test_nameless_tool_result_resolves_name_from_matching_call(self) -> None:
+        ctx = _make_ctx()
+        state = _make_state()
+        acc = self._acc_with_appended_assistant(ctx, sequence=None)
+        acc.assistant_response.tool_calls = [
+            {"id": "c1", "type": "function", "function": {"name": "run_agent"}}
+        ]
+
+        ev = StreamToolOutputAvailable(toolCallId="c1", toolName=None, output="done")
+        _dispatch_response(ev, acc, ctx, state, False, "[test]")
+
+        tool_rows = [m for m in ctx.session.messages if m.role == "tool"]
+        assert len(tool_rows) == 1
+        assert tool_rows[0].name == "run_agent"
+
+    def test_nameless_tool_result_with_no_matching_call_warns(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """No adapter name AND no matching tool_call in history: the row is
+        persisted nameless (nothing to resolve from), but loudly."""
+        ctx = _make_ctx()
+        state = _make_state()
+        acc = self._acc_with_appended_assistant(ctx, sequence=None)
+
+        ev = StreamToolOutputAvailable(toolCallId="ghost", toolName=None, output="?")
+        with caplog.at_level(logging.WARNING):
+            _dispatch_response(ev, acc, ctx, state, False, "[test]")
+
+        tool_rows = [m for m in ctx.session.messages if m.role == "tool"]
+        assert len(tool_rows) == 1
+        assert tool_rows[0].name is None
+        assert any("nameless tool-result" in r.message for r in caplog.records)
+
+    def test_resolve_tool_result_name_no_match_returns_none(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        session = _make_session()
+        session.messages.append(
+            ChatMessage(
+                role="assistant",
+                content="",
+                tool_calls=[
+                    {"id": "other", "type": "function", "function": {"name": "x"}}
+                ],
+            )
+        )
+        with caplog.at_level(logging.WARNING):
+            assert _resolve_tool_result_name(session, "missing", None) is None
+        assert any("nameless tool-result" in r.message for r in caplog.records)

--- a/autogpt_platform/backend/backend/copilot/sdk/session_persistence_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/session_persistence_test.py
@@ -29,6 +29,7 @@ from backend.copilot.response_model import (
     StreamStartStep,
     StreamTextDelta,
     StreamToolInputAvailable,
+    StreamToolOutputAvailable,
 )
 from backend.copilot.sdk.service import (
     _dispatch_response,
@@ -594,3 +595,64 @@ class TestIntermediateFlushBlocked:
             session.messages[0].tool_calls[0]["function"]["name"]
             == "setup_agent_webhook_trigger"
         )
+
+
+class TestLateToolCallPersistence:
+    """Tool calls arriving after the assistant row was flushed to the DB must
+    be flagged for back-fill, and tool-result rows must carry the tool name —
+    otherwise the tool activity is invisible in session history (both UIs
+    render from toolCalls / name)."""
+
+    def _acc_with_appended_assistant(
+        self, ctx: MagicMock, *, sequence: int | None
+    ) -> _StreamAccumulator:
+        msg = ChatMessage(role="assistant", content="Working...", sequence=sequence)
+        ctx.session.messages.append(msg)
+        return _StreamAccumulator(
+            assistant_response=msg,
+            accumulated_tool_calls=[],
+            has_appended_assistant=True,
+            has_tool_results=False,
+        )
+
+    def test_tool_call_after_flush_flags_row_for_backfill(self) -> None:
+        ctx = _make_ctx()
+        state = _make_state()
+        acc = self._acc_with_appended_assistant(ctx, sequence=42)
+
+        ev = StreamToolInputAvailable(
+            toolCallId="c1", toolName="find_block", input={"query": "notion"}
+        )
+        _dispatch_response(ev, acc, ctx, state, False, "[test]")
+
+        assert acc.assistant_response.tool_calls is not None
+        assert acc.assistant_response.tool_calls[0]["function"]["name"] == "find_block"
+        assert acc.assistant_response.tool_calls_pending_save is True
+
+    def test_tool_call_before_flush_is_not_flagged(self) -> None:
+        """Unsaved rows (sequence None) are persisted with their tool_calls by
+        the normal insert path — no back-fill needed."""
+        ctx = _make_ctx()
+        state = _make_state()
+        acc = self._acc_with_appended_assistant(ctx, sequence=None)
+
+        ev = StreamToolInputAvailable(toolCallId="c1", toolName="find_block", input={})
+        _dispatch_response(ev, acc, ctx, state, False, "[test]")
+
+        assert acc.assistant_response.tool_calls is not None
+        assert acc.assistant_response.tool_calls_pending_save is False
+
+    def test_tool_result_row_carries_tool_name(self) -> None:
+        ctx = _make_ctx()
+        state = _make_state()
+        acc = self._acc_with_appended_assistant(ctx, sequence=None)
+
+        ev = StreamToolOutputAvailable(
+            toolCallId="c1", toolName="find_block", output="found 3 blocks"
+        )
+        _dispatch_response(ev, acc, ctx, state, False, "[test]")
+
+        tool_rows = [m for m in ctx.session.messages if m.role == "tool"]
+        assert len(tool_rows) == 1
+        assert tool_rows[0].name == "find_block"
+        assert tool_rows[0].tool_call_id == "c1"

--- a/autogpt_platform/backend/backend/copilot/sdk/session_persistence_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/session_persistence_test.py
@@ -694,6 +694,23 @@ class TestLateToolCallPersistence:
         assert tool_rows[0].name is None
         assert any("nameless tool-result" in r.message for r in caplog.records)
 
+    def test_resolve_tool_result_name_matched_but_nameless_call_warns(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A matching tool_call whose function dict carries no name must not
+        bypass the nameless warning."""
+        session = _make_session()
+        session.messages.append(
+            ChatMessage(
+                role="assistant",
+                content="",
+                tool_calls=[{"id": "c1", "type": "function", "function": {}}],
+            )
+        )
+        with caplog.at_level(logging.WARNING):
+            assert _resolve_tool_result_name(session, "c1", None) is None
+        assert any("has no function name" in r.message for r in caplog.records)
+
     def test_resolve_tool_result_name_no_match_returns_none(
         self, caplog: pytest.LogCaptureFixture
     ) -> None:

--- a/autogpt_platform/backend/backend/data/db_manager.py
+++ b/autogpt_platform/backend/backend/data/db_manager.py
@@ -479,6 +479,7 @@ class DatabaseManager(AppService):
     get_next_sequence = _(chat_db.get_next_sequence)
     update_tool_message_content = _(chat_db.update_tool_message_content)
     update_message_content_by_sequence = _(chat_db.update_message_content_by_sequence)
+    update_chat_message_tool_calls = _(chat_db.update_chat_message_tool_calls)
     update_chat_session_title = _(chat_db.update_chat_session_title)
     update_chat_session_pinned = _(chat_db.update_chat_session_pinned)
     set_turn_duration = _(chat_db.set_turn_duration)
@@ -746,6 +747,7 @@ class DatabaseManagerAsyncClient(AppServiceClient):
     get_next_sequence = d.get_next_sequence
     update_tool_message_content = d.update_tool_message_content
     update_message_content_by_sequence = d.update_message_content_by_sequence
+    update_chat_message_tool_calls = d.update_chat_message_tool_calls
     update_chat_session_title = d.update_chat_session_title
     update_chat_session_pinned = d.update_chat_session_pinned
     set_turn_duration = d.set_turn_duration


### PR DESCRIPTION
### Why / What / How

**Why**: Tool activity is invisible in persisted copilot session history — in the web UI a session can show two compaction markers with seemingly nothing between them, while the transcript actually contains ~13 tool invocations in that span (discovered while analyzing AutoPilot test sessions; the live SSE stream renders everything correctly, but reload/history views lose it). This misleads users reviewing sessions and breaks any downstream consumer of chat history (session analysis, `cli chat view`).

**What**: Fix the persistence race that drops `toolCalls` from assistant rows, and persist the tool name on tool-result rows.

**How**: The streaming loop's intermediate flush writes an assistant row (assigning its `sequence`) while text streams, *before* the turn's tool_use blocks arrive; the save path only inserts `sequence is None` rows, so tool calls attached to the in-memory message afterwards were never written. `ChatMessage` gains a serialization-excluded `tool_calls_pending_save` flag, set when `tool_calls` mutate on an already-sequenced row (adapter accumulation and `add_tool_call_to_current_turn` alike); `_save_session_to_db` back-fills flagged rows concurrently (`asyncio.gather`) via a new `update_chat_message_tool_calls` db helper — a unique-keyed Prisma `update` on the `sessionId_sequence` compound key, so a multi-row match is impossible by construction — retaining the flag on failure so any later save retries. Tool-result rows now also persist `name=toolName` (normal + orphan-flush paths), falling back to the name from the matching assistant `tool_call` when the adapter didn't resolve one. If neither source has a name (e.g. the matching assistant row was windowed out), the row is persisted nameless with a warning log — inventing a placeholder would be dishonest.

**Known limitations**: History persisted before this fix is not repairable — the call data was never written. The retry safety net is in-memory-only by necessity: the dirty flag marks tool_calls content that exists only in the worker process, so a back-fill failure on a turn's final save followed by a worker restart loses that turn's tool activity (persisting the flag wouldn't help — the content to back-fill would be gone with the process).

### Changes 🏗️

- `backend/copilot/model.py`: `ChatMessage.tool_calls_pending_save` (excluded field) + back-fill pass in `_save_session_to_db`
- `backend/copilot/db.py`: `update_chat_message_tool_calls(session_id, sequence, tool_calls)` — unique-keyed update; exceptions handled at the back-fill loop
- `backend/data/db_manager.py`: expose the new helper on the DatabaseManager client
- `backend/copilot/sdk/service.py`: flag already-flushed assistant rows on `StreamToolInputAvailable`; persist `name=toolName` on tool-result rows (dispatch + orphan-flush)
- `backend/copilot/sdk/service.py` also gains `_resolve_tool_result_name` (nameless-result fallback; warns when no name can be resolved)
- Tests: dispatch-level flagging, save-level back-fill incl. failure-retains-flag retry + exception survival + multi-row partial-failure fan-out, db-helper success/not-found branches (payload asserted through to SafeJson), orphan-flush name persistence, nameless fallback resolution + warnings on both nameless outcomes (no matching call, and matched call without a `function.name` — helper and dispatch paths), sequenced-row flag on `add_tool_call_to_current_turn`

### Checklist 📋

#### For code changes:

- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `backend/copilot/sdk/session_persistence_test.py` — 33 pass (7 new: flag set on flushed row / not on unsaved row, tool-result name persisted, fallback resolution from the matching call, nameless warnings for no-match and matched-but-nameless, helper-level no-match)
  - [x] `backend/copilot/model_test.py` — 57 pass (4 new: back-fill awaited + flag cleared, new rows persist without back-fill, exception survival retains flag, multi-row partial failure clears only successes)
  - [x] `backend/copilot/db_test.py` — 38 pass (helper success asserts the payload through to SafeJson; not-found returns False + warns)
  - [x] Wider `backend/copilot/sdk/*` suites green in PR CI (39/39 checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)



