### PR TITLE
feat(backend/copilot): resolve copilot models through the LLM registry

### DIFF
--- a/autogpt_platform/backend/backend/copilot/baseline/service.py
+++ b/autogpt_platform/backend/backend/copilot/baseline/service.py
@@ -56,7 +56,7 @@ from backend.copilot.model import (
     upsert_chat_session,
 )
 from backend.copilot.model_normalize import normalize_model_for_transport
-from backend.copilot.model_router import resolve_model
+from backend.copilot.model_router import ResolvedModel, resolve_model_route
 from backend.copilot.moonshot import is_moonshot_model
 from backend.copilot.pending_message_helpers import (
     combine_pending_with_current,
@@ -401,15 +401,16 @@ def _filter_tools_by_permissions(
 
 async def _resolve_baseline_model(
     tier: CopilotLlmModel | None, user_id: str | None
-) -> str:
+) -> ResolvedModel:
     """Pick the model for the baseline path based on the per-request tier.
 
-    Delegates to :func:`copilot.model_router.resolve_model` so the
-    ``(fast, tier)`` cell is LD-overridable per user.  ``None`` tier
-    maps to ``"standard"``.
+    Delegates to :func:`copilot.model_router.resolve_model_route` so the
+    ``(fast, tier)`` cell resolves LD → registry cell → env.  ``None`` tier
+    maps to ``"standard"``.  The routing source rides along so persisted
+    assistant messages can be stamped for product-intelligence segmentation.
     """
     tier_name = "advanced" if tier == "advanced" else "standard"
-    return await resolve_model("fast", tier_name, user_id, config=config)
+    return await resolve_model_route("fast", tier_name, user_id, config=config)
 
 
 @dataclass
@@ -421,6 +422,9 @@ class _BaselineStreamState:
     """
 
     model: str = ""
+    # Which routing layer picked ``model`` ("ld" | "db" | "env") — stamped
+    # onto persisted assistant messages for product-intelligence segmentation.
+    routing_source: str = "env"
     # Live delivery channel drained concurrently by ``stream_chat_completion_baseline``
     # so reasoning / text / tool events reach the SSE wire **during** the upstream
     # LLM stream, not after ``_baseline_llm_caller`` returns.  Before this was a
@@ -1232,6 +1236,8 @@ def _baseline_conversation_updater(
     if state is not None and tool_results:
         assistant_msg = ChatMessage(
             role="assistant",
+            model=state.model,
+            routing_source=state.routing_source,
             content=response.response_text or "",
             tool_calls=[
                 {
@@ -1639,7 +1645,9 @@ async def stream_chat_completion_baseline(
     # would be rejected by the direct client.  Pass the baseline-side
     # ``config`` so monkeypatch fixtures targeting this module's
     # ``config`` symbol drive the decision.
-    resolved_model = await _resolve_baseline_model(model, user_id)
+    resolved_route = await _resolve_baseline_model(model, user_id)
+    resolved_model = resolved_route.model
+    routing_source = resolved_route.source
     try:
         active_model = normalize_model_for_transport(resolved_model, config)
     except ValueError as exc:
@@ -1660,6 +1668,7 @@ async def stream_chat_completion_baseline(
             active_model = normalize_model_for_transport(tier_default, config)
         except ValueError:
             raise exc
+        routing_source = "env"
         logger.warning(
             "[Baseline] [%s] LD model %r rejected for tier=%s (%s); falling "
             "back to tier default %s",
@@ -2059,7 +2068,7 @@ async def stream_chat_completion_baseline(
         logger.warning("[Baseline] Langfuse trace context setup failed")
 
     _stream_error = False  # Track whether an error occurred during streaming
-    state = _BaselineStreamState(model=active_model)
+    state = _BaselineStreamState(model=active_model, routing_source=routing_source)
 
     # Bind extracted module-level callbacks to this request's state/session
     # using functools.partial so they satisfy the Protocol signatures.
@@ -2199,7 +2208,12 @@ async def stream_chat_completion_baseline(
                     current_session = _session_holder[0]
                     if text_only_text.strip():
                         current_session.messages.append(
-                            ChatMessage(role="assistant", content=text_only_text)
+                            ChatMessage(
+                                role="assistant",
+                                content=text_only_text,
+                                model=state.model,
+                                routing_source=state.routing_source,
+                            )
                         )
                     for _buffered in state.session_messages:
                         current_session.messages.append(_buffered)
@@ -2469,7 +2483,14 @@ async def stream_chat_completion_baseline(
             if final_text.startswith(recorded):
                 final_text = final_text[len(recorded) :]
         if final_text.strip():
-            session.messages.append(ChatMessage(role="assistant", content=final_text))
+            session.messages.append(
+                ChatMessage(
+                    role="assistant",
+                    content=final_text,
+                    model=state.model,
+                    routing_source=state.routing_source,
+                )
+            )
         try:
             await upsert_chat_session(session)
         except Exception as persist_err:

--- a/autogpt_platform/backend/backend/copilot/db.py
+++ b/autogpt_platform/backend/backend/copilot/db.py
@@ -525,6 +525,11 @@ async def add_chat_messages_batch(
                     if msg.get("duration_ms") is not None:
                         data["durationMs"] = msg["duration_ms"]
 
+                    if msg.get("model") is not None:
+                        data["model"] = msg["model"]
+                    if msg.get("routing_source") is not None:
+                        data["routingSource"] = msg["routing_source"]
+
                     messages_data.append(data)
 
                 # Run create_many and session update in parallel within transaction

--- a/autogpt_platform/backend/backend/copilot/model.py
+++ b/autogpt_platform/backend/backend/copilot/model.py
@@ -104,6 +104,12 @@ class ChatMessage(BaseModel):
     duration_ms: int | None = None
     created_at: datetime | None = None
 
+    # Which LLM served this assistant turn and which routing layer picked it
+    # ("ld" | "db" | "env"). Product-intelligence mirrors these to segment
+    # quality judgments by model. None on user/tool rows.
+    model: str | None = None
+    routing_source: str | None = None
+
     # Owning session id and generic per-row JSONB bag.  Today the
     # dispatcher uses ``metadata`` to preserve the submit-time payload
     # (file_ids / mode / model / permissions / context / arrival_at)
@@ -130,6 +136,8 @@ class ChatMessage(BaseModel):
             created_at=prisma_message.createdAt,
             session_id=prisma_message.sessionId,
             metadata=_parse_json_field(prisma_message.metadata),
+            model=prisma_message.model,
+            routing_source=prisma_message.routingSource,
         )
 
 
@@ -872,6 +880,8 @@ async def _save_session_to_db(
                     "refusal": msg.refusal,
                     "tool_calls": msg.tool_calls,
                     "function_call": msg.function_call,
+                    "model": msg.model,
+                    "routing_source": msg.routing_source,
                 }
             )
         logger.info(

--- a/autogpt_platform/backend/backend/copilot/model_router.py
+++ b/autogpt_platform/backend/backend/copilot/model_router.py
@@ -1,11 +1,21 @@
-"""LaunchDarkly-aware model selection for the copilot.
+"""Model selection for the copilot: LaunchDarkly → registry cell → env.
 
-Each cell of the ``(mode, tier)`` matrix has a static default baked into
-``ChatConfig`` (see ``copilot/config.py``) and a single JSON-valued
-LaunchDarkly feature flag — ``copilot-model-routing`` — that can override
-it per-user.  This module centralises the lookup so both the baseline
-and SDK paths agree on the selection rule and so A/B experiments can
-target a single cell without shipping a config change.
+Each cell of the ``(mode, tier)`` matrix resolves through three layers:
+
+1. The JSON-valued LaunchDarkly flag ``copilot-model-routing`` (per-user —
+   cohort experiments and rollouts live here, and the flag returns model
+   slugs directly).
+2. The LLM registry's admin-set routing cell (``LlmModelRoute``, surface
+   ``"copilot"``) — the config layer the admin page edits.
+3. The static ``ChatConfig`` default (env vars) — the bootstrap floor.
+
+The registry is the serve-time gate for layers 1 and 2: a slug the registry
+doesn't know, or one with ``isEnabled=false`` (the kill switch), is refused —
+loudly (log + Sentry + route_warnings record) — and resolution falls through
+to the next layer. ``visibility=HIDDEN`` models DO serve when routed: that's
+the pre-launch testing state (registered + routable, not shown in pickers).
+An EMPTY registry never gates anything, so installs where the registry is
+dormant keep exact pre-registry behavior.
 
 Matrix:
 
@@ -24,22 +34,63 @@ LD payload shape::
     }
 
 Missing mode, missing tier-within-mode, non-string cell value, non-dict
-payload, or LD failure all fall back to the corresponding ``ChatConfig``
-default.
+payload, or LD failure all fall through to the next layer.
 """
 
 from __future__ import annotations
 
 import logging
-from typing import Literal
+from typing import Literal, NamedTuple
 
+import sentry_sdk
+
+import backend.data.llm_registry as llm_registry
 from backend.copilot.config import ChatConfig
+from backend.copilot.route_warnings import record_route_warning
 from backend.util.feature_flag import Flag, get_feature_flag_value
 
 logger = logging.getLogger(__name__)
 
 ModelMode = Literal["fast", "thinking"]
 ModelTier = Literal["standard", "advanced"]
+RoutingSource = Literal["ld", "db", "env"]
+
+ROUTE_SURFACE_COPILOT = "copilot"
+
+
+class ResolvedModel(NamedTuple):
+    model: str
+    source: RoutingSource
+
+
+async def _registry_refuses(slug: str, layer: RoutingSource) -> str | None:
+    """Return a refusal reason if the registry gates *slug*, else None.
+
+    An empty registry gates nothing (dormant-registry installs must keep
+    exact pre-registry behavior). Unknown slug or kill-switched model is
+    refused; HIDDEN visibility serves fine when explicitly routed.
+    """
+    if not llm_registry.get_all_models():
+        return None
+    model = llm_registry.get_model(slug)
+    if model is None:
+        reason = "unknown to the model registry"
+    elif not model.is_enabled:
+        reason = "disabled in the model registry (kill switch)"
+    else:
+        return None
+    logger.warning(
+        "[model_router] %s-layer slug %r refused: %s — falling through",
+        layer,
+        slug,
+        reason,
+    )
+    sentry_sdk.capture_message(
+        f"copilot routing refused {layer} slug {slug!r}: {reason}",
+        level="warning",
+    )
+    await record_route_warning(slug, reason, layer)
+    return reason
 
 
 def _config_default(config: ChatConfig, mode: ModelMode, tier: ModelTier) -> str:
@@ -56,24 +107,8 @@ def _config_default(config: ChatConfig, mode: ModelMode, tier: ModelTier) -> str
     )
 
 
