### PR TITLE
ci(repo): add /reapprove command to restore dismissed PR approvals

### DIFF
--- a/.github/workflows/repo-pr-reapprove-command.yml
+++ b/.github/workflows/repo-pr-reapprove-command.yml
@@ -1,0 +1,77 @@
+name: repo-pr-reapprove-command
+
+# ChatOps: a team member comments `/reapprove` on a PR whose approval was
+# dismissed by a stale-review dismissal (e.g. after merging dev or pushing a
+# small fix), and the github-actions bot re-approves on their behalf.
+# Deterministic — no AI.
+#
+# Prerequisites:
+#   - Repo (and org) setting "Allow GitHub Actions to create and approve pull
+#     requests" must be enabled (Settings → Actions → General), otherwise the
+#     review-creation call is rejected.
+#   - Like all issue_comment workflows, this only triggers once the file is on
+#     the default branch (master).
+#
+# Notes:
+#   - The bot is its own identity, so `/reapprove` works even on your own PR.
+#     Anyone with write access can therefore bypass a fresh human review —
+#     acceptable for a small trusted team; this is why the permission gate
+#     checks real repo permission and not `author_association` (unreliable in
+#     orgs).
+#   - The bot's approval is itself dismissed by the next push, as intended.
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  reapprove:
+    # PR comments only, and only when the comment starts with `/reapprove`
+    if: >-
+      github.event.issue.pull_request != null &&
+      startsWith(github.event.comment.body, '/reapprove')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify commenter has write access
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: context.payload.comment.user.login,
+            });
+            if (!['admin', 'write'].includes(data.permission)) {
+              core.setFailed(
+                `@${context.payload.comment.user.login} does not have write access ` +
+                `(permission: ${data.permission}) — ignoring /reapprove`,
+              );
+            }
+
+      - name: Approve PR
+        uses: actions/github-script@v8
+        with:
+          script: |
+            await github.rest.pulls.createReview({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+              event: 'APPROVE',
+              body:
+                `Re-approved at the request of @${context.payload.comment.user.login} ` +
+                `(${context.payload.comment.html_url})`,
+            });
+
+      - name: React to command comment
+        uses: actions/github-script@v8
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: '+1',
+            });

--- a/.github/workflows/repo-pr-reapprove-command.yml
+++ b/.github/workflows/repo-pr-reapprove-command.yml
@@ -13,15 +13,22 @@ name: repo-pr-reapprove-command
 #     the default branch (master).
 #
 # Notes:
-#   - Only PRs that already received a human review are eligible: dismissed
-#     reviews stay visible in the reviews API (state DISMISSED), so the guard
-#     requires a prior APPROVED or DISMISSED review from a human. `/reapprove`
-#     can restore a stale approval but never substitute for the first one.
+#   - Only PRs that already received an APPROVED review from a user with write
+#     access are eligible. Dismissed approvals are recovered via the timeline
+#     API (review_dismissed events carry the review's original state), so a
+#     dismissed CHANGES_REQUESTED review does not count, and neither does an
+#     approval from a drive-by user without write access (on a public repo
+#     anyone can submit an APPROVE review). `/reapprove` can restore a
+#     dismissed approval but never substitute for the first one.
+#   - Residual risk (accepted by design): the prior approval is not tied to the
+#     current head SHA, so commits pushed after it get re-approved without a
+#     fresh human review. That is the point of the command — restoring an
+#     approval dismissed by a dev-merge or trivial fix — and relies on team
+#     trust. Merging still goes through the merge queue; the bot approval only
+#     makes the PR eligible for it again.
 #   - The bot is its own identity, so `/reapprove` works even on your own PR.
-#     The permission gate checks real repo permission, not `author_association`
+#     The permission gates check real repo permission, not `author_association`
 #     (unreliable in orgs).
-#   - The bot's approval only makes the PR eligible for the merge queue again;
-#     merging still goes through the queue.
 #   - The bot's approval is itself dismissed by the next push, as intended.
 
 on:
@@ -30,6 +37,8 @@ on:
 
 permissions:
   pull-requests: write
+  # The timeline API used to find dismissed approvals reads the PR as an issue.
+  issues: read
 
 jobs:
   reapprove:
