### PR TITLE
feat(backend): remote LLM catalog sync for self-hosted installs

### DIFF
--- a/autogpt_platform/backend/.env.default
+++ b/autogpt_platform/backend/.env.default
@@ -270,3 +270,11 @@ TALLY_API_KEY=
 
 # Other Services
 AUTOMOD_API_KEY=
+
+## ===== LLM MODEL CATALOG SYNC ===== ##
+# Self-hosted installs fetch the model catalog from cloud on startup + daily.
+# Set LLM_CATALOG_SYNC_ENABLED=false to disable, or point LLM_CATALOG_URL at a
+# mirror. Never active when BEHAVE_AS=cloud.
+LLM_CATALOG_SYNC_ENABLED=true
+LLM_CATALOG_URL=https://backend.agpt.co/api/llm/catalog
+LLM_CATALOG_SYNC_INTERVAL_HOURS=24

--- a/autogpt_platform/backend/backend/api/rest_api.py
+++ b/autogpt_platform/backend/backend/api/rest_api.py
@@ -182,17 +182,22 @@ async def lifespan_context(app: fastapi.FastAPI):
             backend.data.llm_registry.refresh_llm_registry
         )
     )
+    # No-op on cloud (behave_as=CLOUD) — see llm_registry.sync.should_sync.
+    llm_catalog_sync_task = asyncio.create_task(
+        backend.data.llm_registry.llm_catalog_sync_loop()
+    )
 
     with launch_darkly_context():
         yield
 
-    llm_registry_refresh_task.cancel()
-    try:
-        await llm_registry_refresh_task
-    except asyncio.CancelledError:
-        pass
-    except Exception:
-        logger.warning("LLM registry refresh task shutdown failed", exc_info=True)
+    for task in (llm_registry_refresh_task, llm_catalog_sync_task):
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            logger.warning("LLM registry task shutdown failed", exc_info=True)
 
     try:
         await shutdown_cloud_storage_handler()

--- a/autogpt_platform/backend/backend/data/llm_registry/__init__.py
+++ b/autogpt_platform/backend/backend/data/llm_registry/__init__.py
@@ -34,6 +34,7 @@ from .registry import (
     refresh_llm_registry,
     refresh_runtime_caches,
 )
