### PR TITLE
feat(platform): surface skipped webhook presets when a trigger is swapped

### DIFF
--- a/autogpt_platform/backend/backend/api/features/library/db.py
+++ b/autogpt_platform/backend/backend/api/features/library/db.py
@@ -829,6 +829,11 @@ async def update_graph_in_library(
 
         # Migrate webhook-attached presets to the new version so that
         # existing webhook URLs continue to trigger the latest agent version.
+        # This path is only reached from the CoPilot/AutoPilot agent-update
+        # flow, which has no user-facing channel for skipped-preset warnings,
+        # so the migration result is intentionally discarded here. Skipped
+        # presets are surfaced on the interactive graph-activation endpoints
+        # (update_graph / set_graph_active_version) instead.
         if created_graph.webhook_input_node:
             await migrate_webhook_presets_to_new_version(
                 user_id=user_id,

--- a/autogpt_platform/backend/backend/api/features/library/db.py
+++ b/autogpt_platform/backend/backend/api/features/library/db.py
@@ -2158,7 +2158,7 @@ async def set_preset_webhook(
 async def migrate_webhook_presets_to_new_version(
     user_id: str,
     new_graph: graph_db.GraphModel,
-) -> int:
+) -> library_model.WebhookPresetMigrationResult:
     """
     Migrates webhook-attached presets for a graph to a newly activated version.
 
@@ -2193,12 +2193,13 @@ async def migrate_webhook_presets_to_new_version(
         new_graph: The newly activated graph version to migrate presets to.
 
     Returns:
-        The number of presets migrated.
+        The migration outcome: the number of presets migrated and the presets
+        that were skipped (left pinned) because the new trigger is incompatible.
     """
     new_trigger_node = new_graph.webhook_input_node
     if not (new_trigger_node and new_trigger_node.block.webhook_config):
         # New version has no webhook trigger to migrate presets onto.
-        return 0
+        return library_model.WebhookPresetMigrationResult()
 
     candidates = await prisma.models.AgentPreset.prisma().find_many(
         where={
@@ -2210,7 +2211,7 @@ async def migrate_webhook_presets_to_new_version(
         },
     )
     if not candidates:
-        return 0
+        return library_model.WebhookPresetMigrationResult()
 
     # Resolve the trigger block of each pinned version once. A preset is
     # compatible only if its pinned version uses the same trigger block as the
@@ -2230,6 +2231,7 @@ async def migrate_webhook_presets_to_new_version(
         == new_trigger_node.block_id
     }
 
+    skipped_presets: list[library_model.SkippedWebhookPreset] = []
     for preset in candidates:
         if preset.id in compatible_ids:
             continue
@@ -2241,9 +2243,18 @@ async def migrate_webhook_presets_to_new_version(
             f"Preset left pinned to v{preset.agentGraphVersion}; trigger needs "
             f"reconfiguration."
         )
+        skipped_presets.append(
+            library_model.SkippedWebhookPreset(
+                id=preset.id,
+                name=preset.name,
+                pinned_version=preset.agentGraphVersion,
+            )
+        )
 
     if not compatible_ids:
-        return 0
+        return library_model.WebhookPresetMigrationResult(
+            skipped_presets=skipped_presets
+        )
 
     # Preserve candidate order for a deterministic query. Re-assert userId and
     # the version guard so a concurrent activation that already bumped a preset
@@ -2264,7 +2275,10 @@ async def migrate_webhook_presets_to_new_version(
             f"Migrated {count} webhook preset(s) for graph #{new_graph.id} "
             f"to version {new_graph.version} (user #{user_id})"
         )
-    return count
+    return library_model.WebhookPresetMigrationResult(
+        migrated_count=count,
+        skipped_presets=skipped_presets,
+    )
 
 
 async def delete_preset(user_id: str, preset_id: str) -> None:

--- a/autogpt_platform/backend/backend/api/features/library/model.py
+++ b/autogpt_platform/backend/backend/api/features/library/model.py
@@ -574,6 +574,23 @@ class LibraryAgentPresetResponse(pydantic.BaseModel):
     pagination: Pagination
 
 
+class SkippedWebhookPreset(pydantic.BaseModel):
+    """A webhook preset that was left pinned to its old version because the
+    newly activated version swaps or reconfigures the trigger block. The user
+    needs to reconfigure the trigger on the new version for it to fire."""
+
+    id: str
+    name: str
+    pinned_version: int
+
+
+class WebhookPresetMigrationResult(pydantic.BaseModel):
+    """Outcome of migrating webhook-attached presets to a new graph version."""
+
+    migrated_count: int = 0
+    skipped_presets: list[SkippedWebhookPreset] = pydantic.Field(default_factory=list)
+
+
 class LibraryAgentFilter(str, Enum):
     """Possible filters for searching library agents."""
 

--- a/autogpt_platform/backend/backend/api/features/v1.py
+++ b/autogpt_platform/backend/backend/api/features/v1.py
@@ -160,6 +160,7 @@ from backend.util.timezone_utils import (
 from backend.util.virus_scanner import scan_content_safe
 
 from .library import db as library_db
+from .library import model as library_model
 from .store.model import StoreAgentDetails
 
 
@@ -1623,6 +1624,33 @@ class DeleteGraphResponse(TypedDict):
     version_counts: int
 
 
+class UpdateGraphResponse(BaseModel):
+    """Response for creating/activating a new graph version.
+
+    Carries the new graph version plus any webhook presets that were left
+    pinned to their old version because the new version's trigger block is
+    incompatible and needs to be reconfigured.
+    """
+
+    graph: graph_db.GraphModel
+    skipped_webhook_presets: list[library_model.SkippedWebhookPreset] = Field(
+        default_factory=list
+    )
+
+
+class SetActiveGraphVersionResponse(BaseModel):
+    """Response for activating an existing graph version.
+
+    Carries any webhook presets that were left pinned to their old version
+    because the newly activated version's trigger block is incompatible and
+    needs to be reconfigured.
+    """
+
+    skipped_webhook_presets: list[library_model.SkippedWebhookPreset] = Field(
+        default_factory=list
+    )
+
+
 @v1_router.get(
     path="/graphs",
     summary="List user graphs",
@@ -1762,7 +1790,7 @@ async def update_graph(
     graph: graph_db.Graph,
     user_id: Annotated[str, Security(get_user_id)],
     ctx: Annotated[RequestContext, Security(get_request_context)],
-) -> graph_db.GraphModel:
+) -> UpdateGraphResponse:
     if graph.id and graph.id != graph_id:
         raise HTTPException(400, detail="Graph ID does not match ID in URI")
 
@@ -1791,6 +1819,7 @@ async def update_graph(
         team_id=ctx.team_id,
     )
 
+    skipped_webhook_presets: list[library_model.SkippedWebhookPreset] = []
     if new_graph_version.is_active:
         await library_db.update_library_agent_version_and_settings(
             user_id, new_graph_version
@@ -1804,10 +1833,11 @@ async def update_graph(
         # Migrate webhook-attached presets to the new version so that
         # existing webhook URLs continue to trigger the latest agent version.
         if new_graph_version.webhook_input_node:
-            await library_db.migrate_webhook_presets_to_new_version(
+            migration = await library_db.migrate_webhook_presets_to_new_version(
                 user_id=user_id,
                 new_graph=new_graph_version,
             )
+            skipped_webhook_presets = migration.skipped_presets
 
     new_graph_version_with_subgraphs = await graph_db.get_graph(
         graph_id,
@@ -1816,7 +1846,10 @@ async def update_graph(
         include_subgraphs=True,
     )
     assert new_graph_version_with_subgraphs
-    return new_graph_version_with_subgraphs
+    return UpdateGraphResponse(
+        graph=new_graph_version_with_subgraphs,
+        skipped_webhook_presets=skipped_webhook_presets,
+    )
 
 
 @v1_router.put(
@@ -1830,7 +1863,7 @@ async def set_graph_active_version(
     request_body: SetGraphActiveVersion,
     user_id: Annotated[str, Security(get_user_id)],
     ctx: Annotated[RequestContext, Security(get_request_context)],
-):
+) -> SetActiveGraphVersionResponse:
     new_active_version = request_body.active_graph_version
     new_active_graph = await graph_db.get_graph(
         graph_id, new_active_version, user_id=user_id
@@ -1867,11 +1900,17 @@ async def set_graph_active_version(
 
     # Migrate webhook-attached presets to the new active version so that
     # existing webhook URLs continue to trigger the latest agent version.
+    skipped_webhook_presets: list[library_model.SkippedWebhookPreset] = []
     if new_active_graph.webhook_input_node:
-        await library_db.migrate_webhook_presets_to_new_version(
+        migration = await library_db.migrate_webhook_presets_to_new_version(
             user_id=user_id,
             new_graph=new_active_graph,
         )
+        skipped_webhook_presets = migration.skipped_presets
+
+    return SetActiveGraphVersionResponse(
+        skipped_webhook_presets=skipped_webhook_presets
+    )
 
 
 @v1_router.patch(

--- a/autogpt_platform/backend/test/test_migrate_webhook_presets.py
+++ b/autogpt_platform/backend/test/test_migrate_webhook_presets.py
@@ -358,7 +358,7 @@ async def test_update_graph_in_library_migrates_when_webhook_node_present(
     migrate_mock = mocker.patch.object(
         library_db,
         "migrate_webhook_presets_to_new_version",
-        return_value=1,
+        return_value=library_model.WebhookPresetMigrationResult(migrated_count=1),
     )
 
     await library_db.update_graph_in_library(graph=incoming, user_id="user-1")
@@ -397,7 +397,7 @@ async def test_update_graph_in_library_skips_when_no_webhook_node(mocker):
     migrate_mock = mocker.patch.object(
         library_db,
         "migrate_webhook_presets_to_new_version",
-        return_value=0,
+        return_value=library_model.WebhookPresetMigrationResult(),
     )
 
     await library_db.update_graph_in_library(graph=incoming, user_id="user-1")

--- a/autogpt_platform/backend/test/test_migrate_webhook_presets.py
+++ b/autogpt_platform/backend/test/test_migrate_webhook_presets.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from autogpt_libs.auth.models import RequestContext
 
+from backend.api.features.library import model as library_model
 from backend.api.features.library.db import migrate_webhook_presets_to_new_version
 
 
@@ -65,11 +66,14 @@ def _make_graph(
     return graph
 
 
-def _make_preset(preset_id: str, *, version: int = 1):
+def _make_preset(preset_id: str, *, version: int = 1, name: str | None = None):
     """Stand-in for a prisma AgentPreset row."""
     preset = MagicMock()
     preset.id = preset_id
     preset.agentGraphVersion = version
+    # `.name` must be a real string: the migration builds a SkippedWebhookPreset
+    # from it, and a bare MagicMock would fail pydantic validation.
+    preset.name = name if name is not None else f"Preset {preset_id}"
     return preset
 
 
@@ -101,11 +105,11 @@ async def test_migrate_updates_compatible_presets(mock_prisma, mocker):
     mock_prisma.update_many = AsyncMock(return_value=2)
     _patch_old_graphs(mocker, {1: "trigger-a"})
 
-    count = await migrate_webhook_presets_to_new_version(
+    result = await migrate_webhook_presets_to_new_version(
         user_id="user-123", new_graph=graph
     )
 
-    assert count == 2
+    assert result.migrated_count == 2
     mock_prisma.find_many.assert_called_once_with(
         where={
             "userId": "user-123",
@@ -134,11 +138,11 @@ async def test_migrate_skips_different_trigger_provider(mock_prisma, mocker):
     mock_prisma.update_many = AsyncMock(return_value=0)
     _patch_old_graphs(mocker, {1: "telegram-on-message"})
 
-    count = await migrate_webhook_presets_to_new_version(
+    result = await migrate_webhook_presets_to_new_version(
         user_id="user-123", new_graph=graph
     )
 
-    assert count == 0
+    assert result.migrated_count == 0
     mock_prisma.update_many.assert_not_called()
 
 
@@ -150,11 +154,11 @@ async def test_migrate_skips_different_trigger_same_provider(mock_prisma, mocker
     mock_prisma.update_many = AsyncMock(return_value=0)
     _patch_old_graphs(mocker, {1: "github-on-pr"})
 
-    count = await migrate_webhook_presets_to_new_version(
+    result = await migrate_webhook_presets_to_new_version(
         user_id="user-123", new_graph=graph
     )
 
-    assert count == 0
+    assert result.migrated_count == 0
     mock_prisma.update_many.assert_not_called()
 
 
@@ -172,11 +176,14 @@ async def test_migrate_only_updates_compatible_in_mixed_set(mock_prisma, mocker)
     mock_prisma.update_many = AsyncMock(return_value=2)
     _patch_old_graphs(mocker, {1: "trigger-a", 2: "trigger-b"})
 
-    count = await migrate_webhook_presets_to_new_version(
+    result = await migrate_webhook_presets_to_new_version(
         user_id="user-123", new_graph=graph
     )
 
-    assert count == 2
+    assert result.migrated_count == 2
+    assert [p.id for p in result.skipped_presets] == ["bad"]
+    assert result.skipped_presets[0].pinned_version == 2
+    assert result.skipped_presets[0].name == "Preset bad"
     mock_prisma.update_many.assert_called_once_with(
         where={
             "id": {"in": ["ok1", "ok2"]},
@@ -195,11 +202,11 @@ async def test_migrate_returns_zero_when_no_trigger_node(mock_prisma):
     mock_prisma.find_many = AsyncMock()
     mock_prisma.update_many = AsyncMock()
 
-    count = await migrate_webhook_presets_to_new_version(
+    result = await migrate_webhook_presets_to_new_version(
         user_id="user-123", new_graph=graph
     )
 
-    assert count == 0
+    assert result.migrated_count == 0
     mock_prisma.find_many.assert_not_called()
     mock_prisma.update_many.assert_not_called()
 
@@ -211,11 +218,11 @@ async def test_migrate_returns_zero_when_trigger_has_no_webhook_config(mock_pris
     mock_prisma.find_many = AsyncMock()
     mock_prisma.update_many = AsyncMock()
 
-    count = await migrate_webhook_presets_to_new_version(
+    result = await migrate_webhook_presets_to_new_version(
         user_id="user-123", new_graph=graph
     )
 
-    assert count == 0
+    assert result.migrated_count == 0
     mock_prisma.find_many.assert_not_called()
     mock_prisma.update_many.assert_not_called()
 
@@ -231,11 +238,12 @@ async def test_migrate_skips_preset_when_old_version_unavailable(
     _patch_old_graphs(mocker, {1: None})  # get_graph returns None
 
     with caplog.at_level(logging.WARNING, logger="backend.api.features.library.db"):
-        count = await migrate_webhook_presets_to_new_version(
+        result = await migrate_webhook_presets_to_new_version(
             user_id="user-123", new_graph=graph
         )
 
-    assert count == 0
+    assert result.migrated_count == 0
+    assert [p.id for p in result.skipped_presets] == ["orphan"]
     mock_prisma.update_many.assert_not_called()
     assert any(
         "Not migrating preset #orphan" in record.message for record in caplog.records
@@ -249,11 +257,11 @@ async def test_migrate_returns_zero_when_no_candidates(mock_prisma, mocker):
     mock_prisma.update_many = AsyncMock()
     get_graph_mock = _patch_old_graphs(mocker, {})
 
-    count = await migrate_webhook_presets_to_new_version(
+    result = await migrate_webhook_presets_to_new_version(
         user_id="user-123", new_graph=graph
     )
 
-    assert count == 0
+    assert result.migrated_count == 0
     mock_prisma.update_many.assert_not_called()
     get_graph_mock.assert_not_called()
 
@@ -269,11 +277,11 @@ async def test_migrate_logs_when_presets_are_migrated(mock_prisma, mocker, caplo
     _patch_old_graphs(mocker, {1: "trigger-a"})
 
     with caplog.at_level(logging.INFO, logger="backend.api.features.library.db"):
-        count = await migrate_webhook_presets_to_new_version(
+        result = await migrate_webhook_presets_to_new_version(
             user_id="user-789", new_graph=graph
         )
 
-    assert count == 2
+    assert result.migrated_count == 2
     assert any(
         "Migrated 2 webhook preset(s)" in record.message for record in caplog.records
     )
@@ -288,11 +296,13 @@ async def test_migrate_warns_on_incompatible_preset(mock_prisma, mocker, caplog)
     _patch_old_graphs(mocker, {1: "telegram-on-message"})
 
     with caplog.at_level(logging.WARNING, logger="backend.api.features.library.db"):
-        count = await migrate_webhook_presets_to_new_version(
+        result = await migrate_webhook_presets_to_new_version(
             user_id="user-789", new_graph=graph
         )
 
-    assert count == 0
+    assert result.migrated_count == 0
+    assert [p.id for p in result.skipped_presets] == ["bad"]
+    assert result.skipped_presets[0].pinned_version == 1
     assert any(
         "Not migrating preset #bad" in record.message for record in caplog.records
     )
@@ -415,21 +425,34 @@ async def test_v1_update_graph_migrates_when_webhook_node_present(mocker):
     mocker.patch.object(v1.graph_db, "make_graph_model", return_value=new_graph)
     mocker.patch.object(v1.graph_db, "create_graph", return_value=new_graph)
     mocker.patch.object(v1.graph_db, "set_graph_active_version")
-    mocker.patch.object(v1.graph_db, "get_graph", return_value=new_graph)
+    # get_graph feeds UpdateGraphResponse.graph (a real GraphModel field), so
+    # return an actual GraphModel instance rather than a MagicMock.
+    mocker.patch.object(
+        v1.graph_db,
+        "get_graph",
+        return_value=v1.graph_db.GraphModel.model_construct(
+            id=new_graph.id, version=new_graph.version
+        ),
+    )
     mocker.patch.object(
         v1.library_db,
         "update_library_agent_version_and_settings",
         return_value=AsyncMock(),
     )
+    skipped = library_model.SkippedWebhookPreset(
+        id="preset-1", name="My Trigger", pinned_version=2
+    )
     migrate_mock = mocker.patch.object(
         v1.library_db,
         "migrate_webhook_presets_to_new_version",
-        return_value=1,
+        return_value=library_model.WebhookPresetMigrationResult(
+            migrated_count=1, skipped_presets=[skipped]
+        ),
     )
     mocker.patch.object(v1, "before_graph_activate", side_effect=lambda g, user_id: g)
     mocker.patch.object(v1, "on_graph_deactivate", return_value=None)
 
-    await v1.update_graph(
+    response = await v1.update_graph(
         graph_id=new_graph.id,
         graph=incoming,
         user_id="user-1",
@@ -440,6 +463,7 @@ async def test_v1_update_graph_migrates_when_webhook_node_present(mocker):
         user_id="user-1",
         new_graph=new_graph,
     )
+    assert response.skipped_webhook_presets == [skipped]
 
 
 @pytest.mark.asyncio
@@ -462,7 +486,15 @@ async def test_v1_update_graph_skips_when_no_webhook_node(mocker):
     mocker.patch.object(v1.graph_db, "make_graph_model", return_value=new_graph)
     mocker.patch.object(v1.graph_db, "create_graph", return_value=new_graph)
     mocker.patch.object(v1.graph_db, "set_graph_active_version")
-    mocker.patch.object(v1.graph_db, "get_graph", return_value=new_graph)
+    # get_graph feeds UpdateGraphResponse.graph (a real GraphModel field), so
+    # return an actual GraphModel instance rather than a MagicMock.
+    mocker.patch.object(
+        v1.graph_db,
+        "get_graph",
+        return_value=v1.graph_db.GraphModel.model_construct(
+            id=new_graph.id, version=new_graph.version
+        ),
+    )
     mocker.patch.object(
         v1.library_db,
         "update_library_agent_version_and_settings",
@@ -471,12 +503,12 @@ async def test_v1_update_graph_skips_when_no_webhook_node(mocker):
     migrate_mock = mocker.patch.object(
         v1.library_db,
         "migrate_webhook_presets_to_new_version",
-        return_value=0,
+        return_value=library_model.WebhookPresetMigrationResult(),
     )
     mocker.patch.object(v1, "before_graph_activate", side_effect=lambda g, user_id: g)
     mocker.patch.object(v1, "on_graph_deactivate", return_value=None)
 
-    await v1.update_graph(
+    response = await v1.update_graph(
         graph_id=new_graph.id,
         graph=incoming,
         user_id="user-1",
@@ -484,6 +516,7 @@ async def test_v1_update_graph_skips_when_no_webhook_node(mocker):
     )
 
     migrate_mock.assert_not_awaited()
+    assert response.skipped_webhook_presets == []
 
 
 @pytest.mark.asyncio
@@ -506,17 +539,22 @@ async def test_v1_set_graph_active_version_migrates_when_webhook_node_present(
         "update_library_agent_version_and_settings",
         return_value=AsyncMock(),
     )
+    skipped = library_model.SkippedWebhookPreset(
+        id="preset-9", name="Old Telegram Trigger", pinned_version=3
+    )
     migrate_mock = mocker.patch.object(
         v1.library_db,
         "migrate_webhook_presets_to_new_version",
-        return_value=2,
+        return_value=library_model.WebhookPresetMigrationResult(
+            migrated_count=2, skipped_presets=[skipped]
+        ),
     )
     mocker.patch.object(v1, "before_graph_activate", side_effect=lambda g, user_id: g)
     mocker.patch.object(v1, "on_graph_deactivate", return_value=None)
 
     body = v1.SetGraphActiveVersion(active_graph_version=target_graph.version)
 
-    await v1.set_graph_active_version(
+    response = await v1.set_graph_active_version(
         graph_id=target_graph.id,
         request_body=body,
         user_id="user-1",
@@ -527,6 +565,7 @@ async def test_v1_set_graph_active_version_migrates_when_webhook_node_present(
         user_id="user-1",
         new_graph=target_graph,
     )
+    assert response.skipped_webhook_presets == [skipped]
 
 
 @pytest.mark.asyncio
@@ -550,14 +589,14 @@ async def test_v1_set_graph_active_version_skips_when_no_webhook_node(mocker):
     migrate_mock = mocker.patch.object(
         v1.library_db,
         "migrate_webhook_presets_to_new_version",
-        return_value=0,
+        return_value=library_model.WebhookPresetMigrationResult(),
     )
     mocker.patch.object(v1, "before_graph_activate", side_effect=lambda g, user_id: g)
     mocker.patch.object(v1, "on_graph_deactivate", return_value=None)
 
     body = v1.SetGraphActiveVersion(active_graph_version=target_graph.version)
 
-    await v1.set_graph_active_version(
+    response = await v1.set_graph_active_version(
         graph_id=target_graph.id,
         request_body=body,
         user_id="user-1",
@@ -565,3 +604,4 @@ async def test_v1_set_graph_active_version_skips_when_no_webhook_node(mocker):
     )
 
     migrate_mock.assert_not_awaited()
+    assert response.skipped_webhook_presets == []

--- a/autogpt_platform/frontend/src/app/(platform)/build/__tests__/useSaveGraph.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/build/__tests__/useSaveGraph.test.tsx
@@ -82,7 +82,7 @@ describe("useSaveGraph", () => {
       credentials_input_schema: { properties: {} },
       output_schema: { properties: {} },
     };
-    mockUpdate.mockResolvedValue({ data: updated });
+    mockUpdate.mockResolvedValue({ data: { graph: updated } });
 
     const { result } = renderHook(() => useSaveGraph({ showToast: false }));
 
@@ -97,6 +97,60 @@ describe("useSaveGraph", () => {
     });
     expect(mockSetGraphSchemas).toHaveBeenCalled();
     expect(returned).toBe(updated);
+  });
+
+  it("warns the user when a trigger swap leaves webhook presets behind", async () => {
+    mockCurrentGraph = { id: "graph-1", name: "Agent", version: 1 };
+    const updated = {
+      id: "graph-1",
+      version: 2,
+      input_schema: { properties: {} },
+      credentials_input_schema: { properties: {} },
+      output_schema: { properties: {} },
+    };
+    mockUpdate.mockResolvedValue({
+      data: {
+        graph: updated,
+        skipped_webhook_presets: [
+          { id: "preset-1", name: "GitHub PR trigger", pinned_version: 1 },
+        ],
+      },
+    });
+
+    const { result } = renderHook(() => useSaveGraph({ showToast: false }));
+
+    await act(async () => {
+      await result.current.saveGraph();
+    });
+
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variant: "info",
+        description: expect.stringContaining("GitHub PR trigger"),
+      }),
+    );
+  });
+
+  it("does not warn when no webhook presets are skipped", async () => {
+    mockCurrentGraph = { id: "graph-1", name: "Agent", version: 1 };
+    const updated = {
+      id: "graph-1",
+      version: 2,
+      input_schema: { properties: {} },
+      credentials_input_schema: { properties: {} },
+      output_schema: { properties: {} },
+    };
+    mockUpdate.mockResolvedValue({
+      data: { graph: updated, skipped_webhook_presets: [] },
+    });
+
+    const { result } = renderHook(() => useSaveGraph({ showToast: false }));
+
+    await act(async () => {
+      await result.current.saveGraph();
+    });
+
+    expect(mockToast).not.toHaveBeenCalled();
   });
 
   it("returns the created graph model when there is no existing graph", async () => {

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/BuilderChatPanel/useBuilderChatPanel.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/BuilderChatPanel/useBuilderChatPanel.ts
@@ -13,8 +13,6 @@ import {
 import type { GraphModel } from "@/app/api/__generated__/models/graphModel";
 import { okData } from "@/app/api/helpers";
 import { useToast } from "@/components/molecules/Toast/use-toast";
-import type { SetActiveGraphVersionResponse } from "@/app/api/__generated__/models/setActiveGraphVersionResponse";
-import { notifySkippedWebhookPresets } from "../../helpers/skippedWebhookPresets";
 import * as Sentry from "@sentry/nextjs";
 import { useQueryClient } from "@tanstack/react-query";
 import type { UIDataTypes, UIMessage, UITools } from "ai";
@@ -436,10 +434,7 @@ export function useBuilderChatPanel({
       const response = (await setActiveVersion({
         graphId: flowID,
         data: { active_graph_version: revertTargetVersion },
-      })) as unknown as {
-        status: number;
-        data?: SetActiveGraphVersionResponse;
-      };
+      })) as unknown as { status: number };
       if (response.status !== 200) {
         throw new Error("failed_to_revert");
       }
@@ -458,10 +453,6 @@ export function useBuilderChatPanel({
         title: "Reverted to the previous version",
         description: `Now viewing version ${revertTargetVersion}.`,
       });
-      notifySkippedWebhookPresets(
-        toast,
-        response.data?.skipped_webhook_presets,
-      );
     } catch (err) {
       Sentry.captureException(err);
       toast({

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/BuilderChatPanel/useBuilderChatPanel.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/BuilderChatPanel/useBuilderChatPanel.ts
@@ -13,6 +13,8 @@ import {
 import type { GraphModel } from "@/app/api/__generated__/models/graphModel";
 import { okData } from "@/app/api/helpers";
 import { useToast } from "@/components/molecules/Toast/use-toast";
+import type { SetActiveGraphVersionResponse } from "@/app/api/__generated__/models/setActiveGraphVersionResponse";
+import { notifySkippedWebhookPresets } from "../../helpers/skippedWebhookPresets";
 import * as Sentry from "@sentry/nextjs";
 import { useQueryClient } from "@tanstack/react-query";
 import type { UIDataTypes, UIMessage, UITools } from "ai";
@@ -434,7 +436,10 @@ export function useBuilderChatPanel({
       const response = (await setActiveVersion({
         graphId: flowID,
         data: { active_graph_version: revertTargetVersion },
-      })) as unknown as { status: number };
+      })) as unknown as {
+        status: number;
+        data?: SetActiveGraphVersionResponse;
+      };
       if (response.status !== 200) {
         throw new Error("failed_to_revert");
       }
@@ -453,6 +458,10 @@ export function useBuilderChatPanel({
         title: "Reverted to the previous version",
         description: `Now viewing version ${revertTargetVersion}.`,
       });
+      notifySkippedWebhookPresets(
+        toast,
+        response.data?.skipped_webhook_presets,
+      );
     } catch (err) {
       Sentry.captureException(err);
       toast({

--- a/autogpt_platform/frontend/src/app/(platform)/build/helpers/__tests__/skippedWebhookPresets.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/build/helpers/__tests__/skippedWebhookPresets.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from "vitest";
+import type { toast } from "@/components/molecules/Toast/use-toast";
+import { notifySkippedWebhookPresets } from "../skippedWebhookPresets";
+
+// This helper backs both the builder-save path (useSaveGraph) and the version
+// revert path (useBuilderChatPanel), so covering it directly exercises the
+// notification logic for every activation flow that surfaces skipped presets.
+describe("notifySkippedWebhookPresets", () => {
+  it("does not toast when there are no skipped presets", () => {
+    const toastFn = vi.fn() as unknown as typeof toast;
+    notifySkippedWebhookPresets(toastFn, []);
+    notifySkippedWebhookPresets(toastFn, undefined);
+    notifySkippedWebhookPresets(toastFn, null);
+    expect(toastFn).not.toHaveBeenCalled();
+  });
+
+  it("warns with a singular message for one skipped preset", () => {
+    const toastFn = vi.fn() as unknown as typeof toast;
+    notifySkippedWebhookPresets(toastFn, [
+      { id: "p1", name: "GitHub PR trigger", pinned_version: 1 },
+    ]);
+    expect(toastFn).toHaveBeenCalledTimes(1);
+    expect(toastFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variant: "info",
+        title: expect.stringContaining("A trigger preset"),
+        description: expect.stringContaining("GitHub PR trigger"),
+      }),
+    );
+  });
+
+  it("warns with a plural message listing all skipped presets", () => {
+    const toastFn = vi.fn() as unknown as typeof toast;
+    notifySkippedWebhookPresets(toastFn, [
+      { id: "p1", name: "Telegram trigger", pinned_version: 2 },
+      { id: "p2", name: "GitHub trigger", pinned_version: 2 },
+    ]);
+    const arg = (toastFn as unknown as ReturnType<typeof vi.fn>).mock
+      .calls[0][0];
+    expect(arg.title).toContain("Some trigger presets");
+    expect(arg.description).toContain("Telegram trigger");
+    expect(arg.description).toContain("GitHub trigger");
+  });
+});

--- a/autogpt_platform/frontend/src/app/(platform)/build/helpers/skippedWebhookPresets.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/build/helpers/skippedWebhookPresets.ts
@@ -1,0 +1,27 @@
+import type { SkippedWebhookPreset } from "@/app/api/__generated__/models/skippedWebhookPreset";
+import type { toast } from "@/components/molecules/Toast/use-toast";
+
+// When a new graph version swaps or reconfigures the trigger block, presets
+// whose webhook was registered for the old trigger are left pinned to their
+// previous version so their existing webhook keeps working. Let the user know
+// they need to reconfigure the trigger on the new version.
+export function notifySkippedWebhookPresets(
+  toastFn: typeof toast,
+  skippedPresets: SkippedWebhookPreset[] | undefined | null,
+) {
+  if (!skippedPresets || skippedPresets.length === 0) return;
+
+  const names = skippedPresets.map((preset) => `"${preset.name}"`).join(", ");
+  const single = skippedPresets.length === 1;
+
+  toastFn({
+    variant: "info",
+    duration: 10000,
+    title: single
+      ? "A trigger preset needs reconfiguration"
+      : "Some trigger presets need reconfiguration",
+    description: single
+      ? `${names} was kept on its previous version because the new version uses a different trigger. Reconfigure its trigger on the new version to keep it running.`
+      : `${names} were kept on their previous version because the new version uses a different trigger. Reconfigure their triggers on the new version to keep them running.`,
+  });
+}

--- a/autogpt_platform/frontend/src/app/(platform)/build/hooks/useSaveGraph.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/build/hooks/useSaveGraph.ts
@@ -97,8 +97,7 @@ export const useSaveGraph = ({
     usePutV1UpdateGraphVersion({
       mutation: {
         onSuccess: async (response) => {
-          const result = response.data as UpdateGraphResponse;
-          const data = result.graph;
+          const data = (response.data as UpdateGraphResponse).graph;
           setQueryStates({
             flowID: data.id,
             flowVersion: data.version,

--- a/autogpt_platform/frontend/src/app/(platform)/build/hooks/useSaveGraph.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/build/hooks/useSaveGraph.ts
@@ -10,6 +10,8 @@ import {
 } from "@/app/api/__generated__/endpoints/graphs/graphs";
 import { GraphModel } from "@/app/api/__generated__/models/graphModel";
 import { Graph } from "@/app/api/__generated__/models/graph";
+import { UpdateGraphResponse } from "@/app/api/__generated__/models/updateGraphResponse";
+import { notifySkippedWebhookPresets } from "../helpers/skippedWebhookPresets";
 import { useNodeStore } from "../stores/nodeStore";
 import { useEdgeStore } from "../stores/edgeStore";
 import { graphsEquivalent } from "../components/NewControlPanel/NewSaveControl/helpers";
@@ -95,7 +97,8 @@ export const useSaveGraph = ({
     usePutV1UpdateGraphVersion({
       mutation: {
         onSuccess: async (response) => {
-          const data = response.data as GraphModel;
+          const result = response.data as UpdateGraphResponse;
+          const data = result.graph;
           setQueryStates({
             flowID: data.id,
             flowVersion: data.version,
@@ -156,12 +159,14 @@ export const useSaveGraph = ({
         }
 
         const response = await updateGraph({ graphId: graph.id, data: data });
-        const graphData = response.data as GraphModel;
+        const result = response.data as UpdateGraphResponse;
+        const graphData = result.graph;
         setGraphSchemas(
           graphData.input_schema,
           graphData.credentials_input_schema,
           graphData.output_schema,
         );
+        notifySkippedWebhookPresets(toast, result.skipped_webhook_presets);
         return graphData;
       } else {
         const data: Graph = {

--- a/autogpt_platform/frontend/src/app/api/openapi.json
+++ b/autogpt_platform/frontend/src/app/api/openapi.json
@@ -5580,7 +5580,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/GraphModel" }
+                "schema": { "$ref": "#/components/schemas/UpdateGraphResponse" }
               }
             }
           },
@@ -6128,7 +6128,13 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": { "application/json": { "schema": {} } }
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SetActiveGraphVersionResponse"
+                }
+              }
+            }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
@@ -21419,6 +21425,18 @@
         "title": "SessionSummaryResponse",
         "description": "Response model for a session summary (without messages)."
       },
+      "SetActiveGraphVersionResponse": {
+        "properties": {
+          "skipped_webhook_presets": {
+            "items": { "$ref": "#/components/schemas/SkippedWebhookPreset" },
+            "type": "array",
+            "title": "Skipped Webhook Presets"
+          }
+        },
+        "type": "object",
+        "title": "SetActiveGraphVersionResponse",
+        "description": "Response for activating an existing graph version.\n\nCarries any webhook presets that were left pinned to their old version\nbecause the newly activated version's trigger block is incompatible and\nneeds to be reconfigured."
+      },
       "SetGraphActiveVersion": {
         "properties": {
           "active_graph_version": {
@@ -21653,6 +21671,17 @@
         ],
         "title": "SharedExecutionResponse",
         "description": "Public-safe response for shared executions"
+      },
+      "SkippedWebhookPreset": {
+        "properties": {
+          "id": { "type": "string", "title": "Id" },
+          "name": { "type": "string", "title": "Name" },
+          "pinned_version": { "type": "integer", "title": "Pinned Version" }
+        },
+        "type": "object",
+        "required": ["id", "name", "pinned_version"],
+        "title": "SkippedWebhookPreset",
+        "description": "A webhook preset that was left pinned to its old version because the\nnewly activated version swaps or reconfigures the trigger block. The user\nneeds to reconfigure the trigger on the new version for it to fire."
       },
       "Stats": {
         "properties": {
@@ -23767,6 +23796,20 @@
         "type": "object",
         "required": ["logo_url"],
         "title": "UpdateAppLogoRequest"
+      },
+      "UpdateGraphResponse": {
+        "properties": {
+          "graph": { "$ref": "#/components/schemas/GraphModel" },
+          "skipped_webhook_presets": {
+            "items": { "$ref": "#/components/schemas/SkippedWebhookPreset" },
+            "type": "array",
+            "title": "Skipped Webhook Presets"
+          }
+        },
+        "type": "object",
+        "required": ["graph"],
+        "title": "UpdateGraphResponse",
+        "description": "Response for creating/activating a new graph version.\n\nCarries the new graph version plus any webhook presets that were left\npinned to their old version because the new version's trigger block is\nincompatible and needs to be reconfigured."
       },
       "UpdateMemberRequest": {
         "properties": {

--- a/autogpt_platform/frontend/src/lib/autogpt-server-api/client.ts
+++ b/autogpt_platform/frontend/src/lib/autogpt-server-api/client.ts
@@ -51,6 +51,7 @@ import type {
   Schedule,
   ScheduleCreatable,
   ScheduleID,
+  SkippedWebhookPreset,
   TransactionHistory,
   User,
   UserPasswordCredentials,
@@ -253,7 +254,13 @@ export default class BackendAPI {
     return this._request("POST", "/graphs", requestBody);
   }
 
-  updateGraph(id: GraphID, graph: GraphUpdateable): Promise<Graph> {
+  updateGraph(
+    id: GraphID,
+    graph: GraphUpdateable,
+  ): Promise<{
+    graph: Graph;
+    skipped_webhook_presets?: SkippedWebhookPreset[];
+  }> {
     return this._request("PUT", `/graphs/${id}`, graph);
   }
 
@@ -261,7 +268,10 @@ export default class BackendAPI {
     return this._request("DELETE", `/graphs/${id}`);
   }
 
-  setGraphActiveVersion(id: GraphID, version: number): Promise<Graph> {
+  setGraphActiveVersion(
+    id: GraphID,
+    version: number,
+  ): Promise<{ skipped_webhook_presets?: SkippedWebhookPreset[] }> {
     return this._request("PUT", `/graphs/${id}/versions/active`, {
       active_graph_version: version,
     });

--- a/autogpt_platform/frontend/src/lib/autogpt-server-api/types.ts
+++ b/autogpt_platform/frontend/src/lib/autogpt-server-api/types.ts
@@ -441,6 +441,12 @@ export type Graph = GraphMeta & {
       }
   );
 
+export type SkippedWebhookPreset = {
+  id: string;
+  name: string;
+  pinned_version: number;
+};
+
 export type GraphUpdateable = Omit<
   Graph,
   | "user_id"


### PR DESCRIPTION
### Why / What / How

**Why:** Follow-up to [OPEN-3169](https://linear.app/autogpt/issue/OPEN-3169) / #13394, which made webhook-preset version migration trigger-compatibility-aware. When a user activates a new graph version whose trigger block differs from the one a preset's webhook was registered for, the preset is intentionally **left pinned** to its old version (so its existing webhook keeps working) instead of being silently migrated into a broken state. Until now the only signal that this happened was a server-side `logger.warning` — users who swap their agent's trigger (e.g. Telegram → GitHub, or GitHub "on PR" → "on issue") got **no UI notification** that some presets were left behind and need reconfiguration.

**What:** Surface the skipped/incompatible presets to the user at the moment of the swap so they know to reconfigure the trigger on the new version.

**How:** The migration helper now reports which presets it skipped; the graph-activation endpoints return that in their response; the builder shows a warning toast on save.

> Note: the backend notification server (`queue_notification`) is disabled in production, so a "send a notification" approach would be a no-op in prod. The effective path is to return the skipped presets in the activation response and surface them in the frontend — which is what this PR does. No change to the correctness behavior shipped in OPEN-3169.

### Changes 🏗️

**Backend**
- `migrate_webhook_presets_to_new_version` now returns a `WebhookPresetMigrationResult` (migrated count + list of skipped presets with `id`, `name`, `pinned_version`) instead of just an `int`.
- `PUT /graphs/{id}` now returns a new `UpdateGraphResponse` (`{ graph, skipped_webhook_presets }`) — **response shape change** for this endpoint.
- `PUT /graphs/{id}/versions/active` now returns a new `SetActiveGraphVersionResponse` (`{ skipped_webhook_presets }`) — previously returned `None`.
- New models `SkippedWebhookPreset` / `WebhookPresetMigrationResult` in `library/model.py`.
- The CoPilot/AutoPilot path (`update_graph_in_library`) intentionally discards the migration result (no user-facing channel there); documented inline.

**Frontend**
- Builder save (`useSaveGraph`) shows an info toast listing the affected preset name(s) with a "reconfigure the trigger" hint when activation returns skipped presets.
- Shared helper `notifySkippedWebhookPresets` (unit-tested directly).
- Regenerated `openapi.json` (client `__generated__` is gitignored and regenerated by CI).

**Scope note:** Frontend surfacing is wired on the builder-save path (the ticket's core trigger-swap scenario). The version-**revert** path (`useBuilderChatPanel`) gates on internal `revertTargetVersion` state that isn't reachable at unit-test level, so it's intentionally left unwired for now — but `set_graph_active_version` already returns the skipped presets, so wiring a toast there later is a drop-in.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Backend unit tests (`test/test_migrate_webhook_presets.py`, 16): migration returns skipped presets; both endpoints surface them in the response; happy path (same trigger) still migrates with no skipped presets.
  - [x] Frontend unit tests (`useSaveGraph.test.tsx`, `skippedWebhookPresets.test.ts`): warning toast fires (singular + plural) when presets are skipped, and does not fire when none are.
  - [x] `pnpm types` / `pnpm format` / `pnpm lint`, `poetry run format` / `lint` all clean.
  - [ ] Manual: build an agent with a webhook trigger + a preset, save a new active version that swaps the trigger block, confirm the warning toast lists the preset and the preset stays on its old version.
