### PR TITLE
feat(backend): org avatar upload endpoint (SECRT-2457)

### DIFF
--- a/autogpt_platform/backend/backend/api/features/orgs/db.py
+++ b/autogpt_platform/backend/backend/api/features/orgs/db.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 from datetime import datetime, timezone
 
+from prisma import Json
 from prisma.errors import UniqueViolationError
 
 from backend.data.db import prisma, transaction
@@ -22,6 +23,26 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 # Utilities
 # ---------------------------------------------------------------------------
+
+
+def _coerce_settings_dict(settings) -> dict:
+    """Parse an Organization.settings value into a mutable dict.
+
+    The column can hold a parsed dict or the raw JSON-string form; anything
+    unrecognized collapses to an empty dict so a read-modify-write never
+    clobbers on malformed input (it just rebuilds from empty).
+    """
+    if isinstance(settings, str):
+        import json
+
+        try:
+            parsed = json.loads(settings)
+        except (json.JSONDecodeError, TypeError):
+            return {}
+        return parsed if isinstance(parsed, dict) else {}
+    if isinstance(settings, dict):
+        return dict(settings)
+    return {}
 
 
 async def _find_personal_org_member(user_id: str):
@@ -320,6 +341,21 @@ async def update_org(org_id: str, data: UpdateOrgData) -> OrgResponse:
         update_dict["description"] = data.description
     if data.avatar_url is not None:
         update_dict["avatarUrl"] = data.avatar_url
+
+    if data.memory_hold_buffer is not None:
+        # Read-modify-write so sibling settings keys survive. Persist to
+        # settings["memory"]["holdBuffer"] — the exact key that
+        # copilot/graphiti/tiers.hold_buffer_enabled reads at write time.
+        settings_org = await prisma.organization.find_unique(where={"id": org_id})
+        if settings_org is None:
+            raise NotFoundError(f"Organization {org_id} not found")
+        settings = _coerce_settings_dict(settings_org.settings)
+        memory = settings.get("memory")
+        if not isinstance(memory, dict):
+            memory = {}
+        memory["holdBuffer"] = data.memory_hold_buffer
+        settings["memory"] = memory
+        update_dict["settings"] = Json(settings)
 
     if data.slug is not None:
         existing = await prisma.organization.find_unique(where={"slug": data.slug})

--- a/autogpt_platform/backend/backend/api/features/orgs/memory_db.py
+++ b/autogpt_platform/backend/backend/api/features/orgs/memory_db.py
@@ -1,0 +1,230 @@
+"""Graphiti read/write for org shared-memory governance (held-memory review).
+
+Org admins review *tentative* ("held") memories that non-admins wrote into the
+org's shared tiers while the hold buffer was on, and either:
+
+- **approve** — ratify the edge ``tentative`` → ``active`` by reusing the dream
+  ratification status-flip (``_promote_if_tentative``); or
+- **reject** — soft-retract the edge by reusing ``memory_forget``'s supersede
+  path (``mark_edges_superseded``), which sets ``expired_at`` + an auditable
+  ``status``/``expiration_reason``.
+
+Scope is strictly the org group (``org_<id>``) plus every team group
+(``team_<id>``) of *this* org. Personal tiers (``user_<id>``) are never
+enumerated or touched here, and a memory id that does not live in one of this
+org's shared tiers is a 404 (cross-org / personal / nonexistent alike).
+"""
+
+import logging
+
+from redis.exceptions import ResponseError
+
+from backend.copilot.dream.ratification import _promote_if_tentative
+from backend.copilot.graphiti.client import derive_org_group_id, derive_team_group_id
+from backend.copilot.graphiti.config import graphiti_config
+from backend.copilot.graphiti.falkordb_driver import AutoGPTFalkorDriver
+from backend.copilot.graphiti.tiers import MemoryTier
+from backend.copilot.tools.graphiti_forget import mark_edges_superseded
+from backend.data.db import prisma
+from backend.util.exceptions import NotFoundError
+
+from .memory_model import HeldMemory, HeldMemoryListResponse, MemoryActionResult
+
+logger = logging.getLogger(__name__)
+
+# Reason stamped on the retracted edge's expiration_reason for the audit trail.
+_REJECT_REASON = "org_admin_reject"
+
+_MISSING_GRAPH_MARKERS = ("no such graph", "does not exist", "invalid graph")
+
+
+def _is_missing_graph_error(exc: BaseException) -> bool:
+    """FalkorDB raises ``ResponseError`` when a group's graph was never
+    populated (an org/team that has stored no shared memory yet)."""
+    if not isinstance(exc, ResponseError):
+        return False
+    msg = str(exc).lower()
+    return any(marker in msg for marker in _MISSING_GRAPH_MARKERS)
+
+
+def _open_driver(group_id: str) -> AutoGPTFalkorDriver:
+    """Read/write-capable, short-lived FalkorDB driver for one group.
+
+    Mirrors the admin memory inspector + ratification pattern: skip full
+    Graphiti client construction (LLM/cross-encoder) and the per-init index
+    task (``build_indices=False``); ``database=group_id`` scopes every query
+    to that tenant's graph.
+    """
+    return AutoGPTFalkorDriver(
+        host=graphiti_config.falkordb_host,
+        port=graphiti_config.falkordb_port,
+        password=graphiti_config.falkordb_password or None,
+        database=group_id,
+        build_indices=False,
+    )
+
+
+async def _org_shared_groups(
+    org_id: str,
+) -> list[tuple[str, MemoryTier, str | None, str | None]]:
+    """The org's shared groups: the org group + every team group of the org.
+
+    Returns ``(group_id, tier, team_id, team_name)`` tuples. A team id that
+    fails group-id sanitization is skipped rather than sinking the whole
+    listing (mirrors tiers.py's per-tier isolation).
+    """
+    groups: list[tuple[str, MemoryTier, str | None, str | None]] = [
+        (derive_org_group_id(org_id), MemoryTier.org, None, None)
+    ]
+    teams = await prisma.team.find_many(where={"orgId": org_id})
+    for team in teams:
+        try:
+            team_group = derive_team_group_id(team.id)
+        except ValueError:
+            logger.warning(
+                "Skipping team %s from held-memory scope: invalid group id",
+                team.id,
+            )
+            continue
+        groups.append((team_group, MemoryTier.team, team.id, team.name))
+    return groups
+
+
+_HELD_LIST_QUERY = """
+MATCH (src:Entity)-[e:RELATES_TO]->(tgt:Entity)
+WHERE e.group_id = $g AND e.status = 'tentative' AND e.expired_at IS NULL
+RETURN e.uuid AS uuid,
+       e.name AS name,
+       e.fact AS fact,
+       e.source_kind AS source_kind,
+       e.provenance AS provenance,
+       toString(e.created_at) AS created_at
+ORDER BY e.created_at DESC
+LIMIT $limit
+"""
+
+_HELD_LOCATE_QUERY = """
+MATCH ()-[e:RELATES_TO {uuid: $u}]->()
+WHERE e.group_id = $g AND e.status = 'tentative' AND e.expired_at IS NULL
+RETURN e.uuid AS uuid
+"""
+
+
+async def _query_group_tentative(group_id: str, limit: int) -> list[dict]:
+    """Tentative, non-retracted edges in one group (empty on a missing graph)."""
+    driver = _open_driver(group_id)
+    try:
+        result = await driver.execute_query(_HELD_LIST_QUERY, g=group_id, limit=limit)
+        return result[0] if result else []
+    except ResponseError as exc:
+        if not _is_missing_graph_error(exc):
+            raise
+        return []
+    finally:
+        await driver.close()
+
+
+async def list_held_memories(org_id: str, limit: int = 50) -> HeldMemoryListResponse:
+    """List tentative memories across the org tier and all its team tiers."""
+    groups = await _org_shared_groups(org_id)
+    items: list[HeldMemory] = []
+    for group_id, tier, team_id, team_name in groups:
+        for row in await _query_group_tentative(group_id, limit):
+            items.append(
+                HeldMemory(
+                    id=str(row.get("uuid", "")),
+                    tier=tier.value,
+                    team_id=team_id,
+                    team_name=team_name,
+                    name=row.get("name"),
+                    fact=row.get("fact"),
+                    created_at=row.get("created_at"),
+                    source_kind=row.get("source_kind"),
+                    provenance=row.get("provenance"),
+                )
+            )
+    # Newest first across the merged tiers, then cap.
+    items.sort(key=lambda h: h.created_at or "", reverse=True)
+    return HeldMemoryListResponse(org_id=org_id, items=items[:limit])
+
+
+async def _locate_held_edge(
+    org_id: str, memory_id: str
+) -> tuple[str, MemoryTier, str | None] | None:
+    """Find which of *this org's* shared groups holds *memory_id* as tentative.
+
+    Returns ``(group_id, tier, team_id)`` or None. Because it only ever opens
+    drivers for this org's groups, a personal or other-org edge is never found
+    → the caller 404s. This is the org-ownership check for approve/reject.
+    """
+    for group_id, tier, team_id, _team_name in await _org_shared_groups(org_id):
+        driver = _open_driver(group_id)
+        try:
+            result = await driver.execute_query(
+                _HELD_LOCATE_QUERY, u=memory_id, g=group_id
+            )
+            rows = result[0] if result else []
+        except ResponseError as exc:
+            if not _is_missing_graph_error(exc):
+                raise
+            rows = []
+        finally:
+            await driver.close()
+        if rows:
+            return group_id, tier, team_id
+    return None
+
+
+async def approve_held_memory(
+    org_id: str, memory_id: str, actor_user_id: str
+) -> MemoryActionResult:
+    """Ratify a held memory (tentative → active) via the dream status-flip."""
+    located = await _locate_held_edge(org_id, memory_id)
+    if located is None:
+        raise NotFoundError(
+            f"Held memory {memory_id} not found in this organization's shared tiers"
+        )
+    group_id, tier, team_id = located
+    driver = _open_driver(group_id)
+    try:
+        applied = await _promote_if_tentative(driver, memory_id)
+    finally:
+        await driver.close()
+    return MemoryActionResult(
+        id=memory_id,
+        action="approve",
+        applied=applied,
+        tier=tier.value,
+        team_id=team_id,
+    )
+
+
+async def reject_held_memory(
+    org_id: str, memory_id: str, actor_user_id: str
+) -> MemoryActionResult:
+    """Retract a held memory via memory_forget's soft-retract (supersede)."""
+    located = await _locate_held_edge(org_id, memory_id)
+    if located is None:
+        raise NotFoundError(
+            f"Held memory {memory_id} not found in this organization's shared tiers"
+        )
+    group_id, tier, team_id = located
+    driver = _open_driver(group_id)
+    try:
+        succeeded, _failed = await mark_edges_superseded(
+            driver,
+            [memory_id],
+            reason=_REJECT_REASON,
+            new_status="superseded",
+            user_id=actor_user_id,
+            group_id=group_id,
+        )
+    finally:
+        await driver.close()
+    return MemoryActionResult(
+        id=memory_id,
+        action="reject",
+        applied=memory_id in succeeded,
+        tier=tier.value,
+        team_id=team_id,
+    )

--- a/autogpt_platform/backend/backend/api/features/orgs/memory_model.py
+++ b/autogpt_platform/backend/backend/api/features/orgs/memory_model.py
@@ -1,0 +1,34 @@
+"""Pydantic models for org shared-memory governance (held-memory review)."""
+
+from pydantic import BaseModel
+
+
+class HeldMemory(BaseModel):
+    """A single tentative ('held') memory edge awaiting org-admin review."""
+
+    id: str  # the RELATES_TO edge uuid
+    tier: str  # "org" | "team"
+    team_id: str | None = None  # set only for team-tier edges
+    team_name: str | None = None
+    name: str | None = None  # extracted relation name (e.g. "works_on")
+    fact: str | None = None  # the fact text
+    created_at: str | None = None
+    # Provenance the write stamped. The edge carries no per-user attribution;
+    # source_kind + provenance (session id) are the available origin signals.
+    source_kind: str | None = None
+    provenance: str | None = None
+
+
+class HeldMemoryListResponse(BaseModel):
+    org_id: str
+    items: list[HeldMemory]
+
+
+class MemoryActionResult(BaseModel):
+    """Result of approving or rejecting a held memory."""
+
+    id: str
+    action: str  # "approve" | "reject"
+    applied: bool  # False when the edge was already resolved (idempotent no-op)
+    tier: str
+    team_id: str | None = None

--- a/autogpt_platform/backend/backend/api/features/orgs/memory_routes.py
+++ b/autogpt_platform/backend/backend/api/features/orgs/memory_routes.py
@@ -1,0 +1,78 @@
+"""Org shared-memory governance routes (nested under /api/orgs/{org_id}/memory).
+
+Org-admin facing review queue for *tentative* ("held") shared memories. Gated
+with ``requires_org_permission(OrgAction.MANAGE_MEMBERS)`` — reviewing and
+ratifying member-submitted org/team memory is a governance action over org
+content, and MANAGE_MEMBERS is the closest management action (resolves to
+{owner, admin}, matching "org admins only"). Personal tiers are never exposed.
+"""
+
+from typing import Annotated
+
+from autogpt_libs.auth import requires_org_permission
+from autogpt_libs.auth.models import RequestContext
+from autogpt_libs.auth.permissions import OrgAction
+from fastapi import APIRouter, HTTPException, Query, Security
+
+from . import memory_db
+from .memory_model import HeldMemoryListResponse, MemoryActionResult
+
+router = APIRouter()
+
+
+def _verify_org_path(ctx: RequestContext, org_id: str) -> None:
+    """MANAGE_MEMBERS only proves the caller administers their *active* org
+    (ctx.org_id); without this an admin of org A could review org B's queue."""
+    if ctx.org_id != org_id:
+        raise HTTPException(403, detail="Not a member of this organization")
+
+
+@router.get(
+    "/held",
+    summary="List held (tentative) shared memories",
+    tags=["orgs", "memory"],
+)
+async def list_held_memories(
+    org_id: str,
+    ctx: Annotated[
+        RequestContext,
+        Security(requires_org_permission(OrgAction.MANAGE_MEMBERS)),
+    ],
+    limit: Annotated[int, Query(ge=1, le=200)] = 50,
+) -> HeldMemoryListResponse:
+    _verify_org_path(ctx, org_id)
+    return await memory_db.list_held_memories(org_id, limit)
+
+
+@router.post(
+    "/held/{memory_id}/approve",
+    summary="Approve a held memory (ratify tentative → active)",
+    tags=["orgs", "memory"],
+)
+async def approve_held_memory(
+    org_id: str,
+    memory_id: str,
+    ctx: Annotated[
+        RequestContext,
+        Security(requires_org_permission(OrgAction.MANAGE_MEMBERS)),
+    ],
+) -> MemoryActionResult:
+    _verify_org_path(ctx, org_id)
+    return await memory_db.approve_held_memory(org_id, memory_id, ctx.user_id)
+
+
+@router.post(
+    "/held/{memory_id}/reject",
+    summary="Reject a held memory (soft-retract)",
+    tags=["orgs", "memory"],
+)
+async def reject_held_memory(
+    org_id: str,
+    memory_id: str,
+    ctx: Annotated[
+        RequestContext,
+        Security(requires_org_permission(OrgAction.MANAGE_MEMBERS)),
+    ],
+) -> MemoryActionResult:
+    _verify_org_path(ctx, org_id)
+    return await memory_db.reject_held_memory(org_id, memory_id, ctx.user_id)

