### PR TITLE
feat(platform): add list_user_credentials CoPilot tool for credential discovery

### DIFF
--- a/autogpt_platform/backend/backend/copilot/permissions.py
+++ b/autogpt_platform/backend/backend/copilot/permissions.py
@@ -104,6 +104,7 @@ ToolName = Literal[
     "list_presets",
     "list_schedules",
     "list_skills",
+    "list_user_credentials",
     "list_workspace_files",
     "memory_forget_confirm",
     "memory_forget_search",

--- a/autogpt_platform/backend/backend/copilot/prompting.py
+++ b/autogpt_platform/backend/backend/copilot/prompting.py
@@ -363,8 +363,9 @@ list, or when execution reports missing/insufficient credentials
 (e.g. a `setup_requirements` response for scopes the stored credential
 lacks).
 
-**1. Surface the sign-in card EAGERLY — in the same turn, before
-collecting other inputs.** Call `connect_integration(provider=...)`
+**1. Once rule 0 shows the credential is missing, surface the sign-in
+card EAGERLY — in the same turn, before collecting other inputs.**
+Call `connect_integration(provider=...)`
 (or `run_agent` / `run_block`) immediately. Do not wait until you have
 the URL / resource ID / other parameters. The user can connect in
 parallel with answering follow-up questions. A frequent failure mode is

--- a/autogpt_platform/backend/backend/copilot/prompting.py
+++ b/autogpt_platform/backend/backend/copilot/prompting.py
@@ -356,10 +356,12 @@ not have them yet, four rules apply:
 
 **0. Check what is already connected FIRST.** Call
 `list_user_credentials` (optionally with `provider=...`) before asking
-the user to sign in to anything. If a matching credential already
-exists, proceed with the task — do not surface a sign-in card or ask
-the user to reconnect. Only surface sign-in for integrations the tool
-shows as missing.
+the user to sign in to anything. If a credential for the provider
+already exists, attempt the task first instead of surfacing a sign-in
+card — only surface sign-in when the provider is missing from the
+list, or when execution reports missing/insufficient credentials
+(e.g. a `setup_requirements` response for scopes the stored credential
+lacks).
 
 **1. Surface the sign-in card EAGERLY — in the same turn, before
 collecting other inputs.** Call `connect_integration(provider=...)`
@@ -433,9 +435,11 @@ The exact sandbox path is shown in the `[Sandbox copy available at ...]` note.
   `git` HTTPS operations (clone, push, pull) work automatically.
 - If the token changes mid-session (e.g. user reconnects with a new token),
   run `gh auth setup-git` to re-register the credential helper.
-- **MANDATORY:** You MUST run `gh auth status` before EVER calling
-  `connect_integration(provider="github")`. If it shows `Logged in`,
-  proceed directly — no integration connection needed. Never skip this check.
+- **MANDATORY:** You MUST run `gh auth status` (or
+  `list_user_credentials(provider="github")`) before EVER calling
+  `connect_integration(provider="github")`. If it shows `Logged in` (or a
+  github credential is listed), proceed directly — no integration
+  connection needed. Never skip this check.
 - If `gh auth status` shows NOT logged in, or `gh`/`git` fails with an
   authentication error (e.g. "authentication required", "could not read
   Username", or exit code 128), THEN call

--- a/autogpt_platform/backend/backend/copilot/prompting.py
+++ b/autogpt_platform/backend/backend/copilot/prompting.py
@@ -181,7 +181,7 @@ Order of fallbacks (only after `find_block` returns nothing usable):
    exists (after `find_block`, the known hosted list, AND a web search for
    an MCP server), use
    `SendAuthenticatedWebRequestBlock` with existing host-scoped
-   credentials. Check available credentials via `connect_integration`.
+   credentials. Check available credentials via `list_user_credentials`.
 
 4. **Manual API call** — As a last resort, guide the user to set up
    credentials and use `SendAuthenticatedWebRequestBlock` with direct API
@@ -352,7 +352,14 @@ modify its fields.
 
 When the user asks to run something that needs credentials (a block, an
 agent, an MCP server, or an authenticated web request) and the user may
-not have them yet, three rules apply:
+not have them yet, four rules apply:
+
+**0. Check what is already connected FIRST.** Call
+`list_user_credentials` (optionally with `provider=...`) before asking
+the user to sign in to anything. If a matching credential already
+exists, proceed with the task — do not surface a sign-in card or ask
+the user to reconnect. Only surface sign-in for integrations the tool
+shows as missing.
 
 **1. Surface the sign-in card EAGERLY — in the same turn, before
 collecting other inputs.** Call `connect_integration(provider=...)`
@@ -420,7 +427,7 @@ sandbox so `bash_exec` can access it for further processing.
 The exact sandbox path is shown in the `[Sandbox copy available at ...]` note.
 
 ### GitHub CLI (`gh`) and git
-- To check if the user has their GitHub account already connected, run `gh auth status`. Always check this before running `connect_integration(provider="github")` which will ask the user to connect their GitHub regardless if it's already connected.
+- To check if the user has their GitHub account already connected, run `gh auth status` (or `list_user_credentials(provider="github")` when no sandbox is needed). Always check this before running `connect_integration(provider="github")` which will ask the user to connect their GitHub regardless if it's already connected.
 - If the user has connected their GitHub account, both `gh` and `git` are
   pre-authenticated — use them directly without any manual login step.
   `git` HTTPS operations (clone, push, pull) work automatically.

--- a/autogpt_platform/backend/backend/copilot/tools/__init__.py
+++ b/autogpt_platform/backend/backend/copilot/tools/__init__.py
@@ -34,6 +34,7 @@ from .graphiti_forget import MemoryForgetConfirmTool, MemoryForgetSearchTool
 from .graphiti_search import MemorySearchTool
 from .graphiti_store import MemoryStoreTool
 from .list_agent_triggers import ListAgentTriggersTool
+from .list_credentials import ListUserCredentialsTool
 from .manage_folders import (
     CreateFolderTool,
     DeleteFolderTool,
@@ -137,6 +138,8 @@ TOOL_REGISTRY: dict[str, BaseTool] = {
     # Sandboxed code execution (bubblewrap)
     "bash_exec": BashExecTool(),
     "connect_integration": ConnectIntegrationTool(),
+    # Connected-credential discovery (metadata only, never secrets)
+    "list_user_credentials": ListUserCredentialsTool(),
     # Persistent workspace tools (cloud storage, survives across sessions)
     # Feature request tools
     "search_feature_requests": SearchFeatureRequestsTool(),

--- a/autogpt_platform/backend/backend/copilot/tools/list_credentials.py
+++ b/autogpt_platform/backend/backend/copilot/tools/list_credentials.py
@@ -1,0 +1,129 @@
+"""List the user's connected integration credentials (metadata only, no secrets)."""
+
+import logging
+from typing import Any
+
+from backend.api.features.integrations.router import (
+    CredentialsMetaResponse,
+    to_meta_response,
+)
+from backend.copilot.model import ChatSession
+from backend.data.model import is_sdk_default
+from backend.integrations.credentials_store import SYSTEM_CREDENTIAL_IDS
+
+from .base import BaseTool
+from .models import ErrorResponse, ResponseType, ToolResponseBase
+from .utils import get_user_credentials
+
+logger = logging.getLogger(__name__)
+
+
+class CredentialListResponse(ToolResponseBase):
+    """Response listing the user's connected credentials."""
+
+    type: ResponseType = ResponseType.CREDENTIAL_LIST
+    credentials: list[CredentialsMetaResponse] = []
+    providers: list[str] = []
+    count: int = 0
+
+
+class ListUserCredentialsTool(BaseTool):
+    """Lists the integrations the user has already connected (never secrets)."""
+
+    @property
+    def name(self) -> str:
+        return "list_user_credentials"
+
+    @property
+    def description(self) -> str:
+        return (
+            "List the integrations the user has already connected (metadata "
+            "only, never secrets). Call before asking the user to sign in or "
+            "connect an integration, so you only surface sign-in for "
+            "integrations that are genuinely missing."
+        )
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "provider": {
+                    "type": "string",
+                    "description": (
+                        "Optional provider slug to filter by "
+                        "(e.g. 'github', 'google', 'notion')."
+                    ),
+                },
+            },
+            "required": [],
+        }
+
+    @property
+    def requires_auth(self) -> bool:
+        return True
+
+    async def _execute(
+        self,
+        user_id: str | None,
+        session: ChatSession,
+        provider: str | None = None,
+        **kwargs: Any,
+    ) -> ToolResponseBase:
+        session_id = session.session_id
+
+        if not user_id:
+            return ErrorResponse(
+                message="Authentication required.",
+                error="missing_user_id",
+                session_id=session_id,
+            )
+
+        try:
+            all_creds = await get_user_credentials(user_id)
+        except Exception:
+            logger.exception("Failed to list credentials for user %s", user_id)
+            return ErrorResponse(
+                message="Could not retrieve the user's connected credentials.",
+                error="credential_lookup_failed",
+                session_id=session_id,
+            )
+
+        # System credentials (platform-provided API keys) and SDK defaults are
+        # not user-connected integrations, so they'd mislead the model here.
+        metas = [
+            to_meta_response(cred)
+            for cred in all_creds
+            if not is_sdk_default(cred.id) and cred.id not in SYSTEM_CREDENTIAL_IDS
+        ]
+
+        if provider:
+            wanted = provider.strip().lower()
+            metas = [m for m in metas if m.provider == wanted]
+
+        providers = sorted({m.provider for m in metas})
+
+        if metas:
+            message = (
+                f"The user has {len(metas)} connected credential(s) across "
+                f"{len(providers)} provider(s): {', '.join(providers)}."
+            )
+        elif provider:
+            message = (
+                f"The user has no connected credentials for provider "
+                f"'{provider}'. Use connect_integration to surface a "
+                "sign-in card if this integration is needed."
+            )
+        else:
+            message = (
+                "The user has not connected any integrations yet. Use "
+                "connect_integration to surface a sign-in card if one is needed."
+            )
+
+        return CredentialListResponse(
+            message=message,
+            credentials=metas,
+            providers=providers,
+            count=len(metas),
+            session_id=session_id,
+        )

--- a/autogpt_platform/backend/backend/copilot/tools/list_credentials.py
+++ b/autogpt_platform/backend/backend/copilot/tools/list_credentials.py
@@ -25,26 +25,6 @@ logger = logging.getLogger(__name__)
 _MANAGED_PROVISION_TIMEOUT_S = 10.0
 
 
-async def _ensure_managed_credentials_bounded(user_id: str) -> None:
-    try:
-        await asyncio.wait_for(
-            ensure_managed_credentials(user_id, IntegrationCredentialsManager().store),
-            timeout=_MANAGED_PROVISION_TIMEOUT_S,
-        )
-    except asyncio.TimeoutError:
-        logger.warning(
-            "Managed credential sweep exceeded %.1fs for user=%s; "
-            "listing without it",
-            _MANAGED_PROVISION_TIMEOUT_S,
-            user_id,
-        )
-    except Exception:
-        logger.exception(
-            "Managed credential provisioning failed for user %s; listing without it",
-            user_id,
-        )
-
-
 class CredentialListResponse(ToolResponseBase):
     """Response listing the user's connected credentials."""
 
@@ -52,6 +32,9 @@ class CredentialListResponse(ToolResponseBase):
     credentials: list[CredentialsMetaResponse] = []
     providers: list[str] = []
     count: int = 0
+    # False when the managed-credential provisioning sweep timed out or
+    # failed, meaning platform-managed integrations may be missing below.
+    provisioning_complete: bool = True
 
 
 class ListUserCredentialsTool(BaseTool):
@@ -106,7 +89,7 @@ class ListUserCredentialsTool(BaseTool):
                 session_id=session_id,
             )
 
-        await _ensure_managed_credentials_bounded(user_id)
+        provisioning_complete = await _ensure_managed_credentials_bounded(user_id)
 
         try:
             all_creds = await get_user_credentials(user_id)
@@ -126,8 +109,8 @@ class ListUserCredentialsTool(BaseTool):
             if not is_sdk_default(cred.id) and cred.id not in SYSTEM_CREDENTIAL_IDS
         ]
 