-async def resolve_model(
-    mode: ModelMode,
-    tier: ModelTier,
-    user_id: str | None,
-    *,
-    config: ChatConfig,
-) -> str:
-    """Return the model identifier for a ``(mode, tier)`` cell.
-
-    Consults ``copilot-model-routing`` (JSON) for *user_id* — LD targeting is
-    still per-user so cohorts can receive different routing — and falls back to
-    the ``ChatConfig`` default on missing user, missing / invalid flag payload,
-    or non-string cell value.
-    """
-    fallback = _config_default(config, mode, tier).strip()
-    if not user_id:
-        return fallback
-
+async def _ld_cell_value(mode: ModelMode, tier: ModelTier, user_id: str) -> str | None:
+    """Extract the (mode, tier) slug from the LD JSON flag, or None."""
     try:
         payload: object = await get_feature_flag_value(
             Flag.COPILOT_MODEL_ROUTING.value, user_id, default=None
@@ -81,27 +116,25 @@ async def resolve_model(
     except Exception:
         logger.warning(
             "[model_router] LD lookup failed for copilot-model-routing — "
-            "using config default %s for (%s, %s)",
-            fallback,
+            "falling through for (%s, %s)",
             mode,
             tier,
             exc_info=True,
         )
-        return fallback
+        return None
 
     if payload is None:
-        return fallback
+        return None
 
     if not isinstance(payload, dict):
         logger.warning(
             "[model_router] copilot-model-routing expected a JSON object, got %r — "
-            "using config default %s for (%s, %s)",
+            "falling through for (%s, %s)",
             payload,
-            fallback,
             mode,
             tier,
         )
-        return fallback
+        return None
 
     mode_cell = payload.get(mode)
     if mode in payload and not isinstance(mode_cell, dict):
@@ -109,14 +142,13 @@ async def resolve_model(
         # a {tier: model} dict — surface the typo in logs.
         logger.warning(
             "[model_router] copilot-model-routing[%s] expected a JSON object, "
-            "got %r — using config default %s for tier %s",
+            "got %r — falling through for tier %s",
             mode,
             mode_cell,
-            fallback,
             tier,
         )
     if not isinstance(mode_cell, dict):
-        return fallback
+        return None
 
     value = mode_cell.get(tier)
     if isinstance(value, str) and value.strip():
@@ -129,10 +161,47 @@ async def resolve_model(
         )
         logger.warning(
             "[model_router] copilot-model-routing[%s][%s] returned %s — "
-            "using config default %s",
+            "falling through",
             mode,
             tier,
             reason,
-            fallback,
         )
-    return fallback
+    return None
+
+
+async def resolve_model_route(
+    mode: ModelMode,
+    tier: ModelTier,
+    user_id: str | None,
+    *,
+    config: ChatConfig,
+) -> ResolvedModel:
+    """Resolve a ``(mode, tier)`` cell through LD → registry cell → env.
+
+    Every layer's slug is validated against the registry (see module
+    docstring); a refused slug falls through to the next layer. The returned
+    ``source`` is stamped onto persisted chat messages so product
+    intelligence can segment quality metrics by model and routing layer.
+    """
+    if user_id:
+        ld_slug = await _ld_cell_value(mode, tier, user_id)
+        if ld_slug and await _registry_refuses(ld_slug, "ld") is None:
+            return ResolvedModel(ld_slug, "ld")
+
+    cell_slug = llm_registry.get_route(ROUTE_SURFACE_COPILOT, mode, tier)
+    if cell_slug and await _registry_refuses(cell_slug, "db") is None:
+        return ResolvedModel(cell_slug, "db")
+
+    return ResolvedModel(_config_default(config, mode, tier).strip(), "env")
+
+
+async def resolve_model(
+    mode: ModelMode,
+    tier: ModelTier,
+    user_id: str | None,
+    *,
+    config: ChatConfig,
+) -> str:
+    """Back-compat wrapper for callers that only need the model id."""
+    resolved = await resolve_model_route(mode, tier, user_id, config=config)
+    return resolved.model

--- a/autogpt_platform/backend/backend/copilot/model_router_test.py
+++ b/autogpt_platform/backend/backend/copilot/model_router_test.py
@@ -314,3 +314,163 @@ class TestResolveModel:
             await resolve_model("thinking", "advanced", "u", config=cfg)
 
         assert calls == ["copilot-model-routing"] * 4
+
+
+class TestRegistryGating:
+    """LD → registry cell → env resolution with serve-time slug validation."""
+
+    @pytest.fixture(autouse=True)
+    def registry_state(self, mocker):
+        import backend.data.llm_registry.registry as reg
+        from backend.data.llm_registry.registry import (
+            RegistryModel,
+            RegistryModelMetadata,
+        )
+
+        def make(slug, *, enabled=True, visibility="GA"):
+            return RegistryModel(
+                slug=slug,
+                display_name=slug,
+                metadata=RegistryModelMetadata(
+                    provider="open_router",
+                    context_window=100000,
+                    max_output_tokens=8192,
+                    display_name=slug,
+                    provider_name="OpenRouter",
+                    creator_name="Test",
+                    price_tier=2,
+                ),
+                provider_display_name="OpenRouter",
+                is_enabled=enabled,
+                visibility=visibility,
+            )
+
+        self.reg = reg
+        self.make = make
+        old_models, old_routes = reg._dynamic_models, reg._routes
+        reg._dynamic_models = {
+            "known/model": make("known/model"),
+            "disabled/model": make("disabled/model", enabled=False),
+            "hidden/model": make("hidden/model", visibility="HIDDEN"),
+            "cell/model": make("cell/model"),
+        }
+        reg._routes = {}
+        self.record = mocker.patch(
+            "backend.copilot.model_router.record_route_warning", new=AsyncMock()
+        )
+        mocker.patch("backend.copilot.model_router.sentry_sdk.capture_message")
+        yield
+        reg._dynamic_models, reg._routes = old_models, old_routes
+
+    def _ld(self, mocker, slug):
+        mocker.patch(
+            "backend.copilot.model_router.get_feature_flag_value",
+            new=AsyncMock(return_value={"fast": {"standard": slug}}),
+        )
+
+    @pytest.mark.asyncio
+    async def test_known_ld_slug_serves_with_ld_source(self, mocker):
+        from backend.copilot.model_router import resolve_model_route
+
+        self._ld(mocker, "known/model")
+        resolved = await resolve_model_route(
+            "fast", "standard", "user-1", config=_make_config()
+        )
+        assert resolved == ("known/model", "ld")
+
+    @pytest.mark.asyncio
+    async def test_unknown_ld_slug_refused_and_falls_through(self, mocker):
+        from backend.copilot.model_router import resolve_model_route
+
+        self._ld(mocker, "typo/model")
+        resolved = await resolve_model_route(
+            "fast", "standard", "user-1", config=_make_config()
+        )
+        assert resolved.source == "env"
+        self.record.assert_called_once()
+        assert self.record.call_args.args[0] == "typo/model"
+
+    @pytest.mark.asyncio
+    async def test_disabled_ld_slug_refused_kill_switch(self, mocker):
+        from backend.copilot.model_router import resolve_model_route
+
+        self._ld(mocker, "disabled/model")
+        resolved = await resolve_model_route(
+            "fast", "standard", "user-1", config=_make_config()
+        )
+        assert resolved.source == "env"
+        self.record.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_hidden_ld_slug_serves(self, mocker):
+        """HIDDEN = registered + routable, just not shown in pickers."""
+        from backend.copilot.model_router import resolve_model_route
+
+        self._ld(mocker, "hidden/model")
+        resolved = await resolve_model_route(
+            "fast", "standard", "user-1", config=_make_config()
+        )
+        assert resolved == ("hidden/model", "ld")
+        self.record.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_db_cell_used_when_no_ld(self, mocker):
+        from backend.copilot.model_router import resolve_model_route
+
+        mocker.patch(
+            "backend.copilot.model_router.get_feature_flag_value",
+            new=AsyncMock(return_value=None),
+        )
+        self.reg._routes = {("copilot", "fast", "standard"): "cell/model"}
+        resolved = await resolve_model_route(
+            "fast", "standard", "user-1", config=_make_config()
+        )
+        assert resolved == ("cell/model", "db")
+
+    @pytest.mark.asyncio
+    async def test_ld_beats_db_cell(self, mocker):
+        from backend.copilot.model_router import resolve_model_route
+
+        self._ld(mocker, "known/model")
+        self.reg._routes = {("copilot", "fast", "standard"): "cell/model"}
+        resolved = await resolve_model_route(
+            "fast", "standard", "user-1", config=_make_config()
+        )
+        assert resolved == ("known/model", "ld")
+
+    @pytest.mark.asyncio
+    async def test_stale_db_cell_refused_falls_to_env(self, mocker):
+        from backend.copilot.model_router import resolve_model_route
+
+        mocker.patch(
+            "backend.copilot.model_router.get_feature_flag_value",
+            new=AsyncMock(return_value=None),
+        )
+        self.reg._routes = {("copilot", "fast", "standard"): "disabled/model"}
+        cfg = _make_config()
+        resolved = await resolve_model_route("fast", "standard", "user-1", config=cfg)
+        assert resolved == (cfg.fast_standard_model, "env")
+        assert self.record.call_args.args[2] == "db"
+
+    @pytest.mark.asyncio
+    async def test_no_user_skips_ld_but_uses_db_cell(self):
+        from backend.copilot.model_router import resolve_model_route
+
+        self.reg._routes = {("copilot", "fast", "standard"): "cell/model"}
+        resolved = await resolve_model_route(
+            "fast", "standard", None, config=_make_config()
+        )
+        assert resolved == ("cell/model", "db")
+
+    @pytest.mark.asyncio
+    async def test_empty_registry_gates_nothing(self, mocker):
+        """Dormant-registry installs keep exact pre-registry behavior."""
+        from backend.copilot.model_router import resolve_model_route
+
+        self.reg._dynamic_models = {}
+        self._ld(mocker, "totally/unregistered")
+        resolved = await resolve_model_route(
+            "fast", "standard", "user-1", config=_make_config()
+        )
+        assert resolved == ("totally/unregistered", "ld")
+        self.record.assert_not_called()

--- a/autogpt_platform/backend/backend/copilot/route_warnings.py
+++ b/autogpt_platform/backend/backend/copilot/route_warnings.py
@@ -1,0 +1,78 @@
+"""Observability for model-routing fallbacks.
+
+When LaunchDarkly (or an admin routing cell) references a model slug the
+registry doesn't know or has disabled, the resolver falls through to the next
+layer. That's the safe behavior — but a typo'd slug in LD would otherwise be
+invisible until someone wonders why an experiment isn't running. Every such
+refusal is recorded here (single Redis hash key — cluster-safe) so the admin
+UI can surface "LD referenced `kimi-k3s` 400× in the last day, no such model".
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+
+from pydantic import BaseModel
+
+from backend.data.redis_client import get_redis_async
+
+logger = logging.getLogger(__name__)
+
+_WARNINGS_KEY = "llm_route:warnings"
+_WARNINGS_TTL_SECONDS = 7 * 24 * 3600
+
+
+class RouteWarning(BaseModel):
+    slug: str
+    reason: str
+    count: int
+    last_seen: datetime
+    last_layer: str  # "ld" | "db"
+
+
+async def record_route_warning(slug: str, reason: str, layer: str) -> None:
+    """Best-effort; never lets observability break routing."""
+    try:
+        redis = await get_redis_async()
+        raw = await redis.hget(_WARNINGS_KEY, slug)
+        count = (json.loads(raw).get("count", 0) if raw else 0) + 1
+        entry = {
+            "reason": reason,
+            "count": count,
+            "last_seen": datetime.now(timezone.utc).isoformat(),
+            "last_layer": layer,
+        }
+        async with redis.pipeline(transaction=True) as pipe:
+            pipe.hset(_WARNINGS_KEY, slug, json.dumps(entry))
+            pipe.expire(_WARNINGS_KEY, _WARNINGS_TTL_SECONDS)
+            await pipe.execute()
+    except Exception:
+        logger.warning("Failed to record route warning for %s", slug, exc_info=True)
+
+
+async def get_route_warnings() -> list[RouteWarning]:
+    """Recent routing refusals, most-hit first. Empty on any Redis trouble."""
+    try:
+        redis = await get_redis_async()
+        entries = await redis.hgetall(_WARNINGS_KEY)
+    except Exception:
+        logger.warning("Failed to read route warnings", exc_info=True)
+        return []
+    warnings: list[RouteWarning] = []
+    for slug, raw in entries.items():
+        try:
+            data = json.loads(raw)
+            warnings.append(
+                RouteWarning(
+                    slug=slug if isinstance(slug, str) else slug.decode(),
+                    reason=data["reason"],
+                    count=data["count"],
+                    last_seen=data["last_seen"],
+                    last_layer=data.get("last_layer", "ld"),
+                )
+            )
+        except Exception:
+            continue
+    return sorted(warnings, key=lambda w: w.count, reverse=True)

--- a/autogpt_platform/backend/backend/copilot/route_warnings.py
+++ b/autogpt_platform/backend/backend/copilot/route_warnings.py
@@ -36,7 +36,7 @@ async def record_route_warning(slug: str, reason: str, layer: str) -> None:
     """Best-effort; never lets observability break routing."""
     try:
         redis = await get_redis_async()
-        raw = await redis.hget(_WARNINGS_KEY, slug)
+        raw = await redis.hget(_WARNINGS_KEY, slug)  # type: ignore[misc]
         count = (json.loads(raw).get("count", 0) if raw else 0) + 1
         entry = {
             "reason": reason,
@@ -56,7 +56,7 @@ async def get_route_warnings() -> list[RouteWarning]:
     """Recent routing refusals, most-hit first. Empty on any Redis trouble."""
     try:
         redis = await get_redis_async()
-        entries = await redis.hgetall(_WARNINGS_KEY)
+        entries = await redis.hgetall(_WARNINGS_KEY)  # type: ignore[misc]
     except Exception:
         logger.warning("Failed to read route warnings", exc_info=True)
         return []

--- a/autogpt_platform/backend/migrations/20260718000000_add_chat_message_model_stamp/migration.sql
+++ b/autogpt_platform/backend/migrations/20260718000000_add_chat_message_model_stamp/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "ChatMessage" ADD COLUMN "model" TEXT,
+ADD COLUMN "routingSource" TEXT;

--- a/autogpt_platform/backend/schema.prisma
+++ b/autogpt_platform/backend/schema.prisma
@@ -420,6 +420,13 @@ model ChatMessage {
   sequence   Int
   durationMs Int? // Wall-clock milliseconds for this assistant turn
 
+  // Which LLM served this assistant turn, and which routing layer picked it
+  // ("ld" | "db" | "env"). Product-intelligence mirrors these columns to
+  // segment quality judgments by model — model experiments are unmeasurable
+  // without them. Null on user/tool rows and rows predating this column.
+  model         String?
+  routingSource String?
+
   // Per-row JSONB metadata bag.  Currently holds the dispatcher's
   // submit-time payload (file_ids, mode, model, permissions, context,
   // request_arrival_at) on the user row that triggered a queued turn,


### PR DESCRIPTION
## Why

Part 6 of 9 of the LLM registry restack (#13605 → #13606 → #13607 → #13608 → #13609 → this). Today copilot routing is an LD JSON flag returning raw model slugs nothing validates — the #13596 failure mode (LD referencing a model the platform has no data for) is structurally possible. This PR makes the registry the serve-time gate while keeping LD as the experiment layer, and stamps served models onto chat messages so model experiments become measurable.

## What

**Resolution chain** (`copilot/model_router.py`): LD slug flag (per-user, unchanged JSON shape) → registry routing cell (`LlmModelRoute`, the admin-page config layer) → `ChatConfig` env default.

- **Serve-time gating**: unknown-to-registry or `isEnabled=false` (kill switch) slugs are refused — warning log + Sentry event + Redis-recorded resolution warning — and resolution falls through to the next layer. A bad LD edit degrades to the default, loudly, instead of erroring at users or serving a dead model.
- **`visibility=HIDDEN` serves when routed**: the pre-launch state — register K3 as HIDDEN, LD-target employees, watch scores, flip GA.
- **Empty registry gates nothing**: installs where the registry is dormant keep exact pre-registry behavior — all 27 pre-existing router tests pass unchanged.
- `resolve_model()` remains as a wrapper; the SDK path keeps working untouched.

**Measurement stamp**: `ChatMessage.model` + `ChatMessage.routingSource` ("ld"/"db"/"env") — nullable columns, own migration — stamped by the baseline service on every persisted assistant message. Product-intelligence's chat mirror currently captures no model identifier, making every model experiment unmeasurable; this is the join key (PI-side mirror column is a follow-up in that repo).

**`route_warnings.py`**: single-key Redis hash (cluster-safe) of recent routing refusals with counts — the admin API (part 7) exposes it so a typo'd LD slug is a minutes-long incident, not an invisible one.

## Known scope cut

The SDK-path service resolves through the same validated chain but doesn't stamp its messages yet — its persistence path differs and the stamp will follow with the part-7 wiring. Called out here so it's a decision, not an accident.

## Verification

- 36/36 model_router tests: all 27 pre-existing behavior tests unchanged + 9 new (known/unknown/disabled/HIDDEN via LD, db-cell hit, LD-beats-cell, stale-cell fall-through with layer attribution, no-user cell resolution, empty-registry passthrough)
- Copilot db/baseline suites: green except 7 pre-existing failures that reproduce identically on the base branch without this diff (local Redis-cluster env quirk; verified via stash)
- `poetry run format` + `poetry run lint` clean; migration applied on the full local chain

## Checklist
- [x] Fall-through preserves current behavior when registry is empty/cells unset (tested)
- [x] Out-of-scope changes: none
