### PR TITLE
feat(copilot): add Kimi K3 model support (moonshotai/kimi-k3)

### DIFF
--- a/autogpt_platform/backend/backend/copilot/anthropic_rates.json
+++ b/autogpt_platform/backend/backend/copilot/anthropic_rates.json
@@ -587,6 +587,18 @@
       "supports_tool_choice": true,
       "supports_vision": true,
       "tool_use_system_prompt_tokens": 346
+    },
+    "moonshotai/kimi-k3": {
+      "input_cost_per_token": 3e-06,
+      "output_cost_per_token": 1.5e-05,
+      "litellm_provider": "openrouter",
+      "max_input_tokens": 1048576,
+      "max_output_tokens": 32768,
+      "max_tokens": 32768,
+      "mode": "chat",
+      "supports_function_calling": true,
+      "supports_reasoning": true,
+      "supports_vision": true
     }
   }
 }

--- a/autogpt_platform/backend/backend/copilot/baseline/reasoning.py
+++ b/autogpt_platform/backend/backend/copilot/baseline/reasoning.py
@@ -153,8 +153,8 @@ def _is_reasoning_route(model: str) -> bool:
 
     OpenRouter exposes reasoning tokens via a unified ``reasoning`` request
     param that works on any provider that supports extended thinking —
-    currently Anthropic (Claude Opus / Sonnet) and Moonshot (Kimi K2.6 +
-    kimi-k2-thinking) advertise it in their ``supported_parameters``.
+    currently Anthropic (Claude Opus / Sonnet) and Moonshot (Kimi K2.6,
+    kimi-k2-thinking, K3) advertise it in their ``supported_parameters``.
     Other providers silently drop the field, but we skip it anyway to keep
     the payload tight and avoid confusing cache diagnostics.
 

--- a/autogpt_platform/backend/backend/copilot/model_router.py
+++ b/autogpt_platform/backend/backend/copilot/model_router.py
@@ -20,7 +20,7 @@ LD payload shape::
 
     {
       "fast":     {"standard": "anthropic/claude-sonnet-4-6", "advanced": "anthropic/claude-opus-4-6"},
-      "thinking": {"standard": "moonshotai/kimi-k2.6",         "advanced": "anthropic/claude-opus-4-6"}
+      "thinking": {"standard": "moonshotai/kimi-k3",            "advanced": "anthropic/claude-opus-4-6"}
     }
 
 Missing mode, missing tier-within-mode, non-string cell value, non-dict


### PR DESCRIPTION
## Summary

Adds support for Kimi K3 (`moonshotai/kimi-k3`) as a routing option for the thinking-standard model cell.

K3 launched on OpenRouter on Jul 16 2026. Open weights are promised by **Jul 27 2026** — keeping as draft until then to verify the model is stable in production and weights have shipped.

## Changes

- **`anthropic_rates.json`**: Add K3 cost entry ($3/M input, $15/M output, 1,048,576 token context)
- **`model_router.py`**: Update LD example payload to reference K3 as `thinking.standard`
- **`reasoning.py`**: Update docstring to mention K3 alongside K2.6

## No logic changes needed

`_is_reasoning_route` already handles the `moonshotai/` prefix, so K3 works on the baseline path immediately via LD override (`copilot-model-routing`) or `CHAT_THINKING_STANDARD_MODEL=moonshotai/kimi-k3`.

## To activate

Set LD flag `copilot-model-routing`:
```json
{
  "thinking": {"standard": "moonshotai/kimi-k3", "advanced": "anthropic/claude-opus-4-6"}
}
```

## Known caveats (recheck on Jul 27)
- K3 always runs max reasoning effort — no dial-down, every call burns reasoning tokens
- 51% hallucination rate on AA-Omniscience (vs 38% for Sonnet 4.6) — monitor in production
- Open weights not yet released; undraft once weights ship and routing has been validated