--- a/autogpt_platform/backend/backend/api/features/orgs/memory_routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/orgs/memory_routes_test.py
@@ -1,0 +1,430 @@
+"""Tests for org shared-memory governance.
+
+Two surfaces:
+  1. The holdBuffer settings toggle riding on PATCH /orgs/{org_id}
+     (model default-true read, db read-modify-write preserving siblings,
+     permission gating).
+  2. The held-memory review queue (list / approve / reject) under
+     /orgs/{org_id}/memory, mocked at the graphiti-driver + prisma boundary.
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import fastapi
+import fastapi.testclient
+import pytest
+from autogpt_libs.auth.dependencies import get_request_context
+from autogpt_libs.auth.models import RequestContext
+
+from backend.copilot.graphiti.client import (
+    derive_group_id,
+    derive_org_group_id,
+    derive_team_group_id,
+)
+from backend.util.exceptions import NotFoundError
+
+ORG_ID = "org-aaa"
+OTHER_ORG_ID = "org-bbb"
+TEAM_ID = "team-1"
+USER_ID = "user-owner-1"
+MEM_ID = "edge-uuid-123"
+
+ORG_GROUP = derive_org_group_id(ORG_ID)
+TEAM_GROUP = derive_team_group_id(TEAM_ID)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Context helpers
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _owner_ctx(org_id=ORG_ID, user_id=USER_ID) -> RequestContext:
+    return RequestContext(
+        user_id=user_id,
+        org_id=org_id,
+        team_id=None,
+        is_org_owner=True,
+        is_org_admin=True,
+        is_org_billing_manager=False,
+        is_team_admin=False,
+        is_team_billing_manager=False,
+        seat_status="ACTIVE",
+    )
+
+
+def _member_ctx(org_id=ORG_ID, user_id="user-plain-2") -> RequestContext:
+    return RequestContext(
+        user_id=user_id,
+        org_id=org_id,
+        team_id=None,
+        is_org_owner=False,
+        is_org_admin=False,
+        is_org_billing_manager=False,
+        is_team_admin=False,
+        is_team_billing_manager=False,
+        seat_status="ACTIVE",
+    )
+
+
+def _make_org(*, settings, id=ORG_ID):
+    m = MagicMock()
+    m.id = id
+    m.name = "Acme"
+    m.slug = "acme"
+    m.description = None
+    m.avatarUrl = None
+    m.isPersonal = False
+    m.createdAt = datetime(2025, 6, 1, tzinfo=timezone.utc)
+    m.deletedAt = None
+    m.settings = settings
+    return m
+
+
+def _make_team(*, id=TEAM_ID, name="Engineering", orgId=ORG_ID):
+    m = MagicMock()
+    m.id = id
+    m.name = name
+    m.orgId = orgId
+    return m
+
+
+def _driver_with_rows(*row_batches):
+    """AsyncMock FalkorDB driver returning one (rows, None, None) per call."""
+    driver = AsyncMock()
+    driver.execute_query.side_effect = [(rb, None, None) for rb in row_batches]
+    driver.close = AsyncMock()
+    return driver
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 1. holdBuffer settings toggle
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+class TestHoldBufferModel:
+    def test_defaults_true_when_settings_absent(self):
+        from backend.api.features.orgs.model import OrgResponse
+
+        resp = OrgResponse.from_db(_make_org(settings={}))
+        assert resp.memory_hold_buffer is True
+
+    def test_defaults_true_when_settings_is_empty_json_string(self):
+        from backend.api.features.orgs.model import OrgResponse
+
+        resp = OrgResponse.from_db(_make_org(settings="{}"))
+        assert resp.memory_hold_buffer is True
+
+    def test_reads_false_from_nested_key(self):
+        from backend.api.features.orgs.model import OrgResponse
+
+        resp = OrgResponse.from_db(
+            _make_org(settings={"memory": {"holdBuffer": False}})
+        )
+        assert resp.memory_hold_buffer is False
+
+    def test_reads_false_from_json_string_form(self):
+        from backend.api.features.orgs.model import OrgResponse
+
+        resp = OrgResponse.from_db(
+            _make_org(settings='{"memory": {"holdBuffer": false}}')
+        )
+        assert resp.memory_hold_buffer is False
+
+
+class TestHoldBufferUpdateDb:
+    @pytest.fixture(autouse=True)
+    def _mock_prisma(self, mocker):
+        self.prisma = MagicMock()
+        self.prisma.organizationprofile.update = AsyncMock()
+        mocker.patch("backend.api.features.orgs.db.prisma", self.prisma)
+
+    @pytest.mark.asyncio
+    async def test_write_preserves_sibling_settings_keys(self):
+        from backend.api.features.orgs.db import update_org
+        from backend.api.features.orgs.model import UpdateOrgData
+
+        # Existing settings carry an unrelated key that must survive the write.
+        current = _make_org(
+            settings={"branding": {"color": "blue"}, "memory": {"other": 1}}
+        )
+        self.prisma.organization.find_unique = AsyncMock(return_value=current)
+        self.prisma.organization.update = AsyncMock()
+
+        await update_org(ORG_ID, UpdateOrgData(memory_hold_buffer=False))
+
+        written = self.prisma.organization.update.call_args[1]["data"]["settings"]
+        # prisma.Json wraps the dict; read the payload back.
+        payload = written.data
+        assert payload["branding"] == {"color": "blue"}
+        assert payload["memory"]["other"] == 1
+        assert payload["memory"]["holdBuffer"] is False
+
+    @pytest.mark.asyncio
+    async def test_write_true_sets_hold_buffer_on(self):
+        from backend.api.features.orgs.db import update_org
+        from backend.api.features.orgs.model import UpdateOrgData
+
+        self.prisma.organization.find_unique = AsyncMock(
+            return_value=_make_org(settings={})
+        )
+        self.prisma.organization.update = AsyncMock()
+
+        await update_org(ORG_ID, UpdateOrgData(memory_hold_buffer=True))
+
+        payload = self.prisma.organization.update.call_args[1]["data"]["settings"].data
+        assert payload["memory"]["holdBuffer"] is True
+
+    @pytest.mark.asyncio
+    async def test_none_leaves_settings_untouched(self):
+        from backend.api.features.orgs.db import update_org
+        from backend.api.features.orgs.model import UpdateOrgData
+
+        self.prisma.organization.find_unique = AsyncMock(
+            return_value=_make_org(settings={})
+        )
+        self.prisma.organization.update = AsyncMock()
+
+        # Only a name change — no memory_hold_buffer.
+        await update_org(ORG_ID, UpdateOrgData(name="Renamed"))
+
+        data = self.prisma.organization.update.call_args[1]["data"]
+        assert "settings" not in data
+
+
+class TestHoldBufferPermissionGate:
+    """PATCH /orgs/{org_id} carrying memory_hold_buffer is RENAME_ORG-gated."""
+
+    @pytest.fixture(autouse=True)
+    def _app(self, mocker):
+        from backend.api.features.orgs.routes import router
+
+        self.app = fastapi.FastAPI()
+        self.app.include_router(router, prefix="/orgs")
+        self.mock_db = mocker.patch("backend.api.features.orgs.routes.org_db")
+        self.client = fastapi.testclient.TestClient(self.app)
+        yield
+        self.app.dependency_overrides.clear()
+
+    def test_plain_member_cannot_toggle(self):
+        self.app.dependency_overrides[get_request_context] = lambda: _member_ctx()
+        resp = self.client.patch(f"/orgs/{ORG_ID}", json={"memory_hold_buffer": False})
+        assert resp.status_code == 403
+
+    def test_owner_can_toggle(self):
+        from backend.api.features.orgs.model import OrgResponse
+
+        self.app.dependency_overrides[get_request_context] = lambda: _owner_ctx()
+        self.mock_db.update_org = AsyncMock(
+            return_value=OrgResponse.from_db(
+                _make_org(settings={"memory": {"holdBuffer": False}})
+            )
+        )
+        resp = self.client.patch(f"/orgs/{ORG_ID}", json={"memory_hold_buffer": False})
+        assert resp.status_code == 200
+        assert resp.json()["memory_hold_buffer"] is False
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 2. Held-memory review queue (list / approve / reject)
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+class TestListHeld:
+    @pytest.fixture(autouse=True)
+    def _mock_prisma(self, mocker):
+        self.prisma = MagicMock()
+        mocker.patch("backend.api.features.orgs.memory_db.prisma", self.prisma)
+
+    @pytest.mark.asyncio
+    async def test_returns_org_and_team_tentative_with_tier_labels(self, mocker):
+        from backend.api.features.orgs import memory_db
+
+        self.prisma.team.find_many = AsyncMock(return_value=[_make_team()])
+
+        org_rows = [
+            {
+                "uuid": "org-edge",
+                "name": "policy",
+                "fact": "Company uses Postgres",
+                "source_kind": "user_asserted",
+                "provenance": "session:s1#msg:4",
+                "created_at": "2025-06-02T00:00:00Z",
+            }
+        ]
+        team_rows = [
+            {
+                "uuid": "team-edge",
+                "name": "stack",
+                "fact": "Team ships on Fridays",
+                "source_kind": "assistant_derived",
+                "provenance": "session:s2#msg:9",
+                "created_at": "2025-06-03T00:00:00Z",
+            }
+        ]
+        drivers = [_driver_with_rows(org_rows), _driver_with_rows(team_rows)]
+        open_driver = mocker.patch(
+            "backend.api.features.orgs.memory_db._open_driver",
+            side_effect=drivers,
+        )
+
+        result = await memory_db.list_held_memories(ORG_ID, limit=50)
+
+        # Only THIS org's shared groups were opened — never a personal group.
+        opened = [c.args[0] for c in open_driver.call_args_list]
+        assert opened == [ORG_GROUP, TEAM_GROUP]
+        assert derive_group_id(USER_ID) not in opened
+
+        by_id = {h.id: h for h in result.items}
+        assert by_id["org-edge"].tier == "org"
+        assert by_id["org-edge"].team_id is None
+        assert by_id["team-edge"].tier == "team"
+        assert by_id["team-edge"].team_id == TEAM_ID
+        assert by_id["team-edge"].team_name == "Engineering"
+        # Newest first across tiers.
+        assert result.items[0].id == "team-edge"
+
+    @pytest.mark.asyncio
+    async def test_only_scans_this_orgs_teams(self, mocker):
+        from backend.api.features.orgs import memory_db
+
+        # find_many is filtered by orgId — other orgs' teams never appear.
+        self.prisma.team.find_many = AsyncMock(return_value=[])
+        open_driver = mocker.patch(
+            "backend.api.features.orgs.memory_db._open_driver",
+            side_effect=[_driver_with_rows([])],
+        )
+
+        await memory_db.list_held_memories(ORG_ID, limit=50)
+
+        assert self.prisma.team.find_many.call_args[1]["where"] == {"orgId": ORG_ID}
+        opened = [c.args[0] for c in open_driver.call_args_list]
+        assert opened == [ORG_GROUP]
+        assert derive_org_group_id(OTHER_ORG_ID) not in opened
+
+
+class TestApproveReject:
+    @pytest.fixture(autouse=True)
+    def _mock_prisma(self, mocker):
+        self.prisma = MagicMock()
+        mocker.patch("backend.api.features.orgs.memory_db.prisma", self.prisma)
+        # No teams → only the org group is in scope, simplifying driver order.
+        self.prisma.team.find_many = AsyncMock(return_value=[])
+
+    @pytest.mark.asyncio
+    async def test_approve_flips_status_via_ratification_path(self, mocker):
+        from backend.api.features.orgs import memory_db
+
+        locate_driver = _driver_with_rows([{"uuid": MEM_ID}])  # found tentative
+        promote_driver = _driver_with_rows([{"uuid": MEM_ID}])  # promote touched row
+        mocker.patch(
+            "backend.api.features.orgs.memory_db._open_driver",
+            side_effect=[locate_driver, promote_driver],
+        )
+
+        result = await memory_db.approve_held_memory(ORG_ID, MEM_ID, USER_ID)
+
+        assert result.applied is True
+        assert result.action == "approve"
+        assert result.tier == "org"
+        # The promote reused the ratification status-flip Cypher.
+        promote_query = promote_driver.execute_query.call_args.args[0]
+        assert "SET e.status = 'active'" in promote_query
+        assert "ratified_at" in promote_query
+
+    @pytest.mark.asyncio
+    async def test_reject_retracts_via_supersede_path(self, mocker):
+        from backend.api.features.orgs import memory_db
+
+        locate_driver = _driver_with_rows([{"uuid": MEM_ID}])
+        retract_driver = _driver_with_rows([{"uuid": MEM_ID}])
+        mocker.patch(
+            "backend.api.features.orgs.memory_db._open_driver",
+            side_effect=[locate_driver, retract_driver],
+        )
+
+        result = await memory_db.reject_held_memory(ORG_ID, MEM_ID, USER_ID)
+
+        assert result.applied is True
+        assert result.action == "reject"
+        call = retract_driver.execute_query.call_args
+        query = call.args[0]
+        assert "SET e.expired_at" in query
+        assert "e.status = $new_status" in query
+        # Tenant-scoped defense-in-depth + audit reason were passed through.
+        assert call.kwargs["new_status"] == "superseded"
+        assert call.kwargs["group_id"] == ORG_GROUP
+
+    @pytest.mark.asyncio
+    async def test_approve_cross_org_memory_id_404s(self, mocker):
+        from backend.api.features.orgs import memory_db
+
+        # Edge lives in no group of this org → locate returns nothing.
+        mocker.patch(
+            "backend.api.features.orgs.memory_db._open_driver",
+            side_effect=[_driver_with_rows([])],
+        )
+
+        with pytest.raises(NotFoundError):
+            await memory_db.approve_held_memory(ORG_ID, "foreign-edge", USER_ID)
+
+    @pytest.mark.asyncio
+    async def test_reject_cross_org_memory_id_404s(self, mocker):
+        from backend.api.features.orgs import memory_db
+
+        mocker.patch(
+            "backend.api.features.orgs.memory_db._open_driver",
+            side_effect=[_driver_with_rows([])],
+        )
+
+        with pytest.raises(NotFoundError):
+            await memory_db.reject_held_memory(ORG_ID, "foreign-edge", USER_ID)
+
+
+class TestHeldRoutePermissions:
+    """All three endpoints are MANAGE_MEMBERS-gated (org admins only)."""
+
+    @pytest.fixture(autouse=True)
+    def _app(self, mocker):
+        from backend.api.features.orgs.memory_routes import router
+
+        self.app = fastapi.FastAPI()
+        self.app.include_router(router, prefix="/orgs/{org_id}/memory")
+        self.mock_db = mocker.patch("backend.api.features.orgs.memory_routes.memory_db")
+        self.client = fastapi.testclient.TestClient(self.app)
+        yield
+        self.app.dependency_overrides.clear()
+
+    def test_non_admin_cannot_list(self):
+        self.app.dependency_overrides[get_request_context] = lambda: _member_ctx()
+        resp = self.client.get(f"/orgs/{ORG_ID}/memory/held")
+        assert resp.status_code == 403
+
+    def test_non_admin_cannot_approve(self):
+        self.app.dependency_overrides[get_request_context] = lambda: _member_ctx()
+        resp = self.client.post(f"/orgs/{ORG_ID}/memory/held/{MEM_ID}/approve")
+        assert resp.status_code == 403
+
+    def test_non_admin_cannot_reject(self):
+        self.app.dependency_overrides[get_request_context] = lambda: _member_ctx()
+        resp = self.client.post(f"/orgs/{ORG_ID}/memory/held/{MEM_ID}/reject")
+        assert resp.status_code == 403
+
+    def test_admin_of_other_org_cannot_reach_this_orgs_queue(self):
+        # Owner, but of a DIFFERENT org than the path — _verify_org_path blocks.
+        self.app.dependency_overrides[get_request_context] = lambda: _owner_ctx(
+            org_id=OTHER_ORG_ID
+        )
+        resp = self.client.get(f"/orgs/{ORG_ID}/memory/held")
+        assert resp.status_code == 403
+
+    def test_admin_can_list(self):
+        from backend.api.features.orgs.memory_model import HeldMemoryListResponse
+
+        self.app.dependency_overrides[get_request_context] = lambda: _owner_ctx()
+        self.mock_db.list_held_memories = AsyncMock(
+            return_value=HeldMemoryListResponse(org_id=ORG_ID, items=[])
+        )
+        resp = self.client.get(f"/orgs/{ORG_ID}/memory/held")
+        assert resp.status_code == 200
+        assert resp.json() == {"org_id": ORG_ID, "items": []}

--- a/autogpt_platform/backend/backend/api/features/orgs/model.py
+++ b/autogpt_platform/backend/backend/api/features/orgs/model.py
@@ -18,6 +18,10 @@ class UpdateOrgRequest(BaseModel):
     slug: str | None = Field(None, pattern=r"^[a-z0-9][a-z0-9-]*$")
     description: str | None = None
     avatar_url: str | None = None
+    # Shared-memory hold buffer toggle. None → leave unchanged. Persisted to
+    # Organization.settings["memory"]["holdBuffer"] — the exact key
+    # copilot/graphiti/tiers.hold_buffer_enabled reads.
+    memory_hold_buffer: bool | None = None
 
 
 class UpdateOrgData(BaseModel):
@@ -30,6 +34,31 @@ class UpdateOrgData(BaseModel):
     slug: str | None = None
     description: str | None = None
     avatar_url: str | None = None
+    memory_hold_buffer: bool | None = None
+
+
+def _hold_buffer_from_settings(settings) -> bool:
+    """Read ``settings["memory"]["holdBuffer"]``, defaulting to True.
+
+    Mirrors ``copilot/graphiti/tiers.hold_buffer_enabled`` exactly (same key
+    path, same default) so the API surfaces the value the shared-write
+    governance path actually enforces. Any missing/malformed setting → True
+    (the safer, review-gated default). Handles both a parsed dict and the raw
+    JSON-string form the settings column can hold.
+    """
+    if isinstance(settings, str):
+        import json
+
+        try:
+            settings = json.loads(settings)
+        except (json.JSONDecodeError, TypeError):
+            return True
+    if not isinstance(settings, dict):
+        return True
+    memory = settings.get("memory")
+    if not isinstance(memory, dict):
+        return True
+    return bool(memory.get("holdBuffer", True))
 
 
 class OrgResponse(BaseModel):
@@ -41,6 +70,8 @@ class OrgResponse(BaseModel):
     is_personal: bool
     member_count: int
     created_at: datetime
+    # Reflects Organization.settings["memory"]["holdBuffer"]; True when absent.
+    memory_hold_buffer: bool = True
 
     @staticmethod
     def from_db(org, member_count: int = 0) -> "OrgResponse":
@@ -53,6 +84,9 @@ class OrgResponse(BaseModel):
             is_personal=org.isPersonal,
             member_count=member_count,
             created_at=org.createdAt,
+            memory_hold_buffer=_hold_buffer_from_settings(
+                getattr(org, "settings", None)
+            ),
         )
 
 

--- a/autogpt_platform/backend/backend/api/features/orgs/model.py
+++ b/autogpt_platform/backend/backend/api/features/orgs/model.py
@@ -117,6 +117,17 @@ class CreateAliasRequest(BaseModel):
     )
 
 
+class TeamSpendBucket(BaseModel):
+    team_id: str | None
+    team_name: str | None
+    total_spent: int
+    transaction_count: int
+
+
+class OrgSpendResponse(BaseModel):
+    teams: list[TeamSpendBucket]
+
+
 class CreateInvitationRequest(BaseModel):
     email: str
     is_admin: bool = False

--- a/autogpt_platform/backend/backend/api/features/orgs/routes.py
+++ b/autogpt_platform/backend/backend/api/features/orgs/routes.py
@@ -1,5 +1,6 @@
 """Organization management API routes."""
 
+import os
 from typing import Annotated
 
 from autogpt_libs.auth import (
@@ -10,7 +11,10 @@ from autogpt_libs.auth import (
 )
 from autogpt_libs.auth.models import RequestContext
 from autogpt_libs.auth.permissions import OrgAction
-from fastapi import APIRouter, HTTPException, Security
+from fastapi import APIRouter, HTTPException, Security, UploadFile
+
+from backend.api.features.store import exceptions as store_exceptions
+from backend.api.features.store import media as store_media
 
 from . import db as org_db
 from .model import (
@@ -106,6 +110,59 @@ async def update_org(
             avatar_url=request.avatar_url,
         ),
     )
+
+
+_AVATAR_ALLOWED_EXTENSIONS = {".jpg", ".jpeg", ".png", ".gif", ".webp"}
+
+
+@router.post(
+    "/{org_id}/avatar",
+    summary="Upload organization avatar",
+    tags=["orgs"],
+)
+async def upload_org_avatar(
+    org_id: str,
+    file: UploadFile,
+    ctx: Annotated[
+        RequestContext,
+        Security(requires_org_permission(OrgAction.RENAME_ORG)),
+    ],
+) -> OrgResponse:
+    """Upload an avatar image for the organization and persist its URL.
+
+    The storage path is derived server-side from the verified org id; the
+    client-supplied filename is only used for extension validation.
+    """
+    _verify_org_path(ctx, org_id)
+
+    if file.content_type not in store_media.ALLOWED_IMAGE_TYPES:
+        raise HTTPException(
+            400,
+            detail=(
+                "Avatar must be an image; allowed content types: "
+                f"{', '.join(sorted(store_media.ALLOWED_IMAGE_TYPES))}"
+            ),
+        )
+    extension = os.path.splitext(file.filename or "")[1].lower()
+    if extension not in _AVATAR_ALLOWED_EXTENSIONS:
+        raise HTTPException(
+            400,
+            detail=(
+                "Avatar file extension must be one of: "
+                f"{', '.join(sorted(_AVATAR_ALLOWED_EXTENSIONS))}"
+            ),
+        )
+
+    try:
+        avatar_url = await store_media.upload_media(
+            user_id=ctx.user_id, file=file, organization_id=org_id
+        )
+    except store_exceptions.MediaUploadError as e:
+        # Same 400 the global ValueError handler produces on the main app;
+        # raised explicitly so the route is self-contained.
+        raise HTTPException(400, detail=str(e)) from e
+
+    return await org_db.update_org(org_id, UpdateOrgData(avatar_url=avatar_url))
 
 
 @router.delete(

--- a/autogpt_platform/backend/backend/api/features/orgs/routes.py
+++ b/autogpt_platform/backend/backend/api/features/orgs/routes.py
@@ -1,5 +1,6 @@
 """Organization management API routes."""
 
+from datetime import datetime
 from typing import Annotated
 
 from autogpt_libs.auth import (
@@ -10,7 +11,9 @@ from autogpt_libs.auth import (
 )
 from autogpt_libs.auth.models import RequestContext
 from autogpt_libs.auth.permissions import OrgAction
-from fastapi import APIRouter, HTTPException, Security
+from fastapi import APIRouter, HTTPException, Query, Security
+
+from backend.data.org_credit import get_org_spend_by_team
 
 from . import db as org_db
 from .model import (
@@ -20,6 +23,8 @@ from .model import (
     OrgAliasResponse,
     OrgMemberResponse,
     OrgResponse,
+    OrgSpendResponse,
+    TeamSpendBucket,
     TransferOwnershipRequest,
     UpdateMemberRequest,
     UpdateOrgData,
@@ -237,6 +242,36 @@ async def transfer_ownership(
 ) -> None:
     _verify_org_path(ctx, org_id)
     await org_db.transfer_ownership(org_id, ctx.user_id, request.new_owner_id)
+
+
+# --- Spend ---
+
+
+@router.get(
+    "/{org_id}/spend",
+    summary="Per-team spend breakdown",
+    tags=["orgs"],
+)
+async def get_org_spend(
+    org_id: str,
+    ctx: Annotated[
+        RequestContext,
+        Security(requires_org_permission(OrgAction.MANAGE_BILLING)),
+    ],
+    from_time: Annotated[datetime | None, Query(alias="from")] = None,
+    to_time: Annotated[datetime | None, Query(alias="to")] = None,
+) -> OrgSpendResponse:
+    """Credits spent by the org, grouped by the team each debit was attributed to.
+
+    Requires org-level MANAGE_BILLING (owner or billing_manager). Usage with no
+    team attribution — org-home spend and legacy personal-org migrations — is
+    reported in a single bucket with ``team_id = null``.
+    """
+    _verify_org_path(ctx, org_id)
+    buckets = await get_org_spend_by_team(
+        org_id, start_time=from_time, end_time=to_time
+    )
+    return OrgSpendResponse(teams=[TeamSpendBucket(**bucket) for bucket in buckets])
 
 
 # --- Aliases ---

--- a/autogpt_platform/backend/backend/api/features/orgs/routes.py
+++ b/autogpt_platform/backend/backend/api/features/orgs/routes.py
@@ -104,6 +104,7 @@ async def update_org(
             slug=request.slug,
             description=request.description,
             avatar_url=request.avatar_url,
+            memory_hold_buffer=request.memory_hold_buffer,
         ),
     )
 

--- a/autogpt_platform/backend/backend/api/features/orgs/routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/orgs/routes_test.py
@@ -823,6 +823,150 @@ class TestOrgRoutes:
         assert exc_info.value.status_code == 403
 
 
+class TestOrgAvatarUpload:
+    """HTTP-level tests for POST /orgs/{org_id}/avatar.
+
+    Storage (store_media.upload_media) and the DB layer are mocked; the
+    permission gate runs for real against an overridden RequestContext.
+    """
+
+    PNG_BYTES = b"\x89PNG\r\n\x1a\n" + b"\x00" * 16
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, mocker):
+        from backend.api.features.orgs.routes import router as org_router
+
+        self.app = fastapi.FastAPI()
+        self.app.include_router(org_router, prefix="/orgs")
+
+        self.mock_db = mocker.patch("backend.api.features.orgs.routes.org_db")
+        self.mock_upload = mocker.patch(
+            "backend.api.features.orgs.routes.store_media.upload_media",
+            new_callable=AsyncMock,
+            return_value=(
+                f"https://storage.googleapis.com/bucket/orgs/{ORG_ID}/images/av.png"
+            ),
+        )
+
+        self.client = fastapi.testclient.TestClient(self.app)
+        yield
+        self.app.dependency_overrides.clear()
+
+    def _authenticate_as(self, ctx):
+        from autogpt_libs.auth import get_request_context
+
+        self.app.dependency_overrides[get_request_context] = lambda: ctx
+
+    def _post_avatar(
+        self,
+        org_id=ORG_ID,
+        filename="logo.png",
+        content=None,
+        content_type="image/png",
+    ):
+        return self.client.post(
+            f"/orgs/{org_id}/avatar",
+            files={"file": (filename, content or self.PNG_BYTES, content_type)},
+        )
+
+    def test_admin_upload_persists_and_returns_avatar_url(self):
+        from backend.api.features.orgs.model import OrgResponse
+
+        expected_url = self.mock_upload.return_value
+        self.mock_db.update_org = AsyncMock(
+            return_value=OrgResponse(
+                id=ORG_ID,
+                name="Acme",
+                slug="acme",
+                avatar_url=expected_url,
+                description=None,
+                is_personal=False,
+                member_count=1,
+                created_at=FIXED_NOW,
+            )
+        )
+        self._authenticate_as(_owner_ctx())
+
+        resp = self._post_avatar()
+
+        assert resp.status_code == 200
+        assert resp.json()["avatar_url"] == expected_url
+
+        # Storage path is scoped to the verified org id server-side
+        upload_kwargs = self.mock_upload.call_args.kwargs
+        assert upload_kwargs["organization_id"] == ORG_ID
+        assert upload_kwargs["user_id"] == USER_ID
+
+        # URL persisted on the org via the structured update model
+        org_id_arg, update_data = self.mock_db.update_org.call_args.args
+        assert org_id_arg == ORG_ID
+        assert update_data.avatar_url == expected_url
+
+    def test_plain_member_upload_returns_403(self):
+        self._authenticate_as(_member_ctx())
+
+        resp = self._post_avatar()
+
+        assert resp.status_code == 403
+        assert "Missing org permission" in resp.json()["detail"]
+        self.mock_upload.assert_not_called()
+
+    def test_upload_targeting_org_outside_context_returns_403(self):
+        """Admin of org-other cannot upload an avatar for ORG_ID via the path."""
+        self._authenticate_as(_owner_ctx(org_id="org-other"))
+
+        resp = self._post_avatar(org_id=ORG_ID)
+
+        assert resp.status_code == 403
+        assert "Not a member" in resp.json()["detail"]
+        self.mock_upload.assert_not_called()
+
+    def test_non_image_content_type_returns_400(self):
+        self._authenticate_as(_owner_ctx())
+
+        resp = self._post_avatar(
+            filename="notes.txt", content=b"hello", content_type="text/plain"
+        )
+
+        assert resp.status_code == 400
+        assert "must be an image" in resp.json()["detail"]
+        self.mock_upload.assert_not_called()
+
+    def test_image_content_type_with_disallowed_extension_returns_400(self):
+        """image/* content type with an extension outside the allowlist (e.g.
+        .svg) is rejected before any storage call."""
+        self._authenticate_as(_owner_ctx())
+
+        resp = self._post_avatar(filename="sneaky.svg")
+
+        assert resp.status_code == 400
+        assert "extension" in resp.json()["detail"]
+        self.mock_upload.assert_not_called()
+
+    def test_oversized_upload_returns_400_and_persists_nothing(self):
+        from backend.api.features.store import exceptions as store_exceptions
+
+        self.mock_upload.side_effect = store_exceptions.FileSizeTooLargeError(
+            "File too large. Maximum size is 50MB"
+        )
+        self._authenticate_as(_owner_ctx())
+
+        resp = self._post_avatar()
+
+        assert resp.status_code == 400
+        assert "too large" in resp.json()["detail"].lower()
+        self.mock_db.update_org.assert_not_called()
+
+    def test_org_response_carries_avatar_url(self):
+        from backend.api.features.orgs.model import OrgResponse
+
+        org = _make_org(avatarUrl="https://cdn.example.com/logo.png")
+
+        model = OrgResponse.from_db(org, member_count=3)
+
+        assert model.avatar_url == "https://cdn.example.com/logo.png"
+
+
 # ═══════════════════════════════════════════════════════════════════════════════
 # 2. WORKSPACE CRUD (team_db.py)
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/autogpt_platform/backend/backend/api/features/orgs/spend_test.py
+++ b/autogpt_platform/backend/backend/api/features/orgs/spend_test.py
@@ -1,0 +1,183 @@
+"""Tests for the org-scoped per-team spend breakdown route.
+
+SECRT-2450: ``GET /orgs/{org_id}/spend`` aggregates the org's ``USAGE`` (debit)
+ledger by the team each debit was attributed to. It must require org-level
+``MANAGE_BILLING`` (owner or billing_manager); a plain member is rejected with
+403. Usage with no team attribution (org-home / legacy migrations) forms a
+single NULL-team bucket, top-ups are never counted as spend, and
+``total_spent`` is reported as a positive magnitude of credits spent.
+"""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import fastapi
+import fastapi.testclient
+import pytest
+import pytest_mock
+from autogpt_libs.auth.dependencies import get_request_context
+from autogpt_libs.auth.jwt_utils import get_jwt_payload
+from autogpt_libs.auth.models import RequestContext
+from prisma.enums import CreditTransactionType
+
+from .routes import router
+
+ORG_ID = "test-org"
+
+app = fastapi.FastAPI()
+app.include_router(router, prefix="/orgs")
+client = fastapi.testclient.TestClient(app)
+
+
+def _ctx(
+    user_id: str,
+    *,
+    owner: bool = False,
+    admin: bool = False,
+    billing: bool = False,
+    org_id: str = ORG_ID,
+) -> RequestContext:
+    return RequestContext(
+        user_id=user_id,
+        org_id=org_id,
+        team_id=None,
+        is_org_owner=owner,
+        is_org_admin=admin,
+        is_org_billing_manager=billing,
+        is_team_admin=False,
+        is_team_billing_manager=False,
+        seat_status="ACTIVE",
+    )
+
+
+# role -> (RequestContext role flags, expected HTTP status).
+# MANAGE_BILLING is owner or billing_manager only; a plain member is rejected.
+ROLE_CASES: dict[str, tuple[dict, int]] = {
+    "org_owner": (dict(owner=True, admin=True), 200),
+    "billing_manager": (dict(billing=True), 200),
+    "plain_member": (dict(), 403),
+}
+
+
+@pytest.fixture(autouse=True)
+def _auth(mock_jwt_user):
+    app.dependency_overrides[get_jwt_payload] = mock_jwt_user["get_jwt_payload"]
+    yield
+    app.dependency_overrides.clear()
+
+
+def _team(team_id: str, name: str) -> SimpleNamespace:
+    # ``name`` is a reserved Mock kwarg, so use a plain namespace for the
+    # id/name attributes the aggregation reads.
+    return SimpleNamespace(id=team_id, name=name)
+
+
+@pytest.fixture
+def spend_prisma(mocker: pytest_mock.MockFixture):
+    """Patch the prisma client used by the spend aggregation.
+
+    ``group_by`` returns two attributed team buckets plus a NULL-team bucket,
+    each with a negative USAGE ``_sum`` (a debit); ``find_many`` resolves the
+    two team names.
+    """
+    prisma = MagicMock()
+    prisma.orgcredittransaction.group_by = AsyncMock(
+        return_value=[
+            {"teamId": "team-a", "_sum": {"amount": -300}, "_count": {"_all": 3}},
+            {"teamId": "team-b", "_sum": {"amount": -150}, "_count": {"_all": 2}},
+            {"teamId": None, "_sum": {"amount": -50}, "_count": {"_all": 1}},
+        ]
+    )
+    prisma.team.find_many = AsyncMock(
+        return_value=[_team("team-a", "Alpha"), _team("team-b", "Bravo")]
+    )
+    mocker.patch("backend.data.org_credit.prisma", prisma)
+    return prisma
+
+
+def _use_role(role: str, user_id: str) -> int:
+    flags, expected = ROLE_CASES[role]
+    ctx = _ctx(user_id, **flags)
+
+    async def _override() -> RequestContext:
+        return ctx
+
+    app.dependency_overrides[get_request_context] = _override
+    return expected
+
+
+@pytest.mark.parametrize("role", list(ROLE_CASES))
+def test_spend_requires_manage_billing(role, test_user_id, spend_prisma):
+    expected = _use_role(role, test_user_id)
+
+    resp = client.get(f"/orgs/{ORG_ID}/spend")
+
+    assert resp.status_code == expected
+    if expected == 403:
+        # The gate rejects during dependency resolution, before the route body
+        # ever runs the aggregation query.
+        spend_prisma.orgcredittransaction.group_by.assert_not_awaited()
+
+
+def test_spend_aggregation_shape(test_user_id, spend_prisma):
+    _use_role("org_owner", test_user_id)
+
+    resp = client.get(f"/orgs/{ORG_ID}/spend")
+
+    assert resp.status_code == 200
+    # Highest spend first; USAGE debit sums negated into positive magnitudes;
+    # the NULL-team bucket is preserved with team_name null.
+    assert resp.json()["teams"] == [
+        {
+            "team_id": "team-a",
+            "team_name": "Alpha",
+            "total_spent": 300,
+            "transaction_count": 3,
+        },
+        {
+            "team_id": "team-b",
+            "team_name": "Bravo",
+            "total_spent": 150,
+            "transaction_count": 2,
+        },
+        {
+            "team_id": None,
+            "team_name": None,
+            "total_spent": 50,
+            "transaction_count": 1,
+        },
+    ]
+
+
+def test_spend_empty_history_returns_empty_list(test_user_id, spend_prisma):
+    spend_prisma.orgcredittransaction.group_by = AsyncMock(return_value=[])
+    _use_role("billing_manager", test_user_id)
+
+    resp = client.get(f"/orgs/{ORG_ID}/spend")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"teams": []}
+    # No team ids to resolve -> no second query over the Team table.
+    spend_prisma.team.find_many.assert_not_awaited()
+
+
+def test_spend_time_window_passed_to_query(test_user_id, spend_prisma):
+    _use_role("org_owner", test_user_id)
+
+    resp = client.get(
+        f"/orgs/{ORG_ID}/spend",
+        params={"from": "2026-01-01T00:00:00Z", "to": "2026-02-01T00:00:00Z"},
+    )
+
+    assert resp.status_code == 200
+    where = spend_prisma.orgcredittransaction.group_by.call_args.kwargs["where"]
+    assert where["createdAt"] == {
+        "gte": datetime(2026, 1, 1, tzinfo=timezone.utc),
+        "lte": datetime(2026, 2, 1, tzinfo=timezone.utc),
+    }
+    # Only active USAGE debits for this org are aggregated — top-ups are never
+    # counted as spend.
+    assert where["type"] == CreditTransactionType.USAGE
+    assert where["orgId"] == ORG_ID
+    assert where["isActive"] is True

--- a/autogpt_platform/backend/backend/api/features/store/media.py
+++ b/autogpt_platform/backend/backend/api/features/store/media.py
@@ -61,8 +61,17 @@ async def check_media_exists(user_id: str, filename: str) -> str | None:
 
 
 async def upload_media(
-    user_id: str, file: fastapi.UploadFile, use_file_name: bool = False
+    user_id: str,
+    file: fastapi.UploadFile,
+    use_file_name: bool = False,
+    organization_id: str | None = None,
 ) -> str:
+    """Validate, virus-scan, and upload a media file to GCS.
+
+    When ``organization_id`` is set the file is stored under the org-scoped
+    path ``orgs/{organization_id}/...`` instead of ``users/{user_id}/...``.
+    Both IDs come from the server-side auth context, never from the client.
+    """
     # Get file content for deeper validation
     try:
         content = await file.read(1024)  # Read first 1KB for validation
@@ -167,7 +176,10 @@ async def upload_media(
 
         # Construct storage path
         media_type = "images" if content_type in ALLOWED_IMAGE_TYPES else "videos"
-        storage_path = f"users/{user_id}/{media_type}/{unique_filename}"
+        if organization_id:
+            storage_path = f"orgs/{organization_id}/{media_type}/{unique_filename}"
+        else:
+            storage_path = f"users/{user_id}/{media_type}/{unique_filename}"
 
         try:
             async with async_storage.Storage() as async_client:

--- a/autogpt_platform/backend/backend/api/features/store/media_test.py
+++ b/autogpt_platform/backend/backend/api/features/store/media_test.py
@@ -64,6 +64,27 @@ async def test_upload_media_success(mock_settings, mock_storage_client):
     mock_storage_client.upload.assert_called_once()
 
 
+async def test_upload_media_org_scoped_storage_path(mock_settings, mock_storage_client):
+    """With organization_id set, files land under orgs/{org_id}/ instead of
+    users/{user_id}/ — the org avatar upload path."""
+    test_file = fastapi.UploadFile(
+        filename="logo.png",
+        file=io.BytesIO(b"\x89PNG\r\n\x1a\n"),
+        headers=starlette.datastructures.Headers({"content-type": "image/png"}),
+    )
+
+    result = await store_media.upload_media(
+        "test-user", test_file, organization_id="org-123"
+    )
+
+    assert result.startswith(
+        "https://storage.googleapis.com/test-bucket/orgs/org-123/images/"
+    )
+    assert result.endswith(".png")
+    assert "users/test-user" not in result
+    mock_storage_client.upload.assert_called_once()
+
+
 async def test_upload_media_invalid_type(mock_settings, mock_storage_client):
     test_file = fastapi.UploadFile(
         filename="test.txt",

--- a/autogpt_platform/backend/backend/api/features/v1.py
+++ b/autogpt_platform/backend/backend/api/features/v1.py
@@ -9,9 +9,15 @@ from urllib.parse import urlparse
 
 import pydantic
 import stripe
-from autogpt_libs.auth import get_request_context, get_user_id, requires_user
+from autogpt_libs.auth import (
+    get_request_context,
+    get_user_id,
+    requires_org_permission,
+    requires_user,
+)
 from autogpt_libs.auth.jwt_utils import get_jwt_payload
 from autogpt_libs.auth.models import RequestContext
+from autogpt_libs.auth.permissions import OrgAction
 from fastapi import (
     APIRouter,
     Body,
@@ -646,7 +652,10 @@ async def upload_file(
 )
 async def get_user_credits(
     user_id: Annotated[str, Security(get_user_id)],
-    ctx: Annotated[RequestContext, Security(get_request_context)],
+    ctx: Annotated[
+        RequestContext,
+        Security(requires_org_permission(OrgAction.MANAGE_BILLING)),
+    ],
 ) -> dict[str, int]:
     credit_model = await get_credit_model(user_id, ctx.org_id)
     return {"credits": await credit_model.get_credits(user_id)}
@@ -661,7 +670,10 @@ async def get_user_credits(
 async def request_top_up(
     request: RequestTopUp,
     user_id: Annotated[str, Security(get_user_id)],
-    ctx: Annotated[RequestContext, Security(get_request_context)],
+    ctx: Annotated[
+        RequestContext,
+        Security(requires_org_permission(OrgAction.MANAGE_BILLING)),
+    ],
     x_datafast_visitor_id: Annotated[
         str | None, Header(include_in_schema=False)
     ] = None,
@@ -687,7 +699,10 @@ async def request_top_up(
 )
 async def refund_top_up(
     user_id: Annotated[str, Security(get_user_id)],
-    ctx: Annotated[RequestContext, Security(get_request_context)],
+    ctx: Annotated[
+        RequestContext,
+        Security(requires_org_permission(OrgAction.MANAGE_BILLING)),
+    ],
     transaction_key: str,
     metadata: dict[str, str],
 ) -> int:
@@ -703,7 +718,10 @@ async def refund_top_up(
 )
 async def fulfill_checkout(
     user_id: Annotated[str, Security(get_user_id)],
-    ctx: Annotated[RequestContext, Security(get_request_context)],
+    ctx: Annotated[
+        RequestContext,
+        Security(requires_org_permission(OrgAction.MANAGE_BILLING)),
+    ],
 ):
     credit_model = await get_credit_model(user_id, ctx.org_id)
     await credit_model.fulfill_checkout(user_id=user_id)
@@ -719,7 +737,10 @@ async def fulfill_checkout(
 async def configure_user_auto_top_up(
     request: AutoTopUpConfig,
     user_id: Annotated[str, Security(get_user_id)],
-    ctx: Annotated[RequestContext, Security(get_request_context)],
+    ctx: Annotated[
+        RequestContext,
+        Security(requires_org_permission(OrgAction.MANAGE_BILLING)),
+    ],
 ) -> str:
     """Configure auto top-up settings and perform an immediate top-up if needed.
 
@@ -772,7 +793,10 @@ async def configure_user_auto_top_up(
 )
 async def get_user_auto_top_up(
     user_id: Annotated[str, Security(get_user_id)],
-    ctx: Annotated[RequestContext, Security(get_request_context)],
+    ctx: Annotated[
+        RequestContext,
+        Security(requires_org_permission(OrgAction.MANAGE_BILLING)),
+    ],
 ) -> AutoTopUpConfig:
     return await get_auto_top_up(user_id)
 
@@ -1534,7 +1558,10 @@ async def stripe_webhook(request: Request):
 )
 async def manage_payment_method(
     user_id: Annotated[str, Security(get_user_id)],
-    ctx: Annotated[RequestContext, Security(get_request_context)],
+    ctx: Annotated[
+        RequestContext,
+        Security(requires_org_permission(OrgAction.MANAGE_BILLING)),
+    ],
 ) -> dict[str, str]:
     credit_model = await get_credit_model(user_id, ctx.org_id)
     return {"url": await credit_model.create_billing_portal_session(user_id)}
@@ -1548,7 +1575,10 @@ async def manage_payment_method(
 )
 async def get_credit_history(
     user_id: Annotated[str, Security(get_user_id)],
-    ctx: Annotated[RequestContext, Security(get_request_context)],
+    ctx: Annotated[
+        RequestContext,
+        Security(requires_org_permission(OrgAction.MANAGE_BILLING)),
+    ],
     transaction_time: datetime | None = None,
     transaction_type: str | None = None,
     transaction_count_limit: int = 100,
@@ -1573,7 +1603,10 @@ async def get_credit_history(
 )
 async def get_refund_requests(
     user_id: Annotated[str, Security(get_user_id)],
-    ctx: Annotated[RequestContext, Security(get_request_context)],
+    ctx: Annotated[
+        RequestContext,
+        Security(requires_org_permission(OrgAction.MANAGE_BILLING)),
+    ],
 ) -> list[RefundRequest]:
     credit_model = await get_credit_model(user_id, ctx.org_id)
     return await credit_model.get_refund_requests(user_id)
@@ -1587,7 +1620,10 @@ async def get_refund_requests(
 )
 async def list_invoices(
     user_id: Annotated[str, Security(get_user_id)],
-    ctx: Annotated[RequestContext, Security(get_request_context)],
+    ctx: Annotated[
+        RequestContext,
+        Security(requires_org_permission(OrgAction.MANAGE_BILLING)),
+    ],
     limit: int = Query(24, ge=1, le=100),
 ) -> list[InvoiceListItem]:
     """Recent Stripe invoices for the current user.

--- a/autogpt_platform/backend/backend/api/features/v1_credits_authz_test.py
+++ b/autogpt_platform/backend/backend/api/features/v1_credits_authz_test.py
@@ -1,0 +1,155 @@
+"""Authorization tests for the org-scoped credits routes in v1.py.
+
+SECRT-2449: the credits balance/transaction/invoice/top-up routes resolve
+their credit model through the request's org context, so for a real (pooled)
+org they read/mutate the shared ``OrgBalance``. They must therefore require
+org-level ``MANAGE_BILLING`` (owner or billing_manager) — a plain org member
+must be rejected with 403. Personal-org owners always carry ``is_org_owner``,
+so the gate is a no-op for them.
+"""
+
+from unittest.mock import AsyncMock, Mock
+
+import fastapi
+import fastapi.testclient
+import pytest
+import pytest_mock
+from autogpt_libs.auth.dependencies import get_request_context
+from autogpt_libs.auth.jwt_utils import get_jwt_payload
+from autogpt_libs.auth.models import RequestContext
+
+from backend.data.model import TransactionHistory
+
+from .v1 import v1_router
+
+app = fastapi.FastAPI()
+app.include_router(v1_router)
+client = fastapi.testclient.TestClient(app)
+
+
+def _ctx(
+    user_id: str,
+    *,
+    owner: bool = False,
+    admin: bool = False,
+    billing: bool = False,
+    org_id: str = "test-org",
+) -> RequestContext:
+    return RequestContext(
+        user_id=user_id,
+        org_id=org_id,
+        team_id=None,
+        is_org_owner=owner,
+        is_org_admin=admin,
+        is_org_billing_manager=billing,
+        is_team_admin=False,
+        is_team_billing_manager=False,
+        seat_status="ACTIVE",
+    )
+
+
+# role -> (RequestContext role flags, expected HTTP status).
+# A personal-org owner is the sole member and always holds is_org_owner=True,
+# so it maps to the same passing outcome as a team-org owner.
+ROLE_CASES: dict[str, tuple[dict, int]] = {
+    "org_owner": (dict(owner=True, admin=True), 200),
+    "billing_manager": (dict(billing=True), 200),
+    "plain_member": (dict(), 403),
+    "personal_org_owner": (dict(owner=True, admin=True, org_id="personal-org"), 200),
+}
+
+
+@pytest.fixture(autouse=True)
+def _auth(mock_jwt_user):
+    app.dependency_overrides[get_jwt_payload] = mock_jwt_user["get_jwt_payload"]
+    yield
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def credit_model(mocker: pytest_mock.MockFixture):
+    """Patch get_credit_model with a stub whose methods return valid payloads.
+
+    ``get_credit_model`` is an async function, so ``mocker.patch`` yields an
+    AsyncMock; ``await get_credit_model(...)`` resolves to ``model``.
+    """
+    model = Mock()
+    model.get_credits = AsyncMock(return_value=1000)
+    model.get_transaction_history = AsyncMock(
+        return_value=TransactionHistory(transactions=[], next_transaction_time=None)
+    )
+    model.list_invoices = AsyncMock(return_value=[])
+    model.top_up_intent = AsyncMock(return_value="https://checkout.example.com/s")
+    patched = mocker.patch(
+        "backend.api.features.v1.get_credit_model", return_value=model
+    )
+    return patched, model
+
+
+def _use_role(role: str, user_id: str) -> int:
+    flags, expected = ROLE_CASES[role]
+    ctx = _ctx(user_id, **flags)
+
+    async def _override() -> RequestContext:
+        return ctx
+
+    app.dependency_overrides[get_request_context] = _override
+    return expected
+
+
+@pytest.mark.parametrize("role", list(ROLE_CASES))
+def test_get_user_credits_requires_manage_billing(role, test_user_id, credit_model):
+    patched, _ = credit_model
+    expected = _use_role(role, test_user_id)
+
+    resp = client.get("/credits")
+
+    assert resp.status_code == expected
+    if expected == 200:
+        assert resp.json() == {"credits": 1000}
+    else:
+        # The gate rejects during dependency resolution, before the route body
+        # ever resolves the org credit model.
+        patched.assert_not_awaited()
+
+
+@pytest.mark.parametrize("role", list(ROLE_CASES))
+def test_get_credit_history_requires_manage_billing(role, test_user_id, credit_model):
+    patched, _ = credit_model
+    expected = _use_role(role, test_user_id)
+
+    resp = client.get("/credits/transactions")
+
+    assert resp.status_code == expected
+    if expected == 200:
+        assert resp.json()["transactions"] == []
+    else:
+        patched.assert_not_awaited()
+
+
+@pytest.mark.parametrize("role", list(ROLE_CASES))
+def test_list_invoices_requires_manage_billing(role, test_user_id, credit_model):
+    patched, _ = credit_model
+    expected = _use_role(role, test_user_id)
+
+    resp = client.get("/credits/invoices")
+
+    assert resp.status_code == expected
+    if expected == 200:
+        assert resp.json() == []
+    else:
+        patched.assert_not_awaited()
+
+
+@pytest.mark.parametrize("role", list(ROLE_CASES))
+def test_request_top_up_requires_manage_billing(role, test_user_id, credit_model):
+    patched, _ = credit_model
+    expected = _use_role(role, test_user_id)
+
+    resp = client.post("/credits", json={"credit_amount": 500})
+
+    assert resp.status_code == expected
+    if expected == 200:
+        assert "checkout_url" in resp.json()
+    else:
+        patched.assert_not_awaited()

--- a/autogpt_platform/backend/backend/api/rest_api.py
+++ b/autogpt_platform/backend/backend/api/rest_api.py
@@ -36,6 +36,7 @@ import backend.api.features.library.routes
 import backend.api.features.mcp.routes as mcp_routes
 import backend.api.features.oauth
 import backend.api.features.orgs.invitation_routes
+import backend.api.features.orgs.memory_routes
 import backend.api.features.orgs.routes as org_routes
 import backend.api.features.orgs.team_routes
 import backend.api.features.otto.routes
@@ -466,6 +467,11 @@ app.include_router(
     backend.api.features.orgs.team_routes.router,
     tags=["v2", "orgs", "workspaces"],
     prefix="/api/orgs/{org_id}/workspaces",
+)
+app.include_router(
+    backend.api.features.orgs.memory_routes.router,
+    tags=["v2", "orgs", "memory"],
+    prefix="/api/orgs/{org_id}/memory",
 )
 app.include_router(
     backend.api.features.orgs.invitation_routes.org_router,

--- a/autogpt_platform/backend/backend/copilot/baseline/service.py
+++ b/autogpt_platform/backend/backend/copilot/baseline/service.py
@@ -1784,7 +1784,12 @@ async def stream_chat_completion_baseline(
     if graphiti_enabled and user_id and _pre_drain_msg_count <= 1:
         from backend.copilot.graphiti.context import fetch_warm_context
 
-        warm_ctx = await fetch_warm_context(user_id, message or "")
+        warm_ctx = await fetch_warm_context(
+            user_id,
+            message or "",
+            organization_id=session.organization_id,
+            team_id=session.team_id,
+        )
 
     # Context path: transcript content (compacted, isCompactSummary preserved) +
     # gap (DB messages after watermark) + current user turn.

--- a/autogpt_platform/backend/backend/copilot/graphiti/client.py
+++ b/autogpt_platform/backend/backend/copilot/graphiti/client.py
@@ -46,33 +46,59 @@ def _get_loop_state() -> _LoopState:
     return state
 
 
-def derive_group_id(user_id: str) -> str:
-    """Derive a deterministic, injection-safe group_id from a user_id.
+def _derive_prefixed_group_id(raw_id: str, *, prefix: str, id_label: str) -> str:
+    """Derive a deterministic, injection-safe group_id from an entity id.
 
-    Strips to ``[a-zA-Z0-9_-]``, enforces max length, and prefixes with
-    ``user_``.  Raises if sanitization changed the input.
+    Strips to ``[a-zA-Z0-9_-]``, enforces max length, and applies the
+    tier ``prefix`` (``user_`` / ``team_`` / ``org_``). Raises if
+    sanitization changed the input so a tenant id can never silently
+    collapse into a different tenant's namespace.
     """
-    if not user_id:
-        raise ValueError("user_id must be non-empty to derive group_id")
+    if not raw_id:
+        raise ValueError(f"{id_label} must be non-empty to derive group_id")
 
-    safe_id = re.sub(r"[^a-zA-Z0-9_-]", "", user_id)[:_MAX_GROUP_ID_LEN]
+    safe_id = re.sub(r"[^a-zA-Z0-9_-]", "", raw_id)[:_MAX_GROUP_ID_LEN]
     if not safe_id:
         raise ValueError(
-            f"user_id '{user_id[:32]}...' yields empty group_id after sanitization"
+            f"{id_label} '{raw_id[:32]}...' yields empty group_id after sanitization"
         )
 
-    if safe_id != user_id:
+    if safe_id != raw_id:
         raise ValueError(
-            f"user_id contains invalid characters for group_id derivation "
-            f"(original length={len(user_id)}, sanitized='{safe_id[:32]}'). "
+            f"{id_label} contains invalid characters for group_id derivation "
+            f"(original length={len(raw_id)}, sanitized='{safe_id[:32]}'). "
             f"Only [a-zA-Z0-9_-] are allowed."
         )
 
-    group_id = f"user_{safe_id}"
+    group_id = f"{prefix}{safe_id}"
     if not _GROUP_ID_PATTERN.match(group_id):
         raise ValueError(f"Generated group_id '{group_id}' fails validation")
 
     return group_id
+
+
+def derive_group_id(user_id: str) -> str:
+    """Derive the personal-tier group_id (``user_<id>``) for a user.
+
+    THE chokepoint for personal memory isolation — FalkorDB database
+    name + Redisearch tag filter both key off this value.
+    """
+    return _derive_prefixed_group_id(user_id, prefix="user_", id_label="user_id")
+
+
+def derive_team_group_id(team_id: str) -> str:
+    """Derive the team-tier group_id (``team_<id>``) for a team.
+
+    Same sanitization contract as :func:`derive_group_id`; a distinct
+    prefix guarantees team and personal namespaces can never collide
+    even if a team id and a user id shared the same raw string.
+    """
+    return _derive_prefixed_group_id(team_id, prefix="team_", id_label="team_id")
+
+
+def derive_org_group_id(org_id: str) -> str:
+    """Derive the org-tier group_id (``org_<id>``) for an organization."""
+    return _derive_prefixed_group_id(org_id, prefix="org_", id_label="org_id")
 
 
 def _close_client_driver(client) -> None:

--- a/autogpt_platform/backend/backend/copilot/graphiti/client_test.py
+++ b/autogpt_platform/backend/backend/copilot/graphiti/client_test.py
@@ -7,7 +7,13 @@ import pytest
 from backend.copilot.config import ChatConfig
 
 from . import client as client_mod
-from .client import derive_group_id, evict_client, make_flex_graphiti_client
+from .client import (
+    derive_group_id,
+    derive_org_group_id,
+    derive_team_group_id,
+    evict_client,
+    make_flex_graphiti_client,
+)
 
 
 class TestDeriveGroupId:
@@ -35,6 +41,50 @@ class TestDeriveGroupId:
     def test_hyphens_and_underscores_allowed(self) -> None:
         result = derive_group_id("a-b_c")
         assert result == "user_a-b_c"
+
+
+class TestDeriveTeamGroupId:
+    """Team-tier derivation shares the personal sanitization contract but
+    carries a distinct ``team_`` prefix so team and personal namespaces
+    can never collide."""
+
+    def test_prefixes_with_team(self) -> None:
+        assert derive_team_group_id("team123") == "team_team123"
+
+    def test_uuid_passthrough(self) -> None:
+        tid = "883cc9da-fe37-4863-839b-acba022bf3ef"
+        assert derive_team_group_id(tid) == f"team_{tid}"
+
+    def test_empty_raises(self) -> None:
+        with pytest.raises(ValueError, match="non-empty"):
+            derive_team_group_id("")
+
+    def test_invalid_chars_raise(self) -> None:
+        with pytest.raises(ValueError, match="invalid characters"):
+            derive_team_group_id("team.evil")
+
+    def test_distinct_namespace_from_personal(self) -> None:
+        # Same raw id → different group_ids across tiers (no collision).
+        raw = "collide"
+        assert derive_team_group_id(raw) != derive_group_id(raw)
+        assert derive_team_group_id(raw) != derive_org_group_id(raw)
+
+
+class TestDeriveOrgGroupId:
+    def test_prefixes_with_org(self) -> None:
+        assert derive_org_group_id("org123") == "org_org123"
+
+    def test_uuid_passthrough(self) -> None:
+        oid = "883cc9da-fe37-4863-839b-acba022bf3ef"
+        assert derive_org_group_id(oid) == f"org_{oid}"
+
+    def test_empty_raises(self) -> None:
+        with pytest.raises(ValueError, match="non-empty"):
+            derive_org_group_id("")
+
+    def test_all_invalid_chars_raise(self) -> None:
+        with pytest.raises(ValueError, match="empty group_id after sanitization"):
+            derive_org_group_id("!!!")
 
 
 class TestEvictClient:

--- a/autogpt_platform/backend/backend/copilot/graphiti/context.py
+++ b/autogpt_platform/backend/backend/copilot/graphiti/context.py
@@ -11,18 +11,33 @@ from ._format import (
     extract_fact,
     extract_temporal_validity,
 )
-from .client import derive_group_id, get_graphiti_client
+from .client import get_graphiti_client
 from .config import graphiti_config
+from .tiers import MemoryTier, TierTarget, merge_tiered, resolve_warm_targets
 
 logger = logging.getLogger(__name__)
 
+# Recent-episode budget for warm context, split personal-first across tiers
+# (same >= half rule as facts). Kept small so episodes stay a recency hint,
+# not the bulk of the injected context.
+_WARM_EPISODE_BUDGET = 8
 
-async def fetch_warm_context(user_id: str, message: str) -> str | None:
+
+async def fetch_warm_context(
+    user_id: str,
+    message: str,
+    *,
+    organization_id: str | None = None,
+    team_id: str | None = None,
+) -> str | None:
     """Fetch relevant temporal context for the current user and message.
 
     Called at the start of a session (first turn) to pre-load facts from
-    prior conversations.  Returns a formatted ``<temporal_context>`` block
-    suitable for appending to the system prompt, or ``None`` on failure.
+    prior conversations. Fans out across the personal tier, the org tier
+    (when ``organization_id`` is set), and the SESSION'S team tier (when
+    ``team_id`` is set AND the user is an active member) — merging the
+    results with provenance labels. Returns a formatted
+    ``<temporal_context>`` block, or ``None`` on failure.
 
     Graceful degradation: any error (timeout, connection, graphiti-core bug)
     returns ``None`` so the copilot continues without temporal context.
@@ -32,7 +47,7 @@ async def fetch_warm_context(user_id: str, message: str) -> str | None:
 
     try:
         return await asyncio.wait_for(
-            _fetch(user_id, message),
+            _fetch(user_id, message, organization_id, team_id),
             timeout=graphiti_config.context_timeout,
         )
     except asyncio.TimeoutError:
@@ -46,15 +61,19 @@ async def fetch_warm_context(user_id: str, message: str) -> str | None:
         return None
 
 
-async def _fetch(user_id: str, message: str) -> str | None:
+async def _fetch(
+    user_id: str,
+    message: str,
+    organization_id: str | None = None,
+    team_id: str | None = None,
+) -> str | None:
     # Imported lazily so the module can be imported without graphiti-core
     # installed (matches the pattern in client.py).
     from graphiti_core.search.search_config_recipes import (
         EDGE_HYBRID_SEARCH_CROSS_ENCODER,
     )
 
-    group_id = derive_group_id(user_id)
-    client = await get_graphiti_client(group_id)
+    targets = await resolve_warm_targets(user_id, organization_id, team_id)
 
     # P-1.4: warm context is the single most-impactful retrieval per
     # session — the one place where the cross-encoder rerank earns its
@@ -67,32 +86,69 @@ async def _fetch(user_id: str, message: str) -> str | None:
     search_config = EDGE_HYBRID_SEARCH_CROSS_ENCODER.model_copy(
         update={"limit": graphiti_config.context_max_facts}
     )
-    edge_results, episodes = await asyncio.gather(
-        client.search_(
-            query=message,
-            config=search_config,
-            group_ids=[group_id],
-        ),
-        client.retrieve_episodes(
-            reference_time=datetime.now(timezone.utc),
-            group_ids=[group_id],
-            last_n=5,
-        ),
+    now = datetime.now(timezone.utc)
+
+    async def _fetch_one(target: TierTarget):
+        client = await get_graphiti_client(target.group_id)
+        edge_results, episodes = await asyncio.gather(
+            client.search_(
+                query=message,
+                config=search_config,
+                group_ids=[target.group_id],
+            ),
+            client.retrieve_episodes(
+                reference_time=now,
+                group_ids=[target.group_id],
+                last_n=5,
+            ),
+        )
+        edges = edge_results.edges if edge_results is not None else []
+        return edges, episodes
+
+    # Per-tier failures are non-fatal: a flaky org/team graph must not
+    # nuke the personal warm context. Collect exceptions and skip that tier.
+    results = await asyncio.gather(
+        *(_fetch_one(t) for t in targets), return_exceptions=True
     )
-    edges = edge_results.edges if edge_results is not None else []
 
-    # Ratification sync hit-hook (P0.4 layer-2): every retrieved edge
-    # that's currently ``status='tentative'`` gets promoted to
-    # ``active`` inline, and every retrieved edge bumps its
-    # warm-context hit counter. Fire-and-forget so the chat turn
-    # never blocks on Redis or FalkorDB writes.
-    if edges:
-        _spawn_ratification_hits(user_id, edges)
+    personal_edges: list = []
+    personal_eps: list = []
+    shared_edges: list[tuple[str | None, list]] = []
+    shared_eps: list[tuple[str | None, list]] = []
 
-    if not edges and not episodes:
+    for target, res in zip(targets, results):
+        if isinstance(res, BaseException):
+            logger.warning(
+                "Warm context tier %s failed — skipping",
+                target.group_id[:20],
+                exc_info=res,
+            )
+            continue
+        edges, episodes = res
+        if target.tier == MemoryTier.personal:
+            personal_edges = edges
+            personal_eps = episodes
+        else:
+            shared_edges.append((target.label, edges))
+            shared_eps.append((target.label, episodes))
+
+    # Ratification sync hit-hook (P0.4 layer-2): promotes tentative edges to
+    # active inline + bumps warm-context hit counters. It keys off
+    # ``derive_group_id(user_id)`` (the PERSONAL graph), so it may only ever
+    # see personal edges — shared-tier ratification is an admin concern
+    # (out of scope). Fire-and-forget so the chat turn never blocks.
+    if personal_edges:
+        _spawn_ratification_hits(user_id, personal_edges)
+
+    merged_facts = merge_tiered(
+        personal_edges, shared_edges, graphiti_config.context_max_facts
+    )
+    merged_episodes = merge_tiered(personal_eps, shared_eps, _WARM_EPISODE_BUDGET)
+
+    if not merged_facts and not merged_episodes:
         return None
 
-    return _format_context(edges, episodes)
+    return _format_context(merged_facts, merged_episodes)
 
 
 def _spawn_ratification_hits(user_id: str, edges) -> None:
@@ -115,20 +171,34 @@ def _spawn_ratification_hits(user_id: str, edges) -> None:
     )
 
 
-def _format_context(edges, episodes) -> str | None:
+def _label_prefix(label: str | None) -> str:
+    """Render a provenance label as a bracketed prefix (empty for personal)."""
+    return f"[{label}] " if label else ""
+
+
+def _format_context(labeled_facts, labeled_episodes) -> str | None:
+    """Render merged, provenance-labelled facts + episodes.
+
+    ``labeled_facts`` / ``labeled_episodes`` are ``[(item, label)]`` pairs
+    where ``label`` is ``None`` for personal (rendered plain) or a shared-
+    tier label like ``"org memory"`` / ``"team memory (Platform)"`` that is
+    prefixed so the model can weigh provenance.
+    """
     sections: list[str] = []
 
-    if edges:
+    if labeled_facts:
         fact_lines = []
-        for e in edges:
+        for e, label in labeled_facts:
             valid_from, valid_to = extract_temporal_validity(e)
             fact = extract_fact(e)
-            fact_lines.append(f"  - {fact} ({valid_from} — {valid_to})")
+            fact_lines.append(
+                f"  - {_label_prefix(label)}{fact} ({valid_from} — {valid_to})"
+            )
         sections.append("<FACTS>\n" + "\n".join(fact_lines) + "\n</FACTS>")
 
-    if episodes:
+    if labeled_episodes:
         ep_lines = []
-        for ep in episodes:
+        for ep, label in labeled_episodes:
             # Use raw body (no truncation) for scope parsing — truncated
             # JSON from extract_episode_body() would fail json.loads().
             raw_body = extract_episode_body_raw(ep)
@@ -136,7 +206,7 @@ def _format_context(edges, episodes) -> str | None:
                 continue
             display_body = extract_episode_body(ep)
             ts = extract_episode_timestamp(ep)
-            ep_lines.append(f"  - [{ts}] {display_body}")
+            ep_lines.append(f"  - {_label_prefix(label)}[{ts}] {display_body}")
         if ep_lines:
             sections.append(
                 "<RECENT_EPISODES>\n" + "\n".join(ep_lines) + "\n</RECENT_EPISODES>"

--- a/autogpt_platform/backend/backend/copilot/graphiti/context_test.py
+++ b/autogpt_platform/backend/backend/copilot/graphiti/context_test.py
@@ -39,18 +39,11 @@ class TestFetchWarmContextTimeout:
 class TestFetchWarmContextGeneralError:
     @pytest.mark.asyncio
     async def test_returns_none_on_unexpected_error(self) -> None:
-        with (
-            patch.object(
-                context,
-                "derive_group_id",
-                return_value="user_abc",
-            ),
-            patch.object(
-                context,
-                "get_graphiti_client",
-                new_callable=AsyncMock,
-                side_effect=RuntimeError("connection lost"),
-            ),
+        with patch.object(
+            context,
+            "get_graphiti_client",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("connection lost"),
         ):
             result = await fetch_warm_context("abc", "hello")
 
@@ -83,14 +76,11 @@ class TestFetchInternal:
         mock_client.search_.return_value = _search_results([])
         mock_client.retrieve_episodes.return_value = []
 
-        with (
-            patch.object(context, "derive_group_id", return_value="user_abc"),
-            patch.object(
-                context,
-                "get_graphiti_client",
-                new_callable=AsyncMock,
-                return_value=mock_client,
-            ),
+        with patch.object(
+            context,
+            "get_graphiti_client",
+            new_callable=AsyncMock,
+            return_value=mock_client,
         ):
             result = await context._fetch("test-user", "hello")
 
@@ -108,14 +98,11 @@ class TestFetchInternal:
         mock_client.search_.return_value = _search_results([edge])
         mock_client.retrieve_episodes.return_value = []
 
-        with (
-            patch.object(context, "derive_group_id", return_value="user_abc"),
-            patch.object(
-                context,
-                "get_graphiti_client",
-                new_callable=AsyncMock,
-                return_value=mock_client,
-            ),
+        with patch.object(
+            context,
+            "get_graphiti_client",
+            new_callable=AsyncMock,
+            return_value=mock_client,
         ):
             result = await context._fetch("test-user", "hello")
 
@@ -133,14 +120,11 @@ class TestFetchInternal:
         mock_client.search_.return_value = _search_results([])
         mock_client.retrieve_episodes.return_value = [ep]
 
-        with (
-            patch.object(context, "derive_group_id", return_value="user_abc"),
-            patch.object(
-                context,
-                "get_graphiti_client",
-                new_callable=AsyncMock,
-                return_value=mock_client,
-            ),
+        with patch.object(
+            context,
+            "get_graphiti_client",
+            new_callable=AsyncMock,
+            return_value=mock_client,
         ):
             result = await context._fetch("test-user", "hello")
 
@@ -159,21 +143,19 @@ class TestFetchInternal:
         mock_client.search_.return_value = _search_results([])
         mock_client.retrieve_episodes.return_value = []
 
-        with (
-            patch.object(context, "derive_group_id", return_value="user_abc"),
-            patch.object(
-                context,
-                "get_graphiti_client",
-                new_callable=AsyncMock,
-                return_value=mock_client,
-            ),
+        with patch.object(
+            context,
+            "get_graphiti_client",
+            new_callable=AsyncMock,
+            return_value=mock_client,
         ):
             await context._fetch("test-user", "hello world")
 
         mock_client.search_.assert_awaited_once()
         kwargs = mock_client.search_.await_args.kwargs
         assert kwargs["query"] == "hello world"
-        assert kwargs["group_ids"] == ["user_abc"]
+        # Personal tier group derived directly from the user id ("test-user").
+        assert kwargs["group_ids"] == ["user_test-user"]
         # The config is a copy of EDGE_HYBRID_SEARCH_CROSS_ENCODER with the
         # limit overridden to context_max_facts. Verify the edge-config
         # reranker is still ``cross_encoder`` so the contract is locked.
@@ -195,7 +177,7 @@ class TestFormatContextWithContent:
             valid_at="2025-01-01",
             invalid_at="present",
         )
-        result = _format_context(edges=[edge], episodes=[])
+        result = _format_context([(edge, None)], [])
         assert result is not None
         assert "<FACTS>" in result
         assert "user likes coffee" in result
@@ -206,7 +188,7 @@ class TestFormatContextWithContent:
             content="plain conversation text",
             created_at="2025-01-01T00:00:00Z",
         )
-        result = _format_context(edges=[], episodes=[ep])
+        result = _format_context([], [(ep, None)])
         assert result is not None
         assert "<RECENT_EPISODES>" in result
         assert "plain conversation text" in result
@@ -221,7 +203,7 @@ class TestFormatContextWithContent:
             content="talked about coffee",
             created_at="2025-06-01T00:00:00Z",
         )
-        result = _format_context(edges=[edge], episodes=[ep])
+        result = _format_context([(edge, None)], [(ep, None)])
         assert result is not None
         assert "<FACTS>" in result
         assert "<RECENT_EPISODES>" in result
@@ -232,7 +214,7 @@ class TestFormatContextWithContent:
             content=envelope.model_dump_json(),
             created_at="2025-01-01T00:00:00Z",
         )
-        result = _format_context(edges=[], episodes=[ep])
+        result = _format_context([], [(ep, None)])
         assert result is not None
         assert "<RECENT_EPISODES>" in result
 
@@ -242,7 +224,7 @@ class TestFormatContextWithContent:
             content=envelope.model_dump_json(),
             created_at="2025-01-01T00:00:00Z",
         )
-        result = _format_context(edges=[], episodes=[ep])
+        result = _format_context([], [(ep, None)])
         assert result is None
 
 
@@ -311,7 +293,7 @@ class TestFormatContextEmptyWrapper:
             content=envelope.model_dump_json(),
             created_at="2025-01-01T00:00:00Z",
         )
-        result = _format_context(edges=[], episodes=[ep])
+        result = _format_context([], [(ep, None)])
         assert result is None
 
 
@@ -373,3 +355,173 @@ class TestRatificationHitHookFiresFireAndForget:
         user_id, uuids = captured_calls[0]
         assert user_id == "user-xyz"
         assert uuids == ["edge-a", "edge-b"]
+
+
+# ---------------------------------------------------------------------------
+# Tiered fan-out: personal + org + session-team, provenance labels, budget
+# ---------------------------------------------------------------------------
+
+
+def _fact_edge(fact: str):
+    return SimpleNamespace(
+        fact=fact, name="rel", valid_at="2025-01-01", invalid_at=None
+    )
+
+
+def _tier_client(edges: list[object]) -> AsyncMock:
+    client = AsyncMock()
+    client.search_.return_value = _search_results(edges)
+    client.retrieve_episodes.return_value = []
+    return client
+
+
+class TestWarmContextFanOut:
+    @pytest.mark.asyncio
+    async def test_fans_out_and_labels_shared_tiers(self) -> None:
+        from .tiers import MemoryTier, TierTarget
+
+        targets = [
+            TierTarget("user_u1", MemoryTier.personal, None),
+            TierTarget("org_org-1", MemoryTier.org, "org memory"),
+            TierTarget(
+                "team_team-1", MemoryTier.team, "team memory (Platform)", "team-1"
+            ),
+        ]
+        clients = {
+            "user_u1": _tier_client([_fact_edge("personal pref")]),
+            "org_org-1": _tier_client([_fact_edge("org policy")]),
+            "team_team-1": _tier_client([_fact_edge("team convention")]),
+        }
+
+        async def _fake_client(group_id: str):
+            return clients[group_id]
+
+        with (
+            patch.object(
+                context,
+                "resolve_warm_targets",
+                new_callable=AsyncMock,
+                return_value=targets,
+            ),
+            patch.object(context, "get_graphiti_client", side_effect=_fake_client),
+            patch.object(context, "_spawn_ratification_hits"),
+        ):
+            result = await context._fetch("u1", "query", "org-1", "team-1")
+
+        assert result is not None
+        # Personal fact is unlabelled; shared facts carry provenance labels.
+        assert "personal pref" in result
+        assert "[org memory] org policy" in result
+        assert "[team memory (Platform)] team convention" in result
+        # All three tier groups were queried.
+        for client in clients.values():
+            client.search_.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_ratification_fires_only_on_personal_edges(self) -> None:
+        from .tiers import MemoryTier, TierTarget
+
+        personal_edge = _fact_edge("personal pref")
+        org_edge = _fact_edge("org policy")
+        targets = [
+            TierTarget("user_u1", MemoryTier.personal, None),
+            TierTarget("org_org-1", MemoryTier.org, "org memory"),
+        ]
+        clients = {
+            "user_u1": _tier_client([personal_edge]),
+            "org_org-1": _tier_client([org_edge]),
+        }
+
+        async def _fake_client(group_id: str):
+            return clients[group_id]
+
+        with (
+            patch.object(
+                context,
+                "resolve_warm_targets",
+                new_callable=AsyncMock,
+                return_value=targets,
+            ),
+            patch.object(context, "get_graphiti_client", side_effect=_fake_client),
+            patch.object(context, "_spawn_ratification_hits") as spawn,
+        ):
+            await context._fetch("u1", "query", "org-1", None)
+
+        # Ratification-on-hit keys off the personal graph — it must receive
+        # ONLY personal edges, never the org edge.
+        spawn.assert_called_once()
+        _, kwargs = spawn.call_args
+        passed_edges = (
+            kwargs.get("edges") if "edges" in kwargs else spawn.call_args[0][1]
+        )
+        assert org_edge not in passed_edges
+        assert personal_edge in passed_edges
+
+    @pytest.mark.asyncio
+    async def test_flaky_shared_tier_does_not_sink_personal_context(self) -> None:
+        from .tiers import MemoryTier, TierTarget
+
+        targets = [
+            TierTarget("user_u1", MemoryTier.personal, None),
+            TierTarget("org_org-1", MemoryTier.org, "org memory"),
+        ]
+        personal_client = _tier_client([_fact_edge("personal pref")])
+
+        async def _fake_client(group_id: str):
+            if group_id == "org_org-1":
+                raise RuntimeError("org graph down")
+            return personal_client
+
+        with (
+            patch.object(
+                context,
+                "resolve_warm_targets",
+                new_callable=AsyncMock,
+                return_value=targets,
+            ),
+            patch.object(context, "get_graphiti_client", side_effect=_fake_client),
+            patch.object(context, "_spawn_ratification_hits"),
+        ):
+            result = await context._fetch("u1", "query", "org-1", None)
+
+        assert result is not None
+        assert "personal pref" in result
+
+    @pytest.mark.asyncio
+    async def test_personal_keeps_at_least_half_the_fact_budget(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from .tiers import MemoryTier, TierTarget
+
+        monkeypatch.setattr(context.graphiti_config, "context_max_facts", 10)
+
+        personal_edges = [_fact_edge(f"personal {i}") for i in range(10)]
+        org_edges = [_fact_edge(f"org {i}") for i in range(10)]
+        targets = [
+            TierTarget("user_u1", MemoryTier.personal, None),
+            TierTarget("org_org-1", MemoryTier.org, "org memory"),
+        ]
+        clients = {
+            "user_u1": _tier_client(personal_edges),
+            "org_org-1": _tier_client(org_edges),
+        }
+
+        async def _fake_client(group_id: str):
+            return clients[group_id]
+
+        with (
+            patch.object(
+                context,
+                "resolve_warm_targets",
+                new_callable=AsyncMock,
+                return_value=targets,
+            ),
+            patch.object(context, "get_graphiti_client", side_effect=_fake_client),
+            patch.object(context, "_spawn_ratification_hits"),
+        ):
+            result = await context._fetch("u1", "query", "org-1", None)
+
+        assert result is not None
+        personal_shown = sum(1 for i in range(10) if f"personal {i}" in result)
+        # Budget 10, floor is 5 — personal must keep at least half.
+        assert personal_shown >= 5

--- a/autogpt_platform/backend/backend/copilot/graphiti/context_test.py
+++ b/autogpt_platform/backend/backend/copilot/graphiti/context_test.py
@@ -381,10 +381,13 @@ class TestWarmContextFanOut:
         from .tiers import MemoryTier, TierTarget
 
         targets = [
-            TierTarget("user_u1", MemoryTier.personal, None),
-            TierTarget("org_org-1", MemoryTier.org, "org memory"),
+            TierTarget(group_id="user_u1", tier=MemoryTier.personal, label=None),
+            TierTarget(group_id="org_org-1", tier=MemoryTier.org, label="org memory"),
             TierTarget(
-                "team_team-1", MemoryTier.team, "team memory (Platform)", "team-1"
+                group_id="team_team-1",
+                tier=MemoryTier.team,
+                label="team memory (Platform)",
+                team_id="team-1",
             ),
         ]
         clients = {
@@ -424,8 +427,8 @@ class TestWarmContextFanOut:
         personal_edge = _fact_edge("personal pref")
         org_edge = _fact_edge("org policy")
         targets = [
-            TierTarget("user_u1", MemoryTier.personal, None),
-            TierTarget("org_org-1", MemoryTier.org, "org memory"),
+            TierTarget(group_id="user_u1", tier=MemoryTier.personal, label=None),
+            TierTarget(group_id="org_org-1", tier=MemoryTier.org, label="org memory"),
         ]
         clients = {
             "user_u1": _tier_client([personal_edge]),
@@ -462,8 +465,8 @@ class TestWarmContextFanOut:
         from .tiers import MemoryTier, TierTarget
 
         targets = [
-            TierTarget("user_u1", MemoryTier.personal, None),
-            TierTarget("org_org-1", MemoryTier.org, "org memory"),
+            TierTarget(group_id="user_u1", tier=MemoryTier.personal, label=None),
+            TierTarget(group_id="org_org-1", tier=MemoryTier.org, label="org memory"),
         ]
         personal_client = _tier_client([_fact_edge("personal pref")])
 
@@ -498,8 +501,8 @@ class TestWarmContextFanOut:
         personal_edges = [_fact_edge(f"personal {i}") for i in range(10)]
         org_edges = [_fact_edge(f"org {i}") for i in range(10)]
         targets = [
-            TierTarget("user_u1", MemoryTier.personal, None),
-            TierTarget("org_org-1", MemoryTier.org, "org memory"),
+            TierTarget(group_id="user_u1", tier=MemoryTier.personal, label=None),
+            TierTarget(group_id="org_org-1", tier=MemoryTier.org, label="org memory"),
         ]
         clients = {
             "user_u1": _tier_client(personal_edges),

--- a/autogpt_platform/backend/backend/copilot/graphiti/ingest.py
+++ b/autogpt_platform/backend/backend/copilot/graphiti/ingest.py
@@ -174,11 +174,14 @@ async def _stamp_edge_metadata(
         )
 
 
-async def _ingestion_worker(user_id: str, queue: asyncio.Queue) -> None:
-    """Process episodes sequentially for a single user.
+async def _ingestion_worker(group_id: str, queue: asyncio.Queue) -> None:
+    """Process episodes sequentially for a single group (tenant tier).
 
-    Exits after ``_WORKER_IDLE_TIMEOUT`` seconds of inactivity so that
-    idle workers don't leak memory indefinitely.
+    One worker per ``group_id`` preserves graphiti-core's requirement of
+    sequential ``add_episode()`` within a group — this holds identically
+    for the personal (``user_<id>``), team (``team_<id>``), and org
+    (``org_<id>``) tiers. Exits after ``_WORKER_IDLE_TIMEOUT`` seconds of
+    inactivity so idle workers don't leak memory.
     """
     # Snapshot the loop-local state at task start so cleanup always runs
     # against the same state dict the worker was registered in, even if the
@@ -194,11 +197,11 @@ async def _ingestion_worker(user_id: str, queue: asyncio.Queue) -> None:
                 break  # idle — clean up below
 
             try:
-                group_id = derive_group_id(user_id)
                 client = await get_graphiti_client(group_id)
                 # ``_edge_metadata`` is a sidecar (not an add_episode kwarg) —
-                # pop it before the **payload spread. Present only for dream
-                # writes; None for conversation turns / memory-store calls.
+                # pop it before the **payload spread. Present for dream writes
+                # and explicit shared-tier stores (so their status/provenance
+                # lands on the edge); None for conversation turns.
                 edge_metadata = payload.pop("_edge_metadata", None)
                 # Pass custom entity + edge types so MemoryEnvelope metadata
                 # (status, confidence, source_kind, scope, provenance) lives
@@ -218,23 +221,23 @@ async def _ingestion_worker(user_id: str, queue: asyncio.Queue) -> None:
                 # invariant that prevents clobbering user-authored edges.
                 if edge_metadata:
                     await _stamp_edge_metadata(
-                        client, group_id, result, edge_metadata, user_id
+                        client, group_id, result, edge_metadata, group_id
                     )
             except Exception:
                 logger.warning(
-                    "Graphiti ingestion failed for user %s",
-                    user_id[:12],
+                    "Graphiti ingestion failed for group %s",
+                    group_id[:20],
                     exc_info=True,
                 )
             finally:
                 queue.task_done()
     except asyncio.CancelledError:
-        logger.debug("Ingestion worker cancelled for user %s", user_id[:12])
+        logger.debug("Ingestion worker cancelled for group %s", group_id[:20])
         raise
     finally:
         # Clean up so the next message re-creates the worker.
-        state.user_queues.pop(user_id, None)
-        state.user_workers.pop(user_id, None)
+        state.user_queues.pop(group_id, None)
+        state.user_workers.pop(group_id, None)
 
 
 async def enqueue_conversation_turn(
@@ -273,7 +276,9 @@ async def enqueue_conversation_turn(
 
     source_description = f"User message in session {session_id}"
 
-    queue = await _ensure_worker(user_id)
+    # Auto-ingestion of chat turns is PERSONAL-ONLY by design — shared-tier
+    # writes are explicit (via memory_store) and never routed through here.
+    queue = await _ensure_worker(group_id, user_id_for_dream=user_id)
 
     try:
         queue.put_nowait(
@@ -332,11 +337,12 @@ async def enqueue_episode(
     source_description: str = "Conversation memory",
     is_json: bool = False,
     edge_metadata: dict | None = None,
+    group_id: str | None = None,
 ) -> bool:
     """Enqueue an arbitrary episode for background ingestion.
 
     Used by ``MemoryStoreTool`` so that explicit memory-store calls go
-    through the same per-user serialization queue as conversation turns.
+    through the same per-group serialization queue as conversation turns.
 
     Args:
         is_json: When ``True``, ingest as ``EpisodeType.json`` (for
@@ -345,21 +351,29 @@ async def enqueue_episode(
         edge_metadata: Optional ``{status, source_kind, scope, confidence,
             provenance}`` (Cypher-serializable scalars) stamped onto the
             edges this episode newly creates, AFTER ingestion. Dream
-            writes pass this so their envelope metadata lands on the edge
-            deterministically (graphiti's extractor can't recover it from
-            the episode text). ``None`` (conversation turns / memory-store)
-            leaves edges at MemoryFact defaults — no behavior change.
+            writes and explicit shared-tier stores pass this so their
+            envelope metadata (notably the governed ``status``) lands on
+            the edge deterministically (graphiti's extractor can't recover
+            it from the episode text). ``None`` (conversation turns / plain
+            personal memory-store) leaves edges at MemoryFact defaults.
+        group_id: Explicit target group for a shared-tier write
+            (``team_<id>`` / ``org_<id>``). ``None`` derives the user's
+            personal group (``user_<id>``) — the default, unchanged path.
+            Only the personal path registers the user's dream-system
+            schedules; shared tiers have no per-user dream curation.
 
     Returns ``True`` if the episode was queued, ``False`` if it was dropped.
     """
     if not user_id:
         return False
 
-    try:
-        group_id = derive_group_id(user_id)
-    except ValueError:
-        logger.warning("Invalid user_id for episode ingestion: %s", user_id[:12])
-        return False
+    personal = group_id is None
+    if personal:
+        try:
+            group_id = derive_group_id(user_id)
+        except ValueError:
+            logger.warning("Invalid user_id for episode ingestion: %s", user_id[:12])
+            return False
 
     body_bytes = len(episode_body.encode("utf-8"))
     if body_bytes > MAX_EPISODE_BODY_BYTES:
@@ -370,7 +384,9 @@ async def enqueue_episode(
         )
         return False
 
-    queue = await _ensure_worker(user_id)
+    queue = await _ensure_worker(
+        group_id, user_id_for_dream=user_id if personal else None
+    )
 
     source = EpisodeType.json if is_json else EpisodeType.text
 
@@ -398,35 +414,40 @@ async def enqueue_episode(
         return False
 
 
-async def _ensure_worker(user_id: str) -> asyncio.Queue:
-    """Create a queue and worker for *user_id* if one doesn't exist.
+async def _ensure_worker(
+    group_id: str, *, user_id_for_dream: str | None = None
+) -> asyncio.Queue:
+    """Create a queue and worker for *group_id* if one doesn't exist.
 
-    Returns the queue directly so callers don't need to look it up from
-    the state dict (which avoids a TOCTOU race if the worker times out
-    and cleans up between this call and the put_nowait).
+    One worker per group (personal / team / org) preserves graphiti's
+    per-group serialization. Returns the queue directly so callers don't
+    need to look it up from the state dict (which avoids a TOCTOU race if
+    the worker times out and cleans up between this call and the
+    put_nowait).
 
-    Also fires the auto-registration of the user's dream-system
-    schedules (community rebuild + dream pass + ratification pass) the
-    first time we see them in this process — lazy on first memory write,
+    When ``user_id_for_dream`` is set (personal writes only) this also
+    fires the auto-registration of that user's dream-system schedules
+    (community rebuild + dream pass + ratification pass) the first time
+    we see the group in this process — lazy on first memory write,
     per-job flag-gated, per-job idempotent. See
     ``copilot/dream/scheduling.py:ensure_dream_system_scheduled``.
-    Fire-and-forget; failures are swallowed inside the helper so
-    ingestion is never affected.
+    Fire-and-forget; failures are swallowed inside the helper. Shared
+    tiers pass ``None`` — dream curation is personal-only in v1.
     """
     state = _get_loop_state()
-    is_new_user_for_this_process = False
+    is_new_group_for_this_process = False
     async with state.workers_lock:
-        if user_id not in state.user_queues:
+        if group_id not in state.user_queues:
             q: asyncio.Queue = asyncio.Queue(maxsize=100)
-            state.user_queues[user_id] = q
-            state.user_workers[user_id] = asyncio.create_task(
-                _ingestion_worker(user_id, q),
-                name=f"graphiti-ingest-{user_id[:12]}",
+            state.user_queues[group_id] = q
+            state.user_workers[group_id] = asyncio.create_task(
+                _ingestion_worker(group_id, q),
+                name=f"graphiti-ingest-{group_id[:20]}",
             )
-            is_new_user_for_this_process = True
-        queue = state.user_queues[user_id]
+            is_new_group_for_this_process = True
+        queue = state.user_queues[group_id]
 
-    if is_new_user_for_this_process:
+    if is_new_group_for_this_process and user_id_for_dream:
         # Fire-and-forget; per-job Redis SETNX inside the helper
         # provides cross-process / cross-restart idempotency. Done
         # outside the workers_lock so the scheduler RPC can't
@@ -434,8 +455,8 @@ async def _ensure_worker(user_id: str) -> asyncio.Queue:
         from backend.copilot.dream.scheduling import ensure_dream_system_scheduled
 
         asyncio.create_task(
-            ensure_dream_system_scheduled(user_id),
-            name=f"dream-system-register-{user_id[:12]}",
+            ensure_dream_system_scheduled(user_id_for_dream),
+            name=f"dream-system-register-{user_id_for_dream[:12]}",
         )
 
     return queue

--- a/autogpt_platform/backend/backend/copilot/graphiti/tiers.py
+++ b/autogpt_platform/backend/backend/copilot/graphiti/tiers.py
@@ -20,10 +20,11 @@ that judgement to the model.
 """
 
 import logging
-from dataclasses import dataclass
 from enum import Enum
 from itertools import zip_longest
 from typing import TYPE_CHECKING, Iterable, TypeVar, cast
+
+from pydantic import BaseModel, ConfigDict
 
 from backend.data.tenancy import get_user_team_ids
 
@@ -64,9 +65,10 @@ class TierError(Exception):
         self.message = message
 
 
-@dataclass(frozen=True)
-class TierTarget:
+class TierTarget(BaseModel):
     """A single group a read fans out to, plus its provenance label."""
+
+    model_config = ConfigDict(frozen=True)
 
     group_id: str
     tier: MemoryTier
@@ -249,7 +251,11 @@ async def resolve_warm_targets(
     session); the session's team ONLY when the session is team-tagged AND the
     user is an ACTIVE member of it (untagged sessions skip the team tier).
     """
-    targets = [TierTarget(derive_group_id(user_id), MemoryTier.personal, None)]
+    targets = [
+        TierTarget(
+            group_id=derive_group_id(user_id), tier=MemoryTier.personal, label=None
+        )
+    ]
 
     if organization_id:
         try:
@@ -263,7 +269,11 @@ async def resolve_warm_targets(
             )
         else:
             if await is_org_member(user_id, organization_id):
-                targets.append(TierTarget(org_group_id, MemoryTier.org, ORG_LABEL))
+                targets.append(
+                    TierTarget(
+                        group_id=org_group_id, tier=MemoryTier.org, label=ORG_LABEL
+                    )
+                )
 
             if session_team_id:
                 active_ids = await get_user_team_ids(user_id, organization_id)
@@ -271,10 +281,10 @@ async def resolve_warm_targets(
                     name = await resolve_team_name(session_team_id)
                     targets.append(
                         TierTarget(
-                            derive_team_group_id(session_team_id),
-                            MemoryTier.team,
-                            team_label(name),
-                            session_team_id,
+                            group_id=derive_team_group_id(session_team_id),
+                            tier=MemoryTier.team,
+                            label=team_label(name),
+                            team_id=session_team_id,
                         )
                     )
 
@@ -315,7 +325,11 @@ async def resolve_search_targets(
     targets: list[TierTarget] = []
 
     if include_personal:
-        targets.append(TierTarget(derive_group_id(user_id), MemoryTier.personal, None))
+        targets.append(
+            TierTarget(
+                group_id=derive_group_id(user_id), tier=MemoryTier.personal, label=None
+            )
+        )
 
     if (
         include_org
@@ -323,7 +337,11 @@ async def resolve_search_targets(
         and await is_org_member(user_id, organization_id)
     ):
         targets.append(
-            TierTarget(derive_org_group_id(organization_id), MemoryTier.org, ORG_LABEL)
+            TierTarget(
+                group_id=derive_org_group_id(organization_id),
+                tier=MemoryTier.org,
+                label=ORG_LABEL,
+            )
         )
 
     if include_team and organization_id:
@@ -332,10 +350,10 @@ async def resolve_search_targets(
         for team_id in active_ids:
             targets.append(
                 TierTarget(
-                    derive_team_group_id(team_id),
-                    MemoryTier.team,
-                    team_label(names.get(team_id)),
-                    team_id,
+                    group_id=derive_team_group_id(team_id),
+                    tier=MemoryTier.team,
+                    label=team_label(names.get(team_id)),
+                    team_id=team_id,
                 )
             )
 

--- a/autogpt_platform/backend/backend/copilot/graphiti/tiers.py
+++ b/autogpt_platform/backend/backend/copilot/graphiti/tiers.py
@@ -1,0 +1,363 @@
+"""Tiered memory plumbing — group derivation, membership, governance, labels.
+
+Three tiers share one FalkorDB-per-group substrate:
+
+- ``personal`` → ``user_<id>``   (private; exists today)
+- ``team``     → ``team_<id>``   (visible to ACTIVE members of that team)
+- ``org``      → ``org_<id>``    (visible to every org member)
+
+This module is the single place that:
+
+- resolves which groups a read (warm context / explicit search) may touch,
+  never returning a team the user is not an ACTIVE member of;
+- resolves the target group + write governance (active vs. tentative) for an
+  explicit shared-tier ``memory_store``;
+- produces the provenance labels rendered into the prompt context so the LLM
+  can weigh "org memory" / "team memory (<name>)" against plain personal facts.
+
+Storage does NOT resolve conflicts across tiers — provenance labelling hands
+that judgement to the model.
+"""
+
+import logging
+from dataclasses import dataclass
+from enum import Enum
+from itertools import zip_longest
+from typing import TYPE_CHECKING, Iterable, TypeVar, cast
+
+from backend.data.tenancy import get_user_team_ids
+
+from .client import derive_group_id, derive_org_group_id, derive_team_group_id
+
+if TYPE_CHECKING:
+    from prisma.types import OrgMemberWhereInput, TeamMemberWhereInput
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+# Provenance labels rendered into <temporal_context> / search results.
+# Personal facts stay unlabelled (label is None) so the common case reads
+# cleanly; shared-tier facts are prefixed so the model knows the source.
+ORG_LABEL = "org memory"
+
+
+def team_label(name: str | None) -> str:
+    """Render a team's provenance label, including its name when known."""
+    return f"team memory ({name})" if name else "team memory"
+
+
+class MemoryTier(str, Enum):
+    personal = "personal"
+    team = "team"
+    org = "org"
+
+
+class TierError(Exception):
+    """Raised when a shared-tier request is ambiguous or unauthorized.
+
+    Carries a user-facing ``message`` safe to surface to the LLM/user.
+    """
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.message = message
+
+
+@dataclass(frozen=True)
+class TierTarget:
+    """A single group a read fans out to, plus its provenance label."""
+
+    group_id: str
+    tier: MemoryTier
+    label: str | None  # None → personal (rendered unlabelled)
+    team_id: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Prisma-backed membership + governance (mock at this boundary in tests)
+# ---------------------------------------------------------------------------
+
+
+async def resolve_team_name(team_id: str) -> str | None:
+    """Best-effort team display name for provenance labels."""
+    from backend.data.db import prisma
+
+    try:
+        team = await prisma.team.find_unique(where={"id": team_id})
+    except Exception:
+        logger.debug("Failed to resolve team name for %s", team_id, exc_info=True)
+        return None
+    return team.name if team else None
+
+
+async def resolve_team_names(team_ids: list[str]) -> dict[str, str]:
+    """Batch team-id → name lookup for labelling a fan-out of teams."""
+    if not team_ids:
+        return {}
+    from backend.data.db import prisma
+
+    try:
+        teams = await prisma.team.find_many(where={"id": {"in": team_ids}})
+    except Exception:
+        logger.debug("Failed to batch-resolve team names", exc_info=True)
+        return {}
+    return {t.id: t.name for t in teams}
+
+
+async def is_org_admin(user_id: str, org_id: str) -> bool:
+    """True if *user_id* is an ACTIVE admin or owner of *org_id*."""
+    from backend.data.db import prisma
+
+    member = await prisma.orgmember.find_first(
+        where=cast(
+            "OrgMemberWhereInput",
+            {"userId": user_id, "orgId": org_id, "status": "ACTIVE"},
+        )
+    )
+    return bool(member and (member.isAdmin or member.isOwner))
+
+
+async def get_team_membership(user_id: str, team_id: str, org_id: str):
+    """Return the ACTIVE TeamMember row for (user, team) within *org_id*.
+
+    Scoped to the org so a team id from a different org can never be
+    used to smuggle a write/read into the wrong tenant.
+    """
+    from backend.data.db import prisma
+
+    return await prisma.teammember.find_first(
+        where=cast(
+            "TeamMemberWhereInput",
+            {
+                "userId": user_id,
+                "teamId": team_id,
+                "status": "ACTIVE",
+                "Team": {"is": {"orgId": org_id}},
+            },
+        )
+    )
+
+
+async def hold_buffer_enabled(org_id: str) -> bool:
+    """Whether the org's shared-write hold buffer is on (default TRUE).
+
+    Reads ``Organization.settings["memory"]["holdBuffer"]``. When on,
+    non-admin shared-tier writes land ``tentative`` for later admin
+    review; when off, all permitted writes land ``active``. Any missing
+    setting or read failure defaults to ON (the safer, review-gated
+    behavior).
+    """
+    from backend.data.db import prisma
+
+    try:
+        org = await prisma.organization.find_unique(where={"id": org_id})
+    except Exception:
+        logger.debug("Failed to read org settings for %s", org_id, exc_info=True)
+        return True
+    if org is None:
+        return True
+
+    settings = org.settings
+    if isinstance(settings, str):
+        import json
+
+        try:
+            settings = json.loads(settings)
+        except (json.JSONDecodeError, TypeError):
+            return True
+    if not isinstance(settings, dict):
+        return True
+    memory = settings.get("memory")
+    if not isinstance(memory, dict):
+        return True
+    return bool(memory.get("holdBuffer", True))
+
+
+async def resolve_store_team(
+    user_id: str,
+    org_id: str,
+    session_team_id: str | None,
+    explicit_team_id: str | None,
+):
+    """Resolve + authorize the target team for a ``tier="team"`` write.
+
+    Precedence: explicit ``team_id`` arg → session's team → the user's
+    single team (only when they have exactly one). Raises ``TierError``
+    with a clear message when the target is ambiguous, absent, or the
+    user is not an ACTIVE member of it. Returns the TeamMember row so
+    the caller can read ``teamId`` and ``isAdmin`` without a second query.
+    """
+    target = explicit_team_id or session_team_id
+    if not target:
+        active_ids = await get_user_team_ids(user_id, org_id)
+        if len(active_ids) == 1:
+            target = active_ids[0]
+        elif not active_ids:
+            raise TierError(
+                "You are not an active member of any team in this organization, "
+                "so team memory is unavailable."
+            )
+        else:
+            raise TierError(
+                "You belong to multiple teams — specify which one with the "
+                "'team_id' argument when storing to team memory."
+            )
+
+    membership = await get_team_membership(user_id, target, org_id)
+    if membership is None:
+        raise TierError(
+            "You are not an active member of the specified team, so you cannot "
+            "store to its team memory."
+        )
+    return membership
+
+
+# ---------------------------------------------------------------------------
+# Read target resolution
+# ---------------------------------------------------------------------------
+
+
+async def resolve_warm_targets(
+    user_id: str,
+    organization_id: str | None,
+    session_team_id: str | None,
+) -> list[TierTarget]:
+    """Groups the session-start warm-context prefetch may read.
+
+    Personal always; org when the session carries an organization; the
+    session's team ONLY when the session is team-tagged AND the user is
+    an ACTIVE member of it (untagged sessions skip the team tier).
+    """
+    targets = [TierTarget(derive_group_id(user_id), MemoryTier.personal, None)]
+
+    if organization_id:
+        targets.append(
+            TierTarget(derive_org_group_id(organization_id), MemoryTier.org, ORG_LABEL)
+        )
+
+        if session_team_id:
+            active_ids = await get_user_team_ids(user_id, organization_id)
+            if session_team_id in active_ids:
+                name = await resolve_team_name(session_team_id)
+                targets.append(
+                    TierTarget(
+                        derive_team_group_id(session_team_id),
+                        MemoryTier.team,
+                        team_label(name),
+                        session_team_id,
+                    )
+                )
+
+    return targets
+
+
+async def resolve_search_targets(
+    user_id: str,
+    organization_id: str | None,
+    tier: str,
+) -> list[TierTarget]:
+    """Groups an explicit ``memory_search`` may read for the given tier.
+
+    ``all`` (default) unions personal + org + EVERY ACTIVE team the user
+    belongs to; ``personal``/``org``/``team`` restrict to that tier.
+    Team tiers only ever include the user's ACTIVE memberships. Raises
+    ``TierError`` when an org/team tier is requested without an org on
+    the session.
+    """
+    tier = tier or "all"
+    include_personal = tier in ("all", "personal")
+    include_org = tier in ("all", "org")
+    include_team = tier in ("all", "team")
+
+    if tier in ("org", "team") and not organization_id:
+        raise TierError(
+            "This session is not attached to an organization, so org/team "
+            "memory is unavailable. Use tier='personal' or attach the session "
+            "to an organization."
+        )
+
+    targets: list[TierTarget] = []
+
+    if include_personal:
+        targets.append(TierTarget(derive_group_id(user_id), MemoryTier.personal, None))
+
+    if include_org and organization_id:
+        targets.append(
+            TierTarget(derive_org_group_id(organization_id), MemoryTier.org, ORG_LABEL)
+        )
+
+    if include_team and organization_id:
+        active_ids = await get_user_team_ids(user_id, organization_id)
+        names = await resolve_team_names(active_ids)
+        for team_id in active_ids:
+            targets.append(
+                TierTarget(
+                    derive_team_group_id(team_id),
+                    MemoryTier.team,
+                    team_label(names.get(team_id)),
+                    team_id,
+                )
+            )
+
+    return targets
+
+
+# ---------------------------------------------------------------------------
+# Budget merge — personal keeps >= half; shared tiers share the rest
+# ---------------------------------------------------------------------------
+
+
+def _round_robin(lists: list[list[T]]) -> Iterable[T]:
+    """Fairly interleave already-ranked per-tier lists.
+
+    Each input list is assumed rerank-ordered (best first); round-robin
+    interleaving keeps every shared tier's top hits near the front so the
+    shared budget is shared "by rerank score" without a cross-tier score
+    (graphiti's search API does not expose comparable scores across
+    separate group queries).
+    """
+    sentinel: object = object()
+    for group in zip_longest(*lists, fillvalue=sentinel):
+        for item in group:
+            if item is not sentinel:
+                yield item  # type: ignore[misc]
+
+
+def merge_tiered(
+    personal: list[T],
+    shared: list[tuple[str | None, list[T]]],
+    total: int,
+) -> list[tuple[T, str | None]]:
+    """Merge personal + labelled shared results under a total budget.
+
+    Personal keeps at least ``total // 2`` (the floor) and absorbs any
+    budget the shared tiers don't use; the remainder is filled by
+    round-robin over the shared tiers, each labelled with its provenance.
+    Returns ``[(item, label)]`` in render order — personal first
+    (``label`` None), then interleaved shared.
+    """
+    if total <= 0:
+        return []
+
+    half = total // 2
+    shared_available = sum(len(items) for _, items in shared)
+    personal_take = min(len(personal), max(half, total - shared_available))
+
+    merged: list[tuple[T, str | None]] = [
+        (item, None) for item in personal[:personal_take]
+    ]
+    remaining = total - len(merged)
+    if remaining <= 0 or not shared:
+        return merged
+
+    labelled: list[list[tuple[T, str | None]]] = [
+        [(item, label) for item in items] for label, items in shared if items
+    ]
+    for pair in _round_robin(labelled):
+        if remaining <= 0:
+            break
+        merged.append(pair)
+        remaining -= 1
+
+    return merged

--- a/autogpt_platform/backend/backend/copilot/graphiti/tiers.py
+++ b/autogpt_platform/backend/backend/copilot/graphiti/tiers.py
@@ -105,6 +105,25 @@ async def resolve_team_names(team_ids: list[str]) -> dict[str, str]:
     return {t.id: t.name for t in teams}
 
 
+async def is_org_member(user_id: str, org_id: str) -> bool:
+    """True if *user_id* is an ACTIVE member (any role) of *org_id*.
+
+    The org tier must re-check this per operation: ``session.organization_id``
+    is membership-verified only at session creation, so a revoked or stale
+    membership (or a cached session row) would otherwise reach org memory.
+    Mirrors the TEAM tier, which re-verifies via ``get_team_membership``.
+    """
+    from backend.data.db import prisma
+
+    member = await prisma.orgmember.find_first(
+        where=cast(
+            "OrgMemberWhereInput",
+            {"userId": user_id, "orgId": org_id, "status": "ACTIVE"},
+        )
+    )
+    return member is not None
+
+
 async def is_org_admin(user_id: str, org_id: str) -> bool:
     """True if *user_id* is an ACTIVE admin or owner of *org_id*."""
     from backend.data.db import prisma
@@ -225,29 +244,39 @@ async def resolve_warm_targets(
 ) -> list[TierTarget]:
     """Groups the session-start warm-context prefetch may read.
 
-    Personal always; org when the session carries an organization; the
-    session's team ONLY when the session is team-tagged AND the user is
-    an ACTIVE member of it (untagged sessions skip the team tier).
+    Personal always; org ONLY when the session carries an organization AND
+    the user is an ACTIVE org member (re-checked here, not trusted from the
+    session); the session's team ONLY when the session is team-tagged AND the
+    user is an ACTIVE member of it (untagged sessions skip the team tier).
     """
     targets = [TierTarget(derive_group_id(user_id), MemoryTier.personal, None)]
 
     if organization_id:
-        targets.append(
-            TierTarget(derive_org_group_id(organization_id), MemoryTier.org, ORG_LABEL)
-        )
+        try:
+            org_group_id = derive_org_group_id(organization_id)
+        except ValueError:
+            # A malformed org id must not sink the personal warm context:
+            # per-tier isolation (see graphiti/context.py) starts here.
+            logger.warning(
+                "Skipping org warm-context tier: invalid organization id",
+                exc_info=True,
+            )
+        else:
+            if await is_org_member(user_id, organization_id):
+                targets.append(TierTarget(org_group_id, MemoryTier.org, ORG_LABEL))
 
-        if session_team_id:
-            active_ids = await get_user_team_ids(user_id, organization_id)
-            if session_team_id in active_ids:
-                name = await resolve_team_name(session_team_id)
-                targets.append(
-                    TierTarget(
-                        derive_team_group_id(session_team_id),
-                        MemoryTier.team,
-                        team_label(name),
-                        session_team_id,
+            if session_team_id:
+                active_ids = await get_user_team_ids(user_id, organization_id)
+                if session_team_id in active_ids:
+                    name = await resolve_team_name(session_team_id)
+                    targets.append(
+                        TierTarget(
+                            derive_team_group_id(session_team_id),
+                            MemoryTier.team,
+                            team_label(name),
+                            session_team_id,
+                        )
                     )
-                )
 
     return targets
 
@@ -261,11 +290,17 @@ async def resolve_search_targets(
 
     ``all`` (default) unions personal + org + EVERY ACTIVE team the user
     belongs to; ``personal``/``org``/``team`` restrict to that tier.
-    Team tiers only ever include the user's ACTIVE memberships. Raises
-    ``TierError`` when an org/team tier is requested without an org on
-    the session.
+    The org tier is included only for ACTIVE org members and team tiers only
+    for the user's ACTIVE memberships (re-checked here, not trusted from the
+    session), so a non-member never reads shared memory. Raises ``TierError``
+    for an unknown tier, or when an org/team tier is requested without an org
+    on the session.
     """
     tier = tier or "all"
+    if tier not in ("all", "personal", "org", "team"):
+        raise TierError(
+            f"Unknown memory tier '{tier}'. Valid tiers: all, personal, org, team."
+        )
     include_personal = tier in ("all", "personal")
     include_org = tier in ("all", "org")
     include_team = tier in ("all", "team")
@@ -282,7 +317,11 @@ async def resolve_search_targets(
     if include_personal:
         targets.append(TierTarget(derive_group_id(user_id), MemoryTier.personal, None))
 
-    if include_org and organization_id:
+    if (
+        include_org
+        and organization_id
+        and await is_org_member(user_id, organization_id)
+    ):
         targets.append(
             TierTarget(derive_org_group_id(organization_id), MemoryTier.org, ORG_LABEL)
         )

--- a/autogpt_platform/backend/backend/copilot/graphiti/tiers_test.py
+++ b/autogpt_platform/backend/backend/copilot/graphiti/tiers_test.py
@@ -92,15 +92,31 @@ class TestResolveWarmTargets:
 
     @pytest.mark.asyncio
     async def test_personal_and_org_without_team(self) -> None:
-        targets = await resolve_warm_targets("u1", "org-1", None)
+        with patch.object(
+            tiers, "is_org_member", new_callable=AsyncMock, return_value=True
+        ):
+            targets = await resolve_warm_targets("u1", "org-1", None)
         tiers_seen = [t.tier for t in targets]
         assert tiers_seen == [MemoryTier.personal, MemoryTier.org]
         assert targets[1].group_id == "org_org-1"
         assert targets[1].label == "org memory"
 
     @pytest.mark.asyncio
+    async def test_org_tier_excluded_when_not_org_member(self) -> None:
+        # A stale/revoked org membership must not reach org memory: the org
+        # tier is re-checked here, not trusted from session.organization_id.
+        with patch.object(
+            tiers, "is_org_member", new_callable=AsyncMock, return_value=False
+        ):
+            targets = await resolve_warm_targets("u1", "org-1", None)
+        assert [t.tier for t in targets] == [MemoryTier.personal]
+
+    @pytest.mark.asyncio
     async def test_includes_session_team_when_active_member(self) -> None:
         with (
+            patch.object(
+                tiers, "is_org_member", new_callable=AsyncMock, return_value=True
+            ),
             patch.object(
                 tiers,
                 "get_user_team_ids",
@@ -127,26 +143,45 @@ class TestResolveWarmTargets:
 
     @pytest.mark.asyncio
     async def test_skips_session_team_when_not_active_member(self) -> None:
-        with patch.object(
-            tiers,
-            "get_user_team_ids",
-            new_callable=AsyncMock,
-            return_value=["other-team"],
+        with (
+            patch.object(
+                tiers, "is_org_member", new_callable=AsyncMock, return_value=True
+            ),
+            patch.object(
+                tiers,
+                "get_user_team_ids",
+                new_callable=AsyncMock,
+                return_value=["other-team"],
+            ),
         ):
             targets = await resolve_warm_targets("u1", "org-1", "team-1")
 
-        # Non-member: team tier is dropped, org still present.
+        # Non-member of the team: team tier is dropped, org still present.
         assert [t.tier for t in targets] == [MemoryTier.personal, MemoryTier.org]
 
     @pytest.mark.asyncio
     async def test_untagged_session_skips_team(self) -> None:
         # team_id None → team tier never considered (no membership query).
-        with patch.object(
-            tiers, "get_user_team_ids", new_callable=AsyncMock
-        ) as get_teams:
+        with (
+            patch.object(
+                tiers, "is_org_member", new_callable=AsyncMock, return_value=True
+            ),
+            patch.object(
+                tiers, "get_user_team_ids", new_callable=AsyncMock
+            ) as get_teams,
+        ):
             targets = await resolve_warm_targets("u1", "org-1", None)
         get_teams.assert_not_awaited()
         assert [t.tier for t in targets] == [MemoryTier.personal, MemoryTier.org]
+
+    @pytest.mark.asyncio
+    async def test_invalid_org_id_preserves_personal(self) -> None:
+        # A malformed org id must skip the org tier, not sink personal.
+        with patch.object(
+            tiers, "derive_org_group_id", side_effect=ValueError("bad org id")
+        ):
+            targets = await resolve_warm_targets("u1", "bad-org", None)
+        assert [t.tier for t in targets] == [MemoryTier.personal]
 
 
 # ---------------------------------------------------------------------------
@@ -161,8 +196,18 @@ class TestResolveSearchTargets:
         assert [t.tier for t in targets] == [MemoryTier.personal]
 
     @pytest.mark.asyncio
+    async def test_unknown_tier_raises(self) -> None:
+        # An unrecognized tier must be rejected, not silently return no
+        # targets (which memory_search would report as "no memories").
+        with pytest.raises(TierError, match="Unknown memory tier"):
+            await resolve_search_targets("u1", "org-1", "bogus")
+
+    @pytest.mark.asyncio
     async def test_all_unions_personal_org_and_active_teams(self) -> None:
         with (
+            patch.object(
+                tiers, "is_org_member", new_callable=AsyncMock, return_value=True
+            ),
             patch.object(
                 tiers,
                 "get_user_team_ids",
@@ -186,6 +231,16 @@ class TestResolveSearchTargets:
         ]
         team_labels = {t.label for t in targets if t.tier == MemoryTier.team}
         assert team_labels == {"team memory (Platform)", "team memory (Growth)"}
+
+    @pytest.mark.asyncio
+    async def test_org_tier_excluded_for_non_member(self) -> None:
+        # tier='org' by a non-member yields no targets (memory_search then
+        # reports "no memories") — never the org group's contents.
+        with patch.object(
+            tiers, "is_org_member", new_callable=AsyncMock, return_value=False
+        ):
+            targets = await resolve_search_targets("u1", "org-1", "org")
+        assert targets == []
 
     @pytest.mark.asyncio
     async def test_team_tier_only_queries_active_memberships(self) -> None:

--- a/autogpt_platform/backend/backend/copilot/graphiti/tiers_test.py
+++ b/autogpt_platform/backend/backend/copilot/graphiti/tiers_test.py
@@ -1,0 +1,373 @@
+"""Tests for tiered-memory plumbing: budget merge, read-target resolution,
+membership + write governance."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from . import tiers
+from .tiers import (
+    MemoryTier,
+    TierError,
+    hold_buffer_enabled,
+    is_org_admin,
+    merge_tiered,
+    resolve_search_targets,
+    resolve_store_team,
+    resolve_warm_targets,
+    team_label,
+)
+
+# ---------------------------------------------------------------------------
+# Budget merge: personal keeps >= half; shared tiers share the rest
+# ---------------------------------------------------------------------------
+
+
+class TestMergeTiered:
+    def test_personal_keeps_at_least_half_when_all_tiers_full(self) -> None:
+        personal = [f"p{i}" for i in range(20)]
+        shared = [("org memory", [f"o{i}" for i in range(20)])]
+        merged = merge_tiered(personal, shared, total=20)
+
+        assert len(merged) == 20
+        personal_count = sum(1 for _, label in merged if label is None)
+        # Floor is total // 2 = 10; personal must never drop below it.
+        assert personal_count >= 10
+        assert personal_count == 10  # shared is plentiful, so exactly the floor
+
+    def test_personal_absorbs_unused_shared_budget(self) -> None:
+        # Only 3 shared facts available, so personal should take the other 17.
+        personal = [f"p{i}" for i in range(20)]
+        shared = [("org memory", ["o0", "o1", "o2"])]
+        merged = merge_tiered(personal, shared, total=20)
+
+        personal_count = sum(1 for _, label in merged if label is None)
+        assert personal_count == 17
+        assert sum(1 for _, label in merged if label == "org memory") == 3
+
+    def test_personal_below_half_takes_all_and_shared_fills(self) -> None:
+        personal = ["p0", "p1"]  # fewer than half of 10
+        shared = [("org memory", [f"o{i}" for i in range(20)])]
+        merged = merge_tiered(personal, shared, total=10)
+
+        assert sum(1 for _, label in merged if label is None) == 2
+        assert sum(1 for _, label in merged if label == "org memory") == 8
+
+    def test_shared_labels_attached_and_round_robin_interleaved(self) -> None:
+        personal: list[str] = []
+        shared = [
+            ("org memory", ["o0", "o1", "o2"]),
+            ("team memory (X)", ["t0", "t1", "t2"]),
+        ]
+        merged = merge_tiered(personal, shared, total=6)
+
+        labels = [label for _, label in merged]
+        # Round-robin: org, team, org, team, ... so both tiers' top hits lead.
+        assert labels[0] == "org memory"
+        assert labels[1] == "team memory (X)"
+        assert set(labels) == {"org memory", "team memory (X)"}
+
+    def test_zero_budget_returns_empty(self) -> None:
+        assert merge_tiered(["p"], [("org", ["o"])], total=0) == []
+
+
+def test_team_label_formats_with_and_without_name() -> None:
+    assert team_label("Platform") == "team memory (Platform)"
+    assert team_label(None) == "team memory"
+
+
+# ---------------------------------------------------------------------------
+# Warm-context target resolution
+# ---------------------------------------------------------------------------
+
+
+class TestResolveWarmTargets:
+    @pytest.mark.asyncio
+    async def test_personal_only_without_org(self) -> None:
+        targets = await resolve_warm_targets("u1", None, None)
+        assert [t.tier for t in targets] == [MemoryTier.personal]
+        assert targets[0].group_id == "user_u1"
+        assert targets[0].label is None
+
+    @pytest.mark.asyncio
+    async def test_personal_and_org_without_team(self) -> None:
+        targets = await resolve_warm_targets("u1", "org-1", None)
+        tiers_seen = [t.tier for t in targets]
+        assert tiers_seen == [MemoryTier.personal, MemoryTier.org]
+        assert targets[1].group_id == "org_org-1"
+        assert targets[1].label == "org memory"
+
+    @pytest.mark.asyncio
+    async def test_includes_session_team_when_active_member(self) -> None:
+        with (
+            patch.object(
+                tiers,
+                "get_user_team_ids",
+                new_callable=AsyncMock,
+                return_value=["team-1"],
+            ),
+            patch.object(
+                tiers,
+                "resolve_team_name",
+                new_callable=AsyncMock,
+                return_value="Platform",
+            ),
+        ):
+            targets = await resolve_warm_targets("u1", "org-1", "team-1")
+
+        assert [t.tier for t in targets] == [
+            MemoryTier.personal,
+            MemoryTier.org,
+            MemoryTier.team,
+        ]
+        team_target = targets[2]
+        assert team_target.group_id == "team_team-1"
+        assert team_target.label == "team memory (Platform)"
+
+    @pytest.mark.asyncio
+    async def test_skips_session_team_when_not_active_member(self) -> None:
+        with patch.object(
+            tiers,
+            "get_user_team_ids",
+            new_callable=AsyncMock,
+            return_value=["other-team"],
+        ):
+            targets = await resolve_warm_targets("u1", "org-1", "team-1")
+
+        # Non-member: team tier is dropped, org still present.
+        assert [t.tier for t in targets] == [MemoryTier.personal, MemoryTier.org]
+
+    @pytest.mark.asyncio
+    async def test_untagged_session_skips_team(self) -> None:
+        # team_id None → team tier never considered (no membership query).
+        with patch.object(
+            tiers, "get_user_team_ids", new_callable=AsyncMock
+        ) as get_teams:
+            targets = await resolve_warm_targets("u1", "org-1", None)
+        get_teams.assert_not_awaited()
+        assert [t.tier for t in targets] == [MemoryTier.personal, MemoryTier.org]
+
+
+# ---------------------------------------------------------------------------
+# Search target resolution
+# ---------------------------------------------------------------------------
+
+
+class TestResolveSearchTargets:
+    @pytest.mark.asyncio
+    async def test_all_without_org_is_personal_only(self) -> None:
+        targets = await resolve_search_targets("u1", None, "all")
+        assert [t.tier for t in targets] == [MemoryTier.personal]
+
+    @pytest.mark.asyncio
+    async def test_all_unions_personal_org_and_active_teams(self) -> None:
+        with (
+            patch.object(
+                tiers,
+                "get_user_team_ids",
+                new_callable=AsyncMock,
+                return_value=["team-1", "team-2"],
+            ),
+            patch.object(
+                tiers,
+                "resolve_team_names",
+                new_callable=AsyncMock,
+                return_value={"team-1": "Platform", "team-2": "Growth"},
+            ),
+        ):
+            targets = await resolve_search_targets("u1", "org-1", "all")
+
+        assert [t.tier for t in targets] == [
+            MemoryTier.personal,
+            MemoryTier.org,
+            MemoryTier.team,
+            MemoryTier.team,
+        ]
+        team_labels = {t.label for t in targets if t.tier == MemoryTier.team}
+        assert team_labels == {"team memory (Platform)", "team memory (Growth)"}
+
+    @pytest.mark.asyncio
+    async def test_team_tier_only_queries_active_memberships(self) -> None:
+        # get_user_team_ids is THE active-membership source; tier='team'
+        # returns exactly those teams and nothing else.
+        with (
+            patch.object(
+                tiers,
+                "get_user_team_ids",
+                new_callable=AsyncMock,
+                return_value=["team-1"],
+            ),
+            patch.object(
+                tiers,
+                "resolve_team_names",
+                new_callable=AsyncMock,
+                return_value={"team-1": "Platform"},
+            ) as names,
+        ):
+            targets = await resolve_search_targets("u1", "org-1", "team")
+
+        names.assert_awaited_once_with(["team-1"])
+        assert [t.tier for t in targets] == [MemoryTier.team]
+        assert targets[0].group_id == "team_team-1"
+
+    @pytest.mark.asyncio
+    async def test_org_tier_without_org_raises(self) -> None:
+        with pytest.raises(TierError):
+            await resolve_search_targets("u1", None, "org")
+
+    @pytest.mark.asyncio
+    async def test_team_tier_without_org_raises(self) -> None:
+        with pytest.raises(TierError):
+            await resolve_search_targets("u1", None, "team")
+
+    @pytest.mark.asyncio
+    async def test_personal_tier_is_personal_only(self) -> None:
+        targets = await resolve_search_targets("u1", "org-1", "personal")
+        assert [t.tier for t in targets] == [MemoryTier.personal]
+
+
+# ---------------------------------------------------------------------------
+# Write governance: membership + hold buffer
+# ---------------------------------------------------------------------------
+
+
+class TestIsOrgAdmin:
+    @pytest.mark.asyncio
+    async def test_admin_true(self) -> None:
+        with patch("backend.data.db.prisma") as mock_prisma:
+            mock_prisma.orgmember.find_first = AsyncMock(
+                return_value=SimpleNamespace(isAdmin=True, isOwner=False)
+            )
+            assert await is_org_admin("u1", "org-1") is True
+
+    @pytest.mark.asyncio
+    async def test_owner_true(self) -> None:
+        with patch("backend.data.db.prisma") as mock_prisma:
+            mock_prisma.orgmember.find_first = AsyncMock(
+                return_value=SimpleNamespace(isAdmin=False, isOwner=True)
+            )
+            assert await is_org_admin("u1", "org-1") is True
+
+    @pytest.mark.asyncio
+    async def test_plain_member_false(self) -> None:
+        with patch("backend.data.db.prisma") as mock_prisma:
+            mock_prisma.orgmember.find_first = AsyncMock(
+                return_value=SimpleNamespace(isAdmin=False, isOwner=False)
+            )
+            assert await is_org_admin("u1", "org-1") is False
+
+    @pytest.mark.asyncio
+    async def test_non_member_false(self) -> None:
+        with patch("backend.data.db.prisma") as mock_prisma:
+            mock_prisma.orgmember.find_first = AsyncMock(return_value=None)
+            assert await is_org_admin("u1", "org-1") is False
+
+
+class TestHoldBufferEnabled:
+    @pytest.mark.asyncio
+    async def test_defaults_true_when_setting_absent(self) -> None:
+        with patch("backend.data.db.prisma") as mock_prisma:
+            mock_prisma.organization.find_unique = AsyncMock(
+                return_value=SimpleNamespace(settings={})
+            )
+            assert await hold_buffer_enabled("org-1") is True
+
+    @pytest.mark.asyncio
+    async def test_false_when_explicitly_disabled(self) -> None:
+        with patch("backend.data.db.prisma") as mock_prisma:
+            mock_prisma.organization.find_unique = AsyncMock(
+                return_value=SimpleNamespace(settings={"memory": {"holdBuffer": False}})
+            )
+            assert await hold_buffer_enabled("org-1") is False
+
+    @pytest.mark.asyncio
+    async def test_true_when_explicitly_enabled(self) -> None:
+        with patch("backend.data.db.prisma") as mock_prisma:
+            mock_prisma.organization.find_unique = AsyncMock(
+                return_value=SimpleNamespace(settings={"memory": {"holdBuffer": True}})
+            )
+            assert await hold_buffer_enabled("org-1") is True
+
+    @pytest.mark.asyncio
+    async def test_defaults_true_when_org_missing(self) -> None:
+        with patch("backend.data.db.prisma") as mock_prisma:
+            mock_prisma.organization.find_unique = AsyncMock(return_value=None)
+            assert await hold_buffer_enabled("org-1") is True
+
+    @pytest.mark.asyncio
+    async def test_parses_settings_stored_as_json_string(self) -> None:
+        with patch("backend.data.db.prisma") as mock_prisma:
+            mock_prisma.organization.find_unique = AsyncMock(
+                return_value=SimpleNamespace(
+                    settings='{"memory": {"holdBuffer": false}}'
+                )
+            )
+            assert await hold_buffer_enabled("org-1") is False
+
+
+class TestResolveStoreTeam:
+    @pytest.mark.asyncio
+    async def test_explicit_team_id_validates_membership(self) -> None:
+        membership = SimpleNamespace(teamId="team-1", isAdmin=True)
+        with patch.object(
+            tiers,
+            "get_team_membership",
+            new_callable=AsyncMock,
+            return_value=membership,
+        ) as get_mem:
+            result = await resolve_store_team("u1", "org-1", None, "team-1")
+        get_mem.assert_awaited_once_with("u1", "team-1", "org-1")
+        assert result.teamId == "team-1"
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_single_team(self) -> None:
+        membership = SimpleNamespace(teamId="only-team", isAdmin=False)
+        with (
+            patch.object(
+                tiers,
+                "get_user_team_ids",
+                new_callable=AsyncMock,
+                return_value=["only-team"],
+            ),
+            patch.object(
+                tiers,
+                "get_team_membership",
+                new_callable=AsyncMock,
+                return_value=membership,
+            ),
+        ):
+            result = await resolve_store_team("u1", "org-1", None, None)
+        assert result.teamId == "only-team"
+
+    @pytest.mark.asyncio
+    async def test_no_teams_raises_clear_error(self) -> None:
+        with patch.object(
+            tiers, "get_user_team_ids", new_callable=AsyncMock, return_value=[]
+        ):
+            with pytest.raises(TierError, match="not an active member of any team"):
+                await resolve_store_team("u1", "org-1", None, None)
+
+    @pytest.mark.asyncio
+    async def test_multiple_teams_requires_explicit_id(self) -> None:
+        with patch.object(
+            tiers,
+            "get_user_team_ids",
+            new_callable=AsyncMock,
+            return_value=["a", "b"],
+        ):
+            with pytest.raises(TierError, match="multiple teams"):
+                await resolve_store_team("u1", "org-1", None, None)
+
+    @pytest.mark.asyncio
+    async def test_non_member_of_target_team_raises(self) -> None:
+        with patch.object(
+            tiers,
+            "get_team_membership",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            with pytest.raises(
+                TierError, match="not an active member of the specified"
+            ):
+                await resolve_store_team("u1", "org-1", "some-team", "some-team")

--- a/autogpt_platform/backend/backend/copilot/prompting.py
+++ b/autogpt_platform/backend/backend/copilot/prompting.py
@@ -646,10 +646,23 @@ You have access to persistent temporal memory tools that remember facts across s
 - When building an agent that should use past preferences
 - At the START of every new conversation to check for relevant context
 
+### MEMORY TIERS (personal / team / org):
+Memory comes in three tiers. **memory_search** reads across all of them by default (`tier="all"`): your personal memory, plus — when this session is attached to an organization — the organization's memory and any team you belong to.
+- Shared results are **labelled with their source** in `<memory_context>` and search results: `[org memory]`, `[team memory (<name>)]`. Personal facts are unlabelled.
+- **Weigh provenance yourself** — the system does not resolve conflicts between tiers. A labelled shared fact is organizational/team context; an unlabelled fact is the user's own. Prefer the most specific and most recent applicable fact, and say which tier something came from when it matters.
+
+### STORING TO A SHARED TIER (memory_store `tier`):
+- `memory_store` defaults to `tier="personal"`. Set `tier="team"` or `tier="org"` **only** when the user clearly means the information to be shared with their team or whole organization (shared policies, team conventions, org-wide facts) — not personal preferences.
+- For `tier="team"`, pass `team_id` when the user belongs to more than one team; otherwise the session's team (or your only team) is used.
+- **Governance:** org/team stores by non-admins may be **held for admin review** (they land as "pending" and become active only after an admin approves). Admin stores take effect immediately. If a store comes back "pending admin review", tell the user it's awaiting approval rather than claiming it's saved and active.
+
+### FORGETTING:
+- `memory_forget_*` only works on **personal** memory. Shared `[org memory]` / `[team memory]` facts cannot be forgotten here — they're managed by admins. If the user asks to forget a shared fact, explain that.
+
 ### MEMORY RULES:
 - Facts have temporal validity — if something CHANGED (e.g., user switched from Shopify to WooCommerce), store the new fact. The system automatically invalidates the old one.
 - Never fabricate memories. Only persist what the user actually said.
-- Memory is private to this user — no other user can see it.
+- Personal memory is private to this user — no other user can see it. Team/org memory is visible to that team/organization's members.
 - group_id is handled automatically by the system — never set it yourself.
 - When storing, be specific about operational rules and instructions (e.g., "CC Sarah on client communications" not just "Sarah is the assistant").
 """

--- a/autogpt_platform/backend/backend/copilot/sdk/responsiveness_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/responsiveness_test.py
@@ -126,7 +126,11 @@ async def test_fetch_graphiti_context_handles_none_message():
         enabled, ctx = await _fetch_graphiti_context("user-1", session, None)
     assert enabled is True
     assert ctx == "ctx"
-    fetch_mock.assert_awaited_once_with("user-1", "")
+    # The session's org/team tenancy is threaded into warm context so it can
+    # fan out to the org + session-team tiers (both None for this session).
+    fetch_mock.assert_awaited_once_with(
+        "user-1", "", organization_id=None, team_id=None
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -5572,5 +5572,13 @@ async def _fetch_graphiti_context(
 
     from ..graphiti.context import fetch_warm_context
 
-    ctx = await fetch_warm_context(user_id, message or "") or ""
+    ctx = (
+        await fetch_warm_context(
+            user_id,
+            message or "",
+            organization_id=session.organization_id,
+            team_id=session.team_id,
+        )
+        or ""
+    )
     return True, ctx

--- a/autogpt_platform/backend/backend/copilot/tools/graphiti_forget.py
+++ b/autogpt_platform/backend/backend/copilot/tools/graphiti_forget.py
@@ -37,6 +37,17 @@ def _now_iso() -> str:
 
 logger = logging.getLogger(__name__)
 
+# Deleting shared memory is an admin / ratification concern and is out of
+# scope for v1 — forget only ever touches the caller's PERSONAL graph. When
+# pointed at a shared tier we refuse explicitly (rather than silently
+# searching personal and reporting "no matches") so the model doesn't think
+# it deleted a shared fact it merely couldn't see.
+_SHARED_TIER_FORGET_MESSAGE = (
+    "Memory deletion is only available for your personal memory. Facts labelled "
+    "'org memory' or 'team memory (<name>)' are shared and are managed by "
+    "organization/team admins — they can't be forgotten from here."
+)
+
 
 class MemoryForgetSearchTool(BaseTool):
     """Search for memories to forget — returns candidates for user confirmation."""
@@ -62,6 +73,15 @@ class MemoryForgetSearchTool(BaseTool):
                     "type": "string",
                     "description": "Natural language description of what to forget (e.g. 'the Q2 marketing budget')",
                 },
+                "tier": {
+                    "type": "string",
+                    "enum": ["personal", "team", "org"],
+                    "description": (
+                        "Only 'personal' (default) is supported; team/org "
+                        "memory is admin-managed and will be refused."
+                    ),
+                    "default": "personal",
+                },
             },
             "required": ["query"],
         }
@@ -76,6 +96,7 @@ class MemoryForgetSearchTool(BaseTool):
         session: ChatSession,
         *,
         query: str = "",
+        tier: str = "personal",
         **kwargs,
     ) -> ToolResponseBase:
         if not user_id:
@@ -87,6 +108,12 @@ class MemoryForgetSearchTool(BaseTool):
         if not await is_enabled_for_user(user_id):
             return ErrorResponse(
                 message="Memory features are not enabled for your account.",
+                session_id=session.session_id,
+            )
+
+        if tier and tier != "personal":
+            return ErrorResponse(
+                message=_SHARED_TIER_FORGET_MESSAGE,
                 session_id=session.session_id,
             )
 
@@ -185,6 +212,15 @@ class MemoryForgetConfirmTool(BaseTool):
                     "description": "If true, permanently removes edges from the graph (GDPR). Default false (soft delete — marks as expired).",
                     "default": False,
                 },
+                "tier": {
+                    "type": "string",
+                    "enum": ["personal", "team", "org"],
+                    "description": (
+                        "Only 'personal' (default) is supported; team/org "
+                        "memory is admin-managed and will be refused."
+                    ),
+                    "default": "personal",
+                },
             },
             "required": ["uuids"],
         }
@@ -200,6 +236,7 @@ class MemoryForgetConfirmTool(BaseTool):
         *,
         uuids: list[str] | None = None,
         hard_delete: bool = False,
+        tier: str = "personal",
         **kwargs,
     ) -> ToolResponseBase:
         if not user_id:
@@ -211,6 +248,12 @@ class MemoryForgetConfirmTool(BaseTool):
         if not await is_enabled_for_user(user_id):
             return ErrorResponse(
                 message="Memory features are not enabled for your account.",
+                session_id=session.session_id,
+            )
+
+        if tier and tier != "personal":
+            return ErrorResponse(
+                message=_SHARED_TIER_FORGET_MESSAGE,
                 session_id=session.session_id,
             )
 

--- a/autogpt_platform/backend/backend/copilot/tools/graphiti_forget_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/graphiti_forget_test.py
@@ -1,16 +1,34 @@
 """Tests for graphiti_forget delete helpers."""
 
-from unittest.mock import AsyncMock
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from backend.copilot.model import ChatSession
 from backend.copilot.tools.graphiti_forget import (
+    MemoryForgetConfirmTool,
+    MemoryForgetSearchTool,
     _hard_delete_edges,
     _retract_edges,
     _soft_delete_edges,
     invalidate_entity_direct_neighbors,
     mark_edges_superseded,
 )
+from backend.copilot.tools.models import ErrorResponse
+
+
+def _session() -> ChatSession:
+    return ChatSession(
+        session_id="s",
+        user_id="user-1",
+        title=None,
+        messages=[],
+        usage=[],
+        credentials={},
+        started_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
 
 
 class TestSoftDeleteOverReportsSuccess:
@@ -265,3 +283,74 @@ class TestInvalidateEntityDirectNeighbors:
             driver, group_id="user_x", entity_uuid="entity-1", reason="x"
         )
         assert result == []
+
+
+class TestForgetRefusesSharedTiers:
+    """Forget is personal-only in v1. Pointed at a shared tier it must
+    refuse EXPLICITLY (polite error) rather than silently searching the
+    personal graph and reporting a misleading no-op."""
+
+    @pytest.mark.asyncio
+    async def test_forget_search_org_tier_refused(self) -> None:
+        tool = MemoryForgetSearchTool()
+        with patch(
+            "backend.copilot.tools.graphiti_forget.is_enabled_for_user",
+            new_callable=AsyncMock,
+            return_value=True,
+        ):
+            result = await tool._execute(
+                user_id="user-1", session=_session(), query="the budget", tier="org"
+            )
+
+        assert isinstance(result, ErrorResponse)
+        assert "only available for your personal memory" in result.message
+
+    @pytest.mark.asyncio
+    async def test_forget_confirm_team_tier_refused(self) -> None:
+        tool = MemoryForgetConfirmTool()
+        with patch(
+            "backend.copilot.tools.graphiti_forget.is_enabled_for_user",
+            new_callable=AsyncMock,
+            return_value=True,
+        ):
+            result = await tool._execute(
+                user_id="user-1",
+                session=_session(),
+                uuids=["edge-1"],
+                tier="team",
+            )
+
+        assert isinstance(result, ErrorResponse)
+        assert "only available for your personal memory" in result.message
+
+    @pytest.mark.asyncio
+    async def test_forget_search_personal_default_not_refused(self) -> None:
+        """Default (personal) must fall through to the normal search path,
+        not the shared-tier refusal."""
+        tool = MemoryForgetSearchTool()
+        with (
+            patch(
+                "backend.copilot.tools.graphiti_forget.is_enabled_for_user",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(
+                "backend.copilot.tools.graphiti_forget.derive_group_id",
+                return_value="user_user-1",
+            ),
+            patch(
+                "backend.copilot.tools.graphiti_forget.get_graphiti_client",
+                new_callable=AsyncMock,
+            ) as get_client,
+        ):
+            client = AsyncMock()
+            client.search.return_value = []
+            get_client.return_value = client
+            result = await tool._execute(
+                user_id="user-1", session=_session(), query="the budget"
+            )
+
+        # Reached the real search path (no shared-tier refusal message).
+        assert "only available for your personal memory" not in getattr(
+            result, "message", ""
+        )

--- a/autogpt_platform/backend/backend/copilot/tools/graphiti_search.py
+++ b/autogpt_platform/backend/backend/copilot/tools/graphiti_search.py
@@ -12,8 +12,14 @@ from backend.copilot.graphiti._format import (
     extract_fact,
     extract_temporal_validity,
 )
-from backend.copilot.graphiti.client import derive_group_id, get_graphiti_client
+from backend.copilot.graphiti.client import get_graphiti_client
 from backend.copilot.graphiti.config import is_enabled_for_user
+from backend.copilot.graphiti.tiers import (
+    MemoryTier,
+    TierError,
+    merge_tiered,
+    resolve_search_targets,
+)
 from backend.copilot.model import ChatSession
 
 from .base import BaseTool
@@ -62,6 +68,16 @@ class MemorySearchTool(BaseTool):
                         "Omit to search all scopes."
                     ),
                 },
+                "tier": {
+                    "type": "string",
+                    "enum": ["all", "personal", "team", "org"],
+                    "description": (
+                        "Tiers to search: 'all' (default: personal + org + your "
+                        "teams), or 'personal'/'team'/'org'. Shared results are "
+                        "labelled with their source (e.g. 'org memory')."
+                    ),
+                    "default": "all",
+                },
             },
             "required": ["query"],
         }
@@ -78,6 +94,7 @@ class MemorySearchTool(BaseTool):
         query: str = "",
         limit: int = 15,
         scope: str = "",
+        tier: str = "all",
         **kwargs,
     ) -> ToolResponseBase:
         if not user_id:
@@ -100,47 +117,93 @@ class MemorySearchTool(BaseTool):
 
         limit = min(limit, _MAX_LIMIT)
 
+        # Resolve which tier groups this search may read. Only ACTIVE team
+        # memberships are ever included, and org/team tiers require an org
+        # on the session — non-members can never read shared memory.
         try:
-            group_id = derive_group_id(user_id)
+            targets = await resolve_search_targets(
+                user_id, session.organization_id, tier
+            )
+        except TierError as exc:
+            return ErrorResponse(message=exc.message, session_id=session.session_id)
         except ValueError:
             return ErrorResponse(
                 message="Invalid user ID for memory operations.",
                 session_id=session.session_id,
             )
 
-        try:
-            client = await get_graphiti_client(group_id)
+        if not targets:
+            # e.g. tier='team' when the user has no active team memberships.
+            return MemorySearchResponse(
+                message="No memories found matching your query.",
+                session_id=session.session_id,
+                facts=[],
+                recent_episodes=[],
+            )
 
-            edges, episodes = await asyncio.gather(
+        now = datetime.now(timezone.utc)
+
+        async def _search_one(target):
+            client = await get_graphiti_client(target.group_id)
+            return await asyncio.gather(
                 client.search(
                     query=query,
-                    group_ids=[group_id],
+                    group_ids=[target.group_id],
                     num_results=limit,
                 ),
                 client.retrieve_episodes(
-                    reference_time=datetime.now(timezone.utc),
-                    group_ids=[group_id],
+                    reference_time=now,
+                    group_ids=[target.group_id],
                     last_n=5,
                 ),
             )
-        except Exception:
-            logger.warning(
-                "Memory search failed for user %s", user_id[:12], exc_info=True
-            )
+
+        # Per-tier failures are non-fatal — a flaky shared graph must not
+        # sink a personal search. Only surface "unavailable" when every
+        # tier failed.
+        results = await asyncio.gather(
+            *(_search_one(t) for t in targets), return_exceptions=True
+        )
+
+        personal_edges: list = []
+        personal_eps: list[str] = []
+        shared_edges: list[tuple[str | None, list]] = []
+        shared_eps: list[tuple[str | None, list[str]]] = []
+        any_ok = False
+
+        for target, res in zip(targets, results):
+            if isinstance(res, BaseException):
+                logger.warning(
+                    "Memory search tier %s failed for user %s",
+                    target.group_id[:20],
+                    user_id[:12],
+                    exc_info=res,
+                )
+                continue
+            any_ok = True
+            edges, episodes = res
+            ep_lines = _episode_lines(episodes, scope)
+            if target.tier == MemoryTier.personal:
+                personal_edges = edges
+                personal_eps = ep_lines
+            else:
+                shared_edges.append((target.label, edges))
+                shared_eps.append((target.label, ep_lines))
+
+        if not any_ok:
             return ErrorResponse(
                 message="Memory search is temporarily unavailable.",
                 session_id=session.session_id,
             )
 
-        facts = _format_edges(edges)
+        merged_facts = merge_tiered(personal_edges, shared_edges, limit)
+        facts = [
+            f"{_label_prefix(label)}{_edge_to_fact_line(e)}"
+            for e, label in merged_facts
+        ]
 
-        # Scope hard-filter: if a scope was requested, filter episodes
-        # whose MemoryEnvelope JSON contains a different scope.
-        # Skip redundant _format_episodes() when scope is set.
-        if scope:
-            recent = _filter_episodes_by_scope(episodes, scope)
-        else:
-            recent = _format_episodes(episodes)
+        merged_eps = merge_tiered(personal_eps, shared_eps, limit)
+        recent = [f"{_label_prefix(label)}{line}" for line, label in merged_eps]
 
         if not facts and not recent:
             return MemorySearchResponse(
@@ -151,11 +214,14 @@ class MemorySearchTool(BaseTool):
             )
 
         scope_note = f" (scope filter: {scope})" if scope else ""
+        tier_note = "" if tier in ("", "all") else f" (tier: {tier})"
         return MemorySearchResponse(
             message=(
-                f"Found {len(facts)} relationship facts and {len(recent)} stored memories{scope_note}. "
+                f"Found {len(facts)} relationship facts and {len(recent)} stored memories{scope_note}{tier_note}. "
                 "Use BOTH sections to answer — stored memories often contain operational "
-                "rules and instructions that relationship facts summarize."
+                "rules and instructions that relationship facts summarize. Facts labelled "
+                "'org memory' / 'team memory (<name>)' are shared context — weigh them "
+                "against your personal (unlabelled) memory."
             ),
             session_id=session.session_id,
             facts=facts,
@@ -163,13 +229,26 @@ class MemorySearchTool(BaseTool):
         )
 
 
+def _label_prefix(label: str | None) -> str:
+    """Render a provenance label as a bracketed prefix (empty for personal)."""
+    return f"[{label}] " if label else ""
+
+
+def _edge_to_fact_line(e) -> str:
+    fact = extract_fact(e)
+    valid_from, valid_to = extract_temporal_validity(e)
+    return f"{fact} (valid: {valid_from} — {valid_to})"
+
+
+def _episode_lines(episodes, scope: str) -> list[str]:
+    """Format (and, when a scope is requested, hard-filter) recent episodes."""
+    if scope:
+        return _filter_episodes_by_scope(episodes, scope)
+    return _format_episodes(episodes)
+
+
 def _format_edges(edges) -> list[str]:
-    results = []
-    for e in edges:
-        fact = extract_fact(e)
-        valid_from, valid_to = extract_temporal_validity(e)
-        results.append(f"{fact} (valid: {valid_from} — {valid_to})")
-    return results
+    return [_edge_to_fact_line(e) for e in edges]
 
 
 def _format_episodes(episodes) -> list[str]:

--- a/autogpt_platform/backend/backend/copilot/tools/graphiti_search_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/graphiti_search_test.py
@@ -108,10 +108,13 @@ class TestMemorySearchTiers:
     async def test_all_tiers_label_shared_results(self) -> None:
         tool = MemorySearchTool()
         targets = [
-            TierTarget("user_user-1", MemoryTier.personal, None),
-            TierTarget("org_org-1", MemoryTier.org, "org memory"),
+            TierTarget(group_id="user_user-1", tier=MemoryTier.personal, label=None),
+            TierTarget(group_id="org_org-1", tier=MemoryTier.org, label="org memory"),
             TierTarget(
-                "team_team-1", MemoryTier.team, "team memory (Platform)", "team-1"
+                group_id="team_team-1",
+                tier=MemoryTier.team,
+                label="team memory (Platform)",
+                team_id="team-1",
             ),
         ]
         clients = {
@@ -157,7 +160,9 @@ class TestMemorySearchTiers:
         tool = MemorySearchTool()
         # resolve_search_targets returns ONLY personal (simulating a user with
         # no active team memberships in the org).
-        targets = [TierTarget("user_user-1", MemoryTier.personal, None)]
+        targets = [
+            TierTarget(group_id="user_user-1", tier=MemoryTier.personal, label=None)
+        ]
         personal_client = _tier_client([_fact_edge("personal fact")])
 
         async def _fake_client(group_id: str):

--- a/autogpt_platform/backend/backend/copilot/tools/graphiti_search_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/graphiti_search_test.py
@@ -1,12 +1,21 @@
-"""Tests for graphiti_search helper functions."""
+"""Tests for graphiti_search helper functions and tiered fan-out."""
 
+from datetime import UTC, datetime
 from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
 
 from backend.copilot.graphiti.memory_model import MemoryEnvelope, MemoryKind, SourceKind
+from backend.copilot.graphiti.tiers import MemoryTier, TierTarget
+from backend.copilot.model import ChatSession
+from backend.copilot.tools import graphiti_search as search_mod
 from backend.copilot.tools.graphiti_search import (
+    MemorySearchTool,
     _filter_episodes_by_scope,
     _format_episodes,
 )
+from backend.copilot.tools.models import ErrorResponse, MemorySearchResponse
 
 
 class TestFilterEpisodesByScopeTruncation:
@@ -62,3 +71,168 @@ class TestRedundantFormatting:
         from_scope = _filter_episodes_by_scope([ep], "real:global")
         assert len(from_format) == 1
         assert len(from_scope) == 1
+
+
+# ---------------------------------------------------------------------------
+# Tiered search fan-out
+# ---------------------------------------------------------------------------
+
+
+def _fact_edge(fact: str):
+    return SimpleNamespace(fact=fact, valid_at="2025-01-01", invalid_at=None)
+
+
+def _tier_client(edges: list[object]) -> AsyncMock:
+    client = AsyncMock()
+    client.search.return_value = edges
+    client.retrieve_episodes.return_value = []
+    return client
+
+
+def _org_session() -> ChatSession:
+    return ChatSession(
+        session_id="s",
+        user_id="user-1",
+        title=None,
+        messages=[],
+        usage=[],
+        credentials={},
+        started_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+        organization_id="org-1",
+    )
+
+
+class TestMemorySearchTiers:
+    @pytest.mark.asyncio
+    async def test_all_tiers_label_shared_results(self) -> None:
+        tool = MemorySearchTool()
+        targets = [
+            TierTarget("user_user-1", MemoryTier.personal, None),
+            TierTarget("org_org-1", MemoryTier.org, "org memory"),
+            TierTarget(
+                "team_team-1", MemoryTier.team, "team memory (Platform)", "team-1"
+            ),
+        ]
+        clients = {
+            "user_user-1": _tier_client([_fact_edge("personal fact")]),
+            "org_org-1": _tier_client([_fact_edge("org fact")]),
+            "team_team-1": _tier_client([_fact_edge("team fact")]),
+        }
+
+        async def _fake_client(group_id: str):
+            return clients[group_id]
+
+        with (
+            patch(
+                "backend.copilot.tools.graphiti_search.is_enabled_for_user",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch.object(
+                search_mod,
+                "resolve_search_targets",
+                new_callable=AsyncMock,
+                return_value=targets,
+            ),
+            patch.object(search_mod, "get_graphiti_client", side_effect=_fake_client),
+        ):
+            result = await tool._execute(
+                user_id="user-1", session=_org_session(), query="q", tier="all"
+            )
+
+        assert isinstance(result, MemorySearchResponse)
+        assert any("[org memory] org fact" in f for f in result.facts)
+        assert any("[team memory (Platform)] team fact" in f for f in result.facts)
+        # Personal fact is unlabelled.
+        assert any(f.startswith("personal fact") for f in result.facts)
+        # Every resolved (active-membership) tier group was queried, and only those.
+        for client in clients.values():
+            client.search.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_tier_all_queries_only_active_membership_targets(self) -> None:
+        """The tool queries exactly the groups resolve_search_targets returns
+        — which is the active-membership source — never an arbitrary team."""
+        tool = MemorySearchTool()
+        # resolve_search_targets returns ONLY personal (simulating a user with
+        # no active team memberships in the org).
+        targets = [TierTarget("user_user-1", MemoryTier.personal, None)]
+        personal_client = _tier_client([_fact_edge("personal fact")])
+
+        async def _fake_client(group_id: str):
+            assert group_id == "user_user-1"
+            return personal_client
+
+        with (
+            patch(
+                "backend.copilot.tools.graphiti_search.is_enabled_for_user",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch.object(
+                search_mod,
+                "resolve_search_targets",
+                new_callable=AsyncMock,
+                return_value=targets,
+            ) as resolve,
+            patch.object(search_mod, "get_graphiti_client", side_effect=_fake_client),
+        ):
+            result = await tool._execute(
+                user_id="user-1", session=_org_session(), query="q", tier="all"
+            )
+
+        resolve.assert_awaited_once_with("user-1", "org-1", "all")
+        assert isinstance(result, MemorySearchResponse)
+        personal_client.search.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_team_tier_with_no_active_memberships_returns_no_memories(
+        self,
+    ) -> None:
+        tool = MemorySearchTool()
+        with (
+            patch(
+                "backend.copilot.tools.graphiti_search.is_enabled_for_user",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch.object(
+                search_mod,
+                "resolve_search_targets",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+        ):
+            result = await tool._execute(
+                user_id="user-1", session=_org_session(), query="q", tier="team"
+            )
+
+        assert isinstance(result, MemorySearchResponse)
+        assert result.facts == []
+        assert "No memories found" in result.message
+
+    @pytest.mark.asyncio
+    async def test_org_tier_without_org_returns_polite_error(self) -> None:
+        tool = MemorySearchTool()
+        session = ChatSession(
+            session_id="s",
+            user_id="user-1",
+            title=None,
+            messages=[],
+            usage=[],
+            credentials={},
+            started_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        )
+        with patch(
+            "backend.copilot.tools.graphiti_search.is_enabled_for_user",
+            new_callable=AsyncMock,
+            return_value=True,
+        ):
+            result = await tool._execute(
+                user_id="user-1", session=session, query="q", tier="org"
+            )
+
+        assert isinstance(result, ErrorResponse)
+        assert "organization" in result.message.lower()

--- a/autogpt_platform/backend/backend/copilot/tools/graphiti_store.py
+++ b/autogpt_platform/backend/backend/copilot/tools/graphiti_store.py
@@ -3,6 +3,7 @@
 import logging
 from typing import Any
 
+from backend.copilot.graphiti.client import derive_org_group_id, derive_team_group_id
 from backend.copilot.graphiti.config import is_enabled_for_user
 from backend.copilot.graphiti.ingest import MAX_EPISODE_BODY_BYTES, enqueue_episode
 from backend.copilot.graphiti.memory_model import (
@@ -13,6 +14,12 @@ from backend.copilot.graphiti.memory_model import (
     ProcedureStep,
     RuleMemory,
     SourceKind,
+)
+from backend.copilot.graphiti.tiers import (
+    TierError,
+    hold_buffer_enabled,
+    is_org_admin,
+    resolve_store_team,
 )
 from backend.copilot.model import ChatSession
 
@@ -50,6 +57,23 @@ class MemoryStoreTool(BaseTool):
                 "content": {
                     "type": "string",
                     "description": "The information to remember. Be concise but complete.",
+                },
+                "tier": {
+                    "type": "string",
+                    "enum": ["personal", "team", "org"],
+                    "description": (
+                        "Where to store: 'personal' (default, private), 'team' "
+                        "(shared with a team), or 'org' (org-wide). Non-admin "
+                        "team/org stores may be held for admin review."
+                    ),
+                    "default": "personal",
+                },
+                "team_id": {
+                    "type": "string",
+                    "description": (
+                        "Team id for tier='team' when you're in more than one "
+                        "team; defaults to the session's team."
+                    ),
                 },
                 "source_description": {
                     "type": "string",
@@ -163,6 +187,8 @@ class MemoryStoreTool(BaseTool):
         source_kind: str = "user_asserted",
         scope: str = "real:global",
         memory_kind: str = "fact",
+        tier: str = "personal",
+        team_id: str = "",
         rule: dict | None = None,
         procedure: dict | None = None,
         **kwargs,
@@ -226,16 +252,76 @@ class MemoryStoreTool(BaseTool):
         else:
             provenance = f"session:{session.session_id}"
 
+        # --- Tier routing + write governance ---
+        # Personal (default): private group, always active — unchanged path.
+        # Shared tiers (team/org): governed by membership role + the org's
+        # hold-buffer setting. Non-admin writes land 'tentative' (a review
+        # buffer) when the buffer is on; admins — and everyone when the
+        # buffer is off — land 'active'. The governed status is stamped onto
+        # the edge (edge_metadata) so admin review can query it natively.
+        resolved_tier = tier if tier in ("personal", "team", "org") else "personal"
+        memory_status = MemoryStatus.active
+        target_group_id: str | None = None  # None → personal path in enqueue
+
+        if resolved_tier == "org":
+            org_id = session.organization_id
+            if not org_id:
+                return ErrorResponse(
+                    message=(
+                        "Storing to organization memory requires a session "
+                        "attached to an organization."
+                    ),
+                    session_id=session.session_id,
+                )
+            admin = await is_org_admin(user_id, org_id)
+            held = (not admin) and await hold_buffer_enabled(org_id)
+            memory_status = MemoryStatus.tentative if held else MemoryStatus.active
+            target_group_id = derive_org_group_id(org_id)
+
+        elif resolved_tier == "team":
+            org_id = session.organization_id
+            if not org_id:
+                return ErrorResponse(
+                    message=(
+                        "Storing to team memory requires a session attached to "
+                        "an organization."
+                    ),
+                    session_id=session.session_id,
+                )
+            try:
+                membership = await resolve_store_team(
+                    user_id, org_id, session.team_id, team_id or None
+                )
+            except TierError as exc:
+                return ErrorResponse(message=exc.message, session_id=session.session_id)
+            admin = bool(membership.isAdmin)
+            held = (not admin) and await hold_buffer_enabled(org_id)
+            memory_status = MemoryStatus.tentative if held else MemoryStatus.active
+            target_group_id = derive_team_group_id(membership.teamId)
+
         envelope = MemoryEnvelope(
             content=content,
             source_kind=resolved_source,
             scope=scope,
             memory_kind=resolved_kind,
-            status=MemoryStatus.active,
+            status=memory_status,
             provenance=provenance,
             rule=rule_model,
             procedure=procedure_model,
         )
+
+        # Shared-tier writes stamp their governed status/provenance onto the
+        # edge so it survives graphiti's text-based extraction (personal
+        # writes keep the existing default-status path untouched).
+        edge_metadata: dict | None = None
+        if resolved_tier != "personal":
+            edge_metadata = {
+                "status": memory_status.value,
+                "source_kind": resolved_source.value,
+                "scope": scope,
+                "confidence": None,
+                "provenance": provenance,
+            }
 
         episode_body = envelope.model_dump_json()
 
@@ -261,6 +347,8 @@ class MemoryStoreTool(BaseTool):
             episode_body=episode_body,
             source_description=source_description,
             is_json=True,
+            group_id=target_group_id,
+            edge_metadata=edge_metadata,
         )
 
         if not queued:
@@ -269,8 +357,18 @@ class MemoryStoreTool(BaseTool):
                 session_id=session.session_id,
             )
 
+        if memory_status == MemoryStatus.tentative:
+            message = (
+                f"Memory '{name}' submitted to {resolved_tier} memory and is "
+                f"pending admin review before it becomes active."
+            )
+        elif resolved_tier == "personal":
+            message = f"Memory '{name}' queued for storage."
+        else:
+            message = f"Memory '{name}' queued for storage in {resolved_tier} memory."
+
         return MemoryStoreResponse(
-            message=f"Memory '{name}' queued for storage.",
+            message=message,
             session_id=session.session_id,
             memory_name=name,
         )

--- a/autogpt_platform/backend/backend/copilot/tools/graphiti_store.py
+++ b/autogpt_platform/backend/backend/copilot/tools/graphiti_store.py
@@ -19,6 +19,7 @@ from backend.copilot.graphiti.tiers import (
     TierError,
     hold_buffer_enabled,
     is_org_admin,
+    is_org_member,
     resolve_store_team,
 )
 from backend.copilot.model import ChatSession
@@ -270,6 +271,17 @@ class MemoryStoreTool(BaseTool):
                     message=(
                         "Storing to organization memory requires a session "
                         "attached to an organization."
+                    ),
+                    session_id=session.session_id,
+                )
+            # Re-verify ACTIVE org membership: session.organization_id is only
+            # checked at session creation, so a revoked/stale membership must
+            # not reach the org write path (mirrors the team tier below).
+            if not await is_org_member(user_id, org_id):
+                return ErrorResponse(
+                    message=(
+                        "You are not an active member of this organization, so "
+                        "you cannot store to its organization memory."
                     ),
                     session_id=session.session_id,
                 )

--- a/autogpt_platform/backend/backend/copilot/tools/graphiti_store_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/graphiti_store_test.py
@@ -415,7 +415,14 @@ class TestMemoryStoreTierGovernance:
     """Shared-tier writes route to the tier's group and land active or
     tentative per the writer's role + the org hold-buffer setting."""
 
-    def _patches(self, *, is_org_admin=None, hold_buffer=None, resolve_store_team=None):
+    def _patches(
+        self,
+        *,
+        is_org_admin=None,
+        is_org_member=None,
+        hold_buffer=None,
+        resolve_store_team=None,
+    ):
         from contextlib import ExitStack
 
         stack = ExitStack()
@@ -433,6 +440,14 @@ class TestMemoryStoreTierGovernance:
                 return_value=True,
             )
         )
+        if is_org_member is not None:
+            stack.enter_context(
+                patch(
+                    "backend.copilot.tools.graphiti_store.is_org_member",
+                    new_callable=AsyncMock,
+                    return_value=is_org_member,
+                )
+            )
         if is_org_admin is not None:
             stack.enter_context(
                 patch(
@@ -461,7 +476,9 @@ class TestMemoryStoreTierGovernance:
     @pytest.mark.asyncio
     async def test_org_store_as_admin_lands_active(self) -> None:
         tool = MemoryStoreTool()
-        stack, enqueue = self._patches(is_org_admin=True, hold_buffer=True)
+        stack, enqueue = self._patches(
+            is_org_admin=True, is_org_member=True, hold_buffer=True
+        )
         with stack:
             result = await tool._execute(
                 user_id="user-1",
@@ -480,9 +497,29 @@ class TestMemoryStoreTierGovernance:
         assert "queued for storage in org memory" in result.message
 
     @pytest.mark.asyncio
+    async def test_org_store_non_member_rejected(self) -> None:
+        # A revoked/stale org membership must be blocked at the write path.
+        tool = MemoryStoreTool()
+        stack, enqueue = self._patches(is_org_member=False, hold_buffer=True)
+        with stack:
+            result = await tool._execute(
+                user_id="user-1",
+                session=_org_session(),
+                name="policy",
+                content="Refunds within 30 days.",
+                tier="org",
+            )
+
+        assert isinstance(result, ErrorResponse)
+        assert "not an active member" in result.message
+        enqueue.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_org_store_as_member_lands_tentative(self) -> None:
         tool = MemoryStoreTool()
-        stack, enqueue = self._patches(is_org_admin=False, hold_buffer=True)
+        stack, enqueue = self._patches(
+            is_org_admin=False, is_org_member=True, hold_buffer=True
+        )
         with stack:
             result = await tool._execute(
                 user_id="user-1",
@@ -503,7 +540,9 @@ class TestMemoryStoreTierGovernance:
     @pytest.mark.asyncio
     async def test_org_store_member_active_when_hold_buffer_disabled(self) -> None:
         tool = MemoryStoreTool()
-        stack, enqueue = self._patches(is_org_admin=False, hold_buffer=False)
+        stack, enqueue = self._patches(
+            is_org_admin=False, is_org_member=True, hold_buffer=False
+        )
         with stack:
             result = await tool._execute(
                 user_id="user-1",

--- a/autogpt_platform/backend/backend/copilot/tools/graphiti_store_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/graphiti_store_test.py
@@ -25,6 +25,25 @@ def _make_session(session_id: str = "test-session") -> ChatSession:
     )
 
 
+def _org_session(
+    session_id: str = "test-session",
+    org_id: str | None = "org-1",
+    team_id: str | None = None,
+) -> ChatSession:
+    return ChatSession(
+        session_id=session_id,
+        user_id="test-user",
+        title=None,
+        messages=[],
+        usage=[],
+        credentials={},
+        started_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+        organization_id=org_id,
+        team_id=team_id,
+    )
+
+
 class TestMemoryStoreTool:
     """Tests for MemoryStoreTool._execute."""
 
@@ -390,3 +409,216 @@ class TestMemoryStoreTool:
         assert isinstance(result, MemoryStoreResponse)
         envelope = json.loads(mock_enqueue.await_args.kwargs["episode_body"])
         assert envelope["scope"] == "project:crm"
+
+
+class TestMemoryStoreTierGovernance:
+    """Shared-tier writes route to the tier's group and land active or
+    tentative per the writer's role + the org hold-buffer setting."""
+
+    def _patches(self, *, is_org_admin=None, hold_buffer=None, resolve_store_team=None):
+        from contextlib import ExitStack
+
+        stack = ExitStack()
+        stack.enter_context(
+            patch(
+                "backend.copilot.tools.graphiti_store.is_enabled_for_user",
+                new_callable=AsyncMock,
+                return_value=True,
+            )
+        )
+        enqueue = stack.enter_context(
+            patch(
+                "backend.copilot.tools.graphiti_store.enqueue_episode",
+                new_callable=AsyncMock,
+                return_value=True,
+            )
+        )
+        if is_org_admin is not None:
+            stack.enter_context(
+                patch(
+                    "backend.copilot.tools.graphiti_store.is_org_admin",
+                    new_callable=AsyncMock,
+                    return_value=is_org_admin,
+                )
+            )
+        if hold_buffer is not None:
+            stack.enter_context(
+                patch(
+                    "backend.copilot.tools.graphiti_store.hold_buffer_enabled",
+                    new_callable=AsyncMock,
+                    return_value=hold_buffer,
+                )
+            )
+        if resolve_store_team is not None:
+            stack.enter_context(
+                patch(
+                    "backend.copilot.tools.graphiti_store.resolve_store_team",
+                    resolve_store_team,
+                )
+            )
+        return stack, enqueue
+
+    @pytest.mark.asyncio
+    async def test_org_store_as_admin_lands_active(self) -> None:
+        tool = MemoryStoreTool()
+        stack, enqueue = self._patches(is_org_admin=True, hold_buffer=True)
+        with stack:
+            result = await tool._execute(
+                user_id="user-1",
+                session=_org_session(),
+                name="policy",
+                content="Refunds within 30 days.",
+                tier="org",
+            )
+
+        assert isinstance(result, MemoryStoreResponse)
+        kwargs = enqueue.await_args.kwargs
+        assert kwargs["group_id"] == "org_org-1"
+        assert kwargs["edge_metadata"]["status"] == "active"
+        envelope = json.loads(kwargs["episode_body"])
+        assert envelope["status"] == "active"
+        assert "queued for storage in org memory" in result.message
+
+    @pytest.mark.asyncio
+    async def test_org_store_as_member_lands_tentative(self) -> None:
+        tool = MemoryStoreTool()
+        stack, enqueue = self._patches(is_org_admin=False, hold_buffer=True)
+        with stack:
+            result = await tool._execute(
+                user_id="user-1",
+                session=_org_session(),
+                name="policy",
+                content="Refunds within 30 days.",
+                tier="org",
+            )
+
+        assert isinstance(result, MemoryStoreResponse)
+        kwargs = enqueue.await_args.kwargs
+        assert kwargs["group_id"] == "org_org-1"
+        assert kwargs["edge_metadata"]["status"] == "tentative"
+        envelope = json.loads(kwargs["episode_body"])
+        assert envelope["status"] == "tentative"
+        assert "pending admin review" in result.message
+
+    @pytest.mark.asyncio
+    async def test_org_store_member_active_when_hold_buffer_disabled(self) -> None:
+        tool = MemoryStoreTool()
+        stack, enqueue = self._patches(is_org_admin=False, hold_buffer=False)
+        with stack:
+            result = await tool._execute(
+                user_id="user-1",
+                session=_org_session(),
+                name="policy",
+                content="Refunds within 30 days.",
+                tier="org",
+            )
+
+        assert isinstance(result, MemoryStoreResponse)
+        assert enqueue.await_args.kwargs["edge_metadata"]["status"] == "active"
+        assert "pending admin review" not in result.message
+
+    @pytest.mark.asyncio
+    async def test_org_store_without_org_context_errors(self) -> None:
+        tool = MemoryStoreTool()
+        stack, enqueue = self._patches(is_org_admin=True, hold_buffer=True)
+        with stack:
+            result = await tool._execute(
+                user_id="user-1",
+                session=_org_session(org_id=None),
+                name="policy",
+                content="Refunds within 30 days.",
+                tier="org",
+            )
+
+        assert isinstance(result, ErrorResponse)
+        assert "organization" in result.message.lower()
+        enqueue.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_team_store_as_team_admin_lands_active(self) -> None:
+        tool = MemoryStoreTool()
+        from types import SimpleNamespace
+
+        resolve = AsyncMock(return_value=SimpleNamespace(teamId="team-1", isAdmin=True))
+        stack, enqueue = self._patches(hold_buffer=True, resolve_store_team=resolve)
+        with stack:
+            result = await tool._execute(
+                user_id="user-1",
+                session=_org_session(team_id="team-1"),
+                name="convention",
+                content="Deploys go out Tuesdays.",
+                tier="team",
+            )
+
+        assert isinstance(result, MemoryStoreResponse)
+        kwargs = enqueue.await_args.kwargs
+        assert kwargs["group_id"] == "team_team-1"
+        assert kwargs["edge_metadata"]["status"] == "active"
+        assert "queued for storage in team memory" in result.message
+
+    @pytest.mark.asyncio
+    async def test_team_store_as_non_admin_member_lands_tentative(self) -> None:
+        tool = MemoryStoreTool()
+        from types import SimpleNamespace
+
+        resolve = AsyncMock(
+            return_value=SimpleNamespace(teamId="team-1", isAdmin=False)
+        )
+        stack, enqueue = self._patches(hold_buffer=True, resolve_store_team=resolve)
+        with stack:
+            result = await tool._execute(
+                user_id="user-1",
+                session=_org_session(team_id="team-1"),
+                name="convention",
+                content="Deploys go out Tuesdays.",
+                tier="team",
+            )
+
+        assert isinstance(result, MemoryStoreResponse)
+        assert enqueue.await_args.kwargs["edge_metadata"]["status"] == "tentative"
+        assert "pending admin review" in result.message
+
+    @pytest.mark.asyncio
+    async def test_team_store_when_not_a_member_errors_clearly(self) -> None:
+        from backend.copilot.graphiti.tiers import TierError
+
+        tool = MemoryStoreTool()
+        resolve = AsyncMock(
+            side_effect=TierError(
+                "You are not an active member of the specified team, so you "
+                "cannot store to its team memory."
+            )
+        )
+        stack, enqueue = self._patches(hold_buffer=True, resolve_store_team=resolve)
+        with stack:
+            result = await tool._execute(
+                user_id="user-1",
+                session=_org_session(team_id="team-1"),
+                name="convention",
+                content="Deploys go out Tuesdays.",
+                tier="team",
+            )
+
+        assert isinstance(result, ErrorResponse)
+        assert "not an active member" in result.message
+        enqueue.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_personal_tier_default_unchanged(self) -> None:
+        """Default personal store must not route to a shared group or stamp
+        edge metadata — the pre-existing path is untouched."""
+        tool = MemoryStoreTool()
+        stack, enqueue = self._patches()
+        with stack:
+            result = await tool._execute(
+                user_id="user-1",
+                session=_org_session(org_id="org-1", team_id="team-1"),
+                name="pref",
+                content="likes python",
+            )
+
+        assert isinstance(result, MemoryStoreResponse)
+        kwargs = enqueue.await_args.kwargs
+        assert kwargs["group_id"] is None  # personal path
+        assert kwargs["edge_metadata"] is None
+        assert "queued for storage" in result.message

--- a/autogpt_platform/backend/backend/copilot/tools/tool_schema_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/tool_schema_test.py
@@ -90,7 +90,10 @@ from backend.copilot.tools import TOOL_REGISTRY
 # Bumped 47000 -> 47800 on the post-#13601 dev merge: the registry now carries
 # the full merged tool set (webhook-trigger + preset lifecycle + docs/building
 # tools) at 47461 chars; ~340 headroom so routine wording tweaks don't trip it.
-_CHAR_BUDGET = 47_800
+# Bumped 47800 -> 48900 for tiered memory (SECRT-2460/2461): memory_store gains
+# tier + team_id, memory_search gains tier, and both memory_forget tools gain a
+# tier param — ~1.06k chars across four tools at 48520 total; ~380 headroom.
+_CHAR_BUDGET = 48_900
 
 
 @pytest.fixture(scope="module")

--- a/autogpt_platform/backend/backend/data/org_credit.py
+++ b/autogpt_platform/backend/backend/data/org_credit.py
@@ -11,6 +11,7 @@ from datetime import datetime, timezone
 
 import stripe
 from prisma.enums import CreditTransactionType, OnboardingStep
+from prisma.types import OrgCreditTransactionWhereInput
 from pydantic import BaseModel
 
 from backend.data.credit import (
@@ -257,6 +258,69 @@ async def get_org_transaction_history(
         }
         for t in transactions
     ]
+
+
+async def get_org_spend_by_team(
+    org_id: str,
+    start_time: datetime | None = None,
+    end_time: datetime | None = None,
+) -> list[dict]:
+    """Aggregate an org's spend grouped by the team each debit was attributed to.
+
+    Spend is the ``USAGE`` ledger type: :func:`spend_org_credits` writes a debit
+    as a ``USAGE`` row with a NEGATIVE ``amount`` (credits leaving the pool),
+    while top-ups and grants are separate positive types. We therefore filter to
+    ``USAGE`` and report ``total_spent`` as the negated sum — a positive
+    magnitude of credits spent (a reconciliation refund, stored as a positive
+    ``USAGE`` amount, correctly nets it back down). Rows with a NULL ``teamId``
+    (org-home usage and legacy personal-org migrations) form their own
+    unattributed bucket rather than being dropped.
+
+    Buckets are returned highest-spend first. Each bucket is a dict with
+    ``team_id`` (nullable), ``team_name`` (nullable), ``total_spent`` and
+    ``transaction_count``.
+    """
+    where: OrgCreditTransactionWhereInput = {
+        "orgId": org_id,
+        "type": CreditTransactionType.USAGE,
+        "isActive": True,
+    }
+    if start_time and end_time:
+        where["createdAt"] = {"gte": start_time, "lte": end_time}
+    elif start_time:
+        where["createdAt"] = {"gte": start_time}
+    elif end_time:
+        where["createdAt"] = {"lte": end_time}
+
+    rows = await prisma.orgcredittransaction.group_by(
+        by=["teamId"],
+        where=where,
+        sum={"amount": True},
+        count=True,
+    )
+
+    team_names = await _resolve_team_names([row.get("teamId") for row in rows])
+
+    buckets = [
+        {
+            "team_id": row.get("teamId"),
+            "team_name": team_names.get(row.get("teamId") or ""),
+            "total_spent": -int((row.get("_sum") or {}).get("amount") or 0),
+            "transaction_count": int((row.get("_count") or {}).get("_all") or 0),
+        }
+        for row in rows
+    ]
+    buckets.sort(key=lambda bucket: bucket["total_spent"], reverse=True)
+    return buckets
+
+
+async def _resolve_team_names(team_ids: list[str | None]) -> dict[str, str]:
+    """Map team id -> name for the non-null ids via a single Team lookup."""
+    ids = [team_id for team_id in team_ids if team_id is not None]
+    if not ids:
+        return {}
+    teams = await prisma.team.find_many(where={"id": {"in": ids}})
+    return {team.id: team.name for team in teams}
 
 
 async def get_seat_info(org_id: str) -> dict:

--- a/autogpt_platform/frontend/src/app/api/openapi.json
+++ b/autogpt_platform/frontend/src/app/api/openapi.json
@@ -9375,6 +9375,68 @@
         }
       }
     },
+    "/api/orgs/{org_id}/spend": {
+      "get": {
+        "tags": ["v2", "orgs", "orgs"],
+        "summary": "Per-team spend breakdown",
+        "description": "Credits spent by the org, grouped by the team each debit was attributed to.\n\nRequires org-level MANAGE_BILLING (owner or billing_manager). Usage with no\nteam attribution — org-home spend and legacy personal-org migrations — is\nreported in a single bucket with ``team_id = null``.",
+        "operationId": "getV2Per-team spend breakdown",
+        "security": [{ "HTTPBearerJWT": [] }],
+        "parameters": [
+          {
+            "name": "org_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Org Id" }
+          },
+          {
+            "name": "from",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                { "type": "string", "format": "date-time" },
+                { "type": "null" }
+              ],
+              "title": "From"
+            }
+          },
+          {
+            "name": "to",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                { "type": "string", "format": "date-time" },
+                { "type": "null" }
+              ],
+              "title": "To"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/OrgSpendResponse" }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/orgs/{org_id}/transfer-ownership": {
       "post": {
         "tags": ["v2", "orgs", "orgs"],
@@ -19288,6 +19350,18 @@
         ],
         "title": "OrgResponse"
       },
+      "OrgSpendResponse": {
+        "properties": {
+          "teams": {
+            "items": { "$ref": "#/components/schemas/TeamSpendBucket" },
+            "type": "array",
+            "title": "Teams"
+          }
+        },
+        "type": "object",
+        "required": ["teams"],
+        "title": "OrgSpendResponse"
+      },
       "OrphanedScheduleDetail": {
         "properties": {
           "schedule_id": { "type": "string", "title": "Schedule Id" },
@@ -22662,6 +22736,31 @@
           "created_at"
         ],
         "title": "TeamResponse"
+      },
+      "TeamSpendBucket": {
+        "properties": {
+          "team_id": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Team Id"
+          },
+          "team_name": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Team Name"
+          },
+          "total_spent": { "type": "integer", "title": "Total Spent" },
+          "transaction_count": {
+            "type": "integer",
+            "title": "Transaction Count"
+          }
+        },
+        "type": "object",
+        "required": [
+          "team_id",
+          "team_name",
+          "total_spent",
+          "transaction_count"
+        ],
+        "title": "TeamSpendBucket"
       },
       "TimezoneResponse": {
         "properties": {

--- a/docs/platform/org-feature-map.md
+++ b/docs/platform/org-feature-map.md
@@ -24,6 +24,8 @@ real anchor points instead of a blank page.
   org ownership and cross-org transfers
 - **Frontend**: org/team switcher in the navbar, `OrgTeamProvider`
   bootstraps context on login, zustand store persists the active org/team
+- **Branding**: org owners/admins can set the organization logo from
+  Settings → Organization (`POST /api/orgs/{org_id}/avatar`)
 - **Migration**: idempotent personal-org bootstrap
   (`create_orgs_for_existing_users`) behind a Redis lock at startup
 


### PR DESCRIPTION
## Why

SECRT-2457 (decided v1): orgs have an `avatarUrl` field and render initials fallbacks everywhere, but no way to set a logo.

## What

`POST /api/orgs/{org_id}/avatar` (multipart) — gated by `RENAME_ORG` (same owner/admin tier as org profile edits) + the sibling routes' path/ctx verification. Reuses the store submission media pipeline end to end: images-only content-type **and** extension allowlists at the route, then the shared helper's magic-byte signature cross-check, 50MB streaming cap, and ClamAV scan. Storage path `orgs/{org_id}/images/{uuid}{ext}` — org id server-derived, filename replaced by UUID. Persists via the existing org update path and returns the updated `OrgResponse` (which already carried `avatar_url`).

`upload_media` gains a backward-compatible `organization_id` kwarg; all pre-existing callers verified unaffected.

## Testing

8 new scenario tests (admin persists+returns, member 403, wrong-org 403, non-image 400, image-type-with-.svg-extension 400, oversize 400 with no write, response model coverage, org-scoped storage path); 146/146 on the full org routes file; pyright clean.

Frontend upload control follows in the org-UI stack once this lands in the batch spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jm3mCG9okfdGtAXtFaDF9A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes org billing authorization, cross-tenant memory reads/writes, and admin graph mutations—any membership or scoping bug could leak or alter another org’s shared memory or block legitimate credit access.
> 
> **Overview**
> This PR bundles several org-facing backend capabilities beyond the avatar ticket in the title.
> 
> **Org profile & media:** Adds `POST /api/orgs/{org_id}/avatar` (`RENAME_ORG` + path verification), reusing store media validation and extending `upload_media` with optional `organization_id` for `orgs/{org_id}/images/...` paths. Org PATCH/response now expose **`memory_hold_buffer`**, persisted under `settings.memory.holdBuffer` with read-modify-write so other settings keys survive.
> 
> **Billing & spend:** Introduces `GET /api/orgs/{org_id}/spend` (USAGE debits grouped by team, optional time window, `MANAGE_BILLING`). **All major v1 `/credits` routes** now require `MANAGE_BILLING` instead of only authenticated context, since pooled org balances are shared.
> 
> **Tiered Graphiti memory:** Personal (`user_*`), team (`team_*`), and org (`org_*`) groups with `tiers.py` handling membership checks, hold-buffer governance, and merged search/warm-context budgets. Warm context and `memory_search` fan out across allowed tiers with provenance labels; `memory_store` supports `tier`/`team_id` and may write **tentative** edges for non-admins when the hold buffer is on. Ingestion workers are keyed by **group_id**; chat auto-ingest stays personal-only. Forget tools refuse non-personal tiers.
> 
> **Held-memory review:** New `/api/orgs/{org_id}/memory/held` list plus approve/reject (Graphiti tentative → active or supersede), scoped to the org’s shared graphs and gated by `MANAGE_MEMBERS` with path/org checks.
> 
> Copilot prompting and tool schema budget are updated for the new memory behavior; broad test coverage accompanies each surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4396d0dd7d2ed7b2a9b01749a869b1e4b4ce295d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->