### PR TITLE
feat(backend): add LLM registry read cache with pub/sub refresh

### DIFF
--- a/autogpt_platform/backend/backend/api/rest_api.py
+++ b/autogpt_platform/backend/backend/api/rest_api.py
@@ -1,3 +1,4 @@
+import asyncio
 import contextlib
 import logging
 import platform
@@ -52,6 +53,7 @@ import backend.api.features.workspace.routes as team_routes
 import backend.data.block
 import backend.data.db
 import backend.data.graph
+import backend.data.llm_registry
 import backend.data.org_migration
 import backend.data.redis_client
 import backend.data.user
@@ -158,8 +160,29 @@ async def lifespan_context(app: fastapi.FastAPI):
     await backend.integrations.webhooks.utils.migrate_legacy_triggered_graphs()
     await backend.data.org_migration.run_migration()
 
+    # Load the LLM registry L1 cache and keep it fresh across pods. Failure is
+    # non-fatal: nothing at runtime depends on the registry yet, and an empty
+    # registry degrades to existing hardcoded behavior.
+    try:
+        await backend.data.llm_registry.refresh_llm_registry()
+    except Exception:
+        logger.warning("LLM registry initial refresh failed", exc_info=True)
+    llm_registry_refresh_task = asyncio.create_task(
+        backend.data.llm_registry.subscribe_to_registry_refresh(
+            backend.data.llm_registry.refresh_llm_registry
+        )
+    )
+
     with launch_darkly_context():
         yield
+
+    llm_registry_refresh_task.cancel()
+    try:
+        await llm_registry_refresh_task
+    except asyncio.CancelledError:
+        pass
+    except Exception:
+        logger.warning("LLM registry refresh task shutdown failed", exc_info=True)
 
     try:
         await shutdown_cloud_storage_handler()

--- a/autogpt_platform/backend/backend/data/llm_registry/__init__.py
+++ b/autogpt_platform/backend/backend/data/llm_registry/__init__.py
@@ -1,0 +1,42 @@
+"""LLM Registry - Dynamic model management system."""
+
+from .notifications import (
+    publish_registry_refresh_notification,
+    subscribe_to_registry_refresh,
+)
+from .registry import (
+    RegistryModel,
+    RegistryModelCost,
+    RegistryModelCreator,
+    RegistryModelMetadata,
+    clear_registry_cache,
+    get_all_model_slugs_for_validation,
+    get_all_models,
+    get_default_model_slug,
+    get_enabled_models,
+    get_model,
+    get_route,
+    get_schema_options,
+    refresh_llm_registry,
+)
+
+__all__ = [
+    # Models
+    "RegistryModel",
+    "RegistryModelCost",
+    "RegistryModelCreator",
+    "RegistryModelMetadata",
+    # Cache management
+    "clear_registry_cache",
+    "publish_registry_refresh_notification",
+    "subscribe_to_registry_refresh",
+    # Read functions
+    "refresh_llm_registry",
+    "get_model",
+    "get_all_models",
+    "get_enabled_models",
+    "get_route",
+    "get_schema_options",
+    "get_default_model_slug",
+    "get_all_model_slugs_for_validation",
+]