@@ -39,40 +48,67 @@ jobs:
       startsWith(github.event.comment.body, '/reapprove')
     runs-on: ubuntu-latest
     steps:
-      - name: Verify commenter has write access and PR had a human review
+      - name: Verify commenter and a prior approver have write access
         uses: actions/github-script@v8
         with:
           script: |
-            const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              username: context.payload.comment.user.login,
-            });
-            if (!['admin', 'write'].includes(data.permission)) {
-              core.setFailed(
-                `@${context.payload.comment.user.login} does not have write access ` +
-                `(permission: ${data.permission}) — ignoring /reapprove`,
-              );
+            async function hasWriteAccess(username) {
+              try {
+                const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  username,
+                });
+                return ['admin', 'write'].includes(data.permission);
+              } catch {
+                return false;
+              }
+            }
+
+            const commenter = context.payload.comment.user.login;
+            if (!(await hasWriteAccess(commenter))) {
+              core.setFailed(`@${commenter} does not have write access — ignoring /reapprove`);
               return;
             }
 
-            // Stale-dismissed approvals remain listed with state DISMISSED, so
-            // this finds both current and dismissed human approvals. (A rare
-            // manually-dismissed CHANGES_REQUESTED review would also count.)
             const reviews = await github.paginate(github.rest.pulls.listReviews, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: context.issue.number,
             });
