### PR TITLE
fix(backend/copilot): Repair `get_doc_page` path resolution and stale docs URLs

### DIFF
--- a/autogpt_platform/backend/Dockerfile
+++ b/autogpt_platform/backend/Dockerfile
@@ -91,6 +91,14 @@ COPY autogpt_platform/backend/migrations ./migrations
 
 # ============================== BACKEND SERVER ============================== #
 
+FROM debian:13-slim AS docs-filter
+# The copilot docs tools read markdown only — strip everything else
+# (images, scripts, configs) so no unused or untrusted files ship in the
+# server image or its layer history.
+COPY docs /docs
+RUN find /docs -type f ! -name '*.md' ! -name '*.mdx' -delete \
+    && find /docs -type d -empty -delete
+
 FROM debian:13-slim AS server
 
 WORKDIR /app
@@ -152,9 +160,9 @@ ENV PATH="/app/autogpt_platform/backend/.venv/bin:$PATH"
 COPY autogpt_platform/autogpt_libs /app/autogpt_platform/autogpt_libs
 COPY autogpt_platform/backend/poetry.lock autogpt_platform/backend/pyproject.toml ./
 
-# Copy backend code + docs (for Copilot docs search)
+# Copy backend code + docs (markdown only — see docs-filter stage)
 COPY autogpt_platform/backend ./
-COPY docs /app/docs
+COPY --from=docs-filter /docs /app/docs
 # Install the project package to create entry point scripts in .venv/bin/
 # (e.g., rest, executor, ws, db, scheduler, notification - see [tool.poetry.scripts])
 RUN POETRY_VIRTUALENVS_CREATE=true POETRY_VIRTUALENVS_IN_PROJECT=true \

--- a/autogpt_platform/backend/backend/api/features/search/content_handlers.py
+++ b/autogpt_platform/backend/backend/api/features/search/content_handlers.py
@@ -21,7 +21,7 @@ from prisma.enums import ContentType
 from backend.blocks import get_blocks
 from backend.blocks.llm import LlmModel
 from backend.data.db import query_raw_with_schema
-from backend.util.docs import get_docs_root_or_none
+from backend.util.docs import get_docs_root
 from backend.util.text import split_camelcase
 
 if TYPE_CHECKING:
@@ -395,7 +395,7 @@ class DocumentationHandler(ContentHandler):
         docs tools so indexed paths and page reads always agree), or None
         when this deployment didn't bundle the docs — the indexer degrades
         to empty results instead of crashing."""
-        return get_docs_root_or_none()
+        return get_docs_root()
 
     def _extract_doc_title(self, file_path: Path) -> str:
         """Extract the document title from a markdown file."""

--- a/autogpt_platform/backend/backend/api/features/search/content_handlers.py
+++ b/autogpt_platform/backend/backend/api/features/search/content_handlers.py
@@ -21,6 +21,7 @@ from prisma.enums import ContentType
 from backend.blocks import get_blocks
 from backend.blocks.llm import LlmModel
 from backend.data.db import query_raw_with_schema
+from backend.util.docs import get_docs_root
 from backend.util.text import split_camelcase
 
 if TYPE_CHECKING:
@@ -390,19 +391,9 @@ class DocumentationHandler(ContentHandler):
         return ContentType.DOCUMENTATION
 
     def _get_docs_root(self) -> Path:
-        """Get the documentation root directory."""
-        # content_handlers.py is at: backend/backend/api/features/store/content_handlers.py
-        # Need to go up to project root then into docs/
-        # In container: /app/autogpt_platform/backend/backend/api/features/store -> /app/docs
-        # In development: /repo/autogpt_platform/backend/backend/api/features/store -> /repo/docs
-        this_file = Path(
-            __file__
-        )  # .../backend/backend/api/features/store/content_handlers.py
-        project_root = (
-            this_file.parent.parent.parent.parent.parent.parent.parent
-        )  # -> /app or /repo
-        docs_root = project_root / "docs"
-        return docs_root
+        """Get the documentation root directory (shared with the copilot
+        docs tools so indexed paths and page reads always agree)."""
+        return get_docs_root()
 
     def _extract_doc_title(self, file_path: Path) -> str:
         """Extract the document title from a markdown file."""

--- a/autogpt_platform/backend/backend/api/features/search/content_handlers.py
+++ b/autogpt_platform/backend/backend/api/features/search/content_handlers.py
@@ -21,7 +21,7 @@ from prisma.enums import ContentType
 from backend.blocks import get_blocks
 from backend.blocks.llm import LlmModel
 from backend.data.db import query_raw_with_schema
-from backend.util.docs import get_docs_root
+from backend.util.docs import get_docs_root_or_none
 from backend.util.text import split_camelcase
 
 if TYPE_CHECKING:
@@ -395,10 +395,7 @@ class DocumentationHandler(ContentHandler):
         docs tools so indexed paths and page reads always agree), or None
         when this deployment didn't bundle the docs — the indexer degrades
         to empty results instead of crashing."""
-        try:
-            return get_docs_root()
-        except FileNotFoundError:
-            return None
+        return get_docs_root_or_none()
 
     def _extract_doc_title(self, file_path: Path) -> str:
         """Extract the document title from a markdown file."""

--- a/autogpt_platform/backend/backend/api/features/search/content_handlers.py
+++ b/autogpt_platform/backend/backend/api/features/search/content_handlers.py
@@ -390,10 +390,15 @@ class DocumentationHandler(ContentHandler):
     def content_type(self) -> ContentType:
         return ContentType.DOCUMENTATION
 
-    def _get_docs_root(self) -> Path:
+    def _get_docs_root(self) -> Path | None:
         """Get the documentation root directory (shared with the copilot
-        docs tools so indexed paths and page reads always agree)."""
-        return get_docs_root()
+        docs tools so indexed paths and page reads always agree), or None
+        when this deployment didn't bundle the docs — the indexer degrades
+        to empty results instead of crashing."""
+        try:
+            return get_docs_root()
+        except FileNotFoundError:
+            return None
 
     def _extract_doc_title(self, file_path: Path) -> str:
         """Extract the document title from a markdown file."""
@@ -553,8 +558,8 @@ class DocumentationHandler(ContentHandler):
         """
         docs_root = self._get_docs_root()
 
-        if not docs_root.exists():
-            logger.warning(f"Documentation root not found: {docs_root}")
+        if docs_root is None:
+            logger.warning("Documentation root not found")
             return []
 
         # Find all .md and .mdx files
@@ -658,7 +663,7 @@ class DocumentationHandler(ContentHandler):
         """
         docs_root = self._get_docs_root()
 
-        if not docs_root.exists():
+        if docs_root is None:
             return {"total": 0, "with_embeddings": 0, "without_embeddings": 0}
 
         # Get all section content IDs
@@ -690,7 +695,7 @@ class DocumentationHandler(ContentHandler):
         # or removed section drops from this set and its embedding gets
         # cleaned up.
         docs_root = self._get_docs_root()
-        if not docs_root.exists():
+        if docs_root is None:
             return set()
         # Filesystem walk is sync; keep it off the event loop.
         return await asyncio.to_thread(self._get_all_section_content_ids, docs_root)

--- a/autogpt_platform/backend/backend/api/features/search/content_handlers_test.py
+++ b/autogpt_platform/backend/backend/api/features/search/content_handlers_test.py
@@ -634,7 +634,7 @@ async def test_library_agent_handler_stats():
 @pytest.mark.asyncio
 async def test_documentation_handler_degrades_without_bundled_docs():
     """A docs-less deployment must no-op (empty results), not crash the
