### PR TITLE
feat(backend/db): add LLM catalog runtime tables

### DIFF
--- a/autogpt_platform/backend/migrations/20260718120000_add_llm_catalog_runtime_tables/migration.sql
+++ b/autogpt_platform/backend/migrations/20260718120000_add_llm_catalog_runtime_tables/migration.sql
@@ -1,0 +1,33 @@
+-- AlterTable
+ALTER TABLE "ChatMessage" ADD COLUMN     "model" TEXT,
+ADD COLUMN     "routingSource" TEXT;
+
+-- CreateTable
+CREATE TABLE "LlmModelMigration" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "sourceModelSlug" TEXT NOT NULL,
+    "targetModelSlug" TEXT NOT NULL,
+    "reason" TEXT,
+    "migratedNodeIds" JSONB NOT NULL DEFAULT '[]',
+    "nodeCount" INTEGER NOT NULL,
+    "isReverted" BOOLEAN NOT NULL DEFAULT false,
+    "revertedAt" TIMESTAMP(3),
+
+    CONSTRAINT "LlmModelMigration_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "LlmModelMigration_targetModelSlug_idx" ON "LlmModelMigration"("targetModelSlug");
+
+-- CreateIndex
+CREATE INDEX "LlmModelMigration_sourceModelSlug_isReverted_idx" ON "LlmModelMigration"("sourceModelSlug", "isReverted");
+
+
+-- CreateIndex (partial unique to prevent multiple active migrations per source)
+CREATE UNIQUE INDEX "LlmModelMigration_active_source_key" ON "LlmModelMigration"("sourceModelSlug") WHERE "isReverted" = false;
+
+-- AddCheckConstraint
+ALTER TABLE "LlmModelMigration"
+    ADD CONSTRAINT "LlmModelMigration_nodeCount_check" CHECK ("nodeCount" >= 0);

--- a/autogpt_platform/backend/schema.prisma
+++ b/autogpt_platform/backend/schema.prisma
@@ -420,6 +420,13 @@ model ChatMessage {
   sequence   Int
   durationMs Int? // Wall-clock milliseconds for this assistant turn
 
+  // Which LLM served this assistant turn, and which routing layer picked it
+  // ("ld" | "db" | "env"). Product-intelligence mirrors these columns to
+  // segment quality judgments by model — model experiments are unmeasurable
+  // without them. Null on user/tool rows and rows predating this column.
+  model         String?
+  routingSource String?
+
   // Per-row JSONB metadata bag.  Currently holds the dispatcher's
   // submit-time payload (file_ids, mode, model, permissions, context,
   // request_arrival_at) on the user row that triggered a queued turn,
@@ -2193,4 +2200,31 @@ model BotInstall {
 
   @@unique([platform, platformServerId])
   @@index([platform, revokedAt])
+}
+
+// Retirement records: which AgentNodes were rewritten when a model was
+// retired via the retirement CLI (backend.data.llm_registry.retire), so the
+// operation is observable and revertable. Slugs are plain strings validated
+// against the catalog file at write time — the catalog is not a DB table.
+// Per-install runtime state, unlike the catalog itself (catalog-as-code).
+model LlmModelMigration {
+  id        String   @id @default(uuid())
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  sourceModelSlug String // The retired model
+  targetModelSlug String // The model workflows were migrated to
+  reason          String?
+
+  // JSON array of rewritten AgentNode ids, for revert
+  migratedNodeIds Json @default("[]")
+  nodeCount       Int // DB constraint: >= 0
+
+  isReverted Boolean   @default(false)
+  revertedAt DateTime?
+
+  // Note: Partial unique index in migration SQL prevents multiple active
+  // migrations per source: UNIQUE (sourceModelSlug) WHERE isReverted = false
+  @@index([targetModelSlug])
+  @@index([sourceModelSlug, isReverted])
 }


### PR DESCRIPTION
## Why

Part 1 of 5 of the **LLM catalog-as-code** stack — the successor to the DB-registry stack (#13605–#13613), which is being closed in favor of a simpler design settled after a post-build review: model definitions, costs, and copilot routing live in **one canonical catalog file** updated by PR (`/review`-bot fast-tracked; catalog-only diffs may ride hotfix→master), propagated by the existing CD, with LaunchDarkly demoted to optional cohort experiments. No admin API/UI, no importer/sync, no per-model DB rows — git is the write path and the audit log.

This PR adds the only two things that genuinely belong in the database: per-install runtime state.

## What

- **`ChatMessage.model` + `ChatMessage.routingSource`** (nullable) — which model served each assistant turn and which routing layer picked it (`ld`/`db`/`env`). Product-intelligence mirrors ChatMessage and currently has no model identifier, making model experiments unmeasurable (PI-side follow-up: product-intelligence#47). Consumed by part 3.
- **`LlmModelMigration`** — retirement records for the CLI (part 5): which AgentNodes were rewritten when a model was retired, revertable. Slugs are plain strings (validated against the catalog at write time) since the catalog isn't a table. Partial unique index blocks concurrent active migrations per source model.

## Verification

- `prisma validate` + `prisma format` clean; client generates
- Full migration chain applied via `prisma migrate reset` locally, incl. the partial unique index and `nodeCount >= 0` check

## Checklist
- [x] Migration verified against a clean database
- [x] Schema-only; no reads/writes exist yet (parts 3/5 add them)
- [x] Out-of-scope changes: none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema-only migration with nullable additive columns and a new table; no runtime behavior changes until follow-up PRs wire reads/writes.
> 
> **Overview**
> Adds **database-only** support for the LLM catalog-as-code stack: per-install runtime state, with no application reads/writes in this PR.
> 
> **`ChatMessage`** gains nullable **`model`** and **`routingSource`** so assistant turns can record which model served the reply and which routing layer chose it (`ld` / `db` / `env`), enabling product-intelligence and model experiment analysis. Existing rows stay null.
> 
> **`LlmModelMigration`** is a new table for retirement CLI audit/revert: source and target model slugs (strings, not FKs to a catalog table), optional reason, JSON list of rewritten `AgentNode` ids, `nodeCount`, and revert flags. Indexes support lookup by target/source; a **partial unique index** on `sourceModelSlug` where `isReverted = false` blocks concurrent active migrations per retired model; a **check constraint** enforces `nodeCount >= 0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4de363d583b46a0943ea4a17a6c1bad387ad3e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->