### PR TITLE
fix(frontend): clamp artifact panel width on narrow viewports

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ArtifactPanel/ArtifactPanel.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ArtifactPanel/ArtifactPanel.tsx
@@ -59,7 +59,12 @@ export function ArtifactPanel({ mobile }: Props) {
     update();
     const observer = new ResizeObserver(update);
     observer.observe(parent);
-    return () => observer.disconnect();
+    return () => {
+      observer.disconnect();
+      // Drop the measurement on close so a reopen after a viewport resize
+      // never renders a frame with a stale width.
+      setAvailableWidth(null);
+    };
   }, [showDesktopPanel]);
 
   if (mobile) {

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ArtifactPanel/ArtifactPanel.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ArtifactPanel/ArtifactPanel.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Drawer } from "vaul";
-import { MIN_ARTIFACT_PANEL_WIDTH } from "../../store";
+import { MIN_ARTIFACT_PANEL_WIDTH, PANEL_RESERVED_WIDTH } from "../../store";
 import { PanelResizeHandle } from "../PanelResizeHandle";
 import { ArtifactContent } from "./components/ArtifactContent";
 import { ArtifactPanelHeader } from "./components/ArtifactPanelHeader";
@@ -41,6 +41,26 @@ export function ArtifactPanel({ mobile }: Props) {
   if (activeArtifact && classification) {
     lastShownRef.current = { artifact: activeArtifact, classification };
   }
+
+  // The stored width is a preference, not a guarantee: the panel is shrink-0,
+  // so on narrow viewports it would overflow the flex row and get clipped on
+  // the right. Clamp the rendered width to the space the row actually leaves
+  // (same reservation the resize handle uses while dragging); the stored
+  // width is left untouched and applies again once the viewport grows.
+  const panelRef = useRef<HTMLDivElement>(null);
+  const [availableWidth, setAvailableWidth] = useState<number | null>(null);
+  const showDesktopPanel = !mobile && !!activeArtifact && !!classification;
+  useEffect(() => {
+    if (!showDesktopPanel || typeof ResizeObserver === "undefined") return;
+    const parent = panelRef.current?.parentElement;
+    if (!parent) return;
+    const update = () =>
+      setAvailableWidth(parent.offsetWidth - PANEL_RESERVED_WIDTH);
+    update();
+    const observer = new ResizeObserver(update);
+    observer.observe(parent);
+    return () => observer.disconnect();
+  }, [showDesktopPanel]);
 
   if (mobile) {
     const shown = lastShownRef.current;
@@ -101,10 +121,18 @@ export function ArtifactPanel({ mobile }: Props) {
 
   if (!activeArtifact || !classification) return null;
 
+  // jsdom reports offsetWidth 0 — treat non-positive readings as "unknown"
+  // and fall back to the stored width.
+  const renderedWidth =
+    availableWidth == null || availableWidth <= 0
+      ? artifactPanelWidth
+      : Math.min(artifactPanelWidth, availableWidth);
+
   return (
     <div
+      ref={panelRef}
       data-artifact-panel
-      style={{ width: artifactPanelWidth, userSelect: "text" }}
+      style={{ width: renderedWidth, userSelect: "text" }}
       className="relative flex h-full shrink-0 flex-col border-l border-l-[#80808017] bg-sidebar"
     >
       <PanelResizeHandle

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ArtifactPanel/__tests__/ArtifactPanel.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ArtifactPanel/__tests__/ArtifactPanel.test.tsx
@@ -1,0 +1,122 @@
+import { act, cleanup, render, screen } from "@/tests/integrations/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ArtifactRef } from "../../../store";
+import {
+  DEFAULT_ARTIFACT_PANEL_WIDTH,
+  PANEL_RESERVED_WIDTH,
+  useCopilotUIStore,
+} from "../../../store";
+import { ArtifactPanel } from "../ArtifactPanel";
+
+const ARTIFACT_ID = "11111111-0000-0000-0000-000000000000";
+const ARTIFACT_SOURCE_URL = `/api/proxy/api/workspace/files/${ARTIFACT_ID}/download`;
+
+function makeArtifact(): ArtifactRef {
+  return {
+    id: ARTIFACT_ID,
+    title: "notes.txt",
+    mimeType: "text/plain",
+    sourceUrl: ARTIFACT_SOURCE_URL,
+    origin: "agent",
+  };
+}
+
+class ResizeObserverMock {
+  static instances: ResizeObserverMock[] = [];
+  callback: ResizeObserverCallback;
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback;
+    ResizeObserverMock.instances.push(this);
+  }
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+  trigger() {
+    this.callback([], this as unknown as ResizeObserver);
+  }
+}
+
+function getPanel(): HTMLElement {
+  const panel = document.querySelector("[data-artifact-panel]");
+  if (!(panel instanceof HTMLElement)) throw new Error("panel not rendered");
+  return panel;
+}
+
+describe("ArtifactPanel (desktop) width clamping", () => {
+  let offsetWidthSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    ResizeObserverMock.instances = [];
+    vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+    // The text artifact fetches its content from the download proxy URL,
+    // which isn't an Orval endpoint — stub global fetch for that URL only.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.includes(ARTIFACT_SOURCE_URL)) {
+          return new Response("hello world", {
+            status: 200,
+            headers: { "Content-Type": "text/plain" },
+          });
+        }
+        throw new Error(`Unexpected fetch in test: ${url}`);
+      }),
+    );
+    useCopilotUIStore.setState((s) => ({
+      artifactPanelWidth: DEFAULT_ARTIFACT_PANEL_WIDTH,
+      artifactPanel: {
+        ...s.artifactPanel,
+        isOpen: true,
+        activeArtifact: null,
+        history: [],
+        activeTab: "files",
+      },
+    }));
+    useCopilotUIStore.getState().openArtifact(makeArtifact());
+  });
+
+  afterEach(() => {
+    cleanup();
+    offsetWidthSpy?.mockRestore();
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("shrinks below the stored width when the row leaves less space", async () => {
+    offsetWidthSpy = vi
+      .spyOn(HTMLElement.prototype, "offsetWidth", "get")
+      .mockReturnValue(1000);
+
+    render(<ArtifactPanel />);
+
+    expect(await screen.findByText("notes.txt")).toBeDefined();
+    expect(getPanel().style.width).toBe(`${1000 - PANEL_RESERVED_WIDTH}px`);
+  });
+
+  it("keeps the stored width when the row leaves enough space", async () => {
+    offsetWidthSpy = vi
+      .spyOn(HTMLElement.prototype, "offsetWidth", "get")
+      .mockReturnValue(2000);
+
+    render(<ArtifactPanel />);
+
+    expect(await screen.findByText("notes.txt")).toBeDefined();
+    expect(getPanel().style.width).toBe(`${DEFAULT_ARTIFACT_PANEL_WIDTH}px`);
+  });
+
+  it("re-clamps when the row is resized", async () => {
+    offsetWidthSpy = vi
+      .spyOn(HTMLElement.prototype, "offsetWidth", "get")
+      .mockReturnValue(2000);
+
+    render(<ArtifactPanel />);
+    expect(await screen.findByText("notes.txt")).toBeDefined();
+    expect(getPanel().style.width).toBe(`${DEFAULT_ARTIFACT_PANEL_WIDTH}px`);
+
+    offsetWidthSpy.mockReturnValue(900);
+    act(() => ResizeObserverMock.instances[0].trigger());
+
+    expect(getPanel().style.width).toBe(`${900 - PANEL_RESERVED_WIDTH}px`);
+  });
+});

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/PanelResizeHandle.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/PanelResizeHandle.tsx
@@ -2,6 +2,7 @@
 
 import { cn } from "@/lib/utils";
 import { useEffect, useRef, useState } from "react";
