### PR TITLE
fix(frontend/library): paginate agent presets so trigger routing has the full set

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/__tests__/trigger-agents.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/__tests__/trigger-agents.test.tsx
@@ -656,8 +656,15 @@ describe("Library agent view — trigger agents", () => {
       "activeTab=triggers&activeItem=beyond-page-1",
     );
 
+    // The Triggers tab count reflects the full membership (101), not just the
+    // first page (100) — this is what fails without eager pagination.
     // Paging through every preset then fetching the detail is a longer async
     // chain than a single-page load, so allow extra time.
+    await screen.findByRole(
+      "tab",
+      { name: /triggers\s*101/i },
+      { timeout: 5000 },
+    );
     await screen.findByText("Trigger Details", undefined, { timeout: 5000 });
     screen.getByDisplayValue("Beyond Page Trigger");
     expect(screen.queryByText("Trigger not found")).toBeNull();

--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/__tests__/trigger-agents.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/__tests__/trigger-agents.test.tsx
@@ -724,6 +724,67 @@ describe("Library agent view — trigger agents", () => {
     expect(presetGetCalls).toBe(0);
   });
 
+  test("an unknown ID beyond the pagination cap falls back to the by-ID preset fetch", async () => {
+    // More presets than the eager pagination cap (MAX_PRESET_PAGES * 100 =
+    // 2000) can page through: the hook stops at the cap, so `presetsComplete`
+    // stays false and list membership is NOT authoritative. An unknown/stale
+    // selection must therefore fall back to the graceful by-ID webhook-trigger
+    // fetch — the beyond-cap path that the fully-paginated test above
+    // deliberately does not exercise (it asserts zero by-ID fetches).
+    const cappedPreset = makeWebhookPreset({
+      id: "beyond-cap-preset",
+      name: "Beyond Cap Trigger",
+    });
+
+    let presetGetCalls = 0;
+    server.use(
+      ...baseHandlers(),
+      emptySchedulesHandler,
+      getGetV2ListTriggerAgentsMockHandler([]),
+      // Report far more presets than the cap can reach, but return one row per
+      // page so the test stays light — it's the pagination metadata (not the
+      // row count) that keeps `hasNextPage` true past the cap and leaves
+      // membership incomplete.
+      getGetV2ListPresetsMockHandler((info) => {
+        const page = Number(
+          new URL(info.request.url).searchParams.get("page") ?? "1",
+        );
+        return {
+          presets: [
+            makeWebhookPreset({
+              id: `page${page}-preset`,
+              name: `Trigger ${page}`,
+            }),
+          ],
+          pagination: {
+            total_items: 5000,
+            total_pages: 50,
+            current_page: page,
+            page_size: PRESETS_PAGE_SIZE,
+          },
+        };
+      }),
+      // The selected ID lives beyond the paginated window, so with membership
+      // incomplete the router resolves it as a webhook trigger and this fires.
+      getGetV2GetASpecificPresetMockHandler(() => {
+        presetGetCalls += 1;
+        return cappedPreset;
+      }),
+    );
+
+    renderWithInitialParams(
+      <NewAgentLibraryView />,
+      `activeTab=triggers&activeItem=${cappedPreset.id}`,
+    );
+
+    // Paging through the full cap before the by-ID fallback resolves the detail
+    // is a long async chain, so allow extra time.
+    await screen.findByText("Trigger Details", undefined, { timeout: 8000 });
+    screen.getByDisplayValue("Beyond Cap Trigger");
+    // The beyond-cap fallback fired the by-ID fetch it's meant to.
+    expect(presetGetCalls).toBeGreaterThan(0);
+  });
+
   test("a later presets page failing degrades gracefully instead of blanking the sidebar", async () => {
     // Page 1 loads 100 webhook presets; page 2 fails. The loaded page stays
     // usable — the Triggers list must still render rather than being replaced

--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/__tests__/trigger-agents.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/__tests__/trigger-agents.test.tsx
@@ -618,19 +618,36 @@ describe("Library agent view — trigger agents", () => {
     });
   });
 
-  test("unknown ID with an incomplete presets page falls back to the preset detail view", async () => {
+  test("a preset beyond the first page resolves from membership once all pages load", async () => {
     const beyondPagePreset = makeWebhookPreset({
       id: "beyond-page-1",
       name: "Beyond Page Trigger",
     });
+    const firstPage = Array.from({ length: PRESETS_PAGE_SIZE }, (_, i) =>
+      makeWebhookPreset({ id: `page1-preset-${i + 1}`, name: `Trigger ${i}` }),
+    );
 
     server.use(
       ...baseHandlers(),
       emptySchedulesHandler,
       getGetV2ListTriggerAgentsMockHandler([]),
-      // The first page doesn't contain the selected ID, but total_items says
-      // the page is incomplete — membership must NOT conclude "not-found".
-      singlePresetListHandler(makeWebhookPreset(), 150),
+      // 101 presets over two pages; the selected ID lives on page 2. The hook
+      // pages through everything, so membership resolves it as a webhook
+      // trigger rather than assuming "not-found".
+      getGetV2ListPresetsMockHandler((info) => {
+        const page = Number(
+          new URL(info.request.url).searchParams.get("page") ?? "1",
+        );
+        return {
+          presets: page <= 1 ? firstPage : [beyondPagePreset],
+          pagination: {
+            total_items: firstPage.length + 1,
+            total_pages: 2,
+            current_page: page,
+            page_size: PRESETS_PAGE_SIZE,
+          },
+        };
+      }),
       getGetV2GetASpecificPresetMockHandler(beyondPagePreset),
     );
 
@@ -639,9 +656,65 @@ describe("Library agent view — trigger agents", () => {
       "activeTab=triggers&activeItem=beyond-page-1",
     );
 
-    await screen.findByText("Trigger Details");
+    // Paging through every preset then fetching the detail is a longer async
+    // chain than a single-page load, so allow extra time.
+    await screen.findByText("Trigger Details", undefined, { timeout: 5000 });
     screen.getByDisplayValue("Beyond Page Trigger");
     expect(screen.queryByText("Trigger not found")).toBeNull();
+  });
+
+  test("unknown ID across a fully paginated presets list resolves to not-found without a by-ID fetch", async () => {
+    // 150 presets over two pages (page_size 100). The selected ID is on
+    // neither page, so once every page has loaded membership is authoritative
+    // and the router must land on not-found WITHOUT a throwaway by-ID fetch.
+    const firstPage = Array.from({ length: PRESETS_PAGE_SIZE }, (_, i) =>
+      makeWebhookPreset({ id: `page1-preset-${i + 1}`, name: `Trigger ${i}` }),
+    );
+    const secondPage = Array.from({ length: 50 }, (_, i) =>
+      makeWebhookPreset({
+        id: `page2-preset-${i + 1}`,
+        name: `Trigger ${i + 100}`,
+      }),
+    );
+    const totalItems = firstPage.length + secondPage.length;
+
+    let presetGetCalls = 0;
+    server.use(
+      ...baseHandlers(),
+      emptySchedulesHandler,
+      getGetV2ListTriggerAgentsMockHandler([]),
+      getGetV2ListPresetsMockHandler((info) => {
+        const page = Number(
+          new URL(info.request.url).searchParams.get("page") ?? "1",
+        );
+        return {
+          presets: page <= 1 ? firstPage : secondPage,
+          pagination: {
+            total_items: totalItems,
+            total_pages: 2,
+            current_page: page,
+            page_size: PRESETS_PAGE_SIZE,
+          },
+        };
+      }),
+      // Fires only if the router wrongly assumes the unknown ID is a preset —
+      // the degraded behavior this fix removes.
+      getGetV2GetASpecificPresetMockHandler(() => {
+        presetGetCalls += 1;
+        return getGetV2GetASpecificPresetResponseMock();
+      }),
+    );
+
+    renderWithInitialParams(
+      <NewAgentLibraryView />,
+      "activeTab=triggers&activeItem=deleted-preset-id",
+    );
+
+    // Paging through every preset before concluding not-found is a longer
+    // async chain than a single-page load, so allow extra time.
+    await screen.findByText("Trigger not found", undefined, { timeout: 5000 });
+    await screen.findByText(/doesn't exist or is no longer available/i);
+    expect(presetGetCalls).toBe(0);
   });
 
   test("webhook trigger deleted between list and detail fetch renders the not-found card", async () => {

--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/__tests__/trigger-agents.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/__tests__/trigger-agents.test.tsx
@@ -724,6 +724,52 @@ describe("Library agent view — trigger agents", () => {
     expect(presetGetCalls).toBe(0);
   });
 
+  test("a later presets page failing degrades gracefully instead of blanking the sidebar", async () => {
+    // Page 1 loads 100 webhook presets; page 2 fails. The loaded page stays
+    // usable — the Triggers list must still render rather than being replaced
+    // by a full error card.
+    const firstPage = Array.from({ length: PRESETS_PAGE_SIZE }, (_, i) =>
+      makeWebhookPreset({ id: `page1-preset-${i + 1}`, name: `Trigger ${i}` }),
+    );
+
+    server.use(
+      ...baseHandlers(),
+      emptySchedulesHandler,
+      getGetV2ListTriggerAgentsMockHandler([]),
+      http.get(
+        "http://localhost:3000/api/proxy/api/library/presets",
+        ({ request }) => {
+          const page = Number(
+            new URL(request.url).searchParams.get("page") ?? "1",
+          );
+          if (page > 1) {
+            return new HttpResponse(JSON.stringify({ detail: "boom" }), {
+              status: 422,
+              headers: { "Content-Type": "application/json" },
+            });
+          }
+          return HttpResponse.json({
+            presets: firstPage,
+            pagination: {
+              total_items: firstPage.length + 50,
+              total_pages: 2,
+              current_page: 1,
+              page_size: PRESETS_PAGE_SIZE,
+            },
+          });
+        },
+      ),
+      getGetV2GetASpecificPresetMockHandler(firstPage[0]),
+    );
+
+    renderWithInitialParams(<NewAgentLibraryView />, "activeTab=triggers");
+
+    // The sidebar keeps rendering the loaded page-1 triggers instead of being
+    // replaced by an error card.
+    await screen.findByText("Webhook Triggers", undefined, { timeout: 5000 });
+    expect(screen.queryByText(/when retrieving/i)).toBeNull();
+  });
+
   test("webhook trigger deleted between list and detail fetch renders the not-found card", async () => {
     const webhookPreset = makeWebhookPreset({ name: "Just Deleted" });
 

--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/sidebar/SidebarRunsList/useSidebarRunsList.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/sidebar/SidebarRunsList/useSidebarRunsList.ts
@@ -128,7 +128,7 @@ export function useSidebarRunsList({
   const loading =
     !runsQuery.isSuccess ||
     !schedulesQuery.isSuccess ||
-    !presetsQuery.isSuccess ||
+    !presetsQuery.presetsSettled ||
     (triggerAgentsEnabled && !triggerAgentsQuery.isSuccess);
   const stale =
     runsQuery.isStale ||

--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/sidebar/SidebarRunsList/useSidebarRunsList.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/sidebar/SidebarRunsList/useSidebarRunsList.ts
@@ -104,8 +104,8 @@ export function useSidebarRunsList({
 
   const schedules = schedulesQuery.data || [];
   const allPresets = useMemo(
-    () => presetsQuery.data?.presets ?? [],
-    [presetsQuery.data],
+    () => presetsQuery.presets ?? [],
+    [presetsQuery.presets],
   );
   const triggers = useMemo(
     () => allPresets.filter(isWebhookPreset),

--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/hooks/useAgentPresetsQuery.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/hooks/useAgentPresetsQuery.ts
@@ -1,25 +1,63 @@
-import { useGetV2ListPresets } from "@/app/api/__generated__/endpoints/presets/presets";
-import { okData } from "@/app/api/helpers";
+import { useEffect } from "react";
+
+import { useGetV2ListPresetsInfinite } from "@/app/api/__generated__/endpoints/presets/presets";
+import { getPaginationNextPageNumber, unpaginate } from "@/app/api/helpers";
 import { retryUnlessClientError } from "../helpers";
 
-// Single-page cap; beyond it unknown IDs fall back to a by-ID preset fetch
-// (see deriveSelectedTriggerKind). Unpaginating the endpoint would remove
-// this — tracked in #13633.
+// Per-request page size. The hook eagerly pages through every preset for the
+// agent (up to MAX_PRESET_PAGES) so membership routing has the complete set at
+// mount — see deriveSelectedTriggerKind.
 export const PRESETS_PAGE_SIZE = 100;
 
+// Safety bound on eager pagination: 20 * 100 = 2000 presets per agent. Beyond
+// it we stop paginating and the graceful by-ID fallback in
+// deriveSelectedTriggerKind takes over for unknown IDs.
+const MAX_PRESET_PAGES = 20;
+
 /**
- * The agent's presets (webhook triggers + templates). Shared by the sidebar
- * and the detail-pane router so both read one React Query cache entry.
+ * The agent's presets (webhook triggers + templates), paged into a single
+ * list. Shared by the sidebar and the detail-pane router so both read one
+ * React Query cache entry.
+ *
+ * `presetsComplete` is true once every page has loaded, so membership is
+ * authoritative. `presetsSettled` is true once no more pages will be fetched
+ * (either complete, or stopped at the page cap) — the router waits while it's
+ * false rather than resolving a selection against a partial list.
  */
 export function useAgentPresetsQuery(graphId: string | undefined) {
-  return useGetV2ListPresets(
+  const query = useGetV2ListPresetsInfinite(
     { graph_id: graphId ?? "", page: 1, page_size: PRESETS_PAGE_SIZE },
     {
       query: {
         enabled: !!graphId,
-        select: okData,
+        getNextPageParam: getPaginationNextPageNumber,
         retry: retryUnlessClientError,
       },
     },
   );
+
+  const { hasNextPage, isFetchingNextPage, fetchNextPage } = query;
+  const reachedPageCap = (query.data?.pages.length ?? 0) >= MAX_PRESET_PAGES;
+  const morePagesPending = hasNextPage && !reachedPageCap;
+
+  useEffect(() => {
+    if (morePagesPending && !isFetchingNextPage) {
+      fetchNextPage();
+    }
+  }, [morePagesPending, isFetchingNextPage, fetchNextPage]);
+
+  const presets = query.data ? unpaginate(query.data, "presets") : undefined;
+  const presetsComplete = query.isSuccess && !hasNextPage;
+  const presetsSettled = query.isSuccess && !morePagesPending;
+
+  return {
+    presets,
+    presetsComplete,
+    presetsSettled,
+    isSuccess: query.isSuccess,
+    isError: query.isError,
+    isStale: query.isStale,
+    error: query.error,
+    refetch: query.refetch,
+  };
 }

--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/hooks/useAgentPresetsQuery.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/hooks/useAgentPresetsQuery.ts
@@ -21,8 +21,10 @@ const MAX_PRESET_PAGES = 20;
  *
  * `presetsComplete` is true once every page has loaded, so membership is
  * authoritative. `presetsSettled` is true once no more pages will be fetched
- * (either complete, or stopped at the page cap) — the router waits while it's
- * false rather than resolving a selection against a partial list.
+ * (complete, stopped at the page cap, or a later page errored) — the router
+ * waits while it's false rather than resolving against a partial list. A
+ * later-page failure only degrades gracefully; `isError` flags a hard failure
+ * (the first page failed, so there's no data at all).
  */
 export function useAgentPresetsQuery(graphId: string | undefined) {
   const query = useGetV2ListPresetsInfinite(
@@ -36,12 +38,8 @@ export function useAgentPresetsQuery(graphId: string | undefined) {
     },
   );
 
-  const {
-    hasNextPage,
-    isFetchingNextPage,
-    isFetchNextPageError,
-    fetchNextPage,
-  } = query;
+  const { hasNextPage, isFetching, isFetchNextPageError, fetchNextPage } =
+    query;
   const reachedPageCap = (query.data?.pages.length ?? 0) >= MAX_PRESET_PAGES;
   // Stop paginating at the cap, or once a page fetch has errored — otherwise a
   // persistently failing page keeps hasNextPage true and re-fires forever.
@@ -49,26 +47,34 @@ export function useAgentPresetsQuery(graphId: string | undefined) {
     hasNextPage && !reachedPageCap && !isFetchNextPageError;
 
   useEffect(() => {
-    if (morePagesPending && !isFetchingNextPage) {
+    // Guard on isFetching (not just isFetchingNextPage) so this never races an
+    // initial load or background refetch.
+    if (morePagesPending && !isFetching) {
       fetchNextPage();
     }
-  }, [morePagesPending, isFetchingNextPage, fetchNextPage]);
+  }, [morePagesPending, isFetching, fetchNextPage]);
 
   const presets = useMemo(
     () => (query.data ? unpaginate(query.data, "presets") : undefined),
     [query.data],
   );
   const presetsComplete = query.isSuccess && !hasNextPage;
-  const presetsSettled = query.isSuccess && !morePagesPending;
+  // A later-page failure flips the query to error while keeping the earlier
+  // pages, so settle on it too — routing then resolves against the partial
+  // list and the by-ID fallback instead of stalling on "loading".
+  const presetsSettled =
+    !morePagesPending && (query.isSuccess || isFetchNextPageError);
+  // Only a first-page failure (no data at all) is a hard error worth surfacing;
+  // a mid-pagination failure leaves partial data the UI can still use.
+  const hasHardFailure = query.isError && presets === undefined;
 
   return {
     presets,
     presetsComplete,
     presetsSettled,
-    isSuccess: query.isSuccess,
-    isError: query.isError,
+    isError: hasHardFailure,
     isStale: query.isStale,
-    error: query.error,
+    error: hasHardFailure ? query.error : null,
     refetch: query.refetch,
   };
 }

--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/hooks/useAgentPresetsQuery.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/hooks/useAgentPresetsQuery.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 
 import { useGetV2ListPresetsInfinite } from "@/app/api/__generated__/endpoints/presets/presets";
 import { getPaginationNextPageNumber, unpaginate } from "@/app/api/helpers";
@@ -36,9 +36,17 @@ export function useAgentPresetsQuery(graphId: string | undefined) {
     },
   );
 
-  const { hasNextPage, isFetchingNextPage, fetchNextPage } = query;
+  const {
+    hasNextPage,
+    isFetchingNextPage,
+    isFetchNextPageError,
+    fetchNextPage,
+  } = query;
   const reachedPageCap = (query.data?.pages.length ?? 0) >= MAX_PRESET_PAGES;
-  const morePagesPending = hasNextPage && !reachedPageCap;
+  // Stop paginating at the cap, or once a page fetch has errored — otherwise a
+  // persistently failing page keeps hasNextPage true and re-fires forever.
+  const morePagesPending =
+    hasNextPage && !reachedPageCap && !isFetchNextPageError;
 
   useEffect(() => {
     if (morePagesPending && !isFetchingNextPage) {
@@ -46,7 +54,10 @@ export function useAgentPresetsQuery(graphId: string | undefined) {
     }
   }, [morePagesPending, isFetchingNextPage, fetchNextPage]);
 
-  const presets = query.data ? unpaginate(query.data, "presets") : undefined;
+  const presets = useMemo(
+    () => (query.data ? unpaginate(query.data, "presets") : undefined),
+    [query.data],
+  );
   const presetsComplete = query.isSuccess && !hasNextPage;
   const presetsSettled = query.isSuccess && !morePagesPending;
 

--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/useNewAgentLibraryView.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/useNewAgentLibraryView.ts
@@ -62,11 +62,8 @@ export function useNewAgentLibraryView() {
   const triggerAgents = triggerAgentsQuery.data;
 
   const presetsQuery = useAgentPresetsQuery(agent?.graph_id);
-  const presets = presetsQuery.data?.presets;
-  const presetsComplete =
-    !!presetsQuery.data &&
-    presetsQuery.data.pagination.total_items <=
-      presetsQuery.data.presets.length;
+  const presets = presetsQuery.presets;
+  const presetsComplete = presetsQuery.presetsComplete;
 
   const [{ activeItem, activeTab: activeTabRaw }, setQueryStates] =
     useQueryStates({
@@ -280,7 +277,8 @@ export function useNewAgentLibraryView() {
           triggerAgents,
           presets,
           presetsComplete,
-          listsResolved: presetsQuery.isSuccess && !triggerAgentsUnresolved,
+          listsResolved:
+            presetsQuery.presetsSettled && !triggerAgentsUnresolved,
           anyListFailed: presetsQuery.isError || triggerAgentsQuery.isError,
         })
       : null;


### PR DESCRIPTION
### Why / What / How

**Why** — Resolves [OPEN-3212](https://linear.app/autogpt/issue/OPEN-3212) / #13633. On the library agent view's **Triggers** tab, the router decides whether a selected item is a *trigger agent* or a *webhook-trigger preset* by checking membership in the agent's presets list. That list was fetched as a single page capped at `PRESETS_PAGE_SIZE = 100`. For an agent with more than 100 presets, `presetsComplete` stayed `false`, so an unknown/stale selection fell back to a throwaway by-ID preset fetch (a graceful not-found card, but one wasted request per unknown selection) and lost the "resolve type before mount" guarantee. The sidebar trigger/template counts were also capped at the first 100.

**What** — `useAgentPresetsQuery` now pages through *all* of an agent's presets so membership routing is authoritative, instead of only reading the first 100. No backend or API-contract change (the shared `/presets` endpoint, its copilot RPC, and the external paginated API are untouched).

**How**
- Switched `useAgentPresetsQuery` from the single-page `useGetV2ListPresets` to the generated `useGetV2ListPresetsInfinite`, and eagerly fetch each next page (via a `useEffect` on `hasNextPage`) up to a safety cap of `MAX_PRESET_PAGES = 20` (2000 presets/agent).
- The hook flattens the pages into one `presets` list (`unpaginate`) and exposes:
  - `presetsComplete` — every page has loaded, so membership is authoritative.
  - `presetsSettled` — no more pages will be fetched (complete **or** stopped at the cap).
- The detail-pane router now treats `presetsSettled` as `listsResolved`, so while pagination is still in flight it shows the loading state rather than prematurely resolving a selection against a partial list. The graceful by-ID fallback (`deriveSelectedTriggerKind` → `webhook-trigger` when `!presetsComplete`) is preserved only for the beyond-cap edge case.
- Common case (≤100 presets) is unchanged: one request, `presetsComplete` true immediately.

### Changes 🏗️

- `NewAgentLibraryView/hooks/useAgentPresetsQuery.ts` — eager full pagination via the infinite presets query; expose `presets` / `presetsComplete` / `presetsSettled`.
- `NewAgentLibraryView/useNewAgentLibraryView.ts` — consume the new shape; gate `listsResolved` on `presetsSettled`.
- `NewAgentLibraryView/.../SidebarRunsList/useSidebarRunsList.ts` — read the flattened `presets` (fixes capped trigger/template counts).
- `agents/[id]/__tests__/trigger-agents.test.tsx` — two multi-page tests: a preset on a later page resolves from membership, and an unknown ID across a fully-paginated list lands on not-found **without** a by-ID fetch. Repurposed the former single-page "incomplete page" test.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `pnpm exec vitest run` on `trigger-agents.test.tsx` — 19 passed (2 new tests fail without the fix, pass with it)
  - [x] `pnpm format`, `pnpm lint`, `pnpm types` all clean
  - [x] Agent with ≤100 presets: Triggers tab resolves selections with a single presets request (unchanged behavior)
  - [x] Agent with >100 presets: all trigger/template rows and counts show; a webhook trigger beyond the first 100 opens its detail view; a stale/deleted trigger ID shows the not-found card without a wasted by-ID request
