### PR TITLE
feat(frontend): paste images from clipboard into CoPilot chat

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/ChatInput.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/ChatInput.tsx
@@ -17,7 +17,13 @@ import {
 import { cn } from "@/lib/utils";
 import { Flag, useGetFlag } from "@/services/feature-flags/use-get-flag";
 import { ArrowUpIcon } from "@phosphor-icons/react";
-import { ChangeEvent, KeyboardEvent, useEffect, useState } from "react";
+import {
+  ChangeEvent,
+  ClipboardEvent,
+  KeyboardEvent,
+  useEffect,
+  useState,
+} from "react";
 import type { WorkspaceFileItem } from "@/app/api/__generated__/models/workspaceFileItem";
 import {
   type Attachment,
@@ -35,6 +41,7 @@ import { RecordingButton } from "./components/RecordingButton";
 import { RecordingIndicator } from "./components/RecordingIndicator";
 import { WorkspaceFilePicker } from "./components/WorkspaceFilePicker/WorkspaceFilePicker";
 import { useCopilotUIStore } from "../../store";
+import { getFilesFromClipboard } from "./helpers";
 import { useChatInput } from "./useChatInput";
 import { useChatMentions } from "./useChatMentions";
 import { useVoiceRecording } from "./useVoiceRecording";
@@ -218,6 +225,14 @@ export function ChatInput({
     voiceHandleKeyDown(e);
   }
 
+  function handlePaste(e: ClipboardEvent<HTMLTextAreaElement>) {
+    if (isBusy) return;
+    const files = getFilesFromClipboard(e.clipboardData);
+    if (files.length === 0) return;
+    e.preventDefault();
+    handleFilesSelected(files);
+  }
+
   const resolvedPlaceholder = isRecording
     ? ""
     : isTranscribing
@@ -293,6 +308,7 @@ export function ChatInput({
             value={value}
             onChange={handleChange}
             onKeyDown={handleKeyDown}
+            onPaste={handlePaste}
             onBlur={mentions.close}
             disabled={isInputDisabled}
             placeholder={resolvedPlaceholder}

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/__tests__/ChatInput.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/__tests__/ChatInput.test.tsx
@@ -108,24 +108,26 @@ vi.mock("@/components/ai-elements/prompt-input", () => ({
         Send
       </button>
     ),
-  PromptInputTextarea: (props: {
+  PromptInputTextarea: function PromptInputTextarea(props: {
     id?: string;
     value?: string;
     onChange?: React.ChangeEventHandler<HTMLTextAreaElement>;
     onPaste?: React.ClipboardEventHandler<HTMLTextAreaElement>;
     disabled?: boolean;
     placeholder?: string;
-  }) => (
-    <textarea
-      id={props.id}
-      value={props.value}
-      onChange={props.onChange}
-      onPaste={props.onPaste}
-      disabled={props.disabled}
-      placeholder={props.placeholder}
-      data-testid="textarea"
-    />
-  ),
+  }) {
+    return (
+      <textarea
+        id={props.id}
+        value={props.value}
+        onChange={props.onChange}
+        onPaste={props.onPaste}
+        disabled={props.disabled}
+        placeholder={props.placeholder}
+        data-testid="textarea"
+      />
+    );
+  },
   PromptInputTools: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="tools">{children}</div>
   ),
@@ -708,6 +710,52 @@ describe("ChatInput clipboard paste", () => {
       expect(onSend).toHaveBeenCalledTimes(1);
     });
     expect(onSend.mock.calls[0][1][0].name).toBe("report.pdf");
+  });
+
+  it("does not rename non-image files with generic image names", async () => {
+    const onSend = vi.fn().mockResolvedValue(undefined);
+    render(<ChatInput onSend={onSend} />);
+    const textarea = screen.getByTestId("textarea") as HTMLTextAreaElement;
+
+    pasteFiles(textarea, [
+      new File(["pdf-bytes"], "image.pdf", { type: "application/pdf" }),
+    ]);
+    fireEvent.submit(textarea.closest("form")!);
+
+    await waitFor(() => {
+      expect(onSend).toHaveBeenCalledTimes(1);
+    });
+    expect(onSend.mock.calls[0][1][0].name).toBe("image.pdf");
+  });
+
+  it("gives images from separate pastes in the same second distinct names", async () => {
+    vi.useFakeTimers();
+    try {
+      const baseTime = new Date("2026-01-01T10:00:00.100Z");
+      vi.setSystemTime(baseTime);
+      const onSend = vi.fn().mockResolvedValue(undefined);
+      render(<ChatInput onSend={onSend} />);
+      const textarea = screen.getByTestId("textarea") as HTMLTextAreaElement;
+
+      pasteFiles(textarea, [
+        new File(["a"], "image.png", { type: "image/png" }),
+      ]);
+      vi.setSystemTime(new Date("2026-01-01T10:00:00.900Z"));
+      pasteFiles(textarea, [
+        new File(["b"], "image.png", { type: "image/png" }),
+      ]);
+
+      vi.useRealTimers();
+      fireEvent.submit(textarea.closest("form")!);
+      await waitFor(() => {
+        expect(onSend).toHaveBeenCalledTimes(1);
+      });
+      const files = onSend.mock.calls[0][1] as File[];
+      expect(files).toHaveLength(2);
+      expect(files[0].name).not.toBe(files[1].name);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("gives multiple generic pasted images distinct names", async () => {

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/__tests__/ChatInput.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/__tests__/ChatInput.test.tsx
@@ -112,6 +112,7 @@ vi.mock("@/components/ai-elements/prompt-input", () => ({
     id?: string;
     value?: string;
     onChange?: React.ChangeEventHandler<HTMLTextAreaElement>;
+    onPaste?: React.ClipboardEventHandler<HTMLTextAreaElement>;
     disabled?: boolean;
     placeholder?: string;
   }) => (
@@ -119,6 +120,7 @@ vi.mock("@/components/ai-elements/prompt-input", () => ({
       id={props.id}
       value={props.value}
       onChange={props.onChange}
+      onPaste={props.onPaste}
       disabled={props.disabled}
       placeholder={props.placeholder}
       data-testid="textarea"
@@ -644,6 +646,114 @@ describe("ChatInput submit behavior", () => {
       window.removeEventListener("unhandledrejection", swallowWindow);
       process.off("unhandledRejection", swallowProcess);
     }
+  });
+});
+
+describe("ChatInput clipboard paste", () => {
+  function pasteFiles(target: HTMLElement, files: File[]) {
+    return fireEvent.paste(target, { clipboardData: { files } });
+  }
+
+  it("attaches a pasted image and sends it with the message", async () => {
+    const onSend = vi.fn().mockResolvedValue(undefined);
+    render(<ChatInput onSend={onSend} />);
+    const textarea = screen.getByTestId("textarea") as HTMLTextAreaElement;
+
+    const image = new File(["png-bytes"], "image.png", { type: "image/png" });
+    pasteFiles(textarea, [image]);
+
+    fireEvent.change(textarea, { target: { value: "see screenshot" } });
+    fireEvent.submit(textarea.closest("form")!);
+
+    await waitFor(() => {
+      expect(onSend).toHaveBeenCalledTimes(1);
+    });
+    const [message, files, workspaceFiles] = onSend.mock.calls[0];
+    expect(message).toBe("see screenshot");
+    expect(files).toHaveLength(1);
+    expect(files[0].name).toMatch(/^pasted-image-.+\.png$/);
+    expect(files[0].type).toBe("image/png");
+    expect(workspaceFiles).toBeUndefined();
+  });
+
+  it("allows sending a pasted image without any text", async () => {
+    const onSend = vi.fn().mockResolvedValue(undefined);
+    render(<ChatInput onSend={onSend} />);
+    const textarea = screen.getByTestId("textarea") as HTMLTextAreaElement;
+
+    const image = new File(["png-bytes"], "image.png", { type: "image/png" });
+    pasteFiles(textarea, [image]);
+    fireEvent.submit(textarea.closest("form")!);
+
+    await waitFor(() => {
+      expect(onSend).toHaveBeenCalledTimes(1);
+    });
+    const [message, files] = onSend.mock.calls[0];
+    expect(message).toBe("");
+    expect(files).toHaveLength(1);
+  });
+
+  it("keeps the original name of pasted non-generic files", async () => {
+    const onSend = vi.fn().mockResolvedValue(undefined);
+    render(<ChatInput onSend={onSend} />);
+    const textarea = screen.getByTestId("textarea") as HTMLTextAreaElement;
+
+    const pdf = new File(["pdf-bytes"], "report.pdf", {
+      type: "application/pdf",
+    });
+    pasteFiles(textarea, [pdf]);
+    fireEvent.submit(textarea.closest("form")!);
+
+    await waitFor(() => {
+      expect(onSend).toHaveBeenCalledTimes(1);
+    });
+    expect(onSend.mock.calls[0][1][0].name).toBe("report.pdf");
+  });
+
+  it("gives multiple generic pasted images distinct names", async () => {
+    const onSend = vi.fn().mockResolvedValue(undefined);
+    render(<ChatInput onSend={onSend} />);
+    const textarea = screen.getByTestId("textarea") as HTMLTextAreaElement;
+
+    pasteFiles(textarea, [
+      new File(["a"], "image.png", { type: "image/png" }),
+      new File(["b"], "image.png", { type: "image/png" }),
+    ]);
+    fireEvent.submit(textarea.closest("form")!);
+
+    await waitFor(() => {
+      expect(onSend).toHaveBeenCalledTimes(1);
+    });
+    const files = onSend.mock.calls[0][1] as File[];
+    expect(files).toHaveLength(2);
+    expect(files[0].name).not.toBe(files[1].name);
+  });
+
+  it("prevents the default paste when files are attached", () => {
+    render(<ChatInput onSend={mockOnSend} />);
+    const textarea = screen.getByTestId("textarea");
+    const image = new File(["png-bytes"], "image.png", { type: "image/png" });
+    const notCancelled = pasteFiles(textarea, [image]);
+    expect(notCancelled).toBe(false);
+  });
+
+  it("leaves plain-text paste untouched", () => {
+    const onSend = vi.fn().mockResolvedValue(undefined);
+    render(<ChatInput onSend={onSend} />);
+    const textarea = screen.getByTestId("textarea");
+    const notCancelled = pasteFiles(textarea, []);
+    expect(notCancelled).toBe(true);
+    fireEvent.submit(textarea.closest("form")!);
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it("does not attach pasted files while uploading", () => {
+    const onSend = vi.fn().mockResolvedValue(undefined);
+    render(<ChatInput onSend={onSend} isUploadingFiles />);
+    const textarea = screen.getByTestId("textarea");
+    const image = new File(["png-bytes"], "image.png", { type: "image/png" });
+    const notCancelled = pasteFiles(textarea, [image]);
+    expect(notCancelled).toBe(true);
   });
 });
 

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/helpers.ts
@@ -10,9 +10,14 @@ export function getFilesFromClipboard(
 }
 
 function renameGenericImage(file: File, index: number): File {
-  if (!GENERIC_CLIPBOARD_IMAGE_NAME.test(file.name)) return file;
+  if (
+    !file.type.startsWith("image/") ||
+    !GENERIC_CLIPBOARD_IMAGE_NAME.test(file.name)
+  ) {
+    return file;
+  }
   const extension = file.name.split(".").pop();
-  const stamp = new Date().toISOString().slice(0, 19).replace(/[T:]/g, "-");
+  const stamp = new Date().toISOString().slice(0, 23).replace(/[T:.]/g, "-");
   const suffix = index > 0 ? `-${index + 1}` : "";
   return new File([file], `pasted-image-${stamp}${suffix}.${extension}`, {
     type: file.type,

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/helpers.ts
@@ -1,3 +1,25 @@
+// Browsers name clipboard screenshots "image.png"; rename so multiple
+// pasted images stay distinguishable in the composer and workspace.
+const GENERIC_CLIPBOARD_IMAGE_NAME = /^image\.\w+$/i;
+
+export function getFilesFromClipboard(
+  clipboardData: DataTransfer | null,
+): File[] {
+  if (!clipboardData) return [];
+  return Array.from(clipboardData.files).map(renameGenericImage);
+}
+
+function renameGenericImage(file: File, index: number): File {
+  if (!GENERIC_CLIPBOARD_IMAGE_NAME.test(file.name)) return file;
+  const extension = file.name.split(".").pop();
+  const stamp = new Date().toISOString().slice(0, 19).replace(/[T:]/g, "-");
+  const suffix = index > 0 ? `-${index + 1}` : "";
+  return new File([file], `pasted-image-${stamp}${suffix}.${extension}`, {
+    type: file.type,
+    lastModified: file.lastModified,
+  });
+}
+
 export function formatElapsedTime(ms: number): string {
   const seconds = Math.floor(ms / 1000);
   const minutes = Math.floor(seconds / 60);


### PR DESCRIPTION
### Why / What / How

**Why:** Users sharing a screenshot with CoPilot currently have to save it to disk, click the "+" button, and pick the file. Pasting an image straight from the clipboard (Ctrl/Cmd+V) — standard UX in ChatGPT, Claude, Slack, Discord — did nothing. Fixes OPEN-3151.

**What:** Pasting into the CoPilot chat input now attaches clipboard files (screenshots, copied images, files copied from the OS) to the message being composed, reusing the exact same local-attachment flow as the "+" menu and drag-and-drop. Plain-text paste is untouched.

**How:** A `handlePaste` handler on the composer textarea reads `ClipboardEvent.clipboardData.files`. When files are present it prevents the default paste and appends them to the existing `attachments` state (`kind: "local"`), so upload, validation (max 10 files / 100MB in `useSendMessage`), chips display, and multimodal handling all work unchanged. Generic clipboard screenshot names (`image.png`) are renamed to timestamped `pasted-image-…` names so multiple pastes stay distinguishable. Paste-attach is ignored while the composer is busy (disabled/streaming/uploading), matching the disabled "+" menu.

### Changes 🏗️

- `ChatInput.tsx`: add `handlePaste` wired to `PromptInputTextarea`'s `onPaste`; attaches clipboard files via the existing `handleFilesSelected` path
- `helpers.ts`: add `getFilesFromClipboard` — extracts files from the clipboard and renames generic `image.*` names to unique `pasted-image-<timestamp>` names
- `ChatInput.test.tsx`: 7 new integration tests covering paste-attach + send, attachment-only send, name preservation for non-generic files, distinct names for multiple generic images, default-paste prevention, plain-text paste passthrough, and no-attach while uploading

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `pnpm vitest run src/app/(platform)/copilot` — all 106 files / 1352 tests pass, including 7 new clipboard-paste tests
  - [x] `prettier --check`, `next lint`, `tsc --noEmit` all clean
  - [ ] Manual verification on preview: copy a screenshot, focus the CoPilot input, press Ctrl/Cmd+V → image attaches as a chip and sends

<details>
  <summary>Example test plan</summary>

  - [ ] Create from scratch and execute an agent with at least 3 blocks
  - [ ] Import an agent from file upload, and confirm it executes correctly
  - [ ] Upload agent to marketplace
  - [ ] Import an agent from marketplace and confirm it executes correctly
  - [ ] Edit an agent from monitor, and confirm it executes correctly
</details>

#### For configuration changes:

- [ ] `.env.default` is updated or already compatible with my changes
- [ ] `docker-compose.yml` is updated or already compatible with my changes
- [ ] I have included a list of my configuration changes in the PR description (under **Changes**)

<details>
  <summary>Examples of configuration changes</summary>

  - Changing ports
  - Adding new services that need to communicate with each other
  - Secrets or environment variable changes
  - New or infrastructure changes such as databases
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Vb399jnB1hWqSWPi6UPCc

---
_Generated by [Claude Code](https://claude.ai/code/session_019Vb399jnB1hWqSWPi6UPCc)_