### PR TITLE
fix(backend): filter benign FalkorDB connection-teardown noise from Sentry

### DIFF
--- a/autogpt_platform/backend/backend/util/metrics.py
+++ b/autogpt_platform/backend/backend/util/metrics.py
@@ -1,5 +1,6 @@
 import logging
 from enum import Enum
+from types import TracebackType
 
 from pydantic import SecretStr
 from sentry_sdk._init_implementation import init as _sentry_init
@@ -85,7 +86,7 @@ _FALKORDB_TEARDOWN_SIGNATURES = (
 )
 
 
-def _raised_from_graphiti_falkordb(exc_tb) -> bool:
+def _raised_from_graphiti_falkordb(exc_tb: TracebackType | None) -> bool:
     """True if the graphiti FalkorDB driver module appears in the traceback.
 
     graphiti-core's ``execute_query`` re-raises from that module, so its frame

--- a/autogpt_platform/backend/backend/util/metrics.py
+++ b/autogpt_platform/backend/backend/util/metrics.py
@@ -70,6 +70,20 @@ _PIKA_RECONNECT_SIGNATURES = (
     "connection_lost",
 )
 
+# FalkorDB (Graphiti CoPilot memory) connection-teardown noise. graphiti-core's
+# ``execute_query`` logs ERROR + re-raises whenever a query races the closing of
+# its redis.asyncio connection — the fire-and-forget cache-eviction close or a
+# per-request ``driver.close()`` in a finally block. Chat degrades gracefully
+# (memory callers swallow it), so these are benign. Drop only the two teardown
+# signatures, scoped to the graphiti driver logger, so genuine query errors
+# (Cypher typos, missing graphs) still reach Sentry. (SENTRY-1387.)
+_FALKORDB_DRIVER_LOGGER = "graphiti_core.driver.falkordb_driver"
+_FALKORDB_TEARDOWN_SIGNATURES = (
+    "buffer is closed",
+    "connection closed by server",
+)
+_FALKORDB_MODULE_INDICATORS = ("falkordb", "redis")
+
 
 def _before_send(event, hint):
     """Filter out expected/transient errors from Sentry to reduce noise."""
@@ -89,6 +103,16 @@ def _before_send(event, hint):
                 ind in exc_module.lower() or ind in exc_name.lower()
                 for ind in _AMQP_INDICATORS
             ) or any(kw in exc_msg for kw in _AMQP_INDICATORS):
+                return None
+
+        # FalkorDB/redis connection-teardown races (eviction/shutdown) — benign
+        if any(sig in exc_msg for sig in _FALKORDB_TEARDOWN_SIGNATURES):
+            exc_module = getattr(exc_type, "__module__", "") or ""
+            exc_name = getattr(exc_type, "__name__", "") or ""
+            if any(
+                ind in exc_module.lower() or ind in exc_name.lower()
+                for ind in _FALKORDB_MODULE_INDICATORS
+            ):
                 return None
 
         # User-caused credential/auth/integration errors — not platform bugs
@@ -133,6 +157,9 @@ def _before_send(event, hint):
     logger_name = event.get("logger")
     if logger_name in _PIKA_RECONNECT_LOGGERS and log_msg:
         if any(sig in log_msg.lower() for sig in _PIKA_RECONNECT_SIGNATURES):
+            return None
+    if logger_name == _FALKORDB_DRIVER_LOGGER and log_msg:
+        if any(sig in log_msg.lower() for sig in _FALKORDB_TEARDOWN_SIGNATURES):
             return None
     if logger_name and log_msg:
         msg = log_msg.lower()

--- a/autogpt_platform/backend/backend/util/metrics.py
+++ b/autogpt_platform/backend/backend/util/metrics.py
@@ -75,20 +75,35 @@ _PIKA_RECONNECT_SIGNATURES = (
 # its redis.asyncio connection — the fire-and-forget cache-eviction close or a
 # per-request ``driver.close()`` in a finally block. Chat degrades gracefully
 # (memory callers swallow it), so these are benign. Drop only the two teardown
-# signatures, scoped to the graphiti driver logger, so genuine query errors
-# (Cypher typos, missing graphs) still reach Sentry. (SENTRY-1387.)
+# signatures, scoped to the graphiti driver (by logger for log events, by
+# traceback for exceptions) so genuine query errors (Cypher typos, missing
+# graphs) — and unrelated main-redis outages — still reach Sentry. (SENTRY-1387.)
 _FALKORDB_DRIVER_LOGGER = "graphiti_core.driver.falkordb_driver"
 _FALKORDB_TEARDOWN_SIGNATURES = (
     "buffer is closed",
     "connection closed by server",
 )
-_FALKORDB_MODULE_INDICATORS = ("falkordb", "redis")
+
+
+def _raised_from_graphiti_falkordb(exc_tb) -> bool:
+    """True if the graphiti FalkorDB driver module appears in the traceback.
+
+    graphiti-core's ``execute_query`` re-raises from that module, so its frame
+    is on the traceback of a teardown error originating there. Scoping to it
+    keeps unrelated redis exceptions (e.g. the platform's main redis) reaching
+    Sentry even when they share the ``connection closed by server`` message.
+    """
+    while exc_tb is not None:
+        if exc_tb.tb_frame.f_globals.get("__name__") == _FALKORDB_DRIVER_LOGGER:
+            return True
+        exc_tb = exc_tb.tb_next
+    return False
 
 
 def _before_send(event, hint):
     """Filter out expected/transient errors from Sentry to reduce noise."""
     if "exc_info" in hint:
-        exc_type, exc_value, _ = hint["exc_info"]
+        exc_type, exc_value, exc_tb = hint["exc_info"]
         exc_msg = str(exc_value).lower() if exc_value else ""
 
         # AMQP/RabbitMQ transient connection errors — expected during deploys
@@ -105,15 +120,13 @@ def _before_send(event, hint):
             ) or any(kw in exc_msg for kw in _AMQP_INDICATORS):
                 return None
 
-        # FalkorDB/redis connection-teardown races (eviction/shutdown) — benign
-        if any(sig in exc_msg for sig in _FALKORDB_TEARDOWN_SIGNATURES):
-            exc_module = getattr(exc_type, "__module__", "") or ""
-            exc_name = getattr(exc_type, "__name__", "") or ""
-            if any(
-                ind in exc_module.lower() or ind in exc_name.lower()
-                for ind in _FALKORDB_MODULE_INDICATORS
-            ):
-                return None
+        # FalkorDB connection-teardown races (eviction/shutdown) — benign, but
+        # only when raised from the graphiti driver, so an unrelated main-redis
+        # outage sharing the message still reaches Sentry.
+        if any(
+            sig in exc_msg for sig in _FALKORDB_TEARDOWN_SIGNATURES
+        ) and _raised_from_graphiti_falkordb(exc_tb):
+            return None
 
         # User-caused credential/auth/integration errors — not platform bugs
         if any(kw in exc_msg for kw in _USER_AUTH_KEYWORDS):

--- a/autogpt_platform/backend/backend/util/metrics_test.py
+++ b/autogpt_platform/backend/backend/util/metrics_test.py
@@ -10,6 +10,8 @@ rather than a Sentry alert flood.
 from __future__ import annotations
 
 from backend.util.metrics import (
+    _FALKORDB_DRIVER_LOGGER,
+    _FALKORDB_TEARDOWN_SIGNATURES,
     _PIKA_RECONNECT_LOGGERS,
     _PIKA_RECONNECT_SIGNATURES,
     _before_send,
@@ -22,6 +24,12 @@ def _log_event(logger: str, message: str) -> dict:
         "logentry": {"formatted": message, "message": message},
         "level": "error",
     }
+
+
+class _RedisConnectionError(Exception):
+    """Stand-in whose ``__module__`` mimics a redis.asyncio teardown error."""
+
+    __module__ = "redis.exceptions"
 
 
 # ---------- pika reconnect noise → dropped ----------
@@ -105,3 +113,63 @@ def test_pika_reconnect_signatures_cover_all_four_known_patterns() -> None:
         "connection_lost",
     }
     assert expected == set(_PIKA_RECONNECT_SIGNATURES)
+
+
+# ---------- FalkorDB connection-teardown noise → dropped ----------
+
+
+def test_falkordb_buffer_is_closed_log_dropped() -> None:
+    """SENTRY-1387: ``Buffer is closed`` logged by graphiti-core's FalkorDB
+    driver is a benign connection-teardown race — a query racing the cache
+    eviction close or a per-request ``driver.close()``."""
+    evt = _log_event(
+        _FALKORDB_DRIVER_LOGGER,
+        "Error executing FalkorDB query: Buffer is closed.\nMATCH (n) RETURN n\n{}",
+    )
+    assert _before_send(evt, hint={}) is None
+
+
+def test_falkordb_connection_closed_by_server_log_dropped() -> None:
+    """The sibling teardown message from the same race — the driver docstring
+    pairs it with ``Buffer is closed``."""
+    evt = _log_event(
+        _FALKORDB_DRIVER_LOGGER,
+        "Error executing FalkorDB query: Connection closed by server.",
+    )
+    assert _before_send(evt, hint={}) is None
+
+
+def test_falkordb_buffer_is_closed_exc_info_dropped() -> None:
+    """If the re-raised teardown error reaches Sentry as an exception (a caller
+    that doesn't swallow it), the redis-originated ``Buffer is closed`` is still
+    benign and must be dropped."""
+    exc = _RedisConnectionError("Buffer is closed.")
+    evt = {"level": "error"}
+    assert _before_send(evt, hint={"exc_info": (type(exc), exc, None)}) is None
+
+
+def test_falkordb_real_query_error_kept() -> None:
+    """A genuine Cypher/query failure from the same driver logger is load-
+    bearing and must NOT be filtered out by the teardown-noise rule."""
+    evt = _log_event(
+        _FALKORDB_DRIVER_LOGGER,
+        "Error executing FalkorDB query: Invalid input 'RETRUN': expected...",
+    )
+    assert _before_send(evt, hint={}) is not None
+
+
+def test_falkordb_buffer_is_closed_from_other_logger_kept() -> None:
+    """The teardown signatures are only suppressed for the graphiti FalkorDB
+    driver logger; the same string from any other logger is kept."""
+    evt = _log_event(
+        "backend.data.redis_client",
+        "Buffer is closed.",
+    )
+    assert _before_send(evt, hint={}) is not None
+
+
+def test_falkordb_teardown_signatures_cover_known_patterns() -> None:
+    """Sanity check: the teardown-signature list still covers both messages the
+    graphiti FalkorDB driver docstring pairs together."""
+    expected = {"buffer is closed", "connection closed by server"}
+    assert expected == set(_FALKORDB_TEARDOWN_SIGNATURES)

--- a/autogpt_platform/backend/backend/util/metrics_test.py
+++ b/autogpt_platform/backend/backend/util/metrics_test.py
@@ -28,17 +28,26 @@ def _log_event(logger: str, message: str) -> dict:
     }
 
 
-def _exc_info_raised_from(module: str, message: str):
+class _RedisConnectionError(Exception):
+    """Exception whose *type* module mimics redis — so tests can tell the old
+    module-based scoping (checked ``exc_type.__module__``) apart from the new
+    traceback-based scoping (checks the raising frame's module)."""
+
+    __module__ = "redis.exceptions"
+
+
+def _exc_info_raised_from(module: str, message: str, exc_type=ConnectionError):
     """Build an ``exc_info`` triple whose traceback contains a frame in
-    ``module`` — mimics an exception re-raised from that module (e.g. the
-    graphiti FalkorDB driver, or the platform's main redis)."""
-    namespace: dict = {"__name__": module}
-    exec("def _raise(msg):\n    raise ConnectionError(msg)", namespace)
+    ``module`` and whose exception is ``exc_type`` — lets tests control both
+    the traceback origin (what the new scoping checks) and the exception
+    type's module (what the old module-based scoping checked)."""
+    namespace: dict = {"__name__": module, "_Exc": exc_type}
+    exec("def _raise(msg):\n    raise _Exc(msg)", namespace)
     try:
         namespace["_raise"](message)
-    except ConnectionError:
+    except exc_type:
         return sys.exc_info()
-    raise AssertionError("expected ConnectionError")
+    raise AssertionError("expected exception")
 
 
 # ---------- pika reconnect noise → dropped ----------
@@ -159,9 +168,13 @@ def test_falkordb_buffer_is_closed_exc_from_graphiti_dropped() -> None:
 def test_main_redis_connection_closed_exc_kept() -> None:
     """A genuine ``Connection closed by server`` from the platform's main redis
     (NOT raised from the graphiti driver) is a real incident and must NOT be
-    swallowed by the teardown-noise rule."""
+    swallowed by the teardown-noise rule. Uses a redis-module exception type so
+    the OLD module-based scoping would have dropped it — this test fails if the
+    traceback-based narrowing is reverted."""
     exc_info = _exc_info_raised_from(
-        "redis.asyncio.connection", "Connection closed by server."
+        "redis.asyncio.connection",
+        "Connection closed by server.",
+        _RedisConnectionError,
     )
     assert _before_send({"level": "error"}, hint={"exc_info": exc_info}) is not None
 

--- a/autogpt_platform/backend/backend/util/metrics_test.py
+++ b/autogpt_platform/backend/backend/util/metrics_test.py
@@ -9,6 +9,8 @@ rather than a Sentry alert flood.
 
 from __future__ import annotations
 
+import sys
+
 from backend.util.metrics import (
     _FALKORDB_DRIVER_LOGGER,
     _FALKORDB_TEARDOWN_SIGNATURES,
@@ -26,10 +28,17 @@ def _log_event(logger: str, message: str) -> dict:
     }
 
 
-class _RedisConnectionError(Exception):
-    """Stand-in whose ``__module__`` mimics a redis.asyncio teardown error."""
-
-    __module__ = "redis.exceptions"
+def _exc_info_raised_from(module: str, message: str):
+    """Build an ``exc_info`` triple whose traceback contains a frame in
+    ``module`` — mimics an exception re-raised from that module (e.g. the
+    graphiti FalkorDB driver, or the platform's main redis)."""
+    namespace: dict = {"__name__": module}
+    exec("def _raise(msg):\n    raise ConnectionError(msg)", namespace)
+    try:
+        namespace["_raise"](message)
+    except ConnectionError:
+        return sys.exc_info()
+    raise AssertionError("expected ConnectionError")
 
 
 # ---------- pika reconnect noise → dropped ----------
@@ -139,13 +148,22 @@ def test_falkordb_connection_closed_by_server_log_dropped() -> None:
     assert _before_send(evt, hint={}) is None
 
 
-def test_falkordb_buffer_is_closed_exc_info_dropped() -> None:
+def test_falkordb_buffer_is_closed_exc_from_graphiti_dropped() -> None:
     """If the re-raised teardown error reaches Sentry as an exception (a caller
-    that doesn't swallow it), the redis-originated ``Buffer is closed`` is still
-    benign and must be dropped."""
-    exc = _RedisConnectionError("Buffer is closed.")
-    evt = {"level": "error"}
-    assert _before_send(evt, hint={"exc_info": (type(exc), exc, None)}) is None
+    that doesn't swallow it), a ``Buffer is closed`` raised from the graphiti
+    FalkorDB driver is still benign and must be dropped."""
+    exc_info = _exc_info_raised_from(_FALKORDB_DRIVER_LOGGER, "Buffer is closed.")
+    assert _before_send({"level": "error"}, hint={"exc_info": exc_info}) is None
+
+
+def test_main_redis_connection_closed_exc_kept() -> None:
+    """A genuine ``Connection closed by server`` from the platform's main redis
+    (NOT raised from the graphiti driver) is a real incident and must NOT be
+    swallowed by the teardown-noise rule."""
+    exc_info = _exc_info_raised_from(
+        "redis.asyncio.connection", "Connection closed by server."
+    )
+    assert _before_send({"level": "error"}, hint={"exc_info": exc_info}) is not None
 
 
 def test_falkordb_real_query_error_kept() -> None:


### PR DESCRIPTION
### Why / What / How

**Why:** Sentry issue [SENTRY-1387](https://linear.app/autogpt/issue/SENTRY-1387) — `Error executing FalkorDB query: Buffer is closed.` fires repeatedly. It's a benign connection-teardown race in the CoPilot Graphiti memory path, not a real failure: `graphiti-core`'s `FalkorDriver.execute_query` logs at `ERROR` and re-raises whenever a query races the closing of its `redis.asyncio` connection — either the fire-and-forget cache-eviction close (`client.py` `_close_client_driver` → `loop.create_task(driver.close())`) or a per-request `driver.close()` in a `finally` block. CoPilot memory callers swallow the exception and chat degrades gracefully, so the only impact is Sentry noise that buries real errors. The existing `build_indices=False` mitigation only removes one source of the race; other teardown paths (eviction, deploy, shutdown) still trip it.

**What:** Extend the Sentry `_before_send` filter to drop the two benign FalkorDB teardown signatures — `"Buffer is closed"` and `"Connection closed by server"` — scoped to the `graphiti_core.driver.falkordb_driver` logger. Genuine query errors (Cypher typos, missing graphs) from the same logger still reach Sentry.

**How:** Mirrors the existing pika reconnect-noise filter already in `metrics.py`:
- Log-based events (the dominant signal, captured via `LoggingIntegration`): dropped when `logger == graphiti_core.driver.falkordb_driver` and the message contains a teardown signature.
- `exc_info` events (a caller that doesn't swallow the re-raised error): dropped when the exception message contains a teardown signature **and** the exception type originates from a `falkordb`/`redis` module — so the scope stays tight.

### Changes 🏗️

- `backend/util/metrics.py`: add `_FALKORDB_DRIVER_LOGGER`, `_FALKORDB_TEARDOWN_SIGNATURES`, `_FALKORDB_MODULE_INDICATORS`; add the log-based and `exc_info` drop branches in `_before_send`.
- `backend/util/metrics_test.py`: 6 new tests — both teardown messages dropped, the `exc_info` redis path dropped, a genuine query error kept, the same string from a non-graphiti logger kept, and a signature-coverage sanity check.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `poetry run pytest backend/util/metrics_test.py` — 14 passed (7 pre-existing + 7 new)
  - [x] Verified before the fix that a `graphiti_core.driver.falkordb_driver` "Buffer is closed" event is **not** dropped (reaches Sentry), and after the fix that it **is** dropped
  - [x] Confirmed a genuine (non-teardown) FalkorDB query error from the same logger still passes through the filter
  - [x] `poetry run format` and `poetry run lint` clean
