### PR TITLE
feat(platform): pause schedules & triggers on payment lapse, resume on payment

### DIFF
--- a/autogpt_platform/backend/backend/api/features/library/db.py
+++ b/autogpt_platform/backend/backend/api/features/library/db.py
@@ -2096,8 +2096,7 @@ async def update_preset(
             update_data["description"] = description
         if is_active is not None:
             update_data["isActive"] = is_active
-            # Explicitly setting the active state is a user decision; drop any
-            # system deactivation reason so auto-resume won't override it.
+            # User decision overrides any system deactivation reason
             update_data["deactivationReason"] = None
         if inputs or credentials:
             if not (inputs and credentials):

--- a/autogpt_platform/backend/backend/api/features/library/db.py
+++ b/autogpt_platform/backend/backend/api/features/library/db.py
@@ -2096,6 +2096,9 @@ async def update_preset(
             update_data["description"] = description
         if is_active is not None:
             update_data["isActive"] = is_active
+            # Explicitly setting the active state is a user decision; drop any
+            # system deactivation reason so auto-resume won't override it.
+            update_data["deactivationReason"] = None
         if inputs or credentials:
             if not (inputs and credentials):
                 raise ValueError(

--- a/autogpt_platform/backend/backend/api/features/library/db_test.py
+++ b/autogpt_platform/backend/backend/api/features/library/db_test.py
@@ -1441,3 +1441,33 @@ async def test_cleanup_trigger_agents_processes_each_independently(mocker):
     recursive_delete.assert_awaited_once_with(
         library_agent_id="sole", user_id="test-user", soft_delete=True
     )
+
+
+@pytest.mark.asyncio
+async def test_update_preset_is_active_clears_deactivation_reason():
+    """A user explicitly setting is_active must clear any system
+    deactivationReason so auto-resume can't override their choice."""
+
+    @asynccontextmanager
+    async def fake_tx():
+        yield None
+
+    with (
+        patch(
+            "backend.api.features.library.db.get_preset",
+            new=AsyncMock(return_value=MagicMock(name="ExistingPreset")),
+        ),
+        patch("backend.api.features.library.db.transaction", fake_tx),
+        patch("prisma.models.AgentPreset.prisma") as mock_prisma,
+        patch(
+            "backend.api.features.library.model.LibraryAgentPreset.from_db",
+            return_value=MagicMock(),
+        ),
+    ):
+        mock_prisma.return_value.update = AsyncMock(return_value=MagicMock())
+
+        await db.update_preset("user-1", "preset-1", is_active=False)
+
+    update_data = mock_prisma.return_value.update.call_args.kwargs["data"]
+    assert update_data["isActive"] is False
+    assert update_data["deactivationReason"] is None

--- a/autogpt_platform/backend/backend/api/features/library/model.py
+++ b/autogpt_platform/backend/backend/api/features/library/model.py
@@ -514,8 +514,7 @@ class LibraryAgentPreset(LibraryAgentPresetCreatable):
     webhook_id: Optional[str] = None
     webhook: "Webhook | None"
 
-    # Set when the system deactivated the preset (e.g. payment lapse);
-    # None when active or user-deactivated.
+    # Set when the system deactivated the preset; None when user-deactivated
     deactivation_reason: Optional[prisma.enums.PresetDeactivationReason] = None
 
     @pydantic.field_serializer("webhook")

--- a/autogpt_platform/backend/backend/api/features/library/model.py
+++ b/autogpt_platform/backend/backend/api/features/library/model.py
@@ -514,6 +514,10 @@ class LibraryAgentPreset(LibraryAgentPresetCreatable):
     webhook_id: Optional[str] = None
     webhook: "Webhook | None"
 
+    # Set when the system deactivated the preset (e.g. payment lapse);
+    # None when active or user-deactivated.
+    deactivation_reason: Optional[prisma.enums.PresetDeactivationReason] = None
+
     @pydantic.field_serializer("webhook")
     def _redact_webhook_signing_material(
         self, webhook: "Webhook | None", info: pydantic.FieldSerializationInfo
@@ -558,6 +562,7 @@ class LibraryAgentPreset(LibraryAgentPresetCreatable):
             name=preset.name,
             description=preset.description,
             is_active=preset.isActive,
+            deactivation_reason=preset.deactivationReason,
             inputs=input_data,
             credentials=input_credentials,
             organization_id=preset.organizationId,

--- a/autogpt_platform/backend/backend/data/automation_pause.py
+++ b/autogpt_platform/backend/backend/data/automation_pause.py
@@ -1,0 +1,117 @@
+"""Pause/resume a user's automations (cron schedules + webhook-trigger presets)
+when their payment lapses / is restored. Resumption only touches automations
+carrying the payment-lapse marker, so anything the user paused themselves stays
+off. Org/team-tagged automations are excluded — they are funded by the org, not
+the member's personal subscription.
+"""
+
+import logging
+
+from prisma.enums import NotificationType, PresetDeactivationReason
+from prisma.models import AgentPreset
+from pydantic import BaseModel
+
+from backend.data.notifications import (
+    AutomationsPausedData,
+    AutomationsResumedData,
+    NotificationEventModel,
+)
+from backend.notifications.notifications import queue_notification_async
+from backend.util.clients import get_scheduler_client
+from backend.util.settings import Settings
+
+logger = logging.getLogger(__name__)
+settings = Settings()
+
+SCHEDULE_PAUSE_REASON_PAYMENT_LAPSED = "payment_lapsed"
+
+
+class AutomationPauseSummary(BaseModel):
+    schedules: int = 0
+    triggers: int = 0
+
+    @property
+    def total(self) -> int:
+        return self.schedules + self.triggers
+
+
+async def pause_automations_for_payment_lapse(user_id: str) -> AutomationPauseSummary:
+    schedules = await get_scheduler_client().pause_user_graph_schedules(
+        user_id=user_id, reason=SCHEDULE_PAUSE_REASON_PAYMENT_LAPSED
+    )
+    # deactivationReason=None keeps user-deactivated presets untouched, so a
+    # repeated webhook can't overwrite a user's own deactivation.
+    triggers = await AgentPreset.prisma().update_many(
+        where={
+            "userId": user_id,
+            "isActive": True,
+            "isDeleted": False,
+            "organizationId": None,
+            "deactivationReason": None,
+        },
+        data={
+            "isActive": False,
+            "deactivationReason": PresetDeactivationReason.PAYMENT_LAPSED,
+        },
+    )
+    summary = AutomationPauseSummary(schedules=schedules, triggers=triggers)
+    if summary.total:
+        logger.info(
+            f"Paused {summary.schedules} schedule(s) and {summary.triggers} "
+            f"trigger(s) for user {user_id} after payment lapse"
+        )
+        await _notify_paused(user_id, summary)
+    return summary
+
+
+async def resume_automations_after_payment_restored(
+    user_id: str,
+) -> AutomationPauseSummary:
+    schedules = await get_scheduler_client().resume_user_graph_schedules(
+        user_id=user_id, reason=SCHEDULE_PAUSE_REASON_PAYMENT_LAPSED
+    )
+    triggers = await AgentPreset.prisma().update_many(
+        where={
+            "userId": user_id,
+            "isActive": False,
+            "isDeleted": False,
+            "deactivationReason": PresetDeactivationReason.PAYMENT_LAPSED,
+        },
+        data={"isActive": True, "deactivationReason": None},
+    )
+    summary = AutomationPauseSummary(schedules=schedules, triggers=triggers)
+    if summary.total:
+        logger.info(
+            f"Resumed {summary.schedules} schedule(s) and {summary.triggers} "
+            f"trigger(s) for user {user_id} after payment restored"
+        )
+        await _notify_resumed(user_id, summary)
+    return summary
+
+
+async def _notify_paused(user_id: str, summary: AutomationPauseSummary) -> None:
+    base_url = settings.config.frontend_base_url or settings.config.platform_base_url
+    await queue_notification_async(
+        NotificationEventModel(
+            user_id=user_id,
+            type=NotificationType.AUTOMATIONS_PAUSED,
+            data=AutomationsPausedData(
+                paused_schedules=summary.schedules,
+                paused_triggers=summary.triggers,
+                billing_page_link=f"{base_url}/settings/billing",
+            ),
+        )
+    )
+
+
+async def _notify_resumed(user_id: str, summary: AutomationPauseSummary) -> None:
+    await queue_notification_async(
+        NotificationEventModel(
+            user_id=user_id,
+            type=NotificationType.AUTOMATIONS_RESUMED,
+            data=AutomationsResumedData(
+                resumed_schedules=summary.schedules,
+                resumed_triggers=summary.triggers,
+            ),
+        )
+    )

--- a/autogpt_platform/backend/backend/data/automation_pause_test.py
+++ b/autogpt_platform/backend/backend/data/automation_pause_test.py
@@ -1,0 +1,140 @@
+"""Unit tests for payment-lapse pause/resume of user automations."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from prisma.enums import NotificationType, PresetDeactivationReason
+
+from backend.data.automation_pause import (
+    SCHEDULE_PAUSE_REASON_PAYMENT_LAPSED,
+    pause_automations_for_payment_lapse,
+    resume_automations_after_payment_restored,
+)
+
+_MODULE = "backend.data.automation_pause"
+
+
+def _mock_scheduler_client(paused: int = 0, resumed: int = 0) -> MagicMock:
+    client = MagicMock()
+    client.pause_user_graph_schedules = AsyncMock(return_value=paused)
+    client.resume_user_graph_schedules = AsyncMock(return_value=resumed)
+    return client
+
+
+@pytest.mark.asyncio
+async def test_pause_marks_schedules_and_triggers_with_reason():
+    client = _mock_scheduler_client(paused=2)
+    with (
+        patch(f"{_MODULE}.get_scheduler_client", return_value=client),
+        patch("prisma.models.AgentPreset.prisma") as mock_prisma,
+        patch(f"{_MODULE}.queue_notification_async", new=AsyncMock()) as mock_notify,
+    ):
+        mock_prisma.return_value.update_many = AsyncMock(return_value=3)
+
+        summary = await pause_automations_for_payment_lapse("user-1")
+
+    assert summary.schedules == 2
+    assert summary.triggers == 3
+    client.pause_user_graph_schedules.assert_awaited_once_with(
+        user_id="user-1", reason=SCHEDULE_PAUSE_REASON_PAYMENT_LAPSED
+    )
+    update_call = mock_prisma.return_value.update_many.call_args
+    assert update_call.kwargs["where"] == {
+        "userId": "user-1",
+        "isActive": True,
+        "isDeleted": False,
+        "organizationId": None,
+        "deactivationReason": None,
+    }
+    assert update_call.kwargs["data"] == {
+        "isActive": False,
+        "deactivationReason": PresetDeactivationReason.PAYMENT_LAPSED,
+    }
+    event = mock_notify.await_args.args[0]
+    assert event.type == NotificationType.AUTOMATIONS_PAUSED
+    assert event.data.paused_schedules == 2
+    assert event.data.paused_triggers == 3
+
+
+@pytest.mark.asyncio
+async def test_pause_skips_user_deactivated_presets_via_where_clause():
+    """The where clause must require deactivationReason=None so presets the
+    user deactivated themselves are never stamped with PAYMENT_LAPSED."""
+    client = _mock_scheduler_client()
+    with (
+        patch(f"{_MODULE}.get_scheduler_client", return_value=client),
+        patch("prisma.models.AgentPreset.prisma") as mock_prisma,
+        patch(f"{_MODULE}.queue_notification_async", new=AsyncMock()),
+    ):
+        mock_prisma.return_value.update_many = AsyncMock(return_value=0)
+        await pause_automations_for_payment_lapse("user-1")
+
+    where = mock_prisma.return_value.update_many.call_args.kwargs["where"]
+    assert where["deactivationReason"] is None
+    assert where["isActive"] is True
+
+
+@pytest.mark.asyncio
+async def test_pause_with_nothing_to_pause_sends_no_notification():
+    client = _mock_scheduler_client(paused=0)
+    with (
+        patch(f"{_MODULE}.get_scheduler_client", return_value=client),
+        patch("prisma.models.AgentPreset.prisma") as mock_prisma,
+        patch(f"{_MODULE}.queue_notification_async", new=AsyncMock()) as mock_notify,
+    ):
+        mock_prisma.return_value.update_many = AsyncMock(return_value=0)
+
+        summary = await pause_automations_for_payment_lapse("user-1")
+
+    assert summary.total == 0
+    mock_notify.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_resume_only_touches_payment_lapsed_automations():
+    client = _mock_scheduler_client(resumed=1)
+    with (
+        patch(f"{_MODULE}.get_scheduler_client", return_value=client),
+        patch("prisma.models.AgentPreset.prisma") as mock_prisma,
+        patch(f"{_MODULE}.queue_notification_async", new=AsyncMock()) as mock_notify,
+    ):
+        mock_prisma.return_value.update_many = AsyncMock(return_value=2)
+
+        summary = await resume_automations_after_payment_restored("user-1")
+
+    assert summary.schedules == 1
+    assert summary.triggers == 2
+    client.resume_user_graph_schedules.assert_awaited_once_with(
+        user_id="user-1", reason=SCHEDULE_PAUSE_REASON_PAYMENT_LAPSED
+    )
+    update_call = mock_prisma.return_value.update_many.call_args
+    assert update_call.kwargs["where"] == {
+        "userId": "user-1",
+        "isActive": False,
+        "isDeleted": False,
+        "deactivationReason": PresetDeactivationReason.PAYMENT_LAPSED,
+    }
+    assert update_call.kwargs["data"] == {
+        "isActive": True,
+        "deactivationReason": None,
+    }
+    event = mock_notify.await_args.args[0]
+    assert event.type == NotificationType.AUTOMATIONS_RESUMED
+    assert event.data.resumed_schedules == 1
+    assert event.data.resumed_triggers == 2
+
+
+@pytest.mark.asyncio
+async def test_resume_with_nothing_to_resume_sends_no_notification():
+    client = _mock_scheduler_client(resumed=0)
+    with (
+        patch(f"{_MODULE}.get_scheduler_client", return_value=client),
+        patch("prisma.models.AgentPreset.prisma") as mock_prisma,
+        patch(f"{_MODULE}.queue_notification_async", new=AsyncMock()) as mock_notify,
+    ):
+        mock_prisma.return_value.update_many = AsyncMock(return_value=0)
+
+        summary = await resume_automations_after_payment_restored("user-1")
+
+    assert summary.total == 0
+    mock_notify.assert_not_awaited()

--- a/autogpt_platform/backend/backend/data/credit.py
+++ b/autogpt_platform/backend/backend/data/credit.py
@@ -26,6 +26,10 @@ from prisma.types import (
 from pydantic import BaseModel
 
 from backend.api.features.admin.model import UserHistoryResponse
+from backend.data.automation_pause import (
+    pause_automations_for_payment_lapse,
+    resume_automations_after_payment_restored,
+)
 from backend.data.block_cost_config import BLOCK_COSTS
 from backend.data.db import query_raw_with_schema
 from backend.data.includes import MAX_CREDIT_REFUND_REQUESTS_FETCH
@@ -1521,11 +1525,16 @@ async def set_subscription_tier(
     tier: SubscriptionTier,
 ) -> None:
     """Set the user's subscription tier."""
+    previous_user = await User.prisma().find_unique(where={"id": user_id})
+    previous_tier = (
+        SubscriptionTier(previous_user.subscriptionTier) if previous_user else None
+    )
     data: UserUpdateInput = {
         "subscriptionTier": tier,
     }
     await User.prisma().update(where={"id": user_id}, data=data)
     get_user_by_id.cache_delete(user_id)
+    await _handle_tier_transition_automations(user_id, previous_tier, tier)
     # Also invalidate the rate-limit tier cache so CoPilot picks up the new
     # tier immediately rather than waiting up to 5 minutes for the TTL to expire.
     from backend.copilot.rate_limit import get_user_tier  # local import avoids circular
@@ -1537,6 +1546,30 @@ async def set_subscription_tier(
     # billing page can show a pending change for up to 30s after the tier
     # has already flipped.
     get_pending_subscription_change.cache_delete(user_id)
+
+
+async def _handle_tier_transition_automations(
+    user_id: str,
+    previous_tier: SubscriptionTier | None,
+    new_tier: SubscriptionTier,
+) -> None:
+    """Pause automations on paid→NO_TIER, resume on NO_TIER→paid.
+
+    Never raises: a failure here must not fail the Stripe webhook whose tier
+    update triggered it (a 500 would make Stripe retry the billing event).
+    """
+    if previous_tier is None or previous_tier == new_tier:
+        return
+    try:
+        if new_tier == SubscriptionTier.NO_TIER:
+            await pause_automations_for_payment_lapse(user_id)
+        elif previous_tier == SubscriptionTier.NO_TIER:
+            await resume_automations_after_payment_restored(user_id)
+    except Exception as e:
+        logger.error(
+            f"Failed to update automations for user {user_id} on tier "
+            f"transition {previous_tier}->{new_tier}: {e}"
+        )
 
 
 async def _cancel_customer_subscriptions(

--- a/autogpt_platform/backend/backend/data/credit_tier_transition_test.py
+++ b/autogpt_platform/backend/backend/data/credit_tier_transition_test.py
@@ -1,0 +1,77 @@
+"""Unit tests for automation pause/resume on subscription tier transitions."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from prisma.enums import SubscriptionTier
+
+from backend.data.credit import _handle_tier_transition_automations
+
+_MODULE = "backend.data.credit"
+
+
+@pytest.mark.asyncio
+async def test_paid_to_no_tier_pauses_automations():
+    with (
+        patch(f"{_MODULE}.pause_automations_for_payment_lapse", new=AsyncMock()) as p,
+        patch(
+            f"{_MODULE}.resume_automations_after_payment_restored", new=AsyncMock()
+        ) as r,
+    ):
+        await _handle_tier_transition_automations(
+            "user-1", SubscriptionTier.PRO, SubscriptionTier.NO_TIER
+        )
+    p.assert_awaited_once_with("user-1")
+    r.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_no_tier_to_paid_resumes_automations():
+    with (
+        patch(f"{_MODULE}.pause_automations_for_payment_lapse", new=AsyncMock()) as p,
+        patch(
+            f"{_MODULE}.resume_automations_after_payment_restored", new=AsyncMock()
+        ) as r,
+    ):
+        await _handle_tier_transition_automations(
+            "user-1", SubscriptionTier.NO_TIER, SubscriptionTier.BASIC
+        )
+    r.assert_awaited_once_with("user-1")
+    p.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "previous,new",
+    [
+        (SubscriptionTier.PRO, SubscriptionTier.BASIC),
+        (SubscriptionTier.PRO, SubscriptionTier.PRO),
+        (None, SubscriptionTier.NO_TIER),
+        (SubscriptionTier.NO_TIER, SubscriptionTier.NO_TIER),
+    ],
+)
+async def test_other_transitions_do_nothing(previous, new):
+    with (
+        patch(f"{_MODULE}.pause_automations_for_payment_lapse", new=AsyncMock()) as p,
+        patch(
+            f"{_MODULE}.resume_automations_after_payment_restored", new=AsyncMock()
+        ) as r,
+    ):
+        await _handle_tier_transition_automations("user-1", previous, new)
+    p.assert_not_awaited()
+    r.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_pause_failure_is_swallowed():
+    """A scheduler outage must not propagate into the Stripe webhook path."""
+    with (
+        patch(
+            f"{_MODULE}.pause_automations_for_payment_lapse",
+            new=AsyncMock(side_effect=RuntimeError("scheduler down")),
+        ),
+        patch(f"{_MODULE}.resume_automations_after_payment_restored", new=AsyncMock()),
+    ):
+        await _handle_tier_transition_automations(
+            "user-1", SubscriptionTier.PRO, SubscriptionTier.NO_TIER
+        )

--- a/autogpt_platform/backend/backend/data/notifications.py
+++ b/autogpt_platform/backend/backend/data/notifications.py
@@ -77,6 +77,17 @@ class LowBalanceData(BaseNotificationData):
     billing_page_link: str = Field(..., description="Link to billing page")
 
 
+class AutomationsPausedData(BaseNotificationData):
+    paused_schedules: int = Field(..., description="Number of schedules paused")
+    paused_triggers: int = Field(..., description="Number of triggers paused")
+    billing_page_link: str = Field(..., description="Link to billing page")
+
+
+class AutomationsResumedData(BaseNotificationData):
+    resumed_schedules: int = Field(..., description="Number of schedules resumed")
+    resumed_triggers: int = Field(..., description="Number of triggers resumed")
+
+
 class BlockExecutionFailedData(BaseNotificationData):
     block_name: str
     block_id: str
@@ -297,6 +308,8 @@ def get_notif_data_type(
         NotificationType.REFUND_PROCESSED: RefundRequestData,
         NotificationType.AGENT_APPROVED: AgentApprovalData,
         NotificationType.AGENT_REJECTED: AgentRejectionData,
+        NotificationType.AUTOMATIONS_PAUSED: AutomationsPausedData,
+        NotificationType.AUTOMATIONS_RESUMED: AutomationsResumedData,
     }[notification_type]
 
 
@@ -342,6 +355,8 @@ class NotificationTypeOverride:
             NotificationType.REFUND_PROCESSED: QueueType.ADMIN,
             NotificationType.AGENT_APPROVED: QueueType.IMMEDIATE,
             NotificationType.AGENT_REJECTED: QueueType.IMMEDIATE,
+            NotificationType.AUTOMATIONS_PAUSED: QueueType.IMMEDIATE,
+            NotificationType.AUTOMATIONS_RESUMED: QueueType.IMMEDIATE,
         }
         return BATCHING_RULES.get(self.notification_type, QueueType.IMMEDIATE)
 
@@ -361,6 +376,8 @@ class NotificationTypeOverride:
             NotificationType.REFUND_PROCESSED: "refund_processed.html",
             NotificationType.AGENT_APPROVED: "agent_approved.html",
             NotificationType.AGENT_REJECTED: "agent_rejected.html",
+            NotificationType.AUTOMATIONS_PAUSED: "automations_paused.html",
+            NotificationType.AUTOMATIONS_RESUMED: "automations_resumed.html",
         }[self.notification_type]
 
     @property
@@ -378,6 +395,8 @@ class NotificationTypeOverride:
             NotificationType.REFUND_PROCESSED: "Refund for ${{data.amount / 100}} to {{data.user_name}} has been processed",
             NotificationType.AGENT_APPROVED: "🎉 Your agent '{{data.agent_name}}' has been approved!",
             NotificationType.AGENT_REJECTED: "Your agent '{{data.agent_name}}' needs some updates",
+            NotificationType.AUTOMATIONS_PAUSED: "Your automations have been paused",
+            NotificationType.AUTOMATIONS_RESUMED: "Your automations are running again",
         }[self.notification_type]
 
 

--- a/autogpt_platform/backend/backend/data/user.py
+++ b/autogpt_platform/backend/backend/data/user.py
@@ -490,6 +490,10 @@ async def get_user_notification_preference(user_id: str) -> NotificationPreferen
             NotificationType.MONTHLY_SUMMARY: user.notifyOnMonthlySummary or False,
             NotificationType.AGENT_APPROVED: user.notifyOnAgentApproved or False,
             NotificationType.AGENT_REJECTED: user.notifyOnAgentRejected or False,
+            NotificationType.AUTOMATIONS_PAUSED: user.notifyOnAutomationsPaused
+            or False,
+            NotificationType.AUTOMATIONS_RESUMED: user.notifyOnAutomationsPaused
+            or False,
         }
         daily_limit = user.maxEmailsPerDay or 3
         notification_preference = NotificationPreference(
@@ -556,6 +560,10 @@ async def update_user_notification_preference(
             update_data["notifyOnAgentRejected"] = data.preferences[
                 NotificationType.AGENT_REJECTED
             ]
+        if NotificationType.AUTOMATIONS_PAUSED in data.preferences:
+            update_data["notifyOnAutomationsPaused"] = data.preferences[
+                NotificationType.AUTOMATIONS_PAUSED
+            ]
         if data.daily_limit:
             update_data["maxEmailsPerDay"] = data.daily_limit
 
@@ -582,6 +590,9 @@ async def update_user_notification_preference(
             NotificationType.MONTHLY_SUMMARY: user.notifyOnMonthlySummary or True,
             NotificationType.AGENT_APPROVED: user.notifyOnAgentApproved or True,
             NotificationType.AGENT_REJECTED: user.notifyOnAgentRejected or True,
+            NotificationType.AUTOMATIONS_PAUSED: user.notifyOnAutomationsPaused or True,
+            NotificationType.AUTOMATIONS_RESUMED: user.notifyOnAutomationsPaused
+            or True,
         }
         notification_preference = NotificationPreference(
             user_id=user.id,
@@ -634,6 +645,7 @@ async def disable_all_user_notifications(user_id: str) -> None:
                 "notifyOnMonthlySummary": False,
                 "notifyOnAgentApproved": False,
                 "notifyOnAgentRejected": False,
+                "notifyOnAutomationsPaused": False,
             },
         )
         # Invalidate cache for this user

--- a/autogpt_platform/backend/backend/executor/scheduler.py
+++ b/autogpt_platform/backend/backend/executor/scheduler.py
@@ -1100,6 +1100,9 @@ class GraphExecutionJobArgs(BaseModel):
     input_credentials: dict[str, CredentialsMetaInput] = Field(default_factory=dict)
     organization_id: str = ""
     team_id: str | None = None
+    # Why the system paused this schedule (e.g. "payment_lapsed"); None when
+    # running. Only schedules paused for a given reason are resumed by it.
+    paused_reason: str | None = None
 
 
 class CopilotTurnJobArgs(BaseModel):
@@ -1162,13 +1165,17 @@ class GraphExecutionJobInfo(GraphExecutionJobArgs):
     name: str
     next_run_time: str
     timezone: str = Field(default="UTC", description="Timezone used for scheduling")
+    is_paused: bool = False
 
     @staticmethod
     def from_db(
         job_args: GraphExecutionJobArgs, job_obj: JobObj
     ) -> "GraphExecutionJobInfo":
         return GraphExecutionJobInfo(
-            **_job_info_fields(job_obj), **job_args.model_dump()
+            **_job_info_fields(job_obj),
+            **job_args.model_dump(),
+            # Cron jobs only lack a next fire time when APScheduler paused them.
+            is_paused=job_obj.next_run_time is None,
         )
 
 
@@ -1744,6 +1751,72 @@ class Scheduler(AppService):
         self._invalidate_jobs_cache()
         return info
 
+    def _user_graph_schedule_jobs(
+        self, user_id: str
+    ) -> list[tuple[JobObj, GraphExecutionJobArgs]]:
+        """Personal graph-kind jobs of *user_id* (org-tagged jobs excluded)."""
+        jobs: list[tuple[JobObj, GraphExecutionJobArgs]] = []
+        for job in self.scheduler.get_jobs(jobstore=Jobstores.EXECUTION.value):
+            if job.kwargs.get("kind", "graph") != "graph":
+                continue
+            try:
+                args = GraphExecutionJobArgs.model_validate(job.kwargs)
+            except ValidationError:
+                continue
+            if args.user_id != user_id or args.organization_id:
+                continue
+            jobs.append((job, args))
+        return jobs
+
+    @expose
+    def pause_user_graph_schedules(self, user_id: str, reason: str) -> int:
+        """Pause the user's graph schedules with *reason*; returns count paused.
+
+        Schedules already carrying a ``paused_reason`` are left untouched.
+        """
+        paused = 0
+        for job, args in self._user_graph_schedule_jobs(user_id):
+            if args.paused_reason is not None:
+                continue
+            args.paused_reason = reason
+            self.scheduler.modify_job(
+                job.id,
+                jobstore=Jobstores.EXECUTION.value,
+                kwargs=args.model_dump(mode="json"),
+            )
+            self.scheduler.pause_job(job.id, jobstore=Jobstores.EXECUTION.value)
+            paused += 1
+        if paused:
+            logger.info(
+                f"Paused {paused} graph schedule(s) for user {user_id} "
+                f"(reason={reason})"
+            )
+            self._invalidate_jobs_cache()
+        return paused
+
+    @expose
+    def resume_user_graph_schedules(self, user_id: str, reason: str) -> int:
+        """Resume schedules paused for *reason* only; returns count resumed."""
+        resumed = 0
+        for job, args in self._user_graph_schedule_jobs(user_id):
+            if args.paused_reason != reason:
+                continue
+            args.paused_reason = None
+            self.scheduler.modify_job(
+                job.id,
+                jobstore=Jobstores.EXECUTION.value,
+                kwargs=args.model_dump(mode="json"),
+            )
+            self.scheduler.resume_job(job.id, jobstore=Jobstores.EXECUTION.value)
+            resumed += 1
+        if resumed:
+            logger.info(
+                f"Resumed {resumed} graph schedule(s) for user {user_id} "
+                f"(reason={reason})"
+            )
+            self._invalidate_jobs_cache()
+        return resumed
+
     @expose
     def get_graph_execution_schedules(
         self,
@@ -1846,8 +1919,14 @@ class Scheduler(AppService):
         jobs: list[JobObj] = self._get_jobs_cached()
         results: list[Union[GraphExecutionJobInfo, CopilotTurnJobInfo]] = []
         for job in jobs:
-            info = _job_to_info(job) if job.next_run_time is not None else None
+            info = _job_to_info(job)
             if info is None:
+                continue
+            if job.next_run_time is None and not (
+                isinstance(info, GraphExecutionJobInfo) and info.paused_reason
+            ):
+                # Skip already-fired one-shot jobs, but keep system-paused
+                # schedules visible so they don't look deleted to the user.
                 continue
             if kind is not None and info.kind != kind:
                 continue
@@ -2201,6 +2280,10 @@ class SchedulerClient(AppServiceClient):
     add_execution_schedule = endpoint_to_async(Scheduler.add_graph_execution_schedule)
     add_copilot_turn_schedule = endpoint_to_async(Scheduler.add_copilot_turn_schedule)
     delete_schedule = endpoint_to_async(Scheduler.delete_graph_execution_schedule)
+    pause_user_graph_schedules = endpoint_to_async(Scheduler.pause_user_graph_schedules)
+    resume_user_graph_schedules = endpoint_to_async(
+        Scheduler.resume_user_graph_schedules
+    )
     # Graph-only typed list — for legacy callers that need GraphExecutionJobInfo.
     get_graph_execution_schedules = endpoint_to_async(
         Scheduler.get_graph_execution_schedules

--- a/autogpt_platform/backend/backend/executor/scheduler_unit_test.py
+++ b/autogpt_platform/backend/backend/executor/scheduler_unit_test.py
@@ -638,3 +638,100 @@ class TestScheduleOrgVisibility:
         ]
         result = self._run(infos, user_id="me")
         assert [r.schedule_id for r in result] == ["mine"]
+
+
+# ---------------------------------------------------------------------------
+# pause/resume_user_graph_schedules
+# ---------------------------------------------------------------------------
+
+
+def _graph_job_kwargs(
+    user_id="u1", organization_id="", paused_reason=None, schedule_id="s1"
+):
+    return {
+        "kind": "graph",
+        "schedule_id": schedule_id,
+        "user_id": user_id,
+        "graph_id": "g1",
+        "graph_version": 1,
+        "cron": "* * * * *",
+        "input_data": {},
+        "input_credentials": {},
+        "organization_id": organization_id,
+        "paused_reason": paused_reason,
+    }
+
+
+class TestPauseResumeUserGraphSchedules:
+    def _scheduler(self, jobs):
+        sched = Scheduler.__new__(Scheduler)
+        aps = MagicMock()
+        aps.get_jobs.return_value = jobs
+        object.__setattr__(sched, "scheduler", aps)
+        return sched, aps
+
+    def test_pause_stamps_reason_and_pauses_jobs(self):
+        job = _mock_job(_graph_job_kwargs())
+        sched, aps = self._scheduler([job])
+        with patch.object(Scheduler, "_invalidate_jobs_cache", MagicMock()):
+            count = sched.pause_user_graph_schedules("u1", "payment_lapsed")
+        assert count == 1
+        modify_kwargs = aps.modify_job.call_args.kwargs["kwargs"]
+        assert modify_kwargs["paused_reason"] == "payment_lapsed"
+        aps.pause_job.assert_called_once()
+
+    def test_pause_skips_other_users_org_jobs_and_already_paused(self):
+        jobs = [
+            _mock_job(_graph_job_kwargs(user_id="other", schedule_id="s2")),
+            _mock_job(_graph_job_kwargs(organization_id="org-1", schedule_id="s3")),
+            _mock_job(
+                _graph_job_kwargs(paused_reason="payment_lapsed", schedule_id="s4")
+            ),
+        ]
+        sched, aps = self._scheduler(jobs)
+        with patch.object(Scheduler, "_invalidate_jobs_cache", MagicMock()):
+            count = sched.pause_user_graph_schedules("u1", "payment_lapsed")
+        assert count == 0
+        aps.pause_job.assert_not_called()
+
+    def test_resume_only_matching_reason(self):
+        jobs = [
+            _mock_job(
+                _graph_job_kwargs(paused_reason="payment_lapsed", schedule_id="s1")
+            ),
+            _mock_job(_graph_job_kwargs(schedule_id="s2")),
+            _mock_job(
+                _graph_job_kwargs(paused_reason="other_reason", schedule_id="s3")
+            ),
+        ]
+        sched, aps = self._scheduler(jobs)
+        with patch.object(Scheduler, "_invalidate_jobs_cache", MagicMock()):
+            count = sched.resume_user_graph_schedules("u1", "payment_lapsed")
+        assert count == 1
+        modify_kwargs = aps.modify_job.call_args.kwargs["kwargs"]
+        assert modify_kwargs["paused_reason"] is None
+        aps.resume_job.assert_called_once()
+
+    def test_paused_schedule_still_listed_with_is_paused(self):
+        job = _mock_job(_graph_job_kwargs(paused_reason="payment_lapsed"))
+        job.next_run_time = None
+        fired_one_shot = _mock_job(
+            {
+                "kind": "copilot_turn",
+                "schedule_id": "c1",
+                "user_id": "u1",
+                "session_id": "sess",
+                "message": "m",
+                "run_at": "2026-05-22T10:00:00+00:00",
+            }
+        )
+        fired_one_shot.next_run_time = None
+        sched = Scheduler.__new__(Scheduler)
+        with patch.object(
+            Scheduler, "_get_jobs_cached", lambda self: [job, fired_one_shot]
+        ):
+            result = sched.get_execution_schedules(user_id="u1")
+        assert [r.schedule_id for r in result] == ["s1"]
+        assert isinstance(result[0], GraphExecutionJobInfo)
+        assert result[0].is_paused is True
+        assert result[0].paused_reason == "payment_lapsed"

--- a/autogpt_platform/backend/backend/notifications/templates/automations_paused.html.jinja2
+++ b/autogpt_platform/backend/backend/notifications/templates/automations_paused.html.jinja2
@@ -1,0 +1,88 @@
+{# Automations Paused Notification Email Template #}
+{# Template variables:
+data.paused_schedules: number of scheduled runs paused
+data.paused_triggers: number of triggers paused
+data.billing_page_link: the link to the billing page
+#}
+
+<p style="
+    font-family: 'Poppins', sans-serif;
+    color: #070629;
+    font-size: 16px;
+    line-height: 165%;
+    margin-top: 0;
+    margin-bottom: 10px;
+  ">
+  <strong>Your automations have been paused</strong>
+</p>
+
+<p style="
+    font-family: 'Poppins', sans-serif;
+    color: #070629;
+    font-size: 16px;
+    line-height: 165%;
+    margin-top: 0;
+    margin-bottom: 20px;
+  ">
+  We couldn't confirm an active subscription on your account, so your scheduled
+  agent runs and triggers have been paused. Nothing was deleted &mdash; everything
+  will resume automatically as soon as your subscription is active again.
+</p>
+
+<div style="
+    margin-left: 15px;
+    margin-bottom: 20px;
+    padding: 15px;
+    border-left: 4px solid #5D23BB;
+    background-color: #f8f8ff;
+  ">
+  <p style="
+    font-family: 'Poppins', sans-serif;
+    color: #070629;
+    font-size: 16px;
+    margin-top: 0;
+    margin-bottom: 10px;
+  ">
+    <strong>Paused schedules:</strong> {{ data.paused_schedules }}
+  </p>
+  <p style="
+    font-family: 'Poppins', sans-serif;
+    color: #070629;
+    font-size: 16px;
+    margin-top: 0;
+    margin-bottom: 10px;
+  ">
+    <strong>Paused triggers:</strong> {{ data.paused_triggers }}
+  </p>
+</div>
+
+<div style="
+    text-align: center;
+    margin: 30px 0;
+  ">
+  <a href="{{ data.billing_page_link }}" style="
+    font-family: 'Poppins', sans-serif;
+    background-color: #5D23BB;
+    color: white;
+    padding: 12px 24px;
+    text-decoration: none;
+    border-radius: 4px;
+    font-weight: 500;
+    display: inline-block;
+  ">
+    Manage Billing
+  </a>
+</div>
+
+<p style="
+    font-family: 'Poppins', sans-serif;
+    color: #070629;
+    font-size: 16px;
+    line-height: 150%;
+    margin-top: 30px;
+    margin-bottom: 10px;
+    font-style: italic;
+  ">
+  This is an automated notification. Any automations you paused yourself will
+  stay paused until you turn them back on.
+</p>

--- a/autogpt_platform/backend/backend/notifications/templates/automations_resumed.html.jinja2
+++ b/autogpt_platform/backend/backend/notifications/templates/automations_resumed.html.jinja2
@@ -1,0 +1,68 @@
+{# Automations Resumed Notification Email Template #}
+{# Template variables:
+data.resumed_schedules: number of scheduled runs resumed
+data.resumed_triggers: number of triggers resumed
+#}
+
+<p style="
+    font-family: 'Poppins', sans-serif;
+    color: #070629;
+    font-size: 16px;
+    line-height: 165%;
+    margin-top: 0;
+    margin-bottom: 10px;
+  ">
+  <strong>Your automations are running again</strong>
+</p>
+
+<p style="
+    font-family: 'Poppins', sans-serif;
+    color: #070629;
+    font-size: 16px;
+    line-height: 165%;
+    margin-top: 0;
+    margin-bottom: 20px;
+  ">
+  Thanks for updating your subscription! The scheduled agent runs and triggers
+  that were paused while your payment lapsed have been resumed automatically.
+</p>
+
+<div style="
+    margin-left: 15px;
+    margin-bottom: 20px;
+    padding: 15px;
+    border-left: 4px solid #5D23BB;
+    background-color: #f8f8ff;
+  ">
+  <p style="
+    font-family: 'Poppins', sans-serif;
+    color: #070629;
+    font-size: 16px;
+    margin-top: 0;
+    margin-bottom: 10px;
+  ">
+    <strong>Resumed schedules:</strong> {{ data.resumed_schedules }}
+  </p>
+  <p style="
+    font-family: 'Poppins', sans-serif;
+    color: #070629;
+    font-size: 16px;
+    margin-top: 0;
+    margin-bottom: 10px;
+  ">
+    <strong>Resumed triggers:</strong> {{ data.resumed_triggers }}
+  </p>
+</div>
+
+<p style="
+    font-family: 'Poppins', sans-serif;
+    color: #070629;
+    font-size: 16px;
+    line-height: 150%;
+    margin-top: 30px;
+    margin-bottom: 10px;
+    font-style: italic;
+  ">
+  This is an automated notification. Automations you paused yourself were left
+  untouched.
+</p>

--- a/autogpt_platform/backend/migrations/20260728120000_add_automation_pause_on_payment_lapse/migration.sql
+++ b/autogpt_platform/backend/migrations/20260728120000_add_automation_pause_on_payment_lapse/migration.sql
@@ -1,0 +1,12 @@
+-- CreateEnum
+CREATE TYPE "PresetDeactivationReason" AS ENUM ('PAYMENT_LAPSED');
+
+-- AlterEnum
+ALTER TYPE "NotificationType" ADD VALUE IF NOT EXISTS 'AUTOMATIONS_PAUSED';
+ALTER TYPE "NotificationType" ADD VALUE IF NOT EXISTS 'AUTOMATIONS_RESUMED';
+
+-- AlterTable
+ALTER TABLE "AgentPreset" ADD COLUMN "deactivationReason" "PresetDeactivationReason";
+
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN "notifyOnAutomationsPaused" BOOLEAN NOT NULL DEFAULT true;

--- a/autogpt_platform/backend/schema.prisma
+++ b/autogpt_platform/backend/schema.prisma
@@ -37,6 +37,7 @@ model User {
   notifyOnMonthlySummary       Boolean @default(true)
   notifyOnAgentApproved        Boolean @default(true)
   notifyOnAgentRejected        Boolean @default(true)
+  notifyOnAutomationsPaused    Boolean @default(true)
 
   timezone String @default("not-set")
 
@@ -497,6 +498,9 @@ model AgentPreset {
   // This bool allows us to disable a configured agent without deleting it
   isActive Boolean @default(true)
 
+  // Why the system deactivated this preset (null when the user did it themselves)
+  deactivationReason PresetDeactivationReason?
+
   userId String
   User   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
 
@@ -539,6 +543,12 @@ enum NotificationType {
   REFUND_PROCESSED
   AGENT_APPROVED
   AGENT_REJECTED
+  AUTOMATIONS_PAUSED
+  AUTOMATIONS_RESUMED
+}
+
+enum PresetDeactivationReason {
+  PAYMENT_LAPSED
 }
 
 model NotificationEvent {

--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/selected-views/SelectedRunView/components/WebhookTriggerSection.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/selected-views/SelectedRunView/components/WebhookTriggerSection.tsx
@@ -14,9 +14,12 @@ interface Props {
 
 function getTriggerStatus(
   preset: LibraryAgentPreset,
-): "active" | "inactive" | "broken" {
+): "active" | "inactive" | "paused" | "broken" {
   if (!preset.webhook_id || !preset.webhook) return "broken";
-  return preset.is_active ? "active" : "inactive";
+  if (preset.is_active) return "active";
+  return preset.deactivation_reason === "PAYMENT_LAPSED"
+    ? "paused"
+    : "inactive";
 }
 
 export function WebhookTriggerSection({ preset, triggerSetupInfo }: Props) {
@@ -38,16 +41,20 @@ export function WebhookTriggerSection({ preset, triggerSetupInfo }: Props) {
             className={`rounded-full px-2 py-0.5 text-xs font-medium ${
               status === "active"
                 ? "bg-green-100 text-green-800"
-                : status === "inactive"
-                  ? "bg-yellow-100 text-yellow-800"
-                  : "bg-red-100 text-red-800"
+                : status === "paused"
+                  ? "bg-amber-100 text-amber-800"
+                  : status === "inactive"
+                    ? "bg-yellow-100 text-yellow-800"
+                    : "bg-red-100 text-red-800"
             }`}
           >
             {status === "active"
               ? "Active"
-              : status === "inactive"
-                ? "Inactive"
-                : "Broken"}
+              : status === "paused"
+                ? "Paused — payment required"
+                : status === "inactive"
+                  ? "Inactive"
+                  : "Broken"}
           </span>
         </div>
 
@@ -83,7 +90,9 @@ export function WebhookTriggerSection({ preset, triggerSetupInfo }: Props) {
             This agent trigger is{" "}
             {preset.is_active
               ? "ready. When a trigger is received, it will run with the provided settings."
-              : "disabled. It will not respond to triggers until you enable it."}
+              : status === "paused"
+                ? "paused because your payment lapsed. It will resume automatically once your subscription is active again."
+                : "disabled. It will not respond to triggers until you enable it."}
           </Text>
         )}
       </div>

--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/selected-views/SelectedScheduleView/SelectedScheduleView.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/selected-views/SelectedScheduleView/SelectedScheduleView.tsx
@@ -126,26 +126,37 @@ export function SelectedScheduleView({
                     </div>
                     <div className="flex flex-col gap-1.5">
                       <Text variant="large-medium">Next run</Text>
-                      <Text variant="body" className="flex items-center gap-3">
-                        {formatInTimezone(
-                          schedule.next_run_time,
-                          userTimezone || "UTC",
-                          {
-                            year: "numeric",
-                            month: "long",
-                            day: "numeric",
-                            hour: "2-digit",
-                            minute: "2-digit",
-                            hour12: false,
-                          },
-                        )}{" "}
-                        <span className="text-zinc-500">•</span>{" "}
-                        <span className="text-zinc-500">
-                          {getTimezoneDisplayName(
-                            schedule.timezone || userTimezone || "UTC",
-                          )}
-                        </span>
-                      </Text>
+                      {schedule.is_paused || !schedule.next_run_time ? (
+                        <Text variant="body" className="text-amber-700">
+                          {schedule.is_paused
+                            ? "Paused — payment required"
+                            : "Pending"}
+                        </Text>
+                      ) : (
+                        <Text
+                          variant="body"
+                          className="flex items-center gap-3"
+                        >
+                          {formatInTimezone(
+                            schedule.next_run_time,
+                            userTimezone || "UTC",
+                            {
+                              year: "numeric",
+                              month: "long",
+                              day: "numeric",
+                              hour: "2-digit",
+                              minute: "2-digit",
+                              hour12: false,
+                            },
+                          )}{" "}
+                          <span className="text-zinc-500">•</span>{" "}
+                          <span className="text-zinc-500">
+                            {getTimezoneDisplayName(
+                              schedule.timezone || userTimezone || "UTC",
+                            )}
+                          </span>
+                        </Text>
+                      )}
                     </div>
                   </div>
                 )}

--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/selected-views/SelectedTemplateView/components/WebhookTriggerCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/selected-views/SelectedTemplateView/components/WebhookTriggerCard.tsx
@@ -14,9 +14,12 @@ interface Props {
 
 function getTriggerStatus(
   template: LibraryAgentPreset,
-): "active" | "inactive" | "broken" {
+): "active" | "inactive" | "paused" | "broken" {
   if (!template.webhook_id || !template.webhook) return "broken";
-  return template.is_active ? "active" : "inactive";
+  if (template.is_active) return "active";
+  return template.deactivation_reason === "PAYMENT_LAPSED"
+    ? "paused"
+    : "inactive";
 }
 
 export function WebhookTriggerCard({ template, triggerSetupInfo }: Props) {
@@ -38,16 +41,20 @@ export function WebhookTriggerCard({ template, triggerSetupInfo }: Props) {
             className={`rounded-full px-2 py-0.5 text-xs font-medium ${
               status === "active"
                 ? "bg-green-100 text-green-800"
-                : status === "inactive"
-                  ? "bg-yellow-100 text-yellow-800"
-                  : "bg-red-100 text-red-800"
+                : status === "paused"
+                  ? "bg-amber-100 text-amber-800"
+                  : status === "inactive"
+                    ? "bg-yellow-100 text-yellow-800"
+                    : "bg-red-100 text-red-800"
             }`}
           >
             {status === "active"
               ? "Active"
-              : status === "inactive"
-                ? "Inactive"
-                : "Broken"}
+              : status === "paused"
+                ? "Paused — payment required"
+                : status === "inactive"
+                  ? "Inactive"
+                  : "Broken"}
           </span>
         </div>
 
@@ -83,7 +90,9 @@ export function WebhookTriggerCard({ template, triggerSetupInfo }: Props) {
             This agent trigger is{" "}
             {template.is_active
               ? "ready. When a trigger is received, it will run with the provided settings."
-              : "disabled. It will not respond to triggers until you enable it."}
+              : status === "paused"
+                ? "paused because your payment lapsed. It will resume automatically once your subscription is active again."
+                : "disabled. It will not respond to triggers until you enable it."}
           </Text>
         )}
       </div>

--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/sidebar/SidebarRunsList/components/ScheduleListItem.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/sidebar/SidebarRunsList/components/ScheduleListItem.tsx
@@ -25,13 +25,26 @@ export function ScheduleListItem({
   onDeleted,
   onRunCreated,
 }: Props) {
+  const isPaused = Boolean(schedule.is_paused);
   return (
     <SidebarItemCard
       title={schedule.name}
-      description={formatDistanceToNow(schedule.next_run_time, {
-        addSuffix: true,
-      })}
-      descriptionTitle={new Date(schedule.next_run_time).toString()}
+      description={
+        isPaused
+          ? "Paused — payment required"
+          : schedule.next_run_time
+            ? formatDistanceToNow(schedule.next_run_time, {
+                addSuffix: true,
+              })
+            : "Pending"
+      }
+      descriptionTitle={
+        isPaused
+          ? "Paused — payment required"
+          : schedule.next_run_time
+            ? new Date(schedule.next_run_time).toString()
+            : "Pending"
+      }
       onClick={onClick}
       selected={selected}
       icon={

--- a/autogpt_platform/frontend/src/app/(platform)/library/followups/__tests__/main.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/followups/__tests__/main.test.tsx
@@ -494,4 +494,26 @@ describe("FollowupsPage", () => {
     expect(screen.queryByTestId("followups-list")).toBeNull();
     expect(screen.queryByTestId("schedules-partial-error")).toBeNull();
   });
+
+  test("graph row: paused schedule shows paused badge instead of next-run time", async () => {
+    server.use(
+      getListCopilotFollowupSchedulesMockHandler([]),
+      getGetV1ListExecutionSchedulesForAUserMockHandler([
+        makeGraphSchedule({
+          id: "paused-sched",
+          next_run_time: "",
+          is_paused: true,
+          paused_reason: "payment_lapsed",
+        }),
+      ]),
+    );
+
+    render(<FollowupsPage />);
+
+    const row = await screen.findByTestId("schedule-row");
+    expect(
+      within(row).getByTestId("schedule-paused-badge").textContent,
+    ).toContain("Paused — payment required");
+    expect(within(row).getByText("Paused")).toBeDefined();
+  });
 });

--- a/autogpt_platform/frontend/src/app/api/openapi.json
+++ b/autogpt_platform/frontend/src/app/api/openapi.json
@@ -16883,6 +16883,10 @@
             "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Team Id"
           },
+          "paused_reason": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Paused Reason"
+          },
           "id": { "type": "string", "title": "Id" },
           "name": { "type": "string", "title": "Name" },
           "next_run_time": { "type": "string", "title": "Next Run Time" },
@@ -16891,6 +16895,11 @@
             "title": "Timezone",
             "description": "Timezone used for scheduling",
             "default": "UTC"
+          },
+          "is_paused": {
+            "type": "boolean",
+            "title": "Is Paused",
+            "default": false
           }
         },
         "type": "object",
@@ -17961,6 +17970,12 @@
           "webhook": {
             "anyOf": [
               { "$ref": "#/components/schemas/Webhook" },
+              { "type": "null" }
+            ]
+          },
+          "deactivation_reason": {
+            "anyOf": [
+              { "$ref": "#/components/schemas/PresetDeactivationReason" },
               { "type": "null" }
             ]
           }
@@ -19091,7 +19106,9 @@
           "REFUND_REQUEST",
           "REFUND_PROCESSED",
           "AGENT_APPROVED",
-          "AGENT_REJECTED"
+          "AGENT_REJECTED",
+          "AUTOMATIONS_PAUSED",
+          "AUTOMATIONS_RESUMED"
         ],
         "title": "NotificationType"
       },
@@ -20121,6 +20138,11 @@
           "Metadata"
         ],
         "title": "PostmarkSubscriptionChangeWebhook"
+      },
+      "PresetDeactivationReason": {
+        "type": "string",
+        "enum": ["PAYMENT_LAPSED"],
+        "title": "PresetDeactivationReason"
       },
       "PresetDeletedResponse": {
         "properties": {

--- a/autogpt_platform/frontend/src/components/contextual/SchedulesPanel/components/GraphScheduleListItem/GraphScheduleListItem.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/SchedulesPanel/components/GraphScheduleListItem/GraphScheduleListItem.tsx
@@ -14,6 +14,7 @@ interface Props {
 
 export function GraphScheduleListItem({ schedule }: Props) {
   const {
+    isPaused,
     nextRunLabel,
     nextRunTitle,
     recurrenceLabel,
@@ -74,6 +75,14 @@ export function GraphScheduleListItem({ schedule }: Props) {
             >
               Agent run
             </span>
+            {isPaused && (
+              <span
+                className="rounded-full bg-amber-100 px-2 py-0.5 text-xs text-amber-700"
+                data-testid="schedule-paused-badge"
+              >
+                Paused — payment required
+              </span>
+            )}
           </div>
         </div>
       </Link>

--- a/autogpt_platform/frontend/src/components/contextual/SchedulesPanel/components/GraphScheduleListItem/useGraphScheduleListItem.ts
+++ b/autogpt_platform/frontend/src/components/contextual/SchedulesPanel/components/GraphScheduleListItem/useGraphScheduleListItem.ts
@@ -20,11 +20,13 @@ export function useGraphScheduleListItem({ schedule }: Args) {
   const { mutateAsync: deleteSchedule, isPending: isDeleting } =
     useDeleteV1DeleteExecutionSchedule();
 
+  const isPaused = Boolean(schedule.is_paused);
   const nextRunDate = schedule.next_run_time
     ? new Date(schedule.next_run_time)
     : null;
-  const nextRunLabel =
-    nextRunDate && !Number.isNaN(nextRunDate.valueOf())
+  const nextRunLabel = isPaused
+    ? "Paused"
+    : nextRunDate && !Number.isNaN(nextRunDate.valueOf())
       ? `Next ${formatDistanceToNow(nextRunDate, { addSuffix: true })}`
       : "Pending";
   const nextRunTitle = nextRunDate ? nextRunDate.toString() : undefined;
@@ -68,6 +70,7 @@ export function useGraphScheduleListItem({ schedule }: Args) {
   }
 
   return {
+    isPaused,
     nextRunLabel,
     nextRunTitle,
     recurrenceLabel,


### PR DESCRIPTION
### Why / What / How

**Why:** When a user's payment lapses, their cron schedules and webhook triggers keep firing. The paywall in `add_graph_execution` only rejects the run *after* the scheduler has already woken up (or the webhook has fanned out), so every tick produces a failed execution row plus log noise for a user who is no longer paying — and nothing ever resumes automatically when they pay again. (SECRT-2376)

**What:** On a paid→`NO_TIER` tier transition, all of the user's personal graph schedules are paused and their webhook-trigger presets deactivated — each stamped with a persisted `payment_lapsed` reason. On `NO_TIER`→paid, only automations carrying that marker are resumed, so anything the user paused themselves stays off. The user is notified on both edges, and the paused state is surfaced in the UI instead of the schedules silently disappearing.

**How:**
- `set_subscription_tier` (`backend/data/credit.py`) is the single write chokepoint for every lapse path (failed-invoice handler, `customer.subscription.*` webhooks, the reconciliation sweep), so the pause/resume hook lives there. It is wrapped so a scheduler failure can never 500 the Stripe webhook that triggered it.
- Schedules have no DB model (APScheduler jobstore only), so the reason is persisted in the job kwargs (`GraphExecutionJobArgs.paused_reason`) and pause/resume use APScheduler's `pause_job`/`resume_job` via new exposed scheduler-service methods. `get_execution_schedules` previously dropped any job with `next_run_time=None`; it now keeps system-paused schedules visible.
- Presets get a nullable `AgentPreset.deactivationReason` enum column. The webhook dispatcher already short-circuits on `isActive`, so deactivation is enough to drop events. A user explicitly setting `is_active` clears the reason, which is what protects manually-disabled automations from auto-resume.
- Org/team-tagged schedules and presets are excluded — they're funded by the org, not the member's personal subscription.

### Changes 🏗️

Backend
- `backend/executor/scheduler.py`: `paused_reason` on graph job args, `is_paused` on job info, `pause_user_graph_schedules`/`resume_user_graph_schedules` service methods + client bindings, paused schedules stay in listings
- `backend/data/automation_pause.py` (new): pause/resume orchestrator over schedules + presets, queues notifications
- `backend/data/credit.py`: tier-transition hook in `set_subscription_tier` (never raises into the webhook path)
- `backend/api/features/library/db.py` / `model.py`: user `is_active` updates clear `deactivationReason`; `deactivation_reason` exposed on `LibraryAgentPreset`
- `schema.prisma` + migration: `PresetDeactivationReason` enum, `AgentPreset.deactivationReason`, `NotificationType.AUTOMATIONS_PAUSED/RESUMED`, `User.notifyOnAutomationsPaused`
- Notifications: payload models, routing/template/subject entries, two email templates, preference wiring

Frontend
- "Paused — payment required" badge on schedule rows (SchedulesPanel + library sidebar) and selected-schedule view; paused/`deactivation_reason` trigger status on webhook trigger cards
- Guard against empty `next_run_time` (previously crashed `formatDistanceToNow` — paused schedules were never listed before, now they are)
- Refreshed committed `openapi.json` (generated client picks up `is_paused`, `paused_reason`, `deactivation_reason`)

Known limitation (intentionally out of scope): `queue_notification*` is a no-op when `app_env == PRODUCTION` (`backend/notifications/notifications.py`), so the new emails won't send in prod until that standing gate is revisited. The pause/resume mechanics themselves are unaffected.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `automation_pause_test.py`: pause stamps reason on schedules+presets, resume restores only `PAYMENT_LAPSED` rows, user-deactivated presets excluded via where-clause, no notification when nothing changed
  - [x] `credit_tier_transition_test.py`: paid→NO_TIER pauses, NO_TIER→paid resumes, paid→paid no-op, scheduler failure swallowed
  - [x] `scheduler_unit_test.py`: pause/resume skip other users / org jobs / already-paused; resume only matching reason; paused schedule still listed with `is_paused=True` while fired one-shots stay hidden
  - [x] `db_test.py`: `update_preset(is_active=...)` clears `deactivationReason`
  - [x] Frontend: paused schedule renders badge + "Paused" label (followups page integration test); full `pnpm test:unit` suite green (3993 tests)

#### For configuration changes:
- [x] `.env.default` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes
- [x] I have included a list of my configuration changes in the PR description (under **Changes**)