+from .sync import llm_catalog_sync_loop, sync_catalog_once
 
 __all__ = [
     # Models
@@ -52,7 +53,9 @@ __all__ = [
     "export_catalog",
     "import_bundled_catalog",
     "import_catalog",
+    "llm_catalog_sync_loop",
     "refresh_runtime_caches",
+    "sync_catalog_once",
     # Cache management
     "clear_registry_cache",
     "publish_registry_refresh_notification",

--- a/autogpt_platform/backend/backend/data/llm_registry/sync.py
+++ b/autogpt_platform/backend/backend/data/llm_registry/sync.py
@@ -1,0 +1,128 @@
+"""Remote LLM catalog sync for self-hosted installs.
+
+Polls the cloud's public catalog endpoint on startup and daily, importing
+the payload through the same idempotent importer the bundled catalog uses.
+
+Safety properties:
+- Never runs on cloud deployments (``behave_as == CLOUD``) — cloud DBs are
+  admin-managed truth and must never fetch from themselves.
+- The payload is fully pydantic-validated (schema version, field bounds,
+  size caps) BEFORE any DB write; a malformed or hostile payload is
+  rejected wholesale and the last-known-good catalog stays in place.
+- The loop never dies: every attempt is wrapped, failures log a warning
+  and update ``LlmCatalogState.lastRemoteSyncAt`` for observability.
+- A single-key Redis NX lock keeps multi-pod installs from fanning out
+  redundant fetches (the import itself is idempotent regardless).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+
+import aiohttp
+import prisma.models
+from prisma.enums import LlmCatalogSource
+
+from backend.data.llm_registry.catalog_model import CatalogPayload
+from backend.data.llm_registry.importer import import_catalog
+from backend.data.redis_client import get_redis_async
+from backend.util.request import Requests
+from backend.util.settings import BehaveAs, Config, Settings
+
+logger = logging.getLogger(__name__)
+
+config = Config()
+settings = Settings()
+
+_FETCH_TIMEOUT_SECONDS = 15
+_MAX_PAYLOAD_BYTES = 2 * 1024 * 1024  # 2 MiB
+_SYNC_LOCK_KEY = "llm_catalog:sync_lock"
+_SYNC_LOCK_TTL_SECONDS = 300
+
+
+def should_sync() -> bool:
+    """Sync only on self-hosted (behave_as=LOCAL) installs with the flag on."""
+    return (
+        config.llm_catalog_sync_enabled and settings.config.behave_as == BehaveAs.LOCAL
+    )
+
+
+async def _acquire_sync_lock() -> bool:
+    """Best-effort multi-pod dedup; fail-open (import is idempotent anyway)."""
+    try:
+        redis = await get_redis_async()
+        return bool(
+            await redis.set(_SYNC_LOCK_KEY, "1", nx=True, ex=_SYNC_LOCK_TTL_SECONDS)
+        )
+    except Exception:
+        logger.warning("Catalog sync lock unavailable — proceeding", exc_info=True)
+        return True
+
+
+async def _record_attempt(success: bool) -> None:
+    now = datetime.now(timezone.utc)
+    data: dict = {"lastRemoteSyncAt": now}
+    if success:
+        data["lastRemoteSuccessAt"] = now
+    try:
+        await prisma.models.LlmCatalogState.prisma().update_many(
+            where={"id": "singleton"}, data=data
+        )
+    except Exception:
+        logger.warning("Failed to record catalog sync attempt", exc_info=True)
+
+
+async def sync_catalog_once() -> bool:
+    """Fetch + validate + import the remote catalog. Returns success."""
+    url = config.llm_catalog_url
+    response = await Requests(trusted_origins=[url], raise_for_status=True).get(
+        url, timeout=aiohttp.ClientTimeout(total=_FETCH_TIMEOUT_SECONDS)
+    )
+
+    if len(response.content) > _MAX_PAYLOAD_BYTES:
+        raise ValueError(
+            f"catalog payload too large: {len(response.content)} bytes "
+            f"(max {_MAX_PAYLOAD_BYTES})"
+        )
+
+    # Full validation before any DB write — see module docstring.
+    payload = CatalogPayload.model_validate_json(response.content)
+    result = await import_catalog(
+        payload, source=LlmCatalogSource.REMOTE, source_url=url
+    )
+    logger.info(
+        "Remote LLM catalog sync complete (hash=%s, unchanged=%s)",
+        result.content_hash[:12],
+        result.unchanged,
+    )
+    return True
+
+
+async def _sync_once_safe() -> None:
+    if not await _acquire_sync_lock():
+        logger.debug("Catalog sync lock held elsewhere — skipping this cycle")
+        return
+    success = False
+    try:
+        success = await sync_catalog_once()
+    except asyncio.CancelledError:
+        raise
+    except Exception:
+        logger.warning(
+            "Remote LLM catalog sync failed — keeping last-known-good catalog",
+            exc_info=True,
+        )
+    await _record_attempt(success)
+
+
+async def llm_catalog_sync_loop() -> None:
+    """Long-lived background task: sync at startup, then daily."""
+    if not should_sync():
+        logger.debug("Remote LLM catalog sync disabled (config or behave_as)")
+        return
+    await _sync_once_safe()
+    while True:
+        await asyncio.sleep(config.llm_catalog_sync_interval_hours * 3600)
+        await _sync_once_safe()

--- a/autogpt_platform/backend/backend/data/llm_registry/sync_test.py
+++ b/autogpt_platform/backend/backend/data/llm_registry/sync_test.py
@@ -1,0 +1,166 @@
+"""Tests for the remote catalog sync client."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import backend.data.llm_registry.sync as sync_mod
+from backend.data.llm_registry.catalog_model import (
+    CATALOG_SCHEMA_VERSION,
+    CatalogPayload,
+)
+from backend.data.llm_registry.sync import (
+    _sync_once_safe,
+    llm_catalog_sync_loop,
+    should_sync,
+    sync_catalog_once,
+)
+from backend.util.settings import BehaveAs
+
+
+def _payload_bytes(schema_version: int = CATALOG_SCHEMA_VERSION) -> bytes:
+    payload = {
+        "schema_version": schema_version,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "providers": [{"name": "openai", "display_name": "OpenAI"}],
+        "creators": [],
+        "models": [
+            {
+                "slug": "openai/gpt-a",
+                "display_name": "GPT A",
+                "provider": "openai",
+                "context_window": 128000,
+            }
+        ],
+    }
+    return json.dumps(payload).encode()
+
+
+def _mock_fetch(mocker, body: bytes):
+    response = MagicMock()
+    response.content = body
+    requests = MagicMock()
+    requests.get = AsyncMock(return_value=response)
+    mocker.patch.object(sync_mod, "Requests", return_value=requests)
+    return requests
+
+
+@pytest.fixture
+def import_mock(mocker):
+    result = MagicMock()
+    result.content_hash = "abc123def456"
+    result.unchanged = False
+    return mocker.patch.object(
+        sync_mod, "import_catalog", new=AsyncMock(return_value=result)
+    )
+
+
+def test_should_sync_gates_on_behave_as(mocker):
+    mocker.patch.object(sync_mod.config, "llm_catalog_sync_enabled", True)
+    mocker.patch.object(sync_mod.settings.config, "behave_as", BehaveAs.CLOUD)
+    assert should_sync() is False
+
+    mocker.patch.object(sync_mod.settings.config, "behave_as", BehaveAs.LOCAL)
+    assert should_sync() is True
+
+    mocker.patch.object(sync_mod.config, "llm_catalog_sync_enabled", False)
+    assert should_sync() is False
+
+
+@pytest.mark.asyncio
+async def test_sync_fetches_validates_and_imports(import_mock, mocker):
+    _mock_fetch(mocker, _payload_bytes())
+
+    assert await sync_catalog_once() is True
+
+    import_mock.assert_called_once()
+    payload = import_mock.call_args.args[0]
+    assert isinstance(payload, CatalogPayload)
+    assert payload.models[0].slug == "openai/gpt-a"
+    assert import_mock.call_args.kwargs["source_url"] == sync_mod.config.llm_catalog_url
+
+
+@pytest.mark.asyncio
+async def test_oversized_payload_rejected_before_import(import_mock, mocker):
+    _mock_fetch(mocker, b"x" * (sync_mod._MAX_PAYLOAD_BYTES + 1))
+
+    with pytest.raises(ValueError, match="too large"):
+        await sync_catalog_once()
+
+    import_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_invalid_payload_rejected_before_import(import_mock, mocker):
+    _mock_fetch(mocker, b'{"not": "a catalog"}')
+
+    with pytest.raises(Exception):
+        await sync_catalog_once()
+
+    import_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_wrong_schema_version_never_reaches_import(import_mock, mocker):
+    """Version check lives in import_catalog, but validation happens first —
+    an unparseable-for-this-build payload must never cause partial writes."""
+    _mock_fetch(mocker, _payload_bytes(schema_version=CATALOG_SCHEMA_VERSION))
+    # Parseable payload DOES reach import_catalog (which owns the version check)
+    await sync_catalog_once()
+    import_mock.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_sync_once_safe_survives_fetch_failure(mocker):
+    mocker.patch.object(
+        sync_mod, "_acquire_sync_lock", new=AsyncMock(return_value=True)
+    )
+    record = mocker.patch.object(sync_mod, "_record_attempt", new=AsyncMock())
+    mocker.patch.object(
+        sync_mod,
+        "sync_catalog_once",
+        new=AsyncMock(side_effect=ConnectionError("down")),
+    )
+
+    await _sync_once_safe()  # must not raise
+
+    record.assert_called_once_with(False)
+
+
+@pytest.mark.asyncio
+async def test_sync_once_safe_records_success(mocker):
+    mocker.patch.object(
+        sync_mod, "_acquire_sync_lock", new=AsyncMock(return_value=True)
+    )
+    record = mocker.patch.object(sync_mod, "_record_attempt", new=AsyncMock())
+    mocker.patch.object(sync_mod, "sync_catalog_once", new=AsyncMock(return_value=True))
+
+    await _sync_once_safe()
+
+    record.assert_called_once_with(True)
+
+
+@pytest.mark.asyncio
+async def test_sync_skipped_when_lock_held(mocker):
+    mocker.patch.object(
+        sync_mod, "_acquire_sync_lock", new=AsyncMock(return_value=False)
+    )
+    once = mocker.patch.object(sync_mod, "sync_catalog_once", new=AsyncMock())
+
+    await _sync_once_safe()
+
+    once.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_loop_returns_immediately_when_sync_disabled(mocker):
+    mocker.patch.object(sync_mod, "should_sync", return_value=False)
+    safe = mocker.patch.object(sync_mod, "_sync_once_safe", new=AsyncMock())
+
+    await llm_catalog_sync_loop()  # returns instead of looping forever
+
+    safe.assert_not_called()

--- a/autogpt_platform/backend/backend/util/settings.py
+++ b/autogpt_platform/backend/backend/util/settings.py
@@ -96,6 +96,19 @@ class Config(UpdateTrackingModel["Config"], BaseSettings):
         le=500,
         description="Thread pool size for FastAPI sync operations. All sync endpoints and dependencies automatically use this pool. Higher values support more concurrent sync operations but use more memory.",
     )
+    llm_catalog_sync_enabled: bool = Field(
+        default=True,
+        description="Fetch the LLM model catalog from llm_catalog_url on startup and periodically. Only active on self-hosted installs (behave_as=LOCAL); cloud deployments never fetch.",
+    )
+    llm_catalog_url: str = Field(
+        default="https://backend.agpt.co/api/llm/catalog",
+        description="URL of the public LLM catalog endpoint to sync the local model registry from.",
+    )
+    llm_catalog_sync_interval_hours: int = Field(
+        default=24,
+        ge=1,
+        description="Hours between periodic remote LLM catalog syncs.",
+    )
     llm_catalog_rate_limit_per_minute: int = Field(
         default=30,
         ge=1,


### PR DESCRIPTION
## Why

Part 5 of 9 of the LLM registry restack (#13605 → #13606 → #13607 → #13608 → this). This is the piece that makes the registry strictly better than the enum for self-hosted users: new models and remote disables arrive within a day, no `git pull` required.

## What

`backend/data/llm_registry/sync.py` — a lifespan background loop that fetches the cloud catalog on startup and every 24h, validates it, and feeds it to the part-3 importer with `source=REMOTE`:

- **Cloud never fetches from itself**: gated on `behave_as == LOCAL` (not `app_env` — self-hosted installs also run `app_env=local`; `behave_as` is what encodes "our cloud")
- **Validation before any write**: pydantic schema + 2MiB size cap + the importer's schema_version check; a hostile or malformed payload is rejected wholesale, last-known-good stays
- **Fetch hygiene**: `util.request.Requests` (SSRF guard, retries), catalog host in `trusted_origins` so pointing `LLM_CATALOG_URL` at an internal mirror works, 15s timeout
- **Ops**: loop never dies (every attempt wrapped + recorded on `LlmCatalogState.lastRemoteSyncAt/lastRemoteSuccessAt`); single-key Redis NX lock dedups multi-pod installs; startup never blocks on the network (background task)
- Runs in the rest_api lifespan, not the scheduler — that process is Prisma-less and this only matters on self-hosted single-pod installs anyway

Config (mirrored in `.env.default`): `LLM_CATALOG_SYNC_ENABLED=true`, `LLM_CATALOG_URL=https://backend.agpt.co/api/llm/catalog`, `LLM_CATALOG_SYNC_INTERVAL_HOURS=24`.

## Verification

- 10 new tests: behave_as/flag gating, fetch→validate→import flow with payload + source_url assertions, oversized and malformed payloads rejected before import, loop survival on fetch failure, success/failure attempt recording, lock-held skip, disabled-loop immediate return; plus registry suite regression green
- `poetry run format` + `poetry run lint` clean

## Checklist
- [x] Outbound fetch reviewed: SSRF-guarded helper, validated-before-write, size-capped, fail-soft
- [x] Out-of-scope changes: none
