### PR TITLE
docs: repoint generate_block_docs links to canonical agpt.co/docs host

### DIFF
--- a/autogpt_platform/backend/load-tests/README.md
+++ b/autogpt_platform/backend/load-tests/README.md
@@ -290,7 +290,7 @@ node generate-tokens.js --count=100 --timeout=60
 ## 🔗 Related Documentation
 
 - [k6 Documentation](https://k6.io/docs/)
-- [AutoGPT Platform API Documentation](https://docs.agpt.co/)
+- [AutoGPT Platform API Documentation](https://agpt.co/docs)
 - [k6 Cloud Dashboard](https://significantgravitas.grafana.net/a/k6-app/)
 
 For questions or issues, please refer to the [AutoGPT Platform issues](https://github.com/Significant-Gravitas/AutoGPT/issues).

--- a/autogpt_platform/backend/scripts/generate_block_docs.py
+++ b/autogpt_platform/backend/scripts/generate_block_docs.py
@@ -515,11 +515,15 @@ def generate_overview_table(blocks: list[BlockDoc], block_dir_prefix: str = "") 
     lines.append("")
     lines.append("Want to create your own custom blocks? Check out our guides:")
     lines.append("")
+    # Build public doc URLs via the shared helper so the host/shape can't drift
+    # from the copilot docs tools (see backend/util/docs.py).
+    from backend.util.docs import make_doc_url
+
     lines.append(
-        "* [Build your own Blocks](https://docs.agpt.co/platform/new_blocks/) - Step-by-step tutorial with examples"
+        f"* [Build your own Blocks]({make_doc_url('platform/new_blocks.md')}) - Step-by-step tutorial with examples"
     )
     lines.append(
-        "* [Block SDK Guide](https://docs.agpt.co/platform/block-sdk-guide/) - Advanced SDK patterns with OAuth, webhooks, and provider configuration"
+        f"* [Block SDK Guide]({make_doc_url('platform/block-sdk-guide.md')}) - Advanced SDK patterns with OAuth, webhooks, and provider configuration"
     )
     lines.append("{% endhint %}")
     lines.append("")

--- a/autogpt_platform/backend/scripts/generate_block_docs.py
+++ b/autogpt_platform/backend/scripts/generate_block_docs.py
@@ -33,6 +33,9 @@ if TYPE_CHECKING:
 backend_dir = Path(__file__).parent.parent
 sys.path.insert(0, str(backend_dir))
 
+# Imported after the sys.path insert above so the backend package resolves.
+from backend.util.docs import make_doc_url  # noqa: E402
+
 logger = logging.getLogger(__name__)
 
 # Default output directory relative to repo root
@@ -517,8 +520,6 @@ def generate_overview_table(blocks: list[BlockDoc], block_dir_prefix: str = "") 
     lines.append("")
     # Build public doc URLs via the shared helper so the host/shape can't drift
     # from the copilot docs tools (see backend/util/docs.py).
-    from backend.util.docs import make_doc_url
-
     lines.append(
         f"* [Build your own Blocks]({make_doc_url('platform/new_blocks.md')}) - Step-by-step tutorial with examples"
     )

--- a/autogpt_platform/backend/scripts/test_generate_block_docs.py
+++ b/autogpt_platform/backend/scripts/test_generate_block_docs.py
@@ -6,6 +6,7 @@ from scripts.generate_block_docs import (
     class_name_to_display_name,
     extract_manual_content,
     generate_anchor,
+    generate_overview_table,
     type_to_readable,
 )
 
@@ -202,6 +203,20 @@ class TestIntegration:
         # Check same block counts per file
         for file_path in mapping1:
             assert len(mapping1[file_path]) == len(mapping2[file_path])
+
+
+class TestOverviewGuideLinks:
+    """The overview's 'Creating Your Own Blocks' guide links must point at the
+    live docs host, not the dead docs.agpt.co one (OPEN-3209)."""
+
+    def test_no_dead_docs_host(self):
+        overview = generate_overview_table([])
+        assert "docs.agpt.co" not in overview
+
+    def test_links_use_agpt_docs_host(self):
+        overview = generate_overview_table([])
+        assert "(https://agpt.co/docs/platform/new-blocks)" in overview
+        assert "(https://agpt.co/docs/platform/block-sdk-guide)" in overview
 
 
 if __name__ == "__main__":

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -82,6 +82,6 @@ This strategy allows us to share previously closed-source components, fostering 
 
 ## Ready to Get Started?
 
-- Read the [Getting Started docs](https://docs.agpt.co/platform/getting-started/) to self-host
+- Read the [Getting Started docs](https://agpt.co/docs/platform/getting-started) to self-host
 - [Join the waitlist](https://agpt.co/waitlist) for the cloud-hosted beta
 - [Contribute](contribute/index.md)

--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -24,8 +24,8 @@ AutoGPT uses a modular approach with various "blocks" to handle different tasks.
 
 Want to create your own custom blocks? Check out our guides:
 
-* [Build your own Blocks](https://docs.agpt.co/platform/new_blocks/) - Step-by-step tutorial with examples
-* [Block SDK Guide](https://docs.agpt.co/platform/block-sdk-guide/) - Advanced SDK patterns with OAuth, webhooks, and provider configuration
+* [Build your own Blocks](https://agpt.co/docs/platform/new-blocks) - Step-by-step tutorial with examples
+* [Block SDK Guide](https://agpt.co/docs/platform/block-sdk-guide) - Advanced SDK patterns with OAuth, webhooks, and provider configuration
 {% endhint %}
 
 Below is a comprehensive list of all available blocks, categorized by their primary function. Click on any block name to view its detailed documentation.

--- a/docs/platform/aimlapi.md
+++ b/docs/platform/aimlapi.md
@@ -7,7 +7,7 @@ Follow these steps to connect **AI/ML API** with the **AutoGPT** platform for hi
 
 ## ✅ Prerequisites
 
-1. Make sure you have gone through and completed the [AutoGPT Setup Guide](https://docs.agpt.co/platform/getting-started/), and AutoGPT is running locally at `http://localhost:3000`.
+1. Make sure you have gone through and completed the [AutoGPT Setup Guide](https://agpt.co/docs/platform/getting-started), and AutoGPT is running locally at `http://localhost:3000`.
 2. You have an **API key** from [AI/ML API](https://aimlapi.com/app/keys?utm_source=autogpt&utm_medium=github&utm_campaign=integration).
 
 ---
@@ -17,7 +17,7 @@ Follow these steps to connect **AI/ML API** with the **AutoGPT** platform for hi
 ### 1. Start AutoGPT Locally
 
 Follow the official guide:
-[📖 AutoGPT Getting Started Guide](https://docs.agpt.co/platform/getting-started/)
+[📖 AutoGPT Getting Started Guide](https://agpt.co/docs/platform/getting-started)
 
 Make sure AutoGPT is running and accessible at:
 [http://localhost:3000](http://localhost:3000)

--- a/docs/platform/gemini.md
+++ b/docs/platform/gemini.md
@@ -6,7 +6,7 @@ This guide covers integrating Google Gemini models with AutoGPT using OpenRouter
 
 ## Prerequisites
 
-1. Make sure you have completed the [AutoGPT Setup Guide](https://docs.agpt.co/platform/getting-started/) and have AutoGPT running locally at `http://localhost:3000`.
+1. Make sure you have completed the [AutoGPT Setup Guide](https://agpt.co/docs/platform/getting-started) and have AutoGPT running locally at `http://localhost:3000`.
 2. You have an **OpenRouter API key** from [OpenRouter](https://openrouter.ai/keys).
 
 ---
@@ -27,7 +27,7 @@ AutoGPT routes all Gemini models through OpenRouter. You need an OpenRouter API 
 ### 1. Start AutoGPT Locally
 
 Follow the official guide:
-[AutoGPT Getting Started Guide](https://docs.agpt.co/platform/getting-started/)
+[AutoGPT Getting Started Guide](https://agpt.co/docs/platform/getting-started)
 
 Ensure AutoGPT is running and accessible at:
 [http://localhost:3000](http://localhost:3000)
@@ -158,7 +158,7 @@ Pricing varies by model tier and usage volume.
 - [Gemini API Quickstart](https://ai.google.dev/gemini-api/docs/quickstart)
 - [Model Capabilities](https://ai.google.dev/gemini-api/docs/models)
 - [OpenRouter Documentation](https://openrouter.ai/docs)
-- [AutoGPT Platform Docs](https://docs.agpt.co/platform/)
+- [AutoGPT Platform Docs](https://agpt.co/docs/platform)
 
 ---
 


### PR DESCRIPTION
### Why / What / How

**Why:** The block-docs generator (`generate_block_docs.py`) emitted "Creating Your Own Blocks" guide links pointing at the legacy `docs.agpt.co` host, which flowed into the generated `docs/integrations/README.md`. That host still 301-redirects to `agpt.co/docs`, but PR #13598 already moved the copilot docs tools onto the canonical `agpt.co/docs` host; this generator (and a few stray manual docs) were left behind, so the links took an extra redirect hop and weren't single-sourced. Fixes [OPEN-3209](https://linear.app/autogpt/issue/OPEN-3209).

**What:** Repoint the generator's guide links to the canonical `agpt.co/docs` host, regenerate the overview, and repoint the stray `docs.agpt.co` references in a few manual docs files.

**How:** Build the two guide URLs via `backend.util.docs.make_doc_url` (the single-source helper #13598 added) instead of hardcoding them, so the host and URL shape can't drift from the copilot docs tools. The helper strips the `.md` extension and canonicalizes `_`→`-`, producing `https://agpt.co/docs/platform/new-blocks` and `.../block-sdk-guide`, both verified to render live.

**Note on the ticket's second gap (site-recategorized pages 404ing):** verified no longer reproducing. Both synthesized URLs now render correctly on the live site via GitBook redirects added since the ticket was filed (`agpt.co/docs/platform/new-blocks` → og:title "Build your own Blocks"), so no sitemap-fetch or redirect machinery is needed here.

### Changes 🏗️

- `scripts/generate_block_docs.py`: build the overview's guide links via `make_doc_url` (module-level import) instead of hardcoded `docs.agpt.co` URLs.
- `docs/integrations/README.md`: regenerated — the two guide links now point at `agpt.co/docs`.
- `scripts/test_generate_block_docs.py`: add `TestOverviewGuideLinks` (fails without the fix) asserting the overview never emits `docs.agpt.co` and uses the `agpt.co/docs` host.
- Repointed the stray `docs.agpt.co` references in these manual files: `docs/content/index.md`, `docs/platform/aimlapi.md`, `docs/platform/gemini.md`, `autogpt_platform/backend/load-tests/README.md`. (Other `docs.agpt.co` references elsewhere in the repo — e.g. root `README.md`, `classic/*`, frontend styleguide — are outside this ticket's scope and left untouched.)

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `poetry run pytest scripts/test_generate_block_docs.py` — 30 passed
  - [x] Verified `TestOverviewGuideLinks` fails on the pre-fix generator and passes after
  - [x] `poetry run python scripts/generate_block_docs.py --check` — "All documentation is in sync!"
  - [x] Confirmed the new URLs render live (`agpt.co/docs/platform/new-blocks`, `.../block-sdk-guide`, `.../getting-started`, `/platform`, `/docs`)
