### PR TITLE
feat(backend/api): public LLM catalog endpoint

### DIFF
--- a/autogpt_platform/backend/backend/api/features/llm/rate_limit.py
+++ b/autogpt_platform/backend/backend/api/features/llm/rate_limit.py
@@ -1,0 +1,67 @@
+"""Per-IP rate limiting for the public LLM catalog endpoint.
+
+Fixed one-minute window on a single Redis key per IP (cluster-safe — one key
+hashes to one slot, so the INCR+EXPIRE pipeline needs no cross-slot MULTI).
+
+Deliberately FAIL-OPEN, unlike copilot's spend limiter: this protects read
+capacity for public facts, not money. A Redis brown-out must not take down
+catalog distribution — the CDN cache in front is the real shield; this limit
+is the backstop against cache-busting abuse.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+
+import fastapi
+from redis.exceptions import ConnectionError as RedisConnectionError
+from redis.exceptions import RedisClusterException, RedisError
+
+from backend.data.redis_client import get_redis_async
+from backend.util.settings import Config
+
+logger = logging.getLogger(__name__)
+
+config = Config()
+
+_WINDOW_SECONDS = 60
+# Key TTL is 2x the window so a clock-edge INCR never resurrects a dead key.
+_KEY_TTL_SECONDS = 120
+
+
+def get_client_ip(request: fastapi.Request) -> str:
+    """Best-effort client IP.
+
+    Behind the cloud LB the socket peer is the LB hop, and the true client is
+    appended to ``X-Forwarded-For``. ``llm_catalog_client_ip_xff_depth`` picks
+    which entry from the END of the list to trust (1 = last entry, the one the
+    LB itself appended; anything earlier is client-forgeable). Self-hosted
+    installs without a proxy have no XFF header and use the socket peer.
+    """
+    xff = request.headers.get("x-forwarded-for", "")
+    if xff:
+        parts = [p.strip() for p in xff.split(",") if p.strip()]
+        depth = max(1, config.llm_catalog_client_ip_xff_depth)
+        if parts:
+            return parts[-depth] if depth <= len(parts) else parts[0]
+    return request.client.host if request.client else "unknown"
+
+
+async def check_catalog_rate_limit(ip: str) -> bool:
+    """Return True if the request is allowed, False if over the limit."""
+    minute = datetime.now(timezone.utc).strftime("%Y%m%d%H%M")
+    key = f"llm_catalog:rl:{ip}:{minute}"
+    try:
+        redis = await get_redis_async()
+        async with redis.pipeline(transaction=True) as pipe:
+            pipe.incrby(key, 1)
+            pipe.expire(key, _KEY_TTL_SECONDS)
+            count, _ = await pipe.execute()
+        return int(count) <= config.llm_catalog_rate_limit_per_minute
+    except (RedisError, RedisClusterException, RedisConnectionError, OSError):
+        logger.warning(
+            "Catalog rate-limit check failed — allowing request (fail-open)",
+            exc_info=True,
+        )
+        return True

--- a/autogpt_platform/backend/backend/api/features/llm/rate_limit_test.py
+++ b/autogpt_platform/backend/backend/api/features/llm/rate_limit_test.py
@@ -1,0 +1,77 @@
+"""Tests for the catalog per-IP rate limiter and client-IP extraction."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import fastapi
+import pytest
+from redis.exceptions import RedisError
+
+from backend.api.features.llm.rate_limit import check_catalog_rate_limit, get_client_ip
+
+
+def _request(headers: dict | None = None, client_host: str = "10.0.0.9"):
+    request = MagicMock(spec=fastapi.Request)
+    request.headers = headers or {}
+    request.client = MagicMock()
+    request.client.host = client_host
+    return request
+
+
+def test_client_ip_no_xff_uses_socket_peer():
+    assert get_client_ip(_request()) == "10.0.0.9"
+
+
+def test_client_ip_takes_lb_appended_xff_entry():
+    # Client-forgeable entries come first; the trusted LB appends last.
+    request = _request({"x-forwarded-for": "6.6.6.6, 203.0.113.7"})
+    assert get_client_ip(request) == "203.0.113.7"
+
+
+def test_client_ip_single_xff_entry():
+    request = _request({"x-forwarded-for": "203.0.113.7"})
+    assert get_client_ip(request) == "203.0.113.7"
+
+
+def test_client_ip_no_client_object():
+    request = _request()
+    request.client = None
+    assert get_client_ip(request) == "unknown"
+
+
+def _mock_redis(mocker, count: int):
+    pipe = MagicMock()
+    pipe.__aenter__ = AsyncMock(return_value=pipe)
+    pipe.__aexit__ = AsyncMock(return_value=False)
+    pipe.incrby = MagicMock()
+    pipe.expire = MagicMock()
+    pipe.execute = AsyncMock(return_value=[count, True])
+    redis = MagicMock()
+    redis.pipeline.return_value = pipe
+    mocker.patch(
+        "backend.api.features.llm.rate_limit.get_redis_async",
+        return_value=redis,
+    )
+    return pipe
+
+
+@pytest.mark.asyncio
+async def test_under_limit_allows(mocker):
+    _mock_redis(mocker, count=1)
+    assert await check_catalog_rate_limit("1.2.3.4") is True
+
+
+@pytest.mark.asyncio
+async def test_over_limit_blocks(mocker):
+    _mock_redis(mocker, count=99999)
+    assert await check_catalog_rate_limit("1.2.3.4") is False
+
+
+@pytest.mark.asyncio
+async def test_redis_error_fails_open(mocker):
+    mocker.patch(
+        "backend.api.features.llm.rate_limit.get_redis_async",
+        side_effect=RedisError("cluster down"),
+    )
+    assert await check_catalog_rate_limit("1.2.3.4") is True

