### PR TITLE
fix(frontend): describe search command dialog

### DIFF
--- a/autogpt_platform/frontend/src/components/organisms/SearchCommandModal/SearchCommandModal.tsx
+++ b/autogpt_platform/frontend/src/components/organisms/SearchCommandModal/SearchCommandModal.tsx
@@ -122,6 +122,9 @@ export function SearchCommandModal({
           onKeyDown={handleKeyDown}
         >
           <RXDialog.Title className="sr-only">Search</RXDialog.Title>
+          <RXDialog.Description className="sr-only">
+            Search commands and results.
+          </RXDialog.Description>
           <div className="flex items-center gap-3 bg-zinc-50 p-3">
             <MagnifyingGlassIcon className="h-5 w-5 shrink-0 text-zinc-800" />
             <Input

--- a/autogpt_platform/frontend/src/components/organisms/SearchCommandModal/__tests__/SearchCommandModal.accessibility.test.tsx
+++ b/autogpt_platform/frontend/src/components/organisms/SearchCommandModal/__tests__/SearchCommandModal.accessibility.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { SearchCommandModal } from "../SearchCommandModal";
+
+describe("SearchCommandModal accessibility", () => {
+  it("describes the dialog content for assistive technology", () => {
+    render(
+      <SearchCommandModal
+        isOpen
+        onClose={vi.fn()}
+        query=""
+        onQueryChange={vi.fn()}
+        buckets={[]}
+        onSelectItem={vi.fn()}
+      />,
+    );
+
+    const dialog = screen.getByRole("dialog", { name: "Search" });
+    const descriptionId = dialog.getAttribute("aria-describedby");
+
+    expect(descriptionId).toBeTruthy();
+    expect(document.getElementById(descriptionId ?? "")?.textContent).toBe(
+      "Search commands and results.",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

* Adds a visually hidden description to the search command dialog content.
* Adds focused regression coverage that verifies the dialog exposes an aria-describedby target.

Fixes Significant-Gravitas/AutoGPT#11035

## Testing

* Focused Vitest run for `SearchCommandModal.accessibility.test.tsx` passed with a local no-setup config.
* `node_modules/.bin/prettier.cmd --check src/components/organisms/SearchCommandModal/SearchCommandModal.tsx src/components/organisms/SearchCommandModal/__tests__/SearchCommandModal.accessibility.test.tsx src/components/organisms/SearchCommandModal/__tests__/SearchCommandModal.test.tsx`

## Notes

* `node_modules/.bin/tsc.cmd --noEmit --pretty false` is currently blocked locally by missing generated API modules under `src/app/api/__generated__`, also present outside this change.