-        if provider:
-            wanted = provider.strip().lower()
+        wanted = provider.strip().lower() if provider else ""
+        if wanted:
             metas = [m for m in metas if m.provider.lower() == wanted]
 
         providers = sorted({m.provider for m in metas})
@@ -137,10 +120,10 @@ class ListUserCredentialsTool(BaseTool):
                 f"The user has {len(metas)} connected credential(s) across "
                 f"{len(providers)} provider(s): {', '.join(providers)}."
             )
-        elif provider:
+        elif wanted:
             message = (
                 f"The user has no connected credentials for provider "
-                f"'{provider}'. Use connect_integration to surface a "
+                f"'{wanted}'. Use connect_integration to surface a "
                 "sign-in card if this integration is needed."
             )
         else:
@@ -149,10 +132,42 @@ class ListUserCredentialsTool(BaseTool):
                 "connect_integration to surface a sign-in card if one is needed."
             )
 
+        if not provisioning_complete:
+            message += (
+                " Note: platform-managed credential provisioning did not "
+                "complete, so managed integrations may be missing from this "
+                "list — do not treat their absence as authoritative."
+            )
+
         return CredentialListResponse(
             message=message,
             credentials=metas,
             providers=providers,
             count=len(metas),
+            provisioning_complete=provisioning_complete,
             session_id=session_id,
         )