+import { PANEL_RESERVED_WIDTH } from "../store";
 
 interface Props {
   /** CSS selector for the panel element this handle resizes (e.g. "[data-artifact-panel]"). */
@@ -18,7 +19,7 @@ export function PanelResizeHandle({
   onWidthChange,
   minWidth,
   maxWidth,
-  reservedWidth = 440,
+  reservedWidth = PANEL_RESERVED_WIDTH,
 }: Props) {
   const [isDragging, setIsDragging] = useState(false);
   const startXRef = useRef(0);

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/store.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/store.ts
@@ -50,6 +50,8 @@ export const DEFAULT_ARTIFACT_PANEL_WIDTH = 640;
 export const MIN_CONTEXT_PANEL_WIDTH = 280;
 export const MAX_CONTEXT_PANEL_WIDTH = 600;
 export const MIN_ARTIFACT_PANEL_WIDTH = 400;
+/** Space kept for the chat + rail when sizing a side panel (drag clamp and viewport clamp). */
+export const PANEL_RESERVED_WIDTH = 440;
 
 /** Autopilot response mode. */
 export type CopilotMode = "extended_thinking" | "fast";


### PR DESCRIPTION
### Why / What / How

**Why:** In the Copilot page, the artifact preview panel renders with a fixed, persisted width (`shrink-0`, default 640px). When the viewport is not wide enough, the flex row overflows and the panel gets clipped on the right edge, cutting off the artifact content (see screenshot in linked report).

**What:** The desktop `ArtifactPanel` now clamps its rendered width to the space its flex row actually leaves, so it shrinks instead of overflowing on narrow viewports.

**How:** A `ResizeObserver` on the panel's parent row tracks the available space (parent width minus `PANEL_RESERVED_WIDTH` = 440px, the same reservation `PanelResizeHandle` already uses while dragging). The rendered width is `min(storedWidth, availableWidth)`; the stored/persisted width is left untouched, so the user's preferred width applies again once the viewport grows. The `440` default is now shared via `PANEL_RESERVED_WIDTH` in the copilot store instead of being hardcoded in `PanelResizeHandle`.

### Changes 🏗️

- `copilot/components/ArtifactPanel/ArtifactPanel.tsx`: observe the parent row and clamp the rendered panel width to the available space (falls back to the stored width when no measurement is available, e.g. jsdom).
- `copilot/store.ts`: new shared `PANEL_RESERVED_WIDTH = 440` constant.
- `copilot/components/PanelResizeHandle.tsx`: use the shared constant as the default `reservedWidth` (behavior unchanged).
- `copilot/components/ArtifactPanel/__tests__/ArtifactPanel.test.tsx`: regression tests covering shrink-on-narrow-row, keep-width-on-wide-row, and re-clamp on row resize.

### Checklist 📋

#### For code changes:
- [ ] I have clearly listed my changes in the PR description
- [ ] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [ ] Unit/integration: `vitest run src/app/(platform)/copilot` — 99 files, 1304 tests pass, including the 3 new clamping tests
  - [ ] `pnpm types` (tsc --noEmit) and `pnpm lint` pass
  - [ ] Manual: open an artifact in `/copilot` on a narrow (~1280px) viewport and confirm the panel shrinks instead of being clipped on the right
  - [ ] Manual: widen the viewport again and confirm the panel returns to its stored width
  - [ ] Manual: drag the resize handle and confirm min/max clamping still behaves as before

#### For configuration changes:

- [ ] `.env.default` is updated or already compatible with my changes
- [ ] `docker-compose.yml` is updated or already compatible with my changes
- [ ] I have included a list of my configuration changes in the PR description (under **Changes**)

<details>
  <summary>Example test plan</summary>

  - [ ] Create from scratch and execute an agent with at least 3 blocks
  - [ ] Import an agent from file upload, and confirm it executes correctly
  - [ ] Upload agent to marketplace
  - [ ] Import an agent from marketplace and confirm it executes correctly
  - [ ] Edit an agent from monitor, and confirm it executes correctly
</details>
