### PR TITLE
fix(backend/copilot): surface sub-session results after fire-and-forget launch

### DIFF
--- a/autogpt_platform/backend/backend/copilot/prompting.py
+++ b/autogpt_platform/backend/backend/copilot/prompting.py
@@ -220,6 +220,13 @@ Correct flow for *any* integration request:
   intermediate tool calls out of the parent context.
 - Do NOT invoke `AutoPilotBlock` via `run_block`; use `run_sub_session`
   instead.
+- When `run_sub_session` comes back `running` or `queued` (always the case
+  with `wait_for_result: 0`) and you are ending the turn, call
+  `schedule_followup` with a poll prompt BEFORE your closing message.
+  `get_sub_session_result` cannot run once the turn is over, so without
+  that follow-up the sub finishes and its result never reaches the user.
+  Never promise "I'll ping you with the results" without scheduling the
+  poll that makes the promise true.
 - For multi-step build/edit work, maintain a `build_state.json` workspace
   file recording the identifiers you will need again: library agent IDs +
   graph IDs + current versions, schedule IDs (full UUIDs), trigger/preset

--- a/autogpt_platform/backend/backend/copilot/tools/get_sub_session_result.py
+++ b/autogpt_platform/backend/backend/copilot/tools/get_sub_session_result.py
@@ -82,7 +82,9 @@ class GetSubSessionResultTool(BaseTool):
                     "type": "string",
                     "description": (
                         "The sub's session_id returned by run_sub_session "
-                        "(also accepted: sub_autopilot_session_id — same value)."
+                        "(its sub_session_id / sub_autopilot_session_id field — "
+                        "both carry the same value, but this argument must be "
+                        "named sub_session_id)."
                     ),
                 },
                 "wait_if_running": {

--- a/autogpt_platform/backend/backend/copilot/tools/run_sub_session.py
+++ b/autogpt_platform/backend/backend/copilot/tools/run_sub_session.py
@@ -59,6 +59,12 @@ MAX_SUB_SESSION_WAIT_SECONDS = MAX_TOOL_WAIT_SECONDS
 # manifest. Bounds context size; a sub producing more than this is pathological.
 _WORKSPACE_FILE_MANIFEST_LIMIT = 50
 
+# Delay suggested for the poll follow-up after a non-terminal launch. Long
+# enough that a typical sub has finished by then (so the follow-up turn reports
+# a real result instead of immediately re-scheduling), short enough that the
+# user is still in the conversation. ``schedule_followup`` enforces a 60s floor.
+FOLLOWUP_POLL_DELAY_SECONDS = 300
+
 
 class RunSubSessionTool(BaseTool):
     """Delegate a task to a fresh sub-AutoPilot via the copilot_executor queue."""
@@ -189,6 +195,7 @@ class RunSubSessionTool(BaseTool):
             parent_session_id=session.session_id,
             elapsed=elapsed,
             workspace_files=workspace_files,
+            suggest_followup_poll=True,
         )
 
 
@@ -202,6 +209,32 @@ def _sub_session_link(inner_session_id: str | None) -> str | None:
     if not inner_session_id:
         return None
     return f"/copilot?sessionId={inner_session_id}"
