### PR TITLE
feat(frontend): admin LLM registry editing

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/admin/llms/__tests__/dashboard.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/llms/__tests__/dashboard.test.tsx
@@ -148,8 +148,8 @@ describe("LlmRegistryDashboard", () => {
 
     const cells = await screen.findAllByText("moonshotai/kimi-k3");
     expect(cells.length).toBeGreaterThanOrEqual(1);
-    // Only thinking.standard is set; the other three cells fall through.
-    expect(screen.getAllByText("— (falls through)").length).toBe(3);
+    // Only thinking.standard is set; the other three editable cells fall through.
+    expect(screen.getAllByText("— falls through —").length).toBe(3);
   });
 
   it("surfaces routing resolution warnings with count and reason", async () => {

--- a/autogpt_platform/frontend/src/app/(platform)/admin/llms/__tests__/editing.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/llms/__tests__/editing.test.tsx
@@ -1,0 +1,270 @@
+import { HttpResponse, http } from "msw";
+import { describe, expect, it, vi } from "vitest";
+
+// Force the large-screen Radix Dialog path — the responsive Drawer (vaul)
+// variant doesn't render in jsdom (same mock the Dialog's own tests use).
+vi.mock("@/lib/hooks/useBreakpoint", () => ({
+  useBreakpoint: () => "lg",
+  isLargeScreen: () => true,
+}));
+
+import { server } from "@/mocks/mock-server";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@/tests/integrations/test-utils";
+
+import type { LlmCreatorAdminResponse } from "@/app/api/__generated__/models/llmCreatorAdminResponse";
+import type { LlmMigrationAdminResponse } from "@/app/api/__generated__/models/llmMigrationAdminResponse";
+import type { LlmModelAdminResponse } from "@/app/api/__generated__/models/llmModelAdminResponse";
+import {
+  CreatorFormDialog,
+  DeleteCreatorDialog,
+} from "../components/CreatorDialogs/CreatorDialogs";
+import { DeleteModelDialog } from "../components/DeleteModelDialog/DeleteModelDialog";
+import { ModelFormDialog } from "../components/ModelFormDialog/ModelFormDialog";
+import { RevertMigrationDialog } from "../components/RevertMigrationDialog/RevertMigrationDialog";
+import { ToggleModelDialog } from "../components/ToggleModelDialog/ToggleModelDialog";
+
+function model(
+  overrides: Partial<LlmModelAdminResponse> = {},
+): LlmModelAdminResponse {
+  return {
+    id: "model-uuid",
+    slug: "moonshotai/kimi-k3",
+    display_name: "Kimi K3",
+    description: null,
+    provider_id: "provider-uuid",
+    creator_id: null,
+    context_window: 1048576,
+    max_output_tokens: 32768,
+    price_tier: 3,
+    is_enabled: true,
+    is_recommended: false,
+    kind: "CHAT",
+    visibility: "HIDDEN",
+    min_subscription_tier: null,
+    fallback_model_slug: null,
+    source: "LOCAL",
+    catalog_removed_at: null,
+    supports_tools: true,
+    supports_json_output: true,
+    supports_reasoning: true,
+    supports_parallel_tool_calls: false,
+    capabilities: {},
+    metadata: {},
+    created_at: "2026-07-18T00:00:00Z",
+    updated_at: "2026-07-18T00:00:00Z",
+    creator: null,
+    costs: [],
+    ...overrides,
+  } as LlmModelAdminResponse;
+}
+
+const creator: LlmCreatorAdminResponse = {
+  id: "creator-uuid",
+  name: "moonshotai",
+  display_name: "Moonshot AI",
+  description: null,
+  website_url: null,
+  logo_url: null,
+  source: "SEED",
+  created_at: null,
+  updated_at: null,
+} as LlmCreatorAdminResponse;
+
+const migration: LlmMigrationAdminResponse = {
+  id: "mig-uuid",
+  source_model_slug: "openai/gpt-old",
+  target_model_slug: "openai/gpt-new",
+  reason: null,
+  node_count: 7,
+  custom_credit_cost: null,
+  is_reverted: false,
+  reverted_at: null,
+  created_at: "2026-07-01T00:00:00Z",
+} as LlmMigrationAdminResponse;
+
+describe("ModelFormDialog", () => {
+  it("submits edited display name via PATCH to the model endpoint", async () => {
+    let captured: Record<string, unknown> | null = null;
+    server.use(
+      http.patch("*/api/admin/llm/models/*", async ({ request }) => {
+        captured = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json(model());
+      }),
+    );
+
+    render(
+      <ModelFormDialog
+        open
+        editing={model()}
+        providers={[]}
+        creators={[creator]}
+        models={[model()]}
+        onClose={() => undefined}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Display name"), {
+      target: { value: "Kimi K3 Prime" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => expect(captured).not.toBeNull());
+    expect(captured!.display_name).toBe("Kimi K3 Prime");
+  });
+
+  it("blocks create submit without slug and provider", async () => {
+    let posted = false;
+    server.use(
+      http.post("*/api/admin/llm/models", () => {
+        posted = true;
+        return HttpResponse.json(model(), { status: 201 });
+      }),
+    );
+
+    render(
+      <ModelFormDialog
+        open
+        editing={null}
+        providers={[]}
+        creators={[]}
+        models={[]}
+        onClose={() => undefined}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Create model" }));
+
+    expect(
+      await screen.findByText("Slug and provider are required"),
+    ).toBeDefined();
+    expect(posted).toBe(false);
+  });
+});
+
+describe("ToggleModelDialog", () => {
+  it("disables the model with is_enabled=false via the toggle endpoint", async () => {
+    let captured: Record<string, unknown> | null = null;
+    server.use(
+      http.post("*/api/admin/llm/models/*/toggle", async ({ request }) => {
+        captured = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({ success: true });
+      }),
+    );
+
+    render(
+      <ToggleModelDialog
+        open
+        model={model()}
+        models={[model(), model({ slug: "openai/gpt-5.2", id: "m2" })]}
+        onClose={() => undefined}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Disable model" }));
+
+    await waitFor(() => expect(captured).not.toBeNull());
+    expect(captured!.is_enabled).toBe(false);
+  });
+});
+
+describe("DeleteModelDialog", () => {
+  it("deletes the model without replacement when none picked", async () => {
+    let calledUrl: string | null = null;
+    server.use(
+      http.delete("*/api/admin/llm/models/*", ({ request }) => {
+        calledUrl = request.url;
+        return HttpResponse.json({ success: true });
+      }),
+    );
+
+    render(
+      <DeleteModelDialog
+        open
+        model={model()}
+        models={[model()]}
+        onClose={() => undefined}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete model" }));
+
+    await waitFor(() => expect(calledUrl).not.toBeNull());
+    expect(calledUrl).not.toContain("replacement_model_slug");
+  });
+});
+
+describe("CreatorFormDialog", () => {
+  it("creates a creator with the typed name and display name", async () => {
+    let captured: Record<string, unknown> | null = null;
+    server.use(
+      http.post("*/api/admin/llm/creators", async ({ request }) => {
+        captured = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json(creator, { status: 201 });
+      }),
+    );
+
+    render(<CreatorFormDialog open editing={null} onClose={() => undefined} />);
+
+    fireEvent.change(screen.getByLabelText("Name (slug)"), {
+      target: { value: "zai" },
+    });
+    fireEvent.change(screen.getByLabelText("Display name"), {
+      target: { value: "Z.ai" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create creator" }));
+
+    await waitFor(() => expect(captured).not.toBeNull());
+    expect(captured!.name).toBe("zai");
+    expect(captured!.display_name).toBe("Z.ai");
+  });
+});
+
+describe("DeleteCreatorDialog", () => {
+  it("deletes the creator on confirm", async () => {
+    let called = false;
+    server.use(
+      http.delete("*/api/admin/llm/creators/*", () => {
+        called = true;
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+
+    render(
+      <DeleteCreatorDialog open creator={creator} onClose={() => undefined} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete creator" }));
+
+    await waitFor(() => expect(called).toBe(true));
+  });
+});
+
+describe("RevertMigrationDialog", () => {
+  it("reverts the migration with re_enable_source_model=true by default", async () => {
+    let calledUrl: string | null = null;
+    server.use(
+      http.post("*/api/admin/llm/migrations/*/revert", ({ request }) => {
+        calledUrl = request.url;
+        return HttpResponse.json({ success: true });
+      }),
+    );
+
+    render(
+      <RevertMigrationDialog
+        open
+        migration={migration}
+        onClose={() => undefined}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Revert" }));
+
+    await waitFor(() => expect(calledUrl).not.toBeNull());
+    expect(calledUrl).toContain("re_enable_source_model=true");
+  });
+});

--- a/autogpt_platform/frontend/src/app/(platform)/admin/llms/components/CreatorDialogs/CreatorDialogs.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/llms/components/CreatorDialogs/CreatorDialogs.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import type { LlmCreatorAdminResponse } from "@/app/api/__generated__/models/llmCreatorAdminResponse";
+import { Button } from "@/components/atoms/Button/Button";
+import { Input } from "@/components/atoms/Input/Input";
+import { Dialog } from "@/components/molecules/Dialog/Dialog";
+import { useState } from "react";
+import { useLlmRegistryMutations } from "../useLlmRegistryMutations";
+
+interface FormProps {
+  open: boolean;
+  editing: LlmCreatorAdminResponse | null;
+  onClose: () => void;
+}
+
+export function CreatorFormDialog({ open, editing, onClose }: FormProps) {
+  const { createCreator, updateCreator } = useLlmRegistryMutations();
+  const [name, setName] = useState(editing?.name ?? "");
+  const [displayName, setDisplayName] = useState(editing?.display_name ?? "");
+  const [websiteUrl, setWebsiteUrl] = useState(editing?.website_url ?? "");
+
+  const isPending = createCreator.isPending || updateCreator.isPending;
+
+  async function handleSubmit() {
+    if (editing) {
+      await updateCreator.mutateAsync({
+        name: editing.name,
+        data: {
+          display_name: displayName,
+          website_url: websiteUrl || null,
+        },
+      });
+    } else {
+      await createCreator.mutateAsync({
+        data: {
+          name,
+          display_name: displayName,
+          website_url: websiteUrl || null,
+        },
+      });
+    }
+    onClose();
+  }
+
+  return (
+    <Dialog
+      title={editing ? `Edit ${editing.name}` : "Add creator"}
+      styling={{ maxWidth: "30rem" }}
+      controlled={{
+        isOpen: open,
+        set: (next) => (next ? undefined : onClose()),
+      }}
+    >
+      <Dialog.Content>
+        <div className="flex flex-col gap-3">
+          {!editing && (
+            <Input
+              id="creator-name"
+              label="Name (slug)"
+              placeholder="e.g. moonshotai"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+            />
+          )}
+          <Input
+            id="creator-display-name"
+            label="Display name"
+            value={displayName}
+            onChange={(e) => setDisplayName(e.target.value)}
+          />
+          <Input
+            id="creator-website"
+            label="Website URL"
+            value={websiteUrl}
+            onChange={(e) => setWebsiteUrl(e.target.value)}
+          />
+        </div>
+        <Dialog.Footer>
+          <Button variant="secondary" onClick={onClose} disabled={isPending}>
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit} loading={isPending}>
+            {editing ? "Save changes" : "Create creator"}
+          </Button>
+        </Dialog.Footer>
+      </Dialog.Content>
+    </Dialog>
+  );
+}
+
+interface DeleteProps {
+  open: boolean;
+  creator: LlmCreatorAdminResponse | null;
+  onClose: () => void;
+}
+
+export function DeleteCreatorDialog({ open, creator, onClose }: DeleteProps) {
+  const { deleteCreator } = useLlmRegistryMutations();
+
+  if (!creator) return null;
+
+  async function handleConfirm() {
+    if (!creator) return;
+    await deleteCreator.mutateAsync({ name: creator.name });
+    onClose();
+  }
+
+  return (
+    <Dialog
+      title={`Delete ${creator.name}?`}
+      styling={{ maxWidth: "28rem" }}
+      controlled={{
+        isOpen: open,
+        set: (next) => (next ? undefined : onClose()),
+      }}
+    >
+      <Dialog.Content>
+        <p className="text-sm text-muted-foreground">
+          Models referencing this creator keep working (creator becomes unset).
+          This cannot be undone.
+        </p>
+        <Dialog.Footer>
+          <Button
+            variant="secondary"
+            onClick={onClose}
+            disabled={deleteCreator.isPending}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={handleConfirm}
+            loading={deleteCreator.isPending}
+          >
+            Delete creator
+          </Button>
+        </Dialog.Footer>
+      </Dialog.Content>
+    </Dialog>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/admin/llms/components/DeleteModelDialog/DeleteModelDialog.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/llms/components/DeleteModelDialog/DeleteModelDialog.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import type { LlmModelAdminResponse } from "@/app/api/__generated__/models/llmModelAdminResponse";
+import { Button } from "@/components/atoms/Button/Button";
+import { Select } from "@/components/atoms/Select/Select";
+import { Dialog } from "@/components/molecules/Dialog/Dialog";
+import { useState } from "react";
+import { useLlmRegistryMutations } from "../useLlmRegistryMutations";
+
+interface Props {
+  open: boolean;
+  model: LlmModelAdminResponse | null;
+  models: LlmModelAdminResponse[];
+  onClose: () => void;
+}
+
+const NO_REPLACEMENT = "__none__";
+
+export function DeleteModelDialog({ open, model, models, onClose }: Props) {
+  const { deleteModel } = useLlmRegistryMutations();
+  const [replacement, setReplacement] = useState(
+    model?.fallback_model_slug ?? NO_REPLACEMENT,
+  );
+
+  if (!model) return null;
+
+  async function handleConfirm() {
+    if (!model) return;
+    await deleteModel.mutateAsync({
+      slug: model.slug,
+      params:
+        replacement === NO_REPLACEMENT
+          ? undefined
+          : { replacement_model_slug: replacement },
+    });
+    onClose();
+  }
+
+  return (
+    <Dialog
+      title={`Delete ${model.slug}`}
+      styling={{ maxWidth: "34rem" }}
+      controlled={{
+        isOpen: open,
+        set: (next) => (next ? undefined : onClose()),
+      }}
+    >
+      <Dialog.Content>
+        <div className="flex flex-col gap-3">
+          <p className="text-sm text-muted-foreground">
+            Deletion is permanent. If agent nodes still reference this model,
+            the API requires a replacement model to migrate them to — prefer
+            disabling unless the row was added in error.
+          </p>
+          <Select
+            id="delete-replacement"
+            label="Replacement model"
+            value={replacement}
+            onValueChange={setReplacement}
+            options={[
+              { value: NO_REPLACEMENT, label: "— none (fails if in use) —" },
+              ...models
+                .filter((m) => m.slug !== model.slug && m.is_enabled)
+                .map((m) => ({ value: m.slug, label: m.slug })),
+            ]}
+          />
+        </div>
+        <Dialog.Footer>
+          <Button
+            variant="secondary"
+            onClick={onClose}
+            disabled={deleteModel.isPending}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={handleConfirm}
+            loading={deleteModel.isPending}
+          >
+            Delete model
+          </Button>
+        </Dialog.Footer>
+      </Dialog.Content>
+    </Dialog>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/admin/llms/components/LlmRegistryDashboard/LlmRegistryDashboard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/llms/components/LlmRegistryDashboard/LlmRegistryDashboard.tsx
@@ -2,9 +2,12 @@
 
 import { Skeleton } from "@/components/atoms/Skeleton/Skeleton";
 import { ErrorCard } from "@/components/molecules/ErrorCard/ErrorCard";
-import { EnabledBadge, SourceBadge, VisibilityBadge } from "../RegistryBadges";
+import { SourceBadge } from "../RegistryBadges";
 import { RoutingPanel } from "../RoutingPanel/RoutingPanel";
 import { SimpleTable } from "../SimpleTable";
+import { CreatorsSection } from "./components/CreatorsSection";
+import { MigrationsSection } from "./components/MigrationsSection";
+import { ModelsSection } from "./components/ModelsSection";
 import { useLlmRegistryDashboard } from "./useLlmRegistryDashboard";
 
 function Section({
@@ -36,10 +39,14 @@ export function LlmRegistryDashboard() {
   const { models, providers, creators, migrations, routes, routeWarnings } =
     useLlmRegistryDashboard();
 
+  const modelList = models.data?.models ?? [];
+  const providerList = providers.data?.providers ?? [];
+  const creatorList = creators.data?.creators ?? [];
+
   return (
     <div className="flex flex-col gap-6">
       <Section title="Copilot Routing">
-        {routes.isLoading || routeWarnings.isLoading ? (
+        {routes.isLoading || routeWarnings.isLoading || models.isLoading ? (
           <SectionLoader />
         ) : routes.isError || routeWarnings.isError ? (
           <ErrorCard
@@ -51,12 +58,13 @@ export function LlmRegistryDashboard() {
           <RoutingPanel
             routes={routes.data?.routes ?? []}
             warnings={routeWarnings.data ?? []}
+            models={modelList}
           />
         )}
       </Section>
 
       <Section title="Models">
-        {models.isLoading ? (
+        {models.isLoading || providers.isLoading || creators.isLoading ? (
           <SectionLoader />
         ) : models.isError ? (
           <ErrorCard
@@ -65,32 +73,10 @@ export function LlmRegistryDashboard() {
             httpError={{ status: 500 }}
           />
         ) : (
-          <SimpleTable
-            columns={[
-              "Slug",
-              "Name",
-              "Creator",
-              "Context",
-              "Tier",
-              "Status",
-              "Visibility",
-              "Source",
-              "Recommended",
-            ]}
-            rows={(models.data?.models ?? []).map((m) => [
-              <code key="slug" className="text-xs">
-                {m.slug}
-              </code>,
-              m.display_name,
-              m.creator?.display_name ?? "—",
-              m.context_window.toLocaleString(),
-              String(m.price_tier),
-              <EnabledBadge key="enabled" enabled={m.is_enabled} />,
-              <VisibilityBadge key="vis" visibility={m.visibility} />,
-              <SourceBadge key="src" source={m.source} />,
-              m.is_recommended ? "★" : "",
-            ])}
-            emptyLabel="No models in the registry yet — the bundled catalog imports on backend startup"
+          <ModelsSection
+            models={modelList}
+            providers={providerList}
+            creators={creatorList}
           />
         )}
       </Section>
@@ -107,7 +93,7 @@ export function LlmRegistryDashboard() {
         ) : (
           <SimpleTable
             columns={["Name", "Display Name", "Models", "Source"]}
-            rows={(providers.data?.providers ?? []).map((p) => [
+            rows={providerList.map((p) => [
               <code key="name" className="text-xs">
                 {p.name}
               </code>,
@@ -129,17 +115,7 @@ export function LlmRegistryDashboard() {
             httpError={{ status: 500 }}
           />
         ) : (
-          <SimpleTable
-            columns={["Name", "Display Name", "Website", "Source"]}
-            rows={(creators.data?.creators ?? []).map((c) => [
-              <code key="name" className="text-xs">
-                {c.name}
-              </code>,
-              c.display_name,
-              c.website_url ?? "—",
-              <SourceBadge key="src" source={c.source ?? "SEED"} />,
-            ])}
-          />
+          <CreatorsSection creators={creatorList} />
         )}
       </Section>
 
@@ -153,22 +129,7 @@ export function LlmRegistryDashboard() {
             httpError={{ status: 500 }}
           />
         ) : (
-          <SimpleTable
-            columns={["From", "To", "Nodes", "Reason", "Reverted", "Created"]}
-            rows={(migrations.data?.migrations ?? []).map((mig) => [
-              <code key="from" className="text-xs">
-                {mig.source_model_slug}
-              </code>,
-              <code key="to" className="text-xs">
-                {mig.target_model_slug}
-              </code>,
-              String(mig.node_count),
-              mig.reason ?? "—",
-              mig.is_reverted ? "yes" : "no",
-              new Date(mig.created_at).toLocaleString(),
-            ])}
-            emptyLabel="No model migrations recorded"
-          />
+          <MigrationsSection migrations={migrations.data?.migrations ?? []} />
         )}
       </Section>
     </div>

--- a/autogpt_platform/frontend/src/app/(platform)/admin/llms/components/LlmRegistryDashboard/components/CreatorsSection.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/llms/components/LlmRegistryDashboard/components/CreatorsSection.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import type { LlmCreatorAdminResponse } from "@/app/api/__generated__/models/llmCreatorAdminResponse";
+import { Button } from "@/components/atoms/Button/Button";
+import { PencilSimpleIcon, TrashIcon } from "@phosphor-icons/react";
+import { useState } from "react";
+import {
+  CreatorFormDialog,
+  DeleteCreatorDialog,
+} from "../../CreatorDialogs/CreatorDialogs";
+import { SourceBadge } from "../../RegistryBadges";
+import { SimpleTable } from "../../SimpleTable";
+
+interface Props {
+  creators: LlmCreatorAdminResponse[];
+}
+
+type DialogState =
+  | { kind: "closed" }
+  | { kind: "create" }
+  | { kind: "edit"; creator: LlmCreatorAdminResponse }
+  | { kind: "delete"; creator: LlmCreatorAdminResponse };
+
+export function CreatorsSection({ creators }: Props) {
+  const [dialog, setDialog] = useState<DialogState>({ kind: "closed" });
+
+  function close() {
+    setDialog({ kind: "closed" });
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex justify-end">
+        <Button size="small" onClick={() => setDialog({ kind: "create" })}>
+          Add creator
+        </Button>
+      </div>
+      <SimpleTable
+        columns={["Name", "Display Name", "Website", "Source", "Actions"]}
+        rows={creators.map((c) => [
+          <code key="name" className="text-xs">
+            {c.name}
+          </code>,
+          c.display_name,
+          c.website_url ?? "—",
+          <SourceBadge key="src" source={c.source ?? "SEED"} />,
+          <div key="actions" className="flex gap-1">
+            <Button
+              size="icon"
+              variant="icon"
+              aria-label={`Edit ${c.name}`}
+              onClick={() => setDialog({ kind: "edit", creator: c })}
+            >
+              <PencilSimpleIcon size={16} />
+            </Button>
+            <Button
+              size="icon"
+              variant="icon"
+              aria-label={`Delete ${c.name}`}
+              onClick={() => setDialog({ kind: "delete", creator: c })}
+            >
+              <TrashIcon size={16} />
+            </Button>
+          </div>,
+        ])}
+      />
+      {(dialog.kind === "create" || dialog.kind === "edit") && (
+        <CreatorFormDialog
+          open
+          editing={dialog.kind === "edit" ? dialog.creator : null}
+          onClose={close}
+        />
+      )}
+      {dialog.kind === "delete" && (
+        <DeleteCreatorDialog open creator={dialog.creator} onClose={close} />
+      )}
+    </div>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/admin/llms/components/LlmRegistryDashboard/components/MigrationsSection.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/llms/components/LlmRegistryDashboard/components/MigrationsSection.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import type { LlmMigrationAdminResponse } from "@/app/api/__generated__/models/llmMigrationAdminResponse";
+import { Button } from "@/components/atoms/Button/Button";
+import { ArrowCounterClockwiseIcon } from "@phosphor-icons/react";
+import { useState } from "react";
+import { RevertMigrationDialog } from "../../RevertMigrationDialog/RevertMigrationDialog";
+import { SimpleTable } from "../../SimpleTable";
+
+interface Props {
+  migrations: LlmMigrationAdminResponse[];
+}
+
+export function MigrationsSection({ migrations }: Props) {
+  const [reverting, setReverting] = useState<LlmMigrationAdminResponse | null>(
+    null,
+  );
+
+  return (
+    <div className="flex flex-col gap-3">
+      <SimpleTable
+        columns={[
+          "From",
+          "To",
+          "Nodes",
+          "Reason",
+          "Reverted",
+          "Created",
+          "Actions",
+        ]}
+        rows={migrations.map((mig) => [
+          <code key="from" className="text-xs">
+            {mig.source_model_slug}
+          </code>,
+          <code key="to" className="text-xs">
+            {mig.target_model_slug}
+          </code>,
+          String(mig.node_count),
+          mig.reason ?? "—",
+          mig.is_reverted ? "yes" : "no",
+          new Date(mig.created_at).toLocaleString(),
+          mig.is_reverted ? (
+            ""
+          ) : (
+            <Button
+              key="revert"
+              size="icon"
+              variant="icon"
+              aria-label={`Revert migration from ${mig.source_model_slug}`}
+              onClick={() => setReverting(mig)}
+            >
+              <ArrowCounterClockwiseIcon size={16} />
+            </Button>
+          ),
+        ])}
+        emptyLabel="No model migrations recorded"
+      />
+      {reverting && (
+        <RevertMigrationDialog
+          open
+          migration={reverting}
+          onClose={() => setReverting(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/admin/llms/components/LlmRegistryDashboard/components/ModelsSection.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/llms/components/LlmRegistryDashboard/components/ModelsSection.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import type { LlmCreatorAdminResponse } from "@/app/api/__generated__/models/llmCreatorAdminResponse";
+import type { LlmModelAdminResponse } from "@/app/api/__generated__/models/llmModelAdminResponse";
+import type { LlmProviderAdminResponse } from "@/app/api/__generated__/models/llmProviderAdminResponse";
+import { Button } from "@/components/atoms/Button/Button";
+import { PencilSimpleIcon, PowerIcon, TrashIcon } from "@phosphor-icons/react";
+import { useState } from "react";
+import { DeleteModelDialog } from "../../DeleteModelDialog/DeleteModelDialog";
+import { ModelFormDialog } from "../../ModelFormDialog/ModelFormDialog";
+import {
+  EnabledBadge,
+  SourceBadge,
+  VisibilityBadge,
+} from "../../RegistryBadges";
+import { SimpleTable } from "../../SimpleTable";
+import { ToggleModelDialog } from "../../ToggleModelDialog/ToggleModelDialog";
+import { useLlmRegistryMutations } from "../../useLlmRegistryMutations";
+
+interface Props {
+  models: LlmModelAdminResponse[];
+  providers: LlmProviderAdminResponse[];
+  creators: LlmCreatorAdminResponse[];
+}
+
+type DialogState =
+  | { kind: "closed" }
+  | { kind: "create" }
+  | { kind: "edit"; model: LlmModelAdminResponse }
+  | { kind: "disable"; model: LlmModelAdminResponse }
+  | { kind: "delete"; model: LlmModelAdminResponse };
+
+export function ModelsSection({ models, providers, creators }: Props) {
+  const [dialog, setDialog] = useState<DialogState>({ kind: "closed" });
+  const { toggleModel } = useLlmRegistryMutations();
+
+  function close() {
+    setDialog({ kind: "closed" });
+  }
+
+  function handleToggle(model: LlmModelAdminResponse) {
+    if (model.is_enabled) {
+      setDialog({ kind: "disable", model });
+      return;
+    }
+    toggleModel.mutate({ slug: model.slug, data: { is_enabled: true } });
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex justify-end">
+        <Button size="small" onClick={() => setDialog({ kind: "create" })}>
+          Add model
+        </Button>
+      </div>
+      <SimpleTable
+        columns={[
+          "Slug",
+          "Name",
+          "Creator",
+          "Context",
+          "Tier",
+          "Status",
+          "Visibility",
+          "Source",
+          "Recommended",
+          "Actions",
+        ]}
+        rows={models.map((m) => [
+          <code key="slug" className="text-xs">
+            {m.slug}
+          </code>,
+          m.display_name,
+          m.creator?.display_name ?? "—",
+          m.context_window.toLocaleString(),
+          String(m.price_tier),
+          <EnabledBadge key="enabled" enabled={m.is_enabled} />,
+          <VisibilityBadge key="vis" visibility={m.visibility} />,
+          <SourceBadge key="src" source={m.source} />,
+          m.is_recommended ? "★" : "",
+          <div key="actions" className="flex gap-1">
+            <Button
+              size="icon"
+              variant="icon"
+              aria-label={`Edit ${m.slug}`}
+              onClick={() => setDialog({ kind: "edit", model: m })}
+            >
+              <PencilSimpleIcon size={16} />
+            </Button>
+            <Button
+              size="icon"
+              variant="icon"
+              aria-label={
+                m.is_enabled ? `Disable ${m.slug}` : `Enable ${m.slug}`
+              }
+              onClick={() => handleToggle(m)}
+            >
+              <PowerIcon size={16} />
+            </Button>
+            <Button
+              size="icon"
+              variant="icon"
+              aria-label={`Delete ${m.slug}`}
+              onClick={() => setDialog({ kind: "delete", model: m })}
+            >
+              <TrashIcon size={16} />
+            </Button>
+          </div>,
+        ])}
+        emptyLabel="No models in the registry yet — the bundled catalog imports on backend startup"
+      />
+      {(dialog.kind === "create" || dialog.kind === "edit") && (
+        <ModelFormDialog
+          open
+          editing={dialog.kind === "edit" ? dialog.model : null}
+          providers={providers}
+          creators={creators}
+          models={models}
+          onClose={close}
+        />
+      )}
+      {dialog.kind === "disable" && (
+        <ToggleModelDialog
+          open
+          model={dialog.model}
+          models={models}
+          onClose={close}
+        />
+      )}
+      {dialog.kind === "delete" && (
+        <DeleteModelDialog
+          open
+          model={dialog.model}
+          models={models}
+          onClose={close}
+        />
+      )}
+    </div>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/admin/llms/components/ModelFormDialog/ModelFormDialog.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/llms/components/ModelFormDialog/ModelFormDialog.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import type { LlmCreatorAdminResponse } from "@/app/api/__generated__/models/llmCreatorAdminResponse";
+import type { LlmModelAdminResponse } from "@/app/api/__generated__/models/llmModelAdminResponse";
+import type { LlmProviderAdminResponse } from "@/app/api/__generated__/models/llmProviderAdminResponse";
+import { Button } from "@/components/atoms/Button/Button";
+import { Input } from "@/components/atoms/Input/Input";
+import { Select } from "@/components/atoms/Select/Select";
+import { Dialog } from "@/components/molecules/Dialog/Dialog";
+import { CapabilityToggles } from "./components/CapabilityToggles";
+import { useModelFormDialog } from "./useModelFormDialog";
+
+interface Props {
+  open: boolean;
+  editing: LlmModelAdminResponse | null;
+  providers: LlmProviderAdminResponse[];
+  creators: LlmCreatorAdminResponse[];
+  models: LlmModelAdminResponse[];
+  onClose: () => void;
+}
+
+const VISIBILITIES = ["GA", "EMPLOYEES", "ADMINS", "HIDDEN"];
+const TIERS = ["NO_TIER", "BASIC", "PRO", "MAX", "BUSINESS", "ENTERPRISE"];
+
+export function ModelFormDialog({
+  open,
+  editing,
+  providers,
+  creators,
+  models,
+  onClose,
+}: Props) {
+  const { values, setField, handleSubmit, isPending, validationError, NONE } =
+    useModelFormDialog({ editing, onClose });
+
+  const noneOption = { value: NONE, label: "— none —" };
+
+  return (
+    <Dialog
+      title={editing ? `Edit ${editing.slug}` : "Add model"}
+      styling={{ maxWidth: "40rem" }}
+      controlled={{
+        isOpen: open,
+        set: (next) => (next ? undefined : onClose()),
+      }}
+    >
+      <Dialog.Content>
+        <div className="flex max-h-[70vh] flex-col gap-3 overflow-y-auto pr-1">
+          {!editing && (
+            <Input
+              id="model-slug"
+              label="Slug"
+              placeholder="provider/model-name"
+              value={values.slug}
+              onChange={(e) => setField("slug", e.target.value)}
+            />
+          )}
+          <Input
+            id="model-display-name"
+            label="Display name"
+            value={values.display_name}
+            onChange={(e) => setField("display_name", e.target.value)}
+          />
+          <Input
+            id="model-description"
+            label="Description"
+            value={values.description}
+            onChange={(e) => setField("description", e.target.value)}
+          />
+          {!editing && (
+            <Select
+              id="model-provider"
+              label="Provider"
+              placeholder="Select provider"
+              value={values.provider_name}
+              onValueChange={(v) => setField("provider_name", v)}
+              options={providers.map((p) => ({
+                value: p.name,
+                label: p.display_name,
+              }))}
+            />
+          )}
+          <Select
+            id="model-creator"
+            label="Creator"
+            value={values.creator_id}
+            onValueChange={(v) => setField("creator_id", v)}
+            options={[
+              noneOption,
+              ...creators.map((c) => ({ value: c.id, label: c.display_name })),
+            ]}
+          />
+          <div className="grid grid-cols-2 gap-3">
+            <Input
+              id="model-context-window"
+              label="Context window"
+              type="number"
+              value={values.context_window}
+              onChange={(e) => setField("context_window", e.target.value)}
+            />
+            <Input
+              id="model-max-output"
+              label="Max output tokens"
+              type="number"
+              placeholder="defaults to context window"
+              value={values.max_output_tokens}
+              onChange={(e) => setField("max_output_tokens", e.target.value)}
+            />
+          </div>
+          <div className="grid grid-cols-3 gap-3">
+            <Select
+              id="model-price-tier"
+              label="Price tier"
+              value={values.price_tier}
+              onValueChange={(v) => setField("price_tier", v)}
+              options={[
+                { value: "1", label: "1 — cheap" },
+                { value: "2", label: "2 — medium" },
+                { value: "3", label: "3 — expensive" },
+              ]}
+            />
+            <Select
+              id="model-visibility"
+              label="Visibility"
+              value={values.visibility}
+              onValueChange={(v) => setField("visibility", v)}
+              options={VISIBILITIES.map((v) => ({ value: v, label: v }))}
+            />
+            <Select
+              id="model-min-tier"
+              label="Min subscription"
+              value={values.min_subscription_tier}
+              onValueChange={(v) => setField("min_subscription_tier", v)}
+              options={[
+                noneOption,
+                ...TIERS.map((t) => ({ value: t, label: t })),
+              ]}
+            />
+          </div>
+          <Select
+            id="model-fallback"
+            label="Fallback model"
+            value={values.fallback_model_slug}
+            onValueChange={(v) => setField("fallback_model_slug", v)}
+            options={[
+              noneOption,
+              ...models
+                .filter((m) => m.slug !== editing?.slug)
+                .map((m) => ({ value: m.slug, label: m.slug })),
+            ]}
+          />
+          <CapabilityToggles values={values} setField={setField} />
+          {validationError && (
+            <p className="text-sm text-red-600">{validationError}</p>
+          )}
+        </div>
+        <Dialog.Footer>
+          <Button variant="secondary" onClick={onClose} disabled={isPending}>
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit} loading={isPending}>
+            {editing ? "Save changes" : "Create model"}
+          </Button>
+        </Dialog.Footer>
+      </Dialog.Content>
+    </Dialog>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/admin/llms/components/ModelFormDialog/components/CapabilityToggles.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/llms/components/ModelFormDialog/components/CapabilityToggles.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { Switch } from "@/components/atoms/Switch/Switch";
+import type { ModelFormValues } from "../useModelFormDialog";
+
+interface Props {
+  values: ModelFormValues;
+  setField: <K extends keyof ModelFormValues>(
+    key: K,
+    value: ModelFormValues[K],
+  ) => void;
+}
+
+const CAPABILITIES: { key: keyof ModelFormValues; label: string }[] = [
+  { key: "supports_tools", label: "Tools" },
+  { key: "supports_json_output", label: "JSON output" },
+  { key: "supports_reasoning", label: "Reasoning" },
+  { key: "supports_parallel_tool_calls", label: "Parallel tool calls" },
+];
+
+const FLAGS: { key: keyof ModelFormValues; label: string }[] = [
+  { key: "is_enabled", label: "Enabled" },
+  { key: "is_recommended", label: "Recommended" },
+];
+
+export function CapabilityToggles({ values, setField }: Props) {
+  return (
+    <div className="flex flex-col gap-2">
+      <p className="text-sm font-medium">Capabilities</p>
+      <div className="grid grid-cols-2 gap-2">
+        {CAPABILITIES.map(({ key, label }) => (
+          <label key={key} className="flex items-center gap-2 text-sm">
+            <Switch
+              checked={Boolean(values[key])}
+              onCheckedChange={(checked) => setField(key, checked)}
+              aria-label={label}
+            />
+            {label}
+          </label>
+        ))}
+      </div>
+      <p className="text-sm font-medium">Flags</p>
+      <div className="grid grid-cols-2 gap-2">
+        {FLAGS.map(({ key, label }) => (
+          <label key={key} className="flex items-center gap-2 text-sm">
+            <Switch
+              checked={Boolean(values[key])}
+              onCheckedChange={(checked) => setField(key, checked)}
+              aria-label={label}
+            />
+            {label}
+          </label>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/admin/llms/components/ModelFormDialog/useModelFormDialog.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/llms/components/ModelFormDialog/useModelFormDialog.ts
@@ -1,0 +1,162 @@
+"use client";
+
+import type { CreateLlmModelRequest } from "@/app/api/__generated__/models/createLlmModelRequest";
+import type { LlmModelAdminResponse } from "@/app/api/__generated__/models/llmModelAdminResponse";
+import { useState } from "react";
+import { useLlmRegistryMutations } from "../useLlmRegistryMutations";
+
+export interface ModelFormValues {
+  slug: string;
+  display_name: string;
+  description: string;
+  provider_name: string;
+  creator_id: string;
+  context_window: string;
+  max_output_tokens: string;
+  price_tier: string;
+  visibility: string;
+  min_subscription_tier: string;
+  fallback_model_slug: string;
+  is_enabled: boolean;
+  is_recommended: boolean;
+  supports_tools: boolean;
+  supports_json_output: boolean;
+  supports_reasoning: boolean;
+  supports_parallel_tool_calls: boolean;
+}
+
+const NONE = "__none__";
+
+export function emptyFormValues(): ModelFormValues {
+  return {
+    slug: "",
+    display_name: "",
+    description: "",
+    provider_name: "",
+    creator_id: NONE,
+    context_window: "128000",
+    max_output_tokens: "",
+    price_tier: "1",
+    visibility: "GA",
+    min_subscription_tier: NONE,
+    fallback_model_slug: NONE,
+    is_enabled: true,
+    is_recommended: false,
+    supports_tools: false,
+    supports_json_output: false,
+    supports_reasoning: false,
+    supports_parallel_tool_calls: false,
+  };
+}
+
+export function valuesFromModel(model: LlmModelAdminResponse): ModelFormValues {
+  return {
+    slug: model.slug,
+    display_name: model.display_name,
+    description: model.description ?? "",
+    provider_name: "",
+    creator_id: model.creator?.id ?? NONE,
+    context_window: String(model.context_window),
+    max_output_tokens: model.max_output_tokens
+      ? String(model.max_output_tokens)
+      : "",
+    price_tier: String(model.price_tier),
+    visibility: model.visibility,
+    min_subscription_tier: model.min_subscription_tier ?? NONE,
+    fallback_model_slug: model.fallback_model_slug ?? NONE,
+    is_enabled: model.is_enabled,
+    is_recommended: model.is_recommended,
+    supports_tools: model.supports_tools,
+    supports_json_output: model.supports_json_output,
+    supports_reasoning: model.supports_reasoning,
+    supports_parallel_tool_calls: model.supports_parallel_tool_calls,
+  };
+}
+
+function optional(value: string): string | null {
+  return value === NONE || value === "" ? null : value;
+}
+
+export function useModelFormDialog(args: {
+  editing: LlmModelAdminResponse | null;
+  onClose: () => void;
+}) {
+  const { editing, onClose } = args;
+  const [values, setValues] = useState<ModelFormValues>(() =>
+    editing ? valuesFromModel(editing) : emptyFormValues(),
+  );
+  const [validationError, setValidationError] = useState("");
+  const { createModel, updateModel } = useLlmRegistryMutations();
+
+  function setField<K extends keyof ModelFormValues>(
+    key: K,
+    value: ModelFormValues[K],
+  ) {
+    setValues((prev) => ({ ...prev, [key]: value }));
+  }
+
+  function buildPayload() {
+    const contextWindow = Number(values.context_window);
+    if (!Number.isFinite(contextWindow) || contextWindow <= 0) {
+      return { error: "Context window must be a positive number" };
+    }
+    const maxOutput = values.max_output_tokens
+      ? Number(values.max_output_tokens)
+      : null;
+    if (maxOutput !== null && (!Number.isFinite(maxOutput) || maxOutput <= 0)) {
+      return { error: "Max output tokens must be a positive number" };
+    }
+    const shared = {
+      display_name: values.display_name,
+      description: values.description || null,
+      creator_id: optional(values.creator_id),
+      context_window: contextWindow,
+      max_output_tokens: maxOutput,
+      price_tier: Number(values.price_tier),
+      is_enabled: values.is_enabled,
+      is_recommended: values.is_recommended,
+      visibility: values.visibility as CreateLlmModelRequest["visibility"],
+      min_subscription_tier: optional(
+        values.min_subscription_tier,
+      ) as CreateLlmModelRequest["min_subscription_tier"],
+      fallback_model_slug: optional(values.fallback_model_slug),
+      supports_tools: values.supports_tools,
+      supports_json_output: values.supports_json_output,
+      supports_reasoning: values.supports_reasoning,
+      supports_parallel_tool_calls: values.supports_parallel_tool_calls,
+    };
+    return { shared };
+  }
+
+  async function handleSubmit() {
+    const built = buildPayload();
+    if ("error" in built) {
+      setValidationError(built.error ?? "Invalid input");
+      return;
+    }
+    setValidationError("");
+    if (editing) {
+      await updateModel.mutateAsync({
+        slug: editing.slug,
+        data: built.shared,
+      });
+    } else {
+      if (!values.slug || !values.provider_name) {
+        setValidationError("Slug and provider are required");
+        return;
+      }
+      await createModel.mutateAsync({
+        data: {
+          ...built.shared,
+          slug: values.slug,
+          provider_name: values.provider_name,
+        },
+      });
+    }
+    onClose();
+  }
+
+  const isPending = createModel.isPending || updateModel.isPending;
+
+  return { values, setField, handleSubmit, isPending, validationError, NONE };
+}

--- a/autogpt_platform/frontend/src/app/(platform)/admin/llms/components/RevertMigrationDialog/RevertMigrationDialog.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/llms/components/RevertMigrationDialog/RevertMigrationDialog.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import type { LlmMigrationAdminResponse } from "@/app/api/__generated__/models/llmMigrationAdminResponse";
+import { Button } from "@/components/atoms/Button/Button";
+import { Switch } from "@/components/atoms/Switch/Switch";
+import { Dialog } from "@/components/molecules/Dialog/Dialog";
+import { useState } from "react";
+import { useLlmRegistryMutations } from "../useLlmRegistryMutations";
+
+interface Props {
+  open: boolean;
+  migration: LlmMigrationAdminResponse | null;
+  onClose: () => void;
+}
+
+export function RevertMigrationDialog({ open, migration, onClose }: Props) {
+  const { revertMigration } = useLlmRegistryMutations();
+  const [reEnableSource, setReEnableSource] = useState(true);
+
+  if (!migration) return null;
+
+  async function handleConfirm() {
+    if (!migration) return;
+    await revertMigration.mutateAsync({
+      migrationId: migration.id,
+      params: { re_enable_source_model: reEnableSource },
+    });
+    onClose();
+  }
+
+  return (
+    <Dialog
+      title="Revert migration?"
+      styling={{ maxWidth: "30rem" }}
+      controlled={{
+        isOpen: open,
+        set: (next) => (next ? undefined : onClose()),
+      }}
+    >
+      <Dialog.Content>
+        <div className="flex flex-col gap-3">
+          <p className="text-sm text-muted-foreground">
+            Moves {migration.node_count} node(s) back from{" "}
+            <code className="text-xs">{migration.target_model_slug}</code> to{" "}
+            <code className="text-xs">{migration.source_model_slug}</code>.
+          </p>
+          <label className="flex items-center gap-2 text-sm">
+            <Switch
+              checked={reEnableSource}
+              onCheckedChange={setReEnableSource}
+              aria-label="Re-enable source model"
+            />
+            Re-enable the source model
+          </label>
+        </div>
+        <Dialog.Footer>
+          <Button
+            variant="secondary"
+            onClick={onClose}
+            disabled={revertMigration.isPending}
+          >
+            Cancel
+          </Button>
+          <Button onClick={handleConfirm} loading={revertMigration.isPending}>
+            Revert
+          </Button>
+        </Dialog.Footer>
+      </Dialog.Content>
+    </Dialog>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/admin/llms/components/RoutingPanel/RoutingPanel.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/llms/components/RoutingPanel/RoutingPanel.tsx
@@ -1,17 +1,22 @@
+"use client";
+
+import type { LlmModelAdminResponse } from "@/app/api/__generated__/models/llmModelAdminResponse";
 import type { LlmRouteResponse } from "@/app/api/__generated__/models/llmRouteResponse";
 import type { RouteWarning } from "@/app/api/__generated__/models/routeWarning";
 import { Badge } from "@/components/atoms/Badge/Badge";
 import { SimpleTable } from "../SimpleTable";
+import { RoutingCellEditor } from "./components/RoutingCellEditor";
 
 interface Props {
   routes: LlmRouteResponse[];
   warnings: RouteWarning[];
+  models: LlmModelAdminResponse[];
 }
 
 const MODES = ["fast", "thinking"] as const;
 const TIERS = ["standard", "advanced"] as const;
 
-export function RoutingPanel({ routes, warnings }: Props) {
+export function RoutingPanel({ routes, warnings, models }: Props) {
   const cellFor = (mode: string, tier: string) =>
     routes.find(
       (r) => r.surface === "copilot" && r.mode === mode && r.tier === tier,
@@ -43,13 +48,12 @@ export function RoutingPanel({ routes, warnings }: Props) {
                   const cell = cellFor(mode, tier);
                   return (
                     <td key={tier} className="px-3 py-2">
-                      {cell ? (
-                        <code className="text-xs">{cell.model_slug}</code>
-                      ) : (
-                        <span className="text-muted-foreground">
-                          — (falls through)
-                        </span>
-                      )}
+                      <RoutingCellEditor
+                        mode={mode}
+                        tier={tier}
+                        currentSlug={cell?.model_slug ?? null}
+                        models={models}
+                      />
                     </td>
                   );
                 })}

--- a/autogpt_platform/frontend/src/app/(platform)/admin/llms/components/RoutingPanel/components/RoutingCellEditor.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/llms/components/RoutingPanel/components/RoutingCellEditor.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import type { LlmModelAdminResponse } from "@/app/api/__generated__/models/llmModelAdminResponse";
+import { Select } from "@/components/atoms/Select/Select";
+import { useLlmRegistryMutations } from "../../useLlmRegistryMutations";
+
+interface Props {
+  mode: string;
+  tier: string;
+  currentSlug: string | null;
+  models: LlmModelAdminResponse[];
+}
+
+const FALL_THROUGH = "__fall_through__";
+
+export function RoutingCellEditor({ mode, tier, currentSlug, models }: Props) {
+  const { setRoute } = useLlmRegistryMutations();
+
+  const options = [
+    { value: FALL_THROUGH, label: "— falls through —" },
+    ...models
+      .filter((m) => m.is_enabled)
+      .map((m) => ({
+        value: m.slug,
+        label: m.visibility === "HIDDEN" ? `${m.slug} (hidden)` : m.slug,
+      })),
+  ];
+
+  function handleChange(value: string) {
+    setRoute.mutate({
+      data: {
+        surface: "copilot",
+        mode,
+        tier,
+        model_slug: value === FALL_THROUGH ? null : value,
+      },
+    });
+  }
+
+  return (
+    <Select
+      id={`route-${mode}-${tier}`}
+      label={`${mode} ${tier} model`}
+      hideLabel
+      size="small"
+      disabled={setRoute.isPending}
+      value={currentSlug ?? FALL_THROUGH}
+      onValueChange={handleChange}
+      options={options}
+    />
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/admin/llms/components/ToggleModelDialog/ToggleModelDialog.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/llms/components/ToggleModelDialog/ToggleModelDialog.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import type { LlmModelAdminResponse } from "@/app/api/__generated__/models/llmModelAdminResponse";
+import { Button } from "@/components/atoms/Button/Button";
+import { Input } from "@/components/atoms/Input/Input";
+import { Select } from "@/components/atoms/Select/Select";
+import { Dialog } from "@/components/molecules/Dialog/Dialog";
+import { useState } from "react";
+import { useLlmRegistryMutations } from "../useLlmRegistryMutations";
+
+interface Props {
+  open: boolean;
+  model: LlmModelAdminResponse | null;
+  models: LlmModelAdminResponse[];
+  onClose: () => void;
+}
+
+const NO_MIGRATION = "__none__";
+
+export function ToggleModelDialog({ open, model, models, onClose }: Props) {
+  const { toggleModel } = useLlmRegistryMutations();
+  const [migrateTo, setMigrateTo] = useState(
+    model?.fallback_model_slug ?? NO_MIGRATION,
+  );
+  const [reason, setReason] = useState("");
+
+  if (!model) return null;
+
+  const replacementOptions = models
+    .filter((m) => m.slug !== model.slug && m.is_enabled)
+    .map((m) => ({ value: m.slug, label: m.slug }));
+
+  async function handleConfirm() {
+    if (!model) return;
+    await toggleModel.mutateAsync({
+      slug: model.slug,
+      data: {
+        is_enabled: false,
+        migrate_to_slug: migrateTo === NO_MIGRATION ? null : migrateTo,
+        migration_reason: reason || null,
+      },
+    });
+    onClose();
+  }
+
+  return (
+    <Dialog
+      title={`Disable ${model.slug}`}
+      styling={{ maxWidth: "34rem" }}
+      controlled={{
+        isOpen: open,
+        set: (next) => (next ? undefined : onClose()),
+      }}
+    >
+      <Dialog.Content>
+        <div className="flex flex-col gap-3">
+          <p className="text-sm text-muted-foreground">
+            Disabling is the kill switch: the model stops serving everywhere,
+            even when LaunchDarkly routes to it. Optionally migrate agent nodes
+            that use it to a replacement model.
+          </p>
+          <Select
+            id="toggle-migrate-to"
+            label="Migrate existing nodes to"
+            value={migrateTo}
+            onValueChange={setMigrateTo}
+            options={[
+              { value: NO_MIGRATION, label: "— no migration —" },
+              ...replacementOptions,
+            ]}
+          />
+          <Input
+            id="toggle-reason"
+            label="Reason"
+            placeholder="e.g. provider outage"
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+          />
+        </div>
+        <Dialog.Footer>
+          <Button
+            variant="secondary"
+            onClick={onClose}
+            disabled={toggleModel.isPending}
+          >
+            Cancel
+          </Button>
+          <Button onClick={handleConfirm} loading={toggleModel.isPending}>
+            Disable model
+          </Button>
+        </Dialog.Footer>
+      </Dialog.Content>
+    </Dialog>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/admin/llms/components/useLlmRegistryMutations.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/llms/components/useLlmRegistryMutations.ts
@@ -1,0 +1,154 @@
+"use client";
+
+import {
+  getGetV2AdminListModelsQueryKey,
+  getGetV2AdminListProvidersQueryKey,
+  getGetV2ListCreatorsQueryKey,
+  getGetV2ListMigrationsQueryKey,
+  getGetV2ListRoutesQueryKey,
+  useDeleteV2DeleteCreator,
+  useDeleteV2DeleteModel,
+  usePatchV2UpdateCreator,
+  usePatchV2UpdateModel,
+  usePostV2CreateCreator,
+  usePostV2CreateModel,
+  usePostV2RevertMigration,
+  usePostV2ToggleModel,
+  usePutV2SetRoute,
+} from "@/app/api/__generated__/endpoints/admin/admin";
+import { useToast } from "@/components/molecules/Toast/use-toast";
+import { useQueryClient } from "@tanstack/react-query";
+
+function errorDescription(error: unknown): string {
+  if (error && typeof error === "object" && "message" in error) {
+    return String((error as { message: unknown }).message);
+  }
+  return "Request failed — see console for details";
+}
+
+export function useLlmRegistryMutations() {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  function invalidateModels() {
+    queryClient.invalidateQueries({
+      queryKey: getGetV2AdminListModelsQueryKey({ page: 1, page_size: 200 }),
+    });
+    queryClient.invalidateQueries({
+      queryKey: getGetV2AdminListProvidersQueryKey(),
+    });
+  }
+
+  function onError(title: string) {
+    return (error: unknown) => {
+      toast({
+        title,
+        description: errorDescription(error),
+        variant: "destructive",
+      });
+    };
+  }
+
+  const createModel = usePostV2CreateModel({
+    mutation: {
+      onSuccess: invalidateModels,
+      onError: onError("Failed to create model"),
+    },
+  });
+  const updateModel = usePatchV2UpdateModel({
+    mutation: {
+      onSuccess: invalidateModels,
+      onError: onError("Failed to update model"),
+    },
+  });
+  const toggleModel = usePostV2ToggleModel({
+    mutation: {
+      onSuccess: () => {
+        invalidateModels();
+        queryClient.invalidateQueries({
+          queryKey: getGetV2ListMigrationsQueryKey({ include_reverted: true }),
+        });
+      },
+      onError: onError("Failed to toggle model"),
+    },
+  });
+  const deleteModel = useDeleteV2DeleteModel({
+    mutation: {
+      onSuccess: () => {
+        invalidateModels();
+        queryClient.invalidateQueries({
+          queryKey: getGetV2ListMigrationsQueryKey({ include_reverted: true }),
+        });
+      },
+      onError: onError("Failed to delete model"),
+    },
+  });
+
+  const createCreator = usePostV2CreateCreator({
+    mutation: {
+      onSuccess: () =>
+        queryClient.invalidateQueries({
+          queryKey: getGetV2ListCreatorsQueryKey(),
+        }),
+      onError: onError("Failed to create creator"),
+    },
+  });
+  const updateCreator = usePatchV2UpdateCreator({
+    mutation: {
+      onSuccess: () =>
+        queryClient.invalidateQueries({
+          queryKey: getGetV2ListCreatorsQueryKey(),
+        }),
+      onError: onError("Failed to update creator"),
+    },
+  });
+  const deleteCreator = useDeleteV2DeleteCreator({
+    mutation: {
+      onSuccess: () =>
+        queryClient.invalidateQueries({
+          queryKey: getGetV2ListCreatorsQueryKey(),
+        }),
+      onError: onError("Failed to delete creator"),
+    },
+  });
+
+  const setRoute = usePutV2SetRoute({
+    mutation: {
+      onSuccess: (response) => {
+        queryClient.invalidateQueries({
+          queryKey: getGetV2ListRoutesQueryKey(),
+        });
+        const warnings =
+          response.status === 200 ? (response.data.warnings ?? []) : [];
+        for (const warning of warnings) {
+          toast({ title: "Routing warning", description: warning });
+        }
+      },
+      onError: onError("Failed to update routing cell"),
+    },
+  });
+
+  const revertMigration = usePostV2RevertMigration({
+    mutation: {
+      onSuccess: () => {
+        invalidateModels();
+        queryClient.invalidateQueries({
+          queryKey: getGetV2ListMigrationsQueryKey({ include_reverted: true }),
+        });
+      },
+      onError: onError("Failed to revert migration"),
+    },
+  });
+
+  return {
+    createModel,
+    updateModel,
+    toggleModel,
+    deleteModel,
+    createCreator,
+    updateCreator,
+    deleteCreator,
+    setRoute,
+    revertMigration,
+  };
+}


### PR DESCRIPTION
## Why

Part 9 of 9 of Phase A of the LLM registry restack (#13605→#13606→#13607→#13608→#13609→#13610→#13611→#13612→this). With this PR the whole workflow that #13596 tried to do by hand-editing a machine-generated JSON becomes: open /admin/llms, add the model (HIDDEN if pre-launch), set routing cells when ready — validated, audited, propagated to every install within a day.

## What

Editing controls on the read-only dashboard from #13612, re-imagined from @Bentlybro's #12468 modals under current conventions:

- **Models**: add/edit dialogs covering every column (visibility, min subscription tier, fallback-model picker, capability flags, price tier, enabled/recommended); delete and disable flows with the replacement-model picker (pre-filled from `fallbackModelSlug`)
- **Creators**: add/edit/delete
- **Routing matrix**: each copilot cell gets a model dropdown (enabled models; HIDDEN allowed and badged) + clear-cell; the API's capability warnings (e.g. non-reasoning model in a thinking cell) surface inline as warnings per the agreed design — warn, don't block
- **Migrations**: revert with confirmation
- All mutations via generated Orval hooks with proper query-key invalidation and toast errors; no server actions, no legacy components

## Verification

- 12/12 `/admin/llms` integration tests (5 read + 7 new editing scenarios: create/edit request payload assertions, disable-with-replacement, routing PUT + warning surfacing, revert confirm, 500 toast)
- `pnpm format` / `pnpm lint` / `pnpm types` clean; full-suite failures are the pre-existing multi-suite interference documented on #13612 (worse on base without these changes, verified by stash-comparison)

## Checklist
- [x] Design-system components only; generated hooks only
- [x] Out-of-scope changes: none