--- a/autogpt_platform/backend/backend/data/llm_registry/notifications.py
+++ b/autogpt_platform/backend/backend/data/llm_registry/notifications.py
@@ -1,0 +1,84 @@
+"""Pub/sub notifications for LLM registry cross-process synchronisation.
+
+Uses sharded pub/sub (SPUBLISH/SSUBSCRIBE) — prod Redis runs in cluster mode,
+where classic pub/sub broadcasts to every node. Mirrors the pattern in
+``backend.data.event_bus.AsyncRedisEventBus``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Awaitable, Callable
+
+from backend.data.redis_client import connect_sharded_pubsub_async, get_redis_async
+
+logger = logging.getLogger(__name__)
+
+REGISTRY_REFRESH_CHANNEL = "llm_registry:refresh"
+
+
+async def publish_registry_refresh_notification() -> None:
+    """Publish a refresh signal so all other workers reload their in-process cache."""
+    try:
+        cluster = await get_redis_async()
+        # redis-py 6.x async cluster has no spublish(); execute_command handles MOVED.
+        await cluster.execute_command("SPUBLISH", REGISTRY_REFRESH_CHANNEL, "refresh")
+        logger.debug("Published LLM registry refresh notification")
+    except Exception as e:
+        logger.warning("Failed to publish registry refresh notification: %s", e)
+
+
+async def subscribe_to_registry_refresh(
+    on_refresh: Callable[[], Awaitable[None]],
+) -> None:
+    """Listen for registry refresh signals and call on_refresh each time one arrives.
+
+    Designed to run as a long-lived background asyncio.Task.  Automatically
+    reconnects if the Redis connection drops.
+
+    Args:
+        on_refresh: Async callable invoked on each refresh signal.
+                    Typically ``llm_registry.refresh_llm_registry``.
+    """
+    while True:
+        client = None
+        pubsub = None
+        try:
+            # Sharded pub/sub only delivers on the keyslot-owning shard, so pin
+            # a plain AsyncRedis to that node (see event_bus.listen_events).
+            client = await connect_sharded_pubsub_async(REGISTRY_REFRESH_CHANNEL)
+            pubsub = client.pubsub()
+            await pubsub.execute_command("SSUBSCRIBE", REGISTRY_REFRESH_CHANNEL)
+            # redis-py 6.x async PubSub.listen() exits when ``channels`` is
+            # empty; raw SSUBSCRIBE doesn't populate it, so do it ourselves.
+            pubsub.channels[REGISTRY_REFRESH_CHANNEL] = None  # type: ignore[index]
+            logger.info("Subscribed to LLM registry refresh channel")
+
+            async for message in pubsub.listen():
+                if message and message.get("type") in ("message", "smessage"):
+                    logger.debug("LLM registry refresh signal received")
+                    try:
+                        await on_refresh()
+                    except Exception as e:
+                        logger.error("Error in registry on_refresh callback: %s", e)
+
+        except asyncio.CancelledError:
+            logger.info("LLM registry subscription task cancelled")
+            break
+        except Exception as e:
+            logger.warning("LLM registry subscription error: %s. Retrying in 5s...", e)
+            await asyncio.sleep(5)
+        finally:
+            if pubsub is not None:
+                try:
+                    await pubsub.aclose()
+                except Exception:
+                    logger.warning("Failed to close PubSub connection", exc_info=True)
+            if client is not None:
+                try:
+                    await client.aclose()
+                except Exception:
+                    logger.warning(
+                        "Failed to close shard-pinned Redis connection", exc_info=True
+                    )

--- a/autogpt_platform/backend/backend/data/llm_registry/notifications_test.py
+++ b/autogpt_platform/backend/backend/data/llm_registry/notifications_test.py
@@ -1,0 +1,202 @@
+"""Tests for LLM registry pub/sub notifications (notifications.py).
+
+Covers:
+- publish_registry_refresh_notification: SPUBLISH happy path and Redis error
+  swallowed
+- subscribe_to_registry_refresh: smessage triggers on_refresh, handshake
+  types ignored, CancelledError stops the loop, connection errors trigger
+  reconnect, connections are closed on exit
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from backend.data.llm_registry.notifications import (
+    REGISTRY_REFRESH_CHANNEL,
+    publish_registry_refresh_notification,
+    subscribe_to_registry_refresh,
+)
+
+# ---------------------------------------------------------------------------
+# publish_registry_refresh_notification
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_publish_spublishes_on_registry_channel(mocker):
+    """publish_registry_refresh_notification SPUBLISHes on the registry channel."""
+    mock_cluster = AsyncMock()
+    mocker.patch(
+        "backend.data.llm_registry.notifications.get_redis_async",
+        return_value=mock_cluster,
+    )
+
+    await publish_registry_refresh_notification()
+
+    mock_cluster.execute_command.assert_called_once_with(
+        "SPUBLISH", REGISTRY_REFRESH_CHANNEL, "refresh"
+    )
+
+
+@pytest.mark.asyncio
+async def test_publish_swallows_redis_error(mocker):
+    """Redis errors during publish are caught and logged, not raised."""
+    mocker.patch(
+        "backend.data.llm_registry.notifications.get_redis_async",
+        side_effect=ConnectionError("Redis unavailable"),
+    )
+
+    # Should not raise — errors are swallowed to avoid crashing the admin op
+    await publish_registry_refresh_notification()
+
+
+# ---------------------------------------------------------------------------
+# subscribe_to_registry_refresh
+# ---------------------------------------------------------------------------
+
+
+def _make_pubsub(messages: list) -> MagicMock:
+    """Build a mock sharded pubsub that yields messages then cancels the loop."""
+    pubsub = MagicMock()
+    pubsub.execute_command = AsyncMock()  # SSUBSCRIBE
+    pubsub.channels = {}
+    pubsub.aclose = AsyncMock()
+
+    async def listen():
+        for m in messages:
+            yield m
+        raise asyncio.CancelledError()
+
+    pubsub.listen = listen
+    return pubsub
+
+
+def _make_client(pubsub: MagicMock) -> MagicMock:
+    client = MagicMock()
+    client.pubsub.return_value = pubsub
+    client.aclose = AsyncMock()
+    return client
+
+
+def _make_message(msg_type: str = "smessage"):
+    return {"type": msg_type, "channel": REGISTRY_REFRESH_CHANNEL, "data": "refresh"}
+
+
+@pytest.mark.asyncio
+async def test_subscribe_calls_on_refresh_for_valid_message(mocker):
+    """An smessage on the registry channel triggers the on_refresh callback."""
+    on_refresh = AsyncMock()
+    pubsub = _make_pubsub([_make_message()])
+    client = _make_client(pubsub)
+    mocker.patch(
+        "backend.data.llm_registry.notifications.connect_sharded_pubsub_async",
+        return_value=client,
+    )
+
+    await subscribe_to_registry_refresh(on_refresh)
+
+    on_refresh.assert_called_once()
+    pubsub.execute_command.assert_called_once_with(
+        "SSUBSCRIBE", REGISTRY_REFRESH_CHANNEL
+    )
+    pubsub.aclose.assert_called_once()
+    client.aclose.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_subscribe_ignores_handshake_types(mocker):
+    """ssubscribe/subscribe handshake messages do not trigger on_refresh."""
+    on_refresh = AsyncMock()
+    pubsub = _make_pubsub(
+        [
+            _make_message(msg_type="ssubscribe"),
+            _make_message(msg_type="subscribe"),
+            None,
+        ]
+    )
+    client = _make_client(pubsub)
+    mocker.patch(
+        "backend.data.llm_registry.notifications.connect_sharded_pubsub_async",
+        return_value=client,
+    )
+
+    await subscribe_to_registry_refresh(on_refresh)
+
+    on_refresh.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_subscribe_processes_multiple_messages(mocker):
+    """Multiple valid messages each trigger on_refresh."""
+    on_refresh = AsyncMock()
+    pubsub = _make_pubsub([_make_message(), _make_message(), _make_message()])
+    client = _make_client(pubsub)
+    mocker.patch(
+        "backend.data.llm_registry.notifications.connect_sharded_pubsub_async",
+        return_value=client,
+    )
+
+    await subscribe_to_registry_refresh(on_refresh)
+
+    assert on_refresh.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_subscribe_on_refresh_error_does_not_kill_loop(mocker):
+    """An exception inside on_refresh is logged; later messages still process."""
+    on_refresh = AsyncMock(side_effect=[RuntimeError("boom"), None])
+    pubsub = _make_pubsub([_make_message(), _make_message()])
+    client = _make_client(pubsub)
+    mocker.patch(
+        "backend.data.llm_registry.notifications.connect_sharded_pubsub_async",
+        return_value=client,
+    )
+
+    await subscribe_to_registry_refresh(on_refresh)
+
+    assert on_refresh.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_subscribe_cancelled_during_subscribe_stops_loop(mocker):
+    """CancelledError during SSUBSCRIBE returns cleanly and closes connections."""
+    on_refresh = AsyncMock()
+    pubsub = _make_pubsub([])
+    pubsub.execute_command = AsyncMock(side_effect=asyncio.CancelledError())
+    client = _make_client(pubsub)
+    mocker.patch(
+        "backend.data.llm_registry.notifications.connect_sharded_pubsub_async",
+        return_value=client,
+    )
+
+    await subscribe_to_registry_refresh(on_refresh)
+
+    on_refresh.assert_not_called()
+    pubsub.aclose.assert_called_once()
+    client.aclose.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_subscribe_reconnects_after_connection_error(mocker):
+    """A connection error on the first attempt triggers a reconnect attempt."""
+    on_refresh = AsyncMock()
+    good_pubsub = _make_pubsub([_make_message()])
+    good_client = _make_client(good_pubsub)
+
+    mock_connect = mocker.patch(
+        "backend.data.llm_registry.notifications.connect_sharded_pubsub_async",
+        side_effect=[ConnectionError("Redis down"), good_client],
+    )
+    mock_sleep = mocker.patch(
+        "backend.data.llm_registry.notifications.asyncio.sleep", new=AsyncMock()
+    )
+
+    await subscribe_to_registry_refresh(on_refresh)
+
+    mock_sleep.assert_called_once_with(5)
+    assert mock_connect.call_count == 2
+    on_refresh.assert_called_once()