-    indexer — get_docs_root_or_none returns None and every consumer guards."""
+    indexer — get_docs_root returns None and every consumer guards."""
     handler = DocumentationHandler()
     with patch(
         "backend.api.features.search.content_handlers.get_docs_root",

--- a/autogpt_platform/backend/backend/api/features/search/content_handlers_test.py
+++ b/autogpt_platform/backend/backend/api/features/search/content_handlers_test.py
@@ -637,7 +637,7 @@ async def test_documentation_handler_degrades_without_bundled_docs():
     indexer — get_docs_root_or_none returns None and every consumer guards."""
     handler = DocumentationHandler()
     with patch(
-        "backend.api.features.search.content_handlers.get_docs_root_or_none",
+        "backend.api.features.search.content_handlers.get_docs_root",
         return_value=None,
     ):
         assert handler._get_docs_root() is None

--- a/autogpt_platform/backend/backend/api/features/search/content_handlers_test.py
+++ b/autogpt_platform/backend/backend/api/features/search/content_handlers_test.py
@@ -629,3 +629,19 @@ async def test_library_agent_handler_stats():
     assert stats["total"] == 10
     assert stats["with_embeddings"] == 4
     assert stats["without_embeddings"] == 6
+
+
+@pytest.mark.asyncio
+async def test_documentation_handler_degrades_without_bundled_docs():
+    """A docs-less deployment must no-op (empty results), not crash the
+    indexer — get_docs_root_or_none returns None and every consumer guards."""
+    handler = DocumentationHandler()
+    with patch(
+        "backend.api.features.search.content_handlers.get_docs_root_or_none",
+        return_value=None,
+    ):
+        assert handler._get_docs_root() is None
+        assert await handler.get_missing_items(batch_size=10) == []
+        assert await handler.get_valid_content_ids() == set()
+        stats = await handler.get_stats()
+    assert stats == {"total": 0, "with_embeddings": 0, "without_embeddings": 0}

--- a/autogpt_platform/backend/backend/copilot/tools/get_doc_page.py
+++ b/autogpt_platform/backend/backend/copilot/tools/get_doc_page.py
@@ -5,7 +5,7 @@ import logging
 from typing import Any
 
 from backend.copilot.model import ChatSession
-from backend.util.docs import get_docs_root_or_none, make_doc_url
+from backend.util.docs import get_docs_root, make_doc_url
 
 from .base import BaseTool
 from .models import DocPageResponse, ErrorResponse, ToolResponseBase
@@ -87,7 +87,7 @@ class GetDocPageTool(BaseTool):
                 session_id=session_id,
             )
 
-        docs_root = get_docs_root_or_none()
+        docs_root = get_docs_root()
         if docs_root is None:
             return ErrorResponse(
                 message="Documentation is not available in this deployment.",
@@ -99,7 +99,7 @@ class GetDocPageTool(BaseTool):
         # Containment before existence: a uniform error for out-of-root
         # paths avoids leaking whether a file exists outside docs_root.
         try:
-            # docs_root is already resolved (see _find_docs_root).
+            # docs_root is already resolved (guaranteed by get_docs_root).
             full_path.resolve().relative_to(docs_root)
         except ValueError:
             return ErrorResponse(

--- a/autogpt_platform/backend/backend/copilot/tools/get_doc_page.py
+++ b/autogpt_platform/backend/backend/copilot/tools/get_doc_page.py
@@ -4,14 +4,12 @@ import logging
 from typing import Any
 
 from backend.copilot.model import ChatSession
-from backend.util.docs import DOCS_BASE_URL, get_docs_root, make_doc_url
+from backend.util.docs import get_docs_root_or_none, make_doc_url
 
 from .base import BaseTool
 from .models import DocPageResponse, ErrorResponse, ToolResponseBase
 
 logger = logging.getLogger(__name__)
-
-__all__ = ["DOCS_BASE_URL", "GetDocPageTool"]
 
 
 class GetDocPageTool(BaseTool):
@@ -52,9 +50,6 @@ class GetDocPageTool(BaseTool):
                 return line[2:].strip()
         return fallback
 
-    def _make_doc_url(self, path: str) -> str:
-        return make_doc_url(path)
-
     async def _execute(
         self,
         user_id: str | None,
@@ -91,9 +86,8 @@ class GetDocPageTool(BaseTool):
                 session_id=session_id,
             )
 
-        try:
-            docs_root = get_docs_root()
-        except FileNotFoundError:
+        docs_root = get_docs_root_or_none()
+        if docs_root is None:
             return ErrorResponse(
                 message="Documentation is not available in this deployment.",
                 error="docs_unavailable",
@@ -104,7 +98,8 @@ class GetDocPageTool(BaseTool):
         # Containment before existence: a uniform error for out-of-root
         # paths avoids leaking whether a file exists outside docs_root.
         try:
-            full_path.resolve().relative_to(docs_root.resolve())
+            # docs_root is already resolved (see _find_docs_root).
+            full_path.resolve().relative_to(docs_root)
         except ValueError:
             return ErrorResponse(
                 message="Invalid documentation path.",
@@ -128,7 +123,7 @@ class GetDocPageTool(BaseTool):
                 title=title,
                 path=path,
                 content=content,
-                doc_url=self._make_doc_url(path),
+                doc_url=make_doc_url(path),
                 session_id=session_id,
             )
 

--- a/autogpt_platform/backend/backend/copilot/tools/get_doc_page.py
+++ b/autogpt_platform/backend/backend/copilot/tools/get_doc_page.py
@@ -94,16 +94,16 @@ class GetDocPageTool(BaseTool):
                 error="docs_unavailable",
                 session_id=session_id,
             )
-        full_path = docs_root / path
-
         # Containment before existence: a uniform error for out-of-root
         # paths avoids leaking whether a file exists outside docs_root.
         try:
             # resolve() both sides: get_docs_root guarantees a resolved root,
             # but the guard stays self-contained rather than coupling a
             # security boundary to another module's invariant (idempotent,
-            # one metadata syscall).
-            full_path.resolve().relative_to(docs_root.resolve())
+            # one metadata syscall). All later access goes through the
+            # resolved path so the validated path is the one read.
+            full_path = (docs_root / path).resolve()
+            full_path.relative_to(docs_root.resolve())
         except ValueError:
             return ErrorResponse(
                 message="Invalid documentation path.",

--- a/autogpt_platform/backend/backend/copilot/tools/get_doc_page.py
+++ b/autogpt_platform/backend/backend/copilot/tools/get_doc_page.py
@@ -1,5 +1,6 @@
 """GetDocPageTool - Fetch full content of a documentation page."""
 
+import asyncio
 import logging
 from typing import Any
 
@@ -115,7 +116,7 @@ class GetDocPageTool(BaseTool):
             )
 
         try:
-            content = full_path.read_text(encoding="utf-8")
+            content = await asyncio.to_thread(full_path.read_text, encoding="utf-8")
             title = self._extract_title(content, path)
 
             return DocPageResponse(

--- a/autogpt_platform/backend/backend/copilot/tools/get_doc_page.py
+++ b/autogpt_platform/backend/backend/copilot/tools/get_doc_page.py
@@ -99,8 +99,11 @@ class GetDocPageTool(BaseTool):
         # Containment before existence: a uniform error for out-of-root
         # paths avoids leaking whether a file exists outside docs_root.
         try:
-            # docs_root is already resolved (guaranteed by get_docs_root).
-            full_path.resolve().relative_to(docs_root)
+            # resolve() both sides: get_docs_root guarantees a resolved root,
+            # but the guard stays self-contained rather than coupling a
+            # security boundary to another module's invariant (idempotent,
+            # one metadata syscall).
+            full_path.resolve().relative_to(docs_root.resolve())
         except ValueError:
             return ErrorResponse(
                 message="Invalid documentation path.",

--- a/autogpt_platform/backend/backend/copilot/tools/get_doc_page.py
+++ b/autogpt_platform/backend/backend/copilot/tools/get_doc_page.py
@@ -4,17 +4,14 @@ import logging
 from typing import Any
 
 from backend.copilot.model import ChatSession
-from backend.util.docs import get_docs_root
+from backend.util.docs import DOCS_BASE_URL, get_docs_root, make_doc_url
 
 from .base import BaseTool
 from .models import DocPageResponse, ErrorResponse, ToolResponseBase
 
 logger = logging.getLogger(__name__)
 
-# Public docs site. It serves the raw repo docs verbatim, INCLUDING the .md
-# extension (https://agpt.co/docs/<repo-relative-path>.md returns the page;
-# the extension-less variant 404s for pages outside the site navigation).
-DOCS_BASE_URL = "https://agpt.co/docs"
+__all__ = ["DOCS_BASE_URL", "GetDocPageTool"]
 
 
 class GetDocPageTool(BaseTool):
@@ -56,9 +53,7 @@ class GetDocPageTool(BaseTool):
         return fallback
 
     def _make_doc_url(self, path: str) -> str:
-        """Create a URL for a documentation page (extension kept — see
-        DOCS_BASE_URL)."""
-        return f"{DOCS_BASE_URL}/{path}"
+        return make_doc_url(path)
 
     async def _execute(
         self,
@@ -106,20 +101,21 @@ class GetDocPageTool(BaseTool):
             )
         full_path = docs_root / path
 
-        if not full_path.exists():
-            return ErrorResponse(
-                message=f"Documentation page not found: {path}",
-                error="not_found",
-                session_id=session_id,
-            )
-
-        # Ensure the path is within docs root
+        # Containment before existence: a uniform error for out-of-root
+        # paths avoids leaking whether a file exists outside docs_root.
         try:
             full_path.resolve().relative_to(docs_root.resolve())
         except ValueError:
             return ErrorResponse(
                 message="Invalid documentation path.",
                 error="invalid_path",
+                session_id=session_id,
+            )
+
+        if not full_path.exists():
+            return ErrorResponse(
+                message=f"Documentation page not found: {path}",
+                error="not_found",
                 session_id=session_id,
             )
 

--- a/autogpt_platform/backend/backend/copilot/tools/get_doc_page.py
+++ b/autogpt_platform/backend/backend/copilot/tools/get_doc_page.py
@@ -1,18 +1,20 @@
 """GetDocPageTool - Fetch full content of a documentation page."""
 
 import logging
-from pathlib import Path
 from typing import Any
 
 from backend.copilot.model import ChatSession
+from backend.util.docs import get_docs_root
 
 from .base import BaseTool
 from .models import DocPageResponse, ErrorResponse, ToolResponseBase
 
 logger = logging.getLogger(__name__)
 
-# Base URL for documentation (can be configured)
-DOCS_BASE_URL = "https://docs.agpt.co"
+# Public docs site. It serves the raw repo docs verbatim, INCLUDING the .md
+# extension (https://agpt.co/docs/<repo-relative-path>.md returns the page;
+# the extension-less variant 404s for pages outside the site navigation).
+DOCS_BASE_URL = "https://agpt.co/docs"
 
 
 class GetDocPageTool(BaseTool):
@@ -45,12 +47,6 @@ class GetDocPageTool(BaseTool):
     def requires_auth(self) -> bool:
         return False  # Documentation is public
 
-    def _get_docs_root(self) -> Path:
-        """Get the documentation root directory."""
-        this_file = Path(__file__)
-        project_root = this_file.parent.parent.parent.parent.parent.parent.parent.parent
-        return project_root / "docs"
-
     def _extract_title(self, content: str, fallback: str) -> str:
         """Extract title from markdown content."""
         lines = content.split("\n")
@@ -60,9 +56,9 @@ class GetDocPageTool(BaseTool):
         return fallback
 
     def _make_doc_url(self, path: str) -> str:
-        """Create a URL for a documentation page."""
-        url_path = path.rsplit(".", 1)[0] if "." in path else path
-        return f"{DOCS_BASE_URL}/{url_path}"
+        """Create a URL for a documentation page (extension kept — see
+        DOCS_BASE_URL)."""
+        return f"{DOCS_BASE_URL}/{path}"
 
     async def _execute(
         self,
@@ -100,7 +96,14 @@ class GetDocPageTool(BaseTool):
                 session_id=session_id,
             )
 
-        docs_root = self._get_docs_root()
+        try:
+            docs_root = get_docs_root()
+        except FileNotFoundError:
+            return ErrorResponse(
+                message="Documentation is not available in this deployment.",
+                error="docs_unavailable",
+                session_id=session_id,
+            )
         full_path = docs_root / path
 
         if not full_path.exists():

--- a/autogpt_platform/backend/backend/copilot/tools/get_doc_page_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/get_doc_page_test.py
@@ -52,7 +52,8 @@ async def test_fetches_real_doc_page(tool, session):
     assert result.path == rel_path
     # The docs site serves rendered pages at the extension-less path;
     # the .md variant is a soft-404 (HTTP 200 + "Page Not Found" body).
-    assert result.doc_url == f"{DOCS_BASE_URL}/{rel_path.removesuffix('.md')}"
+    expected_slug = rel_path.removesuffix(".md").replace("_", "-")
+    assert result.doc_url == f"{DOCS_BASE_URL}/{expected_slug}"
 
 
 @pytest.mark.asyncio
@@ -129,3 +130,4 @@ async def test_directory_path_returns_read_failed(tool, session, tmp_path, mocke
 async def test_empty_path_rejected(tool, session):
     result = await tool._execute(user_id=None, session=session, path="  ")
     assert isinstance(result, ErrorResponse)
+    assert "path" in result.message.lower()

--- a/autogpt_platform/backend/backend/copilot/tools/get_doc_page_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/get_doc_page_test.py
@@ -86,3 +86,40 @@ async def test_docs_unavailable_returns_dedicated_error(tool, session, mocker):
     )
     assert isinstance(result, ErrorResponse)
     assert result.error == "docs_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_symlink_escape_blocked_by_containment(tool, session, tmp_path, mocker):
+    """A path with no ../ that resolves OUTSIDE docs_root via an in-tree
+    symlink must hit the containment check (the string guard can't see it)."""
+    docs = tmp_path / "docs"
+    (docs / "platform").mkdir(parents=True)
+    outside = tmp_path / "secret.txt"
+    outside.write_text("nope")
+    (docs / "platform" / "leak.md").symlink_to(outside)
+    mocker.patch(
+        "backend.copilot.tools.get_doc_page.get_docs_root_or_none",
+        return_value=docs.resolve(),
+    )
+    result = await tool._execute(user_id=None, session=session, path="platform/leak.md")
+    assert isinstance(result, ErrorResponse)
+    assert result.error == "invalid_path"
+
+
+@pytest.mark.asyncio
+async def test_directory_path_returns_read_failed(tool, session, tmp_path, mocker):
+    docs = tmp_path / "docs"
+    (docs / "platform").mkdir(parents=True)
+    mocker.patch(
+        "backend.copilot.tools.get_doc_page.get_docs_root_or_none",
+        return_value=docs.resolve(),
+    )
+    result = await tool._execute(user_id=None, session=session, path="platform")
+    assert isinstance(result, ErrorResponse)
+    assert result.error == "read_failed"
+
+
+@pytest.mark.asyncio
+async def test_empty_path_rejected(tool, session):
+    result = await tool._execute(user_id=None, session=session, path="  ")
+    assert isinstance(result, ErrorResponse)

--- a/autogpt_platform/backend/backend/copilot/tools/get_doc_page_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/get_doc_page_test.py
@@ -57,6 +57,31 @@ async def test_fetches_real_doc_page(tool, session):
 
 
 @pytest.mark.asyncio
+async def test_happy_path_hermetic(tool, session, tmp_path, mocker):
+    """Unconditional (mocked tmp docs root, no bundle needed): a valid
+    in-root path returns a DocPageResponse with content, title, and a
+    canonicalized doc_url — locks the repaired resolution regression in
+    even on docs-less environments."""
+    docs = tmp_path / "docs"
+    (docs / "platform").mkdir(parents=True)
+    (docs / "platform" / "getting_started.md").write_text("# Getting Started\n\nHello.")
+    mocker.patch(
+        "backend.copilot.tools.get_doc_page.get_docs_root",
+        return_value=docs.resolve(),
+    )
+
+    result = await tool._execute(
+        user_id=None, session=session, path="platform/getting_started.md"
+    )
+
+    assert isinstance(result, DocPageResponse)
+    assert result.title == "Getting Started"
+    assert result.content == "# Getting Started\n\nHello."
+    assert result.path == "platform/getting_started.md"
+    assert result.doc_url == f"{DOCS_BASE_URL}/platform/getting-started"
+
+
+@pytest.mark.asyncio
 @requires_docs_bundle
 async def test_missing_page_returns_not_found(tool, session):
     result = await tool._execute(user_id=None, session=session, path="no/such/page.md")

--- a/autogpt_platform/backend/backend/copilot/tools/get_doc_page_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/get_doc_page_test.py
@@ -60,3 +60,18 @@ async def test_traversal_is_blocked(tool, session):
     )
     assert isinstance(result, ErrorResponse)
     assert result.error == "invalid_path"
+
+
+@pytest.mark.asyncio
+async def test_docs_unavailable_returns_dedicated_error(tool, session, mocker):
+    """A deployment without bundled docs degrades to a clear error instead
+    of a misleading not_found."""
+    mocker.patch(
+        "backend.copilot.tools.get_doc_page.get_docs_root",
+        side_effect=FileNotFoundError("no docs"),
+    )
+    result = await tool._execute(
+        user_id=None, session=session, path="platform/getting-started.md"
+    )
+    assert isinstance(result, ErrorResponse)
+    assert result.error == "docs_unavailable"

--- a/autogpt_platform/backend/backend/copilot/tools/get_doc_page_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/get_doc_page_test.py
@@ -4,7 +4,7 @@ import pytest
 
 from backend.copilot.tools.get_doc_page import GetDocPageTool
 from backend.copilot.tools.models import DocPageResponse, ErrorResponse
-from backend.util.docs import DOCS_BASE_URL, get_docs_root
+from backend.util.docs import DOCS_BASE_URL, get_docs_root, get_docs_root_or_none
 
 from ._test_data import make_session
 
@@ -21,6 +21,13 @@ def session():
     return make_session(_TEST_USER_ID)
 
 
+requires_docs_bundle = pytest.mark.skipif(
+    get_docs_root_or_none() is None,
+    reason="integration: needs the repo/image docs bundle on disk",
+)
+
+
+@requires_docs_bundle
 def test_docs_root_resolves_to_bundled_docs():
     """Regression: the old parent-chain arithmetic resolved OUTSIDE the repo
     (two levels too far), making every page read 404 in dev and cloud."""
@@ -31,6 +38,7 @@ def test_docs_root_resolves_to_bundled_docs():
 
 
 @pytest.mark.asyncio
+@requires_docs_bundle
 async def test_fetches_real_doc_page(tool, session):
     """Any indexed-style relative path under docs/ must be readable."""
     root = get_docs_root()
@@ -48,6 +56,7 @@ async def test_fetches_real_doc_page(tool, session):
 
 
 @pytest.mark.asyncio
+@requires_docs_bundle
 async def test_missing_page_returns_not_found(tool, session):
     result = await tool._execute(user_id=None, session=session, path="no/such/page.md")
     assert isinstance(result, ErrorResponse)

--- a/autogpt_platform/backend/backend/copilot/tools/get_doc_page_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/get_doc_page_test.py
@@ -4,7 +4,7 @@ import pytest
 
 from backend.copilot.tools.get_doc_page import GetDocPageTool
 from backend.copilot.tools.models import DocPageResponse, ErrorResponse
-from backend.util.docs import DOCS_BASE_URL, get_docs_root, get_docs_root_or_none
+from backend.util.docs import DOCS_BASE_URL, get_docs_root
 
 from ._test_data import make_session
 
@@ -22,7 +22,7 @@ def session():
 
 
 requires_docs_bundle = pytest.mark.skipif(
-    get_docs_root_or_none() is None,
+    get_docs_root() is None,
     reason="integration: needs the repo/image docs bundle on disk",
 )
 
@@ -72,7 +72,7 @@ async def test_traversal_is_blocked(tool, session, tmp_path, mocker):
     (docs / "platform").mkdir(parents=True)
     (tmp_path / "secret.toml").write_text("nope")
     mocker.patch(
-        "backend.copilot.tools.get_doc_page.get_docs_root_or_none",
+        "backend.copilot.tools.get_doc_page.get_docs_root",
         return_value=docs.resolve(),
     )
     result = await tool._execute(user_id=None, session=session, path="../secret.toml")
@@ -85,7 +85,7 @@ async def test_docs_unavailable_returns_dedicated_error(tool, session, mocker):
     """A deployment without bundled docs degrades to a clear error instead
     of a misleading not_found."""
     mocker.patch(
-        "backend.copilot.tools.get_doc_page.get_docs_root_or_none",
+        "backend.copilot.tools.get_doc_page.get_docs_root",
         return_value=None,
     )
     result = await tool._execute(
@@ -105,7 +105,7 @@ async def test_symlink_escape_blocked_by_containment(tool, session, tmp_path, mo
     outside.write_text("nope")
     (docs / "platform" / "leak.md").symlink_to(outside)
     mocker.patch(
-        "backend.copilot.tools.get_doc_page.get_docs_root_or_none",
+        "backend.copilot.tools.get_doc_page.get_docs_root",
         return_value=docs.resolve(),
     )
     result = await tool._execute(user_id=None, session=session, path="platform/leak.md")
@@ -118,7 +118,7 @@ async def test_directory_path_returns_read_failed(tool, session, tmp_path, mocke
     docs = tmp_path / "docs"
     (docs / "platform").mkdir(parents=True)
     mocker.patch(
-        "backend.copilot.tools.get_doc_page.get_docs_root_or_none",
+        "backend.copilot.tools.get_doc_page.get_docs_root",
         return_value=docs.resolve(),
     )
     result = await tool._execute(user_id=None, session=session, path="platform")

--- a/autogpt_platform/backend/backend/copilot/tools/get_doc_page_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/get_doc_page_test.py
@@ -1,0 +1,62 @@
+"""Tests for GetDocPageTool (and the shared docs-root resolution)."""
+
+import pytest
+
+from backend.copilot.tools.get_doc_page import DOCS_BASE_URL, GetDocPageTool
+from backend.copilot.tools.models import DocPageResponse, ErrorResponse
+from backend.util.docs import get_docs_root
+
+from ._test_data import make_session
+
+_TEST_USER_ID = "test-user-get-doc-page"
+
+
+@pytest.fixture
+def tool():
+    return GetDocPageTool()
+
+
+@pytest.fixture
+def session():
+    return make_session(_TEST_USER_ID)
+
+
+def test_docs_root_resolves_to_bundled_docs():
+    """Regression: the old parent-chain arithmetic resolved OUTSIDE the repo
+    (two levels too far), making every page read 404 in dev and cloud."""
+    root = get_docs_root()
+    assert root.is_dir()
+    assert root.name == "docs"
+    assert any(root.rglob("*.md"))
+
+
+@pytest.mark.asyncio
+async def test_fetches_real_doc_page(tool, session):
+    """Any indexed-style relative path under docs/ must be readable."""
+    root = get_docs_root()
+    doc_file = next(f for f in root.rglob("*.md") if f.stat().st_size > 0)
+    rel_path = str(doc_file.relative_to(root))
+
+    result = await tool._execute(user_id=None, session=session, path=rel_path)
+
+    assert isinstance(result, DocPageResponse)
+    assert result.content
+    assert result.path == rel_path
+    # The docs site serves raw repo paths verbatim, extension included.
+    assert result.doc_url == f"{DOCS_BASE_URL}/{rel_path}"
+
+
+@pytest.mark.asyncio
+async def test_missing_page_returns_not_found(tool, session):
+    result = await tool._execute(user_id=None, session=session, path="no/such/page.md")
+    assert isinstance(result, ErrorResponse)
+    assert result.error == "not_found"
+
+
+@pytest.mark.asyncio
+async def test_traversal_is_blocked(tool, session):
+    result = await tool._execute(
+        user_id=None, session=session, path="../backend/pyproject.toml"
+    )
+    assert isinstance(result, ErrorResponse)
+    assert result.error == "invalid_path"

--- a/autogpt_platform/backend/backend/copilot/tools/get_doc_page_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/get_doc_page_test.py
@@ -64,11 +64,17 @@ async def test_missing_page_returns_not_found(tool, session):
 
 
 @pytest.mark.asyncio
-@requires_docs_bundle
-async def test_traversal_is_blocked(tool, session):
-    result = await tool._execute(
-        user_id=None, session=session, path="../backend/pyproject.toml"
+async def test_traversal_is_blocked(tool, session, tmp_path, mocker):
+    """Unconditional (mocked tmp docs root, no bundle needed): a ../ path
+    targeting a real out-of-root file is rejected before existence leaks."""
+    docs = tmp_path / "docs"
+    (docs / "platform").mkdir(parents=True)
+    (tmp_path / "secret.toml").write_text("nope")
+    mocker.patch(
+        "backend.copilot.tools.get_doc_page.get_docs_root_or_none",
+        return_value=docs.resolve(),
     )
+    result = await tool._execute(user_id=None, session=session, path="../secret.toml")
     assert isinstance(result, ErrorResponse)
     assert result.error == "invalid_path"
 

--- a/autogpt_platform/backend/backend/copilot/tools/get_doc_page_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/get_doc_page_test.py
@@ -2,9 +2,9 @@
 
 import pytest
 
-from backend.copilot.tools.get_doc_page import DOCS_BASE_URL, GetDocPageTool
+from backend.copilot.tools.get_doc_page import GetDocPageTool
 from backend.copilot.tools.models import DocPageResponse, ErrorResponse
-from backend.util.docs import get_docs_root
+from backend.util.docs import DOCS_BASE_URL, get_docs_root
 
 from ._test_data import make_session
 
@@ -67,8 +67,8 @@ async def test_docs_unavailable_returns_dedicated_error(tool, session, mocker):
     """A deployment without bundled docs degrades to a clear error instead
     of a misleading not_found."""
     mocker.patch(
-        "backend.copilot.tools.get_doc_page.get_docs_root",
-        side_effect=FileNotFoundError("no docs"),
+        "backend.copilot.tools.get_doc_page.get_docs_root_or_none",
+        return_value=None,
     )
     result = await tool._execute(
         user_id=None, session=session, path="platform/getting-started.md"

--- a/autogpt_platform/backend/backend/copilot/tools/get_doc_page_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/get_doc_page_test.py
@@ -64,6 +64,7 @@ async def test_missing_page_returns_not_found(tool, session):
 
 
 @pytest.mark.asyncio
+@requires_docs_bundle
 async def test_traversal_is_blocked(tool, session):
     result = await tool._execute(
         user_id=None, session=session, path="../backend/pyproject.toml"

--- a/autogpt_platform/backend/backend/copilot/tools/get_doc_page_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/get_doc_page_test.py
@@ -42,8 +42,9 @@ async def test_fetches_real_doc_page(tool, session):
     assert isinstance(result, DocPageResponse)
     assert result.content
     assert result.path == rel_path
-    # The docs site serves raw repo paths verbatim, extension included.
-    assert result.doc_url == f"{DOCS_BASE_URL}/{rel_path}"
+    # The docs site serves rendered pages at the extension-less path;
+    # the .md variant is a soft-404 (HTTP 200 + "Page Not Found" body).
+    assert result.doc_url == f"{DOCS_BASE_URL}/{rel_path.removesuffix('.md')}"
 
 
 @pytest.mark.asyncio

--- a/autogpt_platform/backend/backend/copilot/tools/search_docs.py
+++ b/autogpt_platform/backend/backend/copilot/tools/search_docs.py
@@ -20,8 +20,10 @@ from .models import (
 
 logger = logging.getLogger(__name__)
 
-# Base URL for documentation (can be configured)
-DOCS_BASE_URL = "https://docs.agpt.co"
+# Public docs site. It serves the raw repo docs verbatim, INCLUDING the .md
+# extension (https://agpt.co/docs/<repo-relative-path>.md returns the page;
+# the extension-less variant 404s for pages outside the site navigation).
+DOCS_BASE_URL = "https://agpt.co/docs"
 
 # Maximum number of results to return
 MAX_RESULTS = 5
@@ -77,10 +79,9 @@ class SearchDocsTool(BaseTool):
         return truncated + "..."
 
     def _make_doc_url(self, path: str) -> str:
-        """Create a URL for a documentation page."""
-        # Remove file extension for URL
-        url_path = path.rsplit(".", 1)[0] if "." in path else path
-        return f"{DOCS_BASE_URL}/{url_path}"
+        """Create a URL for a documentation page (extension kept — see
+        DOCS_BASE_URL)."""
+        return f"{DOCS_BASE_URL}/{path}"
 
     async def _execute(
         self,

--- a/autogpt_platform/backend/backend/copilot/tools/search_docs.py
+++ b/autogpt_platform/backend/backend/copilot/tools/search_docs.py
@@ -8,6 +8,7 @@ from prisma.enums import ContentType
 from backend.api.features.search.hybrid_search import HybridSearchRow
 from backend.copilot.model import ChatSession
 from backend.data.db_accessors import search
+from backend.util.docs import make_doc_url
 
 from .base import BaseTool
 from .models import (
@@ -19,11 +20,6 @@ from .models import (
 )
 
 logger = logging.getLogger(__name__)
-
-# Public docs site. It serves the raw repo docs verbatim, INCLUDING the .md
-# extension (https://agpt.co/docs/<repo-relative-path>.md returns the page;
-# the extension-less variant 404s for pages outside the site navigation).
-DOCS_BASE_URL = "https://agpt.co/docs"
 
 # Maximum number of results to return
 MAX_RESULTS = 5
@@ -79,9 +75,7 @@ class SearchDocsTool(BaseTool):
         return truncated + "..."
 
     def _make_doc_url(self, path: str) -> str:
-        """Create a URL for a documentation page (extension kept — see
-        DOCS_BASE_URL)."""
-        return f"{DOCS_BASE_URL}/{path}"
+        return make_doc_url(path)
 
     async def _execute(
         self,

--- a/autogpt_platform/backend/backend/copilot/tools/search_docs.py
+++ b/autogpt_platform/backend/backend/copilot/tools/search_docs.py
@@ -74,9 +74,6 @@ class SearchDocsTool(BaseTool):
 
         return truncated + "..."
 
-    def _make_doc_url(self, path: str) -> str:
-        return make_doc_url(path)
-
     async def _execute(
         self,
         user_id: str | None,
@@ -178,7 +175,7 @@ class SearchDocsTool(BaseTool):
                         section=section_title,
                         snippet=self._create_snippet(searchable_text),
                         score=round(score, 3),
-                        doc_url=self._make_doc_url(doc_path),
+                        doc_url=make_doc_url(doc_path),
                     )
                 )
 

--- a/autogpt_platform/backend/backend/copilot/tools/search_docs_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/search_docs_test.py
@@ -6,10 +6,14 @@ wrong page. A regression re-introducing extension stripping must not ship
 silently.
 """
 
-from backend.copilot.tools.search_docs import SearchDocsTool
-from backend.util.docs import DOCS_BASE_URL
+import backend.copilot.tools.search_docs as search_docs_module
+from backend.util.docs import DOCS_BASE_URL, make_doc_url
 
 
 def test_doc_url_keeps_md_extension():
-    url = SearchDocsTool()._make_doc_url("platform/block-sdk-guide.md")
+    url = make_doc_url("platform/block-sdk-guide.md")
     assert url == f"{DOCS_BASE_URL}/platform/block-sdk-guide.md"
+
+
+def test_search_docs_uses_shared_url_helper():
+    assert search_docs_module.make_doc_url is make_doc_url

--- a/autogpt_platform/backend/backend/copilot/tools/search_docs_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/search_docs_test.py
@@ -10,7 +10,6 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-import backend.copilot.tools.search_docs as search_docs_module
 from backend.copilot.tools.search_docs import SearchDocsTool
 from backend.util.docs import DOCS_BASE_URL, make_doc_url
 
@@ -18,10 +17,6 @@ from backend.util.docs import DOCS_BASE_URL, make_doc_url
 def test_doc_url_strips_md_extension():
     url = make_doc_url("platform/block-sdk-guide.md")
     assert url == f"{DOCS_BASE_URL}/platform/block-sdk-guide"
-
-
-def test_search_docs_uses_shared_url_helper():
-    assert search_docs_module.make_doc_url is make_doc_url
 
 
 @pytest.mark.asyncio

--- a/autogpt_platform/backend/backend/copilot/tools/search_docs_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/search_docs_test.py
@@ -1,19 +1,52 @@
 """Tests for SearchDocsTool URL construction.
 
-The doc URL shape (extension KEPT) is load-bearing: agpt.co serves the raw
-repo docs verbatim, and the extension-less variant 308-redirects to the
-wrong page. A regression re-introducing extension stripping must not ship
-silently.
+The doc URL shape (extension STRIPPED) is load-bearing: agpt.co serves
+rendered pages at the extension-less path, while the .md variant returns a
+soft-404 (HTTP 200 + "Page Not Found" body). A regression re-introducing
+the extension must not ship silently.
 """
 
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
 import backend.copilot.tools.search_docs as search_docs_module
+from backend.copilot.tools.search_docs import SearchDocsTool
 from backend.util.docs import DOCS_BASE_URL, make_doc_url
 
 
-def test_doc_url_keeps_md_extension():
+def test_doc_url_strips_md_extension():
     url = make_doc_url("platform/block-sdk-guide.md")
-    assert url == f"{DOCS_BASE_URL}/platform/block-sdk-guide.md"
+    assert url == f"{DOCS_BASE_URL}/platform/block-sdk-guide"
 
 
 def test_search_docs_uses_shared_url_helper():
     assert search_docs_module.make_doc_url is make_doc_url
+
+
+@pytest.mark.asyncio
+async def test_search_result_doc_url_shape(mocker):
+    """Behavioral check through the tool: a search hit's doc_url must be the
+    extension-less rendered-page URL."""
+    row = {
+        "metadata": {
+            "path": "platform/block-sdk-guide.md",
+            "doc_title": "Block SDK Guide",
+            "section_title": "Intro",
+        },
+        "searchable_text": "how to build blocks",
+        "combined_score": 0.9,
+    }
+    db = MagicMock()
+    db.unified_hybrid_search = AsyncMock(return_value=([row], 1))
+    mocker.patch(
+        "backend.copilot.tools.search_docs.search",
+        return_value=db,
+    )
+    tool = SearchDocsTool()
+    session = MagicMock()
+    session.session_id = "sess-1"
+    result = await tool._execute(user_id="user-1", session=session, query="blocks")
+
+    assert result.results, getattr(result, "message", result)
+    assert result.results[0].doc_url == f"{DOCS_BASE_URL}/platform/block-sdk-guide"

--- a/autogpt_platform/backend/backend/copilot/tools/search_docs_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/search_docs_test.py
@@ -1,0 +1,15 @@
+"""Tests for SearchDocsTool URL construction.
+
+The doc URL shape (extension KEPT) is load-bearing: agpt.co serves the raw
+repo docs verbatim, and the extension-less variant 308-redirects to the
+wrong page. A regression re-introducing extension stripping must not ship
+silently.
+"""
+
+from backend.copilot.tools.search_docs import SearchDocsTool
+from backend.util.docs import DOCS_BASE_URL
+
+
+def test_doc_url_keeps_md_extension():
+    url = SearchDocsTool()._make_doc_url("platform/block-sdk-guide.md")
+    assert url == f"{DOCS_BASE_URL}/platform/block-sdk-guide.md"

--- a/autogpt_platform/backend/backend/util/docs.py
+++ b/autogpt_platform/backend/backend/util/docs.py
@@ -1,25 +1,41 @@
-"""Locate the platform's bundled documentation directory."""
+"""Locate the platform's bundled documentation and its public URLs."""
 
 from functools import cache
 from pathlib import Path
 
+# Public docs site. It serves the raw repo docs verbatim, INCLUDING the .md
+# extension (https://agpt.co/docs/<repo-relative-path>.md returns the page;
+# the extension-less variant 404s for pages outside the site navigation).
+DOCS_BASE_URL = "https://agpt.co/docs"
+
+
+def make_doc_url(path: str) -> str:
+    """Public URL for a documentation page (extension kept — see
+    ``DOCS_BASE_URL``). Shared by search_docs and get_doc_page so the URL
+    shape can't drift between the two tools."""
+    return f"{DOCS_BASE_URL}/{path}"
+
 
 @cache
-def get_docs_root() -> Path:
+def get_docs_root(start: Path | None = None) -> Path:
     """Return the ``docs/`` directory shipped with the platform.
 
-    Walks up from this file until a directory containing ``docs/`` is found,
-    so one implementation covers both layouts without fragile parent
-    counting: the dev checkout (``<repo>/docs``) and the container image
-    (``/app/docs``, see ``COPY docs /app/docs`` in the backend Dockerfile).
-    ``docs/platform`` is required as a sentinel so an unrelated ``docs``
-    folder closer to this package (e.g. a future ``backend/docs/``) can't
-    shadow the real documentation root.
+    Walks up from *start* (default: this file) until a directory containing
+    ``docs/`` is found, so one implementation covers both layouts without
+    fragile parent counting: the dev checkout (``<repo>/docs``) and the
+    container image (``/app/docs``, see ``COPY docs /app/docs`` in the
+    backend Dockerfile). ``docs/platform`` is required as a sentinel so an
+    unrelated ``docs`` folder closer to this package (e.g. a future
+    ``backend/docs/``) can't shadow the real documentation root.
+
+    *start* exists for testability (point the walk at a tmp tree); results
+    are cached per start path.
 
     Raises FileNotFoundError when no matching directory exists in any
     parent (e.g. a deployment that didn't bundle the docs).
     """
-    for parent in Path(__file__).resolve().parents:
+    origin = (start or Path(__file__)).resolve()
+    for parent in origin.parents:
         candidate = parent / "docs"
         if (candidate / "platform").is_dir():
             return candidate

--- a/autogpt_platform/backend/backend/util/docs.py
+++ b/autogpt_platform/backend/backend/util/docs.py
@@ -13,32 +13,49 @@ def make_doc_url(path: str) -> str:
     """Public URL for a documentation page (extension kept — see
     ``DOCS_BASE_URL``). Shared by search_docs and get_doc_page so the URL
     shape can't drift between the two tools."""
-    return f"{DOCS_BASE_URL}/{path}"
+    return f"{DOCS_BASE_URL}/{path.lstrip('/')}"
+
+
+def get_docs_root(start: Path | None = None) -> Path:
+    """Return the ``docs/`` directory shipped with the platform (resolved).
+
+    Raises FileNotFoundError when no matching directory exists in any
+    parent (e.g. a deployment that didn't bundle the docs). See
+    ``_find_docs_root`` for the resolution strategy.
+    """
+    root = _find_docs_root(start)
+    if root is None:
+        raise FileNotFoundError(
+            "docs/ directory not found in any parent of the backend package"
+        )
+    return root
+
+
+def get_docs_root_or_none(start: Path | None = None) -> Path | None:
+    """Like :func:`get_docs_root`, but ``None`` instead of raising — for
+    callers that degrade gracefully on docs-less deployments."""
+    return _find_docs_root(start)
 
 
 @cache
-def get_docs_root(start: Path | None = None) -> Path:
-    """Return the ``docs/`` directory shipped with the platform.
+def _find_docs_root(start: Path | None = None) -> Path | None:
+    """Walk up from *start* (default: this file) to the bundled docs root.
 
-    Walks up from *start* (default: this file) until a directory containing
-    ``docs/`` is found, so one implementation covers both layouts without
-    fragile parent counting: the dev checkout (``<repo>/docs``) and the
-    container image (``/app/docs``, see ``COPY docs /app/docs`` in the
-    backend Dockerfile). ``docs/platform`` is required as a sentinel so an
-    unrelated ``docs`` folder closer to this package (e.g. a future
-    ``backend/docs/``) can't shadow the real documentation root.
+    One implementation covers both layouts without fragile parent counting:
+    the dev checkout (``<repo>/docs``) and the container image
+    (``/app/docs``, see ``COPY docs /app/docs`` in the backend Dockerfile).
+    ``docs/platform`` is required as a sentinel so an unrelated ``docs``
+    folder closer to this package (e.g. a future ``backend/docs/``) can't
+    shadow the real documentation root.
 
-    *start* exists for testability (point the walk at a tmp tree); results
-    are cached per start path.
-
-    Raises FileNotFoundError when no matching directory exists in any
-    parent (e.g. a deployment that didn't bundle the docs).
+    *start* exists for testability (point the walk at a tmp tree). Both the
+    found path (already resolved — derived from resolved parents) and the
+    not-found ``None`` are memoized, so docs-less deployments don't re-walk
+    the filesystem on every call.
     """
     origin = (start or Path(__file__)).resolve()
     for parent in origin.parents:
         candidate = parent / "docs"
         if (candidate / "platform").is_dir():
             return candidate
-    raise FileNotFoundError(
-        "docs/ directory not found in any parent of the backend package"
-    )
+    return None

--- a/autogpt_platform/backend/backend/util/docs.py
+++ b/autogpt_platform/backend/backend/util/docs.py
@@ -11,15 +11,17 @@ DOCS_BASE_URL = "https://agpt.co/docs"
 
 
 def make_doc_url(path: str) -> str:
-    """Public URL for a documentation page (extension stripped — see
-    ``DOCS_BASE_URL``). Shared by search_docs and get_doc_page so the URL
-    shape can't drift between the two tools."""
+    """Public URL for a documentation page (extension stripped, underscores
+    canonicalized to hyphens — the site's edge worker rewrites ``_`` to
+    ``-``, see ``autogpt_platform/cloudflare_worker.js``). Shared by
+    search_docs and get_doc_page so the URL shape can't drift between the
+    two tools."""
     clean = path.lstrip("/")
     for ext in (".md", ".mdx"):
         if clean.endswith(ext):
             clean = clean[: -len(ext)]
             break
-    return f"{DOCS_BASE_URL}/{clean}"
+    return f"{DOCS_BASE_URL}/{clean.replace('_', '-')}"
 
 
 def get_docs_root(start: Path | None = None) -> Path:

--- a/autogpt_platform/backend/backend/util/docs.py
+++ b/autogpt_platform/backend/backend/util/docs.py
@@ -24,30 +24,10 @@ def make_doc_url(path: str) -> str:
     return f"{DOCS_BASE_URL}/{clean.replace('_', '-')}"
 
 
-def get_docs_root(start: Path | None = None) -> Path:
-    """Return the ``docs/`` directory shipped with the platform (resolved).
-
-    Raises FileNotFoundError when no matching directory exists in any
-    parent (e.g. a deployment that didn't bundle the docs). See
-    ``_find_docs_root`` for the resolution strategy.
-    """
-    root = _find_docs_root(start)
-    if root is None:
-        raise FileNotFoundError(
-            "docs/ directory not found in any parent of the backend package"
-        )
-    return root
-
-
-def get_docs_root_or_none(start: Path | None = None) -> Path | None:
-    """Like :func:`get_docs_root`, but ``None`` instead of raising — for
-    callers that degrade gracefully on docs-less deployments."""
-    return _find_docs_root(start)
-
-
 @cache
-def _find_docs_root(start: Path | None = None) -> Path | None:
-    """Walk up from *start* (default: this file) to the bundled docs root.
+def get_docs_root(start: Path | None = None) -> Path | None:
+    """Walk up from *start* (default: this file) to the bundled docs root,
+    or ``None`` when this deployment didn't bundle the docs.
 
     One implementation covers both layouts without fragile parent counting:
     the dev checkout (``<repo>/docs``) and the container image

--- a/autogpt_platform/backend/backend/util/docs.py
+++ b/autogpt_platform/backend/backend/util/docs.py
@@ -1,0 +1,28 @@
+"""Locate the platform's bundled documentation directory."""
+
+from functools import cache
+from pathlib import Path
+
+
+@cache
+def get_docs_root() -> Path:
+    """Return the ``docs/`` directory shipped with the platform.
+
+    Walks up from this file until a directory containing ``docs/`` is found,
+    so one implementation covers both layouts without fragile parent
+    counting: the dev checkout (``<repo>/docs``) and the container image
+    (``/app/docs``, see ``COPY docs /app/docs`` in the backend Dockerfile).
+    ``docs/platform`` is required as a sentinel so an unrelated ``docs``
+    folder closer to this package (e.g. a future ``backend/docs/``) can't
+    shadow the real documentation root.
+
+    Raises FileNotFoundError when no matching directory exists in any
+    parent (e.g. a deployment that didn't bundle the docs).
+    """
+    for parent in Path(__file__).resolve().parents:
+        candidate = parent / "docs"
+        if (candidate / "platform").is_dir():
+            return candidate
+    raise FileNotFoundError(
+        "docs/ directory not found in any parent of the backend package"
+    )

--- a/autogpt_platform/backend/backend/util/docs.py
+++ b/autogpt_platform/backend/backend/util/docs.py
@@ -3,17 +3,23 @@
 from functools import cache
 from pathlib import Path
 
-# Public docs site. It serves the raw repo docs verbatim, INCLUDING the .md
-# extension (https://agpt.co/docs/<repo-relative-path>.md returns the page;
-# the extension-less variant 404s for pages outside the site navigation).
+# Public docs site. It serves rendered pages at the EXTENSION-LESS repo path
+# (https://agpt.co/docs/<repo-relative-path-without-.md>); the .md variant
+# returns a soft-404 ("Page Not Found" with HTTP 200), so status-code checks
+# alone cannot validate these URLs — grep the body when re-verifying.
 DOCS_BASE_URL = "https://agpt.co/docs"
 
 
 def make_doc_url(path: str) -> str:
-    """Public URL for a documentation page (extension kept — see
+    """Public URL for a documentation page (extension stripped — see
     ``DOCS_BASE_URL``). Shared by search_docs and get_doc_page so the URL
     shape can't drift between the two tools."""
-    return f"{DOCS_BASE_URL}/{path.lstrip('/')}"
+    clean = path.lstrip("/")
+    for ext in (".md", ".mdx"):
+        if clean.endswith(ext):
+            clean = clean[: -len(ext)]
+            break
+    return f"{DOCS_BASE_URL}/{clean}"
 
 
 def get_docs_root(start: Path | None = None) -> Path:
@@ -57,5 +63,7 @@ def _find_docs_root(start: Path | None = None) -> Path | None:
     for parent in origin.parents:
         candidate = parent / "docs"
         if (candidate / "platform").is_dir():
-            return candidate
+            # Final resolve: robustness if docs/ itself is a symlink, so the
+            # containment check in get_doc_page compares real paths.
+            return candidate.resolve()
     return None

--- a/autogpt_platform/backend/backend/util/docs_test.py
+++ b/autogpt_platform/backend/backend/util/docs_test.py
@@ -4,20 +4,14 @@ from pathlib import Path
 
 import pytest
 
-from backend.util.docs import (
-    DOCS_BASE_URL,
-    _find_docs_root,
-    get_docs_root,
-    get_docs_root_or_none,
-    make_doc_url,
-)
+from backend.util.docs import DOCS_BASE_URL, get_docs_root, make_doc_url
 
 
 @pytest.fixture(autouse=True)
 def _clear_cache():
-    _find_docs_root.cache_clear()
+    get_docs_root.cache_clear()
     yield
-    _find_docs_root.cache_clear()
+    get_docs_root.cache_clear()
 
 
 def _make_docs_tree(root: Path) -> Path:
@@ -46,24 +40,23 @@ def test_sentinel_skips_shadowing_docs_dir(tmp_path: Path):
     assert get_docs_root(start) == real_docs
 
 
-def test_missing_docs_raises(tmp_path: Path):
+def test_missing_docs_returns_none(tmp_path: Path):
     start = tmp_path / "app" / "backend" / "util" / "docs.py"
     start.parent.mkdir(parents=True)
     start.touch()
-    with pytest.raises(FileNotFoundError):
-        get_docs_root(start)
+    assert get_docs_root(start) is None
 
 
-def test_or_none_returns_none_and_memoizes(tmp_path: Path):
+def test_negative_result_memoized(tmp_path: Path):
     start = tmp_path / "app" / "backend" / "util" / "docs.py"
     start.parent.mkdir(parents=True)
     start.touch()
-    assert get_docs_root_or_none(start) is None
-    assert _find_docs_root.cache_info().misses == 1
+    assert get_docs_root(start) is None
+    assert get_docs_root.cache_info().misses == 1
     # Negative result is cached — a second identical call must not re-walk.
-    assert get_docs_root_or_none(start) is None
-    assert _find_docs_root.cache_info().hits == 1
-    assert _find_docs_root.cache_info().misses == 1
+    assert get_docs_root(start) is None
+    assert get_docs_root.cache_info().hits == 1
+    assert get_docs_root.cache_info().misses == 1
 
 
 def test_make_doc_url_strips_extension_and_leading_slash():
@@ -93,8 +86,7 @@ def test_sentinel_rejects_platform_file(tmp_path: Path):
     start = tmp_path / "app" / "backend" / "util" / "docs.py"
     start.parent.mkdir(parents=True)
     start.touch()
-    with pytest.raises(FileNotFoundError):
-        get_docs_root(start)
+    assert get_docs_root(start) is None
 
 
 def test_make_doc_url_canonicalizes_underscores():

--- a/autogpt_platform/backend/backend/util/docs_test.py
+++ b/autogpt_platform/backend/backend/util/docs_test.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from backend.util.docs import (
+    DOCS_BASE_URL,
     _find_docs_root,
     get_docs_root,
     get_docs_root_or_none,
@@ -76,8 +77,6 @@ def test_make_doc_url_strips_extension_and_leading_slash():
 def test_docs_base_url_pins_live_host():
     """Guards against a silent revert to the dead docs.agpt.co host — the
     shape tests are all relative to this constant."""
-    from backend.util.docs import DOCS_BASE_URL
-
     assert DOCS_BASE_URL == "https://agpt.co/docs"
 
 

--- a/autogpt_platform/backend/backend/util/docs_test.py
+++ b/autogpt_platform/backend/backend/util/docs_test.py
@@ -96,3 +96,9 @@ def test_sentinel_rejects_platform_file(tmp_path: Path):
     start.touch()
     with pytest.raises(FileNotFoundError):
         get_docs_root(start)
+
+
+def test_make_doc_url_canonicalizes_underscores():
+    """The site's edge worker rewrites _ to - (cloudflare_worker.js);
+    verified live: platform/new-blocks renders, platform/new_blocks 404s."""
+    assert make_doc_url("platform/new_blocks.md").endswith("/docs/platform/new-blocks")

--- a/autogpt_platform/backend/backend/util/docs_test.py
+++ b/autogpt_platform/backend/backend/util/docs_test.py
@@ -75,6 +75,9 @@ def test_docs_base_url_pins_live_host():
 
 def test_make_doc_url_passthrough_without_extension():
     assert make_doc_url("a/b").endswith("/docs/a/b")
+    # Dots inside names are not extensions — only .md/.mdx strip.
+    assert make_doc_url("platform/v1.2").endswith("/docs/platform/v1.2")
+    assert make_doc_url("platform/v1.2-guide.md").endswith("/docs/platform/v1.2-guide")
 
 
 def test_sentinel_rejects_platform_file(tmp_path: Path):

--- a/autogpt_platform/backend/backend/util/docs_test.py
+++ b/autogpt_platform/backend/backend/util/docs_test.py
@@ -4,14 +4,19 @@ from pathlib import Path
 
 import pytest
 
-from backend.util.docs import get_docs_root
+from backend.util.docs import (
+    _find_docs_root,
+    get_docs_root,
+    get_docs_root_or_none,
+    make_doc_url,
+)
 
 
 @pytest.fixture(autouse=True)
 def _clear_cache():
-    get_docs_root.cache_clear()
+    _find_docs_root.cache_clear()
     yield
-    get_docs_root.cache_clear()
+    _find_docs_root.cache_clear()
 
 
 def _make_docs_tree(root: Path) -> Path:
@@ -46,3 +51,19 @@ def test_missing_docs_raises(tmp_path: Path):
     start.touch()
     with pytest.raises(FileNotFoundError):
         get_docs_root(start)
+
+
+def test_or_none_returns_none_and_memoizes(tmp_path: Path):
+    start = tmp_path / "app" / "backend" / "util" / "docs.py"
+    start.parent.mkdir(parents=True)
+    start.touch()
+    assert get_docs_root_or_none(start) is None
+    # Negative result is cached — a second call must not re-walk.
+    assert _find_docs_root.cache_info().hits >= 0
+    assert get_docs_root_or_none(start) is None
+    assert _find_docs_root.cache_info().hits >= 1
+
+
+def test_make_doc_url_keeps_extension_and_strips_leading_slash():
+    assert make_doc_url("a/b.md").endswith("/docs/a/b.md")
+    assert make_doc_url("/a/b.md") == make_doc_url("a/b.md")

--- a/autogpt_platform/backend/backend/util/docs_test.py
+++ b/autogpt_platform/backend/backend/util/docs_test.py
@@ -1,0 +1,48 @@
+"""Tests for the docs-root walk-up resolution."""
+
+from pathlib import Path
+
+import pytest
+
+from backend.util.docs import get_docs_root
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    get_docs_root.cache_clear()
+    yield
+    get_docs_root.cache_clear()
+
+
+def _make_docs_tree(root: Path) -> Path:
+    docs = root / "docs" / "platform"
+    docs.mkdir(parents=True)
+    return root / "docs"
+
+
+def test_walks_up_to_docs_root(tmp_path: Path):
+    docs = _make_docs_tree(tmp_path)
+    start = tmp_path / "app" / "backend" / "util" / "docs.py"
+    start.parent.mkdir(parents=True)
+    start.touch()
+    assert get_docs_root(start) == docs
+
+
+def test_sentinel_skips_shadowing_docs_dir(tmp_path: Path):
+    """A closer docs/ WITHOUT the platform sentinel must not shadow the
+    real documentation root further up."""
+    real_docs = _make_docs_tree(tmp_path)
+    shadow = tmp_path / "app" / "backend" / "docs"
+    shadow.mkdir(parents=True)
+    start = tmp_path / "app" / "backend" / "util" / "docs.py"
+    start.parent.mkdir(parents=True)
+    start.touch()
+    assert get_docs_root(start) == real_docs
+
+
+def test_missing_docs_raises(tmp_path: Path):
+    start = tmp_path / "app" / "backend" / "util" / "docs.py"
+    start.parent.mkdir(parents=True)
+    start.touch()
+    with pytest.raises(FileNotFoundError):
+        get_docs_root(start)

--- a/autogpt_platform/backend/backend/util/docs_test.py
+++ b/autogpt_platform/backend/backend/util/docs_test.py
@@ -64,6 +64,9 @@ def test_or_none_returns_none_and_memoizes(tmp_path: Path):
     assert _find_docs_root.cache_info().hits >= 1
 
 
-def test_make_doc_url_keeps_extension_and_strips_leading_slash():
-    assert make_doc_url("a/b.md").endswith("/docs/a/b.md")
+def test_make_doc_url_strips_extension_and_leading_slash():
+    """agpt.co serves rendered pages extension-less; the .md variant is a
+    soft-404 (HTTP 200 + "Page Not Found" body)."""
+    assert make_doc_url("a/b.md").endswith("/docs/a/b")
+    assert make_doc_url("a/b.mdx").endswith("/docs/a/b")
     assert make_doc_url("/a/b.md") == make_doc_url("a/b.md")

--- a/autogpt_platform/backend/backend/util/docs_test.py
+++ b/autogpt_platform/backend/backend/util/docs_test.py
@@ -58,10 +58,11 @@ def test_or_none_returns_none_and_memoizes(tmp_path: Path):
     start.parent.mkdir(parents=True)
     start.touch()
     assert get_docs_root_or_none(start) is None
-    # Negative result is cached — a second call must not re-walk.
-    assert _find_docs_root.cache_info().hits >= 0
+    assert _find_docs_root.cache_info().misses == 1
+    # Negative result is cached — a second identical call must not re-walk.
     assert get_docs_root_or_none(start) is None
-    assert _find_docs_root.cache_info().hits >= 1
+    assert _find_docs_root.cache_info().hits == 1
+    assert _find_docs_root.cache_info().misses == 1
 
 
 def test_make_doc_url_strips_extension_and_leading_slash():
@@ -70,3 +71,28 @@ def test_make_doc_url_strips_extension_and_leading_slash():
     assert make_doc_url("a/b.md").endswith("/docs/a/b")
     assert make_doc_url("a/b.mdx").endswith("/docs/a/b")
     assert make_doc_url("/a/b.md") == make_doc_url("a/b.md")
+
+
+def test_docs_base_url_pins_live_host():
+    """Guards against a silent revert to the dead docs.agpt.co host — the
+    shape tests are all relative to this constant."""
+    from backend.util.docs import DOCS_BASE_URL
+
+    assert DOCS_BASE_URL == "https://agpt.co/docs"
+
+
+def test_make_doc_url_passthrough_without_extension():
+    assert make_doc_url("a/b").endswith("/docs/a/b")
+
+
+def test_sentinel_rejects_platform_file(tmp_path: Path):
+    """docs/platform must be a DIRECTORY — a stray file must not satisfy
+    the sentinel."""
+    fake = tmp_path / "docs"
+    fake.mkdir()
+    (fake / "platform").touch()
+    start = tmp_path / "app" / "backend" / "util" / "docs.py"
+    start.parent.mkdir(parents=True)
+    start.touch()
+    with pytest.raises(FileNotFoundError):
+        get_docs_root(start)

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/tools/SearchDocs/helpers.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/tools/SearchDocs/helpers.test.ts
@@ -9,10 +9,13 @@ describe("toDocsUrl", () => {
     expect(toDocsUrl("a/b.mdx")).toBe("https://agpt.co/docs/a/b");
   });
 
-  it("only strips markdown extensions, not dots inside names", () => {
-    expect(toDocsUrl("platform/new_blocks")).toBe(
-      "https://agpt.co/docs/platform/new_blocks",
+  it("canonicalizes underscores to hyphens like the site's edge worker", () => {
+    expect(toDocsUrl("platform/new_blocks.md")).toBe(
+      "https://agpt.co/docs/platform/new-blocks",
     );
+  });
+
+  it("only strips markdown extensions, not dots inside names", () => {
     expect(toDocsUrl("platform/v1.2-guide.md")).toBe(
       "https://agpt.co/docs/platform/v1.2-guide",
     );

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/tools/SearchDocs/helpers.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/tools/SearchDocs/helpers.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { toDocsUrl } from "./helpers";
+
+describe("toDocsUrl", () => {
+  it("builds extension-less rendered-page URLs on the live host", () => {
+    expect(toDocsUrl("platform/block-sdk-guide.md")).toBe(
+      "https://agpt.co/docs/platform/block-sdk-guide",
+    );
+    expect(toDocsUrl("a/b.mdx")).toBe("https://agpt.co/docs/a/b");
+  });
+
+  it("only strips markdown extensions, not dots inside names", () => {
+    expect(toDocsUrl("platform/new_blocks")).toBe(
+      "https://agpt.co/docs/platform/new_blocks",
+    );
+    expect(toDocsUrl("platform/v1.2-guide.md")).toBe(
+      "https://agpt.co/docs/platform/v1.2-guide",
+    );
+  });
+});

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/tools/SearchDocs/helpers.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/tools/SearchDocs/helpers.tsx
@@ -209,7 +209,12 @@ export function AccordionIcon({ toolType }: { toolType: DocsToolType }) {
 
 export function toDocsUrl(path: string): string {
   // Mirrors backend.util.docs.make_doc_url: extension-less rendered-page
-  // path on agpt.co (the .md variant is a soft-404; docs.agpt.co is dead).
-  const clean = path.replace(/^\/+/, "").replace(/\.mdx?$/, "");
+  // path on agpt.co with underscores canonicalized to hyphens (the site's
+  // edge worker rewrites _ to -; the .md variant is a soft-404 and
+  // docs.agpt.co is dead).
+  const clean = path
+    .replace(/^\/+/, "")
+    .replace(/\.mdx?$/, "")
+    .replace(/_/g, "-");
   return `https://agpt.co/docs/${clean}`;
 }

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/tools/SearchDocs/helpers.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/tools/SearchDocs/helpers.tsx
@@ -208,8 +208,8 @@ export function AccordionIcon({ toolType }: { toolType: DocsToolType }) {
 }
 
 export function toDocsUrl(path: string): string {
-  const urlPath = path.includes(".")
-    ? path.slice(0, path.lastIndexOf("."))
-    : path;
-  return `https://docs.agpt.co/${urlPath}`;
+  // Mirrors backend.util.docs.make_doc_url: extension-less rendered-page
+  // path on agpt.co (the .md variant is a soft-404; docs.agpt.co is dead).
+  const clean = path.replace(/^\/+/, "").replace(/\.mdx?$/, "");
+  return `https://agpt.co/docs/${clean}`;
 }


### PR DESCRIPTION
### Why / What / How

**Why**: `get_doc_page` is broken in every environment (dev and cloud): each read returns "Documentation page not found" — including for paths `search_docs` itself just returned (4/4 failures observed in an AutoPilot test session). Both docs tools also still link to the dead `docs.agpt.co` site, which sent the copilot on doomed `web_fetch` attempts.

**What**: Fix the docs-root resolution with one shared, layout-agnostic helper; point `DOCS_BASE_URL` at the live `https://agpt.co/docs` site with the correct URL shape.

**How**: `get_doc_page._get_docs_root` climbed 8 parents from a file only 4 directories deep — landing at `~/code/docs` in dev and `/docs` in the container (docs are at `/app/docs`). The search indexer had its own, *correct* parent-chain, so the two could silently drift. New `backend/util/docs.get_docs_root()` walks up from the backend package until it finds a directory containing `docs/platform` (the `platform/` sentinel prevents an unrelated `docs/` folder — e.g. a future `backend/docs/` — from shadowing the real root), covering both the dev checkout and the container image. `get_doc_page` and the `DocumentationHandler` indexer now share it, so indexed paths and page reads always agree; a docs-less deployment gets a clean "docs unavailable" error. The docs site serves rendered pages at the **extension-less** repo path; the `.md` variant returns a soft-404 (“Page Not Found” body with HTTP 200, which fooled an earlier status-code-only curl check). Verified by body-grep across nav and non-nav pages, so `make_doc_url` strips `.md`/`.mdx` and canonicalizes `_`→`-` (the site's edge worker rewrites underscores — see `cloudflare_worker.js`; live-verified: `platform/new-blocks` renders, `platform/new_blocks` soft-404s). The frontend's `toDocsUrl` fallback (used when a search result carries no backend `doc_url`) is aligned to the same host and shape. Site-recategorized pages that can't be derived from the repo path are tracked in #13616. Finally, the server image now ships **markdown only**: `docs/` passes through a dedicated `docs-filter` build stage that strips all non-`.md`/`.mdx` content (images, scripts, anything untrusted) before the final COPY — addressing the docs-bundling scope concern from review.

### Changes 🏗️

- `backend/util/docs.py` (new): single cached `get_docs_root() -> Path | None` walk-up helper (`docs/platform` sentinel; memoizes the not-found outcome too) + shared `make_doc_url`
- `backend/Dockerfile`: `docs-filter` stage — only markdown ships in the server image
- `frontend .../SearchDocs/helpers.tsx`: `toDocsUrl` repointed off the dead host, mirrors `make_doc_url`
- `backend/copilot/tools/get_doc_page.py`: use shared helper; `docs_unavailable` error when docs aren't bundled; `DOCS_BASE_URL` → `https://agpt.co/docs`; `doc_url` uses the extension-less rendered-page path
- `backend/copilot/tools/search_docs.py`: same URL changes
- `backend/api/features/search/content_handlers.py`: `DocumentationHandler._get_docs_root` delegates to the shared helper
- Tests: root-resolution regression, hermetic happy-path on a tmp docs root (unconditional — guards the fix on docs-less environments), real-page fetch + URL shape (underscore-aware), not-found, unconditional traversal block, symlink-escape containment, directory-read, docs-less degradation across the indexer, negative-result memoization, URL-shape suites on both sides. Containment resolves once and all later access (exists/read) uses the validated resolved path.

### Checklist 📋

#### For code changes:

- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `get_doc_page_test.py` + `search_docs_test.py` + `util/docs_test.py` — 20 pass (incl. hermetic happy-path, traversal/symlink containment, docs-less degradation, URL canonicalization)
  - [x] `backend/api/features/search/content_handlers_test.py` — 32 pass
  - [x] Functional check: `get_doc_page("integrations/block-integrations/branching.md")` returns the page with `doc_url` `https://agpt.co/docs/integrations/block-integrations/branching` (body-verified rendered page; the `.md` variant is a soft-404)



