### PR TITLE
feat(backend/db): add LLM model registry schema

### DIFF
--- a/autogpt_platform/backend/migrations/20260717000000_add_llm_registry/migration.sql
+++ b/autogpt_platform/backend/migrations/20260717000000_add_llm_registry/migration.sql
@@ -1,0 +1,208 @@
+-- CreateEnum
+CREATE TYPE "LlmCostUnit" AS ENUM ('RUN', 'TOKENS');
+
+-- CreateEnum
+CREATE TYPE "LlmCatalogSource" AS ENUM ('SEED', 'REMOTE', 'LOCAL');
+
+-- CreateEnum
+CREATE TYPE "LlmModelKind" AS ENUM ('CHAT');
+
+-- CreateEnum
+CREATE TYPE "LlmModelVisibility" AS ENUM ('GA', 'EMPLOYEES', 'ADMINS', 'HIDDEN');
+
+-- CreateTable
+CREATE TABLE "LlmProvider" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "name" TEXT NOT NULL,
+    "displayName" TEXT NOT NULL,
+    "description" TEXT,
+    "source" "LlmCatalogSource" NOT NULL DEFAULT 'SEED',
+    "metadata" JSONB NOT NULL DEFAULT '{}',
+
+    CONSTRAINT "LlmProvider_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "LlmModel" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "slug" TEXT NOT NULL,
+    "displayName" TEXT NOT NULL,
+    "description" TEXT,
+    "providerId" TEXT NOT NULL,
+    "creatorId" TEXT,
+    "kind" "LlmModelKind" NOT NULL DEFAULT 'CHAT',
+    "contextWindow" INTEGER NOT NULL,
+    "maxOutputTokens" INTEGER,
+    "priceTier" INTEGER NOT NULL DEFAULT 1,
+    "isEnabled" BOOLEAN NOT NULL DEFAULT true,
+    "isRecommended" BOOLEAN NOT NULL DEFAULT false,
+    "visibility" "LlmModelVisibility" NOT NULL DEFAULT 'GA',
+    "minSubscriptionTier" "SubscriptionTier",
+    "source" "LlmCatalogSource" NOT NULL DEFAULT 'SEED',
+    "catalogRemovedAt" TIMESTAMP(3),
+    "fallbackModelSlug" TEXT,
+    "supportsTools" BOOLEAN NOT NULL DEFAULT false,
+    "supportsJsonOutput" BOOLEAN NOT NULL DEFAULT false,
+    "supportsReasoning" BOOLEAN NOT NULL DEFAULT false,
+    "supportsParallelToolCalls" BOOLEAN NOT NULL DEFAULT false,
+    "capabilities" JSONB NOT NULL DEFAULT '{}',
+    "metadata" JSONB NOT NULL DEFAULT '{}',
+
+    CONSTRAINT "LlmModel_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "LlmModelCost" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "unit" "LlmCostUnit" NOT NULL DEFAULT 'RUN',
+    "creditCost" INTEGER NOT NULL,
+    "credentialProvider" TEXT NOT NULL,
+    "credentialId" TEXT,
+    "credentialType" TEXT,
+    "currency" TEXT,
+    "metadata" JSONB NOT NULL DEFAULT '{}',
+    "llmModelId" TEXT NOT NULL,
+
+    CONSTRAINT "LlmModelCost_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "LlmModelCreator" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "name" TEXT NOT NULL,
+    "displayName" TEXT NOT NULL,
+    "description" TEXT,
+    "websiteUrl" TEXT,
+    "logoUrl" TEXT,
+    "source" "LlmCatalogSource" NOT NULL DEFAULT 'SEED',
+    "metadata" JSONB NOT NULL DEFAULT '{}',
+
+    CONSTRAINT "LlmModelCreator_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "LlmModelRoute" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "surface" TEXT NOT NULL,
+    "mode" TEXT NOT NULL,
+    "tier" TEXT NOT NULL,
+    "modelSlug" TEXT NOT NULL,
+
+    CONSTRAINT "LlmModelRoute_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "LlmModelMigration" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "sourceModelSlug" TEXT NOT NULL,
+    "targetModelSlug" TEXT NOT NULL,
+    "reason" TEXT,
+    "migratedNodeIds" JSONB NOT NULL DEFAULT '[]',
+    "nodeCount" INTEGER NOT NULL,
+    "customCreditCost" INTEGER,
+    "isReverted" BOOLEAN NOT NULL DEFAULT false,
+    "revertedAt" TIMESTAMP(3),
+
+    CONSTRAINT "LlmModelMigration_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "LlmCatalogState" (
+    "id" TEXT NOT NULL DEFAULT 'singleton',
+    "schemaVersion" INTEGER NOT NULL,
+    "contentHash" TEXT,
+    "lastImportSource" "LlmCatalogSource",
+    "lastImportedAt" TIMESTAMP(3),
+    "lastRemoteSyncAt" TIMESTAMP(3),
+    "lastRemoteSuccessAt" TIMESTAMP(3),
+    "sourceUrl" TEXT,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "LlmCatalogState_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "LlmProvider_name_key" ON "LlmProvider"("name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "LlmModel_slug_key" ON "LlmModel"("slug");
+
+-- CreateIndex
+CREATE INDEX "LlmModel_providerId_isEnabled_idx" ON "LlmModel"("providerId", "isEnabled");
+
+-- CreateIndex
+CREATE INDEX "LlmModel_creatorId_idx" ON "LlmModel"("creatorId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "LlmModelCreator_name_key" ON "LlmModelCreator"("name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "LlmModelRoute_surface_mode_tier_key" ON "LlmModelRoute"("surface", "mode", "tier");
+
+-- CreateIndex
+CREATE INDEX "LlmModelMigration_targetModelSlug_idx" ON "LlmModelMigration"("targetModelSlug");
+
+-- CreateIndex
+CREATE INDEX "LlmModelMigration_sourceModelSlug_isReverted_idx" ON "LlmModelMigration"("sourceModelSlug", "isReverted");
+
+-- AddForeignKey
+ALTER TABLE "LlmModel" ADD CONSTRAINT "LlmModel_providerId_fkey" FOREIGN KEY ("providerId") REFERENCES "LlmProvider"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "LlmModel" ADD CONSTRAINT "LlmModel_creatorId_fkey" FOREIGN KEY ("creatorId") REFERENCES "LlmModelCreator"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "LlmModel" ADD CONSTRAINT "LlmModel_fallbackModelSlug_fkey" FOREIGN KEY ("fallbackModelSlug") REFERENCES "LlmModel"("slug") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "LlmModelCost" ADD CONSTRAINT "LlmModelCost_llmModelId_fkey" FOREIGN KEY ("llmModelId") REFERENCES "LlmModel"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "LlmModelRoute" ADD CONSTRAINT "LlmModelRoute_modelSlug_fkey" FOREIGN KEY ("modelSlug") REFERENCES "LlmModel"("slug") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "LlmModelMigration" ADD CONSTRAINT "LlmModelMigration_sourceModelSlug_fkey" FOREIGN KEY ("sourceModelSlug") REFERENCES "LlmModel"("slug") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "LlmModelMigration" ADD CONSTRAINT "LlmModelMigration_targetModelSlug_fkey" FOREIGN KEY ("targetModelSlug") REFERENCES "LlmModel"("slug") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+
+-- ============================================================================
+-- Hand-written section (not expressible in Prisma schema language)
+-- ============================================================================
+
+-- CreateIndex (partial unique for default costs - no specific credential)
+CREATE UNIQUE INDEX "LlmModelCost_default_cost_key" ON "LlmModelCost"("llmModelId", "credentialProvider", "unit") WHERE "credentialId" IS NULL;
+
+-- CreateIndex (partial unique for credential-specific costs)
+CREATE UNIQUE INDEX "LlmModelCost_credential_cost_key" ON "LlmModelCost"("llmModelId", "credentialProvider", "credentialId", "unit") WHERE "credentialId" IS NOT NULL;
+
+-- CreateIndex (partial unique to prevent multiple active migrations per source)
+CREATE UNIQUE INDEX "LlmModelMigration_active_source_key" ON "LlmModelMigration"("sourceModelSlug") WHERE "isReverted" = false;
+
+-- AddCheckConstraints (enforce data integrity)
+ALTER TABLE "LlmModel"
+    ADD CONSTRAINT "LlmModel_priceTier_check" CHECK ("priceTier" BETWEEN 1 AND 3);
+
+ALTER TABLE "LlmModelCost"
+    ADD CONSTRAINT "LlmModelCost_creditCost_check" CHECK ("creditCost" >= 0);
+
+ALTER TABLE "LlmModelMigration"
+    ADD CONSTRAINT "LlmModelMigration_nodeCount_check" CHECK ("nodeCount" >= 0),
+    ADD CONSTRAINT "LlmModelMigration_customCreditCost_check" CHECK ("customCreditCost" IS NULL OR "customCreditCost" >= 0);
+
+-- Singleton guard: LlmCatalogState must never grow past one row.
+ALTER TABLE "LlmCatalogState"
+    ADD CONSTRAINT "LlmCatalogState_singleton_check" CHECK ("id" = 'singleton');

--- a/autogpt_platform/backend/schema.prisma
+++ b/autogpt_platform/backend/schema.prisma
@@ -2194,3 +2194,223 @@ model BotInstall {
   @@unique([platform, platformServerId])
   @@index([platform, revokedAt])
 }
+
+enum LlmCostUnit {
+  RUN
+  TOKENS
+}
+
+// Who last wrote a catalog row. LOCAL rows are admin-owned: the catalog
+// importer never updates or disables them (enforced via `source != LOCAL`
+// guards inside importer UPDATE WHERE clauses).
+enum LlmCatalogSource {
+  SEED // bundled catalog.json import
+  REMOTE // remote catalog sync (self-hosted installs)
+  LOCAL // admin write — importer keeps hands off
+}
+
+enum LlmModelKind {
+  CHAT
+}
+
+// Who can SEE the model in pickers/catalog. Orthogonal to isEnabled:
+// isEnabled=false is the kill switch (never serves, even when routed via
+// LaunchDarkly); visibility=HIDDEN serves when explicitly routed but is
+// never shown — the pre-launch testing state.
+enum LlmModelVisibility {
+  GA
+  EMPLOYEES
+  ADMINS
+  HIDDEN
+}
+
+model LlmProvider {
+  id        String   @id @default(uuid())
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  name        String  @unique
+  displayName String
+  description String?
+
+  source LlmCatalogSource @default(SEED)
+
+  metadata Json @default("{}")
+
+  Models LlmModel[]
+}
+
+model LlmModel {
+  id        String   @id @default(uuid())
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  slug        String  @unique
+  displayName String
+  description String?
+
+  providerId String
+  Provider   LlmProvider @relation(fields: [providerId], references: [id], onDelete: Restrict)
+
+  // Creator is the organization that created/trained the model (e.g., OpenAI, Meta)
+  // This is distinct from the provider who hosts/serves the model (e.g., OpenRouter)
+  creatorId String?
+  Creator   LlmModelCreator? @relation(fields: [creatorId], references: [id], onDelete: SetNull)
+
+  kind            LlmModelKind @default(CHAT)
+  contextWindow   Int
+  maxOutputTokens Int?
+  priceTier       Int          @default(1) // 1=cheapest, 2=medium, 3=expensive (DB constraint: 1-3)
+  isEnabled       Boolean      @default(true)
+  isRecommended   Boolean      @default(false)
+
+  visibility          LlmModelVisibility @default(GA)
+  // Null = available on every subscription tier. Enforcement lands with the
+  // registry-driven picker; until then this is admin-surfaced metadata.
+  minSubscriptionTier SubscriptionTier?
+
+  source           LlmCatalogSource @default(SEED)
+  // Set when a non-LOCAL row disappears from the imported catalog (the
+  // importer disables it at the same time); cleared if it reappears.
+  // Distinguishes "catalog removed it" from "admin disabled it".
+  catalogRemovedAt DateTime?
+
+  // Standing replacement pointer: pre-fills the disable-with-replacement
+  // flow, and is the hook for future automatic runtime failover.
+  fallbackModelSlug String?
+  FallbackModel     LlmModel?  @relation("LlmModelFallback", fields: [fallbackModelSlug], references: [slug], onDelete: SetNull, onUpdate: Cascade)
+  FallbackFor       LlmModel[] @relation("LlmModelFallback")
+
+  // Model-specific capabilities
+  // These vary per model even within the same provider (e.g., Hugging Face)
+  // Default to false for safety - partially-seeded rows should not be assumed capable
+  supportsTools             Boolean @default(false)
+  supportsJsonOutput        Boolean @default(false)
+  supportsReasoning         Boolean @default(false)
+  supportsParallelToolCalls Boolean @default(false)
+
+  capabilities Json @default("{}")
+  metadata     Json @default("{}")
+
+  Costs            LlmModelCost[]
+  Routes           LlmModelRoute[]
+  SourceMigrations LlmModelMigration[] @relation("SourceMigrations")
+  TargetMigrations LlmModelMigration[] @relation("TargetMigrations")
+
+  @@index([providerId, isEnabled])
+  @@index([creatorId])
+}
+
+model LlmModelCost {
+  id        String      @id @default(uuid())
+  createdAt DateTime    @default(now())
+  updatedAt DateTime    @updatedAt
+  unit      LlmCostUnit @default(RUN)
+
+  creditCost Int // DB constraint: >= 0
+
+  // Provider identifier (e.g., "openai", "anthropic", "openrouter")
+  // Used to determine which credential system provides the API key.
+  // Allows different pricing for:
+  // - Default provider costs (WHERE credentialId IS NULL)
+  // - User's own API key costs (WHERE credentialId IS NOT NULL)
+  credentialProvider String
+  credentialId       String?
+  credentialType     String?
+  currency           String?
+
+  metadata Json @default("{}")
+
+  llmModelId String
+  Model      LlmModel @relation(fields: [llmModelId], references: [id], onDelete: Cascade)
+
+  // Note: Unique constraints are implemented as partial indexes in migration SQL:
+  // - One for default costs (WHERE credentialId IS NULL)
+  // - One for credential-specific costs (WHERE credentialId IS NOT NULL)
+  // This allows both provider-level defaults and credential-specific overrides
+}
+
+model LlmModelCreator {
+  id        String   @id @default(uuid())
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  name        String  @unique // e.g., "openai", "anthropic", "meta"
+  displayName String // e.g., "OpenAI", "Anthropic", "Meta"
+  description String?
+  websiteUrl  String?
+  logoUrl     String?
+
+  source LlmCatalogSource @default(SEED)
+
+  metadata Json @default("{}")
+
+  Models LlmModel[]
+}
+
+// One row per (surface, mode, tier) routing cell — e.g. ("copilot",
+// "thinking", "standard") -> model slug. Admin-set config layer: resolution
+// order is LaunchDarkly slug flag -> this table -> env default.
+model LlmModelRoute {
+  id        String   @id @default(uuid())
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  surface String // e.g. "copilot"
+  mode    String // e.g. "fast" | "thinking"
+  tier    String // e.g. "standard" | "advanced"
+
+  modelSlug String
+  Model     LlmModel @relation(fields: [modelSlug], references: [slug], onDelete: Restrict, onUpdate: Cascade)
+
+  @@unique([surface, mode, tier])
+}
+
+model LlmModelMigration {
+  id        String   @id @default(uuid())
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  sourceModelSlug String // The original model that was disabled
+  targetModelSlug String // The model workflows were migrated to
+  reason          String? // Why the migration happened (e.g., "Provider outage")
+
+  // FK constraints ensure slugs reference valid models
+  SourceModel LlmModel @relation("SourceMigrations", fields: [sourceModelSlug], references: [slug], onDelete: Restrict, onUpdate: Cascade)
+  TargetModel LlmModel @relation("TargetMigrations", fields: [targetModelSlug], references: [slug], onDelete: Restrict, onUpdate: Cascade)
+
+  // Track affected nodes as JSON array of node IDs
+  migratedNodeIds Json @default("[]")
+  nodeCount       Int // Number of nodes migrated (DB constraint: >= 0)
+
+  // Custom pricing override for migrated workflows during the migration
+  // period (e.g., keep the source model's pricing to avoid billing
+  // surprises). Billing integration is deliberately deferred: applied when
+  // DB-driven costs land (Phase B), until then informational.
+  customCreditCost Int? // DB constraint: >= 0 when not null
+
+  // Revert tracking
+  isReverted Boolean   @default(false)
+  revertedAt DateTime?
+
+  // Note: Partial unique index in migration SQL prevents multiple active migrations per source:
+  // UNIQUE (sourceModelSlug) WHERE isReverted = false
+  @@index([targetModelSlug])
+  @@index([sourceModelSlug, isReverted])
+}
+
+// Singleton observability/state row for the catalog importer + remote sync.
+model LlmCatalogState {
+  id String @id @default("singleton")
+
+  schemaVersion    Int
+  contentHash      String? // sha256 of last successfully imported canonical payload
+  lastImportSource LlmCatalogSource?
+  lastImportedAt   DateTime?
+
+  lastRemoteSyncAt    DateTime? // last attempt
+  lastRemoteSuccessAt DateTime?
+  sourceUrl           String?
+
+  updatedAt DateTime @updatedAt
+}


### PR DESCRIPTION
## Why

Adding an LLM model today is a code change in 3+ places plus a deploy, copilot routing lives in a raw LaunchDarkly JSON flag nothing validates (see #13596's dead rates entry), and self-hosted installs only get new models by pulling code. This restarts @Bentlybro's LLM registry stack (#12357 et al. — thanks for the groundwork, co-authored accordingly) as a full re-cut onto current dev: **part 1 of 9**, schema only.

## What

4 enums + 7 tables: `LlmProvider`, `LlmModel`, `LlmModelCost`, `LlmModelCreator`, `LlmModelMigration`, `LlmModelRoute`, `LlmCatalogState`. Nothing reads or writes them yet — this PR is dormant infrastructure so the stack lands in reviewable slices.

Deltas vs the original #12357 design:
- **`source` tracking** (`SEED`/`REMOTE`/`LOCAL`) on provider/model/creator — the upcoming idempotent catalog importer upserts non-LOCAL rows and never touches admin-owned (LOCAL) ones
- **`isEnabled` / `visibility` split** — `isEnabled=false` is the kill switch (never serves, even when LD routes to it); `visibility=HIDDEN` serves when explicitly routed but never shows in pickers/catalog (pre-launch testing state); plus `EMPLOYEES`/`ADMINS` audiences
- **`LlmModelRoute`** — `(surface, mode, tier)` → model cells: the admin-set config layer that will sit under the existing `copilot-model-routing` LD flag
- **`LlmCatalogState`** singleton — importer/sync observability + content-hash fast-path
- `kind` (CHAT), `minSubscriptionTier` (nullable, enforcement later), `fallbackModelSlug` self-relation (pre-fills disable-with-replacement; future failover hook), `catalogRemovedAt`
- **Dropped** `LlmProvider.defaultCredential*` — provider credentials are deferred until vault work; keys keep coming from settings

## How

Schema block re-cut from `origin/feat/llm-registry-schema` with the deltas above; migration SQL generated via `prisma migrate diff` + hand-written tail for what Prisma can't express (partial unique indexes on `LlmModelCost`, active-migration partial unique, CHECK constraints, singleton guard).

The original one-shot seed migration is intentionally NOT carried over — seeding becomes an idempotent startup importer (part 3) fed by a bundled catalog generated from today's `MODEL_METADATA`.

⚠️ If you ever applied the old branch's `20260310*` migrations locally, your `_prisma_migrations` table diverges — `poetry run prisma migrate reset` is needed.

## Verification

- `prisma validate` + `prisma format` clean; client generation succeeds
- Migration applied to a scratch Postgres 16: all 7 tables created; CHECK constraints and partial unique indexes verified; `LlmCatalogState` singleton guard rejects non-singleton rows

## Checklist
- [x] Migration verified against a clean database
- [x] No user-data paths touched (schema-only, no reads/writes exist yet)
- [x] Out-of-scope changes: none