--- a/autogpt_platform/backend/backend/api/features/llm/routes.py
+++ b/autogpt_platform/backend/backend/api/features/llm/routes.py
@@ -1,0 +1,118 @@
+"""Public LLM catalog endpoint.
+
+Unauthenticated by design: the payload is public model facts (see
+``catalog_model.py`` for what is deliberately excluded), and self-hosted
+installs poll this endpoint on cloud prod to keep their registries current
+without a code update.
+
+Served entirely from the registry's in-process L1 cache — no DB reads on the
+request path. The path is allowlisted in ``CACHEABLE_PATHS``, so the security
+middleware leaves our Cache-Control header alone; that also means error
+responses MUST set ``no-store`` explicitly or a CDN could cache a 429.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+
+import fastapi
+import fastapi.responses
+
+import backend.data.llm_registry as llm_registry
+from backend.api.features.llm.rate_limit import check_catalog_rate_limit, get_client_ip
+from backend.data.llm_registry import (
+    CATALOG_SCHEMA_VERSION,
+    CatalogCreator,
+    CatalogModel,
+    CatalogPayload,
+    CatalogProvider,
+)
+
+logger = logging.getLogger(__name__)
+
+router = fastapi.APIRouter()
+
+_CACHE_CONTROL_OK = "public, max-age=300, stale-while-revalidate=3600"
+_CACHE_CONTROL_ERROR = "no-store, no-cache, must-revalidate, private"
+
+
+def _build_catalog_payload() -> CatalogPayload:
+    """Assemble the catalog from the L1 cache. GA-visibility models only."""
+    models = [m for m in llm_registry.get_all_models() if m.visibility == "GA"]
+
+    providers: dict[str, CatalogProvider] = {}
+    creators: dict[str, CatalogCreator] = {}
+    catalog_models: list[CatalogModel] = []
+    for m in models:
+        providers.setdefault(
+            m.metadata.provider,
+            CatalogProvider(
+                name=m.metadata.provider,
+                display_name=m.provider_display_name,
+            ),
+        )
+        if m.creator is not None:
+            creators.setdefault(
+                m.creator.name,
+                CatalogCreator(
+                    name=m.creator.name,
+                    display_name=m.creator.display_name,
+                    description=m.creator.description,
+                    website_url=m.creator.website_url,
+                    logo_url=m.creator.logo_url,
+                ),
+            )
+        catalog_models.append(
+            CatalogModel(
+                slug=m.slug,
+                display_name=m.display_name,
+                description=m.description,
+                provider=m.metadata.provider,
+                creator=m.creator.name if m.creator else None,
+                kind=m.kind,
+                context_window=m.metadata.context_window,
+                max_output_tokens=m.metadata.max_output_tokens,
+                price_tier=m.metadata.price_tier,
+                is_enabled=m.is_enabled,
+                is_recommended=m.is_recommended,
+                fallback_model_slug=m.fallback_model_slug,
+                supports_tools=m.supports_tools,
+                supports_json_output=m.supports_json_output,
+                supports_reasoning=m.supports_reasoning,
+                supports_parallel_tool_calls=m.supports_parallel_tool_calls,
+                capabilities=m.capabilities,
+                metadata=m.extra_metadata,
+            )
+        )
+
+    return CatalogPayload(
+        schema_version=CATALOG_SCHEMA_VERSION,
+        generated_at=datetime.now(timezone.utc),
+        providers=sorted(providers.values(), key=lambda p: p.name),
+        creators=sorted(creators.values(), key=lambda c: c.name),
+        models=sorted(catalog_models, key=lambda m: m.slug),
+    )
+
+
+@router.get("/catalog", response_model=CatalogPayload)
+async def get_llm_catalog(
+    request: fastapi.Request, response: fastapi.Response
+) -> fastapi.responses.Response:
+    ip = get_client_ip(request)
+    if not await check_catalog_rate_limit(ip):
+        return fastapi.responses.JSONResponse(
+            status_code=429,
+            content={"detail": "Rate limit exceeded"},
+            headers={
+                "Retry-After": "60",
+                "Cache-Control": _CACHE_CONTROL_ERROR,
+            },
+        )
+
+    payload = _build_catalog_payload()
+    response.headers["Cache-Control"] = _CACHE_CONTROL_OK
+    return fastapi.responses.JSONResponse(
+        content=payload.model_dump(mode="json"),
+        headers={"Cache-Control": _CACHE_CONTROL_OK},
+    )

--- a/autogpt_platform/backend/backend/api/features/llm/routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/llm/routes_test.py
@@ -1,0 +1,130 @@
+"""Tests for the public LLM catalog endpoint."""
+
+from __future__ import annotations
+
+import fastapi
+import fastapi.testclient
+import pytest
+
+import backend.data.llm_registry.registry as reg
+from backend.api.features.llm.routes import router
+from backend.api.middleware.security import SecurityHeadersMiddleware
+from backend.data.llm_registry.catalog_model import CATALOG_SCHEMA_VERSION
+from backend.data.llm_registry.registry import (
+    RegistryModel,
+    RegistryModelCreator,
+    RegistryModelMetadata,
+)
+
+app = fastapi.FastAPI()
+app.add_middleware(SecurityHeadersMiddleware)
+app.include_router(router, prefix="/api/llm")
+client = fastapi.testclient.TestClient(app)
+
+
+def _model(slug: str, **overrides) -> RegistryModel:
+    defaults = dict(
+        slug=slug,
+        display_name=slug.split("/")[-1].upper(),
+        metadata=RegistryModelMetadata(
+            provider="openai",
+            context_window=128000,
+            max_output_tokens=16384,
+            display_name=slug.split("/")[-1].upper(),
+            provider_name="OpenAI",
+            creator_name="OpenAI",
+            price_tier=2,
+        ),
+        provider_display_name="OpenAI",
+        is_enabled=True,
+        creator=RegistryModelCreator(
+            id="creator-uuid", name="openai", display_name="OpenAI"
+        ),
+    )
+    defaults.update(overrides)
+    return RegistryModel(**defaults)
+
+
+@pytest.fixture(autouse=True)
+def seeded_l1(mocker):
+    """Seed the L1 cache directly and allow all rate-limit checks by default."""
+    reg._dynamic_models = {
+        "openai/gpt-a": _model("openai/gpt-a"),
+        "openai/gpt-disabled": _model("openai/gpt-disabled", is_enabled=False),
+        "openai/gpt-hidden": _model("openai/gpt-hidden", visibility="HIDDEN"),
+        "openai/gpt-employees": _model("openai/gpt-employees", visibility="EMPLOYEES"),
+    }
+    mocker.patch(
+        "backend.api.features.llm.routes.check_catalog_rate_limit",
+        return_value=True,
+    )
+    yield
+    reg._dynamic_models = {}
+
+
+def test_catalog_returns_ga_models_only():
+    resp = client.get("/api/llm/catalog")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["schema_version"] == CATALOG_SCHEMA_VERSION
+    slugs = [m["slug"] for m in body["models"]]
+    assert slugs == ["openai/gpt-a", "openai/gpt-disabled"]
+    assert "openai/gpt-hidden" not in slugs
+    assert "openai/gpt-employees" not in slugs
+
+
+def test_catalog_includes_disabled_ga_models_as_disabled():
+    """A remotely-disabled model must propagate its disabled state to syncers."""
+    resp = client.get("/api/llm/catalog")
+
+    by_slug = {m["slug"]: m for m in resp.json()["models"]}
+    assert by_slug["openai/gpt-disabled"]["is_enabled"] is False
+
+
+def test_catalog_is_publicly_cacheable():
+    resp = client.get("/api/llm/catalog")
+
+    assert "public" in resp.headers["Cache-Control"]
+    assert "max-age=300" in resp.headers["Cache-Control"]
+
+
+def test_catalog_providers_and_creators_are_referenced():
+    body = client.get("/api/llm/catalog").json()
+
+    provider_names = {p["name"] for p in body["providers"]}
+    creator_names = {c["name"] for c in body["creators"]}
+    for m in body["models"]:
+        assert m["provider"] in provider_names
+        if m["creator"]:
+            assert m["creator"] in creator_names
+
+
+def test_catalog_requires_no_auth():
+    """No Authorization header, no cookies — must still be a 200."""
+    resp = client.get("/api/llm/catalog")
+    assert resp.status_code == 200
+
+
+def test_rate_limited_response_is_not_cacheable(mocker):
+    mocker.patch(
+        "backend.api.features.llm.routes.check_catalog_rate_limit",
+        return_value=False,
+    )
+
+    resp = client.get("/api/llm/catalog")
+
+    assert resp.status_code == 429
+    assert resp.headers["Retry-After"] == "60"
+    assert "no-store" in resp.headers["Cache-Control"]
+
+
+def test_middleware_keeps_sibling_paths_uncacheable():
+    """Only the exact catalog path is allowlisted."""
+
+    @app.get("/api/llm/other")
+    def other():
+        return {"ok": True}
+
+    resp = client.get("/api/llm/other")
+    assert "no-store" in resp.headers["Cache-Control"]

--- a/autogpt_platform/backend/backend/api/middleware/security.py
+++ b/autogpt_platform/backend/backend/api/middleware/security.py
@@ -24,6 +24,9 @@ class SecurityHeadersMiddleware:
         "/api/v1/health",
         "/api/status",
         "/api/blocks",
+        # Public LLM catalog: exact path only — never allowlist a bare
+        # "/api/llm" prefix, or future authed sub-routes become CDN-cacheable.
+        "/api/llm/catalog",
         "/api/v1/blocks",
         # Workspace file previews (user-private; response sets Cache-Control: private)
         "/api/workspace/files/*/preview",

--- a/autogpt_platform/backend/backend/api/rest_api.py
+++ b/autogpt_platform/backend/backend/api/rest_api.py
@@ -34,6 +34,7 @@ import backend.api.features.executions.review.routes
 import backend.api.features.library.db
 import backend.api.features.library.model
 import backend.api.features.library.routes
+import backend.api.features.llm.routes
 import backend.api.features.mcp.routes as mcp_routes
 import backend.api.features.oauth
 import backend.api.features.orgs.invitation_routes
@@ -391,6 +392,11 @@ app.include_router(
 )
 app.include_router(
     backend.api.features.builder.routes.router, tags=["v2"], prefix="/api/builder"
+)
+app.include_router(
+    backend.api.features.llm.routes.router,
+    tags=["v2", "llm", "public"],
+    prefix="/api/llm",
 )
 app.include_router(
     backend.api.features.admin.store_admin_routes.router,

--- a/autogpt_platform/backend/backend/util/settings.py
+++ b/autogpt_platform/backend/backend/util/settings.py
@@ -96,6 +96,16 @@ class Config(UpdateTrackingModel["Config"], BaseSettings):
         le=500,
         description="Thread pool size for FastAPI sync operations. All sync endpoints and dependencies automatically use this pool. Higher values support more concurrent sync operations but use more memory.",
     )
+    llm_catalog_rate_limit_per_minute: int = Field(
+        default=30,
+        ge=1,
+        description="Per-IP request limit per minute for the public /api/llm/catalog endpoint.",
+    )
+    llm_catalog_client_ip_xff_depth: int = Field(
+        default=1,
+        ge=1,
+        description="Which X-Forwarded-For entry (from the end) to trust as the client IP behind the load balancer. 1 = the entry appended by the trusted LB.",
+    )
     ollama_host: str = Field(
         default="localhost:11434",
         description="Default Ollama host; exempted from SSRF checks.",

--- a/autogpt_platform/frontend/src/app/api/openapi.json
+++ b/autogpt_platform/frontend/src/app/api/openapi.json
@@ -8059,6 +8059,23 @@
         }
       }
     },
+    "/api/llm/catalog": {
+      "get": {
+        "tags": ["v2", "llm", "public"],
+        "summary": "Get Llm Catalog",
+        "operationId": "getV2GetLlmCatalog",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/CatalogPayload" }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/mcp/discover-tools": {
       "post": {
         "tags": ["v2", "mcp", "mcp"],
@@ -14548,6 +14565,205 @@
         "required": ["cancelled"],
         "title": "CancelSessionResponse",
         "description": "Response model for the cancel session endpoint."
+      },
+      "CatalogCreator": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "pattern": "^[a-z0-9][a-z0-9._-]{0,99}$",
+            "title": "Name"
+          },
+          "display_name": {
+            "type": "string",
+            "maxLength": 200,
+            "minLength": 1,
+            "title": "Display Name"
+          },
+          "description": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Description"
+          },
+          "website_url": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Website Url"
+          },
+          "logo_url": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Logo Url"
+          }
+        },
+        "type": "object",
+        "required": ["name", "display_name"],
+        "title": "CatalogCreator"
+      },
+      "CatalogModel": {
+        "properties": {
+          "slug": {
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9/._:-]{0,199}$",
+            "title": "Slug"
+          },
+          "display_name": {
+            "type": "string",
+            "maxLength": 200,
+            "minLength": 1,
+            "title": "Display Name"
+          },
+          "description": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Description"
+          },
+          "provider": {
+            "type": "string",
+            "pattern": "^[a-z0-9][a-z0-9._-]{0,99}$",
+            "title": "Provider"
+          },
+          "creator": {
+            "anyOf": [
+              { "type": "string", "pattern": "^[a-z0-9][a-z0-9._-]{0,99}$" },
+              { "type": "null" }
+            ],
+            "title": "Creator"
+          },
+          "kind": { "type": "string", "title": "Kind", "default": "CHAT" },
+          "context_window": {
+            "type": "integer",
+            "exclusiveMinimum": 0.0,
+            "title": "Context Window"
+          },
+          "max_output_tokens": {
+            "anyOf": [
+              { "type": "integer", "exclusiveMinimum": 0.0 },
+              { "type": "null" }
+            ],
+            "title": "Max Output Tokens"
+          },
+          "price_tier": {
+            "type": "integer",
+            "maximum": 3.0,
+            "minimum": 1.0,
+            "title": "Price Tier",
+            "default": 1
+          },
+          "is_enabled": {
+            "type": "boolean",
+            "title": "Is Enabled",
+            "default": true
+          },
+          "is_recommended": {
+            "type": "boolean",
+            "title": "Is Recommended",
+            "default": false
+          },
+          "fallback_model_slug": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^[a-zA-Z0-9][a-zA-Z0-9/._:-]{0,199}$"
+              },
+              { "type": "null" }
+            ],
+            "title": "Fallback Model Slug"
+          },
+          "supports_tools": {
+            "type": "boolean",
+            "title": "Supports Tools",
+            "default": false
+          },
+          "supports_json_output": {
+            "type": "boolean",
+            "title": "Supports Json Output",
+            "default": false
+          },
+          "supports_reasoning": {
+            "type": "boolean",
+            "title": "Supports Reasoning",
+            "default": false
+          },
+          "supports_parallel_tool_calls": {
+            "type": "boolean",
+            "title": "Supports Parallel Tool Calls",
+            "default": false
+          },
+          "capabilities": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Capabilities",
+            "default": {}
+          },
+          "metadata": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Metadata",
+            "default": {}
+          }
+        },
+        "type": "object",
+        "required": ["slug", "display_name", "provider", "context_window"],
+        "title": "CatalogModel"
+      },
+      "CatalogPayload": {
+        "properties": {
+          "schema_version": { "type": "integer", "title": "Schema Version" },
+          "generated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Generated At"
+          },
+          "providers": {
+            "items": { "$ref": "#/components/schemas/CatalogProvider" },
+            "type": "array",
+            "title": "Providers"
+          },
+          "creators": {
+            "items": { "$ref": "#/components/schemas/CatalogCreator" },
+            "type": "array",
+            "title": "Creators"
+          },
+          "models": {
+            "items": { "$ref": "#/components/schemas/CatalogModel" },
+            "type": "array",
+            "maxItems": 2000,
+            "title": "Models"
+          }
+        },
+        "type": "object",
+        "required": [
+          "schema_version",
+          "generated_at",
+          "providers",
+          "creators",
+          "models"
+        ],
+        "title": "CatalogPayload"
+      },
+      "CatalogProvider": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "pattern": "^[a-z0-9][a-z0-9._-]{0,99}$",
+            "title": "Name"
+          },
+          "display_name": {
+            "type": "string",
+            "maxLength": 200,
+            "minLength": 1,
+            "title": "Display Name"
+          },
+          "description": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Description"
+          },
+          "metadata": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Metadata",
+            "default": {}
+          }
+        },
+        "type": "object",
+        "required": ["name", "display_name"],
+        "title": "CatalogProvider"
       },
       "ChangelogEntry": {
         "properties": {


### PR DESCRIPTION
## Why

Part 4 of 9 of the LLM registry restack (#13605 → #13606 → #13607 → this). Self-hosted installs need a way to learn about new/disabled models without pulling code; this endpoint is the distribution channel their sync client (part 5) polls.

## What

`GET /api/llm/catalog` — returns the `CatalogPayload` (exact schema the importer validates, so the endpoint literally serves what the sync client consumes):

- **Unauthenticated** (deliberate; fixes the old branch's `Security(requires_user)` which would have made self-hosted sync impossible): public model facts only — no costs, no credentials, no routing cells, and only GA-visibility models
- **Zero DB reads**: assembled from the registry's in-process L1 cache
- **CDN-friendly**: `Cache-Control: public, max-age=300, stale-while-revalidate=3600` on 200s; exact-path `CACHEABLE_PATHS` entry (a bare `/api/llm` prefix would allowlist future authed sub-routes — commented in the middleware); 429s explicitly `no-store` because the middleware leaves allowlisted paths' headers alone
- **Per-IP rate limit** (default 30/min, `LLM_CATALOG_RATE_LIMIT_PER_MINUTE`): single-key INCRBY+EXPIRE pipeline (Redis-cluster-safe), **fail-open** — unlike copilot's spend limiter this protects read capacity, not money; a Redis brown-out must not take down catalog distribution
- **`get_client_ip()`**: first X-Forwarded-For parsing in the backend; trusts the LB-appended entry with configurable depth (`LLM_CATALOG_CLIENT_IP_XFF_DEPTH`), socket peer for proxyless self-hosted

## Verification

- 14/14 tests: GA-only filtering (HIDDEN/EMPLOYEES excluded, disabled-GA included as disabled), payload referential integrity, cacheable 200 vs no-store 429 vs no-store sibling paths (middleware wired into the test app), XFF parsing incl. forgeable-entry ordering, limiter under/over/fail-open
- `poetry run format` + `poetry run lint` clean

## Checklist
- [x] Public endpoint intentionally unauthenticated — serves only non-sensitive global facts, filtered to GA visibility; reviewed against cache middleware semantics
- [x] Out-of-scope changes: none