--- a/autogpt_platform/backend/backend/data/llm_registry/registry.py
+++ b/autogpt_platform/backend/backend/data/llm_registry/registry.py
@@ -1,0 +1,315 @@
+"""Core LLM registry implementation for managing models dynamically."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime
+from typing import Any, Literal
+
+import prisma.models
+from pydantic import BaseModel, ConfigDict
+
+from backend.util.cache import cached
+
+logger = logging.getLogger(__name__)
+
+
+class RegistryModelMetadata(BaseModel):
+    """Model facts in the shape block schemas expect.
+
+    Deliberately a standalone pydantic model rather than reusing the
+    ``ModelMetadata`` NamedTuple from ``backend.blocks.llm`` — the registry
+    must not couple to the hardcoded enum module it will eventually replace,
+    and NamedTuples serialize as JSON arrays, which is wrong for API payloads.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    provider: str
+    context_window: int
+    max_output_tokens: int | None
+    display_name: str
+    provider_name: str
+    creator_name: str
+    price_tier: Literal[1, 2, 3]
+
+
+class RegistryModelCost(BaseModel):
+    """Cost configuration for an LLM model."""
+
+    model_config = ConfigDict(frozen=True)
+
+    unit: str  # "RUN" or "TOKENS"
+    credit_cost: int
+    credential_provider: str
+    credential_id: str | None = None
+    credential_type: str | None = None
+    currency: str | None = None
+    metadata: dict[str, Any] = {}
+
+
+class RegistryModelCreator(BaseModel):
+    """Creator information for an LLM model."""
+
+    model_config = ConfigDict(frozen=True)
+
+    id: str
+    name: str
+    display_name: str
+    description: str | None = None
+    website_url: str | None = None
+    logo_url: str | None = None
+
+
+class RegistryModel(BaseModel):
+    """Represents a model in the LLM registry."""
+
+    model_config = ConfigDict(frozen=True)
+
+    slug: str
+    display_name: str
+    description: str | None = None
+    metadata: RegistryModelMetadata
+    capabilities: dict[str, Any] = {}
+    extra_metadata: dict[str, Any] = {}
+    provider_display_name: str
+    is_enabled: bool
+    is_recommended: bool = False
+    costs: tuple[RegistryModelCost, ...] = ()
+    creator: RegistryModelCreator | None = None
+
+    # isEnabled is the kill switch (never serves when false); visibility only
+    # controls who SEES the model — HIDDEN still serves when explicitly routed.
+    kind: str = "CHAT"
+    visibility: str = "GA"
+    min_subscription_tier: str | None = None
+    source: str = "SEED"
+    catalog_removed_at: datetime | None = None
+    fallback_model_slug: str | None = None
+
+    # Typed capability fields from DB schema
+    supports_tools: bool = False
+    supports_json_output: bool = False
+    supports_reasoning: bool = False
+    supports_parallel_tool_calls: bool = False
+
+
+# L1 in-process cache — Redis is the shared L2 via @cached(shared_cache=True)
+_dynamic_models: dict[str, RegistryModel] = {}
+_schema_options: list[dict[str, str]] = []
+_routes: dict[tuple[str, str, str], str] = {}
+_lock = asyncio.Lock()
+
+
+def _record_to_registry_model(record: prisma.models.LlmModel) -> RegistryModel:  # type: ignore[name-defined]
+    """Transform a raw Prisma LlmModel record into a RegistryModel instance."""
+    costs = tuple(
+        RegistryModelCost(
+            unit=str(cost.unit),
+            credit_cost=cost.creditCost,
+            credential_provider=cost.credentialProvider,
+            credential_id=cost.credentialId,
+            credential_type=cost.credentialType,
+            currency=cost.currency,
+            metadata=dict(cost.metadata or {}),
+        )
+        for cost in (record.Costs or [])
+    )
+
+    creator = None
+    if record.Creator:
+        creator = RegistryModelCreator(
+            id=record.Creator.id,
+            name=record.Creator.name,
+            display_name=record.Creator.displayName,
+            description=record.Creator.description,
+            website_url=record.Creator.websiteUrl,
+            logo_url=record.Creator.logoUrl,
+        )
+
+    capabilities = dict(record.capabilities or {})
+
+    if not record.Provider:
+        logger.warning(
+            "LlmModel %s has no Provider despite NOT NULL FK - "
+            "falling back to providerId %s",
+            record.slug,
+            record.providerId,
+        )
+    provider_name = record.Provider.name if record.Provider else record.providerId
+    provider_display = (
+        record.Provider.displayName if record.Provider else record.providerId
+    )
+    creator_name = record.Creator.displayName if record.Creator else "Unknown"
+
+    if record.priceTier not in (1, 2, 3):
+        logger.warning(
+            "LlmModel %s has out-of-range priceTier=%s, defaulting to 1",
+            record.slug,
+            record.priceTier,
+        )
+    price_tier = record.priceTier if record.priceTier in (1, 2, 3) else 1
+
+    metadata = RegistryModelMetadata(
+        provider=provider_name,
+        context_window=record.contextWindow,
+        max_output_tokens=(
+            record.maxOutputTokens
+            if record.maxOutputTokens is not None
+            else record.contextWindow
+        ),
+        display_name=record.displayName,
+        provider_name=provider_display,
+        creator_name=creator_name,
+        price_tier=price_tier,
+    )
+
+    return RegistryModel(
+        slug=record.slug,
+        display_name=record.displayName,
+        description=record.description,
+        metadata=metadata,
+        capabilities=capabilities,
+        extra_metadata=dict(record.metadata or {}),
+        provider_display_name=provider_display,
+        is_enabled=record.isEnabled,
+        is_recommended=record.isRecommended,
+        costs=costs,
+        creator=creator,
+        kind=str(record.kind),
+        visibility=str(record.visibility),
+        min_subscription_tier=(
+            str(record.minSubscriptionTier)
+            if record.minSubscriptionTier is not None
+            else None
+        ),
+        source=str(record.source),
+        catalog_removed_at=record.catalogRemovedAt,
+        fallback_model_slug=record.fallbackModelSlug,
+        supports_tools=record.supportsTools,
+        supports_json_output=record.supportsJsonOutput,
+        supports_reasoning=record.supportsReasoning,
+        supports_parallel_tool_calls=record.supportsParallelToolCalls,
+    )
+
+
+@cached(maxsize=1, ttl_seconds=300, shared_cache=True, refresh_ttl_on_get=True)
+async def _fetch_registry_from_db() -> list[RegistryModel]:
+    """Fetch all LLM models from the database.
+
+    Results are cached in Redis (shared_cache=True) so subsequent calls within
+    the TTL window skip the DB entirely — both within this process and across
+    all other workers that share the same Redis instance.
+    """
+    records = await prisma.models.LlmModel.prisma().find_many(  # type: ignore[attr-defined]
+        include={"Provider": True, "Costs": True, "Creator": True}
+    )
+    logger.info("Fetched %d LLM models from database", len(records))
+    return [_record_to_registry_model(r) for r in records]
+
+
+@cached(maxsize=1, ttl_seconds=300, shared_cache=True, refresh_ttl_on_get=True)
+async def _fetch_routes_from_db() -> list[tuple[str, str, str, str]]:
+    """Fetch all routing cells as (surface, mode, tier, modelSlug) tuples."""
+    records = await prisma.models.LlmModelRoute.prisma().find_many()  # type: ignore[attr-defined]
+    return [(r.surface, r.mode, r.tier, r.modelSlug) for r in records]
+
+
+def clear_registry_cache() -> None:
+    """Invalidate the shared Redis cache for the registry DB fetches.
+
+    Call this before refresh_llm_registry() after any admin DB mutation so the
+    next fetch hits the database rather than serving the now-stale cached data.
+    """
+    _fetch_registry_from_db.cache_clear()
+    _fetch_routes_from_db.cache_clear()
+
+
+async def refresh_llm_registry() -> None:
+    """Refresh the in-process L1 cache from Redis/DB.
+
+    On the first call (or after clear_registry_cache()), fetches fresh data
+    from the database and stores it in Redis.  Subsequent calls by other
+    workers hit the Redis cache instead of the DB.
+    """
+    async with _lock:
+        try:
+            models = await _fetch_registry_from_db()
+            routes = await _fetch_routes_from_db()
+            new_models = {m.slug: m for m in models}
+
+            global _dynamic_models, _schema_options, _routes
+            _dynamic_models = new_models
+            _schema_options = _build_schema_options()
+            _routes = {(s, m, t): slug for s, m, t, slug in routes}
+
+            logger.info(
+                "LLM registry refreshed: %d models, %d schema options, %d routes",
+                len(_dynamic_models),
+                len(_schema_options),
+                len(_routes),
+            )
+        except Exception as e:
+            logger.error("Failed to refresh LLM registry: %s", e, exc_info=True)
+            raise
+
+
+def _build_schema_options() -> list[dict[str, str]]:
+    """Build schema options for model selection dropdown. Only includes enabled models."""
+    return [
+        {
+            "label": model.display_name,
+            "value": model.slug,
+            "group": model.metadata.provider,
+            "description": model.description or "",
+        }
+        for model in sorted(
+            _dynamic_models.values(), key=lambda m: m.display_name.lower()
+        )
+        if model.is_enabled
+    ]
+
+
+def get_model(slug: str) -> RegistryModel | None:
+    """Get a model by slug from the registry."""
+    return _dynamic_models.get(slug)
+
+
+def get_all_models() -> list[RegistryModel]:
+    """Get all models from the registry (including disabled)."""
+    return list(_dynamic_models.values())
+
+
+def get_enabled_models() -> list[RegistryModel]:
+    """Get only enabled models from the registry."""
+    return [model for model in _dynamic_models.values() if model.is_enabled]
+
+
+def get_schema_options() -> list[dict[str, str]]:
+    """Get schema options for model selection dropdown (enabled models only)."""
+    return list(_schema_options)
+
+
+def get_default_model_slug() -> str | None:
+    """Get the default model slug (first recommended, or first enabled)."""
+    models = sorted(_dynamic_models.values(), key=lambda m: m.display_name)
+    recommended = next(
+        (m.slug for m in models if m.is_recommended and m.is_enabled), None
+    )
+    return recommended or next((m.slug for m in models if m.is_enabled), None)
+
+
+def get_all_model_slugs_for_validation() -> list[str]:
+    """Get all model slugs for validation (enabled models only)."""
+    return [model.slug for model in _dynamic_models.values() if model.is_enabled]
+
+
+def get_route(surface: str, mode: str, tier: str) -> str | None:
+    """Return the admin-configured model slug for a routing cell, if set.
+
+    Pure L1 lookup — callers own validation of the returned slug (existence
+    and isEnabled are checked by the resolver so a stale cell degrades to the
+    next routing layer instead of serving a dead model).
+    """
+    return _routes.get((surface, mode, tier))