+
+
+async def _ensure_managed_credentials_bounded(user_id: str) -> bool:
+    """Run the managed-credential sweep; return False on timeout or failure."""
+    try:
+        await asyncio.wait_for(
+            ensure_managed_credentials(user_id, IntegrationCredentialsManager().store),
+            timeout=_MANAGED_PROVISION_TIMEOUT_S,
+        )
+    except asyncio.TimeoutError:
+        logger.warning(
+            "Managed credential sweep exceeded %.1fs for user=%s; "
+            "listing without it",
+            _MANAGED_PROVISION_TIMEOUT_S,
+            user_id,
+        )
+        return False
+    except Exception:
+        logger.exception(
+            "Managed credential provisioning failed for user %s; listing without it",
+            user_id,
+        )
+        return False
+    return True

--- a/autogpt_platform/backend/backend/copilot/tools/list_credentials.py
+++ b/autogpt_platform/backend/backend/copilot/tools/list_credentials.py
@@ -1,5 +1,6 @@
 """List the user's connected integration credentials (metadata only, no secrets)."""
 
+import asyncio
 import logging
 from typing import Any
 
@@ -10,12 +11,38 @@ from backend.api.features.integrations.router import (
 from backend.copilot.model import ChatSession
 from backend.data.model import is_sdk_default
 from backend.integrations.credentials_store import SYSTEM_CREDENTIAL_IDS
+from backend.integrations.creds_manager import IntegrationCredentialsManager
+from backend.integrations.managed_credentials import ensure_managed_credentials
 
 from .base import BaseTool
 from .models import ErrorResponse, ResponseType, ToolResponseBase
 from .utils import get_user_credentials
 
 logger = logging.getLogger(__name__)
+
+# Mirrors the bound the integrations router puts on its first-time managed
+# credential sweep, so a slow upstream can't hang the tool call.
+_MANAGED_PROVISION_TIMEOUT_S = 10.0
+
+
+async def _ensure_managed_credentials_bounded(user_id: str) -> None:
+    try:
+        await asyncio.wait_for(
+            ensure_managed_credentials(user_id, IntegrationCredentialsManager().store),
+            timeout=_MANAGED_PROVISION_TIMEOUT_S,
+        )
+    except asyncio.TimeoutError:
+        logger.warning(
+            "Managed credential sweep exceeded %.1fs for user=%s; "
+            "listing without it",
+            _MANAGED_PROVISION_TIMEOUT_S,
+            user_id,
+        )
+    except Exception:
+        logger.exception(
+            "Managed credential provisioning failed for user %s; listing without it",
+            user_id,
+        )
 
 
 class CredentialListResponse(ToolResponseBase):
@@ -79,6 +106,8 @@ class ListUserCredentialsTool(BaseTool):
                 session_id=session_id,
             )
 
+        await _ensure_managed_credentials_bounded(user_id)
+
         try:
             all_creds = await get_user_credentials(user_id)
         except Exception:
@@ -99,7 +128,7 @@ class ListUserCredentialsTool(BaseTool):
 
         if provider:
             wanted = provider.strip().lower()
-            metas = [m for m in metas if m.provider == wanted]
+            metas = [m for m in metas if m.provider.lower() == wanted]
 
         providers = sorted({m.provider for m in metas})
 

--- a/autogpt_platform/backend/backend/copilot/tools/list_credentials_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/list_credentials_test.py
@@ -10,10 +10,23 @@ from backend.copilot.tools.list_credentials import (
     ListUserCredentialsTool,
 )
 from backend.copilot.tools.models import ErrorResponse, ResponseType
-from backend.data.model import APIKeyCredentials, OAuth2Credentials
+from backend.data.model import (
+    APIKeyCredentials,
+    HostScopedCredentials,
+    OAuth2Credentials,
+)
 
-# Shorthand patch target
+# Shorthand patch targets
 _CREDS_PATH = "backend.copilot.tools.list_credentials.get_user_credentials"
+_MANAGED_PATH = (
+    "backend.copilot.tools.list_credentials._ensure_managed_credentials_bounded"
+)
+
+
+@pytest.fixture(autouse=True)
+def stub_managed_credentials_sweep():
+    with patch(_MANAGED_PATH, new_callable=AsyncMock) as mock_sweep:
+        yield mock_sweep
 
 
 def _github_oauth() -> OAuth2Credentials:
@@ -37,6 +50,27 @@ def _notion_api_key() -> APIKeyCredentials:
         title="My Notion key",
         api_key=SecretStr("secret_notion"),
         expires_at=None,
+    )
+
+
+def _host_scoped() -> HostScopedCredentials:
+    return HostScopedCredentials(
+        id="33333333-3333-3333-3333-333333333333",
+        provider="http",
+        title="Internal API",
+        host="api.example.com",
+        headers={"Authorization": SecretStr("Bearer host_scoped_secret")},
+    )
+
+
+def _mcp_oauth() -> OAuth2Credentials:
+    return OAuth2Credentials(
+        id="44444444-4444-4444-4444-444444444444",
+        provider="mcp",
+        title="Linear MCP",
+        access_token=SecretStr("mcp_access_secret"),
+        scopes=[],
+        metadata={"mcp_server_url": "https://mcp.linear.app/mcp"},
     )
 
 
@@ -104,6 +138,25 @@ class TestListUserCredentialsTool:
         payload = result.model_dump_json()
         assert "gho_secret" not in payload
         assert "ghr_secret" not in payload
