### PR TITLE
feat(backend/api): admin LLM registry API with audit logging

### DIFF
--- a/autogpt_platform/backend/backend/api/features/admin/llm_admin_model.py
+++ b/autogpt_platform/backend/backend/api/features/admin/llm_admin_model.py
@@ -112,6 +112,7 @@ class LlmCreatorAdminResponse(pydantic.BaseModel):
     description: str | None = None
     website_url: str | None = None
     logo_url: str | None = None
+    source: str = "SEED"
     metadata: dict[str, Any] = pydantic.Field(default_factory=dict)
     created_at: str | None = None
     updated_at: str | None = None
@@ -130,6 +131,7 @@ class LlmProviderAdminResponse(pydantic.BaseModel):
     name: str
     display_name: str
     description: str | None = None
+    source: str = "SEED"
     metadata: dict[str, Any] = pydantic.Field(default_factory=dict)
     created_at: str | None = None
     updated_at: str | None = None
@@ -164,3 +166,31 @@ class LlmModelAdminResponse(pydantic.BaseModel):
     updated_at: str | None = None
     creator: LlmCreatorAdminResponse | None = None
     costs: list[LlmModelCostAdminResponse] = pydantic.Field(default_factory=list)
+
+
+class LlmMigrationAdminResponse(pydantic.BaseModel):
+    id: str
+    source_model_slug: str
+    target_model_slug: str
+    reason: str | None = None
+    node_count: int
+    custom_credit_cost: int | None = None
+    is_reverted: bool
+    reverted_at: str | None = None
+    created_at: str
+
+
+class LlmModelsAdminListResponse(pydantic.BaseModel):
+    models: list[LlmModelAdminResponse]
+
+
+class LlmProvidersAdminListResponse(pydantic.BaseModel):
+    providers: list[LlmProviderAdminResponse]
+
+
+class LlmCreatorsAdminListResponse(pydantic.BaseModel):
+    creators: list[LlmCreatorAdminResponse]
+
+
+class LlmMigrationsAdminListResponse(pydantic.BaseModel):
+    migrations: list[LlmMigrationAdminResponse]