--- a/autogpt_platform/backend/backend/data/llm_registry/registry_test.py
+++ b/autogpt_platform/backend/backend/data/llm_registry/registry_test.py
@@ -1,0 +1,503 @@
+"""Unit tests for the LLM registry module."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, Mock, patch
+
+import pydantic
+import pytest
+
+from backend.data.llm_registry.registry import (
+    RegistryModel,
+    RegistryModelCost,
+    RegistryModelCreator,
+    RegistryModelMetadata,
+    _build_schema_options,
+    _record_to_registry_model,
+    clear_registry_cache,
+    get_all_model_slugs_for_validation,
+    get_all_models,
+    get_default_model_slug,
+    get_enabled_models,
+    get_model,
+    get_route,
+    get_schema_options,
+    refresh_llm_registry,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_record(**overrides):
+    """Build a realistic mock Prisma LlmModel record."""
+    provider = Mock()
+    provider.name = "openai"
+    provider.displayName = "OpenAI"
+
+    record = Mock()
+    record.slug = "openai/gpt-4o"
+    record.displayName = "GPT-4o"
+    record.description = "Latest GPT model"
+    record.providerId = "provider-uuid"
+    record.Provider = provider
+    record.creatorId = "creator-uuid"
+    record.Creator = None
+    record.contextWindow = 128000
+    record.maxOutputTokens = 16384
+    record.priceTier = 2
+    record.isEnabled = True
+    record.isRecommended = False
+    record.supportsTools = True
+    record.supportsJsonOutput = True
+    record.supportsReasoning = False
+    record.supportsParallelToolCalls = True
+    record.capabilities = {}
+    record.metadata = {}
+    record.Costs = []
+    record.kind = "CHAT"
+    record.visibility = "GA"
+    record.minSubscriptionTier = None
+    record.source = "SEED"
+    record.catalogRemovedAt = None
+    record.fallbackModelSlug = None
+
+    for key, value in overrides.items():
+        setattr(record, key, value)
+    return record
+
+
+def _make_registry_model(**kwargs) -> RegistryModel:
+    """Build a minimal RegistryModel for testing registry-level functions."""
+    defaults = dict(
+        slug="openai/gpt-4o",
+        display_name="GPT-4o",
+        description=None,
+        metadata=RegistryModelMetadata(
+            provider="openai",
+            context_window=128000,
+            max_output_tokens=16384,
+            display_name="GPT-4o",
+            provider_name="OpenAI",
+            creator_name="Unknown",
+            price_tier=2,
+        ),
+        capabilities={},
+        extra_metadata={},
+        provider_display_name="OpenAI",
+        is_enabled=True,
+        is_recommended=False,
+    )
+    defaults.update(kwargs)
+    return RegistryModel(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# _record_to_registry_model tests
+# ---------------------------------------------------------------------------
+
+
+def test_record_to_registry_model():
+    """Happy-path: well-formed record produces a correct RegistryModel."""
+    record = _make_mock_record()
+    model = _record_to_registry_model(record)
+
+    assert model.slug == "openai/gpt-4o"
+    assert model.display_name == "GPT-4o"
+    assert model.description == "Latest GPT model"
+    assert model.provider_display_name == "OpenAI"
+    assert model.is_enabled is True
+    assert model.is_recommended is False
+    assert model.supports_tools is True
+    assert model.supports_json_output is True
+    assert model.supports_reasoning is False
+    assert model.supports_parallel_tool_calls is True
+    assert model.metadata.provider == "openai"
+    assert model.metadata.context_window == 128000
+    assert model.metadata.max_output_tokens == 16384
+    assert model.metadata.price_tier == 2
+    assert model.creator is None
+    assert model.costs == ()
+
+
+def test_record_to_registry_model_missing_provider(caplog):
+    """Record with no Provider relation falls back to providerId and logs a warning."""
+    record = _make_mock_record(Provider=None, providerId="provider-uuid")
+    with caplog.at_level("WARNING"):
+        model = _record_to_registry_model(record)
+
+    assert "no Provider" in caplog.text
+    assert model.metadata.provider == "provider-uuid"
+    assert model.provider_display_name == "provider-uuid"
+
+
+def test_record_to_registry_model_missing_creator():
+    """When Creator is None, creator_name defaults to 'Unknown' and creator field is None."""
+    record = _make_mock_record(Creator=None)
+    model = _record_to_registry_model(record)
+
+    assert model.creator is None
+    assert model.metadata.creator_name == "Unknown"
+
+
+def test_record_to_registry_model_with_creator():
+    """When Creator is present, it is parsed into RegistryModelCreator."""
+    creator_mock = Mock()
+    creator_mock.id = "creator-uuid"
+    creator_mock.name = "openai"
+    creator_mock.displayName = "OpenAI"
+    creator_mock.description = "AI company"
+    creator_mock.websiteUrl = "https://openai.com"
+    creator_mock.logoUrl = "https://openai.com/logo.png"
+
+    record = _make_mock_record(Creator=creator_mock)
+    model = _record_to_registry_model(record)
+
+    assert model.creator is not None
+    assert isinstance(model.creator, RegistryModelCreator)
+    assert model.creator.id == "creator-uuid"
+    assert model.creator.display_name == "OpenAI"
+    assert model.metadata.creator_name == "OpenAI"
+
+
+def test_record_to_registry_model_null_max_output_tokens():
+    """maxOutputTokens=None falls back to contextWindow."""
+    record = _make_mock_record(maxOutputTokens=None, contextWindow=64000)
+    model = _record_to_registry_model(record)
+
+    assert model.metadata.max_output_tokens == 64000
+
+
+def test_record_to_registry_model_invalid_price_tier(caplog):
+    """Out-of-range priceTier is coerced to 1 and a warning is logged."""
+    record = _make_mock_record(priceTier=99)
+    with caplog.at_level("WARNING"):
+        model = _record_to_registry_model(record)
+
+    assert "out-of-range priceTier" in caplog.text
+    assert model.metadata.price_tier == 1
+
+
+def test_record_to_registry_model_with_costs():
+    """Costs are parsed into RegistryModelCost tuples."""
+    cost_mock = Mock()
+    cost_mock.unit = "TOKENS"
+    cost_mock.creditCost = 10
+    cost_mock.credentialProvider = "openai"
+    cost_mock.credentialId = None
+    cost_mock.credentialType = None
+    cost_mock.currency = "USD"
+    cost_mock.metadata = {}
+
+    record = _make_mock_record(Costs=[cost_mock])
+    model = _record_to_registry_model(record)
+
+    assert len(model.costs) == 1
+    cost = model.costs[0]
+    assert isinstance(cost, RegistryModelCost)
+    assert cost.unit == "TOKENS"
+    assert cost.credit_cost == 10
+    assert cost.credential_provider == "openai"
+
+
+# ---------------------------------------------------------------------------
+# get_default_model_slug tests
+# ---------------------------------------------------------------------------
+
+
+def test_get_default_model_slug_recommended():
+    """Recommended model is preferred over non-recommended enabled models."""
+    import backend.data.llm_registry.registry as reg
+
+    reg._dynamic_models = {
+        "openai/gpt-4o": _make_registry_model(
+            slug="openai/gpt-4o", display_name="GPT-4o", is_recommended=False
+        ),
+        "openai/gpt-4o-recommended": _make_registry_model(
+            slug="openai/gpt-4o-recommended",
+            display_name="GPT-4o Recommended",
+            is_recommended=True,
+        ),
+    }
+
+    result = get_default_model_slug()
+    assert result == "openai/gpt-4o-recommended"
+
+
+def test_get_default_model_slug_fallback():
+    """With no recommended model, falls back to first enabled (alphabetical)."""
+    import backend.data.llm_registry.registry as reg
+
+    reg._dynamic_models = {
+        "openai/gpt-4o": _make_registry_model(
+            slug="openai/gpt-4o", display_name="GPT-4o", is_recommended=False
+        ),
+        "openai/gpt-3.5": _make_registry_model(
+            slug="openai/gpt-3.5", display_name="GPT-3.5", is_recommended=False
+        ),
+    }
+
+    result = get_default_model_slug()
+    # Sorted alphabetically: GPT-3.5 < GPT-4o
+    assert result == "openai/gpt-3.5"
+
+
+def test_get_default_model_slug_empty():
+    """Empty registry returns None."""
+    import backend.data.llm_registry.registry as reg
+
+    reg._dynamic_models = {}
+
+    result = get_default_model_slug()
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _build_schema_options / get_schema_options tests
+# ---------------------------------------------------------------------------
+
+
+def test_build_schema_options():
+    """Only enabled models appear, sorted case-insensitively."""
+    import backend.data.llm_registry.registry as reg
+
+    reg._dynamic_models = {
+        "openai/gpt-4o": _make_registry_model(
+            slug="openai/gpt-4o", display_name="GPT-4o", is_enabled=True
+        ),
+        "openai/disabled": _make_registry_model(
+            slug="openai/disabled", display_name="Disabled Model", is_enabled=False
+        ),
+        "openai/gpt-3.5": _make_registry_model(
+            slug="openai/gpt-3.5", display_name="gpt-3.5", is_enabled=True
+        ),
+    }
+
+    options = _build_schema_options()
+    slugs = [o["value"] for o in options]
+
+    # disabled model should be excluded
+    assert "openai/disabled" not in slugs
+    # only enabled models
+    assert "openai/gpt-4o" in slugs
+    assert "openai/gpt-3.5" in slugs
+    # case-insensitive sort: "gpt-3.5" < "GPT-4o" (both lowercase: "gpt-3.5" < "gpt-4o")
+    assert slugs.index("openai/gpt-3.5") < slugs.index("openai/gpt-4o")
+
+    # Verify structure
+    for option in options:
+        assert "label" in option
+        assert "value" in option
+        assert "group" in option
+        assert "description" in option
+
+
+def test_get_schema_options_returns_copy():
+    """Mutating the returned list does not affect the internal cache."""
+    import backend.data.llm_registry.registry as reg
+
+    reg._dynamic_models = {
+        "openai/gpt-4o": _make_registry_model(
+            slug="openai/gpt-4o", display_name="GPT-4o"
+        ),
+    }
+    reg._schema_options = _build_schema_options()
+
+    options = get_schema_options()
+    original_length = len(options)
+    options.append(
+        {"label": "Injected", "value": "evil/model", "group": "evil", "description": ""}
+    )
+
+    # Internal state should be unchanged
+    assert len(get_schema_options()) == original_length
+
+
+# ---------------------------------------------------------------------------
+# Pydantic frozen model tests
+# ---------------------------------------------------------------------------
+
+
+def test_registry_model_frozen():
+    """Pydantic frozen=True should reject attribute assignment."""
+    model = _make_registry_model()
+
+    with pytest.raises((pydantic.ValidationError, TypeError)):
+        model.slug = "changed/slug"  # type: ignore[misc]
+
+
+def test_registry_model_cost_frozen():
+    """RegistryModelCost is also frozen."""
+    cost = RegistryModelCost(
+        unit="TOKENS",
+        credit_cost=5,
+        credential_provider="openai",
+    )
+    with pytest.raises((pydantic.ValidationError, TypeError)):
+        cost.unit = "RUN"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# refresh_llm_registry tests
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_route(
+    surface="copilot", mode="thinking", tier="standard", slug="openai/gpt-4o"
+):
+    route = Mock()
+    route.surface = surface
+    route.mode = mode
+    route.tier = tier
+    route.modelSlug = slug
+    return route
+
+
+@pytest.mark.asyncio
+async def test_refresh_llm_registry():
+    """Mock prisma find_many, verify cache is populated after refresh."""
+    import backend.data.llm_registry.registry as reg
+
+    record = _make_mock_record()
+    mock_find_many = AsyncMock(return_value=[record])
+    mock_routes_find_many = AsyncMock(return_value=[_make_mock_route()])
+
+    with (
+        patch("prisma.models.LlmModel.prisma") as mock_prisma_cls,
+        patch("prisma.models.LlmModelRoute.prisma") as mock_route_prisma_cls,
+    ):
+        mock_prisma_instance = Mock()
+        mock_prisma_instance.find_many = mock_find_many
+        mock_prisma_cls.return_value = mock_prisma_instance
+        mock_route_instance = Mock()
+        mock_route_instance.find_many = mock_routes_find_many
+        mock_route_prisma_cls.return_value = mock_route_instance
+
+        # Clear state first — including the shared Redis L2, which would
+        # otherwise serve a value cached by an earlier run and skip the mock.
+        clear_registry_cache()
+        reg._dynamic_models = {}
+        reg._schema_options = []
+        reg._routes = {}
+
+        await refresh_llm_registry()
+
+    assert "openai/gpt-4o" in reg._dynamic_models
+    model = reg._dynamic_models["openai/gpt-4o"]
+    assert isinstance(model, RegistryModel)
+    assert model.slug == "openai/gpt-4o"
+    # Schema options should be populated too
+    assert len(reg._schema_options) == 1
+    assert reg._schema_options[0]["value"] == "openai/gpt-4o"
+    # Routing cells should be populated and readable via get_route
+    assert get_route("copilot", "thinking", "standard") == "openai/gpt-4o"
+    assert get_route("copilot", "fast", "standard") is None
+
+
+# ---------------------------------------------------------------------------
+# clear_registry_cache tests
+# ---------------------------------------------------------------------------
+
+
+def test_clear_registry_cache():
+    """clear_registry_cache clears both cached fetch functions."""
+    from unittest.mock import patch
+
+    import backend.data.llm_registry.registry as reg
+
+    with (
+        patch.object(reg._fetch_registry_from_db, "cache_clear") as mock_clear,
+        patch.object(reg._fetch_routes_from_db, "cache_clear") as mock_routes_clear,
+    ):
+        clear_registry_cache()
+        mock_clear.assert_called_once()
+        mock_routes_clear.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# get_model / get_all_models / get_enabled_models / get_all_model_slugs tests
+# ---------------------------------------------------------------------------
+
+
+def test_get_model_found():
+    """get_model returns the model when the slug exists in the registry."""
+    import backend.data.llm_registry.registry as reg
+
+    m = _make_registry_model(slug="openai/gpt-4o")
+    reg._dynamic_models = {"openai/gpt-4o": m}
+
+    result = get_model("openai/gpt-4o")
+
+    assert result is m
+
+
+def test_get_model_not_found():
+    """get_model returns None for an unknown slug."""
+    import backend.data.llm_registry.registry as reg
+
+    reg._dynamic_models = {}
+
+    assert get_model("nonexistent/model") is None
+
+
+def test_get_all_models_includes_disabled():
+    """get_all_models returns all models, including disabled ones."""
+    import backend.data.llm_registry.registry as reg
+
+    enabled = _make_registry_model(slug="openai/gpt-4", is_enabled=True)
+    disabled = _make_registry_model(slug="openai/old-model", is_enabled=False)
+    reg._dynamic_models = {"openai/gpt-4": enabled, "openai/old-model": disabled}
+
+    result = get_all_models()
+
+    slugs = [m.slug for m in result]
+    assert "openai/gpt-4" in slugs
+    assert "openai/old-model" in slugs
+    assert len(result) == 2
+
+
+def test_get_enabled_models_excludes_disabled():
+    """get_enabled_models returns only models where is_enabled=True."""
+    import backend.data.llm_registry.registry as reg
+
+    enabled = _make_registry_model(slug="openai/gpt-4", is_enabled=True)
+    disabled = _make_registry_model(slug="openai/old-model", is_enabled=False)
+    reg._dynamic_models = {"openai/gpt-4": enabled, "openai/old-model": disabled}
+
+    result = get_enabled_models()
+
+    assert len(result) == 1
+    assert result[0].slug == "openai/gpt-4"
+
+
+def test_get_all_model_slugs_for_validation():
+    """get_all_model_slugs_for_validation returns only enabled model slugs."""
+    import backend.data.llm_registry.registry as reg
+
+    reg._dynamic_models = {
+        "openai/gpt-4": _make_registry_model(slug="openai/gpt-4", is_enabled=True),
+        "openai/old": _make_registry_model(slug="openai/old", is_enabled=False),
+        "anthropic/claude": _make_registry_model(
+            slug="anthropic/claude", is_enabled=True
+        ),
+    }
+
+    result = get_all_model_slugs_for_validation()
+
+    assert "openai/gpt-4" in result
+    assert "anthropic/claude" in result
+    assert "openai/old" not in result
+    assert len(result) == 2
+
+
+@pytest.mark.asyncio
+async def test_refresh_llm_registry_error_is_reraised(mocker):
+    """refresh_llm_registry re-raises exceptions after logging them."""
+    mocker.patch(
+        "backend.data.llm_registry.registry._fetch_registry_from_db",
+        new=AsyncMock(side_effect=RuntimeError("DB unavailable")),
+    )
+
+    with pytest.raises(RuntimeError, match="DB unavailable"):
+        await refresh_llm_registry()


### PR DESCRIPTION
## Why

Part 2 of 9 of the LLM registry restack (see #13605 for the schema and full context). This layer gives every backend pod a fast, always-warm view of the registry so later parts (public catalog endpoint, copilot routing, admin API) never touch the DB on hot paths.

## What

`backend/data/llm_registry/` — re-cut of @Bentlybro's #12359 core layer:

- **Two-level cache**: L1 module-global dict under an `asyncio.Lock`; L2 Redis via `@cached(ttl=300, shared_cache=True)` on the DB fetch. All read functions are sync L1 lookups.
- **Read API**: `get_model`, `get_all_models`, `get_enabled_models`, `get_schema_options`, `get_default_model_slug`, `get_all_model_slugs_for_validation`, and new `get_route(surface, mode, tier)` for the routing cells.
- **Cross-pod refresh**: `llm_registry:refresh` channel; `refresh_llm_registry` + long-lived subscribe task wired into the rest_api lifespan (fail-soft startup, clean cancellation on shutdown).

Still dormant: nothing consumes these reads yet.

## How (deltas vs the original branch)

- Pub/sub rewritten to **sharded SPUBLISH/SSUBSCRIBE** via `connect_sharded_pubsub_async` — prod Redis is cluster mode; classic pub/sub broadcasts to every node. Mirrors `event_bus.AsyncRedisEventBus`.
- `ModelMetadata` NamedTuple import from `blocks/llm.py` replaced with a standalone frozen `RegistryModelMetadata` — decouples the registry from the module it will eventually replace, and NamedTuples serialize as JSON arrays (wrong for API payloads).
- `RegistryModel` carries the new schema columns (`kind`, `visibility`, `minSubscriptionTier`, `source`, `catalogRemovedAt`, `fallbackModelSlug`).

## Verification

- 30/30 tests pass locally (`backend/data/llm_registry/`) — record mapping edge cases, refresh/L1 population incl. routes, cache clearing both fetches, sharded pub/sub happy path + handshake filtering + reconnect + close-on-exit
- `poetry run format` + `poetry run lint` clean

## Checklist
- [x] Data-layer additions have no user-facing routes yet (no user ID checks needed — no user-scoped data involved; registry rows are global config)
- [x] Out-of-scope changes: none