+
+    @pytest.mark.asyncio
+    async def test_host_scoped_and_mcp_credentials(self, tool, mock_session):
+        creds = [_host_scoped(), _mcp_oauth()]
+        with patch(_CREDS_PATH, new_callable=AsyncMock, return_value=creds):
+            result = await tool._execute(user_id="user-1", session=mock_session)
+
+        assert isinstance(result, CredentialListResponse)
+        assert result.count == 2
+
+        host_scoped = next(c for c in result.credentials if c.type == "host_scoped")
+        assert host_scoped.host == "api.example.com"
+        mcp = next(c for c in result.credentials if c.provider == "mcp")
+        assert mcp.host == "https://mcp.linear.app/mcp"
+
+        payload = result.model_dump_json()
+        assert "host_scoped_secret" not in payload
+        assert "Authorization" not in payload
+        assert "mcp_access_secret" not in payload
 
     @pytest.mark.asyncio
     async def test_filters_sdk_default_credentials(self, tool, mock_session):

--- a/autogpt_platform/backend/backend/copilot/tools/list_credentials_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/list_credentials_test.py
@@ -1,0 +1,182 @@
+"""Tests for the list_user_credentials tool."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import SecretStr
+
+from backend.copilot.tools.list_credentials import (
+    CredentialListResponse,
+    ListUserCredentialsTool,
+)
+from backend.copilot.tools.models import ErrorResponse, ResponseType
+from backend.data.model import APIKeyCredentials, OAuth2Credentials
+
+# Shorthand patch target
+_CREDS_PATH = "backend.copilot.tools.list_credentials.get_user_credentials"
+
+
+def _github_oauth() -> OAuth2Credentials:
+    return OAuth2Credentials(
+        id="11111111-1111-1111-1111-111111111111",
+        provider="github",
+        title="GitHub",
+        username="octocat",
+        access_token=SecretStr("gho_secret"),
+        refresh_token=SecretStr("ghr_secret"),
+        access_token_expires_at=None,
+        refresh_token_expires_at=None,
+        scopes=["repo", "read:org"],
+    )
+
+
+def _notion_api_key() -> APIKeyCredentials:
+    return APIKeyCredentials(
+        id="22222222-2222-2222-2222-222222222222",
+        provider="notion",
+        title="My Notion key",
+        api_key=SecretStr("secret_notion"),
+        expires_at=None,
+    )
+
+
+def _sdk_default_cred() -> APIKeyCredentials:
+    return APIKeyCredentials(
+        id="firecrawl-default",
+        provider="firecrawl",
+        title="Firecrawl (SDK default)",
+        api_key=SecretStr("sdk_secret"),
+        expires_at=None,
+    )
+
+
+@pytest.fixture
+def tool():
+    return ListUserCredentialsTool()
+
+
+@pytest.fixture
+def mock_session():
+    session = MagicMock()
+    session.session_id = "test-session-123"
+    return session
+
+
+class TestListUserCredentialsTool:
+    def test_name(self, tool):
+        assert tool.name == "list_user_credentials"
+
+    def test_requires_auth(self, tool):
+        assert tool.requires_auth is True
+
+    def test_is_available(self, tool):
+        assert tool.is_available is True
+
+    def test_parameters_schema(self, tool):
+        params = tool.parameters
+        assert params["type"] == "object"
+        assert "provider" in params["properties"]
+        assert params["required"] == []
+
+    @pytest.mark.asyncio
+    async def test_lists_connected_credentials(self, tool, mock_session):
+        creds = [_github_oauth(), _notion_api_key()]
+        with patch(_CREDS_PATH, new_callable=AsyncMock, return_value=creds):
+            result = await tool._execute(user_id="user-1", session=mock_session)
+
+        assert isinstance(result, CredentialListResponse)
+        assert result.type == ResponseType.CREDENTIAL_LIST
+        assert result.count == 2
+        assert result.providers == ["github", "notion"]
+        assert result.session_id == "test-session-123"
+        assert "github" in result.message and "notion" in result.message
+
+        github = next(c for c in result.credentials if c.provider == "github")
+        assert github.type == "oauth2"
+        assert github.username == "octocat"
+        assert github.scopes == ["repo", "read:org"]
+
+    @pytest.mark.asyncio
+    async def test_no_secrets_in_serialized_output(self, tool, mock_session):
+        with patch(_CREDS_PATH, new_callable=AsyncMock, return_value=[_github_oauth()]):
+            result = await tool._execute(user_id="user-1", session=mock_session)
+
+        payload = result.model_dump_json()
+        assert "gho_secret" not in payload
+        assert "ghr_secret" not in payload
+
+    @pytest.mark.asyncio
+    async def test_filters_sdk_default_credentials(self, tool, mock_session):
+        creds = [_github_oauth(), _sdk_default_cred()]
+        with patch(_CREDS_PATH, new_callable=AsyncMock, return_value=creds):
+            result = await tool._execute(user_id="user-1", session=mock_session)
+
+        assert result.count == 1
+        assert result.providers == ["github"]
+
+    @pytest.mark.asyncio
+    async def test_filters_system_credentials(self, tool, mock_session):
+        from backend.integrations.credentials_store import DEFAULT_CREDENTIALS
+
+        creds = [_notion_api_key(), *DEFAULT_CREDENTIALS]
+        with patch(_CREDS_PATH, new_callable=AsyncMock, return_value=creds):
+            result = await tool._execute(user_id="user-1", session=mock_session)
+
+        assert result.count == 1
+        assert result.providers == ["notion"]
+
+    @pytest.mark.asyncio
+    async def test_provider_filter(self, tool, mock_session):
+        creds = [_github_oauth(), _notion_api_key()]
+        with patch(_CREDS_PATH, new_callable=AsyncMock, return_value=creds):
+            result = await tool._execute(
+                user_id="user-1", session=mock_session, provider="GitHub "
+            )
+
+        assert result.count == 1
+        assert result.providers == ["github"]
+
+    @pytest.mark.asyncio
+    async def test_provider_filter_no_match(self, tool, mock_session):
+        with patch(_CREDS_PATH, new_callable=AsyncMock, return_value=[_github_oauth()]):
+            result = await tool._execute(
+                user_id="user-1", session=mock_session, provider="google"
+            )
+
+        assert isinstance(result, CredentialListResponse)
+        assert result.count == 0
+        assert result.credentials == []
+        assert "google" in result.message
+
+    @pytest.mark.asyncio
+    async def test_empty_credentials(self, tool, mock_session):
+        with patch(_CREDS_PATH, new_callable=AsyncMock, return_value=[]):
+            result = await tool._execute(user_id="user-1", session=mock_session)
+
+        assert isinstance(result, CredentialListResponse)
+        assert result.count == 0
+        assert "not connected any integrations" in result.message
+
+    @pytest.mark.asyncio
+    async def test_lookup_failure_returns_error(self, tool, mock_session):
+        with patch(
+            _CREDS_PATH, new_callable=AsyncMock, side_effect=RuntimeError("boom")
+        ):
+            result = await tool._execute(user_id="user-1", session=mock_session)
+
+        assert isinstance(result, ErrorResponse)
+        assert result.error == "credential_lookup_failed"
+
+    @pytest.mark.asyncio
+    async def test_missing_user_id_returns_error(self, tool, mock_session):
+        result = await tool._execute(user_id=None, session=mock_session)
+
+        assert isinstance(result, ErrorResponse)
+        assert result.error == "missing_user_id"
+
+    @pytest.mark.asyncio
+    async def test_execute_without_auth_returns_need_login(self, tool, mock_session):
+        result = await tool.execute(None, mock_session, "tool-call-1")
+
+        assert result.toolName == "list_user_credentials"
+        assert '"need_login"' in result.output

--- a/autogpt_platform/backend/backend/copilot/tools/list_credentials_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/list_credentials_test.py
@@ -25,7 +25,7 @@ _MANAGED_PATH = (
 
 @pytest.fixture(autouse=True)
 def stub_managed_credentials_sweep():
-    with patch(_MANAGED_PATH, new_callable=AsyncMock) as mock_sweep:
+    with patch(_MANAGED_PATH, new_callable=AsyncMock, return_value=True) as mock_sweep:
         yield mock_sweep
 
 
@@ -200,6 +200,31 @@ class TestListUserCredentialsTool:
         assert result.count == 0
         assert result.credentials == []
         assert "google" in result.message
+
+    @pytest.mark.asyncio
+    async def test_whitespace_provider_treated_as_absent(self, tool, mock_session):
+        creds = [_github_oauth(), _notion_api_key()]
+        with patch(_CREDS_PATH, new_callable=AsyncMock, return_value=creds):
+            result = await tool._execute(
+                user_id="user-1", session=mock_session, provider="   "
+            )
+
+        assert isinstance(result, CredentialListResponse)
+        assert result.count == 2
+        assert result.providers == ["github", "notion"]
+
+    @pytest.mark.asyncio
+    async def test_provisioning_failure_marks_list_incomplete(
+        self, tool, mock_session, stub_managed_credentials_sweep
+    ):
+        stub_managed_credentials_sweep.return_value = False
+        with patch(_CREDS_PATH, new_callable=AsyncMock, return_value=[_github_oauth()]):
+            result = await tool._execute(user_id="user-1", session=mock_session)
+
+        assert isinstance(result, CredentialListResponse)
+        assert result.provisioning_complete is False
+        assert "do not treat their absence as authoritative" in result.message
+        stub_managed_credentials_sweep.assert_awaited_once_with("user-1")
 
     @pytest.mark.asyncio
     async def test_empty_credentials(self, tool, mock_session):

--- a/autogpt_platform/backend/backend/copilot/tools/models.py
+++ b/autogpt_platform/backend/backend/copilot/tools/models.py
@@ -123,6 +123,9 @@ class ResponseType(str, Enum):
     SKILL_DELETED = "skill_deleted"
     SKILL_LIST = "skill_list"
 
+    # Connected integration credentials (metadata only)
+    CREDENTIAL_LIST = "credential_list"
+
 
 # Base response model
 class ToolResponseBase(BaseModel):

--- a/autogpt_platform/backend/backend/copilot/tools/tool_schema_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/tool_schema_test.py
@@ -97,7 +97,12 @@ from backend.copilot.tools import TOOL_REGISTRY
 # ``{}`` and dropping it; nested props are kept type-only to minimise the spend.
 # Merged registry measures 50915 chars (incl. find_library_agent's
 # write_graph_to); ~580 headroom for wording tweaks.
-_CHAR_BUDGET = 51_500
+# Bumped 51500 -> 52000 for REQ-112: the list_user_credentials tool (~500
+# chars: name + "check what's connected before surfacing sign-in" copy +
+# optional provider filter) lets the model discover connected integrations
+# instead of blindly re-prompting sign-in. Registry measures 51291 chars;
+# ~700 headroom for wording tweaks.
+_CHAR_BUDGET = 52_000
 
 
 @pytest.fixture(scope="module")

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatMessagesContainer/components/MessagePartRenderer.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatMessagesContainer/components/MessagePartRenderer.tsx
@@ -17,6 +17,7 @@ import { FindAgentsTool } from "../../../tools/FindAgents/FindAgents";
 import { FolderTool } from "../../../tools/FolderTool/FolderTool";
 import { FindBlocksTool } from "../../../tools/FindBlocks/FindBlocks";
 import { GenericTool } from "../../../tools/GenericTool/GenericTool";
+import { ListCredentialsTool } from "../../../tools/ListCredentialsTool/ListCredentialsTool";
 import { RunAgentTool } from "../../../tools/RunAgent/RunAgent";
 import { RunBlockTool } from "../../../tools/RunBlock/RunBlock";
 import { RunMCPToolComponent } from "../../../tools/RunMCPTool/RunMCPTool";
@@ -210,6 +211,8 @@ export function MessagePartRenderer({
       return <SearchDocsTool key={key} part={part as ToolUIPart} />;
     case "tool-connect_integration":
       return <ConnectIntegrationTool key={key} part={part as ToolUIPart} />;
+    case "tool-list_user_credentials":
+      return <ListCredentialsTool key={key} part={part as ToolUIPart} />;
     case "tool-run_block":
     case "tool-continue_run_block":
       return <RunBlockTool key={key} part={part as ToolUIPart} />;

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatMessagesContainer/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatMessagesContainer/helpers.ts
@@ -40,6 +40,7 @@ const CUSTOM_TOOL_TYPES = new Set([
   "tool-search_docs",
   "tool-get_doc_page",
   "tool-connect_integration",
+  "tool-list_user_credentials",
   "tool-run_block",
   "tool-continue_run_block",
   "tool-connect_integration",

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/tools/ListCredentialsTool/ListCredentialsTool.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/tools/ListCredentialsTool/ListCredentialsTool.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import type { ToolUIPart } from "ai";
+import {
+  KeyIcon,
+  PlugsConnectedIcon,
+  UserIcon,
+  WarningDiamondIcon,
+} from "@phosphor-icons/react";
+import { MorphingTextAnimation } from "../../components/MorphingTextAnimation/MorphingTextAnimation";
+import { OrbitLoader } from "../../components/OrbitLoader/OrbitLoader";
+import { ToolAccordion } from "../../components/ToolAccordion/ToolAccordion";
+import {
+  ContentCard,
+  ContentCardHeader,
+  ContentCardTitle,
+  ContentGrid,
+  ContentHint,
+  ContentMessage,
+} from "../../components/ToolAccordion/AccordionContent";
+import {
+  formatProviderName,
+  getAnimationText,
+  getCredentialTypeLabel,
+  getListCredentialsOutput,
+  isCredentialList,
+  isErrorOutput,
+  type CredentialMeta,
+} from "./helpers";
+
+interface Props {
+  part: ToolUIPart;
+}
+
+function ToolStatusIcon({
+  isStreaming,
+  isError,
+}: {
+  isStreaming: boolean;
+  isError: boolean;
+}) {
+  if (isError) {
+    return (
+      <WarningDiamondIcon size={14} weight="regular" className="text-red-500" />
+    );
+  }
+  if (isStreaming) {
+    return <OrbitLoader size={14} />;
+  }
+  return (
+    <PlugsConnectedIcon
+      size={14}
+      weight="regular"
+      className="text-neutral-400"
+    />
+  );
+}
+
+function CredentialCard({ credential }: { credential: CredentialMeta }) {
+  return (
+    <ContentCard>
+      <ContentCardHeader>
+        <div className="flex items-center gap-2">
+          <KeyIcon size={14} weight="fill" className="text-neutral-600" />
+          <ContentCardTitle>
+            {formatProviderName(credential.provider)}
+          </ContentCardTitle>
+        </div>
+      </ContentCardHeader>
+      <ContentHint>
+        {getCredentialTypeLabel(credential.type)}
+        {credential.title ? ` · ${credential.title}` : ""}
+        {credential.is_managed ? " · Managed by AutoGPT" : ""}
+      </ContentHint>
+      {credential.username && (
+        <div className="mt-1 flex items-center gap-1.5">
+          <UserIcon size={12} weight="duotone" className="text-neutral-600" />
+          <span className="text-xs text-zinc-600">{credential.username}</span>
+        </div>
+      )}
+      {credential.scopes && credential.scopes.length > 0 && (
+        <div className="mt-1">
+          <span className="text-xs text-zinc-500">
+            Scopes: {credential.scopes.join(", ")}
+          </span>
+        </div>
+      )}
+    </ContentCard>
+  );
+}
+
+export function ListCredentialsTool({ part }: Props) {
+  const text = getAnimationText(part);
+  const output = getListCredentialsOutput(part);
+
+  const isStreaming =
+    part.state === "input-streaming" || part.state === "input-available";
+  const isError =
+    part.state === "output-error" || (!!output && isErrorOutput(output));
+
+  const hasContent =
+    part.state === "output-available" && !!output && isCredentialList(output);
+
+  return (
+    <div className="py-2">
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <ToolStatusIcon isStreaming={isStreaming} isError={isError} />
+        <MorphingTextAnimation
+          text={text}
+          className={isError ? "text-red-500" : undefined}
+        />
+      </div>
+
+      {hasContent && output && isCredentialList(output) && (
+        <ToolAccordion
+          icon={<PlugsConnectedIcon size={32} weight="light" />}
+          title={
+            output.count > 0
+              ? `${output.count} connected integration${output.count !== 1 ? "s" : ""}`
+              : "No connected integrations"
+          }
+          defaultExpanded
+        >
+          {output.credentials.length > 0 ? (
+            <ContentGrid className="sm:grid-cols-2">
+              {output.credentials.map((credential) => (
+                <CredentialCard key={credential.id} credential={credential} />
+              ))}
+            </ContentGrid>
+          ) : (
+            <ContentMessage>{output.message}</ContentMessage>
+          )}
+        </ToolAccordion>
+      )}
+    </div>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/tools/ListCredentialsTool/ListCredentialsTool.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/tools/ListCredentialsTool/ListCredentialsTool.tsx
@@ -70,6 +70,7 @@ function CredentialCard({ credential }: { credential: CredentialMeta }) {
       <ContentHint>
         {getCredentialTypeLabel(credential.type)}
         {credential.title ? ` · ${credential.title}` : ""}
+        {credential.host ? ` · ${credential.host}` : ""}
         {credential.is_managed ? " · Managed by AutoGPT" : ""}
       </ContentHint>
       {credential.username && (

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/tools/ListCredentialsTool/__tests__/ListCredentialsTool.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/tools/ListCredentialsTool/__tests__/ListCredentialsTool.test.tsx
@@ -44,7 +44,7 @@ function makeListOutput() {
 describe("ListCredentialsTool", () => {
   it("shows a loading label while streaming", () => {
     const { container } = render(<ListCredentialsTool part={makePart()} />);
-    const normalized = (container.textContent ?? "").replace(/ /g, " ");
+    const normalized = (container.textContent ?? "").replace(/\u00a0/g, " ");
     expect(normalized).toContain("Checking connected integrations");
   });
 
@@ -131,7 +131,7 @@ describe("ListCredentialsTool", () => {
         })}
       />,
     );
-    const normalized = (container.textContent ?? "").replace(/ /g, " ");
+    const normalized = (container.textContent ?? "").replace(/\u00a0/g, " ");
     expect(normalized).toContain("Could not check connected integrations");
   });
 
@@ -144,7 +144,7 @@ describe("ListCredentialsTool", () => {
         })}
       />,
     );
-    const normalized = (container.textContent ?? "").replace(/ /g, " ");
+    const normalized = (container.textContent ?? "").replace(/\u00a0/g, " ");
     expect(normalized).toContain("Done");
   });
 
@@ -157,7 +157,7 @@ describe("ListCredentialsTool", () => {
         })}
       />,
     );
-    const normalized = (container.textContent ?? "").replace(/ /g, " ");
+    const normalized = (container.textContent ?? "").replace(/\u00a0/g, " ");
     expect(normalized).toContain("Could not check connected integrations");
   });
 });

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/tools/ListCredentialsTool/__tests__/ListCredentialsTool.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/tools/ListCredentialsTool/__tests__/ListCredentialsTool.test.tsx
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+
+import type { ToolUIPart } from "ai";
+import { render, screen } from "@/tests/integrations/test-utils";
+import { ListCredentialsTool } from "../ListCredentialsTool";
+
+function makePart(overrides: Record<string, unknown> = {}): ToolUIPart {
+  return {
+    type: "tool-list_user_credentials",
+    toolCallId: "call-list-creds-1",
+    state: "input-streaming",
+    input: {},
+    ...overrides,
+  } as ToolUIPart;
+}
+
+function makeListOutput() {
+  return JSON.stringify({
+    type: "credential_list",
+    message: "The user has 2 connected credential(s) across 2 provider(s).",
+    credentials: [
+      {
+        id: "cred-1",
+        provider: "github",
+        type: "oauth2",
+        title: "GitHub",
+        username: "octocat",
+        scopes: ["repo", "read:org"],
+        is_managed: false,
+      },
+      {
+        id: "cred-2",
+        provider: "notion",
+        type: "api_key",
+        title: "My Notion key",
+        is_managed: false,
+      },
+    ],
+    providers: ["github", "notion"],
+    count: 2,
+  });
+}
+
+describe("ListCredentialsTool", () => {
+  it("shows a loading label while streaming", () => {
+    const { container } = render(<ListCredentialsTool part={makePart()} />);
+    const normalized = (container.textContent ?? "").replace(/ /g, " ");
+    expect(normalized).toContain("Checking connected integrations");
+  });
+
+  it("renders connected credentials with provider, type, and account details", () => {
+    render(
+      <ListCredentialsTool
+        part={makePart({ state: "output-available", output: makeListOutput() })}
+      />,
+    );
+
+    expect(screen.getByText("2 connected integrations")).not.toBeNull();
+    expect(screen.getByText("Github")).not.toBeNull();
+    expect(screen.getByText("Notion")).not.toBeNull();
+    expect(screen.getByText("octocat")).not.toBeNull();
+    expect(screen.getByText(/repo, read:org/)).not.toBeNull();
+    expect(screen.getByText(/API key · My Notion key/)).not.toBeNull();
+  });
+
+  it("shows an empty state when no integrations are connected", () => {
+    render(
+      <ListCredentialsTool
+        part={makePart({
+          state: "output-available",
+          output: JSON.stringify({
+            type: "credential_list",
+            message: "The user has not connected any integrations yet.",
+            credentials: [],
+            providers: [],
+            count: 0,
+          }),
+        })}
+      />,
+    );
+
+    expect(screen.getByText("No connected integrations")).not.toBeNull();
+    expect(
+      screen.getAllByText(/has not connected any integrations/).length,
+    ).toBeGreaterThan(0);
+  });
+
+  it("styles the label as an error on tool failure", () => {
+    const { container } = render(
+      <ListCredentialsTool
+        part={makePart({
+          state: "output-error",
+          output: '{"type":"error","message":"boom"}',
+        })}
+      />,
+    );
+    const normalized = (container.textContent ?? "").replace(/ /g, " ");
+    expect(normalized).toContain("Could not check connected integrations");
+  });
+});

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/tools/ListCredentialsTool/__tests__/ListCredentialsTool.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/tools/ListCredentialsTool/__tests__/ListCredentialsTool.test.tsx
@@ -85,6 +85,69 @@ describe("ListCredentialsTool", () => {
     ).toBeGreaterThan(0);
   });
 
+  it("renders managed and host-scoped credentials with their labels", () => {
+    render(
+      <ListCredentialsTool
+        part={makePart({
+          state: "output-available",
+          output: JSON.stringify({
+            type: "credential_list",
+            message: "The user has 2 connected credential(s).",
+            credentials: [
+              {
+                id: "cred-3",
+                provider: "agent_mail",
+                type: "api_key",
+                is_managed: true,
+              },
+              {
+                id: "cred-4",
+                provider: "http",
+                type: "host_scoped",
+                host: "api.example.com",
+              },
+            ],
+            providers: ["agent_mail", "http"],
+            count: 2,
+          }),
+        })}
+      />,
+    );
+
+    expect(screen.getByText("Agent Mail")).not.toBeNull();
+    expect(screen.getByText(/Managed by AutoGPT/)).not.toBeNull();
+    expect(screen.getByText(/Host-scoped · api\.example\.com/)).not.toBeNull();
+  });
+
+  it("styles the label as an error when the tool returns need_login", () => {
+    const { container } = render(
+      <ListCredentialsTool
+        part={makePart({
+          state: "output-available",
+          output: JSON.stringify({
+            type: "need_login",
+            message: "Please sign in to use list_user_credentials",
+          }),
+        })}
+      />,
+    );
+    const normalized = (container.textContent ?? "").replace(/ /g, " ");
+    expect(normalized).toContain("Could not check connected integrations");
+  });
+
+  it("falls back to a done label when output is unparseable", () => {
+    const { container } = render(
+      <ListCredentialsTool
+        part={makePart({
+          state: "output-available",
+          output: '{"type":"credential_list"',
+        })}
+      />,
+    );
+    const normalized = (container.textContent ?? "").replace(/ /g, " ");
+    expect(normalized).toContain("Done");
+  });
+
   it("styles the label as an error on tool failure", () => {
     const { container } = render(
       <ListCredentialsTool

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/tools/ListCredentialsTool/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/tools/ListCredentialsTool/helpers.ts
@@ -1,0 +1,111 @@
+import type { ToolUIPart } from "ai";
+
+interface CredentialMeta {
+  id: string;
+  provider: string;
+  type: string;
+  title?: string | null;
+  scopes?: string[] | null;
+  username?: string | null;
+  host?: string | null;
+  is_managed?: boolean;
+}
+
+interface CredentialListOutput {
+  type: "credential_list";
+  message: string;
+  credentials: CredentialMeta[];
+  providers: string[];
+  count: number;
+}
+
+interface ErrorOutput {
+  type: "error" | "need_login";
+  message: string;
+  error?: string;
+}
+
+export type ListCredentialsOutput = CredentialListOutput | ErrorOutput;
+
+export type { CredentialMeta };
+
+function parseOutput(output: unknown): ListCredentialsOutput | null {
+  if (!output) return null;
+  if (typeof output === "string") {
+    const trimmed = output.trim();
+    if (!trimmed) return null;
+    try {
+      return parseOutput(JSON.parse(trimmed) as unknown);
+    } catch {
+      return null;
+    }
+  }
+  if (typeof output === "object") {
+    const obj = output as Record<string, unknown>;
+    if (typeof obj.type === "string") {
+      return output as ListCredentialsOutput;
+    }
+  }
+  return null;
+}
+
+export function getListCredentialsOutput(part: {
+  output?: unknown;
+}): ListCredentialsOutput | null {
+  return parseOutput(part.output);
+}
+
+export function isCredentialList(
+  o: ListCredentialsOutput,
+): o is CredentialListOutput {
+  return o.type === "credential_list";
+}
+
+export function isErrorOutput(o: ListCredentialsOutput): o is ErrorOutput {
+  return o.type === "error" || o.type === "need_login";
+}
+
+export function formatProviderName(provider: string): string {
+  return provider
+    .split(/[_-]/)
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+export function getCredentialTypeLabel(type: string): string {
+  switch (type) {
+    case "oauth2":
+      return "OAuth";
+    case "api_key":
+      return "API key";
+    case "user_password":
+      return "Username / password";
+    case "host_scoped":
+      return "Host-scoped";
+    default:
+      return type;
+  }
+}
+
+export function getAnimationText(part: {
+  state: ToolUIPart["state"];
+  output?: unknown;
+}): string {
+  switch (part.state) {
+    case "input-streaming":
+    case "input-available":
+      return "Checking connected integrations…";
+    case "output-available": {
+      const output = getListCredentialsOutput(part);
+      if (!output) return "Done";
+      if (isErrorOutput(output))
+        return "Could not check connected integrations";
+      return output.message;
+    }
+    case "output-error":
+      return "Could not check connected integrations";
+    default:
+      return "Checking connected integrations…";
+  }
+}

--- a/autogpt_platform/frontend/src/app/api/openapi.json
+++ b/autogpt_platform/frontend/src/app/api/openapi.json
@@ -20797,7 +20797,8 @@
           "skill_stored",
           "skill_loaded",
           "skill_deleted",
-          "skill_list"
+          "skill_list",
+          "credential_list"
         ],
         "title": "ResponseType",
         "description": "Types of tool responses."


### PR DESCRIPTION
### Why / What / How

**Why:** CoPilot has no way to know which credentials/integrations the user has already connected before attempting a task (REQ-112). Its only discovery paths today are shelling out to `gh auth status` (GitHub-only, E2B-only) or attempting a `run_block`/`run_agent` and reading back the missing-credentials list. `connect_integration` always assumes the user is not connected. The result is unnecessary sign-in prompts for integrations that are already connected.

**What:** A new `list_user_credentials` CoPilot tool that returns secret-free metadata about every credential the user has connected (provider, type, title, OAuth scopes, username, host, managed flag), with an optional `provider` filter — plus a chat card that renders the connected integrations, and system-prompt guidance telling the model to check before surfacing sign-in cards.

**How:**
- The tool reuses the exact secret-stripping serialization the integrations API already uses (`to_meta_response` → `CredentialsMetaResponse`), so no new secret-handling surface is introduced.
- System credentials (platform-provided API keys from `settings.secrets`, identified via `SYSTEM_CREDENTIAL_IDS`) and SDK default credentials (`is_sdk_default`) are filtered out — they are not user-connected integrations and would mislead the model. Managed credentials (e.g. AgentMail) are included and flagged `is_managed`; the tool runs the same bounded managed-credential provisioning sweep as `GET /credentials`, and marks the inventory `provisioning_complete=false` when that sweep fails.
- Chose the on-demand tool over injecting a summary into the system prompt (the ticket's alternative): the system prompt is deliberately byte-identical across users for cross-session prompt caching, and per-user injection was explicitly declined before for that reason (see `budget_context` notes in `service.py`). A tool has no cache cost and returns fresh data mid-session.
- The tool-schema char budget in `tool_schema_test.py` is bumped 51500 → 52000 with the documented rationale convention (new tool measures ~500 chars; registry now at 51291).

### Changes 🏗️

**Backend**
- `backend/copilot/tools/list_credentials.py` — NEW: `ListUserCredentialsTool` (`requires_auth`, optional `provider` filter) + `CredentialListResponse`
- `backend/copilot/tools/models.py` — `ResponseType.CREDENTIAL_LIST`
- `backend/copilot/tools/__init__.py` — registers `list_user_credentials`
- `backend/copilot/permissions.py` — `list_user_credentials` added to the `ToolName` Literal (registry sync)
- `backend/copilot/prompting.py` — new rule 0 in "Credentials & sign-in surfacing": check `list_user_credentials` before prompting sign-in; fixed the stale "check credentials via `connect_integration`" reference (that tool cannot check anything)
- `backend/copilot/tools/tool_schema_test.py` — budget bump with rationale
- `backend/copilot/tools/list_credentials_test.py` — NEW: 17 unit tests (filtering of system/SDK-default creds, provider filter, no-secrets serialization incl. host-scoped/MCP, provisioning-failure marking, auth guard, error paths)

**Frontend**
- `src/app/(platform)/copilot/tools/ListCredentialsTool/` — NEW: chat card (accordion of connected integrations with provider, auth type, account, host, scopes) + helpers + 7 Vitest tests
- `MessagePartRenderer.tsx` / `ChatMessagesContainer/helpers.ts` — render case + custom-tool allowlist entry
- `src/app/api/openapi.json` — regenerated via `poetry run export-api-schema` (diff is the single new `credential_list` enum value)

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `poetry run pytest backend/copilot/tools/list_credentials_test.py` — 17/17 pass
  - [x] `poetry run pytest backend/copilot/tools/tool_schema_test.py backend/copilot/tools/utils_test.py backend/copilot/tools/test_platform_info.py` — 207/207 pass
  - [x] `poetry run format` (ruff/isort/black/pyright) — clean
  - [x] `npx vitest run ListCredentialsTool` — 7/7 pass; full `pnpm test:unit` suite green (3995 passed)
  - [x] `pnpm format && pnpm lint && pnpm types` — clean
  - [x] `poetry run export-api-schema` + `pnpm generate:api` — regenerated client includes `credential_list`

#### For configuration changes:
- [x] `.env.default` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes
- [x] I have included a list of my configuration changes in the PR description (under **Changes**) — no configuration changes