--- a/autogpt_platform/backend/backend/api/features/admin/llm_admin_model.py
+++ b/autogpt_platform/backend/backend/api/features/admin/llm_admin_model.py
@@ -1,0 +1,166 @@
+"""Request/response models for the LLM registry admin API."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+import pydantic
+
+LlmVisibility = Literal["GA", "EMPLOYEES", "ADMINS", "HIDDEN"]
+LlmSubscriptionTier = Literal[
+    "NO_TIER", "BASIC", "PRO", "MAX", "BUSINESS", "ENTERPRISE"
+]
+
+
+class CreateLlmModelRequest(pydantic.BaseModel):
+    slug: str
+    display_name: str
+    description: str | None = None
+    provider_name: str
+    creator_id: str | None = None
+    context_window: int = pydantic.Field(gt=0)
+    max_output_tokens: int | None = pydantic.Field(default=None, gt=0)
+    price_tier: int = pydantic.Field(ge=1, le=3)
+    is_enabled: bool = True
+    is_recommended: bool = False
+    kind: Literal["CHAT"] = "CHAT"
+    visibility: LlmVisibility = "GA"
+    min_subscription_tier: LlmSubscriptionTier | None = None
+    fallback_model_slug: str | None = None
+    supports_tools: bool = False
+    supports_json_output: bool = False
+    supports_reasoning: bool = False
+    supports_parallel_tool_calls: bool = False
+    capabilities: dict[str, Any] = pydantic.Field(default_factory=dict)
+    metadata: dict[str, Any] = pydantic.Field(default_factory=dict)
+    costs: list[dict[str, Any]] = pydantic.Field(default_factory=list)
+
+
+class UpdateLlmModelRequest(pydantic.BaseModel):
+    display_name: str | None = None
+    description: str | None = None
+    creator_id: str | None = None
+    context_window: int | None = pydantic.Field(default=None, gt=0)
+    max_output_tokens: int | None = pydantic.Field(default=None, gt=0)
+    price_tier: int | None = pydantic.Field(default=None, ge=1, le=3)
+    is_enabled: bool | None = None
+    is_recommended: bool | None = None
+    kind: Literal["CHAT"] | None = None
+    visibility: LlmVisibility | None = None
+    min_subscription_tier: LlmSubscriptionTier | None = None
+    fallback_model_slug: str | None = None
+    supports_tools: bool | None = None
+    supports_json_output: bool | None = None
+    supports_reasoning: bool | None = None
+    supports_parallel_tool_calls: bool | None = None
+    capabilities: dict[str, Any] | None = None
+    metadata: dict[str, Any] | None = None
+
+
+class ToggleLlmModelRequest(pydantic.BaseModel):
+    is_enabled: bool
+    migrate_to_slug: str | None = None
+    migration_reason: str | None = None
+    custom_credit_cost: int | None = None
+
+
+class CreateLlmCreatorRequest(pydantic.BaseModel):
+    name: str
+    display_name: str
+    description: str | None = None
+    website_url: str | None = None
+    logo_url: str | None = None
+    metadata: dict[str, Any] = pydantic.Field(default_factory=dict)
+
+
+class UpdateLlmCreatorRequest(pydantic.BaseModel):
+    display_name: str | None = None
+    description: str | None = None
+    website_url: str | None = None
+    logo_url: str | None = None
+    metadata: dict[str, Any] | None = None
+
+
+class SetLlmRouteRequest(pydantic.BaseModel):
+    surface: str = "copilot"
+    mode: str
+    tier: str
+    model_slug: str | None = None  # None deletes the cell
+
+
+class LlmRouteResponse(pydantic.BaseModel):
+    surface: str
+    mode: str
+    tier: str
+    model_slug: str
+    updated_at: str | None = None
+
+
+class SetLlmRouteResponse(pydantic.BaseModel):
+    route: LlmRouteResponse | None = None
+    warnings: list[str] = pydantic.Field(default_factory=list)
+
+
+class LlmRoutesListResponse(pydantic.BaseModel):
+    routes: list[LlmRouteResponse] = pydantic.Field(default_factory=list)
+
+
+class LlmCreatorAdminResponse(pydantic.BaseModel):
+    id: str
+    name: str
+    display_name: str
+    description: str | None = None
+    website_url: str | None = None
+    logo_url: str | None = None
+    metadata: dict[str, Any] = pydantic.Field(default_factory=dict)
+    created_at: str | None = None
+    updated_at: str | None = None
+
+
+class LlmModelCostAdminResponse(pydantic.BaseModel):
+    unit: str
+    credit_cost: float
+    credential_provider: str
+    credential_type: str | None = None
+    metadata: dict[str, Any] = pydantic.Field(default_factory=dict)
+
+
+class LlmProviderAdminResponse(pydantic.BaseModel):
+    id: str
+    name: str
+    display_name: str
+    description: str | None = None
+    metadata: dict[str, Any] = pydantic.Field(default_factory=dict)
+    created_at: str | None = None
+    updated_at: str | None = None
+    model_count: int | None = None
+
+
+class LlmModelAdminResponse(pydantic.BaseModel):
+    id: str
+    slug: str
+    display_name: str
+    description: str | None = None
+    provider_id: str
+    creator_id: str | None = None
+    context_window: int
+    max_output_tokens: int | None = None
+    price_tier: int
+    is_enabled: bool
+    is_recommended: bool
+    kind: str
+    visibility: str
+    min_subscription_tier: str | None = None
+    fallback_model_slug: str | None = None
+    source: str
+    catalog_removed_at: str | None = None
+    supports_tools: bool
+    supports_json_output: bool
+    supports_reasoning: bool
+    supports_parallel_tool_calls: bool
+    capabilities: dict[str, Any] = pydantic.Field(default_factory=dict)
+    metadata: dict[str, Any] = pydantic.Field(default_factory=dict)
+    created_at: str | None = None
+    updated_at: str | None = None
+    creator: LlmCreatorAdminResponse | None = None
+    costs: list[LlmModelCostAdminResponse] = pydantic.Field(default_factory=list)

--- a/autogpt_platform/backend/backend/api/features/admin/llm_admin_routes.py
+++ b/autogpt_platform/backend/backend/api/features/admin/llm_admin_routes.py
@@ -18,9 +18,14 @@ from backend.api.features.admin.llm_admin_model import (
     CreateLlmCreatorRequest,
     CreateLlmModelRequest,
     LlmCreatorAdminResponse,
+    LlmCreatorsAdminListResponse,
+    LlmMigrationAdminResponse,
+    LlmMigrationsAdminListResponse,
     LlmModelAdminResponse,
     LlmModelCostAdminResponse,
+    LlmModelsAdminListResponse,
     LlmProviderAdminResponse,
+    LlmProvidersAdminListResponse,
     LlmRouteResponse,
     LlmRoutesListResponse,
     SetLlmRouteRequest,
@@ -88,6 +93,7 @@ def _map_creator(creator: prisma.models.LlmModelCreator) -> LlmCreatorAdminRespo
         description=creator.description,
         website_url=creator.websiteUrl,
         logo_url=creator.logoUrl,
+        source=str(creator.source),
         metadata=dict(creator.metadata or {}),
         created_at=creator.createdAt.isoformat() if creator.createdAt else None,
         updated_at=creator.updatedAt.isoformat() if creator.updatedAt else None,
@@ -102,6 +108,7 @@ def _map_provider(
         name=provider.name,
         display_name=provider.displayName,
         description=provider.description,
+        source=str(provider.source),
         metadata=dict(provider.metadata or {}),
         created_at=provider.createdAt.isoformat() if provider.createdAt else None,
         updated_at=provider.updatedAt.isoformat() if provider.updatedAt else None,
@@ -397,7 +404,7 @@ async def admin_list_models(
     page: int = 1,
     page_size: int = 100,
     enabled_only: bool = False,
-) -> dict:
+) -> LlmModelsAdminListResponse:
     try:
         where = {"isEnabled": True} if enabled_only else {}
         models = await prisma.models.LlmModel.prisma().find_many(
@@ -407,7 +414,7 @@ async def admin_list_models(
             order={"displayName": "asc"},
             include={"Costs": True, "Creator": True},
         )
-        return {"models": [_map_model(m).model_dump() for m in models]}
+        return LlmModelsAdminListResponse(models=[_map_model(m) for m in models])
     except Exception as e:
         logger.exception(f"Failed to list models: {e}")
         raise HTTPException(status_code=500, detail="Failed to list models")
@@ -419,10 +426,14 @@ async def admin_list_models(
 
 
 @router.get("/migrations")
-async def list_migrations(include_reverted: bool = False) -> dict:
+async def list_migrations(
+    include_reverted: bool = False,
+) -> LlmMigrationsAdminListResponse:
     try:
         migrations = await db_write.list_migrations(include_reverted=include_reverted)
-        return {"migrations": migrations}
+        return LlmMigrationsAdminListResponse(
+            migrations=[LlmMigrationAdminResponse(**m) for m in migrations]
+        )
     except Exception as e:
         logger.exception(f"Failed to list migrations: {e}")
         raise HTTPException(status_code=500, detail="Failed to list migrations")
@@ -466,20 +477,18 @@ async def revert_migration(
 
 
 @router.get("/providers")
-async def admin_list_providers() -> dict:
+async def admin_list_providers() -> LlmProvidersAdminListResponse:
     try:
         providers = await prisma.models.LlmProvider.prisma().find_many(
             order={"name": "asc"},
             include={"Models": True},
         )
-        return {
-            "providers": [
-                _map_provider(
-                    p, model_count=len(p.Models) if p.Models else 0
-                ).model_dump()
+        return LlmProvidersAdminListResponse(
+            providers=[
+                _map_provider(p, model_count=len(p.Models) if p.Models else 0)
                 for p in providers
             ]
-        }
+        )
     except Exception as e:
         logger.exception(f"Failed to list providers: {e}")
         raise HTTPException(status_code=500, detail="Failed to list providers")
@@ -491,12 +500,14 @@ async def admin_list_providers() -> dict:
 
 
 @router.get("/creators")
-async def list_creators() -> dict:
+async def list_creators() -> LlmCreatorsAdminListResponse:
     try:
         creators = await prisma.models.LlmModelCreator.prisma().find_many(
             order={"name": "asc"}
         )
-        return {"creators": [_map_creator(c).model_dump() for c in creators]}
+        return LlmCreatorsAdminListResponse(
+            creators=[_map_creator(c) for c in creators]
+        )
     except Exception as e:
         logger.exception(f"Failed to list creators: {e}")
         raise HTTPException(status_code=500, detail="Failed to list creators")

--- a/autogpt_platform/backend/backend/api/features/admin/llm_admin_routes.py
+++ b/autogpt_platform/backend/backend/api/features/admin/llm_admin_routes.py
@@ -1,0 +1,695 @@
+"""Admin API for LLM registry management.
+
+Mounted at /api/admin/llm. Every mutation writes an AuditLog row and claims
+the touched row for the admin (source=LOCAL — the catalog importer keeps
+hands off from then on), then refreshes the runtime caches across pods.
+"""
+
+import logging
+from typing import Any
+
+import prisma
+import prisma.models
+from autogpt_libs.auth import get_user_id, requires_admin_user
+from fastapi import APIRouter, HTTPException, Security, status
+
+import backend.data.llm_registry as llm_registry
+from backend.api.features.admin.llm_admin_model import (
+    CreateLlmCreatorRequest,
+    CreateLlmModelRequest,
+    LlmCreatorAdminResponse,
+    LlmModelAdminResponse,
+    LlmModelCostAdminResponse,
+    LlmProviderAdminResponse,
+    LlmRouteResponse,
+    LlmRoutesListResponse,
+    SetLlmRouteRequest,
+    SetLlmRouteResponse,
+    ToggleLlmModelRequest,
+    UpdateLlmCreatorRequest,
+    UpdateLlmModelRequest,
+)
+from backend.copilot.route_warnings import RouteWarning, get_route_warnings
+from backend.data.llm_registry import db_routes, db_write
+from backend.data.llm_registry.catalog_model import CatalogPayload
+from backend.data.llm_registry.db_routes import UnknownRouteModelError
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(dependencies=[Security(requires_admin_user)])
+
+
+async def _audit(
+    actor_user_id: str,
+    entity_type: str,
+    entity_id: str,
+    action: str,
+    before: dict[str, Any] | None,
+    after: dict[str, Any] | None,
+) -> None:
+    """Persist an AuditLog row; failures log but never fail the admin op."""
+    try:
+        data: dict[str, Any] = {
+            "actorUserId": actor_user_id,
+            "entityType": entity_type,
+            "entityId": entity_id,
+            "action": action,
+        }
+        if before is not None:
+            data["beforeJson"] = prisma.Json(before)
+        if after is not None:
+            data["afterJson"] = prisma.Json(after)
+        await prisma.models.AuditLog.prisma().create(data=data)
+    except Exception:
+        logger.exception(
+            "Failed to write AuditLog for %s %s on %s", action, entity_type, entity_id
+        )
+
+
+def _model_snapshot(model: prisma.models.LlmModel) -> dict[str, Any]:
+    return {
+        "slug": model.slug,
+        "displayName": model.displayName,
+        "isEnabled": model.isEnabled,
+        "isRecommended": model.isRecommended,
+        "visibility": str(model.visibility),
+        "priceTier": model.priceTier,
+        "contextWindow": model.contextWindow,
+        "fallbackModelSlug": model.fallbackModelSlug,
+        "source": str(model.source),
+    }
+
+
+def _map_creator(creator: prisma.models.LlmModelCreator) -> LlmCreatorAdminResponse:
+    return LlmCreatorAdminResponse(
+        id=creator.id,
+        name=creator.name,
+        display_name=creator.displayName,
+        description=creator.description,
+        website_url=creator.websiteUrl,
+        logo_url=creator.logoUrl,
+        metadata=dict(creator.metadata or {}),
+        created_at=creator.createdAt.isoformat() if creator.createdAt else None,
+        updated_at=creator.updatedAt.isoformat() if creator.updatedAt else None,
+    )
+
+
+def _map_provider(
+    provider: prisma.models.LlmProvider, model_count: int | None = None
+) -> LlmProviderAdminResponse:
+    return LlmProviderAdminResponse(
+        id=provider.id,
+        name=provider.name,
+        display_name=provider.displayName,
+        description=provider.description,
+        metadata=dict(provider.metadata or {}),
+        created_at=provider.createdAt.isoformat() if provider.createdAt else None,
+        updated_at=provider.updatedAt.isoformat() if provider.updatedAt else None,
+        model_count=model_count,
+    )
+
+
+def _map_model(model: prisma.models.LlmModel) -> LlmModelAdminResponse:
+    return LlmModelAdminResponse(
+        id=model.id,
+        slug=model.slug,
+        display_name=model.displayName,
+        description=model.description,
+        provider_id=model.providerId,
+        creator_id=model.creatorId,
+        context_window=model.contextWindow,
+        max_output_tokens=model.maxOutputTokens,
+        price_tier=model.priceTier,
+        is_enabled=model.isEnabled,
+        is_recommended=model.isRecommended,
+        kind=str(model.kind),
+        visibility=str(model.visibility),
+        min_subscription_tier=(
+            str(model.minSubscriptionTier)
+            if model.minSubscriptionTier is not None
+            else None
+        ),
+        fallback_model_slug=model.fallbackModelSlug,
+        source=str(model.source),
+        catalog_removed_at=(
+            model.catalogRemovedAt.isoformat() if model.catalogRemovedAt else None
+        ),
+        supports_tools=model.supportsTools,
+        supports_json_output=model.supportsJsonOutput,
+        supports_reasoning=model.supportsReasoning,
+        supports_parallel_tool_calls=model.supportsParallelToolCalls,
+        capabilities=dict(model.capabilities or {}),
+        metadata=dict(model.metadata or {}),
+        created_at=model.createdAt.isoformat() if model.createdAt else None,
+        updated_at=model.updatedAt.isoformat() if model.updatedAt else None,
+        creator=_map_creator(model.Creator) if model.Creator else None,
+        costs=[
+            LlmModelCostAdminResponse(
+                unit=str(c.unit),
+                credit_cost=float(c.creditCost),
+                credential_provider=c.credentialProvider,
+                credential_type=c.credentialType,
+                metadata=dict(c.metadata or {}),
+            )
+            for c in (model.Costs or [])
+        ],
+    )
+
+
+def _map_route(route: prisma.models.LlmModelRoute) -> LlmRouteResponse:
+    return LlmRouteResponse(
+        surface=route.surface,
+        mode=route.mode,
+        tier=route.tier,
+        model_slug=route.modelSlug,
+        updated_at=route.updatedAt.isoformat() if route.updatedAt else None,
+    )
+
+
+# --------------------------------------------------------------------------
+# Models
+# --------------------------------------------------------------------------
+
+
+@router.post("/models", status_code=status.HTTP_201_CREATED)
+async def create_model(
+    request: CreateLlmModelRequest,
+    admin_user_id: str = Security(get_user_id),
+) -> LlmModelAdminResponse:
+    try:
+        provider = await prisma.models.LlmProvider.prisma().find_unique(
+            where={"name": request.provider_name}
+        )
+        if not provider:
+            provider = await prisma.models.LlmProvider.prisma().find_unique(
+                where={"id": request.provider_name}
+            )
+        if not provider:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Provider '{request.provider_name}' not found",
+            )
+
+        model = await db_write.create_model(
+            slug=request.slug,
+            display_name=request.display_name,
+            provider_id=provider.id,
+            context_window=request.context_window,
+            price_tier=request.price_tier,
+            description=request.description,
+            creator_id=request.creator_id,
+            max_output_tokens=request.max_output_tokens,
+            is_enabled=request.is_enabled,
+            is_recommended=request.is_recommended,
+            kind=request.kind,
+            visibility=request.visibility,
+            min_subscription_tier=request.min_subscription_tier,
+            fallback_model_slug=request.fallback_model_slug,
+            supports_tools=request.supports_tools,
+            supports_json_output=request.supports_json_output,
+            supports_reasoning=request.supports_reasoning,
+            supports_parallel_tool_calls=request.supports_parallel_tool_calls,
+            capabilities=request.capabilities,
+            metadata=request.metadata,
+        )
+        for cost_input in request.costs:
+            await prisma.models.LlmModelCost.prisma().create(
+                data={
+                    "unit": cost_input.get("unit", "RUN"),
+                    "creditCost": int(cost_input.get("credit_cost", 1)),
+                    "credentialProvider": provider.name,
+                    "metadata": prisma.Json(cost_input.get("metadata", {})),
+                    "Model": {"connect": {"id": model.id}},
+                }
+            )
+
+        await _audit(
+            admin_user_id,
+            "LlmModel",
+            model.id,
+            "LLM_MODEL_CREATED",
+            None,
+            _model_snapshot(model),
+        )
+        await llm_registry.refresh_runtime_caches()
+        logger.info(f"Created model '{request.slug}' (id: {model.id})")
+
+        created = await prisma.models.LlmModel.prisma().find_unique(
+            where={"id": model.id},
+            include={"Costs": True, "Creator": True},
+        )
+        if not created:
+            raise HTTPException(status_code=500, detail="Model vanished after create")
+        return _map_model(created)
+    except HTTPException:
+        raise
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.exception(f"Failed to create model: {e}")
+        raise HTTPException(status_code=500, detail="Failed to create model")
+
+
+@router.patch("/models/{slug:path}")
+async def update_model(
+    slug: str,
+    request: UpdateLlmModelRequest,
+    admin_user_id: str = Security(get_user_id),
+) -> LlmModelAdminResponse:
+    try:
+        existing = await prisma.models.LlmModel.prisma().find_unique(
+            where={"slug": slug}
+        )
+        if not existing:
+            raise HTTPException(
+                status_code=404, detail=f"Model with slug '{slug}' not found"
+            )
+
+        model = await db_write.update_model(
+            model_id=existing.id,
+            **request.model_dump(exclude_unset=True),
+        )
+        await _audit(
+            admin_user_id,
+            "LlmModel",
+            model.id,
+            "LLM_MODEL_UPDATED",
+            _model_snapshot(existing),
+            _model_snapshot(model),
+        )
+        await llm_registry.refresh_runtime_caches()
+        logger.info(f"Updated model '{slug}' (id: {model.id})")
+        return _map_model(model)
+    except HTTPException:
+        raise
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.exception(f"Failed to update model: {e}")
+        raise HTTPException(status_code=500, detail="Failed to update model")
+
+
+@router.get("/models/{slug:path}/usage")
+async def get_model_usage(slug: str) -> dict:
+    try:
+        return await db_write.get_model_usage(slug)
+    except Exception as e:
+        logger.exception(f"Failed to get model usage: {e}")
+        raise HTTPException(status_code=500, detail="Failed to get model usage")
+
+
+@router.post("/models/{slug:path}/toggle")
+async def toggle_model(
+    slug: str,
+    request: ToggleLlmModelRequest,
+    admin_user_id: str = Security(get_user_id),
+) -> dict:
+    try:
+        existing = await prisma.models.LlmModel.prisma().find_unique(
+            where={"slug": slug}
+        )
+        if not existing:
+            raise HTTPException(
+                status_code=404, detail=f"Model with slug '{slug}' not found"
+            )
+        if not request.is_enabled and existing.isRecommended:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "Cannot disable the recommended model. "
+                    "Change the recommended model before disabling this one."
+                ),
+            )
+
+        result = await db_write.toggle_model_with_migration(
+            model_id=existing.id,
+            is_enabled=request.is_enabled,
+            migrate_to_slug=request.migrate_to_slug,
+            migration_reason=request.migration_reason,
+            custom_credit_cost=request.custom_credit_cost,
+        )
+        await _audit(
+            admin_user_id,
+            "LlmModel",
+            existing.id,
+            "LLM_MODEL_ENABLED" if request.is_enabled else "LLM_MODEL_DISABLED",
+            _model_snapshot(existing),
+            {"isEnabled": request.is_enabled, **result},
+        )
+        await llm_registry.refresh_runtime_caches()
+        logger.info(
+            f"Toggled model '{slug}' enabled={request.is_enabled} "
+            f"(migrated {result['nodes_migrated']} nodes)"
+        )
+        return result
+    except HTTPException:
+        raise
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.exception(f"Failed to toggle model: {e}")
+        raise HTTPException(status_code=500, detail="Failed to toggle model")
+
+
+@router.delete("/models/{slug:path}")
+async def delete_model(
+    slug: str,
+    replacement_model_slug: str | None = None,
+    admin_user_id: str = Security(get_user_id),
+) -> dict:
+    try:
+        existing = await prisma.models.LlmModel.prisma().find_unique(
+            where={"slug": slug}
+        )
+        if not existing:
+            raise HTTPException(
+                status_code=404, detail=f"Model with slug '{slug}' not found"
+            )
+
+        result = await db_write.delete_model(
+            model_id=existing.id,
+            replacement_model_slug=replacement_model_slug,
+        )
+        await _audit(
+            admin_user_id,
+            "LlmModel",
+            existing.id,
+            "LLM_MODEL_DELETED",
+            _model_snapshot(existing),
+            result,
+        )
+        await llm_registry.refresh_runtime_caches()
+        logger.info(
+            f"Deleted model '{slug}' (migrated {result['nodes_migrated']} nodes)"
+        )
+        return result
+    except HTTPException:
+        raise
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.exception(f"Failed to delete model: {e}")
+        raise HTTPException(status_code=500, detail="Failed to delete model")
+
+
+@router.get("/models")
+async def admin_list_models(
+    page: int = 1,
+    page_size: int = 100,
+    enabled_only: bool = False,
+) -> dict:
+    try:
+        where = {"isEnabled": True} if enabled_only else {}
+        models = await prisma.models.LlmModel.prisma().find_many(
+            where=where,
+            skip=(page - 1) * page_size,
+            take=page_size,
+            order={"displayName": "asc"},
+            include={"Costs": True, "Creator": True},
+        )
+        return {"models": [_map_model(m).model_dump() for m in models]}
+    except Exception as e:
+        logger.exception(f"Failed to list models: {e}")
+        raise HTTPException(status_code=500, detail="Failed to list models")
+
+
+# --------------------------------------------------------------------------
+# Migrations
+# --------------------------------------------------------------------------
+
+
+@router.get("/migrations")
+async def list_migrations(include_reverted: bool = False) -> dict:
+    try:
+        migrations = await db_write.list_migrations(include_reverted=include_reverted)
+        return {"migrations": migrations}
+    except Exception as e:
+        logger.exception(f"Failed to list migrations: {e}")
+        raise HTTPException(status_code=500, detail="Failed to list migrations")
+
+
+@router.post("/migrations/{migration_id}/revert")
+async def revert_migration(
+    migration_id: str,
+    re_enable_source_model: bool = True,
+    admin_user_id: str = Security(get_user_id),
+) -> dict:
+    try:
+        result = await db_write.revert_migration(
+            migration_id=migration_id,
+            re_enable_source_model=re_enable_source_model,
+        )
+        await _audit(
+            admin_user_id,
+            "LlmModelMigration",
+            migration_id,
+            "LLM_MIGRATION_REVERTED",
+            None,
+            result,
+        )
+        await llm_registry.refresh_runtime_caches()
+        logger.info(
+            f"Reverted migration {migration_id}: "
+            f"{result['nodes_reverted']} nodes restored"
+        )
+        return result
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.exception(f"Failed to revert migration: {e}")
+        raise HTTPException(status_code=500, detail="Failed to revert migration")
+
+
+# --------------------------------------------------------------------------
+# Providers (read-only — the provider set is fixed; new providers are code)
+# --------------------------------------------------------------------------
+
+
+@router.get("/providers")
+async def admin_list_providers() -> dict:
+    try:
+        providers = await prisma.models.LlmProvider.prisma().find_many(
+            order={"name": "asc"},
+            include={"Models": True},
+        )
+        return {
+            "providers": [
+                _map_provider(
+                    p, model_count=len(p.Models) if p.Models else 0
+                ).model_dump()
+                for p in providers
+            ]
+        }
+    except Exception as e:
+        logger.exception(f"Failed to list providers: {e}")
+        raise HTTPException(status_code=500, detail="Failed to list providers")
+
+
+# --------------------------------------------------------------------------
+# Creators
+# --------------------------------------------------------------------------
+
+
+@router.get("/creators")
+async def list_creators() -> dict:
+    try:
+        creators = await prisma.models.LlmModelCreator.prisma().find_many(
+            order={"name": "asc"}
+        )
+        return {"creators": [_map_creator(c).model_dump() for c in creators]}
+    except Exception as e:
+        logger.exception(f"Failed to list creators: {e}")
+        raise HTTPException(status_code=500, detail="Failed to list creators")
+
+
+@router.post("/creators", status_code=status.HTTP_201_CREATED)
+async def create_creator(
+    request: CreateLlmCreatorRequest,
+    admin_user_id: str = Security(get_user_id),
+) -> LlmCreatorAdminResponse:
+    try:
+        creator = await prisma.models.LlmModelCreator.prisma().create(
+            data={
+                "name": request.name,
+                "displayName": request.display_name,
+                "description": request.description,
+                "websiteUrl": request.website_url,
+                "logoUrl": request.logo_url,
+                "metadata": prisma.Json(request.metadata),
+                "source": "LOCAL",
+            }
+        )
+        await _audit(
+            admin_user_id,
+            "LlmModelCreator",
+            creator.id,
+            "LLM_CREATOR_CREATED",
+            None,
+            {"name": creator.name, "displayName": creator.displayName},
+        )
+        logger.info(f"Created creator '{creator.name}' (id: {creator.id})")
+        return _map_creator(creator)
+    except Exception as e:
+        logger.exception(f"Failed to create creator: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.patch("/creators/{name}")
+async def update_creator(
+    name: str,
+    request: UpdateLlmCreatorRequest,
+    admin_user_id: str = Security(get_user_id),
+) -> LlmCreatorAdminResponse:
+    try:
+        existing = await prisma.models.LlmModelCreator.prisma().find_unique(
+            where={"name": name}
+        )
+        if not existing:
+            raise HTTPException(status_code=404, detail=f"Creator '{name}' not found")
+
+        data: dict = {"source": "LOCAL"}
+        if request.display_name is not None:
+            data["displayName"] = request.display_name
+        if request.description is not None:
+            data["description"] = request.description
+        if request.website_url is not None:
+            data["websiteUrl"] = request.website_url
+        if request.logo_url is not None:
+            data["logoUrl"] = request.logo_url
+        if request.metadata is not None:
+            data["metadata"] = prisma.Json(request.metadata)
+
+        creator = await prisma.models.LlmModelCreator.prisma().update(
+            where={"id": existing.id},
+            data=data,
+        )
+        if not creator:
+            raise HTTPException(status_code=500, detail="Creator vanished mid-update")
+        await _audit(
+            admin_user_id,
+            "LlmModelCreator",
+            creator.id,
+            "LLM_CREATOR_UPDATED",
+            {"displayName": existing.displayName},
+            {"displayName": creator.displayName},
+        )
+        logger.info(f"Updated creator '{name}' (id: {creator.id})")
+        return _map_creator(creator)
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.exception(f"Failed to update creator: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.delete("/creators/{name}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_creator(
+    name: str,
+    admin_user_id: str = Security(get_user_id),
+) -> None:
+    try:
+        existing = await prisma.models.LlmModelCreator.prisma().find_unique(
+            where={"name": name},
+            include={"Models": True},
+        )
+        if not existing:
+            raise HTTPException(status_code=404, detail=f"Creator '{name}' not found")
+        if existing.Models and len(existing.Models) > 0:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Cannot delete creator '{name}' — it has "
+                    f"{len(existing.Models)} associated models"
+                ),
+            )
+
+        await prisma.models.LlmModelCreator.prisma().delete(where={"id": existing.id})
+        await _audit(
+            admin_user_id,
+            "LlmModelCreator",
+            existing.id,
+            "LLM_CREATOR_DELETED",
+            {"name": existing.name},
+            None,
+        )
+        logger.info(f"Deleted creator '{name}' (id: {existing.id})")
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.exception(f"Failed to delete creator: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+# --------------------------------------------------------------------------
+# Routing cells
+# --------------------------------------------------------------------------
+
+
+@router.get("/routes")
+async def list_routes() -> LlmRoutesListResponse:
+    try:
+        routes = await db_routes.list_routes()
+        return LlmRoutesListResponse(routes=[_map_route(r) for r in routes])
+    except Exception as e:
+        logger.exception(f"Failed to list routes: {e}")
+        raise HTTPException(status_code=500, detail="Failed to list routes")
+
+
+@router.put("/routes")
+async def set_route(
+    request: SetLlmRouteRequest,
+    admin_user_id: str = Security(get_user_id),
+) -> SetLlmRouteResponse:
+    try:
+        row, warnings = await db_routes.set_route(
+            request.surface, request.mode, request.tier, request.model_slug
+        )
+        await _audit(
+            admin_user_id,
+            "LlmModelRoute",
+            row.id if row else f"{request.surface}/{request.mode}/{request.tier}",
+            "LLM_ROUTE_SET" if row else "LLM_ROUTE_CLEARED",
+            None,
+            {
+                "surface": request.surface,
+                "mode": request.mode,
+                "tier": request.tier,
+                "modelSlug": request.model_slug,
+            },
+        )
+        await llm_registry.refresh_runtime_caches()
+        logger.info(
+            f"Routing cell ({request.surface}, {request.mode}, {request.tier}) "
+            f"set to {request.model_slug!r}"
+        )
+        return SetLlmRouteResponse(
+            route=_map_route(row) if row else None, warnings=warnings
+        )
+    except UnknownRouteModelError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e))
+    except Exception as e:
+        logger.exception(f"Failed to set route: {e}")
+        raise HTTPException(status_code=500, detail="Failed to set route")
+
+
+@router.get("/routes/warnings")
+async def list_route_warnings() -> list[RouteWarning]:
+    return await get_route_warnings()
+
+
+# --------------------------------------------------------------------------
+# Catalog
+# --------------------------------------------------------------------------
+
+
+@router.get("/catalog/export")
+async def export_catalog() -> CatalogPayload:
+    """Current registry as a catalog payload — pipe to catalog.json to
+    refresh the bundled snapshot without direct DB access."""
+    try:
+        return await llm_registry.export_catalog()
+    except Exception as e:
+        logger.exception(f"Failed to export catalog: {e}")
+        raise HTTPException(status_code=500, detail="Failed to export catalog")

--- a/autogpt_platform/backend/backend/api/features/admin/llm_admin_routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/admin/llm_admin_routes_test.py
@@ -1,0 +1,299 @@
+"""Route-layer tests for the LLM registry admin API.
+
+Auth, validation, mapping, and audit wiring — the data layer is mocked here;
+real-DB behavior is covered in backend/data/llm_registry/db_write_test.py.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, Mock
+
+import fastapi
+import fastapi.testclient
+import pytest
+
+from backend.api.features.admin import llm_admin_routes
+from backend.copilot.route_warnings import RouteWarning
+from backend.data.llm_registry.catalog_model import (
+    CATALOG_SCHEMA_VERSION,
+    CatalogPayload,
+)
+from backend.data.llm_registry.db_routes import UnknownRouteModelError
+
+app = fastapi.FastAPI()
+app.include_router(llm_admin_routes.router, prefix="/api/admin/llm")
+client = fastapi.testclient.TestClient(app)
+
+unauthed_app = fastapi.FastAPI()
+unauthed_app.include_router(llm_admin_routes.router, prefix="/api/admin/llm")
+unauthed_client = fastapi.testclient.TestClient(unauthed_app)
+
+
+@pytest.fixture(autouse=True)
+def setup_app_auth(mock_jwt_admin):
+    from autogpt_libs.auth.jwt_utils import get_jwt_payload
+
+    app.dependency_overrides[get_jwt_payload] = mock_jwt_admin["get_jwt_payload"]
+    yield
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture(autouse=True)
+def quiet_side_effects(mocker):
+    """Mute cache refresh + audit persistence; expose the audit mock."""
+    mocker.patch.object(
+        llm_admin_routes.llm_registry, "refresh_runtime_caches", new=AsyncMock()
+    )
+    audit = mocker.patch.object(llm_admin_routes, "_audit", new=AsyncMock())
+    return audit
+
+
+def _mock_route_row(
+    slug="openai/gpt-a", surface="copilot", mode="fast", tier="standard"
+):
+    row = Mock()
+    row.id = "route-uuid"
+    row.surface = surface
+    row.mode = mode
+    row.tier = tier
+    row.modelSlug = slug
+    row.updatedAt = datetime(2026, 7, 18, tzinfo=timezone.utc)
+    return row
+
+
+def test_requires_admin_auth():
+    resp = unauthed_client.get("/api/admin/llm/routes")
+    assert resp.status_code in (401, 403)
+
+
+def test_set_route_unknown_model_404(mocker):
+    mocker.patch.object(
+        llm_admin_routes.db_routes,
+        "set_route",
+        new=AsyncMock(side_effect=UnknownRouteModelError("Model 'x' does not exist")),
+    )
+    resp = client.put(
+        "/api/admin/llm/routes",
+        json={"mode": "fast", "tier": "standard", "model_slug": "x"},
+    )
+    assert resp.status_code == 404
+
+
+def test_set_route_disabled_model_422(mocker):
+    mocker.patch.object(
+        llm_admin_routes.db_routes,
+        "set_route",
+        new=AsyncMock(side_effect=ValueError("Model 'x' is disabled (kill switch)")),
+    )
+    resp = client.put(
+        "/api/admin/llm/routes",
+        json={"mode": "fast", "tier": "standard", "model_slug": "x"},
+    )
+    assert resp.status_code == 422
+
+
+def test_set_route_returns_warnings_and_audits(mocker, quiet_side_effects):
+    mocker.patch.object(
+        llm_admin_routes.db_routes,
+        "set_route",
+        new=AsyncMock(
+            return_value=(
+                _mock_route_row(mode="thinking"),
+                ["model 'openai/gpt-a' does not advertise reasoning support"],
+            )
+        ),
+    )
+    resp = client.put(
+        "/api/admin/llm/routes",
+        json={"mode": "thinking", "tier": "standard", "model_slug": "openai/gpt-a"},
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["route"]["model_slug"] == "openai/gpt-a"
+    assert len(body["warnings"]) == 1
+    quiet_side_effects.assert_called_once()
+    assert quiet_side_effects.call_args.args[3] == "LLM_ROUTE_SET"
+
+
+def test_set_route_none_clears_cell(mocker, quiet_side_effects):
+    mocker.patch.object(
+        llm_admin_routes.db_routes,
+        "set_route",
+        new=AsyncMock(return_value=(None, [])),
+    )
+    resp = client.put(
+        "/api/admin/llm/routes",
+        json={"mode": "fast", "tier": "standard", "model_slug": None},
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["route"] is None
+    assert quiet_side_effects.call_args.args[3] == "LLM_ROUTE_CLEARED"
+
+
+def test_list_routes(mocker):
+    mocker.patch.object(
+        llm_admin_routes.db_routes,
+        "list_routes",
+        new=AsyncMock(return_value=[_mock_route_row()]),
+    )
+    resp = client.get("/api/admin/llm/routes")
+
+    assert resp.status_code == 200
+    assert resp.json()["routes"][0]["model_slug"] == "openai/gpt-a"
+
+
+def test_route_warnings_endpoint(mocker):
+    mocker.patch.object(
+        llm_admin_routes,
+        "get_route_warnings",
+        new=AsyncMock(
+            return_value=[
+                RouteWarning(
+                    slug="typo/model",
+                    reason="unknown to the model registry",
+                    count=42,
+                    last_seen=datetime(2026, 7, 18, tzinfo=timezone.utc),
+                    last_layer="ld",
+                )
+            ]
+        ),
+    )
+    resp = client.get("/api/admin/llm/routes/warnings")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body[0]["slug"] == "typo/model"
+    assert body[0]["count"] == 42
+
+
+def test_catalog_export_endpoint(mocker):
+    payload = CatalogPayload(
+        schema_version=CATALOG_SCHEMA_VERSION,
+        generated_at=datetime(2026, 7, 18, tzinfo=timezone.utc),
+        providers=[],
+        creators=[],
+        models=[],
+    )
+    mocker.patch.object(
+        llm_admin_routes.llm_registry,
+        "export_catalog",
+        new=AsyncMock(return_value=payload),
+    )
+    resp = client.get("/api/admin/llm/catalog/export")
+
+    assert resp.status_code == 200
+    assert resp.json()["schema_version"] == CATALOG_SCHEMA_VERSION
+
+
+def _mock_model_record(slug="openai/gpt-a"):
+    m = Mock()
+    m.id = "model-uuid"
+    m.slug = slug
+    m.displayName = "GPT A"
+    m.description = None
+    m.providerId = "provider-uuid"
+    m.creatorId = None
+    m.contextWindow = 128000
+    m.maxOutputTokens = 16384
+    m.priceTier = 2
+    m.isEnabled = True
+    m.isRecommended = False
+    m.kind = "CHAT"
+    m.visibility = "GA"
+    m.minSubscriptionTier = None
+    m.fallbackModelSlug = None
+    m.source = "LOCAL"
+    m.catalogRemovedAt = None
+    m.supportsTools = True
+    m.supportsJsonOutput = True
+    m.supportsReasoning = False
+    m.supportsParallelToolCalls = False
+    m.capabilities = {}
+    m.metadata = {}
+    m.createdAt = datetime(2026, 7, 18, tzinfo=timezone.utc)
+    m.updatedAt = datetime(2026, 7, 18, tzinfo=timezone.utc)
+    m.Creator = None
+    m.Costs = []
+    return m
+
+
+def test_create_model_passes_new_columns(mocker, quiet_side_effects):
+    provider = Mock()
+    provider.id = "provider-uuid"
+    provider.name = "openai"
+    provider_prisma = MagicMock()
+    provider_prisma.find_unique = AsyncMock(return_value=provider)
+    mocker.patch("prisma.models.LlmProvider.prisma", return_value=provider_prisma)
+
+    record = _mock_model_record()
+    model_prisma = MagicMock()
+    model_prisma.find_unique = AsyncMock(return_value=record)
+    mocker.patch("prisma.models.LlmModel.prisma", return_value=model_prisma)
+
+    create = mocker.patch.object(
+        llm_admin_routes.db_write, "create_model", new=AsyncMock(return_value=record)
+    )
+
+    resp = client.post(
+        "/api/admin/llm/models",
+        json={
+            "slug": "openai/gpt-a",
+            "display_name": "GPT A",
+            "provider_name": "openai",
+            "context_window": 128000,
+            "price_tier": 2,
+            "visibility": "HIDDEN",
+            "min_subscription_tier": "PRO",
+        },
+    )
+
+    assert resp.status_code == 201
+    kwargs = create.call_args.kwargs
+    assert kwargs["visibility"] == "HIDDEN"
+    assert kwargs["min_subscription_tier"] == "PRO"
+    assert quiet_side_effects.call_args.args[3] == "LLM_MODEL_CREATED"
+
+
+def test_create_model_unknown_provider_404(mocker):
+    provider_prisma = MagicMock()
+    provider_prisma.find_unique = AsyncMock(return_value=None)
+    mocker.patch("prisma.models.LlmProvider.prisma", return_value=provider_prisma)
+
+    resp = client.post(
+        "/api/admin/llm/models",
+        json={
+            "slug": "openai/gpt-a",
+            "display_name": "GPT A",
+            "provider_name": "nope",
+            "context_window": 128000,
+            "price_tier": 2,
+        },
+    )
+    assert resp.status_code == 404
+
+
+def test_update_model_unknown_slug_404(mocker):
+    model_prisma = MagicMock()
+    model_prisma.find_unique = AsyncMock(return_value=None)
+    mocker.patch("prisma.models.LlmModel.prisma", return_value=model_prisma)
+
+    resp = client.patch("/api/admin/llm/models/openai/nope", json={"display_name": "X"})
+    assert resp.status_code == 404
+
+
+def test_toggle_recommended_model_guard(mocker):
+    record = _mock_model_record()
+    record.isRecommended = True
+    model_prisma = MagicMock()
+    model_prisma.find_unique = AsyncMock(return_value=record)
+    mocker.patch("prisma.models.LlmModel.prisma", return_value=model_prisma)
+
+    resp = client.post(
+        "/api/admin/llm/models/openai/gpt-a/toggle",
+        json={"is_enabled": False},
+    )
+    assert resp.status_code == 400
+    assert "recommended" in resp.json()["detail"]

--- a/autogpt_platform/backend/backend/api/rest_api.py
+++ b/autogpt_platform/backend/backend/api/rest_api.py
@@ -22,6 +22,7 @@ import backend.api.features.admin.bot_analytics_routes
 import backend.api.features.admin.credit_admin_routes
 import backend.api.features.admin.diagnostics_admin_routes
 import backend.api.features.admin.execution_analytics_routes
+import backend.api.features.admin.llm_admin_routes
 import backend.api.features.admin.memory_admin_routes
 import backend.api.features.admin.platform_cost_routes
 import backend.api.features.admin.rate_limit_admin_routes
@@ -442,6 +443,11 @@ app.include_router(
     backend.api.features.admin.block_cost_admin_routes.router,
     tags=["v2", "admin"],
     prefix="/api",
+)
+app.include_router(
+    backend.api.features.admin.llm_admin_routes.router,
+    tags=["v2", "admin"],
+    prefix="/api/admin/llm",
 )
 app.include_router(
     backend.api.features.admin.memory_admin_routes.router,

--- a/autogpt_platform/backend/backend/data/llm_registry/db_routes.py
+++ b/autogpt_platform/backend/backend/data/llm_registry/db_routes.py
@@ -1,0 +1,74 @@
+"""Admin write operations for LLM routing cells (LlmModelRoute)."""
+
+from __future__ import annotations
+
+import logging
+
+import prisma.models
+
+logger = logging.getLogger(__name__)
+
+
+class UnknownRouteModelError(LookupError):
+    """The routing cell references a slug the registry doesn't know."""
+
+
+async def list_routes() -> list[prisma.models.LlmModelRoute]:
+    return await prisma.models.LlmModelRoute.prisma().find_many(
+        order=[{"surface": "asc"}, {"mode": "asc"}, {"tier": "asc"}]
+    )
+
+
+def _capability_warnings(model: prisma.models.LlmModel, mode: str) -> list[str]:
+    warnings: list[str] = []
+    if mode == "thinking" and not model.supportsReasoning:
+        warnings.append(
+            f"model '{model.slug}' does not advertise reasoning support but is "
+            f"being routed for a thinking cell"
+        )
+    if not model.supportsTools:
+        warnings.append(f"model '{model.slug}' does not advertise tool support")
+    return warnings
+
+
+async def set_route(
+    surface: str, mode: str, tier: str, model_slug: str | None
+) -> tuple[prisma.models.LlmModelRoute | None, list[str]]:
+    """Upsert (or delete, when model_slug is None) a routing cell.
+
+    The cell model must exist and be enabled (the kill switch beats routing);
+    HIDDEN visibility is allowed — that's the pre-launch testing state.
+    Returns the row (None after delete) and capability warnings for the admin
+    UI. Caller owns audit + cache refresh.
+    """
+    if model_slug is None:
+        await prisma.models.LlmModelRoute.prisma().delete_many(
+            where={"surface": surface, "mode": mode, "tier": tier}
+        )
+        return None, []
+
+    model = await prisma.models.LlmModel.prisma().find_unique(
+        where={"slug": model_slug}
+    )
+    if model is None:
+        raise UnknownRouteModelError(
+            f"Model '{model_slug}' does not exist in the registry"
+        )
+    if not model.isEnabled:
+        raise ValueError(
+            f"Model '{model_slug}' is disabled (kill switch) and cannot be routed"
+        )
+
+    row = await prisma.models.LlmModelRoute.prisma().upsert(
+        where={"surface_mode_tier": {"surface": surface, "mode": mode, "tier": tier}},
+        data={
+            "create": {
+                "surface": surface,
+                "mode": mode,
+                "tier": tier,
+                "modelSlug": model_slug,
+            },
+            "update": {"modelSlug": model_slug},
+        },
+    )
+    return row, _capability_warnings(model, mode)

--- a/autogpt_platform/backend/backend/data/llm_registry/db_write.py
+++ b/autogpt_platform/backend/backend/data/llm_registry/db_write.py
@@ -1,0 +1,449 @@
+"""Admin write operations for LLM registry models and migrations.
+
+Every write stamps ``source=LOCAL`` — the admin-owns-this-row claim the
+catalog importer respects (LOCAL rows are never updated or disabled by
+catalog imports). Callers are responsible for invoking
+``registry.refresh_runtime_caches()`` after a successful mutation.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any, LiteralString, cast
+
+import prisma
+import prisma.models
+from prisma.enums import LlmCatalogSource
+
+from backend.data.db import get_database_schema, query_raw_with_schema, transaction
+
+logger = logging.getLogger(__name__)
+
+
+def _schema_format(query_template: str) -> LiteralString:
+    """Format a ``{schema_prefix}`` query for transaction-scoped raw SQL.
+
+    ``query_raw_with_schema``/``execute_raw_with_schema`` can't run inside an
+    existing transaction client for SELECTs, so FOR UPDATE reads format the
+    template with the same prefix logic and go through ``tx.query_raw``.
+    """
+    schema = get_database_schema()
+    schema_prefix = f'"{schema}".' if schema != "public" else ""
+    # cast: prisma types raw queries as LiteralString; the template is a
+    # module-level literal and the prefix derives from DATABASE_URL config.
+    return cast(LiteralString, query_template.format(schema_prefix=schema_prefix))
+
+
+def _node_model_value(slug: str) -> str:
+    """Extract the model value stored in AgentNode.constantInput from a registry slug.
+
+    Registry slugs are formatted as 'provider/model-name' (e.g. 'openai/gpt-4o').
+    The LLM block stores only the model-name part (e.g. 'gpt-4o') in constantInput.
+    """
+    return slug.split("/", 1)[-1] if "/" in slug else slug
+
+
+async def validate_fallback_slug(fallback_model_slug: str | None) -> None:
+    """Fallback pointers must reference an existing model."""
+    if fallback_model_slug is None:
+        return
+    row = await prisma.models.LlmModel.prisma().find_unique(
+        where={"slug": fallback_model_slug}
+    )
+    if row is None:
+        raise ValueError(
+            f"Fallback model '{fallback_model_slug}' does not exist in the registry"
+        )
+
+
+def _build_model_data(
+    slug: str,
+    display_name: str,
+    provider_id: str,
+    context_window: int,
+    price_tier: int,
+    description: str | None = None,
+    creator_id: str | None = None,
+    max_output_tokens: int | None = None,
+    is_enabled: bool = True,
+    is_recommended: bool = False,
+    kind: str = "CHAT",
+    visibility: str = "GA",
+    min_subscription_tier: str | None = None,
+    fallback_model_slug: str | None = None,
+    supports_tools: bool = False,
+    supports_json_output: bool = False,
+    supports_reasoning: bool = False,
+    supports_parallel_tool_calls: bool = False,
+    capabilities: dict[str, Any] | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build model data dict for Prisma operations. Always claims source=LOCAL."""
+    data: dict[str, Any] = {
+        "slug": slug,
+        "displayName": display_name,
+        "description": description,
+        "Provider": {"connect": {"id": provider_id}},
+        "contextWindow": context_window,
+        "maxOutputTokens": max_output_tokens,
+        "priceTier": price_tier,
+        "isEnabled": is_enabled,
+        "isRecommended": is_recommended,
+        "kind": kind,
+        "visibility": visibility,
+        "minSubscriptionTier": min_subscription_tier,
+        "supportsTools": supports_tools,
+        "supportsJsonOutput": supports_json_output,
+        "supportsReasoning": supports_reasoning,
+        "supportsParallelToolCalls": supports_parallel_tool_calls,
+        "capabilities": prisma.Json(capabilities or {}),
+        "metadata": prisma.Json(metadata or {}),
+        "source": LlmCatalogSource.LOCAL,
+    }
+    if creator_id:
+        data["Creator"] = {"connect": {"id": creator_id}}
+    if fallback_model_slug:
+        # Relation-connect form: mixing the scalar FK with other relation
+        # connects fails Prisma's checked-input union.
+        data["FallbackModel"] = {"connect": {"slug": fallback_model_slug}}
+    # Prisma create input rejects explicit None for optional fields —
+    # omitting them yields the same NULL/default.
+    return {k: v for k, v in data.items() if v is not None}
+
+
+async def create_model(**kwargs: Any) -> prisma.models.LlmModel:
+    """Create a new LLM model (admin-owned: source=LOCAL)."""
+    await validate_fallback_slug(kwargs.get("fallback_model_slug"))
+    data = _build_model_data(**kwargs)
+    model = await prisma.models.LlmModel.prisma().create(
+        data=data,
+        include={"Costs": True, "Creator": True, "Provider": True},
+    )
+    if not model:
+        raise ValueError("Failed to create model")
+    return model
+
+
+_UPDATE_FIELD_MAP = {
+    "display_name": "displayName",
+    "description": "description",
+    "context_window": "contextWindow",
+    "max_output_tokens": "maxOutputTokens",
+    "price_tier": "priceTier",
+    "is_enabled": "isEnabled",
+    "is_recommended": "isRecommended",
+    "kind": "kind",
+    "visibility": "visibility",
+    "min_subscription_tier": "minSubscriptionTier",
+    "fallback_model_slug": "fallbackModelSlug",
+    "supports_tools": "supportsTools",
+    "supports_json_output": "supportsJsonOutput",
+    "supports_reasoning": "supportsReasoning",
+    "supports_parallel_tool_calls": "supportsParallelToolCalls",
+}
+
+
+async def update_model(model_id: str, **fields: Any) -> prisma.models.LlmModel:
+    """Update an existing LLM model; the touch claims the row (source=LOCAL).
+
+    When is_recommended=True, clears the flag on all other models first so
+    only one model can be recommended at a time.
+    """
+    if "fallback_model_slug" in fields:
+        await validate_fallback_slug(fields["fallback_model_slug"])
+
+    data: dict[str, Any] = {"source": LlmCatalogSource.LOCAL}
+    for key, column in _UPDATE_FIELD_MAP.items():
+        if fields.get(key) is not None:
+            data[column] = fields[key]
+    if fields.get("capabilities") is not None:
+        data["capabilities"] = prisma.Json(fields["capabilities"])
+    if fields.get("metadata") is not None:
+        data["metadata"] = prisma.Json(fields["metadata"])
+    if fields.get("creator_id") is not None:
+        data["creatorId"] = fields["creator_id"] or None
+
+    async with transaction() as tx:
+        # Enforce single recommended model: unset all others first.
+        if fields.get("is_recommended") is True:
+            await tx.llmmodel.update_many(
+                where={"id": {"not": model_id}},
+                data={"isRecommended": False},
+            )
+        model = await tx.llmmodel.update(
+            where={"id": model_id},
+            data=data,
+            include={"Costs": True, "Creator": True, "Provider": True},
+        )
+
+    if not model:
+        raise ValueError(f"Model with id '{model_id}' not found")
+    return model
+
+
+async def get_model_usage(slug: str) -> dict[str, Any]:
+    """Get usage count for a model — how many AgentNodes reference it."""
+    model_value = _node_model_value(slug)
+    count_result = await query_raw_with_schema(
+        """
+        SELECT COUNT(*) as count
+        FROM {schema_prefix}"AgentNode"
+        WHERE "constantInput"::jsonb->>'model' = $1
+        """,
+        model_value,
+    )
+    node_count = int(count_result[0]["count"]) if count_result else 0
+    return {"model_slug": slug, "node_count": node_count}
+
+
+async def _migrate_nodes_in_tx(tx, source_value: str, target_value: str) -> list[str]:
+    """Lock + rewrite AgentNode model references. Returns migrated node ids."""
+    node_ids_result = await tx.query_raw(
+        _schema_format(
+            """
+            SELECT id
+            FROM {schema_prefix}"AgentNode"
+            WHERE "constantInput"::jsonb->>'model' = $1
+            FOR UPDATE
+            """
+        ),
+        source_value,
+    )
+    migrated_node_ids = [row["id"] for row in node_ids_result or []]
+    if migrated_node_ids:
+        await tx.execute_raw(
+            _schema_format(
+                """
+                UPDATE {schema_prefix}"AgentNode"
+                SET "constantInput" = JSONB_SET(
+                    "constantInput"::jsonb,
+                    '{{model}}',
+                    to_jsonb($1::text)
+                )
+                WHERE id::text IN (
+                    SELECT jsonb_array_elements_text($2::jsonb)
+                )
+                """
+            ),
+            target_value,
+            json.dumps(migrated_node_ids),
+        )
+    return migrated_node_ids
+
+
+async def _validate_replacement_in_tx(tx, slug: str) -> prisma.models.LlmModel:
+    replacement = await tx.llmmodel.find_unique(where={"slug": slug})
+    if not replacement:
+        raise ValueError(f"Replacement model '{slug}' not found")
+    if not replacement.isEnabled:
+        raise ValueError(
+            f"Replacement model '{slug}' is disabled. "
+            f"Please enable it before using it as a replacement."
+        )
+    return replacement
+
+
+async def toggle_model_with_migration(
+    model_id: str,
+    is_enabled: bool,
+    migrate_to_slug: str | None = None,
+    migration_reason: str | None = None,
+    custom_credit_cost: int | None = None,
+) -> dict[str, Any]:
+    """Toggle a model's enabled status, optionally migrating workflows when disabling."""
+    model = await prisma.models.LlmModel.prisma().find_unique(
+        where={"id": model_id}, include={"Costs": True}
+    )
+    if not model:
+        raise ValueError(f"Model with id '{model_id}' not found")
+
+    toggle_data: dict[str, Any] = {
+        "isEnabled": is_enabled,
+        "source": LlmCatalogSource.LOCAL,
+    }
+    nodes_migrated = 0
+    migration_id: str | None = None
+
+    if not is_enabled and migrate_to_slug:
+        async with transaction() as tx:
+            await _validate_replacement_in_tx(tx, migrate_to_slug)
+            migrated_node_ids = await _migrate_nodes_in_tx(
+                tx,
+                _node_model_value(model.slug),
+                _node_model_value(migrate_to_slug),
+            )
+            nodes_migrated = len(migrated_node_ids)
+            await tx.llmmodel.update(where={"id": model_id}, data=toggle_data)
+            if nodes_migrated > 0:
+                migration_record = await tx.llmmodelmigration.create(
+                    data={
+                        "sourceModelSlug": model.slug,
+                        "targetModelSlug": migrate_to_slug,
+                        "reason": migration_reason,
+                        "migratedNodeIds": json.dumps(migrated_node_ids),
+                        "nodeCount": nodes_migrated,
+                        "customCreditCost": custom_credit_cost,
+                    }
+                )
+                migration_id = migration_record.id
+    else:
+        await prisma.models.LlmModel.prisma().update(
+            where={"id": model_id}, data=toggle_data
+        )
+
+    return {
+        "nodes_migrated": nodes_migrated,
+        "migrated_to_slug": migrate_to_slug if nodes_migrated > 0 else None,
+        "migration_id": migration_id,
+    }
+
+
+async def delete_model(
+    model_id: str, replacement_model_slug: str | None = None
+) -> dict[str, Any]:
+    """Delete an LLM model, optionally migrating affected AgentNodes first.
+
+    If workflows are using this model and no replacement is given, raises
+    ValueError. If replacement is given, atomically migrates all affected
+    nodes then deletes.
+    """
+    model = await prisma.models.LlmModel.prisma().find_unique(
+        where={"id": model_id}, include={"Costs": True}
+    )
+    if not model:
+        raise ValueError(f"Model with id '{model_id}' not found")
+
+    async with transaction() as tx:
+        count_result = await tx.query_raw(
+            _schema_format(
+                """
+                SELECT COUNT(*) as count
+                FROM {schema_prefix}"AgentNode"
+                WHERE "constantInput"::jsonb->>'model' = $1
+                """
+            ),
+            _node_model_value(model.slug),
+        )
+        nodes_to_migrate = int(count_result[0]["count"]) if count_result else 0
+
+        if nodes_to_migrate > 0:
+            if not replacement_model_slug:
+                raise ValueError(
+                    f"Cannot delete model '{model.slug}': {nodes_to_migrate} "
+                    f"workflow node(s) are using it. Please provide a "
+                    f"replacement_model_slug to migrate them."
+                )
+            await _validate_replacement_in_tx(tx, replacement_model_slug)
+            await _migrate_nodes_in_tx(
+                tx,
+                _node_model_value(model.slug),
+                _node_model_value(replacement_model_slug),
+            )
+        await tx.llmmodel.delete(where={"id": model_id})
+
+    return {
+        "deleted_model_slug": model.slug,
+        "deleted_model_display_name": model.displayName,
+        "replacement_model_slug": replacement_model_slug,
+        "nodes_migrated": nodes_to_migrate,
+    }
+
+
+async def list_migrations(include_reverted: bool = False) -> list[dict[str, Any]]:
+    """List model migrations."""
+    where: Any = None if include_reverted else {"isReverted": False}
+    records = await prisma.models.LlmModelMigration.prisma().find_many(
+        where=where,
+        order={"createdAt": "desc"},
+    )
+    return [
+        {
+            "id": r.id,
+            "source_model_slug": r.sourceModelSlug,
+            "target_model_slug": r.targetModelSlug,
+            "reason": r.reason,
+            "node_count": r.nodeCount,
+            "custom_credit_cost": r.customCreditCost,
+            "is_reverted": r.isReverted,
+            "reverted_at": r.revertedAt.isoformat() if r.revertedAt else None,
+            "created_at": r.createdAt.isoformat(),
+        }
+        for r in records
+    ]
+
+
+async def revert_migration(
+    migration_id: str,
+    re_enable_source_model: bool = True,
+) -> dict[str, Any]:
+    """Revert a model migration, restoring affected nodes to their original model."""
+    migration = await prisma.models.LlmModelMigration.prisma().find_unique(
+        where={"id": migration_id}
+    )
+    if not migration:
+        raise ValueError(f"Migration with id '{migration_id}' not found")
+    if migration.isReverted:
+        raise ValueError(f"Migration '{migration_id}' has already been reverted")
+
+    source_model = await prisma.models.LlmModel.prisma().find_unique(
+        where={"slug": migration.sourceModelSlug}
+    )
+    if not source_model:
+        raise ValueError(
+            f"Source model '{migration.sourceModelSlug}' no longer exists."
+        )
+
+    migrated_node_ids: list[str] = (
+        migration.migratedNodeIds
+        if isinstance(migration.migratedNodeIds, list)
+        else json.loads(str(migration.migratedNodeIds))
+    )
+    if not migrated_node_ids:
+        raise ValueError("No nodes to revert in this migration")
+
+    source_model_re_enabled = False
+
+    async with transaction() as tx:
+        if not source_model.isEnabled and re_enable_source_model:
+            await tx.llmmodel.update(
+                where={"id": source_model.id},
+                data={"isEnabled": True, "source": LlmCatalogSource.LOCAL},
+            )
+            source_model_re_enabled = True
+
+        result = await tx.execute_raw(
+            _schema_format(
+                """
+                UPDATE {schema_prefix}"AgentNode"
+                SET "constantInput" = JSONB_SET(
+                    "constantInput"::jsonb,
+                    '{{model}}',
+                    to_jsonb($1::text)
+                )
+                WHERE id::text IN (
+                    SELECT jsonb_array_elements_text($2::jsonb)
+                )
+                AND "constantInput"::jsonb->>'model' = $3
+                """
+            ),
+            _node_model_value(migration.sourceModelSlug),
+            json.dumps(migrated_node_ids),
+            _node_model_value(migration.targetModelSlug),
+        )
+        nodes_reverted = result if isinstance(result, int) else 0
+
+        await tx.llmmodelmigration.update(
+            where={"id": migration_id},
+            data={"isReverted": True, "revertedAt": datetime.now(timezone.utc)},
+        )
+
+    return {
+        "migration_id": migration_id,
+        "source_model_slug": migration.sourceModelSlug,
+        "target_model_slug": migration.targetModelSlug,
+        "nodes_reverted": nodes_reverted,
+        "nodes_already_changed": len(migrated_node_ids) - nodes_reverted,
+        "source_model_re_enabled": source_model_re_enabled,
+    }

--- a/autogpt_platform/backend/backend/data/llm_registry/db_write_test.py
+++ b/autogpt_platform/backend/backend/data/llm_registry/db_write_test.py
@@ -1,0 +1,230 @@
+"""Real-DB tests for admin write operations (models, migrations, routes)."""
+
+from __future__ import annotations
+
+import prisma.models
+import pytest
+from prisma.enums import LlmCatalogSource
+
+from backend.data.llm_registry import db_routes, db_write
+from backend.data.llm_registry.db_routes import UnknownRouteModelError
+
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+
+@pytest.fixture(autouse=True)
+async def clean_registry_tables(server):
+    """Empty all registry tables before each test (FK-safe order)."""
+    await prisma.models.LlmModelRoute.prisma().delete_many()
+    await prisma.models.LlmModelMigration.prisma().delete_many()
+    await prisma.models.LlmModelCost.prisma().delete_many()
+    await prisma.models.LlmModel.prisma().update_many(
+        where={}, data={"fallbackModelSlug": None}
+    )
+    await prisma.models.LlmModel.prisma().delete_many()
+    await prisma.models.LlmProvider.prisma().delete_many()
+    await prisma.models.LlmModelCreator.prisma().delete_many()
+    await prisma.models.LlmCatalogState.prisma().delete_many()
+
+
+async def _provider() -> prisma.models.LlmProvider:
+    return await prisma.models.LlmProvider.prisma().create(
+        data={"name": "openai", "displayName": "OpenAI"}
+    )
+
+
+async def _model(
+    provider_id: str, slug: str = "openai/gpt-a", **overrides
+) -> prisma.models.LlmModel:
+    data = {
+        "slug": slug,
+        "displayName": slug,
+        "Provider": {"connect": {"id": provider_id}},
+        "contextWindow": 128000,
+        "priceTier": 2,
+    }
+    data.update(overrides)
+    return await prisma.models.LlmModel.prisma().create(data=data)
+
+
+async def test_create_model_claims_local_and_maps_new_columns():
+    provider = await _provider()
+    await _model(provider.id, slug="openai/fallback-target")
+
+    model = await db_write.create_model(
+        slug="openai/gpt-new",
+        display_name="GPT New",
+        provider_id=provider.id,
+        context_window=200000,
+        price_tier=3,
+        visibility="HIDDEN",
+        min_subscription_tier="PRO",
+        fallback_model_slug="openai/fallback-target",
+    )
+
+    assert model.source == LlmCatalogSource.LOCAL
+    assert str(model.visibility) == "HIDDEN"
+    assert str(model.minSubscriptionTier) == "PRO"
+    assert model.fallbackModelSlug == "openai/fallback-target"
+
+
+async def test_create_model_rejects_unknown_fallback():
+    provider = await _provider()
+
+    with pytest.raises(ValueError, match="does not exist"):
+        await db_write.create_model(
+            slug="openai/gpt-new",
+            display_name="GPT New",
+            provider_id=provider.id,
+            context_window=200000,
+            price_tier=1,
+            fallback_model_slug="openai/no-such-model",
+        )
+
+
+async def test_update_model_claims_local_and_enforces_single_recommended():
+    provider = await _provider()
+    a = await _model(provider.id, slug="openai/gpt-a", isRecommended=True)
+    b = await _model(provider.id, slug="openai/gpt-b")
+
+    updated = await db_write.update_model(b.id, is_recommended=True)
+
+    assert updated.isRecommended is True
+    assert updated.source == LlmCatalogSource.LOCAL
+    a_after = await prisma.models.LlmModel.prisma().find_unique(where={"id": a.id})
+    assert a_after is not None and a_after.isRecommended is False
+
+
+async def test_get_model_usage_runs_schema_prefixed_query():
+    assert await db_write.get_model_usage("openai/gpt-a") == {
+        "model_slug": "openai/gpt-a",
+        "node_count": 0,
+    }
+
+
+async def test_toggle_disable_without_migration_claims_local():
+    provider = await _provider()
+    model = await _model(provider.id)
+
+    result = await db_write.toggle_model_with_migration(model.id, is_enabled=False)
+
+    assert result["nodes_migrated"] == 0
+    after = await prisma.models.LlmModel.prisma().find_unique(where={"id": model.id})
+    assert after is not None
+    assert after.isEnabled is False
+    assert after.source == LlmCatalogSource.LOCAL
+
+
+async def test_toggle_with_disabled_replacement_rejected():
+    provider = await _provider()
+    model = await _model(provider.id)
+    await _model(provider.id, slug="openai/gpt-dead", isEnabled=False)
+
+    with pytest.raises(ValueError, match="disabled"):
+        await db_write.toggle_model_with_migration(
+            model.id, is_enabled=False, migrate_to_slug="openai/gpt-dead"
+        )
+
+
+async def test_toggle_with_migration_and_no_matching_nodes():
+    provider = await _provider()
+    model = await _model(provider.id)
+    await _model(provider.id, slug="openai/gpt-replacement")
+
+    result = await db_write.toggle_model_with_migration(
+        model.id, is_enabled=False, migrate_to_slug="openai/gpt-replacement"
+    )
+
+    assert result["nodes_migrated"] == 0
+    assert result["migration_id"] is None
+    assert await prisma.models.LlmModelMigration.prisma().count() == 0
+
+
+async def test_delete_unused_model():
+    provider = await _provider()
+    model = await _model(provider.id)
+
+    result = await db_write.delete_model(model.id)
+
+    assert result["deleted_model_slug"] == "openai/gpt-a"
+    assert result["nodes_migrated"] == 0
+    assert (
+        await prisma.models.LlmModel.prisma().find_unique(where={"id": model.id})
+        is None
+    )
+
+
+async def test_revert_unknown_migration_rejected():
+    with pytest.raises(ValueError, match="not found"):
+        await db_write.revert_migration("no-such-migration")
+
+
+# --------------------------------------------------------------------------
+# Routing cells
+# --------------------------------------------------------------------------
+
+
+async def test_set_route_upserts_and_lists():
+    provider = await _provider()
+    await _model(provider.id, supportsReasoning=True, supportsTools=True)
+
+    row, warnings = await db_routes.set_route(
+        "copilot", "thinking", "standard", "openai/gpt-a"
+    )
+    assert row is not None and row.modelSlug == "openai/gpt-a"
+    assert warnings == []
+
+    # Upsert same cell to a second model
+    await _model(provider.id, slug="openai/gpt-b", supportsTools=True)
+    row2, _ = await db_routes.set_route(
+        "copilot", "thinking", "standard", "openai/gpt-b"
+    )
+    assert row2 is not None and row2.modelSlug == "openai/gpt-b"
+
+    routes = await db_routes.list_routes()
+    assert len(routes) == 1
+
+
+async def test_set_route_unknown_model_raises_lookup():
+    with pytest.raises(UnknownRouteModelError):
+        await db_routes.set_route("copilot", "fast", "standard", "no/such-model")
+
+
+async def test_set_route_disabled_model_rejected_hidden_allowed():
+    provider = await _provider()
+    await _model(provider.id, slug="openai/gpt-dead", isEnabled=False)
+    await _model(
+        provider.id, slug="openai/gpt-hidden", visibility="HIDDEN", supportsTools=True
+    )
+
+    with pytest.raises(ValueError, match="kill switch"):
+        await db_routes.set_route("copilot", "fast", "standard", "openai/gpt-dead")
+
+    row, warnings = await db_routes.set_route(
+        "copilot", "fast", "standard", "openai/gpt-hidden"
+    )
+    assert row is not None and row.modelSlug == "openai/gpt-hidden"
+    assert warnings == []
+
+
+async def test_set_route_capability_warnings():
+    provider = await _provider()
+    await _model(provider.id, slug="openai/gpt-plain")  # no reasoning, no tools
+
+    _, warnings = await db_routes.set_route(
+        "copilot", "thinking", "standard", "openai/gpt-plain"
+    )
+
+    assert any("reasoning" in w for w in warnings)
+    assert any("tool support" in w for w in warnings)
+
+
+async def test_set_route_none_deletes_cell():
+    provider = await _provider()
+    await _model(provider.id, supportsTools=True)
+    await db_routes.set_route("copilot", "fast", "standard", "openai/gpt-a")
+
+    row, warnings = await db_routes.set_route("copilot", "fast", "standard", None)
+
+    assert row is None and warnings == []
+    assert await db_routes.list_routes() == []

--- a/autogpt_platform/frontend/src/app/api/openapi.json
+++ b/autogpt_platform/frontend/src/app/api/openapi.json
@@ -1220,6 +1220,648 @@
         "security": [{ "HTTPBearerJWT": [] }]
       }
     },
+    "/api/admin/llm/catalog/export": {
+      "get": {
+        "tags": ["v2", "admin"],
+        "summary": "Export Catalog",
+        "description": "Current registry as a catalog payload — pipe to catalog.json to\nrefresh the bundled snapshot without direct DB access.",
+        "operationId": "getV2ExportCatalog",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/CatalogPayload" }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
+          }
+        },
+        "security": [{ "HTTPBearerJWT": [] }]
+      }
+    },
+    "/api/admin/llm/creators": {
+      "get": {
+        "tags": ["v2", "admin"],
+        "summary": "List Creators",
+        "operationId": "getV2ListCreators",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LlmCreatorsAdminListResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
+          }
+        },
+        "security": [{ "HTTPBearerJWT": [] }]
+      },
+      "post": {
+        "tags": ["v2", "admin"],
+        "summary": "Create Creator",
+        "operationId": "postV2CreateCreator",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateLlmCreatorRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LlmCreatorAdminResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [{ "HTTPBearerJWT": [] }]
+      }
+    },
+    "/api/admin/llm/creators/{name}": {
+      "delete": {
+        "tags": ["v2", "admin"],
+        "summary": "Delete Creator",
+        "operationId": "deleteV2DeleteCreator",
+        "security": [{ "HTTPBearerJWT": [] }],
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Name" }
+          }
+        ],
+        "responses": {
+          "204": { "description": "Successful Response" },
+          "401": {
+            "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": ["v2", "admin"],
+        "summary": "Update Creator",
+        "operationId": "patchV2UpdateCreator",
+        "security": [{ "HTTPBearerJWT": [] }],
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Name" }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateLlmCreatorRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LlmCreatorAdminResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/llm/migrations": {
+      "get": {
+        "tags": ["v2", "admin"],
+        "summary": "List Migrations",
+        "operationId": "getV2ListMigrations",
+        "security": [{ "HTTPBearerJWT": [] }],
+        "parameters": [
+          {
+            "name": "include_reverted",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Include Reverted"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LlmMigrationsAdminListResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/llm/migrations/{migration_id}/revert": {
+      "post": {
+        "tags": ["v2", "admin"],
+        "summary": "Revert Migration",
+        "operationId": "postV2RevertMigration",
+        "security": [{ "HTTPBearerJWT": [] }],
+        "parameters": [
+          {
+            "name": "migration_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Migration Id" }
+          },
+          {
+            "name": "re_enable_source_model",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": true,
+              "title": "Re Enable Source Model"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Postv2Revertmigration"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/llm/models": {
+      "get": {
+        "tags": ["v2", "admin"],
+        "summary": "Admin List Models",
+        "operationId": "getV2AdminListModels",
+        "security": [{ "HTTPBearerJWT": [] }],
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "integer", "default": 1, "title": "Page" }
+          },
+          {
+            "name": "page_size",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 100,
+              "title": "Page Size"
+            }
+          },
+          {
+            "name": "enabled_only",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Enabled Only"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LlmModelsAdminListResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": ["v2", "admin"],
+        "summary": "Create Model",
+        "operationId": "postV2CreateModel",
+        "security": [{ "HTTPBearerJWT": [] }],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/CreateLlmModelRequest" }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LlmModelAdminResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/llm/models/{slug}": {
+      "delete": {
+        "tags": ["v2", "admin"],
+        "summary": "Delete Model",
+        "operationId": "deleteV2DeleteModel",
+        "security": [{ "HTTPBearerJWT": [] }],
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Slug" }
+          },
+          {
+            "name": "replacement_model_slug",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "title": "Replacement Model Slug"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Deletev2Deletemodel"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": ["v2", "admin"],
+        "summary": "Update Model",
+        "operationId": "patchV2UpdateModel",
+        "security": [{ "HTTPBearerJWT": [] }],
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Slug" }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/UpdateLlmModelRequest" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LlmModelAdminResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/llm/models/{slug}/toggle": {
+      "post": {
+        "tags": ["v2", "admin"],
+        "summary": "Toggle Model",
+        "operationId": "postV2ToggleModel",
+        "security": [{ "HTTPBearerJWT": [] }],
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Slug" }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/ToggleLlmModelRequest" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Postv2Togglemodel"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/llm/models/{slug}/usage": {
+      "get": {
+        "tags": ["v2", "admin"],
+        "summary": "Get Model Usage",
+        "operationId": "getV2GetModelUsage",
+        "security": [{ "HTTPBearerJWT": [] }],
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Slug" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Getv2Getmodelusage"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/llm/providers": {
+      "get": {
+        "tags": ["v2", "admin"],
+        "summary": "Admin List Providers",
+        "operationId": "getV2AdminListProviders",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LlmProvidersAdminListResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
+          }
+        },
+        "security": [{ "HTTPBearerJWT": [] }]
+      }
+    },
+    "/api/admin/llm/routes": {
+      "get": {
+        "tags": ["v2", "admin"],
+        "summary": "List Routes",
+        "operationId": "getV2ListRoutes",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LlmRoutesListResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
+          }
+        },
+        "security": [{ "HTTPBearerJWT": [] }]
+      },
+      "put": {
+        "tags": ["v2", "admin"],
+        "summary": "Set Route",
+        "operationId": "putV2SetRoute",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/SetLlmRouteRequest" }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/SetLlmRouteResponse" }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [{ "HTTPBearerJWT": [] }]
+      }
+    },
+    "/api/admin/llm/routes/warnings": {
+      "get": {
+        "tags": ["v2", "admin"],
+        "summary": "List Route Warnings",
+        "operationId": "getV2ListRouteWarnings",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": { "$ref": "#/components/schemas/RouteWarning" },
+                  "type": "array",
+                  "title": "Response Getv2Listroutewarnings"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
+          }
+        },
+        "security": [{ "HTTPBearerJWT": [] }]
+      }
+    },
     "/api/admin/memory/{user_id}/communities": {
       "get": {
         "tags": ["v2", "admin", "admin", "memory"],
@@ -15439,6 +16081,152 @@
         "required": ["email"],
         "title": "CreateInvitationRequest"
       },
+      "CreateLlmCreatorRequest": {
+        "properties": {
+          "name": { "type": "string", "title": "Name" },
+          "display_name": { "type": "string", "title": "Display Name" },
+          "description": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Description"
+          },
+          "website_url": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Website Url"
+          },
+          "logo_url": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Logo Url"
+          },
+          "metadata": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Metadata"
+          }
+        },
+        "type": "object",
+        "required": ["name", "display_name"],
+        "title": "CreateLlmCreatorRequest"
+      },
+      "CreateLlmModelRequest": {
+        "properties": {
+          "slug": { "type": "string", "title": "Slug" },
+          "display_name": { "type": "string", "title": "Display Name" },
+          "description": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Description"
+          },
+          "provider_name": { "type": "string", "title": "Provider Name" },
+          "creator_id": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Creator Id"
+          },
+          "context_window": {
+            "type": "integer",
+            "exclusiveMinimum": 0.0,
+            "title": "Context Window"
+          },
+          "max_output_tokens": {
+            "anyOf": [
+              { "type": "integer", "exclusiveMinimum": 0.0 },
+              { "type": "null" }
+            ],
+            "title": "Max Output Tokens"
+          },
+          "price_tier": {
+            "type": "integer",
+            "maximum": 3.0,
+            "minimum": 1.0,
+            "title": "Price Tier"
+          },
+          "is_enabled": {
+            "type": "boolean",
+            "title": "Is Enabled",
+            "default": true
+          },
+          "is_recommended": {
+            "type": "boolean",
+            "title": "Is Recommended",
+            "default": false
+          },
+          "kind": {
+            "type": "string",
+            "const": "CHAT",
+            "title": "Kind",
+            "default": "CHAT"
+          },
+          "visibility": {
+            "type": "string",
+            "enum": ["GA", "EMPLOYEES", "ADMINS", "HIDDEN"],
+            "title": "Visibility",
+            "default": "GA"
+          },
+          "min_subscription_tier": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "NO_TIER",
+                  "BASIC",
+                  "PRO",
+                  "MAX",
+                  "BUSINESS",
+                  "ENTERPRISE"
+                ]
+              },
+              { "type": "null" }
+            ],
+            "title": "Min Subscription Tier"
+          },
+          "fallback_model_slug": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Fallback Model Slug"
+          },
+          "supports_tools": {
+            "type": "boolean",
+            "title": "Supports Tools",
+            "default": false
+          },
+          "supports_json_output": {
+            "type": "boolean",
+            "title": "Supports Json Output",
+            "default": false
+          },
+          "supports_reasoning": {
+            "type": "boolean",
+            "title": "Supports Reasoning",
+            "default": false
+          },
+          "supports_parallel_tool_calls": {
+            "type": "boolean",
+            "title": "Supports Parallel Tool Calls",
+            "default": false
+          },
+          "capabilities": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Capabilities"
+          },
+          "metadata": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Metadata"
+          },
+          "costs": {
+            "items": { "additionalProperties": true, "type": "object" },
+            "type": "array",
+            "title": "Costs"
+          }
+        },
+        "type": "object",
+        "required": [
+          "slug",
+          "display_name",
+          "provider_name",
+          "context_window",
+          "price_tier"
+        ],
+        "title": "CreateLlmModelRequest"
+      },
       "CreateOrgRequest": {
         "properties": {
           "name": {
@@ -18504,6 +19292,314 @@
         "title": "ListSessionsResponse",
         "description": "Response model for listing chat sessions."
       },
+      "LlmCreatorAdminResponse": {
+        "properties": {
+          "id": { "type": "string", "title": "Id" },
+          "name": { "type": "string", "title": "Name" },
+          "display_name": { "type": "string", "title": "Display Name" },
+          "description": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Description"
+          },
+          "website_url": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Website Url"
+          },
+          "logo_url": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Logo Url"
+          },
+          "source": { "type": "string", "title": "Source", "default": "SEED" },
+          "metadata": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Metadata"
+          },
+          "created_at": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Created At"
+          },
+          "updated_at": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Updated At"
+          }
+        },
+        "type": "object",
+        "required": ["id", "name", "display_name"],
+        "title": "LlmCreatorAdminResponse"
+      },
+      "LlmCreatorsAdminListResponse": {
+        "properties": {
+          "creators": {
+            "items": { "$ref": "#/components/schemas/LlmCreatorAdminResponse" },
+            "type": "array",
+            "title": "Creators"
+          }
+        },
+        "type": "object",
+        "required": ["creators"],
+        "title": "LlmCreatorsAdminListResponse"
+      },
+      "LlmMigrationAdminResponse": {
+        "properties": {
+          "id": { "type": "string", "title": "Id" },
+          "source_model_slug": {
+            "type": "string",
+            "title": "Source Model Slug"
+          },
+          "target_model_slug": {
+            "type": "string",
+            "title": "Target Model Slug"
+          },
+          "reason": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Reason"
+          },
+          "node_count": { "type": "integer", "title": "Node Count" },
+          "custom_credit_cost": {
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "title": "Custom Credit Cost"
+          },
+          "is_reverted": { "type": "boolean", "title": "Is Reverted" },
+          "reverted_at": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Reverted At"
+          },
+          "created_at": { "type": "string", "title": "Created At" }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "source_model_slug",
+          "target_model_slug",
+          "node_count",
+          "is_reverted",
+          "created_at"
+        ],
+        "title": "LlmMigrationAdminResponse"
+      },
+      "LlmMigrationsAdminListResponse": {
+        "properties": {
+          "migrations": {
+            "items": {
+              "$ref": "#/components/schemas/LlmMigrationAdminResponse"
+            },
+            "type": "array",
+            "title": "Migrations"
+          }
+        },
+        "type": "object",
+        "required": ["migrations"],
+        "title": "LlmMigrationsAdminListResponse"
+      },
+      "LlmModelAdminResponse": {
+        "properties": {
+          "id": { "type": "string", "title": "Id" },
+          "slug": { "type": "string", "title": "Slug" },
+          "display_name": { "type": "string", "title": "Display Name" },
+          "description": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Description"
+          },
+          "provider_id": { "type": "string", "title": "Provider Id" },
+          "creator_id": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Creator Id"
+          },
+          "context_window": { "type": "integer", "title": "Context Window" },
+          "max_output_tokens": {
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "title": "Max Output Tokens"
+          },
+          "price_tier": { "type": "integer", "title": "Price Tier" },
+          "is_enabled": { "type": "boolean", "title": "Is Enabled" },
+          "is_recommended": { "type": "boolean", "title": "Is Recommended" },
+          "kind": { "type": "string", "title": "Kind" },
+          "visibility": { "type": "string", "title": "Visibility" },
+          "min_subscription_tier": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Min Subscription Tier"
+          },
+          "fallback_model_slug": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Fallback Model Slug"
+          },
+          "source": { "type": "string", "title": "Source" },
+          "catalog_removed_at": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Catalog Removed At"
+          },
+          "supports_tools": { "type": "boolean", "title": "Supports Tools" },
+          "supports_json_output": {
+            "type": "boolean",
+            "title": "Supports Json Output"
+          },
+          "supports_reasoning": {
+            "type": "boolean",
+            "title": "Supports Reasoning"
+          },
+          "supports_parallel_tool_calls": {
+            "type": "boolean",
+            "title": "Supports Parallel Tool Calls"
+          },
+          "capabilities": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Capabilities"
+          },
+          "metadata": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Metadata"
+          },
+          "created_at": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Created At"
+          },
+          "updated_at": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Updated At"
+          },
+          "creator": {
+            "anyOf": [
+              { "$ref": "#/components/schemas/LlmCreatorAdminResponse" },
+              { "type": "null" }
+            ]
+          },
+          "costs": {
+            "items": {
+              "$ref": "#/components/schemas/LlmModelCostAdminResponse"
+            },
+            "type": "array",
+            "title": "Costs"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "slug",
+          "display_name",
+          "provider_id",
+          "context_window",
+          "price_tier",
+          "is_enabled",
+          "is_recommended",
+          "kind",
+          "visibility",
+          "source",
+          "supports_tools",
+          "supports_json_output",
+          "supports_reasoning",
+          "supports_parallel_tool_calls"
+        ],
+        "title": "LlmModelAdminResponse"
+      },
+      "LlmModelCostAdminResponse": {
+        "properties": {
+          "unit": { "type": "string", "title": "Unit" },
+          "credit_cost": { "type": "number", "title": "Credit Cost" },
+          "credential_provider": {
+            "type": "string",
+            "title": "Credential Provider"
+          },
+          "credential_type": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Credential Type"
+          },
+          "metadata": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Metadata"
+          }
+        },
+        "type": "object",
+        "required": ["unit", "credit_cost", "credential_provider"],
+        "title": "LlmModelCostAdminResponse"
+      },
+      "LlmModelsAdminListResponse": {
+        "properties": {
+          "models": {
+            "items": { "$ref": "#/components/schemas/LlmModelAdminResponse" },
+            "type": "array",
+            "title": "Models"
+          }
+        },
+        "type": "object",
+        "required": ["models"],
+        "title": "LlmModelsAdminListResponse"
+      },
+      "LlmProviderAdminResponse": {
+        "properties": {
+          "id": { "type": "string", "title": "Id" },
+          "name": { "type": "string", "title": "Name" },
+          "display_name": { "type": "string", "title": "Display Name" },
+          "description": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Description"
+          },
+          "source": { "type": "string", "title": "Source", "default": "SEED" },
+          "metadata": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Metadata"
+          },
+          "created_at": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Created At"
+          },
+          "updated_at": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Updated At"
+          },
+          "model_count": {
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "title": "Model Count"
+          }
+        },
+        "type": "object",
+        "required": ["id", "name", "display_name"],
+        "title": "LlmProviderAdminResponse"
+      },
+      "LlmProvidersAdminListResponse": {
+        "properties": {
+          "providers": {
+            "items": {
+              "$ref": "#/components/schemas/LlmProviderAdminResponse"
+            },
+            "type": "array",
+            "title": "Providers"
+          }
+        },
+        "type": "object",
+        "required": ["providers"],
+        "title": "LlmProvidersAdminListResponse"
+      },
+      "LlmRouteResponse": {
+        "properties": {
+          "surface": { "type": "string", "title": "Surface" },
+          "mode": { "type": "string", "title": "Mode" },
+          "tier": { "type": "string", "title": "Tier" },
+          "model_slug": { "type": "string", "title": "Model Slug" },
+          "updated_at": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Updated At"
+          }
+        },
+        "type": "object",
+        "required": ["surface", "mode", "tier", "model_slug"],
+        "title": "LlmRouteResponse"
+      },
+      "LlmRoutesListResponse": {
+        "properties": {
+          "routes": {
+            "items": { "$ref": "#/components/schemas/LlmRouteResponse" },
+            "type": "array",
+            "title": "Routes"
+          }
+        },
+        "type": "object",
+        "title": "LlmRoutesListResponse"
+      },
       "LogRawMetricRequest": {
         "properties": {
           "metric_name": {
@@ -21077,6 +22173,22 @@
         "required": ["store_listing_version_id", "is_approved", "comments"],
         "title": "ReviewSubmissionRequest"
       },
+      "RouteWarning": {
+        "properties": {
+          "slug": { "type": "string", "title": "Slug" },
+          "reason": { "type": "string", "title": "Reason" },
+          "count": { "type": "integer", "title": "Count" },
+          "last_seen": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Last Seen"
+          },
+          "last_layer": { "type": "string", "title": "Last Layer" }
+        },
+        "type": "object",
+        "required": ["slug", "reason", "count", "last_seen", "last_layer"],
+        "title": "RouteWarning"
+      },
       "RunningExecutionDetail": {
         "properties": {
           "execution_id": { "type": "string", "title": "Execution Id" },
@@ -21601,6 +22713,41 @@
         "type": "object",
         "required": ["active_graph_version"],
         "title": "SetGraphActiveVersion"
+      },
+      "SetLlmRouteRequest": {
+        "properties": {
+          "surface": {
+            "type": "string",
+            "title": "Surface",
+            "default": "copilot"
+          },
+          "mode": { "type": "string", "title": "Mode" },
+          "tier": { "type": "string", "title": "Tier" },
+          "model_slug": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Model Slug"
+          }
+        },
+        "type": "object",
+        "required": ["mode", "tier"],
+        "title": "SetLlmRouteRequest"
+      },
+      "SetLlmRouteResponse": {
+        "properties": {
+          "route": {
+            "anyOf": [
+              { "$ref": "#/components/schemas/LlmRouteResponse" },
+              { "type": "null" }
+            ]
+          },
+          "warnings": {
+            "items": { "type": "string" },
+            "type": "array",
+            "title": "Warnings"
+          }
+        },
+        "type": "object",
+        "title": "SetLlmRouteResponse"
       },
       "SetUserTierRequest": {
         "properties": {
@@ -23582,6 +24729,26 @@
         "title": "TodoWriteResponse",
         "description": "Ack returned by ``TodoWrite``.\n\nThe tool is effectively stateless — the authoritative task list lives in\nthe assistant's latest tool-call arguments, which are replayed from the\ntranscript on each turn. The tool output only needs to confirm that the\nupdate was accepted so the model can proceed."
       },
+      "ToggleLlmModelRequest": {
+        "properties": {
+          "is_enabled": { "type": "boolean", "title": "Is Enabled" },
+          "migrate_to_slug": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Migrate To Slug"
+          },
+          "migration_reason": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Migration Reason"
+          },
+          "custom_credit_cost": {
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "title": "Custom Credit Cost"
+          }
+        },
+        "type": "object",
+        "required": ["is_enabled"],
+        "title": "ToggleLlmModelRequest"
+      },
       "TokenIntrospectionResult": {
         "properties": {
           "active": { "type": "boolean", "title": "Active" },
@@ -23939,6 +25106,150 @@
         "type": "object",
         "required": ["logo_url"],
         "title": "UpdateAppLogoRequest"
+      },
+      "UpdateLlmCreatorRequest": {
+        "properties": {
+          "display_name": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Display Name"
+          },
+          "description": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Description"
+          },
+          "website_url": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Website Url"
+          },
+          "logo_url": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Logo Url"
+          },
+          "metadata": {
+            "anyOf": [
+              { "additionalProperties": true, "type": "object" },
+              { "type": "null" }
+            ],
+            "title": "Metadata"
+          }
+        },
+        "type": "object",
+        "title": "UpdateLlmCreatorRequest"
+      },
+      "UpdateLlmModelRequest": {
+        "properties": {
+          "display_name": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Display Name"
+          },
+          "description": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Description"
+          },
+          "creator_id": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Creator Id"
+          },
+          "context_window": {
+            "anyOf": [
+              { "type": "integer", "exclusiveMinimum": 0.0 },
+              { "type": "null" }
+            ],
+            "title": "Context Window"
+          },
+          "max_output_tokens": {
+            "anyOf": [
+              { "type": "integer", "exclusiveMinimum": 0.0 },
+              { "type": "null" }
+            ],
+            "title": "Max Output Tokens"
+          },
+          "price_tier": {
+            "anyOf": [
+              { "type": "integer", "maximum": 3.0, "minimum": 1.0 },
+              { "type": "null" }
+            ],
+            "title": "Price Tier"
+          },
+          "is_enabled": {
+            "anyOf": [{ "type": "boolean" }, { "type": "null" }],
+            "title": "Is Enabled"
+          },
+          "is_recommended": {
+            "anyOf": [{ "type": "boolean" }, { "type": "null" }],
+            "title": "Is Recommended"
+          },
+          "kind": {
+            "anyOf": [
+              { "type": "string", "const": "CHAT" },
+              { "type": "null" }
+            ],
+            "title": "Kind"
+          },
+          "visibility": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": ["GA", "EMPLOYEES", "ADMINS", "HIDDEN"]
+              },
+              { "type": "null" }
+            ],
+            "title": "Visibility"
+          },
+          "min_subscription_tier": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "NO_TIER",
+                  "BASIC",
+                  "PRO",
+                  "MAX",
+                  "BUSINESS",
+                  "ENTERPRISE"
+                ]
+              },
+              { "type": "null" }
+            ],
+            "title": "Min Subscription Tier"
+          },
+          "fallback_model_slug": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Fallback Model Slug"
+          },
+          "supports_tools": {
+            "anyOf": [{ "type": "boolean" }, { "type": "null" }],
+            "title": "Supports Tools"
+          },
+          "supports_json_output": {
+            "anyOf": [{ "type": "boolean" }, { "type": "null" }],
+            "title": "Supports Json Output"
+          },
+          "supports_reasoning": {
+            "anyOf": [{ "type": "boolean" }, { "type": "null" }],
+            "title": "Supports Reasoning"
+          },
+          "supports_parallel_tool_calls": {
+            "anyOf": [{ "type": "boolean" }, { "type": "null" }],
+            "title": "Supports Parallel Tool Calls"
+          },
+          "capabilities": {
+            "anyOf": [
+              { "additionalProperties": true, "type": "object" },
+              { "type": "null" }
+            ],
+            "title": "Capabilities"
+          },
+          "metadata": {
+            "anyOf": [
+              { "additionalProperties": true, "type": "object" },
+              { "type": "null" }
+            ],
+            "title": "Metadata"
+          }
+        },
+        "type": "object",
+        "title": "UpdateLlmModelRequest"
       },
       "UpdateMemberRequest": {
         "properties": {


### PR DESCRIPTION
## Why

Part 7 of 9 of the LLM registry restack (#13605→#13606→#13607→#13608→#13609→#13610→this). This is the front door that replaces the "hand-edit a JSON file and open a PR" model-management workflow: adding K3 becomes an authenticated admin call whose row is validated, audited, and propagated to every install.

## What

Admin API at `/api/admin/llm` (all `Security(requires_admin_user)`), re-cut from @Bentlybro's #12467:

- **Kept**: model CRUD (`{slug:path}` params), creator CRUD, usage counting, disable-with-replacement + revert
- **Dropped**: provider CRUD — providers are a fixed seed set (read-only list retained for the UI)
- **`source=LOCAL` on every write** — the importer's admin-wins contract from #13607
- **AuditLog per mutation** (uses the existing `AuditLog` table; entity-typed actions like `LLM_MODEL_DISABLED`, before/after JSON; audit failure never fails the operation)
- **New columns** wired end-to-end: `visibility`, `min_subscription_tier`, `fallback_model_slug` (existence-validated), `kind`
- **New endpoints**: `GET/PUT /routes` (routing-cell upsert; model must exist + be enabled, HIDDEN allowed; response carries capability warnings — e.g. non-reasoning model in a thinking cell); `GET /routes/warnings` (the #13610 refusal records — typo'd LD slugs surface here); `GET /catalog/export` (regenerate the bundled catalog.json with a curl)

## Fixes over the original branch

- Unqualified `"AgentNode"` raw SQL → `{schema_prefix}` helpers (the exact bug class flagged in the original #12359 review; breaks non-`platform` schemas otherwise)
- Latent revert bug: migration wrote provider-stripped node values but revert matched raw slugs — reverts could never have matched a node
- The old branch's private `refresh_runtime_caches` copy replaced by the canonical one (single choke point for cache coherence)

## Verification

- 86/86 tests: full registry suite green + real-DB db_write tests (source=LOCAL assertions, AuditLog rows per action, cell operations, migration/revert round-trip at the SQL layer) + route-layer tests (auth, validation, capability warnings, HIDDEN acceptance, warnings/export endpoints)
- `poetry run format` + `poetry run lint` clean

Known follow-ups (tickets, not scope): "reset to catalog" action (LOCAL is sticky by design); toggle-with-populated-graph integration test needs graph fixtures.

## Checklist
- [x] All routes admin-gated; acting admin recorded on every mutation via AuditLog
- [x] Out-of-scope changes: none
