### PR TITLE
fix(frontend): queue DataFast events fired before the script loads

### DIFF
--- a/autogpt_platform/frontend/src/services/analytics/index.test.ts
+++ b/autogpt_platform/frontend/src/services/analytics/index.test.ts
@@ -1,25 +1,41 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { consent } from "@/services/consent/cookies";
 import { analytics, flushDatafastQueue } from "./index";
+
+vi.mock("@/services/consent/cookies", () => ({
+  consent: { hasConsentFor: vi.fn() },
+}));
+
+function drainQueue() {
+  window.datafast = vi.fn();
+  flushDatafastQueue();
+  delete window.datafast;
+}
 
 describe("sendDatafastEvent", () => {
   beforeEach(() => {
-    delete window.datafast;
+    drainQueue();
+    vi.mocked(consent.hasConsentFor).mockReturnValue(true);
+    window.history.pushState({}, "", "/");
   });
 
   afterEach(() => {
-    // Drain anything left queued so tests can't leak events into each other.
-    window.datafast = vi.fn();
-    flushDatafastQueue();
-    delete window.datafast;
+    drainQueue();
   });
 
   it("sends immediately when the DataFast script has loaded", () => {
     const datafast = vi.fn();
     window.datafast = datafast;
 
-    analytics.sendDatafastEvent("tour_start", {});
+    analytics.sendDatafastEvent("tour_scenario_start", {
+      scenario: "chat",
+      step: 2,
+    });
 
-    expect(datafast).toHaveBeenCalledWith("tour_start", {});
+    expect(datafast).toHaveBeenCalledWith("tour_scenario_start", {
+      scenario: "chat",
+      step: 2,
+    });
   });
 
   it("queues events fired before the script loads and flushes them in order", () => {
@@ -72,15 +88,45 @@ describe("sendDatafastEvent", () => {
     ]);
   });
 
-  it("caps the queue so a blocked script cannot grow it unbounded", () => {
+  it("does not queue pre-consent events outside the tour", () => {
+    vi.mocked(consent.hasConsentFor).mockReturnValue(false);
+
+    analytics.sendDatafastEvent("run_agent", { agent_name: "x" });
+
+    const datafast = vi.fn();
+    window.datafast = datafast;
+    flushDatafastQueue();
+
+    expect(datafast).not.toHaveBeenCalled();
+  });
+
+  it("queues pre-consent events on the consent-exempt tour pages", () => {
+    vi.mocked(consent.hasConsentFor).mockReturnValue(false);
+    window.history.pushState({}, "", "/tour/chat");
+
+    analytics.sendDatafastEvent("tour_start", {});
+
+    const datafast = vi.fn();
+    window.datafast = datafast;
+    flushDatafastQueue();
+
+    expect(datafast).toHaveBeenCalledWith("tour_start", {});
+  });
+
+  it("caps the queue at 100, keeps the earliest events, and warns once", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     for (let i = 0; i < 150; i++) {
-      analytics.sendDatafastEvent("tour_start", {});
+      analytics.sendDatafastEvent("tour_start", { i });
     }
 
     const datafast = vi.fn();
     window.datafast = datafast;
     flushDatafastQueue();
 
-    expect(datafast.mock.calls).toHaveLength(100);
+    expect(datafast.mock.calls.map(([, metadata]) => metadata)).toEqual(
+      Array.from({ length: 100 }, (_, i) => ({ i })),
+    );
+    expect(warn).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
   });
 });

--- a/autogpt_platform/frontend/src/services/analytics/index.test.ts
+++ b/autogpt_platform/frontend/src/services/analytics/index.test.ts
@@ -59,6 +59,19 @@ describe("sendDatafastEvent", () => {
     expect(datafast).toHaveBeenCalledTimes(1);
   });
 
+  it("flushes the backlog before sending when the script loads without onLoad", () => {
+    analytics.sendDatafastEvent("tour_start", {});
+
+    const datafast = vi.fn();
+    window.datafast = datafast;
+    analytics.sendDatafastEvent("tour_cta_click", { label: "pricing" });
+
+    expect(datafast.mock.calls).toEqual([
+      ["tour_start", {}],
+      ["tour_cta_click", { label: "pricing" }],
+    ]);
+  });
+
   it("caps the queue so a blocked script cannot grow it unbounded", () => {
     for (let i = 0; i < 150; i++) {
       analytics.sendDatafastEvent("tour_start", {});

--- a/autogpt_platform/frontend/src/services/analytics/index.test.ts
+++ b/autogpt_platform/frontend/src/services/analytics/index.test.ts
@@ -68,6 +68,6 @@ describe("sendDatafastEvent", () => {
     window.datafast = datafast;
     flushDatafastQueue();
 
-    expect(datafast.mock.calls.length).toBeLessThan(150);
+    expect(datafast.mock.calls).toHaveLength(100);
   });
 });

--- a/autogpt_platform/frontend/src/services/analytics/index.test.ts
+++ b/autogpt_platform/frontend/src/services/analytics/index.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { analytics, flushDatafastQueue } from "./index";
+
+describe("sendDatafastEvent", () => {
+  beforeEach(() => {
+    delete window.datafast;
+  });
+
+  afterEach(() => {
+    // Drain anything left queued so tests can't leak events into each other.
+    window.datafast = vi.fn();
+    flushDatafastQueue();
+    delete window.datafast;
+  });
+
+  it("sends immediately when the DataFast script has loaded", () => {
+    const datafast = vi.fn();
+    window.datafast = datafast;
+
+    analytics.sendDatafastEvent("tour_start", {});
+
+    expect(datafast).toHaveBeenCalledWith("tour_start", {});
+  });
+
+  it("queues events fired before the script loads and flushes them in order", () => {
+    analytics.sendDatafastEvent("tour_start", {});
+    analytics.sendDatafastEvent("tour_scenario_start", { scenario: "x" });
+
+    const datafast = vi.fn();
+    window.datafast = datafast;
+    flushDatafastQueue();
+
+    expect(datafast.mock.calls).toEqual([
+      ["tour_start", {}],
+      ["tour_scenario_start", { scenario: "x" }],
+    ]);
+  });
+
+  it("keeps events queued when flushing before the script loads", () => {
+    analytics.sendDatafastEvent("tour_start", {});
+    flushDatafastQueue();
+
+    const datafast = vi.fn();
+    window.datafast = datafast;
+    flushDatafastQueue();
+
+    expect(datafast).toHaveBeenCalledTimes(1);
+    expect(datafast).toHaveBeenCalledWith("tour_start", {});
+  });
+
+  it("does not replay events after a flush", () => {
+    analytics.sendDatafastEvent("tour_start", {});
+
+    const datafast = vi.fn();
+    window.datafast = datafast;
+    flushDatafastQueue();
+    flushDatafastQueue();
+
+    expect(datafast).toHaveBeenCalledTimes(1);
+  });
+
+  it("caps the queue so a blocked script cannot grow it unbounded", () => {
+    for (let i = 0; i < 150; i++) {
+      analytics.sendDatafastEvent("tour_start", {});
+    }
+
+    const datafast = vi.fn();
+    window.datafast = datafast;
+    flushDatafastQueue();
+
+    expect(datafast.mock.calls.length).toBeLessThan(150);
+  });
+});

--- a/autogpt_platform/frontend/src/services/analytics/index.test.ts
+++ b/autogpt_platform/frontend/src/services/analytics/index.test.ts
@@ -113,6 +113,33 @@ describe("sendDatafastEvent", () => {
     expect(datafast).toHaveBeenCalledWith("tour_start", {});
   });
 
+  it("does not treat /tourism as a consent-exempt tour page", () => {
+    vi.mocked(consent.hasConsentFor).mockReturnValue(false);
+    window.history.pushState({}, "", "/tourism");
+
+    analytics.sendDatafastEvent("tour_start", {});
+
+    const datafast = vi.fn();
+    window.datafast = datafast;
+    flushDatafastQueue();
+
+    expect(datafast).not.toHaveBeenCalled();
+  });
+
+  it("warns again when the queue overflows after a successful flush", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    for (let i = 0; i < 101; i++) {
+      analytics.sendDatafastEvent("tour_start", {});
+    }
+    drainQueue();
+    for (let i = 0; i < 101; i++) {
+      analytics.sendDatafastEvent("tour_start", {});
+    }
+
+    expect(warn).toHaveBeenCalledTimes(2);
+    warn.mockRestore();
+  });
+
   it("caps the queue at 100, keeps the earliest events, and warns once", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     for (let i = 0; i < 150; i++) {

--- a/autogpt_platform/frontend/src/services/analytics/index.tsx
+++ b/autogpt_platform/frontend/src/services/analytics/index.tsx
@@ -12,9 +12,11 @@ import Script from "next/script";
 import { useEffect, useState } from "react";
 import { environment } from "../environment";
 
+type DatafastEvent = [name: string, metadata: Record<string, unknown>];
+
 declare global {
   interface Window {
-    datafast?: (name: string, metadata: Record<string, unknown>) => void;
+    datafast?: (...event: DatafastEvent) => void;
     [key: string]: unknown[] | ((...args: unknown[]) => void) | unknown;
   }
 }
@@ -95,7 +97,8 @@ export function SetupAnalytics(props: SetupProps) {
           />
         </>
       ) : null}
-      {/* Datafa.st */}
+      {/* Datafa.st — onLoad is load-bearing: it delivers the events that were
+          queued before the script finished loading */}
       {dataFastEnabled ? (
         <Script
           strategy="afterInteractive"
@@ -128,6 +131,15 @@ function sendGAEvent(...args: unknown[]) {
   }
 }
 
+// Module scope means the queue survives client-side navigation: queued events
+// are delivered wherever the script loads next, so metadata must never carry
+// PII. On overflow the earliest events win — funnel starts fire first. The cap
+// bounds memory when the script never loads (ad blockers, non-production
+// domains where dataFastEnabled is false).
+const MAX_QUEUED_DATAFAST_EVENTS = 100;
+const datafastQueue: DatafastEvent[] = [];
+let datafastQueueOverflowWarned = false;
+
 function sendDatafastEvent(name: string, metadata: Record<string, unknown>) {
   if (typeof window === "undefined") return;
   if (window.datafast) {
@@ -140,15 +152,22 @@ function sendDatafastEvent(name: string, metadata: Record<string, unknown>) {
   }
   // The script loads afterInteractive, so mount-time events (tour_start,
   // tour_scenario_start) fire before window.datafast exists. Queue them and
-  // flush from the Script's onLoad instead of dropping them.
-  if (datafastQueue.length >= MAX_QUEUED_DATAFAST_EVENTS) return;
+  // flush from the Script's onLoad instead of dropping them. Pre-consent
+  // events must not queue — they would be replayed once consent is granted.
+  // /tour is exempt: it loads DataFast without consent by design.
+  const consentExempt = window.location.pathname.startsWith("/tour");
+  if (!consentExempt && !consent.hasConsentFor("analytics")) return;
+  if (datafastQueue.length >= MAX_QUEUED_DATAFAST_EVENTS) {
+    if (!datafastQueueOverflowWarned) {
+      datafastQueueOverflowWarned = true;
+      console.warn(
+        `DataFast queue full (${MAX_QUEUED_DATAFAST_EVENTS} events); dropping new events until the script loads`,
+      );
+    }
+    return;
+  }
   datafastQueue.push([name, metadata]);
 }
-
-// Bounds memory when the script never loads (ad blockers, non-production
-// domains where dataFastEnabled is false).
-const MAX_QUEUED_DATAFAST_EVENTS = 100;
-const datafastQueue: Array<[string, Record<string, unknown>]> = [];
 
 export function flushDatafastQueue() {
   if (typeof window === "undefined" || !window.datafast) return;

--- a/autogpt_platform/frontend/src/services/analytics/index.tsx
+++ b/autogpt_platform/frontend/src/services/analytics/index.tsx
@@ -14,7 +14,7 @@ import { environment } from "../environment";
 
 declare global {
   interface Window {
-    datafast: (name: string, metadata: Record<string, unknown>) => void;
+    datafast?: (name: string, metadata: Record<string, unknown>) => void;
     [key: string]: unknown[] | ((...args: unknown[]) => void) | unknown;
   }
 }
@@ -102,6 +102,7 @@ export function SetupAnalytics(props: SetupProps) {
           data-website-id="dfid_g5wtBIiHUwSkWKcGz80lu"
           data-domain="agpt.co"
           src="https://datafa.st/js/script.js"
+          onLoad={flushDatafastQueue}
         />
       ) : null}
     </>
@@ -128,6 +129,27 @@ function sendGAEvent(...args: unknown[]) {
 }
 
 function sendDatafastEvent(name: string, metadata: Record<string, unknown>) {
+  if (typeof window === "undefined") return;
+  if (window.datafast) {
+    window.datafast(name, metadata);
+    return;
+  }
+  // The script loads afterInteractive, so mount-time events (tour_start,
+  // tour_scenario_start) fire before window.datafast exists. Queue them and
+  // flush from the Script's onLoad instead of dropping them.
+  if (datafastQueue.length >= MAX_QUEUED_DATAFAST_EVENTS) return;
+  datafastQueue.push([name, metadata]);
+}
+
+// Bounds memory when the script never loads (ad blockers, non-production
+// domains where dataFastEnabled is false).
+const MAX_QUEUED_DATAFAST_EVENTS = 100;
+const datafastQueue: Array<[string, Record<string, unknown>]> = [];
+
+export function flushDatafastQueue() {
   if (typeof window === "undefined" || !window.datafast) return;
-  window.datafast(name, metadata);
+  const datafast = window.datafast;
+  datafastQueue
+    .splice(0, datafastQueue.length)
+    .forEach(([name, metadata]) => datafast(name, metadata));
 }

--- a/autogpt_platform/frontend/src/services/analytics/index.tsx
+++ b/autogpt_platform/frontend/src/services/analytics/index.tsx
@@ -131,6 +131,10 @@ function sendGAEvent(...args: unknown[]) {
 function sendDatafastEvent(name: string, metadata: Record<string, unknown>) {
   if (typeof window === "undefined") return;
   if (window.datafast) {
+    // Self-heal if the Script's onLoad never fired (e.g. consent toggle
+    // remounted it after the script had already loaded): replay the backlog
+    // first so queued events keep their order ahead of this one.
+    flushDatafastQueue();
     window.datafast(name, metadata);
     return;
   }

--- a/autogpt_platform/frontend/src/services/analytics/index.tsx
+++ b/autogpt_platform/frontend/src/services/analytics/index.tsx
@@ -45,7 +45,7 @@ export function SetupAnalytics(props: SetupProps) {
   // the consent gate — otherwise tour funnel events would never fire for
   // first-touch visitors.
   const pathname = usePathname();
-  const isPublicTourPage = pathname?.startsWith("/tour") ?? false;
+  const isPublicTourPage = isTourPath(pathname);
 
   // Datafa.st journey analytics only on production AND with consent
   const dataFastEnabled =
@@ -155,7 +155,7 @@ function sendDatafastEvent(name: string, metadata: Record<string, unknown>) {
   // flush from the Script's onLoad instead of dropping them. Pre-consent
   // events must not queue — they would be replayed once consent is granted.
   // /tour is exempt: it loads DataFast without consent by design.
-  const consentExempt = window.location.pathname.startsWith("/tour");
+  const consentExempt = isTourPath(window.location.pathname);
   if (!consentExempt && !consent.hasConsentFor("analytics")) return;
   if (datafastQueue.length >= MAX_QUEUED_DATAFAST_EVENTS) {
     if (!datafastQueueOverflowWarned) {
@@ -175,4 +175,14 @@ export function flushDatafastQueue() {
   datafastQueue
     .splice(0, datafastQueue.length)
     .forEach(([name, metadata]) => datafast(name, metadata));
+  // A successful drain ends the blocked episode; warn again if a later one
+  // overflows too.
+  datafastQueueOverflowWarned = false;
+}
+
+// Segment-boundary match: /tourism must not inherit the tour's consent
+// exemption.
+function isTourPath(pathname: string | null): boolean {
+  if (!pathname) return false;
+  return pathname === "/tour" || pathname.startsWith("/tour/");
 }


### PR DESCRIPTION
### Why / What / How

**Why:** Tour funnel numbers in DataFast don't add up: over the last 7 days `/tour/chat` had ~2.8k pageviews but only 117 `tour_start`, 405 `tour_scenario_start`, and 858 `tour_scenario_complete` — more completes than starts, which is impossible. Root cause: the DataFast script loads with `strategy="afterInteractive"`, but `tour_start` and `tour_scenario_start` fire in mount effects, so they race the script load. `sendDatafastEvent` silently dropped any event fired before `window.datafast` existed. Late events (scenario completes, CTA clicks) were recorded fine, which is exactly why completes outnumbered starts.

**What:** Events fired before the DataFast script loads are now queued instead of dropped, and flushed once the script is ready.

**How:** `sendDatafastEvent` pushes to a module-level queue when `window.datafast` is undefined; the DataFast `<Script>`'s new `onLoad` handler calls `flushDatafastQueue()`, which replays the queue in order. The queue is capped at 100 events so it can't grow unbounded when the script never loads (ad blockers, or non-production domains where DataFast is disabled). `window.datafast` is now typed optional to reflect that it's absent until the script runs.

### Changes 🏗️

- `frontend/src/services/analytics/index.tsx`: queue DataFast events fired before the script loads; flush them from the `<Script>` `onLoad`; cap the queue at 100 events; make `window.datafast` optional in the global `Window` typing
- `frontend/src/services/analytics/index.test.ts`: new tests covering immediate send, queue + flush ordering, no-op flush before load, no replay after flush, and the queue cap

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] New unit tests for the queue/flush behavior pass (`vitest run src/services/analytics/index.test.ts`)
  - [x] Existing suites for affected areas pass (137 tests: `src/services/analytics`, `src/app/(public)/tour`, `src/app/api/proxy`, billing DataFast attribution, auth callback)
  - [x] `tsc --noEmit`, `prettier --check`, and `eslint` pass on the changed files
  - [ ] Verify on production data after deploy: on a fresh day, `tour_start` roughly matches `/tour/chat` pageviews and `tour_scenario_start` ≥ `tour_scenario_complete`

#### For configuration changes:

- [x] `.env.default` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes
- [x] I have included a list of my configuration changes in the PR description (under **Changes**) — no configuration changes
