### PR TITLE
feat(platform): pause schedules & triggers on payment lapse, resume on payment

### DIFF
--- a/autogpt_platform/backend/backend/api/features/library/db.py
+++ b/autogpt_platform/backend/backend/api/features/library/db.py
@@ -2096,8 +2096,7 @@ async def update_preset(
             update_data["description"] = description
         if is_active is not None:
             update_data["isActive"] = is_active
-            # Explicitly setting the active state is a user decision; drop any
-            # system deactivation reason so auto-resume won't override it.
+            # User decision overrides any system deactivation reason
             update_data["deactivationReason"] = None
         if inputs or credentials:
             if not (inputs and credentials):

--- a/autogpt_platform/backend/backend/api/features/library/db.py
+++ b/autogpt_platform/backend/backend/api/features/library/db.py
@@ -2096,6 +2096,9 @@ async def update_preset(
             update_data["description"] = description
         if is_active is not None:
             update_data["isActive"] = is_active
+            # Explicitly setting the active state is a user decision; drop any
+            # system deactivation reason so auto-resume won't override it.
+            update_data["deactivationReason"] = None
         if inputs or credentials:
             if not (inputs and credentials):
                 raise ValueError(

--- a/autogpt_platform/backend/backend/api/features/library/db_test.py
+++ b/autogpt_platform/backend/backend/api/features/library/db_test.py
@@ -1441,3 +1441,33 @@ async def test_cleanup_trigger_agents_processes_each_independently(mocker):
     recursive_delete.assert_awaited_once_with(
         library_agent_id="sole", user_id="test-user", soft_delete=True
     )
+
+
+@pytest.mark.asyncio
+async def test_update_preset_is_active_clears_deactivation_reason():
+    """A user explicitly setting is_active must clear any system
+    deactivationReason so auto-resume can't override their choice."""
+
+    @asynccontextmanager
+    async def fake_tx():
+        yield None
+
+    with (
+        patch(
+            "backend.api.features.library.db.get_preset",
+            new=AsyncMock(return_value=MagicMock(name="ExistingPreset")),
+        ),
+        patch("backend.api.features.library.db.transaction", fake_tx),
+        patch("prisma.models.AgentPreset.prisma") as mock_prisma,
+        patch(
+            "backend.api.features.library.model.LibraryAgentPreset.from_db",
+            return_value=MagicMock(),
+        ),
+    ):
+        mock_prisma.return_value.update = AsyncMock(return_value=MagicMock())
+
+        await db.update_preset("user-1", "preset-1", is_active=False)
+
+    update_data = mock_prisma.return_value.update.call_args.kwargs["data"]
+    assert update_data["isActive"] is False
+    assert update_data["deactivationReason"] is None

--- a/autogpt_platform/backend/backend/api/features/library/model.py
+++ b/autogpt_platform/backend/backend/api/features/library/model.py
@@ -514,8 +514,7 @@ class LibraryAgentPreset(LibraryAgentPresetCreatable):
     webhook_id: Optional[str] = None
     webhook: "Webhook | None"
 
-    # Set when the system deactivated the preset (e.g. payment lapse);
-    # None when active or user-deactivated.
+    # Set when the system deactivated the preset; None when user-deactivated
     deactivation_reason: Optional[prisma.enums.PresetDeactivationReason] = None
 
     @pydantic.field_serializer("webhook")

--- a/autogpt_platform/backend/backend/api/features/library/model.py
+++ b/autogpt_platform/backend/backend/api/features/library/model.py
@@ -514,6 +514,10 @@ class LibraryAgentPreset(LibraryAgentPresetCreatable):
     webhook_id: Optional[str] = None
     webhook: "Webhook | None"
 
+    # Set when the system deactivated the preset (e.g. payment lapse);
+    # None when active or user-deactivated.
+    deactivation_reason: Optional[prisma.enums.PresetDeactivationReason] = None
+
     @pydantic.field_serializer("webhook")
     def _redact_webhook_signing_material(
         self, webhook: "Webhook | None", info: pydantic.FieldSerializationInfo
@@ -558,6 +562,7 @@ class LibraryAgentPreset(LibraryAgentPresetCreatable):
             name=preset.name,
             description=preset.description,
             is_active=preset.isActive,
+            deactivation_reason=preset.deactivationReason,
             inputs=input_data,
             credentials=input_credentials,
             organization_id=preset.organizationId,

--- a/autogpt_platform/backend/backend/api/features/store/db_test.py
+++ b/autogpt_platform/backend/backend/api/features/store/db_test.py
@@ -189,6 +189,7 @@ async def test_create_store_submission(mocker):
         notifyOnMonthlySummary=True,
         notifyOnAgentApproved=True,
         notifyOnAgentRejected=True,
+        notifyOnAutomationsPaused=True,
         timezone="Europe/Delft",
         subscriptionTier=prisma.enums.SubscriptionTier.BASIC,  # type: ignore[reportCallIssue,reportAttributeAccessIssue]
     )

--- a/autogpt_platform/backend/backend/data/automation_pause.py
+++ b/autogpt_platform/backend/backend/data/automation_pause.py
@@ -127,6 +127,25 @@ async def resume_automations_after_payment_restored(
     return summary
 
 
+async def has_payment_lapsed_automations(user_id: str) -> bool:
+    """Cheap indexed check for presets still deactivated by a payment lapse.
+
+    Lets the tier-transition hook self-heal a partially-failed resume on a
+    same-tier paid retry without paying for the scheduler scan on every paid
+    webhook where nothing is marked. Schedule-only stranded pauses aren't
+    covered here — full recovery of those needs a persisted pending marker.
+    """
+    count = await AgentPreset.prisma().count(
+        where={
+            "userId": user_id,
+            "isActive": False,
+            "isDeleted": False,
+            "deactivationReason": PresetDeactivationReason.PAYMENT_LAPSED,
+        }
+    )
+    return count > 0
+
+
 async def _get_personal_org_id(user_id: str) -> str | None:
     # Mirrors orgs.db._find_personal_org_member without the bootstrap side
     # effect — a billing event must not create orgs.

--- a/autogpt_platform/backend/backend/data/automation_pause.py
+++ b/autogpt_platform/backend/backend/data/automation_pause.py
@@ -39,7 +39,7 @@ class AutomationPauseSummary(BaseModel):
 
 
 async def pause_automations_for_payment_lapse(user_id: str) -> AutomationPauseSummary:
-    personal_org_id = await _get_personal_org_id(user_id)
+    personal_org_id = await _require_personal_org(user_id)
     # A scheduler outage must not skip trigger deactivation; the error is
     # re-raised after the preset update so the caller still alerts/retries.
     schedules = 0
@@ -60,7 +60,10 @@ async def pause_automations_for_payment_lapse(user_id: str) -> AutomationPauseSu
         "isActive": True,
         "isDeleted": False,
         "deactivationReason": None,
-        "OR": _personal_org_or(user_id, personal_org_id),
+        "OR": [
+            {"organizationId": None},
+            {"organizationId": personal_org_id},
+        ],
     }
     triggers = await AgentPreset.prisma().update_many(
         where=where,
@@ -84,7 +87,7 @@ async def pause_automations_for_payment_lapse(user_id: str) -> AutomationPauseSu
 async def resume_automations_after_payment_restored(
     user_id: str,
 ) -> AutomationPauseSummary:
-    personal_org_id = await _get_personal_org_id(user_id)
+    personal_org_id = await _require_personal_org(user_id)
     schedules = 0
     scheduler_error: Exception | None = None
     try:
@@ -104,7 +107,10 @@ async def resume_automations_after_payment_restored(
         "isActive": False,
         "isDeleted": False,
         "deactivationReason": PresetDeactivationReason.PAYMENT_LAPSED,
-        "OR": _personal_org_or(user_id, personal_org_id),
+        "OR": [
+            {"organizationId": None},
+            {"organizationId": personal_org_id},
+        ],
     }
     triggers = await AgentPreset.prisma().update_many(
         where=resume_where,
@@ -122,21 +128,21 @@ async def resume_automations_after_payment_restored(
     return summary
 
 
-def _personal_org_or(
-    user_id: str, personal_org_id: str | None
-) -> list[AgentPresetWhereInput]:
-    """`OR` predicate restricting to personally-funded presets (untagged or the
-    user's personal org). If the personal org couldn't be resolved, fall back to
-    any org (userId-only scope) with a warning: every preset is org-tagged after
-    the org dual-write, so a `personal org` predicate would otherwise exclude all
-    of them and silently pause/resume nothing."""
+async def _require_personal_org(user_id: str) -> str:
+    """Resolve the user's personal org id or raise.
+
+    Every user has a personal org after the org dual-write, so a missing one is
+    an exceptional (usually transient) state. Without it we can't tell personal
+    from team automations, so we defer loudly — the caller alerts and a later
+    retry re-attempts — rather than skipping everything (silently under-pausing)
+    or matching every org (wrongly touching team-funded automations)."""
+    personal_org_id = await _get_personal_org_id(user_id)
     if personal_org_id is None:
-        logger.warning(
-            f"No personal org resolved for user {user_id}; applying "
-            f"payment-lapse pause/resume without the org filter"
+        raise RuntimeError(
+            f"Cannot resolve personal org for user {user_id}; "
+            f"deferring payment-lapse pause/resume"
         )
-        return [{"organizationId": None}, {"organizationId": {"not": None}}]
-    return [{"organizationId": None}, {"organizationId": personal_org_id}]
+    return personal_org_id
 
 
 async def has_payment_lapsed_automations(user_id: str) -> bool:

--- a/autogpt_platform/backend/backend/data/automation_pause.py
+++ b/autogpt_platform/backend/backend/data/automation_pause.py
@@ -1,14 +1,17 @@
 """Pause/resume a user's automations (cron schedules + webhook-trigger presets)
 when their payment lapses / is restored. Resumption only touches automations
 carrying the payment-lapse marker, so anything the user paused themselves stays
-off. Org/team-tagged automations are excluded — they are funded by the org, not
-the member's personal subscription.
+off. Automations tagged with a team/external org are excluded — those are funded
+by the org, not the member's personal subscription — but the user's own personal
+org (which every schedule/preset is tagged with since org dual-write) counts as
+personally funded.
 """
 
 import logging
 
 from prisma.enums import NotificationType, PresetDeactivationReason
-from prisma.models import AgentPreset
+from prisma.models import AgentPreset, OrgMember
+from prisma.types import AgentPresetWhereInput
 from pydantic import BaseModel
 
 from backend.data.notifications import (
@@ -36,19 +39,26 @@ class AutomationPauseSummary(BaseModel):
 
 
 async def pause_automations_for_payment_lapse(user_id: str) -> AutomationPauseSummary:
+    personal_org_id = await _get_personal_org_id(user_id)
     schedules = await get_scheduler_client().pause_user_graph_schedules(
-        user_id=user_id, reason=SCHEDULE_PAUSE_REASON_PAYMENT_LAPSED
+        user_id=user_id,
+        reason=SCHEDULE_PAUSE_REASON_PAYMENT_LAPSED,
+        personal_org_id=personal_org_id,
     )
     # deactivationReason=None keeps user-deactivated presets untouched, so a
     # repeated webhook can't overwrite a user's own deactivation.
+    where: AgentPresetWhereInput = {
+        "userId": user_id,
+        "isActive": True,
+        "isDeleted": False,
+        "deactivationReason": None,
+        "OR": [
+            {"organizationId": None},
+            {"organizationId": personal_org_id},
+        ],
+    }
     triggers = await AgentPreset.prisma().update_many(
-        where={
-            "userId": user_id,
-            "isActive": True,
-            "isDeleted": False,
-            "organizationId": None,
-            "deactivationReason": None,
-        },
+        where=where,
         data={
             "isActive": False,
             "deactivationReason": PresetDeactivationReason.PAYMENT_LAPSED,
@@ -67,8 +77,11 @@ async def pause_automations_for_payment_lapse(user_id: str) -> AutomationPauseSu
 async def resume_automations_after_payment_restored(
     user_id: str,
 ) -> AutomationPauseSummary:
+    personal_org_id = await _get_personal_org_id(user_id)
     schedules = await get_scheduler_client().resume_user_graph_schedules(
-        user_id=user_id, reason=SCHEDULE_PAUSE_REASON_PAYMENT_LAPSED
+        user_id=user_id,
+        reason=SCHEDULE_PAUSE_REASON_PAYMENT_LAPSED,
+        personal_org_id=personal_org_id,
     )
     triggers = await AgentPreset.prisma().update_many(
         where={
@@ -87,6 +100,20 @@ async def resume_automations_after_payment_restored(
         )
         await _notify_resumed(user_id, summary)
     return summary
+
+
+async def _get_personal_org_id(user_id: str) -> str | None:
+    # Mirrors orgs.db._find_personal_org_member without the bootstrap side
+    # effect — a billing event must not create orgs.
+    member = await OrgMember.prisma().find_first(
+        where={
+            "userId": user_id,
+            "isOwner": True,
+            "Org": {"is": {"isPersonal": True, "deletedAt": None}},
+        },
+        order={"createdAt": "asc"},
+    )
+    return member.orgId if member else None
 
 
 async def _notify_paused(user_id: str, summary: AutomationPauseSummary) -> None:

--- a/autogpt_platform/backend/backend/data/automation_pause.py
+++ b/autogpt_platform/backend/backend/data/automation_pause.py
@@ -60,10 +60,7 @@ async def pause_automations_for_payment_lapse(user_id: str) -> AutomationPauseSu
         "isActive": True,
         "isDeleted": False,
         "deactivationReason": None,
-        "OR": [
-            {"organizationId": None},
-            {"organizationId": personal_org_id},
-        ],
+        "OR": _personal_org_or(user_id, personal_org_id),
     }
     triggers = await AgentPreset.prisma().update_many(
         where=where,
@@ -99,20 +96,18 @@ async def resume_automations_after_payment_restored(
     except Exception as e:
         scheduler_error = e
         logger.error(f"Failed to resume schedules for user {user_id}: {e}")
+    # Same personal-org predicate as pause: a preset that became team-owned
+    # after being payment-lapsed stays off — it's funded by the org, not the
+    # member's restored personal subscription.
+    resume_where: AgentPresetWhereInput = {
+        "userId": user_id,
+        "isActive": False,
+        "isDeleted": False,
+        "deactivationReason": PresetDeactivationReason.PAYMENT_LAPSED,
+        "OR": _personal_org_or(user_id, personal_org_id),
+    }
     triggers = await AgentPreset.prisma().update_many(
-        where={
-            "userId": user_id,
-            "isActive": False,
-            "isDeleted": False,
-            "deactivationReason": PresetDeactivationReason.PAYMENT_LAPSED,
-            # Same personal-org predicate as pause: a preset that became
-            # team-owned after being payment-lapsed stays off — it's funded by
-            # the org, not the member's restored personal subscription.
-            "OR": [
-                {"organizationId": None},
-                {"organizationId": personal_org_id},
-            ],
-        },
+        where=resume_where,
         data={"isActive": True, "deactivationReason": None},
     )
     summary = AutomationPauseSummary(schedules=schedules, triggers=triggers)
@@ -125,6 +120,23 @@ async def resume_automations_after_payment_restored(
     if scheduler_error is not None:
         raise scheduler_error
     return summary
+
+
+def _personal_org_or(
+    user_id: str, personal_org_id: str | None
+) -> list[AgentPresetWhereInput]:
+    """`OR` predicate restricting to personally-funded presets (untagged or the
+    user's personal org). If the personal org couldn't be resolved, fall back to
+    any org (userId-only scope) with a warning: every preset is org-tagged after
+    the org dual-write, so a `personal org` predicate would otherwise exclude all
+    of them and silently pause/resume nothing."""
+    if personal_org_id is None:
+        logger.warning(
+            f"No personal org resolved for user {user_id}; applying "
+            f"payment-lapse pause/resume without the org filter"
+        )
+        return [{"organizationId": None}, {"organizationId": {"not": None}}]
+    return [{"organizationId": None}, {"organizationId": personal_org_id}]
 
 
 async def has_payment_lapsed_automations(user_id: str) -> bool:

--- a/autogpt_platform/backend/backend/data/automation_pause.py
+++ b/autogpt_platform/backend/backend/data/automation_pause.py
@@ -40,11 +40,19 @@ class AutomationPauseSummary(BaseModel):
 
 async def pause_automations_for_payment_lapse(user_id: str) -> AutomationPauseSummary:
     personal_org_id = await _get_personal_org_id(user_id)
-    schedules = await get_scheduler_client().pause_user_graph_schedules(
-        user_id=user_id,
-        reason=SCHEDULE_PAUSE_REASON_PAYMENT_LAPSED,
-        personal_org_id=personal_org_id,
-    )
+    # A scheduler outage must not skip trigger deactivation; the error is
+    # re-raised after the preset update so the caller still alerts/retries.
+    schedules = 0
+    scheduler_error: Exception | None = None
+    try:
+        schedules = await get_scheduler_client().pause_user_graph_schedules(
+            user_id=user_id,
+            reason=SCHEDULE_PAUSE_REASON_PAYMENT_LAPSED,
+            personal_org_id=personal_org_id,
+        )
+    except Exception as e:
+        scheduler_error = e
+        logger.error(f"Failed to pause schedules for user {user_id}: {e}")
     # deactivationReason=None keeps user-deactivated presets untouched, so a
     # repeated webhook can't overwrite a user's own deactivation.
     where: AgentPresetWhereInput = {
@@ -71,6 +79,8 @@ async def pause_automations_for_payment_lapse(user_id: str) -> AutomationPauseSu
             f"trigger(s) for user {user_id} after payment lapse"
         )
         await _notify_paused(user_id, summary)
+    if scheduler_error is not None:
+        raise scheduler_error
     return summary
 
 
@@ -78,11 +88,17 @@ async def resume_automations_after_payment_restored(
     user_id: str,
 ) -> AutomationPauseSummary:
     personal_org_id = await _get_personal_org_id(user_id)
-    schedules = await get_scheduler_client().resume_user_graph_schedules(
-        user_id=user_id,
-        reason=SCHEDULE_PAUSE_REASON_PAYMENT_LAPSED,
-        personal_org_id=personal_org_id,
-    )
+    schedules = 0
+    scheduler_error: Exception | None = None
+    try:
+        schedules = await get_scheduler_client().resume_user_graph_schedules(
+            user_id=user_id,
+            reason=SCHEDULE_PAUSE_REASON_PAYMENT_LAPSED,
+            personal_org_id=personal_org_id,
+        )
+    except Exception as e:
+        scheduler_error = e
+        logger.error(f"Failed to resume schedules for user {user_id}: {e}")
     triggers = await AgentPreset.prisma().update_many(
         where={
             "userId": user_id,
@@ -99,6 +115,8 @@ async def resume_automations_after_payment_restored(
             f"trigger(s) for user {user_id} after payment restored"
         )
         await _notify_resumed(user_id, summary)
+    if scheduler_error is not None:
+        raise scheduler_error
     return summary
 
 

--- a/autogpt_platform/backend/backend/data/automation_pause.py
+++ b/autogpt_platform/backend/backend/data/automation_pause.py
@@ -105,6 +105,13 @@ async def resume_automations_after_payment_restored(
             "isActive": False,
             "isDeleted": False,
             "deactivationReason": PresetDeactivationReason.PAYMENT_LAPSED,
+            # Same personal-org predicate as pause: a preset that became
+            # team-owned after being payment-lapsed stays off — it's funded by
+            # the org, not the member's restored personal subscription.
+            "OR": [
+                {"organizationId": None},
+                {"organizationId": personal_org_id},
+            ],
         },
         data={"isActive": True, "deactivationReason": None},
     )

--- a/autogpt_platform/backend/backend/data/automation_pause.py
+++ b/autogpt_platform/backend/backend/data/automation_pause.py
@@ -1,0 +1,117 @@
+"""Pause/resume a user's automations (cron schedules + webhook-trigger presets)
+when their payment lapses / is restored. Resumption only touches automations
+carrying the payment-lapse marker, so anything the user paused themselves stays
+off. Org/team-tagged automations are excluded — they are funded by the org, not
+the member's personal subscription.
+"""
+
+import logging
+
+from prisma.enums import NotificationType, PresetDeactivationReason
+from prisma.models import AgentPreset
+from pydantic import BaseModel
+
+from backend.data.notifications import (
+    AutomationsPausedData,
+    AutomationsResumedData,
+    NotificationEventModel,
+)
+from backend.notifications.notifications import queue_notification_async
+from backend.util.clients import get_scheduler_client
+from backend.util.settings import Settings
+
+logger = logging.getLogger(__name__)
+settings = Settings()
+
+SCHEDULE_PAUSE_REASON_PAYMENT_LAPSED = "payment_lapsed"
+
+
+class AutomationPauseSummary(BaseModel):
+    schedules: int = 0
+    triggers: int = 0
+
+    @property
+    def total(self) -> int:
+        return self.schedules + self.triggers
+
+
+async def pause_automations_for_payment_lapse(user_id: str) -> AutomationPauseSummary:
+    schedules = await get_scheduler_client().pause_user_graph_schedules(
+        user_id=user_id, reason=SCHEDULE_PAUSE_REASON_PAYMENT_LAPSED
+    )
+    # deactivationReason=None keeps user-deactivated presets untouched, so a
+    # repeated webhook can't overwrite a user's own deactivation.
+    triggers = await AgentPreset.prisma().update_many(
+        where={
+            "userId": user_id,
+            "isActive": True,
+            "isDeleted": False,
+            "organizationId": None,
+            "deactivationReason": None,
+        },
+        data={
+            "isActive": False,
+            "deactivationReason": PresetDeactivationReason.PAYMENT_LAPSED,
+        },
+    )
+    summary = AutomationPauseSummary(schedules=schedules, triggers=triggers)
+    if summary.total:
+        logger.info(
+            f"Paused {summary.schedules} schedule(s) and {summary.triggers} "
+            f"trigger(s) for user {user_id} after payment lapse"
+        )
+        await _notify_paused(user_id, summary)
+    return summary
+
+
+async def resume_automations_after_payment_restored(
+    user_id: str,
+) -> AutomationPauseSummary:
+    schedules = await get_scheduler_client().resume_user_graph_schedules(
+        user_id=user_id, reason=SCHEDULE_PAUSE_REASON_PAYMENT_LAPSED
+    )
+    triggers = await AgentPreset.prisma().update_many(
+        where={
+            "userId": user_id,
+            "isActive": False,
+            "isDeleted": False,
+            "deactivationReason": PresetDeactivationReason.PAYMENT_LAPSED,
+        },
+        data={"isActive": True, "deactivationReason": None},
+    )
+    summary = AutomationPauseSummary(schedules=schedules, triggers=triggers)
+    if summary.total:
+        logger.info(
+            f"Resumed {summary.schedules} schedule(s) and {summary.triggers} "
+            f"trigger(s) for user {user_id} after payment restored"
+        )
+        await _notify_resumed(user_id, summary)
+    return summary
+
+
+async def _notify_paused(user_id: str, summary: AutomationPauseSummary) -> None:
+    base_url = settings.config.frontend_base_url or settings.config.platform_base_url
+    await queue_notification_async(
+        NotificationEventModel(
+            user_id=user_id,
+            type=NotificationType.AUTOMATIONS_PAUSED,
+            data=AutomationsPausedData(
+                paused_schedules=summary.schedules,
+                paused_triggers=summary.triggers,
+                billing_page_link=f"{base_url}/settings/billing",
+            ),
+        )
+    )
+
+
+async def _notify_resumed(user_id: str, summary: AutomationPauseSummary) -> None:
+    await queue_notification_async(
+        NotificationEventModel(
+            user_id=user_id,
+            type=NotificationType.AUTOMATIONS_RESUMED,
+            data=AutomationsResumedData(
+                resumed_schedules=summary.schedules,
+                resumed_triggers=summary.triggers,
+            ),
+        )
+    )

--- a/autogpt_platform/backend/backend/data/automation_pause_test.py
+++ b/autogpt_platform/backend/backend/data/automation_pause_test.py
@@ -7,6 +7,7 @@ from prisma.enums import NotificationType, PresetDeactivationReason
 
 from backend.data.automation_pause import (
     SCHEDULE_PAUSE_REASON_PAYMENT_LAPSED,
+    has_payment_lapsed_automations,
     pause_automations_for_payment_lapse,
     resume_automations_after_payment_restored,
 )
@@ -139,6 +140,18 @@ async def test_resume_only_touches_payment_lapsed_automations():
     assert event.type == NotificationType.AUTOMATIONS_RESUMED
     assert event.data.resumed_schedules == 1
     assert event.data.resumed_triggers == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("count,expected", [(2, True), (0, False)])
+async def test_has_payment_lapsed_automations(count, expected):
+    preset_prisma = MagicMock()
+    preset_prisma.return_value.count = AsyncMock(return_value=count)
+    with patch("prisma.models.AgentPreset.prisma", preset_prisma):
+        assert await has_payment_lapsed_automations("user-1") is expected
+    where = preset_prisma.return_value.count.call_args.kwargs["where"]
+    assert where["deactivationReason"] == PresetDeactivationReason.PAYMENT_LAPSED
+    assert where["userId"] == "user-1"
 
 
 @pytest.mark.asyncio

--- a/autogpt_platform/backend/backend/data/automation_pause_test.py
+++ b/autogpt_platform/backend/backend/data/automation_pause_test.py
@@ -126,6 +126,10 @@ async def test_resume_only_touches_payment_lapsed_automations():
         "isActive": False,
         "isDeleted": False,
         "deactivationReason": PresetDeactivationReason.PAYMENT_LAPSED,
+        "OR": [
+            {"organizationId": None},
+            {"organizationId": _PERSONAL_ORG},
+        ],
     }
     assert update_call.kwargs["data"] == {
         "isActive": True,
@@ -135,6 +139,25 @@ async def test_resume_only_touches_payment_lapsed_automations():
     assert event.type == NotificationType.AUTOMATIONS_RESUMED
     assert event.data.resumed_schedules == 1
     assert event.data.resumed_triggers == 2
+
+
+@pytest.mark.asyncio
+async def test_resume_excludes_team_owned_presets():
+    """A preset that became team-owned after being payment-lapsed must not be
+    reactivated by the member's restored personal subscription — resume applies
+    the same personal-org predicate as pause."""
+    client = _mock_scheduler_client(resumed=0)
+    preset_prisma = MagicMock()
+    preset_prisma.return_value.update_many = AsyncMock(return_value=0)
+    p1, p2, p3, p4 = _patches(client, preset_prisma, AsyncMock())
+    with p1, p2, p3, p4:
+        await resume_automations_after_payment_restored("user-1")
+
+    where = preset_prisma.return_value.update_many.call_args.kwargs["where"]
+    assert where["OR"] == [
+        {"organizationId": None},
+        {"organizationId": _PERSONAL_ORG},
+    ]
 
 
 @pytest.mark.asyncio

--- a/autogpt_platform/backend/backend/data/automation_pause_test.py
+++ b/autogpt_platform/backend/backend/data/automation_pause_test.py
@@ -1,0 +1,140 @@
+"""Unit tests for payment-lapse pause/resume of user automations."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from prisma.enums import NotificationType, PresetDeactivationReason
+
+from backend.data.automation_pause import (
+    SCHEDULE_PAUSE_REASON_PAYMENT_LAPSED,
+    pause_automations_for_payment_lapse,
+    resume_automations_after_payment_restored,
+)
+
+_MODULE = "backend.data.automation_pause"
+
+
+def _mock_scheduler_client(paused: int = 0, resumed: int = 0) -> MagicMock:
+    client = MagicMock()
+    client.pause_user_graph_schedules = AsyncMock(return_value=paused)
+    client.resume_user_graph_schedules = AsyncMock(return_value=resumed)
+    return client
+
+
+@pytest.mark.asyncio
+async def test_pause_marks_schedules_and_triggers_with_reason():
+    client = _mock_scheduler_client(paused=2)
+    with (
+        patch(f"{_MODULE}.get_scheduler_client", return_value=client),
+        patch("prisma.models.AgentPreset.prisma") as mock_prisma,
+        patch(f"{_MODULE}.queue_notification_async", new=AsyncMock()) as mock_notify,
+    ):
+        mock_prisma.return_value.update_many = AsyncMock(return_value=3)
+
+        summary = await pause_automations_for_payment_lapse("user-1")
+
+    assert summary.schedules == 2
+    assert summary.triggers == 3
+    client.pause_user_graph_schedules.assert_awaited_once_with(
+        user_id="user-1", reason=SCHEDULE_PAUSE_REASON_PAYMENT_LAPSED
+    )
+    update_call = mock_prisma.return_value.update_many.call_args
+    assert update_call.kwargs["where"] == {
+        "userId": "user-1",
+        "isActive": True,
+        "isDeleted": False,
+        "organizationId": None,
+        "deactivationReason": None,
+    }
+    assert update_call.kwargs["data"] == {
+        "isActive": False,
+        "deactivationReason": PresetDeactivationReason.PAYMENT_LAPSED,
+    }
+    event = mock_notify.await_args.args[0]
+    assert event.type == NotificationType.AUTOMATIONS_PAUSED
+    assert event.data.paused_schedules == 2
+    assert event.data.paused_triggers == 3
+
+
+@pytest.mark.asyncio
+async def test_pause_skips_user_deactivated_presets_via_where_clause():
+    """The where clause must require deactivationReason=None so presets the
+    user deactivated themselves are never stamped with PAYMENT_LAPSED."""
+    client = _mock_scheduler_client()
+    with (
+        patch(f"{_MODULE}.get_scheduler_client", return_value=client),
+        patch("prisma.models.AgentPreset.prisma") as mock_prisma,
+        patch(f"{_MODULE}.queue_notification_async", new=AsyncMock()),
+    ):
+        mock_prisma.return_value.update_many = AsyncMock(return_value=0)
+        await pause_automations_for_payment_lapse("user-1")
+
+    where = mock_prisma.return_value.update_many.call_args.kwargs["where"]
+    assert where["deactivationReason"] is None
+    assert where["isActive"] is True
+
+
+@pytest.mark.asyncio
+async def test_pause_with_nothing_to_pause_sends_no_notification():
+    client = _mock_scheduler_client(paused=0)
+    with (
+        patch(f"{_MODULE}.get_scheduler_client", return_value=client),
+        patch("prisma.models.AgentPreset.prisma") as mock_prisma,
+        patch(f"{_MODULE}.queue_notification_async", new=AsyncMock()) as mock_notify,
+    ):
+        mock_prisma.return_value.update_many = AsyncMock(return_value=0)
+
+        summary = await pause_automations_for_payment_lapse("user-1")
+
+    assert summary.total == 0
+    mock_notify.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_resume_only_touches_payment_lapsed_automations():
+    client = _mock_scheduler_client(resumed=1)
+    with (
+        patch(f"{_MODULE}.get_scheduler_client", return_value=client),
+        patch("prisma.models.AgentPreset.prisma") as mock_prisma,
+        patch(f"{_MODULE}.queue_notification_async", new=AsyncMock()) as mock_notify,
+    ):
+        mock_prisma.return_value.update_many = AsyncMock(return_value=2)
+
+        summary = await resume_automations_after_payment_restored("user-1")
+
+    assert summary.schedules == 1
+    assert summary.triggers == 2
+    client.resume_user_graph_schedules.assert_awaited_once_with(
+        user_id="user-1", reason=SCHEDULE_PAUSE_REASON_PAYMENT_LAPSED
+    )
+    update_call = mock_prisma.return_value.update_many.call_args
+    assert update_call.kwargs["where"] == {
+        "userId": "user-1",
+        "isActive": False,
+        "isDeleted": False,
+        "deactivationReason": PresetDeactivationReason.PAYMENT_LAPSED,
+    }
+    assert update_call.kwargs["data"] == {
+        "isActive": True,
+        "deactivationReason": None,
+    }
+    event = mock_notify.await_args.args[0]
+    assert event.type == NotificationType.AUTOMATIONS_RESUMED
+    assert event.data.resumed_schedules == 1
+    assert event.data.resumed_triggers == 2
+
+
+@pytest.mark.asyncio
+async def test_resume_with_nothing_to_resume_sends_no_notification():
+    client = _mock_scheduler_client(resumed=0)
+    with (
+        patch(f"{_MODULE}.get_scheduler_client", return_value=client),
+        patch("prisma.models.AgentPreset.prisma") as mock_prisma,
+        patch(f"{_MODULE}.queue_notification_async", new=AsyncMock()) as mock_notify,
+    ):
+        mock_prisma.return_value.update_many = AsyncMock(return_value=0)
+
+        summary = await resume_automations_after_payment_restored("user-1")
+
+    assert summary.total == 0
+    mock_notify.assert_not_awaited()

--- a/autogpt_platform/backend/backend/data/automation_pause_test.py
+++ b/autogpt_platform/backend/backend/data/automation_pause_test.py
@@ -12,6 +12,7 @@ from backend.data.automation_pause import (
 )
 
 _MODULE = "backend.data.automation_pause"
+_PERSONAL_ORG = "personal-org-1"
 
 
 def _mock_scheduler_client(paused: int = 0, resumed: int = 0) -> MagicMock:
@@ -21,55 +22,69 @@ def _mock_scheduler_client(paused: int = 0, resumed: int = 0) -> MagicMock:
     return client
 
 
+def _patches(client, preset_prisma, notify):
+    return (
+        patch(f"{_MODULE}.get_scheduler_client", return_value=client),
+        patch("prisma.models.AgentPreset.prisma", preset_prisma),
+        patch(f"{_MODULE}.queue_notification_async", new=notify),
+        patch(
+            f"{_MODULE}._get_personal_org_id",
+            new=AsyncMock(return_value=_PERSONAL_ORG),
+        ),
+    )
+
+
 @pytest.mark.asyncio
 async def test_pause_marks_schedules_and_triggers_with_reason():
     client = _mock_scheduler_client(paused=2)
-    with (
-        patch(f"{_MODULE}.get_scheduler_client", return_value=client),
-        patch("prisma.models.AgentPreset.prisma") as mock_prisma,
-        patch(f"{_MODULE}.queue_notification_async", new=AsyncMock()) as mock_notify,
-    ):
-        mock_prisma.return_value.update_many = AsyncMock(return_value=3)
-
+    preset_prisma = MagicMock()
+    preset_prisma.return_value.update_many = AsyncMock(return_value=3)
+    notify = AsyncMock()
+    p1, p2, p3, p4 = _patches(client, preset_prisma, notify)
+    with p1, p2, p3, p4:
         summary = await pause_automations_for_payment_lapse("user-1")
 
     assert summary.schedules == 2
     assert summary.triggers == 3
     client.pause_user_graph_schedules.assert_awaited_once_with(
-        user_id="user-1", reason=SCHEDULE_PAUSE_REASON_PAYMENT_LAPSED
+        user_id="user-1",
+        reason=SCHEDULE_PAUSE_REASON_PAYMENT_LAPSED,
+        personal_org_id=_PERSONAL_ORG,
     )
-    update_call = mock_prisma.return_value.update_many.call_args
+    update_call = preset_prisma.return_value.update_many.call_args
     assert update_call.kwargs["where"] == {
         "userId": "user-1",
         "isActive": True,
         "isDeleted": False,
-        "organizationId": None,
         "deactivationReason": None,
+        "OR": [
+            {"organizationId": None},
+            {"organizationId": _PERSONAL_ORG},
+        ],
     }
     assert update_call.kwargs["data"] == {
         "isActive": False,
         "deactivationReason": PresetDeactivationReason.PAYMENT_LAPSED,
     }
-    event = mock_notify.await_args.args[0]
+    event = notify.await_args.args[0]
     assert event.type == NotificationType.AUTOMATIONS_PAUSED
     assert event.data.paused_schedules == 2
     assert event.data.paused_triggers == 3
 
 
 @pytest.mark.asyncio
-async def test_pause_skips_user_deactivated_presets_via_where_clause():
-    """The where clause must require deactivationReason=None so presets the
-    user deactivated themselves are never stamped with PAYMENT_LAPSED."""
+async def test_pause_covers_personal_org_tagged_presets():
+    """Presets carry the user's personal org id since org dual-write; the
+    where-clause must match those, not only untagged legacy rows."""
     client = _mock_scheduler_client()
-    with (
-        patch(f"{_MODULE}.get_scheduler_client", return_value=client),
-        patch("prisma.models.AgentPreset.prisma") as mock_prisma,
-        patch(f"{_MODULE}.queue_notification_async", new=AsyncMock()),
-    ):
-        mock_prisma.return_value.update_many = AsyncMock(return_value=0)
+    preset_prisma = MagicMock()
+    preset_prisma.return_value.update_many = AsyncMock(return_value=0)
+    p1, p2, p3, p4 = _patches(client, preset_prisma, AsyncMock())
+    with p1, p2, p3, p4:
         await pause_automations_for_payment_lapse("user-1")
 
-    where = mock_prisma.return_value.update_many.call_args.kwargs["where"]
+    where = preset_prisma.return_value.update_many.call_args.kwargs["where"]
+    assert {"organizationId": _PERSONAL_ORG} in where["OR"]
     assert where["deactivationReason"] is None
     assert where["isActive"] is True
 
@@ -77,37 +92,35 @@ async def test_pause_skips_user_deactivated_presets_via_where_clause():
 @pytest.mark.asyncio
 async def test_pause_with_nothing_to_pause_sends_no_notification():
     client = _mock_scheduler_client(paused=0)
-    with (
-        patch(f"{_MODULE}.get_scheduler_client", return_value=client),
-        patch("prisma.models.AgentPreset.prisma") as mock_prisma,
-        patch(f"{_MODULE}.queue_notification_async", new=AsyncMock()) as mock_notify,
-    ):
-        mock_prisma.return_value.update_many = AsyncMock(return_value=0)
-
+    preset_prisma = MagicMock()
+    preset_prisma.return_value.update_many = AsyncMock(return_value=0)
+    notify = AsyncMock()
+    p1, p2, p3, p4 = _patches(client, preset_prisma, notify)
+    with p1, p2, p3, p4:
         summary = await pause_automations_for_payment_lapse("user-1")
 
     assert summary.total == 0
-    mock_notify.assert_not_awaited()
+    notify.assert_not_awaited()
 
 
 @pytest.mark.asyncio
 async def test_resume_only_touches_payment_lapsed_automations():
     client = _mock_scheduler_client(resumed=1)
-    with (
-        patch(f"{_MODULE}.get_scheduler_client", return_value=client),
-        patch("prisma.models.AgentPreset.prisma") as mock_prisma,
-        patch(f"{_MODULE}.queue_notification_async", new=AsyncMock()) as mock_notify,
-    ):
-        mock_prisma.return_value.update_many = AsyncMock(return_value=2)
-
+    preset_prisma = MagicMock()
+    preset_prisma.return_value.update_many = AsyncMock(return_value=2)
+    notify = AsyncMock()
+    p1, p2, p3, p4 = _patches(client, preset_prisma, notify)
+    with p1, p2, p3, p4:
         summary = await resume_automations_after_payment_restored("user-1")
 
     assert summary.schedules == 1
     assert summary.triggers == 2
     client.resume_user_graph_schedules.assert_awaited_once_with(
-        user_id="user-1", reason=SCHEDULE_PAUSE_REASON_PAYMENT_LAPSED
+        user_id="user-1",
+        reason=SCHEDULE_PAUSE_REASON_PAYMENT_LAPSED,
+        personal_org_id=_PERSONAL_ORG,
     )
-    update_call = mock_prisma.return_value.update_many.call_args
+    update_call = preset_prisma.return_value.update_many.call_args
     assert update_call.kwargs["where"] == {
         "userId": "user-1",
         "isActive": False,
@@ -118,7 +131,7 @@ async def test_resume_only_touches_payment_lapsed_automations():
         "isActive": True,
         "deactivationReason": None,
     }
-    event = mock_notify.await_args.args[0]
+    event = notify.await_args.args[0]
     assert event.type == NotificationType.AUTOMATIONS_RESUMED
     assert event.data.resumed_schedules == 1
     assert event.data.resumed_triggers == 2
@@ -127,14 +140,12 @@ async def test_resume_only_touches_payment_lapsed_automations():
 @pytest.mark.asyncio
 async def test_resume_with_nothing_to_resume_sends_no_notification():
     client = _mock_scheduler_client(resumed=0)
-    with (
-        patch(f"{_MODULE}.get_scheduler_client", return_value=client),
-        patch("prisma.models.AgentPreset.prisma") as mock_prisma,
-        patch(f"{_MODULE}.queue_notification_async", new=AsyncMock()) as mock_notify,
-    ):
-        mock_prisma.return_value.update_many = AsyncMock(return_value=0)
-
+    preset_prisma = MagicMock()
+    preset_prisma.return_value.update_many = AsyncMock(return_value=0)
+    notify = AsyncMock()
+    p1, p2, p3, p4 = _patches(client, preset_prisma, notify)
+    with p1, p2, p3, p4:
         summary = await resume_automations_after_payment_restored("user-1")
 
     assert summary.total == 0
-    mock_notify.assert_not_awaited()
+    notify.assert_not_awaited()

--- a/autogpt_platform/backend/backend/data/automation_pause_test.py
+++ b/autogpt_platform/backend/backend/data/automation_pause_test.py
@@ -149,3 +149,37 @@ async def test_resume_with_nothing_to_resume_sends_no_notification():
 
     assert summary.total == 0
     notify.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_pause_deactivates_presets_even_when_scheduler_fails():
+    client = MagicMock()
+    client.pause_user_graph_schedules = AsyncMock(side_effect=RuntimeError("down"))
+    preset_prisma = MagicMock()
+    preset_prisma.return_value.update_many = AsyncMock(return_value=2)
+    notify = AsyncMock()
+    p1, p2, p3, p4 = _patches(client, preset_prisma, notify)
+    with p1, p2, p3, p4:
+        with pytest.raises(RuntimeError):
+            await pause_automations_for_payment_lapse("user-1")
+
+    preset_prisma.return_value.update_many.assert_awaited_once()
+    event = notify.await_args.args[0]
+    assert event.data.paused_triggers == 2
+
+
+@pytest.mark.asyncio
+async def test_resume_reactivates_presets_even_when_scheduler_fails():
+    client = MagicMock()
+    client.resume_user_graph_schedules = AsyncMock(side_effect=RuntimeError("down"))
+    preset_prisma = MagicMock()
+    preset_prisma.return_value.update_many = AsyncMock(return_value=1)
+    notify = AsyncMock()
+    p1, p2, p3, p4 = _patches(client, preset_prisma, notify)
+    with p1, p2, p3, p4:
+        with pytest.raises(RuntimeError):
+            await resume_automations_after_payment_restored("user-1")
+
+    preset_prisma.return_value.update_many.assert_awaited_once()
+    event = notify.await_args.args[0]
+    assert event.data.resumed_triggers == 1

--- a/autogpt_platform/backend/backend/data/automation_pause_test.py
+++ b/autogpt_platform/backend/backend/data/automation_pause_test.py
@@ -91,11 +91,11 @@ async def test_pause_covers_personal_org_tagged_presets():
 
 
 @pytest.mark.asyncio
-async def test_pause_falls_back_to_user_scope_without_personal_org():
-    """If the personal org can't be resolved, pause everything the user owns
-    (userId-only) rather than silently matching nothing — every preset is
-    org-tagged after dual-write, so the org predicate would exclude all."""
-    client = _mock_scheduler_client(paused=0)
+async def test_pause_defers_when_personal_org_unresolved():
+    """Without a resolvable personal org we can't tell personal from team
+    automations, so pause raises (the caller alerts) instead of skipping all or
+    touching team-funded automations."""
+    client = _mock_scheduler_client()
     preset_prisma = MagicMock()
     preset_prisma.return_value.update_many = AsyncMock(return_value=0)
     with (
@@ -103,21 +103,30 @@ async def test_pause_falls_back_to_user_scope_without_personal_org():
         patch("prisma.models.AgentPreset.prisma", preset_prisma),
         patch(f"{_MODULE}.queue_notification_async", new=AsyncMock()),
         patch(f"{_MODULE}._get_personal_org_id", new=AsyncMock(return_value=None)),
+        pytest.raises(RuntimeError, match="personal org"),
     ):
         await pause_automations_for_payment_lapse("user-1")
 
-    where = preset_prisma.return_value.update_many.call_args.kwargs["where"]
-    # Any org (untagged OR any organizationId) == userId-only scope.
-    assert where["OR"] == [
-        {"organizationId": None},
-        {"organizationId": {"not": None}},
-    ]
-    assert where["userId"] == "user-1"
-    client.pause_user_graph_schedules.assert_awaited_once_with(
-        user_id="user-1",
-        reason=SCHEDULE_PAUSE_REASON_PAYMENT_LAPSED,
-        personal_org_id=None,
-    )
+    client.pause_user_graph_schedules.assert_not_awaited()
+    preset_prisma.return_value.update_many.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_resume_defers_when_personal_org_unresolved():
+    client = _mock_scheduler_client()
+    preset_prisma = MagicMock()
+    preset_prisma.return_value.update_many = AsyncMock(return_value=0)
+    with (
+        patch(f"{_MODULE}.get_scheduler_client", return_value=client),
+        patch("prisma.models.AgentPreset.prisma", preset_prisma),
+        patch(f"{_MODULE}.queue_notification_async", new=AsyncMock()),
+        patch(f"{_MODULE}._get_personal_org_id", new=AsyncMock(return_value=None)),
+        pytest.raises(RuntimeError, match="personal org"),
+    ):
+        await resume_automations_after_payment_restored("user-1")
+
+    client.resume_user_graph_schedules.assert_not_awaited()
+    preset_prisma.return_value.update_many.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/autogpt_platform/backend/backend/data/automation_pause_test.py
+++ b/autogpt_platform/backend/backend/data/automation_pause_test.py
@@ -91,6 +91,36 @@ async def test_pause_covers_personal_org_tagged_presets():
 
 
 @pytest.mark.asyncio
+async def test_pause_falls_back_to_user_scope_without_personal_org():
+    """If the personal org can't be resolved, pause everything the user owns
+    (userId-only) rather than silently matching nothing — every preset is
+    org-tagged after dual-write, so the org predicate would exclude all."""
+    client = _mock_scheduler_client(paused=0)
+    preset_prisma = MagicMock()
+    preset_prisma.return_value.update_many = AsyncMock(return_value=0)
+    with (
+        patch(f"{_MODULE}.get_scheduler_client", return_value=client),
+        patch("prisma.models.AgentPreset.prisma", preset_prisma),
+        patch(f"{_MODULE}.queue_notification_async", new=AsyncMock()),
+        patch(f"{_MODULE}._get_personal_org_id", new=AsyncMock(return_value=None)),
+    ):
+        await pause_automations_for_payment_lapse("user-1")
+
+    where = preset_prisma.return_value.update_many.call_args.kwargs["where"]
+    # Any org (untagged OR any organizationId) == userId-only scope.
+    assert where["OR"] == [
+        {"organizationId": None},
+        {"organizationId": {"not": None}},
+    ]
+    assert where["userId"] == "user-1"
+    client.pause_user_graph_schedules.assert_awaited_once_with(
+        user_id="user-1",
+        reason=SCHEDULE_PAUSE_REASON_PAYMENT_LAPSED,
+        personal_org_id=None,
+    )
+
+
+@pytest.mark.asyncio
 async def test_pause_with_nothing_to_pause_sends_no_notification():
     client = _mock_scheduler_client(paused=0)
     preset_prisma = MagicMock()

--- a/autogpt_platform/backend/backend/data/credit.py
+++ b/autogpt_platform/backend/backend/data/credit.py
@@ -18,11 +18,7 @@ from prisma.enums import (
 )
 from prisma.errors import PrismaError, UniqueViolationError
 from prisma.models import CreditRefundRequest, CreditTransaction, User, UserBalance
-from prisma.types import (
-    CreditRefundRequestCreateInput,
-    CreditTransactionWhereInput,
-    UserUpdateInput,
-)
+from prisma.types import CreditRefundRequestCreateInput, CreditTransactionWhereInput
 from pydantic import BaseModel
 
 from backend.api.features.admin.model import UserHistoryResponse
@@ -1525,14 +1521,24 @@ async def set_subscription_tier(
     tier: SubscriptionTier,
 ) -> None:
     """Set the user's subscription tier."""
-    previous_user = await User.prisma().find_unique(where={"id": user_id})
-    previous_tier = (
-        SubscriptionTier(previous_user.subscriptionTier) if previous_user else None
+    # Single UPDATE ... RETURNING the pre-update tier: concurrent callers
+    # (webhook retry + reconciliation sweep) each observe a distinct
+    # transition, so a paid<->NO_TIER edge can't be lost to interleaving.
+    rows = await query_raw_with_schema(
+        """
+        UPDATE {schema_prefix}"User" u
+        SET "subscriptionTier" = $2::text::{schema_prefix}"SubscriptionTier"
+        FROM (
+            SELECT id, "subscriptionTier" AS previous_tier
+            FROM {schema_prefix}"User" WHERE id = $1 FOR UPDATE
+        ) prev
+        WHERE u.id = prev.id
+        RETURNING prev.previous_tier
+        """,
+        user_id,
+        tier.value,
     )
-    data: UserUpdateInput = {
-        "subscriptionTier": tier,
-    }
-    await User.prisma().update(where={"id": user_id}, data=data)
+    previous_tier = SubscriptionTier(rows[0]["previous_tier"]) if rows else None
     get_user_by_id.cache_delete(user_id)
     await _handle_tier_transition_automations(user_id, previous_tier, tier)
     # Also invalidate the rate-limit tier cache so CoPilot picks up the new
@@ -1566,10 +1572,17 @@ async def _handle_tier_transition_automations(
         elif previous_tier == SubscriptionTier.NO_TIER:
             await resume_automations_after_payment_restored(user_id)
     except Exception as e:
-        logger.error(
-            f"Failed to update automations for user {user_id} on tier "
+        # Edge-triggered: a missed pause/resume won't retry on its own, so page
+        # ops loudly instead of just logging.
+        message = (
+            f"Automation pause/resume FAILED for user {user_id} on tier "
             f"transition {previous_tier}->{new_tier}: {e}"
         )
+        logger.error(message)
+        try:
+            await discord_send_alert(message, DiscordChannel.PLATFORM)
+        except Exception:
+            logger.error(f"Discord alert delivery failed for: {message}")
 
 
 async def _cancel_customer_subscriptions(

--- a/autogpt_platform/backend/backend/data/credit.py
+++ b/autogpt_platform/backend/backend/data/credit.py
@@ -22,10 +22,6 @@ from prisma.types import CreditRefundRequestCreateInput, CreditTransactionWhereI
 from pydantic import BaseModel
 
 from backend.api.features.admin.model import UserHistoryResponse
-from backend.data.automation_pause import (
-    pause_automations_for_payment_lapse,
-    resume_automations_after_payment_restored,
-)
 from backend.data.block_cost_config import BLOCK_COSTS
 from backend.data.db import query_raw_with_schema
 from backend.data.includes import MAX_CREDIT_REFUND_REQUESTS_FETCH
@@ -1539,7 +1535,18 @@ async def set_subscription_tier(
         user_id,
         tier.value,
     )
-    previous_tier = SubscriptionTier(rows[0]["previous_tier"]) if rows else None
+    # The RETURNING value is a raw enum string (raw SQL bypasses Prisma's typed
+    # decoding), so guard against a null/legacy value rather than raising
+    # ValueError inside the Stripe webhook path.
+    previous_tier: SubscriptionTier | None = None
+    if rows and rows[0].get("previous_tier"):
+        try:
+            previous_tier = SubscriptionTier(rows[0]["previous_tier"])
+        except ValueError:
+            logger.warning(
+                f"Unrecognized previous subscription tier "
+                f"{rows[0]['previous_tier']!r} for user {user_id}"
+            )
     get_user_by_id.cache_delete(user_id)
     await _handle_tier_transition_automations(user_id, previous_tier, tier)
     # Also invalidate the rate-limit tier cache so CoPilot picks up the new
@@ -1565,12 +1572,32 @@ async def _handle_tier_transition_automations(
     Never raises: a failure here must not fail the Stripe webhook whose tier
     update triggered it (a 500 would make Stripe retry the billing event).
     """
-    if previous_tier is None or previous_tier == new_tier:
+    if previous_tier is None:
         return
+    # Local import avoids a circular import at module load: automation_pause
+    # transitively pulls in notifications/scheduler/settings.
+    from backend.data.automation_pause import (
+        has_payment_lapsed_automations,
+        pause_automations_for_payment_lapse,
+        resume_automations_after_payment_restored,
+    )
+
     try:
         if new_tier == SubscriptionTier.NO_TIER:
-            await pause_automations_for_payment_lapse(user_id)
-        elif previous_tier == SubscriptionTier.NO_TIER:
+            # Pause only on a real lapse. A same-tier NO_TIER retry isn't
+            # reconciled here: without a persisted pending marker a never-paid
+            # free user is indistinguishable from a lapsed user whose pause
+            # partially failed (tracked as a follow-up).
+            if previous_tier != new_tier:
+                await pause_automations_for_payment_lapse(user_id)
+        elif (
+            previous_tier == SubscriptionTier.NO_TIER
+            or await has_payment_lapsed_automations(user_id)
+        ):
+            # Resume on restore, and self-heal a resume that partially failed on
+            # a prior restore: a same-tier paid webhook retry re-attempts while
+            # any payment-lapsed automations remain. Resume only touches
+            # PAYMENT_LAPSED-marked rows, so this is idempotent.
             await resume_automations_after_payment_restored(user_id)
     except Exception as e:
         # Edge-triggered: a missed pause/resume won't retry on its own, so page

--- a/autogpt_platform/backend/backend/data/credit.py
+++ b/autogpt_platform/backend/backend/data/credit.py
@@ -26,6 +26,10 @@ from prisma.types import (
 from pydantic import BaseModel
 
 from backend.api.features.admin.model import UserHistoryResponse
+from backend.data.automation_pause import (
+    pause_automations_for_payment_lapse,
+    resume_automations_after_payment_restored,
+)
 from backend.data.block_cost_config import BLOCK_COSTS
 from backend.data.db import query_raw_with_schema
 from backend.data.includes import MAX_CREDIT_REFUND_REQUESTS_FETCH
@@ -1521,11 +1525,16 @@ async def set_subscription_tier(
     tier: SubscriptionTier,
 ) -> None:
     """Set the user's subscription tier."""
+    previous_user = await User.prisma().find_unique(where={"id": user_id})
+    previous_tier = (
+        SubscriptionTier(previous_user.subscriptionTier) if previous_user else None
+    )
     data: UserUpdateInput = {
         "subscriptionTier": tier,
     }
     await User.prisma().update(where={"id": user_id}, data=data)
     get_user_by_id.cache_delete(user_id)
+    await _handle_tier_transition_automations(user_id, previous_tier, tier)
     # Also invalidate the rate-limit tier cache so CoPilot picks up the new
     # tier immediately rather than waiting up to 5 minutes for the TTL to expire.
     from backend.copilot.rate_limit import get_user_tier  # local import avoids circular
@@ -1537,6 +1546,30 @@ async def set_subscription_tier(
     # billing page can show a pending change for up to 30s after the tier
     # has already flipped.
     get_pending_subscription_change.cache_delete(user_id)
+
+
+async def _handle_tier_transition_automations(
+    user_id: str,
+    previous_tier: SubscriptionTier | None,
+    new_tier: SubscriptionTier,
+) -> None:
+    """Pause automations on paid→NO_TIER, resume on NO_TIER→paid.
+
+    Never raises: a failure here must not fail the Stripe webhook whose tier
+    update triggered it (a 500 would make Stripe retry the billing event).
+    """
+    if previous_tier is None or previous_tier == new_tier:
+        return
+    try:
+        if new_tier == SubscriptionTier.NO_TIER:
+            await pause_automations_for_payment_lapse(user_id)
+        elif previous_tier == SubscriptionTier.NO_TIER:
+            await resume_automations_after_payment_restored(user_id)
+    except Exception as e:
+        logger.error(
+            f"Failed to update automations for user {user_id} on tier "
+            f"transition {previous_tier}->{new_tier}: {e}"
+        )
 
 
 async def _cancel_customer_subscriptions(

--- a/autogpt_platform/backend/backend/data/credit.py
+++ b/autogpt_platform/backend/backend/data/credit.py
@@ -1527,7 +1527,8 @@ async def set_subscription_tier(
     rows = await query_raw_with_schema(
         """
         UPDATE {schema_prefix}"User" u
-        SET "subscriptionTier" = $2::text::{schema_prefix}"SubscriptionTier"
+        SET "subscriptionTier" = $2::text::{schema_prefix}"SubscriptionTier",
+            "updatedAt" = now()
         FROM (
             SELECT id, "subscriptionTier" AS previous_tier
             FROM {schema_prefix}"User" WHERE id = $1 FOR UPDATE

--- a/autogpt_platform/backend/backend/data/credit_subscription_test.py
+++ b/autogpt_platform/backend/backend/data/credit_subscription_test.py
@@ -48,28 +48,45 @@ def _clear_cache(fn: _CacheClearable) -> None:
 async def test_set_subscription_tier_updates_db():
     with (
         patch(
-            "backend.data.credit.User.prisma",
-            return_value=MagicMock(update=AsyncMock()),
-        ) as mock_prisma,
+            "backend.data.credit.query_raw_with_schema",
+            new=AsyncMock(return_value=[{"previous_tier": "PRO"}]),
+        ) as mock_query,
         patch("backend.data.credit.get_user_by_id"),
     ):
         await set_subscription_tier("user-1", SubscriptionTier.PRO)
-        update_call = mock_prisma.return_value.update.await_args
-        assert update_call.kwargs["where"] == {"id": "user-1"}
-        assert update_call.kwargs["data"]["subscriptionTier"] == SubscriptionTier.PRO
+        query_args = mock_query.await_args.args
+        assert query_args[1] == "user-1"
+        assert query_args[2] == SubscriptionTier.PRO.value
 
 
 @pytest.mark.asyncio
 async def test_set_subscription_tier_downgrade():
     with (
         patch(
-            "backend.data.credit.User.prisma",
-            return_value=MagicMock(update=AsyncMock()),
+            "backend.data.credit.query_raw_with_schema",
+            new=AsyncMock(return_value=[{"previous_tier": "PRO"}]),
         ),
         patch("backend.data.credit.get_user_by_id"),
     ):
         # Downgrade to BASIC should not raise
         await set_subscription_tier("user-1", SubscriptionTier.BASIC)
+
+
+@pytest.mark.asyncio
+async def test_set_subscription_tier_pauses_automations_on_lapse():
+    with (
+        patch(
+            "backend.data.credit.query_raw_with_schema",
+            new=AsyncMock(return_value=[{"previous_tier": "PRO"}]),
+        ),
+        patch("backend.data.credit.get_user_by_id"),
+        patch(
+            "backend.data.credit.pause_automations_for_payment_lapse",
+            new=AsyncMock(),
+        ) as mock_pause,
+    ):
+        await set_subscription_tier("user-1", SubscriptionTier.NO_TIER)
+        mock_pause.assert_awaited_once_with("user-1")
 
 
 def _make_user(

--- a/autogpt_platform/backend/backend/data/credit_subscription_test.py
+++ b/autogpt_platform/backend/backend/data/credit_subscription_test.py
@@ -52,6 +52,10 @@ async def test_set_subscription_tier_updates_db():
             new=AsyncMock(return_value=[{"previous_tier": "PRO"}]),
         ) as mock_query,
         patch("backend.data.credit.get_user_by_id"),
+        patch(
+            "backend.data.automation_pause.has_payment_lapsed_automations",
+            new=AsyncMock(return_value=False),
+        ),
     ):
         await set_subscription_tier("user-1", SubscriptionTier.PRO)
         query_args = mock_query.await_args.args
@@ -67,6 +71,10 @@ async def test_set_subscription_tier_downgrade():
             new=AsyncMock(return_value=[{"previous_tier": "PRO"}]),
         ),
         patch("backend.data.credit.get_user_by_id"),
+        patch(
+            "backend.data.automation_pause.has_payment_lapsed_automations",
+            new=AsyncMock(return_value=False),
+        ),
     ):
         # Downgrade to BASIC should not raise
         await set_subscription_tier("user-1", SubscriptionTier.BASIC)
@@ -81,7 +89,7 @@ async def test_set_subscription_tier_pauses_automations_on_lapse():
         ),
         patch("backend.data.credit.get_user_by_id"),
         patch(
-            "backend.data.credit.pause_automations_for_payment_lapse",
+            "backend.data.automation_pause.pause_automations_for_payment_lapse",
             new=AsyncMock(),
         ) as mock_pause,
     ):

--- a/autogpt_platform/backend/backend/data/credit_tier_transition_test.py
+++ b/autogpt_platform/backend/backend/data/credit_tier_transition_test.py
@@ -1,5 +1,6 @@
 """Unit tests for automation pause/resume on subscription tier transitions."""
 
+from contextlib import contextmanager
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -7,17 +8,29 @@ from prisma.enums import SubscriptionTier
 
 from backend.data.credit import _handle_tier_transition_automations
 
-_MODULE = "backend.data.credit"
+# Patched on automation_pause (not credit): the transition hook imports these
+# locally from that module to avoid a circular import at load time.
+_MODULE = "backend.data.automation_pause"
 
 
-@pytest.mark.asyncio
-async def test_paid_to_no_tier_pauses_automations():
+@contextmanager
+def _mock_automation_ops(has_lapsed: bool = False):
     with (
         patch(f"{_MODULE}.pause_automations_for_payment_lapse", new=AsyncMock()) as p,
         patch(
             f"{_MODULE}.resume_automations_after_payment_restored", new=AsyncMock()
         ) as r,
+        patch(
+            f"{_MODULE}.has_payment_lapsed_automations",
+            new=AsyncMock(return_value=has_lapsed),
+        ) as h,
     ):
+        yield p, r, h
+
+
+@pytest.mark.asyncio
+async def test_paid_to_no_tier_pauses_automations():
+    with _mock_automation_ops() as (p, r, _):
         await _handle_tier_transition_automations(
             "user-1", SubscriptionTier.PRO, SubscriptionTier.NO_TIER
         )
@@ -27,14 +40,21 @@ async def test_paid_to_no_tier_pauses_automations():
 
 @pytest.mark.asyncio
 async def test_no_tier_to_paid_resumes_automations():
-    with (
-        patch(f"{_MODULE}.pause_automations_for_payment_lapse", new=AsyncMock()) as p,
-        patch(
-            f"{_MODULE}.resume_automations_after_payment_restored", new=AsyncMock()
-        ) as r,
-    ):
+    with _mock_automation_ops() as (p, r, _):
         await _handle_tier_transition_automations(
             "user-1", SubscriptionTier.NO_TIER, SubscriptionTier.BASIC
+        )
+    r.assert_awaited_once_with("user-1")
+    p.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_same_tier_paid_self_heals_when_automations_still_lapsed():
+    """A same-tier paid webhook retry re-attempts resume while payment-lapsed
+    automations remain, repairing a resume that partially failed earlier."""
+    with _mock_automation_ops(has_lapsed=True) as (p, r, _):
+        await _handle_tier_transition_automations(
+            "user-1", SubscriptionTier.PRO, SubscriptionTier.PRO
         )
     r.assert_awaited_once_with("user-1")
     p.assert_not_awaited()
@@ -51,12 +71,8 @@ async def test_no_tier_to_paid_resumes_automations():
     ],
 )
 async def test_other_transitions_do_nothing(previous, new):
-    with (
-        patch(f"{_MODULE}.pause_automations_for_payment_lapse", new=AsyncMock()) as p,
-        patch(
-            f"{_MODULE}.resume_automations_after_payment_restored", new=AsyncMock()
-        ) as r,
-    ):
+    # No payment-lapsed automations remain, so a same-tier paid retry is a no-op.
+    with _mock_automation_ops(has_lapsed=False) as (p, r, _):
         await _handle_tier_transition_automations("user-1", previous, new)
     p.assert_not_awaited()
     r.assert_not_awaited()
@@ -71,7 +87,16 @@ async def test_pause_failure_is_swallowed():
             new=AsyncMock(side_effect=RuntimeError("scheduler down")),
         ),
         patch(f"{_MODULE}.resume_automations_after_payment_restored", new=AsyncMock()),
+        patch(
+            f"{_MODULE}.has_payment_lapsed_automations",
+            new=AsyncMock(return_value=False),
+        ),
+        patch(
+            "backend.data.credit.discord_send_alert", new=AsyncMock()
+        ) as discord_alert,
     ):
         await _handle_tier_transition_automations(
             "user-1", SubscriptionTier.PRO, SubscriptionTier.NO_TIER
         )
+    # The except block's purpose is to page ops loudly, not just swallow.
+    discord_alert.assert_awaited_once()

--- a/autogpt_platform/backend/backend/data/credit_tier_transition_test.py
+++ b/autogpt_platform/backend/backend/data/credit_tier_transition_test.py
@@ -52,12 +52,14 @@ async def test_no_tier_to_paid_resumes_automations():
 async def test_same_tier_paid_self_heals_when_automations_still_lapsed():
     """A same-tier paid webhook retry re-attempts resume while payment-lapsed
     automations remain, repairing a resume that partially failed earlier."""
-    with _mock_automation_ops(has_lapsed=True) as (p, r, _):
+    with _mock_automation_ops(has_lapsed=True) as (p, r, h):
         await _handle_tier_transition_automations(
             "user-1", SubscriptionTier.PRO, SubscriptionTier.PRO
         )
     r.assert_awaited_once_with("user-1")
     p.assert_not_awaited()
+    # The self-heal must consult the lapse gate, not resume unconditionally.
+    h.assert_awaited_once_with("user-1")
 
 
 @pytest.mark.asyncio

--- a/autogpt_platform/backend/backend/data/credit_tier_transition_test.py
+++ b/autogpt_platform/backend/backend/data/credit_tier_transition_test.py
@@ -1,0 +1,77 @@
+"""Unit tests for automation pause/resume on subscription tier transitions."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from prisma.enums import SubscriptionTier
+
+from backend.data.credit import _handle_tier_transition_automations
+
+_MODULE = "backend.data.credit"
+
+
+@pytest.mark.asyncio
+async def test_paid_to_no_tier_pauses_automations():
+    with (
+        patch(f"{_MODULE}.pause_automations_for_payment_lapse", new=AsyncMock()) as p,
+        patch(
+            f"{_MODULE}.resume_automations_after_payment_restored", new=AsyncMock()
+        ) as r,
+    ):
+        await _handle_tier_transition_automations(
+            "user-1", SubscriptionTier.PRO, SubscriptionTier.NO_TIER
+        )
+    p.assert_awaited_once_with("user-1")
+    r.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_no_tier_to_paid_resumes_automations():
+    with (
+        patch(f"{_MODULE}.pause_automations_for_payment_lapse", new=AsyncMock()) as p,
+        patch(
+            f"{_MODULE}.resume_automations_after_payment_restored", new=AsyncMock()
+        ) as r,
+    ):
+        await _handle_tier_transition_automations(
+            "user-1", SubscriptionTier.NO_TIER, SubscriptionTier.BASIC
+        )
+    r.assert_awaited_once_with("user-1")
+    p.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "previous,new",
+    [
+        (SubscriptionTier.PRO, SubscriptionTier.BASIC),
+        (SubscriptionTier.PRO, SubscriptionTier.PRO),
+        (None, SubscriptionTier.NO_TIER),
+        (SubscriptionTier.NO_TIER, SubscriptionTier.NO_TIER),
+    ],
+)
+async def test_other_transitions_do_nothing(previous, new):
+    with (
+        patch(f"{_MODULE}.pause_automations_for_payment_lapse", new=AsyncMock()) as p,
+        patch(
+            f"{_MODULE}.resume_automations_after_payment_restored", new=AsyncMock()
+        ) as r,
+    ):
+        await _handle_tier_transition_automations("user-1", previous, new)
+    p.assert_not_awaited()
+    r.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_pause_failure_is_swallowed():
+    """A scheduler outage must not propagate into the Stripe webhook path."""
+    with (
+        patch(
+            f"{_MODULE}.pause_automations_for_payment_lapse",
+            new=AsyncMock(side_effect=RuntimeError("scheduler down")),
+        ),
+        patch(f"{_MODULE}.resume_automations_after_payment_restored", new=AsyncMock()),
+    ):
+        await _handle_tier_transition_automations(
+            "user-1", SubscriptionTier.PRO, SubscriptionTier.NO_TIER
+        )

--- a/autogpt_platform/backend/backend/data/notifications.py
+++ b/autogpt_platform/backend/backend/data/notifications.py
@@ -77,6 +77,17 @@ class LowBalanceData(BaseNotificationData):
     billing_page_link: str = Field(..., description="Link to billing page")
 
 
+class AutomationsPausedData(BaseNotificationData):
+    paused_schedules: int = Field(..., description="Number of schedules paused")
+    paused_triggers: int = Field(..., description="Number of triggers paused")
+    billing_page_link: str = Field(..., description="Link to billing page")
+
+
+class AutomationsResumedData(BaseNotificationData):
+    resumed_schedules: int = Field(..., description="Number of schedules resumed")
+    resumed_triggers: int = Field(..., description="Number of triggers resumed")
+
+
 class BlockExecutionFailedData(BaseNotificationData):
     block_name: str
     block_id: str
@@ -297,6 +308,8 @@ def get_notif_data_type(
         NotificationType.REFUND_PROCESSED: RefundRequestData,
         NotificationType.AGENT_APPROVED: AgentApprovalData,
         NotificationType.AGENT_REJECTED: AgentRejectionData,
+        NotificationType.AUTOMATIONS_PAUSED: AutomationsPausedData,
+        NotificationType.AUTOMATIONS_RESUMED: AutomationsResumedData,
     }[notification_type]
 
 
@@ -342,6 +355,8 @@ class NotificationTypeOverride:
             NotificationType.REFUND_PROCESSED: QueueType.ADMIN,
             NotificationType.AGENT_APPROVED: QueueType.IMMEDIATE,
             NotificationType.AGENT_REJECTED: QueueType.IMMEDIATE,
+            NotificationType.AUTOMATIONS_PAUSED: QueueType.IMMEDIATE,
+            NotificationType.AUTOMATIONS_RESUMED: QueueType.IMMEDIATE,
         }
         return BATCHING_RULES.get(self.notification_type, QueueType.IMMEDIATE)
 
@@ -361,6 +376,8 @@ class NotificationTypeOverride:
             NotificationType.REFUND_PROCESSED: "refund_processed.html",
             NotificationType.AGENT_APPROVED: "agent_approved.html",
             NotificationType.AGENT_REJECTED: "agent_rejected.html",
+            NotificationType.AUTOMATIONS_PAUSED: "automations_paused.html",
+            NotificationType.AUTOMATIONS_RESUMED: "automations_resumed.html",
         }[self.notification_type]
 
     @property
@@ -378,6 +395,8 @@ class NotificationTypeOverride:
             NotificationType.REFUND_PROCESSED: "Refund for ${{data.amount / 100}} to {{data.user_name}} has been processed",
             NotificationType.AGENT_APPROVED: "🎉 Your agent '{{data.agent_name}}' has been approved!",
             NotificationType.AGENT_REJECTED: "Your agent '{{data.agent_name}}' needs some updates",
+            NotificationType.AUTOMATIONS_PAUSED: "Your automations have been paused",
+            NotificationType.AUTOMATIONS_RESUMED: "Your automations are running again",
         }[self.notification_type]
 
 

--- a/autogpt_platform/backend/backend/data/user.py
+++ b/autogpt_platform/backend/backend/data/user.py
@@ -560,9 +560,14 @@ async def update_user_notification_preference(
             update_data["notifyOnAgentRejected"] = data.preferences[
                 NotificationType.AGENT_REJECTED
             ]
+        # PAUSED and RESUMED share one column; PAUSED wins if both are sent.
         if NotificationType.AUTOMATIONS_PAUSED in data.preferences:
             update_data["notifyOnAutomationsPaused"] = data.preferences[
                 NotificationType.AUTOMATIONS_PAUSED
+            ]
+        elif NotificationType.AUTOMATIONS_RESUMED in data.preferences:
+            update_data["notifyOnAutomationsPaused"] = data.preferences[
+                NotificationType.AUTOMATIONS_RESUMED
             ]
         if data.daily_limit:
             update_data["maxEmailsPerDay"] = data.daily_limit

--- a/autogpt_platform/backend/backend/data/user.py
+++ b/autogpt_platform/backend/backend/data/user.py
@@ -595,8 +595,9 @@ async def update_user_notification_preference(
             NotificationType.MONTHLY_SUMMARY: user.notifyOnMonthlySummary or True,
             NotificationType.AGENT_APPROVED: user.notifyOnAgentApproved or True,
             NotificationType.AGENT_REJECTED: user.notifyOnAgentRejected or True,
-            NotificationType.AUTOMATIONS_PAUSED: user.notifyOnAutomationsPaused,
-            NotificationType.AUTOMATIONS_RESUMED: user.notifyOnAutomationsPaused,
+            NotificationType.AUTOMATIONS_PAUSED: user.notifyOnAutomationsPaused or True,
+            NotificationType.AUTOMATIONS_RESUMED: user.notifyOnAutomationsPaused
+            or True,
         }
         notification_preference = NotificationPreference(
             user_id=user.id,

--- a/autogpt_platform/backend/backend/data/user.py
+++ b/autogpt_platform/backend/backend/data/user.py
@@ -590,9 +590,8 @@ async def update_user_notification_preference(
             NotificationType.MONTHLY_SUMMARY: user.notifyOnMonthlySummary or True,
             NotificationType.AGENT_APPROVED: user.notifyOnAgentApproved or True,
             NotificationType.AGENT_REJECTED: user.notifyOnAgentRejected or True,
-            NotificationType.AUTOMATIONS_PAUSED: user.notifyOnAutomationsPaused or True,
-            NotificationType.AUTOMATIONS_RESUMED: user.notifyOnAutomationsPaused
-            or True,
+            NotificationType.AUTOMATIONS_PAUSED: user.notifyOnAutomationsPaused,
+            NotificationType.AUTOMATIONS_RESUMED: user.notifyOnAutomationsPaused,
         }
         notification_preference = NotificationPreference(
             user_id=user.id,

--- a/autogpt_platform/backend/backend/data/user.py
+++ b/autogpt_platform/backend/backend/data/user.py
@@ -490,6 +490,10 @@ async def get_user_notification_preference(user_id: str) -> NotificationPreferen
             NotificationType.MONTHLY_SUMMARY: user.notifyOnMonthlySummary or False,
             NotificationType.AGENT_APPROVED: user.notifyOnAgentApproved or False,
             NotificationType.AGENT_REJECTED: user.notifyOnAgentRejected or False,
+            NotificationType.AUTOMATIONS_PAUSED: user.notifyOnAutomationsPaused
+            or False,
+            NotificationType.AUTOMATIONS_RESUMED: user.notifyOnAutomationsPaused
+            or False,
         }
         daily_limit = user.maxEmailsPerDay or 3
         notification_preference = NotificationPreference(
@@ -556,6 +560,10 @@ async def update_user_notification_preference(
             update_data["notifyOnAgentRejected"] = data.preferences[
                 NotificationType.AGENT_REJECTED
             ]
+        if NotificationType.AUTOMATIONS_PAUSED in data.preferences:
+            update_data["notifyOnAutomationsPaused"] = data.preferences[
+                NotificationType.AUTOMATIONS_PAUSED
+            ]
         if data.daily_limit:
             update_data["maxEmailsPerDay"] = data.daily_limit
 
@@ -582,6 +590,9 @@ async def update_user_notification_preference(
             NotificationType.MONTHLY_SUMMARY: user.notifyOnMonthlySummary or True,
             NotificationType.AGENT_APPROVED: user.notifyOnAgentApproved or True,
             NotificationType.AGENT_REJECTED: user.notifyOnAgentRejected or True,
+            NotificationType.AUTOMATIONS_PAUSED: user.notifyOnAutomationsPaused or True,
+            NotificationType.AUTOMATIONS_RESUMED: user.notifyOnAutomationsPaused
+            or True,
         }
         notification_preference = NotificationPreference(
             user_id=user.id,
@@ -634,6 +645,7 @@ async def disable_all_user_notifications(user_id: str) -> None:
                 "notifyOnMonthlySummary": False,
                 "notifyOnAgentApproved": False,
                 "notifyOnAgentRejected": False,
+                "notifyOnAutomationsPaused": False,
             },
         )
         # Invalidate cache for this user

--- a/autogpt_platform/backend/backend/executor/scheduler.py
+++ b/autogpt_platform/backend/backend/executor/scheduler.py
@@ -1767,13 +1767,7 @@ class Scheduler(AppService):
                 continue
             if args.user_id != user_id:
                 continue
-            # When the personal org couldn't be resolved, fall back to userId
-            # only rather than excluding every org-tagged (dual-write) job.
-            if (
-                personal_org_id is not None
-                and args.organization_id
-                and args.organization_id != personal_org_id
-            ):
+            if args.organization_id and args.organization_id != personal_org_id:
                 continue
             jobs.append((job, args))
         return jobs

--- a/autogpt_platform/backend/backend/executor/scheduler.py
+++ b/autogpt_platform/backend/backend/executor/scheduler.py
@@ -1767,7 +1767,13 @@ class Scheduler(AppService):
                 continue
             if args.user_id != user_id:
                 continue
-            if args.organization_id and args.organization_id != personal_org_id:
+            # When the personal org couldn't be resolved, fall back to userId
+            # only rather than excluding every org-tagged (dual-write) job.
+            if (
+                personal_org_id is not None
+                and args.organization_id
+                and args.organization_id != personal_org_id
+            ):
                 continue
             jobs.append((job, args))
         return jobs

--- a/autogpt_platform/backend/backend/executor/scheduler.py
+++ b/autogpt_platform/backend/backend/executor/scheduler.py
@@ -1802,11 +1802,18 @@ class Scheduler(AppService):
         already_stamped = args.paused_reason == reason
         if not already_stamped:
             args.paused_reason = reason
-            self.scheduler.modify_job(
-                job.id,
-                jobstore=Jobstores.EXECUTION.value,
-                kwargs=args.model_dump(mode="json"),
-            )
+            try:
+                self.scheduler.modify_job(
+                    job.id,
+                    jobstore=Jobstores.EXECUTION.value,
+                    kwargs=args.model_dump(mode="json"),
+                )
+            except Exception:
+                # Guard like pause_job below: a transient jobstore error on the
+                # stamp write must not abort the whole batch — skip this job so
+                # the remaining eligible schedules are still attempted.
+                logger.exception(f"Failed to stamp pause reason on {job.id}")
+                return False
         try:
             self.scheduler.pause_job(job.id, jobstore=Jobstores.EXECUTION.value)
         except Exception:

--- a/autogpt_platform/backend/backend/executor/scheduler.py
+++ b/autogpt_platform/backend/backend/executor/scheduler.py
@@ -1752,9 +1752,11 @@ class Scheduler(AppService):
         return info
 
     def _user_graph_schedule_jobs(
-        self, user_id: str
+        self, user_id: str, personal_org_id: str | None
     ) -> list[tuple[JobObj, GraphExecutionJobArgs]]:
-        """Personal graph-kind jobs of *user_id* (org-tagged jobs excluded)."""
+        """The user's graph-kind jobs that are personally funded: untagged or
+        tagged with the user's own personal org. Team/external-org jobs are
+        excluded — those are funded by the org, not this user's subscription."""
         jobs: list[tuple[JobObj, GraphExecutionJobArgs]] = []
         for job in self.scheduler.get_jobs(jobstore=Jobstores.EXECUTION.value):
             if job.kwargs.get("kind", "graph") != "graph":
@@ -1763,19 +1765,23 @@ class Scheduler(AppService):
                 args = GraphExecutionJobArgs.model_validate(job.kwargs)
             except ValidationError:
                 continue
-            if args.user_id != user_id or args.organization_id:
+            if args.user_id != user_id:
+                continue
+            if args.organization_id and args.organization_id != personal_org_id:
                 continue
             jobs.append((job, args))
         return jobs
 
     @expose
-    def pause_user_graph_schedules(self, user_id: str, reason: str) -> int:
+    def pause_user_graph_schedules(
+        self, user_id: str, reason: str, personal_org_id: str | None = None
+    ) -> int:
         """Pause the user's graph schedules with *reason*; returns count paused.
 
         Schedules already carrying a ``paused_reason`` are left untouched.
         """
         paused = 0
-        for job, args in self._user_graph_schedule_jobs(user_id):
+        for job, args in self._user_graph_schedule_jobs(user_id, personal_org_id):
             if args.paused_reason is not None:
                 continue
             args.paused_reason = reason
@@ -1784,7 +1790,19 @@ class Scheduler(AppService):
                 jobstore=Jobstores.EXECUTION.value,
                 kwargs=args.model_dump(mode="json"),
             )
-            self.scheduler.pause_job(job.id, jobstore=Jobstores.EXECUTION.value)
+            try:
+                self.scheduler.pause_job(job.id, jobstore=Jobstores.EXECUTION.value)
+            except Exception:
+                # Roll back the reason stamp so a retry still matches this job;
+                # otherwise it would run forever while looking paused.
+                args.paused_reason = None
+                self.scheduler.modify_job(
+                    job.id,
+                    jobstore=Jobstores.EXECUTION.value,
+                    kwargs=args.model_dump(mode="json"),
+                )
+                logger.exception(f"Failed to pause schedule {job.id}")
+                continue
             paused += 1
         if paused:
             logger.info(
@@ -1795,11 +1813,21 @@ class Scheduler(AppService):
         return paused
 
     @expose
-    def resume_user_graph_schedules(self, user_id: str, reason: str) -> int:
+    def resume_user_graph_schedules(
+        self, user_id: str, reason: str, personal_org_id: str | None = None
+    ) -> int:
         """Resume schedules paused for *reason* only; returns count resumed."""
         resumed = 0
-        for job, args in self._user_graph_schedule_jobs(user_id):
+        for job, args in self._user_graph_schedule_jobs(user_id, personal_org_id):
             if args.paused_reason != reason:
+                continue
+            # Resume before clearing the reason: if the clear fails the job is
+            # running but still marked, and a retry resumes+clears it again;
+            # the reverse order could strand an invisible paused job.
+            try:
+                self.scheduler.resume_job(job.id, jobstore=Jobstores.EXECUTION.value)
+            except Exception:
+                logger.exception(f"Failed to resume schedule {job.id}")
                 continue
             args.paused_reason = None
             self.scheduler.modify_job(
@@ -1807,7 +1835,6 @@ class Scheduler(AppService):
                 jobstore=Jobstores.EXECUTION.value,
                 kwargs=args.model_dump(mode="json"),
             )
-            self.scheduler.resume_job(job.id, jobstore=Jobstores.EXECUTION.value)
             resumed += 1
         if resumed:
             logger.info(

--- a/autogpt_platform/backend/backend/executor/scheduler.py
+++ b/autogpt_platform/backend/backend/executor/scheduler.py
@@ -1778,32 +1778,16 @@ class Scheduler(AppService):
     ) -> int:
         """Pause the user's graph schedules with *reason*; returns count paused.
 
-        Schedules already carrying a ``paused_reason`` are left untouched.
+        Schedules paused for a different reason are left untouched.
         """
         paused = 0
         for job, args in self._user_graph_schedule_jobs(user_id, personal_org_id):
-            if args.paused_reason is not None:
+            if args.paused_reason is not None and args.paused_reason != reason:
                 continue
-            args.paused_reason = reason
-            self.scheduler.modify_job(
-                job.id,
-                jobstore=Jobstores.EXECUTION.value,
-                kwargs=args.model_dump(mode="json"),
-            )
-            try:
-                self.scheduler.pause_job(job.id, jobstore=Jobstores.EXECUTION.value)
-            except Exception:
-                # Roll back the reason stamp so a retry still matches this job;
-                # otherwise it would run forever while looking paused.
-                args.paused_reason = None
-                self.scheduler.modify_job(
-                    job.id,
-                    jobstore=Jobstores.EXECUTION.value,
-                    kwargs=args.model_dump(mode="json"),
-                )
-                logger.exception(f"Failed to pause schedule {job.id}")
-                continue
-            paused += 1
+            if args.paused_reason == reason and job.next_run_time is None:
+                continue  # already fully paused
+            if self._pause_one_graph_schedule(job, args, reason):
+                paused += 1
         if paused:
             logger.info(
                 f"Paused {paused} graph schedule(s) for user {user_id} "
@@ -1811,6 +1795,36 @@ class Scheduler(AppService):
             )
             self._invalidate_jobs_cache()
         return paused
+
+    def _pause_one_graph_schedule(
+        self, job: JobObj, args: GraphExecutionJobArgs, reason: str
+    ) -> bool:
+        already_stamped = args.paused_reason == reason
+        if not already_stamped:
+            args.paused_reason = reason
+            self.scheduler.modify_job(
+                job.id,
+                jobstore=Jobstores.EXECUTION.value,
+                kwargs=args.model_dump(mode="json"),
+            )
+        try:
+            self.scheduler.pause_job(job.id, jobstore=Jobstores.EXECUTION.value)
+        except Exception:
+            logger.exception(f"Failed to pause schedule {job.id}")
+            if not already_stamped:
+                # Roll back the reason stamp so a retry still matches this job;
+                # otherwise it would run forever while looking paused.
+                try:
+                    args.paused_reason = None
+                    self.scheduler.modify_job(
+                        job.id,
+                        jobstore=Jobstores.EXECUTION.value,
+                        kwargs=args.model_dump(mode="json"),
+                    )
+                except Exception:
+                    logger.exception(f"Failed to roll back pause stamp on {job.id}")
+            return False
+        return True
 
     @expose
     def resume_user_graph_schedules(
@@ -1826,15 +1840,15 @@ class Scheduler(AppService):
             # the reverse order could strand an invisible paused job.
             try:
                 self.scheduler.resume_job(job.id, jobstore=Jobstores.EXECUTION.value)
+                args.paused_reason = None
+                self.scheduler.modify_job(
+                    job.id,
+                    jobstore=Jobstores.EXECUTION.value,
+                    kwargs=args.model_dump(mode="json"),
+                )
             except Exception:
                 logger.exception(f"Failed to resume schedule {job.id}")
                 continue
-            args.paused_reason = None
-            self.scheduler.modify_job(
-                job.id,
-                jobstore=Jobstores.EXECUTION.value,
-                kwargs=args.model_dump(mode="json"),
-            )
             resumed += 1
         if resumed:
             logger.info(

--- a/autogpt_platform/backend/backend/executor/scheduler.py
+++ b/autogpt_platform/backend/backend/executor/scheduler.py
@@ -1100,6 +1100,9 @@ class GraphExecutionJobArgs(BaseModel):
     input_credentials: dict[str, CredentialsMetaInput] = Field(default_factory=dict)
     organization_id: str = ""
     team_id: str | None = None
+    # Why the system paused this schedule (e.g. "payment_lapsed"); None when
+    # running. Only schedules paused for a given reason are resumed by it.
+    paused_reason: str | None = None
 
 
 class CopilotTurnJobArgs(BaseModel):
@@ -1162,13 +1165,17 @@ class GraphExecutionJobInfo(GraphExecutionJobArgs):
     name: str
     next_run_time: str
     timezone: str = Field(default="UTC", description="Timezone used for scheduling")
+    is_paused: bool = False
 
     @staticmethod
     def from_db(
         job_args: GraphExecutionJobArgs, job_obj: JobObj
     ) -> "GraphExecutionJobInfo":
         return GraphExecutionJobInfo(
-            **_job_info_fields(job_obj), **job_args.model_dump()
+            **_job_info_fields(job_obj),
+            **job_args.model_dump(),
+            # Cron jobs only lack a next fire time when APScheduler paused them.
+            is_paused=job_obj.next_run_time is None,
         )
 
 
@@ -1744,6 +1751,72 @@ class Scheduler(AppService):
         self._invalidate_jobs_cache()
         return info
 
+    def _user_graph_schedule_jobs(
+        self, user_id: str
+    ) -> list[tuple[JobObj, GraphExecutionJobArgs]]:
+        """Personal graph-kind jobs of *user_id* (org-tagged jobs excluded)."""
+        jobs: list[tuple[JobObj, GraphExecutionJobArgs]] = []
+        for job in self.scheduler.get_jobs(jobstore=Jobstores.EXECUTION.value):
+            if job.kwargs.get("kind", "graph") != "graph":
+                continue
+            try:
+                args = GraphExecutionJobArgs.model_validate(job.kwargs)
+            except ValidationError:
+                continue
+            if args.user_id != user_id or args.organization_id:
+                continue
+            jobs.append((job, args))
+        return jobs
+
+    @expose
+    def pause_user_graph_schedules(self, user_id: str, reason: str) -> int:
+        """Pause the user's graph schedules with *reason*; returns count paused.
+
+        Schedules already carrying a ``paused_reason`` are left untouched.
+        """
+        paused = 0
+        for job, args in self._user_graph_schedule_jobs(user_id):
+            if args.paused_reason is not None:
+                continue
+            args.paused_reason = reason
+            self.scheduler.modify_job(
+                job.id,
+                jobstore=Jobstores.EXECUTION.value,
+                kwargs=args.model_dump(mode="json"),
+            )
+            self.scheduler.pause_job(job.id, jobstore=Jobstores.EXECUTION.value)
+            paused += 1
+        if paused:
+            logger.info(
+                f"Paused {paused} graph schedule(s) for user {user_id} "
+                f"(reason={reason})"
+            )
+            self._invalidate_jobs_cache()
+        return paused
+
+    @expose
+    def resume_user_graph_schedules(self, user_id: str, reason: str) -> int:
+        """Resume schedules paused for *reason* only; returns count resumed."""
+        resumed = 0
+        for job, args in self._user_graph_schedule_jobs(user_id):
+            if args.paused_reason != reason:
+                continue
+            args.paused_reason = None
+            self.scheduler.modify_job(
+                job.id,
+                jobstore=Jobstores.EXECUTION.value,
+                kwargs=args.model_dump(mode="json"),
+            )
+            self.scheduler.resume_job(job.id, jobstore=Jobstores.EXECUTION.value)
+            resumed += 1
+        if resumed:
+            logger.info(
+                f"Resumed {resumed} graph schedule(s) for user {user_id} "
+                f"(reason={reason})"
+            )
+            self._invalidate_jobs_cache()
+        return resumed
+
     @expose
     def get_graph_execution_schedules(
         self,
@@ -1846,8 +1919,14 @@ class Scheduler(AppService):
         jobs: list[JobObj] = self._get_jobs_cached()
         results: list[Union[GraphExecutionJobInfo, CopilotTurnJobInfo]] = []
         for job in jobs:
-            info = _job_to_info(job) if job.next_run_time is not None else None
+            info = _job_to_info(job)
             if info is None:
+                continue
+            if job.next_run_time is None and not (
+                isinstance(info, GraphExecutionJobInfo) and info.paused_reason
+            ):
+                # Skip already-fired one-shot jobs, but keep system-paused
+                # schedules visible so they don't look deleted to the user.
                 continue
             if kind is not None and info.kind != kind:
                 continue
@@ -2201,6 +2280,10 @@ class SchedulerClient(AppServiceClient):
     add_execution_schedule = endpoint_to_async(Scheduler.add_graph_execution_schedule)
     add_copilot_turn_schedule = endpoint_to_async(Scheduler.add_copilot_turn_schedule)
     delete_schedule = endpoint_to_async(Scheduler.delete_graph_execution_schedule)
+    pause_user_graph_schedules = endpoint_to_async(Scheduler.pause_user_graph_schedules)
+    resume_user_graph_schedules = endpoint_to_async(
+        Scheduler.resume_user_graph_schedules
+    )
     # Graph-only typed list — for legacy callers that need GraphExecutionJobInfo.
     get_graph_execution_schedules = endpoint_to_async(
         Scheduler.get_graph_execution_schedules

--- a/autogpt_platform/backend/backend/executor/scheduler_unit_test.py
+++ b/autogpt_platform/backend/backend/executor/scheduler_unit_test.py
@@ -638,3 +638,100 @@ class TestScheduleOrgVisibility:
         ]
         result = self._run(infos, user_id="me")
         assert [r.schedule_id for r in result] == ["mine"]
+
+
+# ---------------------------------------------------------------------------
+# pause/resume_user_graph_schedules
+# ---------------------------------------------------------------------------
+
+
+def _graph_job_kwargs(
+    user_id="u1", organization_id="", paused_reason=None, schedule_id="s1"
+):
+    return {
+        "kind": "graph",
+        "schedule_id": schedule_id,
+        "user_id": user_id,
+        "graph_id": "g1",
+        "graph_version": 1,
+        "cron": "* * * * *",
+        "input_data": {},
+        "input_credentials": {},
+        "organization_id": organization_id,
+        "paused_reason": paused_reason,
+    }
+
+
+class TestPauseResumeUserGraphSchedules:
+    def _scheduler(self, jobs):
+        sched = Scheduler.__new__(Scheduler)
+        aps = MagicMock()
+        aps.get_jobs.return_value = jobs
+        object.__setattr__(sched, "scheduler", aps)
+        return sched, aps
+
+    def test_pause_stamps_reason_and_pauses_jobs(self):
+        job = _mock_job(_graph_job_kwargs())
+        sched, aps = self._scheduler([job])
+        with patch.object(Scheduler, "_invalidate_jobs_cache", MagicMock()):
+            count = sched.pause_user_graph_schedules("u1", "payment_lapsed")
+        assert count == 1
+        modify_kwargs = aps.modify_job.call_args.kwargs["kwargs"]
+        assert modify_kwargs["paused_reason"] == "payment_lapsed"
+        aps.pause_job.assert_called_once()
+
+    def test_pause_skips_other_users_org_jobs_and_already_paused(self):
+        jobs = [
+            _mock_job(_graph_job_kwargs(user_id="other", schedule_id="s2")),
+            _mock_job(_graph_job_kwargs(organization_id="org-1", schedule_id="s3")),
+            _mock_job(
+                _graph_job_kwargs(paused_reason="payment_lapsed", schedule_id="s4")
+            ),
+        ]
+        sched, aps = self._scheduler(jobs)
+        with patch.object(Scheduler, "_invalidate_jobs_cache", MagicMock()):
+            count = sched.pause_user_graph_schedules("u1", "payment_lapsed")
+        assert count == 0
+        aps.pause_job.assert_not_called()
+
+    def test_resume_only_matching_reason(self):
+        jobs = [
+            _mock_job(
+                _graph_job_kwargs(paused_reason="payment_lapsed", schedule_id="s1")
+            ),
+            _mock_job(_graph_job_kwargs(schedule_id="s2")),
+            _mock_job(
+                _graph_job_kwargs(paused_reason="other_reason", schedule_id="s3")
+            ),
+        ]
+        sched, aps = self._scheduler(jobs)
+        with patch.object(Scheduler, "_invalidate_jobs_cache", MagicMock()):
+            count = sched.resume_user_graph_schedules("u1", "payment_lapsed")
+        assert count == 1
+        modify_kwargs = aps.modify_job.call_args.kwargs["kwargs"]
+        assert modify_kwargs["paused_reason"] is None
+        aps.resume_job.assert_called_once()
+
+    def test_paused_schedule_still_listed_with_is_paused(self):
+        job = _mock_job(_graph_job_kwargs(paused_reason="payment_lapsed"))
+        job.next_run_time = None
+        fired_one_shot = _mock_job(
+            {
+                "kind": "copilot_turn",
+                "schedule_id": "c1",
+                "user_id": "u1",
+                "session_id": "sess",
+                "message": "m",
+                "run_at": "2026-05-22T10:00:00+00:00",
+            }
+        )
+        fired_one_shot.next_run_time = None
+        sched = Scheduler.__new__(Scheduler)
+        with patch.object(
+            Scheduler, "_get_jobs_cached", lambda self: [job, fired_one_shot]
+        ):
+            result = sched.get_execution_schedules(user_id="u1")
+        assert [r.schedule_id for r in result] == ["s1"]
+        assert isinstance(result[0], GraphExecutionJobInfo)
+        assert result[0].is_paused is True
+        assert result[0].paused_reason == "payment_lapsed"

--- a/autogpt_platform/backend/backend/executor/scheduler_unit_test.py
+++ b/autogpt_platform/backend/backend/executor/scheduler_unit_test.py
@@ -695,9 +695,24 @@ class TestPauseResumeUserGraphSchedules:
         ]
         sched, aps = self._scheduler(jobs)
         with patch.object(Scheduler, "_invalidate_jobs_cache", MagicMock()):
-            count = sched.pause_user_graph_schedules("u1", "payment_lapsed")
+            # A resolved personal org excludes the org-1-tagged job (s3).
+            count = sched.pause_user_graph_schedules(
+                "u1", "payment_lapsed", personal_org_id="u1-org"
+            )
         assert count == 0
         aps.pause_job.assert_not_called()
+
+    def test_pause_without_personal_org_includes_org_tagged_jobs(self):
+        """When the personal org can't be resolved, fall back to userId-only
+        rather than excluding every org-tagged (dual-write) job."""
+        job = _mock_job(_graph_job_kwargs(organization_id="org-1", schedule_id="s1"))
+        sched, aps = self._scheduler([job])
+        with patch.object(Scheduler, "_invalidate_jobs_cache", MagicMock()):
+            count = sched.pause_user_graph_schedules(
+                "u1", "payment_lapsed", personal_org_id=None
+            )
+        assert count == 1
+        aps.pause_job.assert_called_once()
 
     def test_pause_heals_stamped_but_still_running_job(self):
         """A crash between the reason stamp and pause_job leaves a running job

--- a/autogpt_platform/backend/backend/executor/scheduler_unit_test.py
+++ b/autogpt_platform/backend/backend/executor/scheduler_unit_test.py
@@ -681,18 +681,36 @@ class TestPauseResumeUserGraphSchedules:
         aps.pause_job.assert_called_once()
 
     def test_pause_skips_other_users_org_jobs_and_already_paused(self):
+        already_paused = _mock_job(
+            _graph_job_kwargs(paused_reason="payment_lapsed", schedule_id="s4")
+        )
+        already_paused.next_run_time = None
         jobs = [
             _mock_job(_graph_job_kwargs(user_id="other", schedule_id="s2")),
             _mock_job(_graph_job_kwargs(organization_id="org-1", schedule_id="s3")),
             _mock_job(
-                _graph_job_kwargs(paused_reason="payment_lapsed", schedule_id="s4")
+                _graph_job_kwargs(paused_reason="other_reason", schedule_id="s5")
             ),
+            already_paused,
         ]
         sched, aps = self._scheduler(jobs)
         with patch.object(Scheduler, "_invalidate_jobs_cache", MagicMock()):
             count = sched.pause_user_graph_schedules("u1", "payment_lapsed")
         assert count == 0
         aps.pause_job.assert_not_called()
+
+    def test_pause_heals_stamped_but_still_running_job(self):
+        """A crash between the reason stamp and pause_job leaves a running job
+        that already carries the reason; a retry must still pause it."""
+        job = _mock_job(
+            _graph_job_kwargs(paused_reason="payment_lapsed", schedule_id="s1")
+        )
+        sched, aps = self._scheduler([job])
+        with patch.object(Scheduler, "_invalidate_jobs_cache", MagicMock()):
+            count = sched.pause_user_graph_schedules("u1", "payment_lapsed")
+        assert count == 1
+        aps.pause_job.assert_called_once()
+        aps.modify_job.assert_not_called()
 
     def test_pause_includes_personal_org_tagged_jobs(self):
         jobs = [

--- a/autogpt_platform/backend/backend/executor/scheduler_unit_test.py
+++ b/autogpt_platform/backend/backend/executor/scheduler_unit_test.py
@@ -694,6 +694,53 @@ class TestPauseResumeUserGraphSchedules:
         assert count == 0
         aps.pause_job.assert_not_called()
 
+    def test_pause_includes_personal_org_tagged_jobs(self):
+        jobs = [
+            _mock_job(
+                _graph_job_kwargs(organization_id="personal-org", schedule_id="s1")
+            ),
+            _mock_job(_graph_job_kwargs(organization_id="team-org", schedule_id="s2")),
+        ]
+        sched, aps = self._scheduler(jobs)
+        with patch.object(Scheduler, "_invalidate_jobs_cache", MagicMock()):
+            count = sched.pause_user_graph_schedules(
+                "u1", "payment_lapsed", personal_org_id="personal-org"
+            )
+        assert count == 1
+        assert aps.pause_job.call_count == 1
+
+    def test_pause_rolls_back_reason_stamp_when_pause_job_fails(self):
+        job = _mock_job(_graph_job_kwargs())
+        sched, aps = self._scheduler([job])
+        aps.pause_job.side_effect = RuntimeError("jobstore down")
+        with patch.object(Scheduler, "_invalidate_jobs_cache", MagicMock()):
+            count = sched.pause_user_graph_schedules("u1", "payment_lapsed")
+        assert count == 0
+        assert aps.modify_job.call_count == 2
+        rollback_kwargs = aps.modify_job.call_args.kwargs["kwargs"]
+        assert rollback_kwargs["paused_reason"] is None
+
+    def test_resume_resumes_before_clearing_reason(self):
+        job = _mock_job(
+            _graph_job_kwargs(paused_reason="payment_lapsed", schedule_id="s1")
+        )
+        sched, aps = self._scheduler([job])
+        with patch.object(Scheduler, "_invalidate_jobs_cache", MagicMock()):
+            sched.resume_user_graph_schedules("u1", "payment_lapsed")
+        calls = [c[0] for c in aps.method_calls]
+        assert calls.index("resume_job") < calls.index("modify_job")
+
+    def test_resume_failure_keeps_reason_for_retry(self):
+        job = _mock_job(
+            _graph_job_kwargs(paused_reason="payment_lapsed", schedule_id="s1")
+        )
+        sched, aps = self._scheduler([job])
+        aps.resume_job.side_effect = RuntimeError("jobstore down")
+        with patch.object(Scheduler, "_invalidate_jobs_cache", MagicMock()):
+            count = sched.resume_user_graph_schedules("u1", "payment_lapsed")
+        assert count == 0
+        aps.modify_job.assert_not_called()
+
     def test_resume_only_matching_reason(self):
         jobs = [
             _mock_job(

--- a/autogpt_platform/backend/backend/executor/scheduler_unit_test.py
+++ b/autogpt_platform/backend/backend/executor/scheduler_unit_test.py
@@ -738,6 +738,20 @@ class TestPauseResumeUserGraphSchedules:
         rollback_kwargs = aps.modify_job.call_args.kwargs["kwargs"]
         assert rollback_kwargs["paused_reason"] is None
 
+    def test_pause_stamp_write_failure_does_not_abort_batch(self):
+        # First job's reason-stamp write raises; the loop must still attempt the
+        # remaining eligible schedules instead of propagating out mid-batch.
+        jobs = [
+            _mock_job(_graph_job_kwargs(schedule_id="s1")),
+            _mock_job(_graph_job_kwargs(schedule_id="s2")),
+        ]
+        sched, aps = self._scheduler(jobs)
+        aps.modify_job.side_effect = [RuntimeError("jobstore down"), None]
+        with patch.object(Scheduler, "_invalidate_jobs_cache", MagicMock()):
+            count = sched.pause_user_graph_schedules("u1", "payment_lapsed")
+        assert count == 1
+        assert aps.pause_job.call_count == 1
+
     def test_resume_resumes_before_clearing_reason(self):
         job = _mock_job(
             _graph_job_kwargs(paused_reason="payment_lapsed", schedule_id="s1")

--- a/autogpt_platform/backend/backend/executor/scheduler_unit_test.py
+++ b/autogpt_platform/backend/backend/executor/scheduler_unit_test.py
@@ -702,18 +702,6 @@ class TestPauseResumeUserGraphSchedules:
         assert count == 0
         aps.pause_job.assert_not_called()
 
-    def test_pause_without_personal_org_includes_org_tagged_jobs(self):
-        """When the personal org can't be resolved, fall back to userId-only
-        rather than excluding every org-tagged (dual-write) job."""
-        job = _mock_job(_graph_job_kwargs(organization_id="org-1", schedule_id="s1"))
-        sched, aps = self._scheduler([job])
-        with patch.object(Scheduler, "_invalidate_jobs_cache", MagicMock()):
-            count = sched.pause_user_graph_schedules(
-                "u1", "payment_lapsed", personal_org_id=None
-            )
-        assert count == 1
-        aps.pause_job.assert_called_once()
-
     def test_pause_heals_stamped_but_still_running_job(self):
         """A crash between the reason stamp and pause_job leaves a running job
         that already carries the reason; a retry must still pause it."""

--- a/autogpt_platform/backend/backend/notifications/templates/automations_paused.html.jinja2
+++ b/autogpt_platform/backend/backend/notifications/templates/automations_paused.html.jinja2
@@ -1,0 +1,88 @@
+{# Automations Paused Notification Email Template #}
+{# Template variables:
+data.paused_schedules: number of scheduled runs paused
+data.paused_triggers: number of triggers paused
+data.billing_page_link: the link to the billing page
+#}
+
+<p style="
+    font-family: 'Poppins', sans-serif;
+    color: #070629;
+    font-size: 16px;
+    line-height: 165%;
+    margin-top: 0;
+    margin-bottom: 10px;
+  ">
+  <strong>Your automations have been paused</strong>
+</p>
+
+<p style="
+    font-family: 'Poppins', sans-serif;
+    color: #070629;
+    font-size: 16px;
+    line-height: 165%;
+    margin-top: 0;
+    margin-bottom: 20px;
+  ">
+  We couldn't confirm an active subscription on your account, so your scheduled
+  agent runs and triggers have been paused. Nothing was deleted &mdash; everything
+  will resume automatically as soon as your subscription is active again.
+</p>
+
+<div style="
+    margin-left: 15px;
+    margin-bottom: 20px;
+    padding: 15px;
+    border-left: 4px solid #5D23BB;
+    background-color: #f8f8ff;
+  ">
+  <p style="
+    font-family: 'Poppins', sans-serif;
+    color: #070629;
+    font-size: 16px;
+    margin-top: 0;
+    margin-bottom: 10px;
+  ">
+    <strong>Paused schedules:</strong> {{ data.paused_schedules }}
+  </p>
+  <p style="
+    font-family: 'Poppins', sans-serif;
+    color: #070629;
+    font-size: 16px;
+    margin-top: 0;
+    margin-bottom: 10px;
+  ">
+    <strong>Paused triggers:</strong> {{ data.paused_triggers }}
+  </p>
+</div>
+
+<div style="
+    text-align: center;
+    margin: 30px 0;
+  ">
+  <a href="{{ data.billing_page_link }}" style="
+    font-family: 'Poppins', sans-serif;
+    background-color: #5D23BB;
+    color: white;
+    padding: 12px 24px;
+    text-decoration: none;
+    border-radius: 4px;
+    font-weight: 500;
+    display: inline-block;
+  ">
+    Manage Billing
+  </a>
+</div>
+
+<p style="
+    font-family: 'Poppins', sans-serif;
+    color: #070629;
+    font-size: 16px;
+    line-height: 150%;
+    margin-top: 30px;
+    margin-bottom: 10px;
+    font-style: italic;
+  ">
+  This is an automated notification. Any automations you paused yourself will
+  stay paused until you turn them back on.
+</p>

--- a/autogpt_platform/backend/backend/notifications/templates/automations_resumed.html.jinja2
+++ b/autogpt_platform/backend/backend/notifications/templates/automations_resumed.html.jinja2
@@ -24,7 +24,8 @@ data.resumed_triggers: number of triggers resumed
     margin-bottom: 20px;
   ">
   Thanks for updating your subscription! The scheduled agent runs and triggers
-  that were paused while your payment lapsed have been resumed automatically.
+  that were paused while your subscription was inactive have been resumed
+  automatically.
 </p>
 
 <div style="

--- a/autogpt_platform/backend/backend/notifications/templates/automations_resumed.html.jinja2
+++ b/autogpt_platform/backend/backend/notifications/templates/automations_resumed.html.jinja2
@@ -1,0 +1,68 @@
+{# Automations Resumed Notification Email Template #}
+{# Template variables:
+data.resumed_schedules: number of scheduled runs resumed
+data.resumed_triggers: number of triggers resumed
+#}
+
+<p style="
+    font-family: 'Poppins', sans-serif;
+    color: #070629;
+    font-size: 16px;
+    line-height: 165%;
+    margin-top: 0;
+    margin-bottom: 10px;
+  ">
+  <strong>Your automations are running again</strong>
+</p>
+
+<p style="
+    font-family: 'Poppins', sans-serif;
+    color: #070629;
+    font-size: 16px;
+    line-height: 165%;
+    margin-top: 0;
+    margin-bottom: 20px;
+  ">
+  Thanks for updating your subscription! The scheduled agent runs and triggers
+  that were paused while your payment lapsed have been resumed automatically.
+</p>
+
+<div style="
+    margin-left: 15px;
+    margin-bottom: 20px;
+    padding: 15px;
+    border-left: 4px solid #5D23BB;
+    background-color: #f8f8ff;
+  ">
+  <p style="
+    font-family: 'Poppins', sans-serif;
+    color: #070629;
+    font-size: 16px;
+    margin-top: 0;
+    margin-bottom: 10px;
+  ">
+    <strong>Resumed schedules:</strong> {{ data.resumed_schedules }}
+  </p>
+  <p style="
+    font-family: 'Poppins', sans-serif;
+    color: #070629;
+    font-size: 16px;
+    margin-top: 0;
+    margin-bottom: 10px;
+  ">
+    <strong>Resumed triggers:</strong> {{ data.resumed_triggers }}
+  </p>
+</div>
+
+<p style="
+    font-family: 'Poppins', sans-serif;
+    color: #070629;
+    font-size: 16px;
+    line-height: 150%;
+    margin-top: 30px;
+    margin-bottom: 10px;
+    font-style: italic;
+  ">
+  This is an automated notification. Automations you paused yourself were left
+  untouched.
+</p>

--- a/autogpt_platform/backend/migrations/20260728120000_add_automation_pause_on_payment_lapse/migration.sql
+++ b/autogpt_platform/backend/migrations/20260728120000_add_automation_pause_on_payment_lapse/migration.sql
@@ -1,0 +1,12 @@
+-- CreateEnum
+CREATE TYPE "PresetDeactivationReason" AS ENUM ('PAYMENT_LAPSED');
+
+-- AlterEnum
+ALTER TYPE "NotificationType" ADD VALUE IF NOT EXISTS 'AUTOMATIONS_PAUSED';
+ALTER TYPE "NotificationType" ADD VALUE IF NOT EXISTS 'AUTOMATIONS_RESUMED';
+
+-- AlterTable
+ALTER TABLE "AgentPreset" ADD COLUMN "deactivationReason" "PresetDeactivationReason";
+
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN "notifyOnAutomationsPaused" BOOLEAN NOT NULL DEFAULT true;

--- a/autogpt_platform/backend/schema.prisma
+++ b/autogpt_platform/backend/schema.prisma
@@ -37,6 +37,7 @@ model User {
   notifyOnMonthlySummary       Boolean @default(true)
   notifyOnAgentApproved        Boolean @default(true)
   notifyOnAgentRejected        Boolean @default(true)
+  notifyOnAutomationsPaused    Boolean @default(true)
 
   timezone String @default("not-set")
 
@@ -497,6 +498,9 @@ model AgentPreset {
   // This bool allows us to disable a configured agent without deleting it
   isActive Boolean @default(true)
 
+  // Why the system deactivated this preset (null when the user did it themselves)
+  deactivationReason PresetDeactivationReason?
+
   userId String
   User   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
 
@@ -539,6 +543,12 @@ enum NotificationType {
   REFUND_PROCESSED
   AGENT_APPROVED
   AGENT_REJECTED
+  AUTOMATIONS_PAUSED
+  AUTOMATIONS_RESUMED
+}
+
+enum PresetDeactivationReason {
+  PAYMENT_LAPSED
 }
 
 model NotificationEvent {

--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/selected-views/SelectedRunView/components/WebhookTriggerSection.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/selected-views/SelectedRunView/components/WebhookTriggerSection.tsx
@@ -4,7 +4,9 @@ import { GraphTriggerInfo } from "@/app/api/__generated__/models/graphTriggerInf
 import { LibraryAgentPreset } from "@/app/api/__generated__/models/libraryAgentPreset";
 import { Button } from "@/components/atoms/Button/Button";
 import { Text } from "@/components/atoms/Text/Text";
+import { getWebhookTriggerStatus } from "@/lib/automations/paused";
 import { CopyIcon } from "@phosphor-icons/react";
+import Link from "next/link";
 import { RunDetailCard } from "../../RunDetailCard/RunDetailCard";
 
 interface Props {
@@ -12,18 +14,8 @@ interface Props {
   triggerSetupInfo: GraphTriggerInfo;
 }
 
-function getTriggerStatus(
-  preset: LibraryAgentPreset,
-): "active" | "inactive" | "paused" | "broken" {
-  if (!preset.webhook_id || !preset.webhook) return "broken";
-  if (preset.is_active) return "active";
-  return preset.deactivation_reason === "PAYMENT_LAPSED"
-    ? "paused"
-    : "inactive";
-}
-
 export function WebhookTriggerSection({ preset, triggerSetupInfo }: Props) {
-  const status = getTriggerStatus(preset);
+  const status = getWebhookTriggerStatus(preset);
   const webhook = preset.webhook;
 
   function handleCopyWebhookUrl() {
@@ -88,14 +80,24 @@ export function WebhookTriggerSection({ preset, triggerSetupInfo }: Props) {
             </div>
           </div>
         ) : (
-          <Text variant="body" className="text-muted-foreground">
-            This agent trigger is{" "}
-            {preset.is_active
-              ? "ready. When a trigger is received, it will run with the provided settings."
-              : status === "paused"
-                ? "paused because your payment lapsed. It will resume automatically once your subscription is active again."
-                : "disabled. It will not respond to triggers until you enable it."}
-          </Text>
+          <div className="flex flex-col gap-1.5">
+            <Text variant="body" className="text-muted-foreground">
+              This agent trigger is{" "}
+              {preset.is_active
+                ? "ready. When a trigger is received, it will run with the provided settings."
+                : status === "paused"
+                  ? "paused because your payment lapsed. It will resume automatically once your subscription is active again."
+                  : "disabled. It will not respond to triggers until you enable it."}
+            </Text>
+            {status === "paused" && (
+              <Link
+                href="/settings/billing"
+                className="text-sm font-medium text-violet-600 hover:underline"
+              >
+                Manage billing
+              </Link>
+            )}
+          </div>
         )}
       </div>
     </RunDetailCard>

--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/selected-views/SelectedRunView/components/WebhookTriggerSection.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/selected-views/SelectedRunView/components/WebhookTriggerSection.tsx
@@ -63,7 +63,9 @@ export function WebhookTriggerSection({ preset, triggerSetupInfo }: Props) {
             This trigger is not attached to a webhook. Use &quot;Set up
             trigger&quot; to fix this.
           </Text>
-        ) : !triggerSetupInfo.credentials_input_name && webhook ? (
+        ) : status === "active" &&
+          !triggerSetupInfo.credentials_input_name &&
+          webhook ? (
           <div className="flex flex-col gap-2">
             <Text variant="body">
               This trigger is ready to be used. Use the Webhook URL below to set

--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/selected-views/SelectedRunView/components/WebhookTriggerSection.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/selected-views/SelectedRunView/components/WebhookTriggerSection.tsx
@@ -83,11 +83,13 @@ export function WebhookTriggerSection({ preset, triggerSetupInfo }: Props) {
           <div className="flex flex-col gap-1.5">
             <Text variant="body" className="text-muted-foreground">
               This agent trigger is{" "}
-              {preset.is_active
+              {status === "active"
                 ? "ready. When a trigger is received, it will run with the provided settings."
                 : status === "paused"
                   ? "paused because your payment lapsed. It will resume automatically once your subscription is active again."
-                  : "disabled. It will not respond to triggers until you enable it."}
+                  : status === "broken"
+                    ? 'missing its webhook connection. Re-run "Set up trigger" to reconnect it.'
+                    : "disabled. It will not respond to triggers until you enable it."}
             </Text>
             {status === "paused" && (
               <Link

--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/selected-views/SelectedRunView/components/WebhookTriggerSection.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/selected-views/SelectedRunView/components/WebhookTriggerSection.tsx
@@ -14,9 +14,12 @@ interface Props {
 
 function getTriggerStatus(
   preset: LibraryAgentPreset,
-): "active" | "inactive" | "broken" {
+): "active" | "inactive" | "paused" | "broken" {
   if (!preset.webhook_id || !preset.webhook) return "broken";
-  return preset.is_active ? "active" : "inactive";
+  if (preset.is_active) return "active";
+  return preset.deactivation_reason === "PAYMENT_LAPSED"
+    ? "paused"
+    : "inactive";
 }
 
 export function WebhookTriggerSection({ preset, triggerSetupInfo }: Props) {
@@ -38,16 +41,20 @@ export function WebhookTriggerSection({ preset, triggerSetupInfo }: Props) {
             className={`rounded-full px-2 py-0.5 text-xs font-medium ${
               status === "active"
                 ? "bg-green-100 text-green-800"
-                : status === "inactive"
-                  ? "bg-yellow-100 text-yellow-800"
-                  : "bg-red-100 text-red-800"
+                : status === "paused"
+                  ? "bg-amber-100 text-amber-800"
+                  : status === "inactive"
+                    ? "bg-yellow-100 text-yellow-800"
+                    : "bg-red-100 text-red-800"
             }`}
           >
             {status === "active"
               ? "Active"
-              : status === "inactive"
-                ? "Inactive"
-                : "Broken"}
+              : status === "paused"
+                ? "Paused — payment required"
+                : status === "inactive"
+                  ? "Inactive"
+                  : "Broken"}
           </span>
         </div>
 
@@ -83,7 +90,9 @@ export function WebhookTriggerSection({ preset, triggerSetupInfo }: Props) {
             This agent trigger is{" "}
             {preset.is_active
               ? "ready. When a trigger is received, it will run with the provided settings."
-              : "disabled. It will not respond to triggers until you enable it."}
+              : status === "paused"
+                ? "paused because your payment lapsed. It will resume automatically once your subscription is active again."
+                : "disabled. It will not respond to triggers until you enable it."}
           </Text>
         )}
       </div>

--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/selected-views/SelectedRunView/components/__tests__/WebhookTriggerSection.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/selected-views/SelectedRunView/components/__tests__/WebhookTriggerSection.test.tsx
@@ -1,0 +1,85 @@
+import type { GraphTriggerInfo } from "@/app/api/__generated__/models/graphTriggerInfo";
+import type { LibraryAgentPreset } from "@/app/api/__generated__/models/libraryAgentPreset";
+import { render, screen } from "@/tests/integrations/test-utils";
+import { describe, expect, test } from "vitest";
+import { WebhookTriggerSection } from "../WebhookTriggerSection";
+
+function makePreset(
+  overrides: Partial<LibraryAgentPreset>,
+): LibraryAgentPreset {
+  return {
+    id: "preset-1",
+    user_id: "user-1",
+    graph_id: "graph-1",
+    graph_version: 1,
+    name: "My trigger",
+    description: "",
+    inputs: {},
+    credentials: {},
+    is_active: true,
+    created_at: new Date(),
+    updated_at: new Date(),
+    webhook_id: "wh-1",
+    webhook: {
+      id: "wh-1",
+      user_id: "user-1",
+      url: "https://example.com/hooks/wh-1",
+      provider: "generic_webhook",
+      credentials_id: "",
+      webhook_type: "manual",
+      resource: "",
+      events: [],
+      config: {},
+      secret: "",
+      provider_webhook_id: "",
+    } as LibraryAgentPreset["webhook"],
+    ...overrides,
+  } as LibraryAgentPreset;
+}
+
+const triggerSetupInfo = {
+  provider: "generic_webhook",
+  config_schema: {},
+  credentials_input_name: null,
+} as unknown as GraphTriggerInfo;
+
+describe("WebhookTriggerSection", () => {
+  test("active preset shows Active status and webhook URL", () => {
+    render(
+      <WebhookTriggerSection
+        preset={makePreset({})}
+        triggerSetupInfo={triggerSetupInfo}
+      />,
+    );
+    expect(screen.getByText("Active")).toBeDefined();
+    expect(screen.getByText("https://example.com/hooks/wh-1")).toBeDefined();
+  });
+
+  test("payment-lapse deactivated preset shows paused status, not the ready copy", () => {
+    render(
+      <WebhookTriggerSection
+        preset={makePreset({
+          is_active: false,
+          deactivation_reason: "PAYMENT_LAPSED",
+        })}
+        triggerSetupInfo={triggerSetupInfo}
+      />,
+    );
+    expect(screen.getByText("Paused — payment required")).toBeDefined();
+    expect(screen.queryByText("https://example.com/hooks/wh-1")).toBeNull();
+    expect(
+      screen.getByText(/paused because your payment lapsed/i),
+    ).toBeDefined();
+  });
+
+  test("user-deactivated preset shows Inactive, not payment copy", () => {
+    render(
+      <WebhookTriggerSection
+        preset={makePreset({ is_active: false })}
+        triggerSetupInfo={triggerSetupInfo}
+      />,
+    );
+    expect(screen.getByText("Inactive")).toBeDefined();
+    expect(screen.queryByText(/payment/i)).toBeNull();
+  });
+});

--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/selected-views/SelectedScheduleView/SelectedScheduleView.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/selected-views/SelectedScheduleView/SelectedScheduleView.test.tsx
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "vitest";
+import { render, screen } from "@/tests/integrations/test-utils";
+import { server } from "@/mocks/mock-server";
+
+import { getGetV1ListExecutionSchedulesForAGraphMockHandler } from "@/app/api/__generated__/endpoints/schedules/schedules.msw";
+import type { GraphExecutionJobInfo } from "@/app/api/__generated__/models/graphExecutionJobInfo";
+import type { LibraryAgent } from "@/app/api/__generated__/models/libraryAgent";
+import { SelectedScheduleView } from "./SelectedScheduleView";
+
+const agent = {
+  id: "lib-agent-1",
+  name: "Nightly cleanup",
+  graph_id: "graph-abc",
+  graph_version: 1,
+} as unknown as LibraryAgent;
+
+function makeSchedule(
+  overrides: Partial<GraphExecutionJobInfo> = {},
+): GraphExecutionJobInfo {
+  return {
+    id: "sched-1",
+    name: "Daily summary",
+    user_id: "user-1",
+    graph_id: "graph-abc",
+    graph_version: 1,
+    agent_name: "Daily summary agent",
+    cron: "0 9 * * *",
+    input_data: {},
+    next_run_time: new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString(),
+    timezone: "UTC",
+    ...overrides,
+  };
+}
+
+describe("SelectedScheduleView", () => {
+  test("payment-lapsed schedule shows the paused label instead of the next-run time", async () => {
+    server.use(
+      getGetV1ListExecutionSchedulesForAGraphMockHandler([
+        makeSchedule({
+          is_paused: true,
+          next_run_time: "",
+          paused_reason: "payment_lapsed",
+        }),
+      ]),
+    );
+
+    render(<SelectedScheduleView agent={agent} scheduleId="sched-1" />);
+
+    expect(await screen.findByText("Paused — payment required")).toBeDefined();
+  });
+
+  test("schedule with no next run time shows Pending", async () => {
+    server.use(
+      getGetV1ListExecutionSchedulesForAGraphMockHandler([
+        makeSchedule({ is_paused: false, next_run_time: "" }),
+      ]),
+    );
+
+    render(<SelectedScheduleView agent={agent} scheduleId="sched-1" />);
+
+    expect(await screen.findByText("Pending")).toBeDefined();
+    expect(screen.queryByText("Paused — payment required")).toBeNull();
+  });
+});

--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/selected-views/SelectedScheduleView/SelectedScheduleView.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/selected-views/SelectedScheduleView/SelectedScheduleView.tsx
@@ -4,7 +4,12 @@ import type { LibraryAgent } from "@/app/api/__generated__/models/libraryAgent";
 import { LoadingSpinner } from "@/components/atoms/LoadingSpinner/LoadingSpinner";
 import { Text } from "@/components/atoms/Text/Text";
 import { ErrorCard } from "@/components/molecules/ErrorCard/ErrorCard";
+import {
+  getSchedulePausedLabel,
+  SCHEDULE_PAYMENT_LAPSED_REASON,
+} from "@/lib/automations/paused";
 import { humanizeCronExpression } from "@/lib/cron-expression-utils";
+import Link from "next/link";
 import { isLargeScreen, useBreakpoint } from "@/lib/hooks/useBreakpoint";
 import { useUserTimezone } from "@/lib/hooks/useUserTimezone";
 import { formatInTimezone, getTimezoneDisplayName } from "@/lib/timezone-utils";
@@ -127,13 +132,23 @@ export function SelectedScheduleView({
                     <div className="flex flex-col gap-1.5">
                       <Text variant="large-medium">Next run</Text>
                       {schedule.is_paused || !schedule.next_run_time ? (
-                        <Text variant="body" className="text-amber-700">
-                          {!schedule.is_paused
-                            ? "Pending"
-                            : schedule.paused_reason === "payment_lapsed"
-                              ? "Paused — payment required"
-                              : "Paused"}
-                        </Text>
+                        <div className="flex flex-col gap-1.5">
+                          <Text variant="body" className="text-amber-700">
+                            {schedule.is_paused
+                              ? getSchedulePausedLabel(schedule.paused_reason)
+                              : "Pending"}
+                          </Text>
+                          {schedule.is_paused &&
+                            schedule.paused_reason ===
+                              SCHEDULE_PAYMENT_LAPSED_REASON && (
+                              <Link
+                                href="/settings/billing"
+                                className="text-sm font-medium text-violet-600 hover:underline"
+                              >
+                                Manage billing
+                              </Link>
+                            )}
+                        </div>
                       ) : (
                         <Text
                           variant="body"

--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/selected-views/SelectedScheduleView/SelectedScheduleView.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/selected-views/SelectedScheduleView/SelectedScheduleView.tsx
@@ -126,26 +126,37 @@ export function SelectedScheduleView({
                     </div>
                     <div className="flex flex-col gap-1.5">
                       <Text variant="large-medium">Next run</Text>
-                      <Text variant="body" className="flex items-center gap-3">
-                        {formatInTimezone(
-                          schedule.next_run_time,
-                          userTimezone || "UTC",
-                          {
-                            year: "numeric",
-                            month: "long",
-                            day: "numeric",
-                            hour: "2-digit",
-                            minute: "2-digit",
-                            hour12: false,
-                          },
-                        )}{" "}
-                        <span className="text-zinc-500">•</span>{" "}
-                        <span className="text-zinc-500">
-                          {getTimezoneDisplayName(
-                            schedule.timezone || userTimezone || "UTC",
-                          )}
-                        </span>
-                      </Text>
+                      {schedule.is_paused || !schedule.next_run_time ? (
+                        <Text variant="body" className="text-amber-700">
+                          {schedule.is_paused
+                            ? "Paused — payment required"
+                            : "Pending"}
+                        </Text>
+                      ) : (
+                        <Text
+                          variant="body"
+                          className="flex items-center gap-3"
+                        >
+                          {formatInTimezone(
+                            schedule.next_run_time,
+                            userTimezone || "UTC",
+                            {
+                              year: "numeric",
+                              month: "long",
+                              day: "numeric",
+                              hour: "2-digit",
+                              minute: "2-digit",
+                              hour12: false,
+                            },
+                          )}{" "}
+                          <span className="text-zinc-500">•</span>{" "}
+                          <span className="text-zinc-500">
+                            {getTimezoneDisplayName(
+                              schedule.timezone || userTimezone || "UTC",
+                            )}
+                          </span>
+                        </Text>
+                      )}
                     </div>
                   </div>
                 )}

--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/selected-views/SelectedScheduleView/SelectedScheduleView.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/selected-views/SelectedScheduleView/SelectedScheduleView.tsx
@@ -128,9 +128,11 @@ export function SelectedScheduleView({
                       <Text variant="large-medium">Next run</Text>
                       {schedule.is_paused || !schedule.next_run_time ? (
                         <Text variant="body" className="text-amber-700">
-                          {schedule.is_paused
-                            ? "Paused — payment required"
-                            : "Pending"}
+                          {!schedule.is_paused
+                            ? "Pending"
+                            : schedule.paused_reason === "payment_lapsed"
+                              ? "Paused — payment required"
+                              : "Paused"}
                         </Text>
                       ) : (
                         <Text

--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/selected-views/SelectedTemplateView/components/WebhookTriggerCard.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/selected-views/SelectedTemplateView/components/WebhookTriggerCard.test.tsx
@@ -1,0 +1,100 @@
+import { describe, expect, test } from "vitest";
+import { render, screen } from "@/tests/integrations/test-utils";
+
+import type { GraphTriggerInfo } from "@/app/api/__generated__/models/graphTriggerInfo";
+import type { LibraryAgentPreset } from "@/app/api/__generated__/models/libraryAgentPreset";
+import type { Webhook } from "@/app/api/__generated__/models/webhook";
+import { WebhookTriggerCard } from "./WebhookTriggerCard";
+
+const webhook = {
+  id: "webhook-1",
+  user_id: "user-1",
+  provider: "github",
+  credentials_id: "cred-1",
+  webhook_type: "repo",
+  resource: "owner/repo",
+  events: ["push"],
+  secret: "shh",
+  provider_webhook_id: "prov-1",
+  url: "https://example.com/webhook",
+} satisfies Webhook;
+
+function makeTemplate(overrides: Partial<LibraryAgentPreset> = {}) {
+  return {
+    id: "template-1",
+    user_id: "user-1",
+    graph_id: "graph-1",
+    graph_version: 1,
+    name: "Template",
+    description: "",
+    inputs: {},
+    credentials: {},
+    is_active: true,
+    webhook_id: "webhook-1",
+    webhook,
+    created_at: new Date("2026-01-01T00:00:00.000Z"),
+    updated_at: new Date("2026-01-01T00:00:00.000Z"),
+    ...overrides,
+  } as LibraryAgentPreset;
+}
+
+// credentials_input_name truthy so the component falls through to the
+// status-dependent description text rather than the webhook-URL block.
+const triggerSetupInfo = {
+  provider: "github",
+  config_schema: {},
+  credentials_input_name: "credentials",
+} as GraphTriggerInfo;
+
+describe("WebhookTriggerCard", () => {
+  test("payment-lapsed template shows the paused badge and explanation", async () => {
+    render(
+      <WebhookTriggerCard
+        template={makeTemplate({
+          is_active: false,
+          deactivation_reason: "PAYMENT_LAPSED",
+        })}
+        triggerSetupInfo={triggerSetupInfo}
+      />,
+    );
+
+    expect(await screen.findByText("Paused — payment required")).toBeDefined();
+    expect(
+      screen.getByText(/paused because your payment lapsed/i),
+    ).toBeDefined();
+  });
+
+  test("active template shows the active badge", async () => {
+    render(
+      <WebhookTriggerCard
+        template={makeTemplate({ is_active: true })}
+        triggerSetupInfo={triggerSetupInfo}
+      />,
+    );
+
+    expect(await screen.findByText("Active")).toBeDefined();
+  });
+
+  test("user-disabled template (no reason) shows inactive, not paused", async () => {
+    render(
+      <WebhookTriggerCard
+        template={makeTemplate({ is_active: false })}
+        triggerSetupInfo={triggerSetupInfo}
+      />,
+    );
+
+    expect(await screen.findByText("Inactive")).toBeDefined();
+    expect(screen.queryByText("Paused — payment required")).toBeNull();
+  });
+
+  test("template without a webhook shows broken", async () => {
+    render(
+      <WebhookTriggerCard
+        template={makeTemplate({ webhook: null, webhook_id: undefined })}
+        triggerSetupInfo={triggerSetupInfo}
+      />,
+    );
+
+    expect(await screen.findByText("Broken")).toBeDefined();
+  });
+});

--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/selected-views/SelectedTemplateView/components/WebhookTriggerCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/selected-views/SelectedTemplateView/components/WebhookTriggerCard.tsx
@@ -4,7 +4,9 @@ import { GraphTriggerInfo } from "@/app/api/__generated__/models/graphTriggerInf
 import { LibraryAgentPreset } from "@/app/api/__generated__/models/libraryAgentPreset";
 import { Button } from "@/components/atoms/Button/Button";
 import { Text } from "@/components/atoms/Text/Text";
+import { getWebhookTriggerStatus } from "@/lib/automations/paused";
 import { CopyIcon } from "@phosphor-icons/react";
+import Link from "next/link";
 import { RunDetailCard } from "../../RunDetailCard/RunDetailCard";
 
 interface Props {
@@ -12,18 +14,8 @@ interface Props {
   triggerSetupInfo: GraphTriggerInfo;
 }
 
-function getTriggerStatus(
-  template: LibraryAgentPreset,
-): "active" | "inactive" | "paused" | "broken" {
-  if (!template.webhook_id || !template.webhook) return "broken";
-  if (template.is_active) return "active";
-  return template.deactivation_reason === "PAYMENT_LAPSED"
-    ? "paused"
-    : "inactive";
-}
-
 export function WebhookTriggerCard({ template, triggerSetupInfo }: Props) {
-  const status = getTriggerStatus(template);
+  const status = getWebhookTriggerStatus(template);
   const webhook = template.webhook;
 
   function handleCopyWebhookUrl() {
@@ -88,14 +80,24 @@ export function WebhookTriggerCard({ template, triggerSetupInfo }: Props) {
             </div>
           </div>
         ) : (
-          <Text variant="body" className="text-muted-foreground">
-            This agent trigger is{" "}
-            {template.is_active
-              ? "ready. When a trigger is received, it will run with the provided settings."
-              : status === "paused"
-                ? "paused because your payment lapsed. It will resume automatically once your subscription is active again."
-                : "disabled. It will not respond to triggers until you enable it."}
-          </Text>
+          <div className="flex flex-col gap-1.5">
+            <Text variant="body" className="text-muted-foreground">
+              This agent trigger is{" "}
+              {template.is_active
+                ? "ready. When a trigger is received, it will run with the provided settings."
+                : status === "paused"
+                  ? "paused because your payment lapsed. It will resume automatically once your subscription is active again."
+                  : "disabled. It will not respond to triggers until you enable it."}
+            </Text>
+            {status === "paused" && (
+              <Link
+                href="/settings/billing"
+                className="text-sm font-medium text-violet-600 hover:underline"
+              >
+                Manage billing
+              </Link>
+            )}
+          </div>
         )}
       </div>
     </RunDetailCard>

--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/selected-views/SelectedTemplateView/components/WebhookTriggerCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/selected-views/SelectedTemplateView/components/WebhookTriggerCard.tsx
@@ -83,11 +83,13 @@ export function WebhookTriggerCard({ template, triggerSetupInfo }: Props) {
           <div className="flex flex-col gap-1.5">
             <Text variant="body" className="text-muted-foreground">
               This agent trigger is{" "}
-              {template.is_active
+              {status === "active"
                 ? "ready. When a trigger is received, it will run with the provided settings."
                 : status === "paused"
                   ? "paused because your payment lapsed. It will resume automatically once your subscription is active again."
-                  : "disabled. It will not respond to triggers until you enable it."}
+                  : status === "broken"
+                    ? 'missing its webhook connection. Re-run "Set up trigger" to reconnect it.'
+                    : "disabled. It will not respond to triggers until you enable it."}
             </Text>
             {status === "paused" && (
               <Link

--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/selected-views/SelectedTemplateView/components/WebhookTriggerCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/selected-views/SelectedTemplateView/components/WebhookTriggerCard.tsx
@@ -14,9 +14,12 @@ interface Props {
 
 function getTriggerStatus(
   template: LibraryAgentPreset,
-): "active" | "inactive" | "broken" {
+): "active" | "inactive" | "paused" | "broken" {
   if (!template.webhook_id || !template.webhook) return "broken";
-  return template.is_active ? "active" : "inactive";
+  if (template.is_active) return "active";
+  return template.deactivation_reason === "PAYMENT_LAPSED"
+    ? "paused"
+    : "inactive";
 }
 
 export function WebhookTriggerCard({ template, triggerSetupInfo }: Props) {
@@ -38,16 +41,20 @@ export function WebhookTriggerCard({ template, triggerSetupInfo }: Props) {
             className={`rounded-full px-2 py-0.5 text-xs font-medium ${
               status === "active"
                 ? "bg-green-100 text-green-800"
-                : status === "inactive"
-                  ? "bg-yellow-100 text-yellow-800"
-                  : "bg-red-100 text-red-800"
+                : status === "paused"
+                  ? "bg-amber-100 text-amber-800"
+                  : status === "inactive"
+                    ? "bg-yellow-100 text-yellow-800"
+                    : "bg-red-100 text-red-800"
             }`}
           >
             {status === "active"
               ? "Active"
-              : status === "inactive"
-                ? "Inactive"
-                : "Broken"}
+              : status === "paused"
+                ? "Paused — payment required"
+                : status === "inactive"
+                  ? "Inactive"
+                  : "Broken"}
           </span>
         </div>
 
@@ -83,7 +90,9 @@ export function WebhookTriggerCard({ template, triggerSetupInfo }: Props) {
             This agent trigger is{" "}
             {template.is_active
               ? "ready. When a trigger is received, it will run with the provided settings."
-              : "disabled. It will not respond to triggers until you enable it."}
+              : status === "paused"
+                ? "paused because your payment lapsed. It will resume automatically once your subscription is active again."
+                : "disabled. It will not respond to triggers until you enable it."}
           </Text>
         )}
       </div>

--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/selected-views/SelectedTemplateView/components/WebhookTriggerCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/selected-views/SelectedTemplateView/components/WebhookTriggerCard.tsx
@@ -63,7 +63,9 @@ export function WebhookTriggerCard({ template, triggerSetupInfo }: Props) {
             This trigger is not attached to a webhook. Use &quot;Set up
             trigger&quot; to fix this.
           </Text>
-        ) : !triggerSetupInfo.credentials_input_name && webhook ? (
+        ) : status === "active" &&
+          !triggerSetupInfo.credentials_input_name &&
+          webhook ? (
           <div className="flex flex-col gap-2">
             <Text variant="body">
               This trigger is ready to be used. Use the Webhook URL below to set

--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/sidebar/SidebarRunsList/components/ScheduleListItem.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/sidebar/SidebarRunsList/components/ScheduleListItem.test.tsx
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "vitest";
+import { render, screen } from "@/tests/integrations/test-utils";
+
+import type { GraphExecutionJobInfo } from "@/app/api/__generated__/models/graphExecutionJobInfo";
+import type { LibraryAgent } from "@/app/api/__generated__/models/libraryAgent";
+import { ScheduleListItem } from "./ScheduleListItem";
+
+const agent = {
+  id: "lib-agent-1",
+  graph_id: "graph-1",
+  graph_version: 1,
+} as unknown as LibraryAgent;
+
+function makeSchedule(
+  overrides: Partial<GraphExecutionJobInfo> = {},
+): GraphExecutionJobInfo {
+  return {
+    id: "sched-1",
+    user_id: "user-1",
+    graph_id: "graph-1",
+    graph_version: 1,
+    name: "Daily run",
+    cron: "0 0 * * *",
+    input_data: {},
+    next_run_time: "2099-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("ScheduleListItem", () => {
+  test("payment-lapsed schedule shows the paused description instead of a run time", async () => {
+    render(
+      <ScheduleListItem
+        schedule={makeSchedule({
+          is_paused: true,
+          next_run_time: "",
+          paused_reason: "payment_lapsed",
+        })}
+        agent={agent}
+      />,
+    );
+
+    expect(await screen.findByText("Paused — payment required")).toBeDefined();
+  });
+
+  test("schedule without a next run time falls back to Pending", async () => {
+    render(
+      <ScheduleListItem
+        schedule={makeSchedule({ is_paused: false, next_run_time: "" })}
+        agent={agent}
+      />,
+    );
+
+    expect(await screen.findByText("Pending")).toBeDefined();
+    expect(screen.queryByText("Paused — payment required")).toBeNull();
+  });
+
+  test("active schedule shows a relative next-run time", async () => {
+    render(<ScheduleListItem schedule={makeSchedule()} agent={agent} />);
+
+    expect(await screen.findByText("Daily run")).toBeDefined();
+    expect(screen.queryByText("Paused — payment required")).toBeNull();
+    expect(screen.queryByText("Pending")).toBeNull();
+  });
+});

--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/sidebar/SidebarRunsList/components/ScheduleListItem.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/sidebar/SidebarRunsList/components/ScheduleListItem.tsx
@@ -25,13 +25,26 @@ export function ScheduleListItem({
   onDeleted,
   onRunCreated,
 }: Props) {
+  const isPaused = Boolean(schedule.is_paused);
   return (
     <SidebarItemCard
       title={schedule.name}
-      description={formatDistanceToNow(schedule.next_run_time, {
-        addSuffix: true,
-      })}
-      descriptionTitle={new Date(schedule.next_run_time).toString()}
+      description={
+        isPaused
+          ? "Paused — payment required"
+          : schedule.next_run_time
+            ? formatDistanceToNow(schedule.next_run_time, {
+                addSuffix: true,
+              })
+            : "Pending"
+      }
+      descriptionTitle={
+        isPaused
+          ? "Paused — payment required"
+          : schedule.next_run_time
+            ? new Date(schedule.next_run_time).toString()
+            : "Pending"
+      }
       onClick={onClick}
       selected={selected}
       icon={

--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/sidebar/SidebarRunsList/components/ScheduleListItem.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/sidebar/SidebarRunsList/components/ScheduleListItem.tsx
@@ -26,24 +26,25 @@ export function ScheduleListItem({
   onRunCreated,
 }: Props) {
   const isPaused = Boolean(schedule.is_paused);
+  const pausedLabel =
+    schedule.paused_reason === "payment_lapsed"
+      ? "Paused — payment required"
+      : "Paused";
+  const description = isPaused
+    ? pausedLabel
+    : schedule.next_run_time
+      ? formatDistanceToNow(schedule.next_run_time, {
+          addSuffix: true,
+        })
+      : "Pending";
   return (
     <SidebarItemCard
       title={schedule.name}
-      description={
-        isPaused
-          ? "Paused — payment required"
-          : schedule.next_run_time
-            ? formatDistanceToNow(schedule.next_run_time, {
-                addSuffix: true,
-              })
-            : "Pending"
-      }
+      description={description}
       descriptionTitle={
-        isPaused
-          ? "Paused — payment required"
-          : schedule.next_run_time
-            ? new Date(schedule.next_run_time).toString()
-            : "Pending"
+        !isPaused && schedule.next_run_time
+          ? new Date(schedule.next_run_time).toString()
+          : description
       }
       onClick={onClick}
       selected={selected}

--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/sidebar/SidebarRunsList/components/ScheduleListItem.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/sidebar/SidebarRunsList/components/ScheduleListItem.tsx
@@ -2,6 +2,7 @@
 
 import { GraphExecutionJobInfo } from "@/app/api/__generated__/models/graphExecutionJobInfo";
 import { LibraryAgent } from "@/app/api/__generated__/models/libraryAgent";
+import { getSchedulePausedLabel } from "@/lib/automations/paused";
 import { ClockClockwiseIcon } from "@phosphor-icons/react";
 import { formatDistanceToNow } from "date-fns";
 import { IconWrapper } from "./IconWrapper";
@@ -26,10 +27,7 @@ export function ScheduleListItem({
   onRunCreated,
 }: Props) {
   const isPaused = Boolean(schedule.is_paused);
-  const pausedLabel =
-    schedule.paused_reason === "payment_lapsed"
-      ? "Paused — payment required"
-      : "Paused";
+  const pausedLabel = getSchedulePausedLabel(schedule.paused_reason);
   const description = isPaused
     ? pausedLabel
     : schedule.next_run_time

--- a/autogpt_platform/frontend/src/app/(platform)/library/followups/__tests__/main.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/followups/__tests__/main.test.tsx
@@ -494,4 +494,26 @@ describe("FollowupsPage", () => {
     expect(screen.queryByTestId("followups-list")).toBeNull();
     expect(screen.queryByTestId("schedules-partial-error")).toBeNull();
   });
+
+  test("graph row: paused schedule shows paused badge instead of next-run time", async () => {
+    server.use(
+      getListCopilotFollowupSchedulesMockHandler([]),
+      getGetV1ListExecutionSchedulesForAUserMockHandler([
+        makeGraphSchedule({
+          id: "paused-sched",
+          next_run_time: "",
+          is_paused: true,
+          paused_reason: "payment_lapsed",
+        }),
+      ]),
+    );
+
+    render(<FollowupsPage />);
+
+    const row = await screen.findByTestId("schedule-row");
+    expect(
+      within(row).getByTestId("schedule-paused-badge").textContent,
+    ).toContain("Paused — payment required");
+    expect(within(row).getByText("Paused")).toBeDefined();
+  });
 });

--- a/autogpt_platform/frontend/src/app/api/openapi.json
+++ b/autogpt_platform/frontend/src/app/api/openapi.json
@@ -16883,6 +16883,10 @@
             "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Team Id"
           },
+          "paused_reason": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Paused Reason"
+          },
           "id": { "type": "string", "title": "Id" },
           "name": { "type": "string", "title": "Name" },
           "next_run_time": { "type": "string", "title": "Next Run Time" },
@@ -16891,6 +16895,11 @@
             "title": "Timezone",
             "description": "Timezone used for scheduling",
             "default": "UTC"
+          },
+          "is_paused": {
+            "type": "boolean",
+            "title": "Is Paused",
+            "default": false
           }
         },
         "type": "object",
@@ -17961,6 +17970,12 @@
           "webhook": {
             "anyOf": [
               { "$ref": "#/components/schemas/Webhook" },
+              { "type": "null" }
+            ]
+          },
+          "deactivation_reason": {
+            "anyOf": [
+              { "$ref": "#/components/schemas/PresetDeactivationReason" },
               { "type": "null" }
             ]
           }
@@ -19091,7 +19106,9 @@
           "REFUND_REQUEST",
           "REFUND_PROCESSED",
           "AGENT_APPROVED",
-          "AGENT_REJECTED"
+          "AGENT_REJECTED",
+          "AUTOMATIONS_PAUSED",
+          "AUTOMATIONS_RESUMED"
         ],
         "title": "NotificationType"
       },
@@ -20121,6 +20138,11 @@
           "Metadata"
         ],
         "title": "PostmarkSubscriptionChangeWebhook"
+      },
+      "PresetDeactivationReason": {
+        "type": "string",
+        "enum": ["PAYMENT_LAPSED"],
+        "title": "PresetDeactivationReason"
       },
       "PresetDeletedResponse": {
         "properties": {

--- a/autogpt_platform/frontend/src/components/contextual/SchedulesPanel/components/GraphScheduleListItem/GraphScheduleListItem.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/SchedulesPanel/components/GraphScheduleListItem/GraphScheduleListItem.tsx
@@ -14,6 +14,7 @@ interface Props {
 
 export function GraphScheduleListItem({ schedule }: Props) {
   const {
+    isPaused,
     nextRunLabel,
     nextRunTitle,
     recurrenceLabel,
@@ -74,6 +75,14 @@ export function GraphScheduleListItem({ schedule }: Props) {
             >
               Agent run
             </span>
+            {isPaused && (
+              <span
+                className="rounded-full bg-amber-100 px-2 py-0.5 text-xs text-amber-700"
+                data-testid="schedule-paused-badge"
+              >
+                Paused — payment required
+              </span>
+            )}
           </div>
         </div>
       </Link>

--- a/autogpt_platform/frontend/src/components/contextual/SchedulesPanel/components/GraphScheduleListItem/GraphScheduleListItem.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/SchedulesPanel/components/GraphScheduleListItem/GraphScheduleListItem.tsx
@@ -15,6 +15,7 @@ interface Props {
 export function GraphScheduleListItem({ schedule }: Props) {
   const {
     isPaused,
+    pausedLabel,
     nextRunLabel,
     nextRunTitle,
     recurrenceLabel,
@@ -80,7 +81,7 @@ export function GraphScheduleListItem({ schedule }: Props) {
                 className="rounded-full bg-amber-100 px-2 py-0.5 text-xs text-amber-700"
                 data-testid="schedule-paused-badge"
               >
-                Paused — payment required
+                {pausedLabel}
               </span>
             )}
           </div>

--- a/autogpt_platform/frontend/src/components/contextual/SchedulesPanel/components/GraphScheduleListItem/useGraphScheduleListItem.ts
+++ b/autogpt_platform/frontend/src/components/contextual/SchedulesPanel/components/GraphScheduleListItem/useGraphScheduleListItem.ts
@@ -20,11 +20,13 @@ export function useGraphScheduleListItem({ schedule }: Args) {
   const { mutateAsync: deleteSchedule, isPending: isDeleting } =
     useDeleteV1DeleteExecutionSchedule();
 
+  const isPaused = Boolean(schedule.is_paused);
   const nextRunDate = schedule.next_run_time
     ? new Date(schedule.next_run_time)
     : null;
-  const nextRunLabel =
-    nextRunDate && !Number.isNaN(nextRunDate.valueOf())
+  const nextRunLabel = isPaused
+    ? "Paused"
+    : nextRunDate && !Number.isNaN(nextRunDate.valueOf())
       ? `Next ${formatDistanceToNow(nextRunDate, { addSuffix: true })}`
       : "Pending";
   const nextRunTitle = nextRunDate ? nextRunDate.toString() : undefined;
@@ -68,6 +70,7 @@ export function useGraphScheduleListItem({ schedule }: Args) {
   }
 
   return {
+    isPaused,
     nextRunLabel,
     nextRunTitle,
     recurrenceLabel,

--- a/autogpt_platform/frontend/src/components/contextual/SchedulesPanel/components/GraphScheduleListItem/useGraphScheduleListItem.ts
+++ b/autogpt_platform/frontend/src/components/contextual/SchedulesPanel/components/GraphScheduleListItem/useGraphScheduleListItem.ts
@@ -1,5 +1,6 @@
 import { useDeleteV1DeleteExecutionSchedule } from "@/app/api/__generated__/endpoints/schedules/schedules";
 import type { GraphExecutionJobInfo } from "@/app/api/__generated__/models/graphExecutionJobInfo";
+import { getSchedulePausedLabel } from "@/lib/automations/paused";
 import { useToast } from "@/components/molecules/Toast/use-toast";
 import { humanizeCronExpression } from "@/lib/cron-expression-utils";
 import { invalidateAllScheduleQueries } from "@/services/schedules/invalidate-schedules";
@@ -21,10 +22,7 @@ export function useGraphScheduleListItem({ schedule }: Args) {
     useDeleteV1DeleteExecutionSchedule();
 
   const isPaused = Boolean(schedule.is_paused);
-  const pausedLabel =
-    schedule.paused_reason === "payment_lapsed"
-      ? "Paused — payment required"
-      : "Paused";
+  const pausedLabel = getSchedulePausedLabel(schedule.paused_reason);
   const nextRunDate = schedule.next_run_time
     ? new Date(schedule.next_run_time)
     : null;

--- a/autogpt_platform/frontend/src/components/contextual/SchedulesPanel/components/GraphScheduleListItem/useGraphScheduleListItem.ts
+++ b/autogpt_platform/frontend/src/components/contextual/SchedulesPanel/components/GraphScheduleListItem/useGraphScheduleListItem.ts
@@ -21,6 +21,10 @@ export function useGraphScheduleListItem({ schedule }: Args) {
     useDeleteV1DeleteExecutionSchedule();
 
   const isPaused = Boolean(schedule.is_paused);
+  const pausedLabel =
+    schedule.paused_reason === "payment_lapsed"
+      ? "Paused — payment required"
+      : "Paused";
   const nextRunDate = schedule.next_run_time
     ? new Date(schedule.next_run_time)
     : null;
@@ -71,6 +75,7 @@ export function useGraphScheduleListItem({ schedule }: Args) {
 
   return {
     isPaused,
+    pausedLabel,
     nextRunLabel,
     nextRunTitle,
     recurrenceLabel,

--- a/autogpt_platform/frontend/src/components/contextual/SchedulesPanel/components/GraphScheduleListItem/useGraphScheduleListItem.ts
+++ b/autogpt_platform/frontend/src/components/contextual/SchedulesPanel/components/GraphScheduleListItem/useGraphScheduleListItem.ts
@@ -33,7 +33,11 @@ export function useGraphScheduleListItem({ schedule }: Args) {
     : nextRunDate && !Number.isNaN(nextRunDate.valueOf())
       ? `Next ${formatDistanceToNow(nextRunDate, { addSuffix: true })}`
       : "Pending";
-  const nextRunTitle = nextRunDate ? nextRunDate.toString() : undefined;
+  const nextRunTitle = isPaused
+    ? pausedLabel
+    : nextRunDate && !Number.isNaN(nextRunDate.valueOf())
+      ? nextRunDate.toString()
+      : undefined;
 
   const recurrenceLabel = schedule.cron
     ? safeHumanizeCron(schedule.cron)

--- a/autogpt_platform/frontend/src/lib/automations/paused.ts
+++ b/autogpt_platform/frontend/src/lib/automations/paused.ts
@@ -1,0 +1,29 @@
+import type { LibraryAgentPreset } from "@/app/api/__generated__/models/libraryAgentPreset";
+
+// Single source of truth for the payment-lapse markers the backend stamps:
+// schedules carry a lowercase free-form `paused_reason`, presets an uppercase
+// `PresetDeactivationReason` enum. Keeping them here avoids the string drifting
+// across the schedule and trigger components that render the paused state.
+export const SCHEDULE_PAYMENT_LAPSED_REASON = "payment_lapsed";
+export const PRESET_PAYMENT_LAPSED_REASON = "PAYMENT_LAPSED";
+
+const PAUSED_PAYMENT_REQUIRED_LABEL = "Paused — payment required";
+const PAUSED_LABEL = "Paused";
+
+export function getSchedulePausedLabel(pausedReason?: string | null): string {
+  return pausedReason === SCHEDULE_PAYMENT_LAPSED_REASON
+    ? PAUSED_PAYMENT_REQUIRED_LABEL
+    : PAUSED_LABEL;
+}
+
+export type WebhookTriggerStatus = "active" | "inactive" | "paused" | "broken";
+
+export function getWebhookTriggerStatus(
+  preset: LibraryAgentPreset,
+): WebhookTriggerStatus {
+  if (!preset.webhook_id || !preset.webhook) return "broken";
+  if (preset.is_active) return "active";
+  return preset.deactivation_reason === PRESET_PAYMENT_LAPSED_REASON
+    ? "paused"
+    : "inactive";
+}


### PR DESCRIPTION
### Why / What / How

**Why:** When a user's payment lapses (subscription drops to `NO_TIER`), their cron schedules and webhook triggers keep firing. The paywall in `add_graph_execution` only rejects the run *after* the scheduler has woken up (or the webhook has fanned out), so every tick produces a failed execution row plus log noise for a user who is no longer paying — and nothing ever resumes automatically when they pay again. (SECRT-2376)

**What:** On a paid→`NO_TIER` tier transition, all of the user's personal graph schedules are paused and their webhook-trigger presets deactivated — each stamped with a persisted `payment_lapsed` reason. On `NO_TIER`→paid, only automations carrying that marker are resumed, so anything the user paused/disabled themselves stays off. The user is notified on both edges, and the paused state is surfaced in the UI instead of the schedules silently disappearing.

**How:**
- `set_subscription_tier` (`backend/data/credit.py`) is the single write chokepoint for every lapse path (failed-invoice handler, `customer.subscription.*` webhooks, the reconciliation sweep). It now performs one `UPDATE … RETURNING` the pre-update tier under `FOR UPDATE`, so concurrent callers (webhook retry + reconciliation sweep) each observe a distinct transition and a paid↔NO_TIER edge can't be lost to interleaving. The pause/resume hook runs off that observed transition and is wrapped so a scheduler failure can never 500 the Stripe webhook that triggered it.
- Schedules have no DB model (APScheduler jobstore only), so the reason is persisted in the job kwargs (`GraphExecutionJobArgs.paused_reason`) and pause/resume use APScheduler's `pause_job`/`resume_job` via new exposed scheduler-service methods. Retries are self-healing — a resume that races a just-paused job converges rather than erroring. `get_execution_schedules` previously dropped any job with `next_run_time=None`; it now keeps system-paused schedules visible.
- Presets get a nullable `AgentPreset.deactivationReason` enum column. The webhook dispatcher already short-circuits on `isActive`, so deactivation is enough to drop events. A user explicitly setting `is_active` clears the reason, which is what protects manually-disabled automations from auto-resume.
- Org/team-tagged schedules and presets are excluded — they're funded by the org, not the member's personal subscription; personal-org automations are still covered.
- The user is notified on both pause and resume; the paused state is rendered in the schedules list, the library sidebar, the selected-schedule view, and the webhook trigger cards.

### Changes 🏗️

**Backend**
- `backend/data/credit.py`: `set_subscription_tier` rewritten as an atomic `UPDATE … RETURNING` chokepoint; tier-transition hook that pauses/resumes and never raises into the webhook path
- `backend/data/automation_pause.py` (new): pause/resume orchestrator over schedules + presets, queues notifications, excludes org/team automations
- `backend/executor/scheduler.py`: `paused_reason` on graph job args, `is_paused` on job info, `pause_user_graph_schedules`/`resume_user_graph_schedules` service methods + client bindings, self-healing retries, paused schedules stay in listings
- `backend/api/features/library/db.py` / `model.py`: user `is_active` updates clear `deactivationReason`; `deactivation_reason` exposed on `LibraryAgentPreset`
- `schema.prisma` + migration: `PresetDeactivationReason` enum, `AgentPreset.deactivationReason`, `NotificationType.AUTOMATIONS_PAUSED/RESUMED`, `User.notifyOnAutomationsPaused`
- Notifications: payload models, routing/template/subject entries, two email templates, preference wiring

**Frontend**
- "Paused — payment required" badge on schedule rows (SchedulesPanel + library sidebar) and the selected-schedule view; paused/`deactivation_reason` trigger status on webhook trigger cards
- Guard against empty `next_run_time` (previously crashed `formatDistanceToNow` — paused schedules were never listed before, now they are)
- Refreshed committed `openapi.json` (generated client picks up `is_paused`, `paused_reason`, `deactivation_reason`)

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `automation_pause_test.py`: pause stamps reason on schedules+presets, resume restores only `PAYMENT_LAPSED` rows, user-deactivated presets excluded, org/team automations skipped, no notification when nothing changed
  - [x] `credit_tier_transition_test.py`: paid→NO_TIER pauses, NO_TIER→paid resumes, paid→paid no-op, scheduler failure swallowed
  - [x] `credit_subscription_test.py`: `set_subscription_tier` UPDATE…RETURNING chokepoint and transition dispatch
  - [x] `scheduler_unit_test.py`: pause/resume skip other users / org jobs / already-paused; resume only matching reason; paused schedule still listed with `is_paused=True` while fired one-shots stay hidden; self-healing retries
  - [x] `library/db_test.py` + `store/db_test.py`: `update_preset(is_active=...)` clears `deactivationReason`; user fixture carries the new preference field
  - [x] Frontend: paused state renders on the schedules list (followups), webhook trigger section + card, sidebar schedule item, and selected schedule view; `pnpm types` + `pnpm lint` clean

#### For configuration changes:
- [x] `.env.default` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes
- [x] I have included a list of my configuration changes in the PR description (under **Changes**)