+
+
+def _followup_poll_nudge(inner_session_id: str) -> str:
+    """Instruction appended to a non-terminal *launch* response telling the
+    model to schedule the poll that will surface the sub's result.
+
+    ``get_sub_session_result`` only runs *inside* a turn. When the model
+    launches a sub and then ends its turn — always the case for
+    ``wait_for_result=0``, and the common case once a wait times out —
+    nothing ever polls the sub, so a promised "I'll ping you with the
+    results" is silently never kept and the user has to ask manually
+    (SECRT-2471). This response is the last thing the model reads before it
+    composes that promise, so the reminder has to live here and not only in
+    the system prompt.
+    """
+    return (
+        " IMPORTANT — if you are ending your turn here (always the case when "
+        "you passed wait_for_result=0, and whenever you tell the user you will "
+        "report back), you MUST schedule the poll before your closing message: "
+        f"schedule_followup(delay_seconds={FOLLOWUP_POLL_DELAY_SECONDS}, "
+        "session_id=<the session_id from <session_context>>, message='Call "
+        f'get_sub_session_result(sub_autopilot_session_id="{inner_session_id}") '
+        "and report the outcome to the user; if it is still running, schedule "
+        "another follow-up.'). Without it get_sub_session_result never runs "
+        "again and the result never reaches the user."
+    )
 
 
 async def list_sub_workspace_files(
@@ -321,6 +354,7 @@ def response_from_outcome(
     parent_session_id: str | None,
     elapsed: float,
     workspace_files: list[WorkspaceFileInfoData] | None = None,
+    suggest_followup_poll: bool = False,
 ) -> SubSessionStatusResponse:
     """Translate a ``(SessionOutcome, SessionResult)`` tuple into the
     ``SubSessionStatusResponse`` contract the LLM sees.
@@ -335,8 +369,15 @@ def response_from_outcome(
     ``queued`` means the target session already had a turn in flight; the
     message was appended to its pending buffer and will be processed by
     the existing turn on its next drain.
+
+    ``suggest_followup_poll`` appends the "schedule the poll before you end
+    the turn" instruction to the two non-terminal outcomes. Callers that are
+    *launching* a sub set it; ``get_sub_session_result`` leaves it off,
+    because its ``running`` replies are read mid-poll by a model that is
+    already in the polling loop (SECRT-2471).
     """
     link = _sub_session_link(inner_session_id)
+    followup = _followup_poll_nudge(inner_session_id) if suggest_followup_poll else ""
     if outcome == "queued":
         return SubSessionStatusResponse(
             message=(
@@ -345,6 +386,7 @@ def response_from_outcome(
                 "will be processed by the existing turn on its next drain. "
                 f"Call get_sub_session_result to poll progress"
                 f"{f' or watch live at {link}' if link else ''}."
+                f"{followup}"
             ),
             session_id=parent_session_id,
             status="queued",
@@ -361,6 +403,7 @@ def response_from_outcome(
                 f"{f' Watch live at {link}.' if link else ''} "
                 "Call get_sub_session_result (optionally with "
                 "include_progress=true) to wait, poll, or inspect progress."
+                f"{followup}"
             ),
             session_id=parent_session_id,
             status="running",

--- a/autogpt_platform/backend/backend/copilot/tools/run_sub_session.py
+++ b/autogpt_platform/backend/backend/copilot/tools/run_sub_session.py
@@ -230,7 +230,7 @@ def _followup_poll_nudge(inner_session_id: str) -> str:
         "report back), you MUST schedule the poll before your closing message: "
         f"schedule_followup(delay_seconds={FOLLOWUP_POLL_DELAY_SECONDS}, "
         "session_id=<the session_id from <session_context>>, message='Call "
-        f'get_sub_session_result(sub_autopilot_session_id="{inner_session_id}") '
+        f'get_sub_session_result(sub_session_id="{inner_session_id}") '
         "and report the outcome to the user; if it is still running, schedule "
         "another follow-up.'). Without it get_sub_session_result never runs "
         "again and the result never reaches the user."

--- a/autogpt_platform/backend/backend/copilot/tools/sub_session_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/sub_session_test.py
@@ -285,9 +285,12 @@ class TestRunSubSession:
         message = r.message or ""
         assert "schedule_followup" in message
         assert f"delay_seconds={FOLLOWUP_POLL_DELAY_SECONDS}" in message
-        # The scheduled prompt has to name the sub, or the follow-up turn has
-        # nothing to poll.
-        assert "inner-1" in message
+        # The scheduled prompt must name the sub using the argument
+        # get_sub_session_result actually binds. `sub_autopilot_session_id` is
+        # only a *response* field name — passed as an argument it lands in
+        # **kwargs and the tool errors with "sub_session_id is required",
+        # which would silently defeat the whole follow-up.
+        assert 'get_sub_session_result(sub_session_id="inner-1")' in message
 
     @pytest.mark.asyncio
     async def test_queued_launch_instructs_scheduling_a_followup_poll(

--- a/autogpt_platform/backend/backend/copilot/tools/sub_session_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/sub_session_test.py
@@ -22,6 +22,7 @@ from backend.copilot.sdk.stream_accumulator import ToolCallEntry
 from .get_sub_session_result import GetSubSessionResultTool
 from .models import ErrorResponse, SubSessionStatusResponse, WorkspaceFileInfoData
 from .run_sub_session import (
+    FOLLOWUP_POLL_DELAY_SECONDS,
     MAX_SUB_SESSION_WAIT_SECONDS,
     RunSubSessionTool,
     response_from_outcome,
@@ -265,6 +266,79 @@ class TestRunSubSession:
         assert r.sub_autopilot_session_link == "/copilot?sessionId=inner-1"
         mock_waiter.assert_awaited_once()
         assert mock_waiter.await_args.kwargs["timeout"] == 0
+
+    @pytest.mark.asyncio
+    async def test_fire_and_forget_instructs_scheduling_a_followup_poll(
+        self, mock_queue, mock_waiter, mock_model
+    ):
+        """A fire-and-forget launch ends the turn, and get_sub_session_result
+        cannot run after that — so the launch response must tell the model to
+        schedule the poll that surfaces the result (SECRT-2471). Without this
+        the sub finishes and nobody ever reports back."""
+        r = await RunSubSessionTool()._execute(
+            user_id="alice",
+            session=_session("alice"),
+            prompt="investigate the thing",
+            wait_for_result=0,
+        )
+        assert isinstance(r, SubSessionStatusResponse)
+        message = r.message or ""
+        assert "schedule_followup" in message
+        assert f"delay_seconds={FOLLOWUP_POLL_DELAY_SECONDS}" in message
+        # The scheduled prompt has to name the sub, or the follow-up turn has
+        # nothing to poll.
+        assert "inner-1" in message
+
+    @pytest.mark.asyncio
+    async def test_queued_launch_instructs_scheduling_a_followup_poll(
+        self, mock_queue, mock_waiter, mock_model
+    ):
+        """A queued launch drains on someone else's turn, so the same
+        surfacing gap applies — nudge the follow-up poll there too."""
+        mock_waiter.return_value = (
+            "queued",
+            SessionResult(queued=True, pending_buffer_length=2),
+        )
+        r = await RunSubSessionTool()._execute(
+            user_id="alice",
+            session=_session("alice"),
+            prompt="another thing",
+            wait_for_result=0,
+        )
+        assert isinstance(r, SubSessionStatusResponse)
+        assert "schedule_followup" in (r.message or "")
+
+    @pytest.mark.asyncio
+    async def test_completed_launch_omits_followup_nudge(
+        self, mock_queue, mock_waiter, mock_model
+    ):
+        """A sub that already finished inline needs no follow-up — the model
+        has the result in hand and scheduling one would be pure noise."""
+        res = SessionResult()
+        res.response_text = "done"
+        mock_waiter.return_value = ("completed", res)
+
+        r = await RunSubSessionTool()._execute(
+            user_id="alice",
+            session=_session("alice"),
+            prompt="quick thing",
+            wait_for_result=60,
+        )
+        assert isinstance(r, SubSessionStatusResponse)
+        assert "schedule_followup" not in (r.message or "")
+
+    def test_poll_responses_omit_followup_nudge_by_default(self):
+        """``response_from_outcome`` is shared with get_sub_session_result,
+        whose 'running' replies are read mid-turn while the model is already
+        polling. The nudge is opt-in so those stay unchanged."""
+        running = response_from_outcome(
+            outcome="running",
+            result=SessionResult(),
+            inner_session_id="inner-1",
+            parent_session_id="s1",
+            elapsed=30.0,
+        )
+        assert "schedule_followup" not in (running.message or "")
 
     @pytest.mark.asyncio
     async def test_wait_for_result_completed_returns_final_response(


### PR DESCRIPTION
### Why / What / How

**Why** — When AutoPilot delegates work with `run_sub_session(wait_for_result=0)`, the tool returns `status="running"` and the turn ends. `get_sub_session_result` only runs *inside* a turn, so nothing ever polls the sub. The sub completes, its result sits in the sub-session, and the "I'll ping you back with the results" the model just promised is silently never kept — the user has to ask manually. Fixes SECRT-2471.

The existing launch response actively pointed the wrong way: it said *"Call get_sub_session_result to wait, poll, or inspect progress"* — advice that is impossible to act on once the turn is over.

**What** — The non-terminal launch responses (`running`, `queued`) now instruct the model to call `schedule_followup` with a concrete poll prompt before its closing message. The same rule is added to the system prompt.

**How** — A `_followup_poll_nudge()` helper builds the instruction, including the sub's session id so the scheduled prompt has something to poll, and a self-perpetuating clause ("if it is still running, schedule another follow-up") so a slow sub doesn't drop the chain after one hop.

The nudge is opt-in through a new `suggest_followup_poll` flag on `response_from_outcome`. That function is shared with `get_sub_session_result`, whose `running` replies are read mid-poll by a model already inside the polling loop — those messages are deliberately left unchanged, so the diff only affects the *launch* path.

Guidance-level fix rather than a server-side auto-schedule: every fire-and-forget sub would otherwise create a schedule row, including the many the model never intended to report back on.

No tool schemas changed, so the tool-schema character budget in `tool_schema_test.py` is untouched.

### Changes 🏗️

- `backend/copilot/tools/run_sub_session.py`
  - New `FOLLOWUP_POLL_DELAY_SECONDS = 300` (above `schedule_followup`'s 60s floor; long enough that the follow-up turn usually reports a real result instead of immediately re-scheduling).
  - New `_followup_poll_nudge()` building the instruction.
  - `response_from_outcome(..., suggest_followup_poll=False)` appends it to the `running` and `queued` branches; `RunSubSessionTool._execute` passes `True`.
- `backend/copilot/prompting.py` — new bullet under **Complex multi-step work** stating the rule and that a "report back" promise requires scheduling the poll that makes it true.
- `backend/copilot/tools/sub_session_test.py` — 4 new tests.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `poetry run pytest backend/copilot/tools/sub_session_test.py` — 26 passed, including 4 new:
    - `test_fire_and_forget_instructs_scheduling_a_followup_poll` — `wait_for_result=0` response names `schedule_followup`, the delay, and the sub's session id
    - `test_queued_launch_instructs_scheduling_a_followup_poll` — same for the `queued` outcome
    - `test_completed_launch_omits_followup_nudge` — a sub that finished inline gets no nudge
    - `test_poll_responses_omit_followup_nudge_by_default` — `get_sub_session_result`'s `running` replies are unchanged
  - [x] Each new test fails against the pre-fix code and passes after
  - [x] `poetry run pytest backend/copilot/tools/tool_schema_test.py backend/copilot/tools/schedule_followup_test.py` — 199 passed (schema budget unaffected)
  - [x] `poetry run format` / `poetry run lint` clean (ruff, black, isort, pyright)

Note: `backend/copilot/prompting_test.py` could not be run in my sandbox — it hangs on service dependencies (Postgres/Redis) that aren't available there. Verified the hang reproduces on an unmodified `dev` checkout, so it is unrelated to this change; leaving it to CI.

#### For configuration changes:

- [x] `.env.default` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes
- [x] I have included a list of my configuration changes in the PR description (under **Changes**)

No configuration changes.