-            const humanReview = reviews.some(
-              (r) => r.user?.type !== 'Bot' && ['APPROVED', 'DISMISSED'].includes(r.state),
+            const reviewByID = new Map(reviews.map((r) => [r.id, r]));
+
+            // A review dismissed while APPROVED only shows state DISMISSED in the
+            // reviews API; its original state lives in the review_dismissed
+            // timeline event, so a dismissed CHANGES_REQUESTED review never
+            // counts as a prior approval.
+            const timeline = await github.paginate(github.rest.issues.listEventsForTimeline, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const approvers = new Set(
+              [
+                ...reviews.filter((r) => r.state === 'APPROVED'),
+                ...timeline
+                  .filter((e) => e.event === 'review_dismissed' && e.dismissed_review?.state === 'approved')
+                  .map((e) => reviewByID.get(e.dismissed_review.review_id))
+                  .filter(Boolean),
+              ]
+                .filter((r) => r.user && r.user.type !== 'Bot')
+                .map((r) => r.user.login),
             );
-            if (!humanReview) {
-              core.setFailed(
-                'No prior human approval found on this PR — /reapprove only ' +
-                'restores dismissed approvals, it cannot grant the first one.',
-              );
+
+            // On a public repo anyone can submit an APPROVE review, so the prior
+            // approval only counts when the approver has write access.
+            for (const approver of approvers) {
+              if (await hasWriteAccess(approver)) return;
             }
+            core.setFailed(
+              'No prior approval from a user with write access found — /reapprove ' +
+              'only restores dismissed approvals, it cannot grant the first one.',
+            );
+            return;
 
       - name: Approve PR
         uses: actions/github-script@v8

--- a/.github/workflows/repo-pr-reapprove-command.yml
+++ b/.github/workflows/repo-pr-reapprove-command.yml
@@ -13,11 +13,15 @@ name: repo-pr-reapprove-command
 #     the default branch (master).
 #
 # Notes:
+#   - Only PRs that already received a human review are eligible: dismissed
+#     reviews stay visible in the reviews API (state DISMISSED), so the guard
+#     requires a prior APPROVED or DISMISSED review from a human. `/reapprove`
+#     can restore a stale approval but never substitute for the first one.
 #   - The bot is its own identity, so `/reapprove` works even on your own PR.
-#     Anyone with write access can therefore bypass a fresh human review —
-#     acceptable for a small trusted team; this is why the permission gate
-#     checks real repo permission and not `author_association` (unreliable in
-#     orgs).
+#     The permission gate checks real repo permission, not `author_association`
+#     (unreliable in orgs).
+#   - The bot's approval only makes the PR eligible for the merge queue again;
+#     merging still goes through the queue.
 #   - The bot's approval is itself dismissed by the next push, as intended.
 
 on:
@@ -35,7 +39,7 @@ jobs:
       startsWith(github.event.comment.body, '/reapprove')
     runs-on: ubuntu-latest
     steps:
-      - name: Verify commenter has write access
+      - name: Verify commenter has write access and PR had a human review
         uses: actions/github-script@v8
         with:
           script: |
@@ -48,6 +52,25 @@ jobs:
               core.setFailed(
                 `@${context.payload.comment.user.login} does not have write access ` +
                 `(permission: ${data.permission}) — ignoring /reapprove`,
+              );
+              return;
+            }
+
+            // Stale-dismissed approvals remain listed with state DISMISSED, so
+            // this finds both current and dismissed human approvals. (A rare
+            // manually-dismissed CHANGES_REQUESTED review would also count.)
+            const reviews = await github.paginate(github.rest.pulls.listReviews, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            const humanReview = reviews.some(
+              (r) => r.user?.type !== 'Bot' && ['APPROVED', 'DISMISSED'].includes(r.state),
+            );
+            if (!humanReview) {
+              core.setFailed(
+                'No prior human approval found on this PR — /reapprove only ' +
+                'restores dismissed approvals, it cannot grant the first one.',
               );
             }
 


### PR DESCRIPTION
### Why / What / How

**Why:** Branch protection dismisses PR approvals on every new push. When the push is just a `dev` merge or a trivial fix on an already-approved PR, we end up pinging each other for rubber-stamp re-approvals, which slows down merging. This adds a self-service way to restore a dismissed approval.

**What:** A new ChatOps workflow: commenting `/reapprove` on a PR makes the `github-actions` bot submit an approving review, making the PR eligible for the merge queue again. Merging still goes through the merge queue — nothing bypasses it.

**How:** `issue_comment`-triggered workflow (deterministic, no AI) with two guards before approving:

1. **Commenter permission** — real collaborator-permission lookup (`admin`/`write`), not `author_association` (unreliable in orgs).
2. **Prior approval by a team member with write access** — the PR must already have an `APPROVED` review from a user with write access. Dismissed approvals are recovered via the timeline API (`review_dismissed` events carry the review's original state), so a dismissed `CHANGES_REQUESTED` review does not count, and neither does an `APPROVE` from a drive-by user without write access (anyone can submit one on a public repo). `/reapprove` can restore a dismissed approval but can never grant the first one.

**Residual risk (accepted by design):** the prior approval is not tied to the current head SHA — commits pushed after the approval get re-approved without a fresh human review. That is the entire point of the command (restoring an approval dismissed by a dev-merge or trivial fix) and relies on team trust. The blast radius is bounded: it requires a write-access commenter *and* a prior write-access approval on that PR, the bot approval is itself dismissed by the next push, every use leaves an audit trail (command comment + bot review linking to it), and merging still goes through the merge queue.

The bot's approval is itself dismissed by the next push, as intended.

⚠️ **Activation prerequisites** (for whoever has admin):
- `issue_comment` workflows only run from the default branch, so the command goes live once this reaches `master` via the regular `dev` → `master` flow.
- Repo (and org) setting **"Allow GitHub Actions to create and approve pull requests"** must be enabled under Settings → Actions → General.
- If branch protection ever requires Code Owners review specifically, a bot approval won't satisfy that requirement (only the required-approvals count).

### Changes 🏗️

- Added `.github/workflows/repo-pr-reapprove-command.yml`: `/reapprove` PR-comment command that re-approves via the `github-actions` bot, gated on commenter write access and a prior write-access approval.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [ ] After merge to `master` + enabling the Actions approve setting: comment `/reapprove` on a PR with a dismissed approval → bot approves, 👍 reaction appears
  - [ ] Comment `/reapprove` on a PR with no prior write-access approval → run fails, no approval
  - [ ] Comment `/reapprove` on a PR whose only dismissed review was CHANGES_REQUESTED → run fails, no approval
  - [ ] Comment `/reapprove` as a user without write access → run fails, no approval

#### For configuration changes:

- [x] `.env.default` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes
- [x] I have included a list of my configuration changes in the PR description (under **Changes**)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
